### PR TITLE
Vagrantfile: install libcap-dev for Makefile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
       cd /home/vagrant/go/src/github.com/cilium/tetragon
       apt-get update
-      apt-get install -y build-essential clang conntrack libelf-dev net-tools
+      apt-get install -y build-essential clang conntrack libcap-dev libelf-dev net-tools
       snap install go --channel=1.16/stable --classic
       make tools-install LIBBPF_INSTALL_DIR=/usr/local/lib CLANG_INSTALL_DIR=/usr/bin
       ldconfig /usr/local/


### PR DESCRIPTION
Currently `make` in the VM instance started from the included `Vagrantfile` fails with:
```
make -C contrib/capabilities-tester
make[1]: Entering directory '/home/vagrant/go/src/github.com/cilium/tetragon/contrib/capabilities-tester'
gcc -Wall test_caps.c -o test_caps -static -lcap
test_caps.c:11:10: fatal error: sys/capability.h: No such file or directory
   11 | #include <sys/capability.h>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:4: test_caps] Error 1
make[1]: Leaving directory '/home/vagrant/go/src/github.com/cilium/tetragon/contrib/capabilities-tester'
make: *** [Makefile:208: contrib-progs] Error 2
```

The change should allow `make` to complete cleanly.