### PR TITLE
metrics: add a per-exec-id counter for missing parents

### DIFF
--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -44,6 +44,7 @@ func (e *Grpc) GetProcessExec(
 	parent, err := process.Get(parentId)
 	if err != nil {
 		metrics.ErrorCount.WithLabelValues(string(metrics.ExecMissingParent)).Inc()
+		metrics.ExecMissingParentErrors.WithLabelValues(parentId).Inc()
 		logger.GetLogger().WithField("processId", processId).WithField("parentId", parentId).Debug("Process missing parent")
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -123,6 +123,11 @@ var (
 		Help:        "The total of times we failed to fetch cached process info for a given event type.",
 		ConstLabels: nil,
 	}, []string{"event_type"})
+	ExecMissingParentErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        MetricNamePrefix + "exec_missing_parent_errors",
+		Help:        "The total of times a given parent exec id could not be found in an exec event.",
+		ConstLabels: nil,
+	}, []string{"parent_exec_id"})
 )
 
 // DNS metrics


### PR DESCRIPTION
This counter is useful to help debug cases where process exec events are missing a parent.
Using the parent exec ID in the metric, we can determine the corresponding pid and cross
check against Tetragon event logs. This can help establish patterns and determine an
underlying root cause.

As a practical example, this counter recently helped me diagnose the underlying cause of
missing parents in kind deployments.

Signed-off-by: William Findlay <will@isovalent.com>