### PR TITLE
tetragon: silence missing parent warning + add metric

### DIFF
--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/tetragon/pkg/execcache"
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/process"
 	readerexec "github.com/cilium/tetragon/pkg/reader/exec"
 	"github.com/cilium/tetragon/pkg/reader/node"
@@ -42,7 +43,8 @@ func (e *Grpc) GetProcessExec(
 
 	parent, err := process.Get(parentId)
 	if err != nil {
-		logger.GetLogger().WithField("processId", processId).WithField("parentId", parentId).Infof("Process missing parent")
+		metrics.ErrorCount.WithLabelValues(string(metrics.ExecMissingParent)).Inc()
+		logger.GetLogger().WithField("processId", processId).WithField("parentId", parentId).Debug("Process missing parent")
 	}
 
 	// Set the cap field only if --enable-process-cred flag is set.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -60,6 +60,8 @@ const (
 	PidMapEvicted ErrorType = "pid_map_evicted"
 	// PID not found in the pid map on remove() call.
 	PidMapMissOnRemove ErrorType = "pid_map_miss_on_remove"
+	// An exec event without parent info.
+	ExecMissingParent ErrorType = "exec_missing_parent"
 	// MetricNamePrefix defines the prefix for Prometheus metrics.
 	MetricNamePrefix string = "isovalent_"
 )


### PR DESCRIPTION
Missing parent warnings on exec events were producing noise, so hide them behind a debug
flag and add a metric for it.

Signed-off-by: William Findlay <will@isovalent.com>