### PR TITLE
selectors: fix missing bounds check on int conversion

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -265,14 +265,26 @@ func parseMatchValues(k *KernelSelectorState, values []string, ty uint32) error 
 			value, size := ArgSelectorValue(v)
 			WriteSelectorUint32(k, size)
 			WriteSelectorByteArray(k, value, size)
-		case argTypeU32, argTypeS32, argTypeInt, argTypeSizet:
-			i, err := strconv.ParseInt(v, 10, 64)
+		case argTypeS32, argTypeInt, argTypeSizet:
+			i, err := strconv.ParseInt(v, 10, 32)
+			if err != nil {
+				return fmt.Errorf("MatchArgs value %s invalid: %x", v, err)
+			}
+			WriteSelectorInt32(k, int32(i))
+		case argTypeU32:
+			i, err := strconv.ParseUint(v, 10, 32)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %x", v, err)
 			}
 			WriteSelectorUint32(k, uint32(i))
-		case argTypeU64, argTypeS64:
+		case argTypeS64:
 			i, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return fmt.Errorf("MatchArgs value %s invalid: %x", v, err)
+			}
+			WriteSelectorInt64(k, int64(i))
+		case argTypeU64:
+			i, err := strconv.ParseUint(v, 10, 64)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %x", v, err)
 			}

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -26,6 +26,11 @@ func WriteSelectorUint32(k *KernelSelectorState, v uint32) {
 	k.off += 4
 }
 
+func WriteSelectorInt64(k *KernelSelectorState, v int64) {
+	binary.LittleEndian.PutUint64(k.e[k.off:], uint64(v))
+	k.off += 4
+}
+
 func WriteSelectorUint64(k *KernelSelectorState, v uint64) {
 	binary.LittleEndian.PutUint64(k.e[k.off:], v)
 	k.off += 8


### PR DESCRIPTION
This PR fixes an issue revealed by the new codeql lints ci job.

We were parsing a 64-bit integer here and converting to a u32 without a bounds check. This
is obviously wrong, so drop the bit size on the ParseInt call down to 32 and make it
ParseUint. Additionally, split up signed and unsigned cases in parseMatchValues() so that
we can properly parse the signed/unsigned integer types.

Signed-off-by: William Findlay <will@isovalent.com>