### PR TITLE
Remove -static flag

### DIFF
--- a/contrib/capabilities-tester/Makefile
+++ b/contrib/capabilities-tester/Makefile
@@ -1,4 +1,4 @@
 GCC ?= gcc
 
 test_caps: test_caps.c
-	$(GCC) -Wall $< -o $@ -static -lcap
+	$(GCC) -Wall $< -o $@ -lcap

--- a/contrib/namespace-tester/Makefile
+++ b/contrib/namespace-tester/Makefile
@@ -1,4 +1,4 @@
 GCC ?= gcc
 
 test_ns: test_ns.c
-	$(GCC) -Wall $< -o $@ -static
+	$(GCC) -Wall $< -o $@


### PR DESCRIPTION
`-static` breaks the builds on RHEL8.  With this change 7aac0cc49df35320a867e3e5da63d31925766015, `sudo make test` runs fine in the Vagrant instance. 

Cumulative with https://github.com/cilium/tetragon/pull/43, can rebase when merged.

References:
* https://cilium.slack.com/archives/C03EV7KJPJ9/p1652902163455029?thread_ts=1652887764.380829&cid=C03EV7KJPJ9 
* https://access.redhat.com/articles/rhel8-abi-compatibility
* https://github.com/cri-o/cri-o/issues/2993
* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/developing_c_and_cpp_applications_in_rhel_8/index#static-and-dynamic-linking_using-libraries-with-gcc