### PR TITLE
tetragon: Add event config map

### DIFF
--- a/bpf/include/vmlinux.h
+++ b/bpf/include/vmlinux.h
@@ -3,37 +3,8 @@
 
 /* User configurable BTF */
 enum generic_func_args_enum {
-	func_id = 0x1,
-	/* arg{0..4}: types of arguments */
-	arg0    = 0x2,
-	arg1    = 0x3,
-	arg2    = 0x4,
-	arg3    = 0x5,
-	arg4    = 0x6,
-	syscall = 0x7,
-	/* arg{0..4}m: metadata of arguments */
-	arg0m   = 0x8,
-	arg1m   = 0x9,
-	arg2m   = 0x10,
-	arg3m   = 0x11,
-	arg4m   = 0x12,
-	/* return arguments */
-	argreturn = 0x31,
-	/* use return argument for buffer copy */
-	argreturncopy = 0x32,
-	/* actions enabled */
-	sigkill = 0x40,
 	/* tcp sock stat sample info */
 	send_check_pkt_sample = 0x50,
-	/*
-	 * Tracepoints are using the same enum as kprobes
-	 */
-	/* offset of argument fields from ctx pointer */
-	t_arg0_ctx_off = 0x100,
-	t_arg1_ctx_off = 0x101,
-	t_arg2_ctx_off = 0x102,
-	t_arg3_ctx_off = 0x103,
-	t_arg4_ctx_off = 0x104,
 };
 
 /* Kernel BTF */

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -175,35 +175,35 @@ __attribute__((section(("kprobe/6")), used)) int
 generic_kprobe_filter_arg1(void *ctx)
 {
 	return filter_read_arg(ctx, 0, &process_call_heap, &filter_map,
-			       &kprobe_calls, &override_tasks);
+			       &kprobe_calls, &override_tasks, &config_map);
 }
 
 __attribute__((section(("kprobe/7")), used)) int
 generic_kprobe_filter_arg2(void *ctx)
 {
 	return filter_read_arg(ctx, 1, &process_call_heap, &filter_map,
-			       &kprobe_calls, &override_tasks);
+			       &kprobe_calls, &override_tasks, &config_map);
 }
 
 __attribute__((section(("kprobe/8")), used)) int
 generic_kprobe_filter_arg3(void *ctx)
 {
 	return filter_read_arg(ctx, 2, &process_call_heap, &filter_map,
-			       &kprobe_calls, &override_tasks);
+			       &kprobe_calls, &override_tasks, &config_map);
 }
 
 __attribute__((section(("kprobe/9")), used)) int
 generic_kprobe_filter_arg4(void *ctx)
 {
 	return filter_read_arg(ctx, 3, &process_call_heap, &filter_map,
-			       &kprobe_calls, &override_tasks);
+			       &kprobe_calls, &override_tasks, &config_map);
 }
 
 __attribute__((section(("kprobe/10")), used)) int
 generic_kprobe_filter_arg5(void *ctx)
 {
 	return filter_read_arg(ctx, 4, &process_call_heap, &filter_map,
-			       &kprobe_calls, &override_tasks);
+			       &kprobe_calls, &override_tasks, &config_map);
 }
 
 __attribute__((section(("kprobe/override")), used)) int

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -126,28 +126,28 @@ __attribute__((section(("kprobe/1")), used)) int
 generic_kprobe_process_event1(void *ctx)
 {
 	return generic_process_event1(ctx, &process_call_heap, &filter_map,
-				      &kprobe_calls);
+				      &kprobe_calls, &config_map);
 }
 
 __attribute__((section(("kprobe/2")), used)) int
 generic_kprobe_process_event2(void *ctx)
 {
 	return generic_process_event2(ctx, &process_call_heap, &filter_map,
-				      &kprobe_calls);
+				      &kprobe_calls, &config_map);
 }
 
 __attribute__((section(("kprobe/3")), used)) int
 generic_kprobe_process_event3(void *ctx)
 {
 	return generic_process_event3(ctx, &process_call_heap, &filter_map,
-				      &kprobe_calls);
+				      &kprobe_calls, &config_map);
 }
 
 __attribute__((section(("kprobe/4")), used)) int
 generic_kprobe_process_event4(void *ctx)
 {
 	return generic_process_event4(ctx, &process_call_heap, &filter_map,
-				      &kprobe_calls);
+				      &kprobe_calls, &config_map);
 }
 
 __attribute__((section(("kprobe/5")), used)) int

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -45,6 +45,13 @@ struct bpf_map_def __attribute__((section("maps"), used)) filter_map = {
 	.max_entries = 1,
 };
 
+struct bpf_map_def __attribute__((section("maps"), used)) config_map = {
+	.type = BPF_MAP_TYPE_ARRAY,
+	.key_size = sizeof(int),
+	.value_size = sizeof(struct event_config),
+	.max_entries = 1,
+};
+
 static inline __attribute__((always_inline)) int
 generic_kprobe_start_process_filter(void *ctx)
 {
@@ -111,7 +118,8 @@ __attribute__((section(("kprobe/0")), used)) int
 generic_kprobe_process_event0(void *ctx)
 {
 	return generic_process_event_and_setup(ctx, &process_call_heap,
-					       &filter_map, &kprobe_calls);
+					       &filter_map, &kprobe_calls,
+					       &config_map);
 }
 
 __attribute__((section(("kprobe/1")), used)) int

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -57,7 +57,7 @@ generic_kprobe_event(struct pt_regs *ctx)
 		return 0;
 
 	ty_arg = bpf_core_enum_value(tetragon_args, argreturn);
-	do_copy = bpf_core_enum_value(tetragon_args, argreturncopy);
+	do_copy = config->argreturncopy;
 	if (ty_arg)
 		size += read_call_arg(ctx, e, 0, ty_arg, 0,
 				      (unsigned long)ctx->ax, 0, 0);

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -100,44 +100,49 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 {
 	enum generic_func_args_enum tetragon_args;
 	struct msg_generic_kprobe *msg;
+	struct event_config *config;
 	int zero = 0, i;
 
 	msg = map_lookup_elem(&tp_heap, &zero);
 	if (!msg)
 		return 0;
 
+	config = map_lookup_elem(&config_map, &zero);
+	if (!config)
+		return 0;
+
 	msg->a0 = ({
 		unsigned long ctx_off =
 			bpf_core_enum_value(tetragon_args, t_arg0_ctx_off);
-		int ty = bpf_core_enum_value(tetragon_args, arg0);
+		int ty = config->arg0;
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a1 = ({
 		unsigned long ctx_off =
 			bpf_core_enum_value(tetragon_args, t_arg1_ctx_off);
-		int ty = bpf_core_enum_value(tetragon_args, arg1);
+		int ty = config->arg1;
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a2 = ({
 		unsigned long ctx_off =
 			bpf_core_enum_value(tetragon_args, t_arg2_ctx_off);
-		int ty = bpf_core_enum_value(tetragon_args, arg2);
+		int ty = config->arg2;
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a3 = ({
 		unsigned long ctx_off =
 			bpf_core_enum_value(tetragon_args, t_arg3_ctx_off);
-		int ty = bpf_core_enum_value(tetragon_args, arg3);
+		int ty = config->arg3;
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a4 = ({
 		unsigned long ctx_off =
 			bpf_core_enum_value(tetragon_args, t_arg4_ctx_off);
-		int ty = bpf_core_enum_value(tetragon_args, arg4);
+		int ty = config->arg4;
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
@@ -160,25 +165,29 @@ generic_tracepoint_event0(void *ctx)
 __attribute__((section(("kprobe/1")), used)) int
 generic_tracepoint_event1(void *ctx)
 {
-	return generic_process_event1(ctx, &tp_heap, &filter_map, &tp_calls);
+	return generic_process_event1(ctx, &tp_heap, &filter_map, &tp_calls,
+				      &config_map);
 }
 
 __attribute__((section(("kprobe/2")), used)) int
 generic_tracepoint_event2(void *ctx)
 {
-	return generic_process_event2(ctx, &tp_heap, &filter_map, &tp_calls);
+	return generic_process_event2(ctx, &tp_heap, &filter_map, &tp_calls,
+				      &config_map);
 }
 
 __attribute__((section(("kprobe/3")), used)) int
 generic_tracepoint_event3(void *ctx)
 {
-	return generic_process_event3(ctx, &tp_heap, &filter_map, &tp_calls);
+	return generic_process_event3(ctx, &tp_heap, &filter_map, &tp_calls,
+				      &config_map);
 }
 
 __attribute__((section(("kprobe/4")), used)) int
 generic_tracepoint_event4(void *ctx)
 {
-	return generic_process_event4(ctx, &tp_heap, &filter_map, &tp_calls);
+	return generic_process_event4(ctx, &tp_heap, &filter_map, &tp_calls,
+				      &config_map);
 }
 
 __attribute__((section(("kprobe/5")), used)) int

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -98,7 +98,6 @@ static inline __attribute__((always_inline)) unsigned long get_ctx_ul(void *src,
 __attribute__((section(("tracepoint/generic_tracepoint")), used)) int
 generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 {
-	enum generic_func_args_enum tetragon_args;
 	struct msg_generic_kprobe *msg;
 	struct event_config *config;
 	int zero = 0, i;
@@ -112,37 +111,42 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 		return 0;
 
 	msg->a0 = ({
-		unsigned long ctx_off =
-			bpf_core_enum_value(tetragon_args, t_arg0_ctx_off);
+		unsigned long ctx_off = config->t_arg0_ctx_off;
 		int ty = config->arg0;
+		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
+			     :);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a1 = ({
-		unsigned long ctx_off =
-			bpf_core_enum_value(tetragon_args, t_arg1_ctx_off);
+		unsigned long ctx_off = config->t_arg1_ctx_off;
 		int ty = config->arg1;
+		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
+			     :);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a2 = ({
-		unsigned long ctx_off =
-			bpf_core_enum_value(tetragon_args, t_arg2_ctx_off);
+		unsigned long ctx_off = config->t_arg2_ctx_off;
 		int ty = config->arg2;
+		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
+			     :);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a3 = ({
-		unsigned long ctx_off =
-			bpf_core_enum_value(tetragon_args, t_arg3_ctx_off);
+		unsigned long ctx_off = config->t_arg3_ctx_off;
 		int ty = config->arg3;
+		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
+			     :);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a4 = ({
-		unsigned long ctx_off =
-			bpf_core_enum_value(tetragon_args, t_arg4_ctx_off);
+		unsigned long ctx_off = config->t_arg4_ctx_off;
 		int ty = config->arg4;
+		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
+			     :);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -34,6 +34,13 @@ struct bpf_map_def __attribute__((section("maps"), used)) filter_map = {
 	.max_entries = 1,
 };
 
+struct bpf_map_def __attribute__((section("maps"), used)) config_map = {
+	.type = BPF_MAP_TYPE_ARRAY,
+	.key_size = sizeof(int),
+	.value_size = sizeof(struct event_config),
+	.max_entries = 1,
+};
+
 struct generic_tracepoint_event_arg {
 	/* common header */
 	__u16 common_type;
@@ -147,7 +154,8 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 __attribute__((section(("kprobe/0")), used)) int
 generic_tracepoint_event0(void *ctx)
 {
-	return generic_process_event0(ctx, &tp_heap, &filter_map, &tp_calls);
+	return generic_process_event0(ctx, &tp_heap, &filter_map, &tp_calls,
+				      &config_map);
 }
 __attribute__((section(("kprobe/1")), used)) int
 generic_tracepoint_event1(void *ctx)

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -219,34 +219,34 @@ __attribute__((section(("kprobe/6")), used)) int
 generic_tracepoint_arg1(void *ctx)
 {
 	return filter_read_arg(ctx, 0, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, &config_map);
 }
 
 __attribute__((section(("kprobe/7")), used)) int
 generic_tracepoint_arg2(void *ctx)
 {
 	return filter_read_arg(ctx, 1, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, &config_map);
 }
 
 __attribute__((section(("kprobe/8")), used)) int
 generic_tracepoint_arg3(void *ctx)
 {
 	return filter_read_arg(ctx, 2, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, &config_map);
 }
 
 __attribute__((section(("kprobe/9")), used)) int
 generic_tracepoint_arg4(void *ctx)
 {
 	return filter_read_arg(ctx, 3, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, &config_map);
 }
 
 __attribute__((section(("kprobe/10")), used)) int
 generic_tracepoint_arg5(void *ctx)
 {
 	return filter_read_arg(ctx, 4, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, &config_map);
 }
 char _license[] __attribute__((section(("license")), used)) = "GPL";

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -59,7 +59,7 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 #endif
 
 	/* Read out args1-5 */
-	ty = bpf_core_enum_value(tetragon_args, arg0);
+	ty = config->arg0;
 	if (total < MAX_TOTAL) {
 		long errv;
 		int a0m;
@@ -139,12 +139,14 @@ generic_filter_submit(void *ctx, struct msg_generic_kprobe *e, long total)
 
 static inline __attribute__((always_inline)) int
 generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
-		       struct bpf_map_def *map, struct bpf_map_def *tailcals)
+		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
+		       struct bpf_map_def *config_map)
 {
 	enum generic_func_args_enum tetragon_args;
 	unsigned long a0, a1, a2, a3, a4;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
+	struct event_config *config;
 	int zero = 0;
 	bool walker = 0;
 	long ty, total;
@@ -159,6 +161,10 @@ generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
 	if (!e)
 		return 0;
 
+	config = map_lookup_elem(config_map, &zero);
+	if (!config)
+		return 0;
+
 	total = e->common.size;
 
 	a0 = e->a0;
@@ -167,7 +173,7 @@ generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
 	a3 = e->a3;
 	a4 = e->a4;
 
-	ty = bpf_core_enum_value(tetragon_args, arg1);
+	ty = config->arg1;
 	if (total < MAX_TOTAL) {
 		long errv;
 		int a1m;
@@ -186,12 +192,14 @@ generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
 
 static inline __attribute__((always_inline)) int
 generic_process_event2(void *ctx, struct bpf_map_def *heap_map,
-		       struct bpf_map_def *map, struct bpf_map_def *tailcals)
+		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
+		       struct bpf_map_def *config_map)
 {
 	enum generic_func_args_enum tetragon_args;
 	unsigned long a0, a1, a2, a3, a4;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
+	struct event_config *config;
 	int zero = 0;
 	bool walker = 0;
 	long ty, total;
@@ -206,6 +214,10 @@ generic_process_event2(void *ctx, struct bpf_map_def *heap_map,
 	if (!e)
 		return 0;
 
+	config = map_lookup_elem(config_map, &zero);
+	if (!config)
+		return 0;
+
 	total = e->common.size;
 
 	a0 = e->a0;
@@ -214,7 +226,7 @@ generic_process_event2(void *ctx, struct bpf_map_def *heap_map,
 	a3 = e->a3;
 	a4 = e->a4;
 
-	ty = bpf_core_enum_value(tetragon_args, arg2);
+	ty = config->arg2;
 	if (total < MAX_TOTAL) {
 		long errv;
 		int a2m;
@@ -233,12 +245,14 @@ generic_process_event2(void *ctx, struct bpf_map_def *heap_map,
 
 static inline __attribute__((always_inline)) int
 generic_process_event3(void *ctx, struct bpf_map_def *heap_map,
-		       struct bpf_map_def *map, struct bpf_map_def *tailcals)
+		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
+		       struct bpf_map_def *config_map)
 {
 	enum generic_func_args_enum tetragon_args;
 	unsigned long a0, a1, a2, a3, a4;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
+	struct event_config *config;
 	int zero = 0;
 	bool walker = 0;
 	long ty, total;
@@ -253,6 +267,10 @@ generic_process_event3(void *ctx, struct bpf_map_def *heap_map,
 	if (!e)
 		return 0;
 
+	config = map_lookup_elem(config_map, &zero);
+	if (!config)
+		return 0;
+
 	total = e->common.size;
 
 	a0 = e->a0;
@@ -262,7 +280,7 @@ generic_process_event3(void *ctx, struct bpf_map_def *heap_map,
 	a4 = e->a4;
 
 	/* Arg filter and copy logic */
-	ty = bpf_core_enum_value(tetragon_args, arg3);
+	ty = config->arg3;
 	if (total < MAX_TOTAL) {
 		long errv;
 		int a3m;
@@ -281,12 +299,14 @@ generic_process_event3(void *ctx, struct bpf_map_def *heap_map,
 
 static inline __attribute__((always_inline)) int
 generic_process_event4(void *ctx, struct bpf_map_def *heap_map,
-		       struct bpf_map_def *map, struct bpf_map_def *tailcals)
+		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
+		       struct bpf_map_def *config_map)
 {
 	enum generic_func_args_enum tetragon_args;
 	unsigned long a0, a1, a2, a3, a4;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
+	struct event_config *config;
 	int zero = 0;
 	bool walker = 0;
 	long ty, total;
@@ -301,6 +321,10 @@ generic_process_event4(void *ctx, struct bpf_map_def *heap_map,
 	if (!e)
 		return 0;
 
+	config = map_lookup_elem(config_map, &zero);
+	if (!config)
+		return 0;
+
 	total = e->common.size;
 
 	a0 = e->a0;
@@ -309,7 +333,7 @@ generic_process_event4(void *ctx, struct bpf_map_def *heap_map,
 	a3 = e->a3;
 	a4 = e->a4;
 
-	ty = bpf_core_enum_value(tetragon_args, arg4);
+	ty = config->arg4;
 	if (total < MAX_TOTAL) {
 		long errv;
 		int a4m;

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -92,17 +92,20 @@ generic_process_event_and_setup(struct pt_regs *ctx,
 				struct bpf_map_def *tailcals,
 				struct bpf_map_def *config_map)
 {
-	enum generic_func_args_enum tetragon_args;
 	struct msg_generic_kprobe *e;
-	int zero = 0, is_syscall;
+	struct event_config *config;
+	int zero = 0;
 
 	/* Pid/Ktime Passed through per cpu map in process heap. */
 	e = map_lookup_elem(heap_map, &zero);
 	if (!e)
 		return 0;
 
-	is_syscall = bpf_core_enum_value(tetragon_args, syscall);
-	if (is_syscall) {
+	config = map_lookup_elem(config_map, &zero);
+	if (!config)
+		return 0;
+
+	if (config->syscall) {
 		struct pt_regs *_ctx;
 		_ctx = (struct pt_regs *)ctx->di;
 		if (!_ctx)

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -52,9 +52,7 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 
 	/* If return arg is needed mark retprobe */
 #ifdef GENERIC_KPROBE
-	enum generic_func_args_enum tetragon_args;
-
-	ty = bpf_core_enum_value(tetragon_args, argreturn);
+	ty = config->argreturn;
 	if (ty > 0)
 		retprobe_map_set(e->thread_id, 1);
 #endif

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -5,7 +5,6 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)
 {
-	enum generic_func_args_enum tetragon_args;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
 	unsigned long a0, a1, a2, a3, a4;
@@ -53,6 +52,8 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 
 	/* If return arg is needed mark retprobe */
 #ifdef GENERIC_KPROBE
+	enum generic_func_args_enum tetragon_args;
+
 	ty = bpf_core_enum_value(tetragon_args, argreturn);
 	if (ty > 0)
 		retprobe_map_set(e->thread_id, 1);
@@ -64,7 +65,9 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 		long errv;
 		int a0m;
 
-		a0m = bpf_core_enum_value(tetragon_args, arg0m);
+		a0m = config->arg0m;
+		asm volatile("%[a0m] &= 0xffff;\n" ::[a0m] "+r"(a0m) :);
+
 		errv = read_call_arg(ctx, e, 0, ty, total, a0, a0m, map);
 		if (errv > 0)
 			total += errv;
@@ -142,7 +145,6 @@ generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)
 {
-	enum generic_func_args_enum tetragon_args;
 	unsigned long a0, a1, a2, a3, a4;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
@@ -178,7 +180,9 @@ generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
 		long errv;
 		int a1m;
 
-		a1m = bpf_core_enum_value(tetragon_args, arg1m);
+		a1m = config->arg1m;
+		asm volatile("%[a1m] &= 0xffff;\n" ::[a1m] "+r"(a1m) :);
+
 		errv = read_call_arg(ctx, e, 1, ty, total, a1, a1m, map);
 		if (errv > 0)
 			total += errv;
@@ -195,7 +199,6 @@ generic_process_event2(void *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)
 {
-	enum generic_func_args_enum tetragon_args;
 	unsigned long a0, a1, a2, a3, a4;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
@@ -231,7 +234,9 @@ generic_process_event2(void *ctx, struct bpf_map_def *heap_map,
 		long errv;
 		int a2m;
 
-		a2m = bpf_core_enum_value(tetragon_args, arg2m);
+		a2m = config->arg2m;
+		asm volatile("%[a2m] &= 0xffff;\n" ::[a2m] "+r"(a2m) :);
+
 		errv = read_call_arg(ctx, e, 2, ty, total, a2, a2m, map);
 		if (errv > 0)
 			total += errv;
@@ -248,7 +253,6 @@ generic_process_event3(void *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)
 {
-	enum generic_func_args_enum tetragon_args;
 	unsigned long a0, a1, a2, a3, a4;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
@@ -285,7 +289,9 @@ generic_process_event3(void *ctx, struct bpf_map_def *heap_map,
 		long errv;
 		int a3m;
 
-		a3m = bpf_core_enum_value(tetragon_args, arg3m);
+		a3m = config->arg3m;
+		asm volatile("%[a3m] &= 0xffff;\n" ::[a3m] "+r"(a3m) :);
+
 		errv = read_call_arg(ctx, e, 3, ty, total, a3, a3m, map);
 		if (errv > 0)
 			total += errv;
@@ -302,7 +308,6 @@ generic_process_event4(void *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)
 {
-	enum generic_func_args_enum tetragon_args;
 	unsigned long a0, a1, a2, a3, a4;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
@@ -338,7 +343,9 @@ generic_process_event4(void *ctx, struct bpf_map_def *heap_map,
 		long errv;
 		int a4m;
 
-		a4m = bpf_core_enum_value(tetragon_args, arg4m);
+		a4m = config->arg4m;
+		asm volatile("%[a4m] &= 0xffff;\n" ::[a4m] "+r"(a4m) :);
+
 		errv = read_call_arg(ctx, e, 4, ty, total, a4, a4m, map);
 		if (errv > 0)
 			total += errv;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -75,6 +75,11 @@ struct selector_arg_filter {
 
 struct event_config {
 	__u32 func_id;
+	__s32 arg0;
+	__s32 arg1;
+	__s32 arg2;
+	__s32 arg3;
+	__s32 arg4;
 } __attribute__((packed));
 
 #define MAX_ARGS_SIZE	 80

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -91,6 +91,7 @@ struct event_config {
 	__u32 t_arg3_ctx_off;
 	__u32 t_arg4_ctx_off;
 	__u32 sigkill;
+	__u32 syscall;
 } __attribute__((packed));
 
 #define MAX_ARGS_SIZE	 80

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -92,6 +92,7 @@ struct event_config {
 	__u32 t_arg4_ctx_off;
 	__u32 sigkill;
 	__u32 syscall;
+	__s32 argreturncopy;
 } __attribute__((packed));
 
 #define MAX_ARGS_SIZE	 80

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -93,6 +93,7 @@ struct event_config {
 	__u32 sigkill;
 	__u32 syscall;
 	__s32 argreturncopy;
+	__s32 argreturn;
 } __attribute__((packed));
 
 #define MAX_ARGS_SIZE	 80

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -73,6 +73,10 @@ struct selector_arg_filter {
 	__u8 value;
 } __attribute__((packed));
 
+struct event_config {
+	__u32 func_id;
+} __attribute__((packed));
+
 #define MAX_ARGS_SIZE	 80
 #define MAX_ARGS_ENTRIES 8
 #define MAX_MATCH_VALUES 4

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -80,6 +80,11 @@ struct event_config {
 	__s32 arg2;
 	__s32 arg3;
 	__s32 arg4;
+	__u32 arg0m;
+	__u32 arg1m;
+	__u32 arg2m;
+	__u32 arg3m;
+	__u32 arg4m;
 } __attribute__((packed));
 
 #define MAX_ARGS_SIZE	 80

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -85,6 +85,11 @@ struct event_config {
 	__u32 arg2m;
 	__u32 arg3m;
 	__u32 arg4m;
+	__u32 t_arg0_ctx_off;
+	__u32 t_arg1_ctx_off;
+	__u32 t_arg2_ctx_off;
+	__u32 t_arg3_ctx_off;
+	__u32 t_arg4_ctx_off;
 } __attribute__((packed));
 
 #define MAX_ARGS_SIZE	 80

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -228,7 +228,8 @@ type KprobeArgs struct {
 }
 
 type EventConfig struct {
-	FuncId uint32
-	Arg    [5]int32
-	ArgM   [5]uint32
+	FuncId      uint32
+	Arg         [5]int32
+	ArgM        [5]uint32
+	ArgTpCtxOff [5]uint32
 }

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -228,10 +228,11 @@ type KprobeArgs struct {
 }
 
 type EventConfig struct {
-	FuncId      uint32
-	Arg         [5]int32
-	ArgM        [5]uint32
-	ArgTpCtxOff [5]uint32
-	Sigkill     uint32
-	Syscall     uint32
+	FuncId        uint32
+	Arg           [5]int32
+	ArgM          [5]uint32
+	ArgTpCtxOff   [5]uint32
+	Sigkill       uint32
+	Syscall       uint32
+	ArgReturnCopy int32
 }

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -229,4 +229,5 @@ type KprobeArgs struct {
 
 type EventConfig struct {
 	FuncId uint32
+	Arg    [5]int32
 }

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -226,3 +226,7 @@ type KprobeArgs struct {
 	Args3 []byte
 	Args4 []byte
 }
+
+type EventConfig struct {
+	FuncId uint32
+}

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -230,4 +230,5 @@ type KprobeArgs struct {
 type EventConfig struct {
 	FuncId uint32
 	Arg    [5]int32
+	ArgM   [5]uint32
 }

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -232,4 +232,5 @@ type EventConfig struct {
 	Arg         [5]int32
 	ArgM        [5]uint32
 	ArgTpCtxOff [5]uint32
+	Sigkill     uint32
 }

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -233,4 +233,5 @@ type EventConfig struct {
 	ArgM        [5]uint32
 	ArgTpCtxOff [5]uint32
 	Sigkill     uint32
+	Syscall     uint32
 }

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -235,4 +235,5 @@ type EventConfig struct {
 	Sigkill       uint32
 	Syscall       uint32
 	ArgReturnCopy int32
+	ArgReturn     int32
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -50,26 +50,6 @@ func init() {
 }
 
 const (
-	genericFuncArgsEnum = "generic_func_args_enum"
-
-	kprobeGenericId = "func_id"
-	arg0            = "arg0"
-	arg1            = "arg1"
-	arg2            = "arg2"
-	arg3            = "arg3"
-	arg4            = "arg4"
-	argreturn       = "argreturn"
-	argreturncopy   = "argreturncopy"
-	is_syscall      = "syscall"
-	argm0           = "arg0m"
-	argm1           = "arg1m"
-	argm2           = "arg2m"
-	argm3           = "arg3m"
-	argm4           = "arg4m"
-	argm5           = "arg5m"
-)
-
-const (
 	CharBufErrorENOMEM      = -1
 	CharBufErrorPageFault   = -2
 	CharBufErrorTooLarge    = -3
@@ -233,11 +213,6 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 		btfobj, err = btf.NewBTF()
 		if err != nil {
 			return nil, err
-		}
-
-		ret := btfobj.AddEnum(genericFuncArgsEnum, 4)
-		if ret < 0 {
-			return nil, fmt.Errorf("Error add enum args (%s) failed %d", genericFuncArgsEnum, ret)
 		}
 
 		if err := btf.ValidateKprobeSpec(btfobj, f); err != nil {

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -312,19 +312,12 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 			setRetprobe = true
 
 			argType := gt.GenericTypeFromString(argRetprobe.Type)
-
-			ret = btfobj.AddEnumValue(argreturncopy, argType)
-			if ret < 0 {
-				return nil, fmt.Errorf("Error add enum value '%s'='0' failed %d", argreturncopy, argType)
-			}
+			config.ArgReturnCopy = int32(argType)
 
 			argP := argPrinters{index: int(argRetprobe.Index), ty: argType}
 			argReturnPrinters = append(argReturnPrinters, argP)
 		} else {
-			ret = btfobj.AddEnumValue(argreturncopy, 0)
-			if ret < 0 {
-				return nil, fmt.Errorf("Error add enum value '%s'='0' failed %d", argreturncopy, 0)
-			}
+			config.ArgReturnCopy = int32(0)
 		}
 
 		// Mark remaining arguments as 'nops' the kernel side will skip

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -293,18 +293,12 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 				}
 				return nil, fmt.Errorf("ReturnArg type '%s' unsupported", f.ReturnArg.Type)
 			}
-			retVal := btfobj.AddEnumValue(argreturn, argType)
-			if retVal < 0 {
-				return nil, fmt.Errorf("Error add enum value '%s'='%d' failed %d", argreturn, argType, retVal)
-			}
+			config.ArgReturn = int32(argType)
 			argsBTFSet[api.ReturnArgIndex] = true
 			argP := argPrinters{index: api.ReturnArgIndex, ty: argType}
 			argReturnPrinters = append(argReturnPrinters, argP)
 		} else {
-			retVal := btfobj.AddEnumValue(argreturn, 0)
-			if retVal < 0 {
-				return nil, fmt.Errorf("Error add enum value '%s'='0' failed %d", argreturn, retVal)
-			}
+			config.ArgReturn = int32(0)
 		}
 
 		if argRetprobe != nil {

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -385,15 +385,9 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 
 		has_sigkill := selectors.MatchActionSigKill(f)
 		if has_sigkill {
-			retVal := btfobj.AddEnumValue("sigkill", 1)
-			if retVal < 0 {
-				return nil, fmt.Errorf("Error add enum value 'sigkill = 1' failed %d", retVal)
-			}
+			config.Sigkill = 1
 		} else {
-			retVal := btfobj.AddEnumValue("sigkill", 0)
-			if retVal < 0 {
-				return nil, fmt.Errorf("Error add enum value 'sigkill = 0' failed %d", retVal)
-			}
+			config.Sigkill = 0
 		}
 
 		// create a new entry on the table, and pass its id to BPF-side

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -369,15 +369,10 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 		}
 
 		if is_syscall {
-			retVal := btfobj.AddEnumValue("syscall", 1)
-			if retVal < 0 {
-				return nil, fmt.Errorf("Error add enum value 'syscall = 1' failed %d", retVal)
-			}
+			config.Syscall = 1
 		} else {
-			retVal := btfobj.AddEnumValue("syscall", 0)
-			if retVal < 0 {
-				return nil, fmt.Errorf("Error add enum value 'syscall = 0' failed %d", retVal)
-			}
+			config.Syscall = 0
+
 			if hasOverride {
 				return nil, fmt.Errorf("Error override action can be used only with syscalls")
 			}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -88,24 +88,6 @@ func kprobeCharBufErrorToString(e int32) string {
 	return "CharBufErrorUnknown"
 }
 
-func kprobeArgMToString(a int) string {
-	switch a {
-	case 0:
-		return argm0
-	case 1:
-		return argm1
-	case 2:
-		return argm2
-	case 3:
-		return argm3
-	case 4:
-		return argm4
-	case 5:
-		return argm5
-	}
-	return ""
-}
-
 type kprobeLoadArgs struct {
 	filters  [4096]byte
 	btf      uintptr
@@ -287,10 +269,7 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 						a.Type, int(a.Index))
 			}
 			config.Arg[a.Index] = int32(argType)
-			retVal := btfobj.AddEnumValue(kprobeArgMToString(int(a.Index)), argMValue)
-			if retVal < 0 {
-				return nil, fmt.Errorf("Error add enum value '%s' failed %d", kprobeArgMToString(int(a.Index)), retVal)
-			}
+			config.ArgM[a.Index] = uint32(argMValue)
 
 			argsBTFSet[a.Index] = true
 			argP := argPrinters{index: j, ty: argType}
@@ -354,11 +333,7 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 			if a == false {
 				if j != api.ReturnArgIndex {
 					config.Arg[j] = gt.GenericNopType
-				}
-				retVal := btfobj.AddEnumValue(kprobeArgMToString(j), 0)
-				if retVal < 0 {
-					return nil, fmt.Errorf("Error add enum value '%s' failed %d",
-						kprobeArgMToString(j), retVal)
+					config.ArgM[j] = 0
 				}
 			}
 		}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -375,7 +375,7 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 				retVal = btfobj.AddEnumValue(kprobeArgMToString(j), 0)
 				if retVal < 0 {
 					return nil, fmt.Errorf("Error add enum value '%s' failed %d",
-						kprobeArgToString(j), retVal)
+						kprobeArgMToString(j), retVal)
 				}
 			}
 		}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
+	api "github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
@@ -341,6 +342,8 @@ func createGenericTracepointSensor(confs []GenericTracepointConf) (*sensors.Sens
 }
 
 func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, version, verbose int) (int, error) {
+	config := &api.EventConfig{}
+
 	tracepointLog = logger.GetLogger()
 
 	btfCtxOffsetFn := func(i int) string {
@@ -375,9 +378,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 		return 0, fmt.Errorf("failed to add %s=%d BTF enum (ret=%d)", genericFuncArgsEnum, 4, ret)
 	}
 
-	if err := btfAddEnumValue(kprobeGenericId, tp.tableIdx); err != nil {
-		return 0, err
-	}
+	config.FuncId = uint32(tp.tableIdx)
 
 	// iterate over output arguments
 	for i := range tp.args {
@@ -466,6 +467,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 		mapDir,
 		load.RetProbe,
 		kernelSelectors,
+		config,
 	)
 }
 

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -392,9 +392,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 			return 0, fmt.Errorf("output argument %v unsupported: %w", tpArg, err)
 		}
 
-		if err := btfAddEnumValue(kprobeArgToString(i), tpArg.genericTypeId); err != nil {
-			return 0, err
-		}
+		config.Arg[i] = int32(tpArg.genericTypeId)
 
 		if err := btfAddEnumValue(kprobeArgMToString(i), tpArg.MetaArg); err != nil {
 			return 0, err
@@ -409,9 +407,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 			return 0, err
 		}
 
-		if err := btfAddEnumValue(kprobeArgToString(i), gt.GenericNopType); err != nil {
-			return 0, err
-		}
+		config.Arg[i] = int32(gt.GenericNopType)
 
 		if err := btfAddEnumValue(kprobeArgMToString(i), 0); err != nil {
 			return 0, err

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -393,10 +393,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 		}
 
 		config.Arg[i] = int32(tpArg.genericTypeId)
-
-		if err := btfAddEnumValue(kprobeArgMToString(i), tpArg.MetaArg); err != nil {
-			return 0, err
-		}
+		config.ArgM[i] = uint32(tpArg.MetaArg)
 
 		tracepointLog.Infof("configured argument #%d: %+v (type:%d)", i, tpArg, tpArg.genericTypeId)
 	}
@@ -408,10 +405,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 		}
 
 		config.Arg[i] = int32(gt.GenericNopType)
-
-		if err := btfAddEnumValue(kprobeArgMToString(i), 0); err != nil {
-			return 0, err
-		}
+		config.ArgM[i] = uint32(0)
 	}
 
 	// actions nop

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -346,10 +346,6 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 
 	tracepointLog = logger.GetLogger()
 
-	btfCtxOffsetFn := func(i int) string {
-		return fmt.Sprintf("t_arg%d_ctx_off", i)
-	}
-
 	tpIdx, ok := load.LoaderData.(int)
 	if !ok {
 		return 0, fmt.Errorf("loaderData for genericTracepoint %s is %T (%v) (not an int)", load.Name, load.LoaderData, load.LoaderData)
@@ -383,10 +379,8 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 	// iterate over output arguments
 	for i := range tp.args {
 		tpArg := &tp.args[i]
-		if err := btfAddEnumValue(btfCtxOffsetFn(i), tpArg.CtxOffset); err != nil {
-			return 0, err
-		}
 
+		config.ArgTpCtxOff[i] = uint32(tpArg.CtxOffset)
 		_, err := tpArg.setGenericTypeId()
 		if err != nil {
 			return 0, fmt.Errorf("output argument %v unsupported: %w", tpArg, err)
@@ -400,10 +394,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 
 	// nop args
 	for i := len(tp.args); i < genericTP_MaxArgs; i++ {
-		if err := btfAddEnumValue(btfCtxOffsetFn(i), 0); err != nil {
-			return 0, err
-		}
-
+		config.ArgTpCtxOff[i] = uint32(0)
 		config.Arg[i] = int32(gt.GenericNopType)
 		config.ArgM[i] = uint32(0)
 	}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -362,11 +362,6 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 	}
 	defer btfObj.Close()
 
-	ret := btfObj.AddEnum(genericFuncArgsEnum, 4)
-	if ret < 0 {
-		return 0, fmt.Errorf("failed to add %s=%d BTF enum (ret=%d)", genericFuncArgsEnum, 4, ret)
-	}
-
 	config.FuncId = uint32(tp.tableIdx)
 
 	// iterate over output arguments

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -362,13 +362,6 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 	}
 	defer btfObj.Close()
 
-	btfAddEnumValue := func(s string, val int) error {
-		if ret := btfObj.AddEnumValue(s, val); ret < 0 {
-			return fmt.Errorf("failed to add %s=%d BTF value (error=%d)", s, val, ret)
-		}
-		return nil
-	}
-
 	ret := btfObj.AddEnum(genericFuncArgsEnum, 4)
 	if ret < 0 {
 		return 0, fmt.Errorf("failed to add %s=%d BTF enum (ret=%d)", genericFuncArgsEnum, 4, ret)
@@ -397,11 +390,6 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 		config.ArgTpCtxOff[i] = uint32(0)
 		config.Arg[i] = int32(gt.GenericNopType)
 		config.ArgM[i] = uint32(0)
-	}
-
-	// actions nop
-	if err := btfAddEnumValue("sigkill", 0); err != nil {
-		return 0, err
 	}
 
 	// rewrite arg index

--- a/pkg/sensors/tracing/kprobe_copyfd_test.go
+++ b/pkg/sensors/tracing/kprobe_copyfd_test.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
@@ -34,7 +35,7 @@ func TestCopyFd(t *testing.T) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
-	ctx, cancel := context.WithTimeout(context.Background(), cmdWaitTime)
+	ctx, cancel := context.WithTimeout(context.Background(), 60000*time.Millisecond)
 	defer cancel()
 
 	testBin := testutils.ContribPath("tester-progs/dup-tester")


### PR DESCRIPTION
Getting rid of extra configuration inside BTF and moving it to map.

The new internal config_map map is loaded for both tracepoints
and kprobes and loaded with config data at zero index.

Signed-off-by: Jiri Olsa [jolsa@kernel.org](mailto:jolsa@kernel.org)