### PR TITLE
encoder: Update TCP event format

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,11 +456,11 @@ kubectl exec -it xwing -- curl http://cilium.io
 ```
 The output in the first terminal will capture the new connect and write,
 ```bash
-🚀 process      default/xwing /usr/bin/curl http://cilium.io
-🔧 tcp_connect  default/xwing /usr/bin/curl 192.168.86.200:55513 -> 104.198.14.52:80
-🔧 tcp_sendmsg  default/xwing /usr/bin/curl 192.168.86.200:55513 -> 104.198.14.52:80 bytes 73
-🔧 tcp_close    default/xwing /usr/bin/curl 192.168.86.200:55513 -> 104.198.14.52:80
-💥 exit         default/xwing /usr/bin/curl http://cilium.io 0
+🚀 process default/xwing /usr/bin/curl http://cilium.io
+🔌 connect default/xwing /usr/bin/curl tcp 10.244.0.6:34965 -> 104.198.14.52:80
+📤 sendmsg default/xwing /usr/bin/curl tcp 10.244.0.6:34965 -> 104.198.14.52:80 bytes 73
+🧹 close   default/xwing /usr/bin/curl tcp 10.244.0.6:34965 -> 104.198.14.52:80
+💥 exit    default/xwing /usr/bin/curl http://cilium.io 0
 ```
 
 To disable the TracingPolicy run:

--- a/pkg/encoder/encoder.go
+++ b/pkg/encoder/encoder.go
@@ -209,27 +209,27 @@ func (p *CompactEncoder) eventToString(response *tetragon.GetEventsResponse) (st
 			}
 			return capTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, netns), caps), nil
 		case "tcp_connect":
-			event := p.colorer.blue.Sprintf("🔧 %-7s", "tcp_connect")
+			event := p.colorer.blue.Sprintf("🔌 %-7s", "connect")
 			sock := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil {
 				sa := kprobe.Args[0].GetSockArg()
-				sock = p.colorer.cyan.Sprintf("%s:%d -> %s:%d", sa.Saddr, sa.Sport, sa.Daddr, sa.Dport)
+				sock = p.colorer.cyan.Sprintf("tcp %s:%d -> %s:%d", sa.Saddr, sa.Sport, sa.Daddr, sa.Dport)
 			}
 			return capTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, sock), caps), nil
 		case "tcp_close":
-			event := p.colorer.blue.Sprintf("🔧 %-7s", "tcp_close")
+			event := p.colorer.blue.Sprintf("\U0001F9F9 %-7s", "close")
 			sock := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil {
 				sa := kprobe.Args[0].GetSockArg()
-				sock = p.colorer.cyan.Sprintf("%s:%d -> %s:%d", sa.Saddr, sa.Sport, sa.Daddr, sa.Dport)
+				sock = p.colorer.cyan.Sprintf("tcp %s:%d -> %s:%d", sa.Saddr, sa.Sport, sa.Daddr, sa.Dport)
 			}
 			return capTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, sock), caps), nil
 		case "tcp_sendmsg":
-			event := p.colorer.blue.Sprintf("🔧 %-7s", "tcp_sendmsg")
+			event := p.colorer.blue.Sprintf("📤 %-7s", "sendmsg")
 			args := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil {
 				sa := kprobe.Args[0].GetSockArg()
-				args = p.colorer.cyan.Sprintf("%s:%d -> %s:%d", sa.Saddr, sa.Sport, sa.Daddr, sa.Dport)
+				args = p.colorer.cyan.Sprintf("tcp %s:%d -> %s:%d", sa.Saddr, sa.Sport, sa.Daddr, sa.Dport)
 			}
 			bytes := int32(0)
 			if len(kprobe.Args) > 1 && kprobe.Args[1] != nil {


### PR DESCRIPTION
Rename tcp_connect/tcp_sendmsg/tcp_close to connect/sendmsg/close to
align them with other events, and change their emojis to make them look
slightly more interesting.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>