### PR TITLE
remove last \ in gcloud container clusters create

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ export NAME="$(whoami)-$RANDOM"
 gcloud container clusters create "${NAME}" \
   --zone us-west2-a \
   --release-channel rapid \
-  --num-nodes 1 \
+  --num-nodes 1 
 ```
 
 ### Deploy Tetragon


### PR DESCRIPTION
remove last \ so it can execute without waiting for another line/option.

Signed-off-by: Walter Lee <quietwalter@gmail.com>