### PR TITLE
static-check: Run checkpatch.pl

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run checkpatch.pl
+        uses: docker://quay.io/cilium/cilium-checkpatch:2f0f4f512e795d5668ea4e7ef0ba85abc75eb225@sha256:f307bf0315954e8b8c31edc1864d949bf211b0c6522346359317d757b5a6cea0
       - name: Install Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
This is mainly to check commits are signed off, among other things.

Sample failure output: https://github.com/cilium/tetragon/runs/6462531785?check_suite_focus=true

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>
Co-authored-by: Joe Stringer <joe@cilium.io>