### PR TITLE
kprobe/process: silence verbose warnings + add metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -66,7 +66,7 @@ const (
 	MetricNamePrefix string = "isovalent_"
 )
 
-// TETRAGON debugging and core info metrics
+// Tetragon debugging and core info metrics
 var (
 	MsgOpsCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        MetricNamePrefix + "msg_op_total",
@@ -75,17 +75,17 @@ var (
 	}, []string{"msg_op"})
 	EventsProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        MetricNamePrefix + "events_total",
-		Help:        "The total number of TETRAGON events",
+		Help:        "The total number of Tetragon events",
 		ConstLabels: nil,
 	}, []string{"type", "namespace", "pod", "binary"})
 	FlagCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        MetricNamePrefix + "flags_total",
-		Help:        "The total number of TETRAGON flags. For internal use only.",
+		Help:        "The total number of Tetragon flags. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
 	ErrorCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        MetricNamePrefix + "errors_total",
-		Help:        "The total number of TETRAGON errors. For internal use only.",
+		Help:        "The total number of Tetragon errors. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
 	ExecveMapSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -100,22 +100,22 @@ var (
 	}, []string{"map", "total"})
 	EventCacheCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        MetricNamePrefix + "event_cache",
-		Help:        "The total number of TETRAGON event cache access/errors. For internal use only.",
+		Help:        "The total number of Tetragon event cache access/errors. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
 	RingBufPerfEventReceived = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        MetricNamePrefix + "ringbuf_perf_event_received",
-		Help:        "The total number of TETRAGON ringbuf perf events received.",
+		Help:        "The total number of Tetragon ringbuf perf events received.",
 		ConstLabels: nil,
 	}, nil)
 	RingBufPerfEventLost = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        MetricNamePrefix + "ringbuf_perf_event_lost",
-		Help:        "The total number of TETRAGON ringbuf perf events lost.",
+		Help:        "The total number of Tetragon ringbuf perf events lost.",
 		ConstLabels: nil,
 	}, nil)
 	RingBufPerfEventErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        MetricNamePrefix + "ringbuf_perf_event_errors",
-		Help:        "The total number of TETRAGON ringbuf perf event error count.",
+		Help:        "The total number of Tetragon ringbuf perf event error count.",
 		ConstLabels: nil,
 	}, nil)
 	ProcessInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -128,6 +128,11 @@ var (
 		Help:        "The total of times a given parent exec id could not be found in an exec event.",
 		ConstLabels: nil,
 	}, []string{"parent_exec_id"})
+	GenericKprobeMergeErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        MetricNamePrefix + "generic_kprobe_merge_errors",
+		Help:        "The total number of failed attempts to merge a kprobe and kretprobe event.",
+		ConstLabels: nil,
+	}, []string{"curr_fn", "curr_type", "prev_fn", "prev_type"})
 )
 
 // DNS metrics

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -128,6 +128,11 @@ var (
 		Help:        "The total of times a given parent exec id could not be found in an exec event.",
 		ConstLabels: nil,
 	}, []string{"parent_exec_id"})
+	SameExecIdErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        MetricNamePrefix + "exec_parent_child_same_id_errors",
+		Help:        "The total of times an error occurs due to a parent and child process have the same exec id.",
+		ConstLabels: nil,
+	}, []string{"exec_id"})
 	GenericKprobeMergeErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        MetricNamePrefix + "generic_kprobe_merge_errors",
 		Help:        "The total number of failed attempts to merge a kprobe and kretprobe event.",

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -85,7 +85,7 @@ func Test_handleProcessedEvent(t *testing.T) {
 		},
 	}}})
 
-	expected := strings.NewReader(`# HELP isovalent_events_total The total number of TETRAGON events
+	expected := strings.NewReader(`# HELP isovalent_events_total The total number of Tetragon events
 # TYPE isovalent_events_total counter
 isovalent_events_total{binary="",namespace="",pod="",type="PROCESS_KPROBE"} 1
 isovalent_events_total{binary="",namespace="",pod="",type="PROCESS_EXEC"} 1
@@ -116,7 +116,7 @@ func Test_handleOriginalEvent(t *testing.T) {
 			Flags: api.EventClone | api.EventExecve,
 		},
 	})
-	expected := strings.NewReader(`# HELP isovalent_flags_total The total number of TETRAGON flags. For internal use only.
+	expected := strings.NewReader(`# HELP isovalent_flags_total The total number of Tetragon flags. For internal use only.
 # TYPE isovalent_flags_total counter
 isovalent_flags_total{type="clone"} 1
 isovalent_flags_total{type="execve"} 1

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -241,9 +241,9 @@ func Add(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 	}
 	if parent.process.ExecId == proc.process.ExecId {
 		logger.GetLogger().WithFields(logrus.Fields{
-			"parent":  parent,
-			"current": proc,
-		}).Warn("parent and current process has the same exec ID")
+			"exec_id": parent.process.ExecId,
+		}).Debug("Parent and current process have the same exec ID")
+		metrics.SameExecIdErrors.WithLabelValues(parent.process.ExecId).Inc()
 		return proc
 	}
 	proc.process.ParentExecId = parent.process.ExecId

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/exec/procevents"
@@ -62,7 +63,7 @@ func execParse(reader *bytes.Reader) (api.MsgProcess, bool, error) {
 	exec := api.MsgExec{}
 
 	if err := binary.Read(reader, binary.LittleEndian, &exec); err != nil {
-		fmt.Printf("read error!\n")
+		logger.GetLogger().WithError(err).Debug("Failed to read exec event")
 		return proc, true, err
 	}
 


### PR DESCRIPTION
There were some very verbose warnings that were inundating the logs. Let's silence them behind a debug flag and add a metric to help with debugging.

Best reviewed by commit.