### PR TITLE
helm: make gRPC and metrics address/port configurable

### DIFF
--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -60,10 +60,14 @@ Helm chart for Tetragon
 | tetragon.extraArgs | object | `{}` |  |
 | tetragon.extraEnv | list | `[]` |  |
 | tetragon.extraVolumeMounts | list | `[]` |  |
+| tetragon.grpc.address | string | `"localhost"` | The address at which to expose gRPC. Set it to "" to listen on all available interfaces. |
+| tetragon.grpc.enabled | bool | `true` | Whether to enable exposing Tetragon gRPC. |
+| tetragon.grpc.port | int | `54321` | The port at which to expose gRPC. |
 | tetragon.image.override | string | `nil` |  |
 | tetragon.image.repository | string | `"quay.io/cilium/tetragon"` |  |
 | tetragon.image.tag | string | `"v0.8.0"` |  |
 | tetragon.processCacheSize | int | `65536` |  |
+| tetragon.prometheus.address | string | `""` | The address at which to expose metrics. Set it to "" to expose on all available interfaces. |
 | tetragon.prometheus.enabled | bool | `true` | Whether to enable exposing Tetragon metrics. |
 | tetragon.prometheus.port | int | `2112` | The port at which to expose metrics. |
 | tetragon.prometheus.serviceMonitor.enabled | bool | `false` | Whether to create a 'ServiceMonitor' resource targeting the 'tetragon' pods. |

--- a/install/kubernetes/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/templates/tetragon_configmap.yaml
@@ -32,7 +32,13 @@ data:
   cilium-bpf: /sys/fs/bpf/tc/globals/
 {{- end }}
 {{- if .Values.tetragon.prometheus.enabled }}
-  metrics-server: :{{ .Values.tetragon.prometheus.port }}
+  metrics-server: {{ .Values.tetragon.prometheus.address }}:{{ .Values.tetragon.prometheus.port }}
+{{- else }}
+  metrics-server: ""
+{{- end }}
+{{- if .Values.tetragon.grpc.enabled }}
+  server-address: {{ .Values.tetragon.grpc.address }}:{{ .Values.tetragon.grpc.port }}
+{{- else }}
 {{- end }}
 {{- if .Values.tetragon.tcpStatsSampleSegs }}
   tcp-stats-sample-segs: {{ .Values.tetragon.tcpStatsSampleSegs | quote }}

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -126,6 +126,8 @@ tetragon:
   prometheus:
     # -- Whether to enable exposing Tetragon metrics.
     enabled: true
+    # -- The address at which to expose metrics. Set it to "" to expose on all available interfaces.
+    address: ""
     # -- The port at which to expose metrics.
     port: 2112
     serviceMonitor:
@@ -133,6 +135,14 @@ tetragon:
       enabled: false
       # -- The set of labels to place on the 'ServiceMonitor' resource.
       labelsOverride: {}
+
+  grpc:
+    # -- Whether to enable exposing Tetragon gRPC.
+    enabled: true
+    # -- The address at which to expose gRPC. Set it to "" to listen on all available interfaces.
+    address: "localhost"
+    # -- The port at which to expose gRPC.
+    port: 54321
 
 tetragonOperator:
   # -- Enable the tetragon-operator component (required).


### PR DESCRIPTION
This patch makes the gRPC address and port configurable in helm and adds a similar option
to configure the metrics address. Fixes #40.

Signed-off-by: William Findlay <will@isovalent.com>