### PR TITLE
metrics: split metrics into separate packages

### DIFF
--- a/api/v1/tetragon/codegen/eventcache/eventcache.pb.go
+++ b/api/v1/tetragon/codegen/eventcache/eventcache.pb.go
@@ -9,6 +9,7 @@ import (
 	fmt "fmt"
 	tetragon "github.com/cilium/tetragon/api/v1/tetragon"
 	metrics "github.com/cilium/tetragon/pkg/metrics"
+	errormetrics "github.com/cilium/tetragon/pkg/metrics/errormetrics"
 	process "github.com/cilium/tetragon/pkg/process"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -25,7 +26,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 			e.Process = internal.GetProcessCopy()
 		} else {
 			metrics.ProcessInfoErrors.WithLabelValues("ProcessExec").Inc()
-			metrics.ErrorCount.WithLabelValues(string(metrics.EventCacheProcessInfoFailed)).Inc()
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
 			Event:    &tetragon.GetEventsResponse_ProcessExec{ProcessExec: e},
@@ -38,7 +39,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 			e.Process = internal.GetProcessCopy()
 		} else {
 			metrics.ProcessInfoErrors.WithLabelValues("ProcessExit").Inc()
-			metrics.ErrorCount.WithLabelValues(string(metrics.EventCacheProcessInfoFailed)).Inc()
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
 			Event:    &tetragon.GetEventsResponse_ProcessExit{ProcessExit: e},
@@ -51,7 +52,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 			e.Process = internal.GetProcessCopy()
 		} else {
 			metrics.ProcessInfoErrors.WithLabelValues("ProcessKprobe").Inc()
-			metrics.ErrorCount.WithLabelValues(string(metrics.EventCacheProcessInfoFailed)).Inc()
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
 			Event:    &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: e},
@@ -64,7 +65,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 			e.Process = internal.GetProcessCopy()
 		} else {
 			metrics.ProcessInfoErrors.WithLabelValues("ProcessTracepoint").Inc()
-			metrics.ErrorCount.WithLabelValues(string(metrics.EventCacheProcessInfoFailed)).Inc()
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
 			Event:    &tetragon.GetEventsResponse_ProcessTracepoint{ProcessTracepoint: e},
@@ -77,7 +78,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 			e.Process = internal.GetProcessCopy()
 		} else {
 			metrics.ProcessInfoErrors.WithLabelValues("ProcessDns").Inc()
-			metrics.ErrorCount.WithLabelValues(string(metrics.EventCacheProcessInfoFailed)).Inc()
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
 			Event:    &tetragon.GetEventsResponse_ProcessDns{ProcessDns: e},

--- a/api/v1/tetragon/codegen/eventcache/eventcache.pb.go
+++ b/api/v1/tetragon/codegen/eventcache/eventcache.pb.go
@@ -8,8 +8,8 @@ package eventcache
 import (
 	fmt "fmt"
 	tetragon "github.com/cilium/tetragon/api/v1/tetragon"
-	metrics "github.com/cilium/tetragon/pkg/metrics"
 	errormetrics "github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	eventcachemetrics "github.com/cilium/tetragon/pkg/metrics/eventcachemetrics"
 	process "github.com/cilium/tetragon/pkg/process"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -25,7 +25,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			metrics.ProcessInfoErrors.WithLabelValues("ProcessExec").Inc()
+			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessExec")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
@@ -38,7 +38,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			metrics.ProcessInfoErrors.WithLabelValues("ProcessExit").Inc()
+			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessExit")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
@@ -51,7 +51,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			metrics.ProcessInfoErrors.WithLabelValues("ProcessKprobe").Inc()
+			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessKprobe")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
@@ -64,7 +64,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			metrics.ProcessInfoErrors.WithLabelValues("ProcessTracepoint").Inc()
+			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessTracepoint")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
@@ -77,7 +77,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			metrics.ProcessInfoErrors.WithLabelValues("ProcessDns").Inc()
+			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessDns")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{

--- a/cmd/protoc-gen-go-tetragon/eventcache/eventcache.go
+++ b/cmd/protoc-gen-go-tetragon/eventcache/eventcache.go
@@ -29,7 +29,7 @@ func generateDoHandleEvents(g *protogen.GeneratedFile, f *protogen.File) error {
 
 	incErrorCount := common.TetragonIdent(g, "pkg/metrics/errormetrics", "ErrorTotalInc")
 	mInfoFailed := common.TetragonIdent(g, "pkg/metrics/errormetrics", "EventCacheProcessInfoFailed")
-	mProcessInfoErrors := common.TetragonIdent(g, "pkg/metrics", "ProcessInfoErrors")
+	incProcessInfoErrors := common.TetragonIdent(g, "pkg/metrics/eventcachemetrics", "ProcessInfoErrorTotalInc")
 
 	g.P(`func DoHandleEvent(event eventObj, internal *` + tetragonProcessInternal + `, labels []string, nodeName string, timestamp *` + timestamp + `) (*` + tetragonGER + `, error) {
         switch e := event.(type) {`)
@@ -42,7 +42,7 @@ func generateDoHandleEvents(g *protogen.GeneratedFile, f *protogen.File) error {
             if internal != nil {
                 e.Process = internal.GetProcessCopy()
             } else {
-                ` + mProcessInfoErrors + `.WithLabelValues("` + msg.GoIdent.GoName + `").Inc()
+                ` + incProcessInfoErrors + `("` + msg.GoIdent.GoName + `")
                 ` + incErrorCount + `(` + mInfoFailed + `)
             }
             return &` + doGetEventsResponse(g, msg.GoIdent.GoName) + `, nil`)

--- a/cmd/protoc-gen-go-tetragon/eventcache/eventcache.go
+++ b/cmd/protoc-gen-go-tetragon/eventcache/eventcache.go
@@ -27,8 +27,8 @@ func generateDoHandleEvents(g *protogen.GeneratedFile, f *protogen.File) error {
 	tetragonGER := common.TetragonApiIdent(g, "GetEventsResponse")
 	timestamp := common.GoIdent(g, "google.golang.org/protobuf/types/known/timestamppb", "Timestamp")
 
-	mErrorCount := common.TetragonIdent(g, "pkg/metrics", "ErrorCount")
-	mInfoFailed := common.TetragonIdent(g, "pkg/metrics", "EventCacheProcessInfoFailed")
+	incErrorCount := common.TetragonIdent(g, "pkg/metrics/errormetrics", "ErrorTotalInc")
+	mInfoFailed := common.TetragonIdent(g, "pkg/metrics/errormetrics", "EventCacheProcessInfoFailed")
 	mProcessInfoErrors := common.TetragonIdent(g, "pkg/metrics", "ProcessInfoErrors")
 
 	g.P(`func DoHandleEvent(event eventObj, internal *` + tetragonProcessInternal + `, labels []string, nodeName string, timestamp *` + timestamp + `) (*` + tetragonGER + `, error) {
@@ -43,7 +43,7 @@ func generateDoHandleEvents(g *protogen.GeneratedFile, f *protogen.File) error {
                 e.Process = internal.GetProcessCopy()
             } else {
                 ` + mProcessInfoErrors + `.WithLabelValues("` + msg.GoIdent.GoName + `").Inc()
-                ` + mErrorCount + `.WithLabelValues(string(` + mInfoFailed + `)).Inc()
+                ` + incErrorCount + `(` + mInfoFailed + `)
             }
             return &` + doGetEventsResponse(g, msg.GoIdent.GoName) + `, nil`)
 	}

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -10,8 +10,8 @@ import (
 	codegen "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventcache"
 	"github.com/cilium/tetragon/pkg/dns"
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/mapmetrics"
 	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/server"
@@ -95,7 +95,7 @@ func (ec *Cache) loop() {
 			 * event anyways.
 			 */
 			ec.handleNetEvents()
-			metrics.ExecveMapSize.WithLabelValues("netCache", "0").Set(float64(len(ec.cache)))
+			mapmetrics.MapSizeSet("netCache", 0, float64(len(ec.cache)))
 
 		case event := <-ec.objsChan:
 			errormetrics.EventCacheInc(errormetrics.EventCacheNetworkCount)

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/tetragon/pkg/dns"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
 	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/server"
@@ -68,7 +69,7 @@ func (ec *Cache) handleNetEvents() {
 					tmp = append(tmp, e)
 					continue
 				}
-				metrics.EventCacheCount.WithLabelValues(string(metrics.EventCacheEndpointRetryFailed)).Inc()
+				errormetrics.EventCacheInc(errormetrics.EventCacheEndpointRetryFailed)
 			}
 		}
 
@@ -97,7 +98,7 @@ func (ec *Cache) loop() {
 			metrics.ExecveMapSize.WithLabelValues("netCache", "0").Set(float64(len(ec.cache)))
 
 		case event := <-ec.objsChan:
-			metrics.EventCacheCount.WithLabelValues(string(metrics.EventCacheNetworkCount)).Inc()
+			errormetrics.EventCacheInc(errormetrics.EventCacheNetworkCount)
 			ec.cache = append(ec.cache, event)
 		}
 	}

--- a/pkg/execcache/execcache.go
+++ b/pkg/execcache/execcache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/dns"
 	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
 	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/server"
@@ -60,7 +61,7 @@ func (ec *Cache) handleExecEvents() {
 				tmp = append(tmp, e)
 				continue
 			}
-			metrics.EventCacheCount.WithLabelValues(string(metrics.EventCachePodInfoRetryFailed)).Inc()
+			errormetrics.EventCacheInc(errormetrics.EventCachePodInfoRetryFailed)
 		}
 
 		if e.internal != nil {
@@ -95,7 +96,7 @@ func (ec *Cache) loop() {
 			metrics.ExecveMapSize.WithLabelValues("cache", "0").Set(float64(len(ec.cache)))
 
 		case event := <-ec.objsChan:
-			metrics.EventCacheCount.WithLabelValues(string(metrics.EventCacheProcessCount)).Inc()
+			errormetrics.EventCacheInc(errormetrics.EventCacheProcessCount)
 			ec.cache = append(ec.cache, event)
 		}
 	}

--- a/pkg/execcache/execcache.go
+++ b/pkg/execcache/execcache.go
@@ -9,8 +9,8 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/dns"
-	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/mapmetrics"
 	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/server"
@@ -93,7 +93,7 @@ func (ec *Cache) loop() {
 			 * event anyways.
 			 */
 			ec.handleExecEvents()
-			metrics.ExecveMapSize.WithLabelValues("cache", "0").Set(float64(len(ec.cache)))
+			mapmetrics.MapSizeSet("cache", 0, float64(len(ec.cache)))
 
 		case event := <-ec.objsChan:
 			errormetrics.EventCacheInc(errormetrics.EventCacheProcessCount)

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -12,8 +12,8 @@ import (
 	"github.com/cilium/tetragon/pkg/execcache"
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/processexecmetrics"
 	"github.com/cilium/tetragon/pkg/process"
 	readerexec "github.com/cilium/tetragon/pkg/reader/exec"
 	"github.com/cilium/tetragon/pkg/reader/node"
@@ -45,7 +45,7 @@ func (e *Grpc) GetProcessExec(
 	parent, err := process.Get(parentId)
 	if err != nil {
 		errormetrics.ErrorTotalInc(errormetrics.ExecMissingParent)
-		metrics.ExecMissingParentErrors.WithLabelValues(parentId).Inc()
+		processexecmetrics.MissingParentInc(parentId)
 		logger.GetLogger().WithField("processId", processId).WithField("parentId", parentId).Debug("Process missing parent")
 	}
 

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
 	"github.com/cilium/tetragon/pkg/process"
 	readerexec "github.com/cilium/tetragon/pkg/reader/exec"
 	"github.com/cilium/tetragon/pkg/reader/node"
@@ -43,7 +44,7 @@ func (e *Grpc) GetProcessExec(
 
 	parent, err := process.Get(parentId)
 	if err != nil {
-		metrics.ErrorCount.WithLabelValues(string(metrics.ExecMissingParent)).Inc()
+		errormetrics.ErrorTotalInc(errormetrics.ExecMissingParent)
 		metrics.ExecMissingParentErrors.WithLabelValues(parentId).Inc()
 		logger.GetLogger().WithField("processId", processId).WithField("parentId", parentId).Debug("Process missing parent")
 	}

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/server"
@@ -116,7 +117,7 @@ func (pm *ProcessManager) Notify(event interface{}) error {
 
 	default:
 		logger.GetLogger().WithField("event", event).Warnf("unhandled event of type %T", msg)
-		metrics.ErrorCount.WithLabelValues(string(metrics.UnhandledEvent)).Inc()
+		errormetrics.ErrorTotalInc(errormetrics.UnhandledEvent)
 		return nil
 	}
 	if processedEvent != nil {

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -20,8 +20,8 @@ import (
 	"github.com/cilium/tetragon/pkg/grpc/test"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/server"
@@ -151,5 +151,5 @@ func (pm *ProcessManager) NotifyListener(original interface{}, processed *tetrag
 	for l := range pm.listeners {
 		l.Notify(processed)
 	}
-	metrics.ProcessEvent(original, processed)
+	eventmetrics.ProcessEvent(original, processed)
 }

--- a/pkg/metrics/consts/consts.go
+++ b/pkg/metrics/consts/consts.go
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package consts
+
+var MetricNamePrefix = "tetragon_"

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package errormetrics
+
+import (
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type ErrorType string
+
+var (
+	// Parent process was not found in the pid map for a process without the clone flag.
+	NoParentNoClone ErrorType = "no_parent_no_clone"
+	// Process not found on get() call.
+	ProcessCacheMissOnGet ErrorType = "process_cache_miss_on_get"
+	// Process evicted from the cache.
+	ProcessCacheEvicted ErrorType = "process_cache_evicted"
+	// Process not found on remove() call.
+	ProcessCacheMissOnRemove ErrorType = "process_cache_miss_on_remove"
+	// Missing event handler.
+	UnhandledEvent ErrorType = "unhandled_event"
+	// Event cache add network entry to cache.
+	EventCacheNetworkCount ErrorType = "event_cache_network_count"
+	// Event cache add process entry to cache.
+	EventCacheProcessCount ErrorType = "event_cache_process_count"
+	// Event cache podInfo retries failed.
+	EventCachePodInfoRetryFailed ErrorType = "event_cache_podinfo_retry_failed"
+	// Event cache endpoint retries failed.
+	EventCacheEndpointRetryFailed ErrorType = "event_cache_endpoint_retry_failed"
+	// Event cache failed to set process information for an event.
+	EventCacheProcessInfoFailed ErrorType = "event_cache_process_info_failed"
+	// There was an invalid entry in the pid map.
+	PidMapInvalidEntry ErrorType = "pid_map_invalid_entry"
+	// An entry was evicted from the pid map because the map was full.
+	PidMapEvicted ErrorType = "pid_map_evicted"
+	// PID not found in the pid map on remove() call.
+	PidMapMissOnRemove ErrorType = "pid_map_miss_on_remove"
+	// An exec event without parent info.
+	ExecMissingParent ErrorType = "exec_missing_parent"
+)
+
+// Get a new handle on an errorsTotal metric for an ErrorType
+func ErrorTotal(t ErrorType) prometheus.Counter {
+	return errorsTotal.WithLabelValues(string(t))
+}
+
+// Increment an errorsTotal for an ErrorType
+func ErrorTotalInc(t ErrorType) {
+	ErrorTotal(t).Inc()
+}
+
+// Get a new handle on an eventCacheCount metric for an ErrorType
+func EventCache(t ErrorType) prometheus.Counter {
+	return eventCacheCount.WithLabelValues(string(t))
+}
+
+// Increment an eventCacheCount for an ErrorType
+func EventCacheInc(t ErrorType) {
+	ErrorTotal(t).Inc()
+}
+
+var (
+	errorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "errors_total",
+		Help:        "The total number of Tetragon errors. For internal use only.",
+		ConstLabels: nil,
+	}, []string{"type"})
+	eventCacheCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "event_cache",
+		Help:        "The total number of Tetragon event cache access/errors. For internal use only.",
+		ConstLabels: nil,
+	}, []string{"type"})
+)

--- a/pkg/metrics/eventcachemetrics/eventcachemetrics.go
+++ b/pkg/metrics/eventcachemetrics/eventcachemetrics.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package eventcachemetrics
+
+import (
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	processInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "process_info_errors",
+		Help:        "The total of times we failed to fetch cached process info for a given event type.",
+		ConstLabels: nil,
+	}, []string{"event_type"})
+)
+
+// Get a new handle on an processInfoErrors metric for an eventType
+func ProcessInfoErrorTotal(eventType string) prometheus.Counter {
+	return processInfoErrors.WithLabelValues(eventType)
+}
+
+// Increment an errorsTotal for an eventType
+func ProcessInfoErrorTotalInc(eventType string) {
+	ProcessInfoErrorTotal(eventType).Inc()
+}

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package eventmetrics
+
+import (
+	"strings"
+
+	v1 "github.com/cilium/hubble/pkg/api/v1"
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/api/v1/tetragon/codegen/helpers"
+	"github.com/cilium/tetragon/pkg/api/processapi"
+	"github.com/cilium/tetragon/pkg/filters"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	readerdns "github.com/cilium/tetragon/pkg/reader/dns"
+	"github.com/cilium/tetragon/pkg/reader/exec"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	eventsProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "events_total",
+		Help:        "The total number of Tetragon events",
+		ConstLabels: nil,
+	}, []string{"type", "namespace", "pod", "binary"})
+	flagCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "flags_total",
+		Help:        "The total number of Tetragon flags. For internal use only.",
+		ConstLabels: nil,
+	}, []string{"type"})
+	dnsRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: consts.MetricNamePrefix + "dns_total",
+		Help: "Dns request/response statistics",
+	}, []string{"namespace", "pod", "binary", "names", "rcodes", "response"})
+)
+
+func getProcessInfo(process *tetragon.Process) (binary, pod, namespace string) {
+	if process != nil {
+		binary = process.Binary
+		if process.Pod != nil {
+			namespace = process.Pod.Namespace
+			pod = process.Pod.Name
+		}
+	}
+	return binary, pod, namespace
+}
+
+func handleOriginalEvent(originalEvent interface{}) {
+	var flags uint32
+	switch msg := originalEvent.(type) {
+	case *processapi.MsgExecveEventUnix:
+		flags = msg.Process.Flags
+	}
+	for _, flag := range exec.DecodeCommonFlags(flags) {
+		flagCount.WithLabelValues(flag).Inc()
+	}
+}
+
+func postDnsMetric(ev *tetragon.GetEventsResponse, res *tetragon.ProcessDns) {
+	var rr string
+
+	binary, pod, ns := getProcessInfo(filters.GetProcess(&v1.Event{Event: ev}))
+
+	dns := res.Dns
+	names := strings.Join(dns.GetNames(), ",")
+	codes := readerdns.GetRCodeString(uint16(dns.GetRcode()))
+
+	if dns.Response {
+		rr = "Response"
+	} else {
+		rr = "Request"
+	}
+
+	dnsRequestTotal.WithLabelValues(ns, pod, binary, names, codes, rr).Inc()
+}
+
+func handleDnsEvent(processedEvent interface{}) {
+	switch ev := processedEvent.(type) {
+	case *tetragon.GetEventsResponse:
+		switch res := ev.Event.(type) {
+		case *tetragon.GetEventsResponse_ProcessDns:
+			postDnsMetric(ev, res.ProcessDns)
+		}
+	}
+}
+
+func handleProcessedEvent(processedEvent interface{}) {
+	var eventType, namespace, pod, binary string
+	switch ev := processedEvent.(type) {
+	case *tetragon.GetEventsResponse:
+		binary, pod, namespace = getProcessInfo(filters.GetProcess(&v1.Event{Event: ev}))
+		var err error
+		eventType, err = helpers.EventTypeString(ev.Event)
+		if err != nil {
+			logger.GetLogger().WithField("event", processedEvent).WithError(err).Warn("metrics: handleProcessedEvent: unhandled event")
+			eventType = "unhandled"
+		}
+	default:
+		eventType = "unknown"
+	}
+	eventsProcessed.WithLabelValues(eventType, namespace, pod, binary).Inc()
+}
+
+func ProcessEvent(originalEvent interface{}, processedEvent interface{}) {
+	handleOriginalEvent(originalEvent)
+	handleProcessedEvent(processedEvent)
+	handleDnsEvent(processedEvent)
+}

--- a/pkg/metrics/kprobemetrics/kprobemetrics.go
+++ b/pkg/metrics/kprobemetrics/kprobemetrics.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package kprobemetrics
+
+import (
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	mergeErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "generic_kprobe_merge_errors",
+		Help:        "The total number of failed attempts to merge a kprobe and kretprobe event.",
+		ConstLabels: nil,
+	}, []string{"curr_fn", "curr_type", "prev_fn", "prev_type"})
+)
+
+// Get a new handle on the mergeErrors metric for a current and previous function
+// name and probe type
+func MergeErrors(currFn, currType, prevFn, prevType string) prometheus.Counter {
+	return mergeErrors.WithLabelValues(currFn, currType, prevFn, prevType)
+}
+
+// Increment the mergeErrors metric for a current and previous function
+// name and probe type
+func MergeErrorsInc(currFn, currType, prevFn, prevType string) {
+	MergeErrors(currFn, currType, prevFn, prevType).Inc()
+}

--- a/pkg/metrics/mapmetrics/mapmetrics.go
+++ b/pkg/metrics/mapmetrics/mapmetrics.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package mapmetrics
+
+import (
+	"fmt"
+
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	mapSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        consts.MetricNamePrefix + "map_in_use_gauge",
+		Help:        "The total number of in-use entries per map.",
+		ConstLabels: nil,
+	}, []string{"map", "total"})
+)
+
+// Get a new handle on a mapSize metric for a mapName and totalCapacity
+func MapSize(mapName string, totalCapacity int) prometheus.Gauge {
+	return mapSize.WithLabelValues(mapName, fmt.Sprint(totalCapacity))
+}
+
+// Increment a mapSize metric for a mapName and totalCapacity
+func MapSizeInc(mapName string, totalCapacity int) {
+	MapSize(mapName, totalCapacity).Inc()
+}
+
+// Set a mapSize metric to size for a mapName and totalCapacity
+func MapSizeSet(mapName string, totalCapacity int, size float64) {
+	MapSize(mapName, totalCapacity).Set(size)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,26 +15,6 @@ import (
 
 // Tetragon debugging and core info metrics
 var (
-	LruMapSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "lru_in_use_gauge",
-		Help:        "The total number of LRU in-use entries.",
-		ConstLabels: nil,
-	}, []string{"map", "total"})
-	RingBufPerfEventReceived = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_received",
-		Help:        "The total number of Tetragon ringbuf perf events received.",
-		ConstLabels: nil,
-	}, nil)
-	RingBufPerfEventLost = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_lost",
-		Help:        "The total number of Tetragon ringbuf perf events lost.",
-		ConstLabels: nil,
-	}, nil)
-	RingBufPerfEventErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_errors",
-		Help:        "The total number of Tetragon ringbuf perf event error count.",
-		ConstLabels: nil,
-	}, nil)
 	ExecMissingParentErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "exec_missing_parent_errors",
 		Help:        "The total of times a given parent exec id could not be found in an exec event.",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -5,17 +5,9 @@ package metrics
 
 import (
 	"net/http"
-	"strings"
 
-	v1 "github.com/cilium/hubble/pkg/api/v1"
-	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/api/v1/tetragon/codegen/helpers"
-	"github.com/cilium/tetragon/pkg/api/processapi"
-	"github.com/cilium/tetragon/pkg/filters"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
-	readerdns "github.com/cilium/tetragon/pkg/reader/dns"
-	"github.com/cilium/tetragon/pkg/reader/exec"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -23,16 +15,6 @@ import (
 
 // Tetragon debugging and core info metrics
 var (
-	EventsProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "events_total",
-		Help:        "The total number of Tetragon events",
-		ConstLabels: nil,
-	}, []string{"type", "namespace", "pod", "binary"})
-	FlagCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "flags_total",
-		Help:        "The total number of Tetragon flags. For internal use only.",
-		ConstLabels: nil,
-	}, []string{"type"})
 	ExecveMapSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        consts.MetricNamePrefix + "map_in_use_gauge",
 		Help:        "The total number of in-use entries per map.",
@@ -79,87 +61,6 @@ var (
 		ConstLabels: nil,
 	}, []string{"curr_fn", "curr_type", "prev_fn", "prev_type"})
 )
-
-// DNS metrics
-var (
-	DnsRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: consts.MetricNamePrefix + "dns_total",
-		Help: "Dns request/response statistics",
-	}, []string{"namespace", "pod", "binary", "names", "rcodes", "response"})
-)
-
-func getProcessInfo(process *tetragon.Process) (binary, pod, namespace string) {
-	if process != nil {
-		binary = process.Binary
-		if process.Pod != nil {
-			namespace = process.Pod.Namespace
-			pod = process.Pod.Name
-		}
-	}
-	return binary, pod, namespace
-}
-
-func handleOriginalEvent(originalEvent interface{}) {
-	var flags uint32
-	switch msg := originalEvent.(type) {
-	case *processapi.MsgExecveEventUnix:
-		flags = msg.Process.Flags
-	}
-	for _, flag := range exec.DecodeCommonFlags(flags) {
-		FlagCount.WithLabelValues(flag).Inc()
-	}
-}
-
-func postDnsMetric(ev *tetragon.GetEventsResponse, res *tetragon.ProcessDns) {
-	var rr string
-
-	binary, pod, ns := getProcessInfo(filters.GetProcess(&v1.Event{Event: ev}))
-
-	dns := res.Dns
-	names := strings.Join(dns.GetNames(), ",")
-	codes := readerdns.GetRCodeString(uint16(dns.GetRcode()))
-
-	if dns.Response {
-		rr = "Response"
-	} else {
-		rr = "Request"
-	}
-
-	DnsRequestTotal.WithLabelValues(ns, pod, binary, names, codes, rr).Inc()
-}
-
-func handleDnsEvent(processedEvent interface{}) {
-	switch ev := processedEvent.(type) {
-	case *tetragon.GetEventsResponse:
-		switch res := ev.Event.(type) {
-		case *tetragon.GetEventsResponse_ProcessDns:
-			postDnsMetric(ev, res.ProcessDns)
-		}
-	}
-}
-
-func handleProcessedEvent(processedEvent interface{}) {
-	var eventType, namespace, pod, binary string
-	switch ev := processedEvent.(type) {
-	case *tetragon.GetEventsResponse:
-		binary, pod, namespace = getProcessInfo(filters.GetProcess(&v1.Event{Event: ev}))
-		var err error
-		eventType, err = helpers.EventTypeString(ev.Event)
-		if err != nil {
-			logger.GetLogger().WithField("event", processedEvent).WithError(err).Warn("metrics: handleProcessedEvent: unhandled event")
-			eventType = "unhandled"
-		}
-	default:
-		eventType = "unknown"
-	}
-	EventsProcessed.WithLabelValues(eventType, namespace, pod, binary).Inc()
-}
-
-func ProcessEvent(originalEvent interface{}, processedEvent interface{}) {
-	handleOriginalEvent(originalEvent)
-	handleProcessedEvent(processedEvent)
-	handleDnsEvent(processedEvent)
-}
 
 func EnableMetrics(address string) {
 	logger.GetLogger().WithField("addr", address).Info("Starting metrics server")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -40,11 +40,6 @@ var (
 		Help:        "The total number of Tetragon ringbuf perf event error count.",
 		ConstLabels: nil,
 	}, nil)
-	ProcessInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "process_info_errors",
-		Help:        "The total of times we failed to fetch cached process info for a given event type.",
-		ConstLabels: nil,
-	}, []string{"event_type"})
 	ExecMissingParentErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "exec_missing_parent_errors",
 		Help:        "The total of times a given parent exec id could not be found in an exec event.",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -7,19 +7,7 @@ import (
 	"net/http"
 
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/metrics/consts"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-)
-
-// Tetragon debugging and core info metrics
-var (
-	GenericKprobeMergeErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "generic_kprobe_merge_errors",
-		Help:        "The total number of failed attempts to merge a kprobe and kretprobe event.",
-		ConstLabels: nil,
-	}, []string{"curr_fn", "curr_type", "prev_fn", "prev_type"})
 )
 
 func EnableMetrics(address string) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,11 +23,6 @@ import (
 
 // Tetragon debugging and core info metrics
 var (
-	MsgOpsCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "msg_op_total",
-		Help:        "The total number of times we encounter a given message opcode. For internal use only.",
-		ConstLabels: nil,
-	}, []string{"msg_op"})
 	EventsProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "events_total",
 		Help:        "The total number of Tetragon events",
@@ -48,11 +43,6 @@ var (
 		Help:        "The total number of LRU in-use entries.",
 		ConstLabels: nil,
 	}, []string{"map", "total"})
-	EventCacheCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "event_cache",
-		Help:        "The total number of Tetragon event cache access/errors. For internal use only.",
-		ConstLabels: nil,
-	}, []string{"type"})
 	RingBufPerfEventReceived = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_received",
 		Help:        "The total number of Tetragon ringbuf perf events received.",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,11 +15,6 @@ import (
 
 // Tetragon debugging and core info metrics
 var (
-	ExecveMapSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "map_in_use_gauge",
-		Help:        "The total number of in-use entries per map.",
-		ConstLabels: nil,
-	}, []string{"map", "total"})
 	LruMapSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        consts.MetricNamePrefix + "lru_in_use_gauge",
 		Help:        "The total number of LRU in-use entries.",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,16 +15,6 @@ import (
 
 // Tetragon debugging and core info metrics
 var (
-	ExecMissingParentErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "exec_missing_parent_errors",
-		Help:        "The total of times a given parent exec id could not be found in an exec event.",
-		ConstLabels: nil,
-	}, []string{"parent_exec_id"})
-	SameExecIdErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "exec_parent_child_same_id_errors",
-		Help:        "The total of times an error occurs due to a parent and child process have the same exec id.",
-		ConstLabels: nil,
-	}, []string{"exec_id"})
 	GenericKprobeMergeErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        consts.MetricNamePrefix + "generic_kprobe_merge_errors",
 		Help:        "The total number of failed attempts to merge a kprobe and kretprobe event.",

--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package opcodemetrics
+
+import (
+	"github.com/cilium/tetragon/pkg/api/ops"
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	msgOpsCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "msg_op_total",
+		Help:        "The total number of times we encounter a given message opcode. For internal use only.",
+		ConstLabels: nil,
+	}, []string{"msg_op"})
+)
+
+// Get a new handle on a msgOpsCount metric for an OpCode
+func OpTotal(op ops.OpCode) prometheus.Counter {
+	return msgOpsCount.WithLabelValues(op.String())
+}
+
+// Increment an msgOpsCount for an OpCode
+func OpTotalInc(op ops.OpCode) {
+	OpTotal(op).Inc()
+}

--- a/pkg/metrics/processexecmetrics/processexecmetrics.go
+++ b/pkg/metrics/processexecmetrics/processexecmetrics.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package processexecmetrics
+
+import (
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	missingParentErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "exec_missing_parent_errors",
+		Help:        "The total of times a given parent exec id could not be found in an exec event.",
+		ConstLabels: nil,
+	}, []string{"parent_exec_id"})
+	sameExecIdErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "exec_parent_child_same_id_errors",
+		Help:        "The total of times an error occurs due to a parent and child process have the same exec id.",
+		ConstLabels: nil,
+	}, []string{"exec_id"})
+)
+
+// Get a new handle on the missingParentErrors metric for an execId
+func MissingParent(execId string) prometheus.Counter {
+	return missingParentErrors.WithLabelValues(execId)
+}
+
+// Increment the missingParentErrors metric for an execId
+func MissingParentInc(execId string) {
+	MissingParent(execId).Inc()
+}
+
+// Get a new handle on the sameExecIdErrors metric for an execId
+func SameExecId(execId string) prometheus.Counter {
+	return sameExecIdErrors.WithLabelValues(execId)
+}
+
+// Increment the sameExecIdErrors metric for an execId
+func SameExecIdInc(execId string) {
+	SameExecId(execId).Inc()
+}

--- a/pkg/metrics/ringbufmetrics/ringbufmetrics.go
+++ b/pkg/metrics/ringbufmetrics/ringbufmetrics.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package ringbufmetrics
+
+import (
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	ringbufPerfEventReceived = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_received",
+		Help:        "The total number of Tetragon ringbuf perf events received.",
+		ConstLabels: nil,
+	}, nil)
+	ringbufPerfEventLost = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_lost",
+		Help:        "The total number of Tetragon ringbuf perf events lost.",
+		ConstLabels: nil,
+	}, nil)
+	ringbufPerfEventErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_errors",
+		Help:        "The total number of Tetragon ringbuf perf event error count.",
+		ConstLabels: nil,
+	}, nil)
+)
+
+// Get a new handle on the metric for received events
+func Received() prometheus.Gauge {
+	return ringbufPerfEventReceived.WithLabelValues()
+}
+
+// Get a new handle on the metric for received events
+func ReceivedSet(val float64) {
+	Received().Set(val)
+}
+
+// Get a new handle on the metric for lost events
+func Lost() prometheus.Gauge {
+	return ringbufPerfEventLost.WithLabelValues()
+}
+
+// Get a new handle on the metric for lost events
+func LostSet(val float64) {
+	Lost().Set(val)
+}
+
+// Get a new handle on the metric for ringbuf errors
+func Errors() prometheus.Gauge {
+	return ringbufPerfEventErrors.WithLabelValues()
+}
+
+// Get a new handle on the metric for ringbuf errors
+func ErrorsSet(val float64) {
+	Errors().Set(val)
+}

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
 	"github.com/cilium/tetragon/pkg/sensors"
 
 	"github.com/sirupsen/logrus"
@@ -93,7 +94,7 @@ func (k *Observer) receiveEvent(data []byte, cpu int) {
 	r := bytes.NewReader(data)
 
 	// Increment the counter for the msg opcode
-	metrics.MsgOpsCount.WithLabelValues(ops.OpCode(op).String()).Add(1)
+	opcodemetrics.OpTotalInc(ops.OpCode(op))
 
 	// These ops handlers are registered by RegisterEventHandlerAtInit().
 	if h, ok := eventHandler[op]; ok {

--- a/pkg/observer/observer_stats.go
+++ b/pkg/observer/observer_stats.go
@@ -7,12 +7,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"time"
 	"unsafe"
 
 	"github.com/cilium/tetragon/pkg/bpf"
-	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/mapmetrics"
 	"github.com/cilium/tetragon/pkg/sensors"
 )
 
@@ -76,7 +75,7 @@ func (k *Observer) startUpdateMapMetrics() {
 			for cpu := int(0); cpu < runtime.NumCPU(); cpu++ {
 				sum += v.Value[cpu]
 			}
-			metrics.ExecveMapSize.WithLabelValues(m.Name, strconv.Itoa(int(mapLink.MapInfo.MaxEntries))).Set(float64(sum))
+			mapmetrics.MapSizeSet(m.Name, int(mapLink.MapInfo.MaxEntries), float64(sum))
 			mapLink.Close()
 			mapLinkStats.Close()
 		}

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -5,14 +5,13 @@ package process
 
 import (
 	"fmt"
-	"strconv"
 	"sync/atomic"
 	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/mapmetrics"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/sirupsen/logrus"
 )
@@ -147,8 +146,8 @@ func NewCache(
 		pidMap: pidMap,
 	}
 	update := func() {
-		metrics.ExecveMapSize.WithLabelValues("processLru", strconv.Itoa(processCacheSize)).Set(float64(pm.cache.Len()))
-		metrics.ExecveMapSize.WithLabelValues("pidMap", strconv.Itoa(processCacheSize)).Set(float64(pm.pidMap.Len()))
+		mapmetrics.MapSizeSet("processLru", processCacheSize, float64(pm.cache.Len()))
+		mapmetrics.MapSizeSet("pidMap", processCacheSize, float64(pm.pidMap.Len()))
 	}
 	ticker := time.NewTicker(60 * time.Second)
 	go func() {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cilium/tetragon/pkg/cilium"
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/processexecmetrics"
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	"github.com/cilium/tetragon/pkg/reader/exec"
 	"github.com/cilium/tetragon/pkg/reader/namespace"
@@ -255,7 +255,7 @@ func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 		logger.GetLogger().WithFields(logrus.Fields{
 			"exec_id": parent.process.ExecId,
 		}).Debug("Parent and current process have the same exec ID")
-		metrics.SameExecIdErrors.WithLabelValues(parent.process.ExecId).Inc()
+		processexecmetrics.SameExecIdInc(parent.process.ExecId)
 		return proc
 	}
 	proc.process.ParentExecId = parent.process.ExecId

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	"github.com/cilium/tetragon/pkg/reader/exec"
 	"github.com/cilium/tetragon/pkg/reader/namespace"
@@ -243,7 +244,7 @@ func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 	// and use that as the parent.
 	parent, err := procCache.get(parentExecID)
 	if err != nil {
-		metrics.ErrorCount.WithLabelValues(string(metrics.NoParentNoClone)).Inc()
+		errormetrics.ErrorTotalInc(errormetrics.NoParentNoClone)
 		logger.GetLogger().WithFields(logrus.Fields{
 			"parent exec id": parentExecID,
 			"process":        proc,

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/kprobemetrics"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/reader/network"
@@ -930,7 +930,7 @@ func reportMergeError(curr pendingEvent, prev pendingEvent) {
 		prevType = "exit"
 	}
 
-	metrics.GenericKprobeMergeErrors.WithLabelValues(currFn, currType, prevFn, prevType).Inc()
+	kprobemetrics.MergeErrorsInc(currFn, currType, prevFn, prevType)
 	logger.GetLogger().WithFields(logrus.Fields{
 		"currFn":   currFn,
 		"currType": currType,


### PR DESCRIPTION
This PR splits the metrics into separate packages to make them easier to work with and reason about. It also adds some convenience helpers to avoid developer error when setting metric labels.