### PR TITLE
hubble-fgs: Add support to copy the full lenght of argument's data

### DIFF
--- a/bpf/lib/data_msg.h
+++ b/bpf/lib/data_msg.h
@@ -1,0 +1,27 @@
+#ifndef __DATA_MSG_
+#define __DATA_MSG_
+
+struct data_event_id {
+	__u64 pid;
+	__u64 time;
+} __attribute__((packed));
+
+struct data_event_desc {
+	__s32 error;
+	__u32 leftover;
+	struct data_event_id id;
+} __attribute__((packed));
+
+struct msg_data {
+	struct msg_common common;
+	struct data_event_id id;
+	/* To have a fast way to check buffer size we use 32736
+	 * as arg size, which is:
+	 *   0x8000 - offsetof(struct msg_kprobe_arg, arg)
+	 * so we can make verifier happy with:
+	 *   'size &= 0x7fff' check
+	*/
+	char arg[32736];
+} __attribute__((packed));
+
+#endif /* __DATA_MSG_ */

--- a/bpf/lib/data_msg.h
+++ b/bpf/lib/data_msg.h
@@ -6,9 +6,12 @@ struct data_event_id {
 	__u64 time;
 } __attribute__((packed));
 
+#define DATA_EVENT_DESC_FLAGS_CONT 1 << 0
+
 struct data_event_desc {
 	__s32 error;
 	__u32 leftover;
+	__u32 flags;
 	struct data_event_id id;
 } __attribute__((packed));
 

--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -17,6 +17,12 @@
 #define SELECTORS_ACTIVE	 31
 #define MAX_CONFIGURED_SELECTORS MAX_POSSIBLE_SELECTORS + 1
 
+struct full_copy_data {
+	long off;
+	unsigned long arg;
+	size_t bytes;
+};
+
 struct msg_generic_kprobe {
 	struct msg_common common;
 	struct msg_execve_key current;
@@ -38,6 +44,12 @@ struct msg_generic_kprobe {
 #ifdef __CAP_CHANGES_FILTER
 	__u64 match_cap;
 #endif
+	struct {
+		long off;
+		size_t bytes;
+		int cnt;
+		struct full_copy_data data[8];
+	} full_copy;
 };
 
 static inline __attribute__((always_inline)) size_t generic_kprobe_common_size()

--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -21,6 +21,7 @@ struct full_copy_data {
 	long off;
 	unsigned long arg;
 	size_t bytes;
+	bool cont;
 };
 
 struct msg_generic_kprobe {

--- a/bpf/lib/msg_types.h
+++ b/bpf/lib/msg_types.h
@@ -24,6 +24,8 @@ enum msg_ops {
 
 	MSG_OP_CLONE = 23,
 
+	MSG_OP_DATA = 24,
+
 	MSG_OP_MAX,
 };
 #endif // _MSG_TYPES_

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -61,8 +61,8 @@ generic_kprobe_event(struct pt_regs *ctx)
 		size += __copy_char_buf(size, retprobe_buffer, ctx->ax, e);
 		break;
 	case char_iovec:
-		size += __copy_char_iovec(&e->args[size], retprobe_buffer, cnt,
-					  ctx->ax);
+		size += __copy_char_iovec(size, retprobe_buffer, cnt, ctx->ax,
+					  e);
 	default:
 		break;
 	}

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -8,6 +8,8 @@
 #include "bpf_events.h"
 #include "retprobe_map.h"
 #include "types/basic.h"
+#include "data_event.h"
+#include "full_copy.h"
 
 #define MAX_FILENAME 8096
 
@@ -24,6 +26,13 @@ struct bpf_map_def __attribute__((section("maps"), used)) retkprobe_calls = {
 	.type = BPF_MAP_TYPE_PROG_ARRAY,
 	.key_size = sizeof(__u32),
 	.value_size = sizeof(__u32),
+	.max_entries = 1,
+};
+
+struct bpf_map_def __attribute__((section("maps"), used)) data_heap = {
+	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
+	.key_size = sizeof(__u32),
+	.value_size = sizeof(struct msg_data),
 	.max_entries = 1,
 };
 
@@ -46,6 +55,7 @@ generic_kprobe_event(struct pt_regs *ctx)
 		return 0;
 
 	e->thread_id = retprobe_map_get_key(ctx);
+	full_copy_init(e);
 
 	if (!retprobe_map_get(e->thread_id, &info))
 		return 0;
@@ -57,7 +67,8 @@ generic_kprobe_event(struct pt_regs *ctx)
 				      (unsigned long)ctx->ax, 0, 0);
 	switch (do_copy) {
 	case char_buf:
-		size += __copy_char_buf(size, info.ptr, ctx->ax, e, false);
+		size += __copy_char_buf(size, info.ptr, ctx->ax, e,
+					info.fullCopy);
 		break;
 	case char_iovec:
 		size += __copy_char_iovec(size, info.ptr, info.cnt, ctx->ax, e,
@@ -97,6 +108,18 @@ generic_kprobe_event(struct pt_regs *ctx)
 		     : [total] "+r"(total)
 		     :);
 	e->common.size = total;
+
+	if (e->full_copy.cnt) {
+		tail_call(ctx, &retkprobe_calls, 0);
+		return 2;
+	}
+
 	perf_event_output(ctx, &tcpmon_map, BPF_F_CURRENT_CPU, e, total);
 	return 0;
+}
+
+__attribute__((section(("kprobe/0")), used)) int
+generic_retkprobe_full_copy(void *ctx)
+{
+	return full_copy(ctx, &process_call_heap, &data_heap);
 }

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -20,6 +20,13 @@ struct bpf_map_def __attribute__((section("maps"), used)) process_call_heap = {
 	.max_entries = 1,
 };
 
+struct bpf_map_def __attribute__((section("maps"), used)) retkprobe_calls = {
+	.type = BPF_MAP_TYPE_PROG_ARRAY,
+	.key_size = sizeof(__u32),
+	.value_size = sizeof(__u32),
+	.max_entries = 1,
+};
+
 __attribute__((section(("kprobe/generic_retkprobe")), used)) int
 generic_kprobe_event(struct pt_regs *ctx)
 {

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -60,7 +60,8 @@ generic_kprobe_event(struct pt_regs *ctx)
 		size += __copy_char_buf(size, info.ptr, ctx->ax, e, false);
 		break;
 	case char_iovec:
-		size += __copy_char_iovec(size, info.ptr, info.cnt, ctx->ax, e);
+		size += __copy_char_iovec(size, info.ptr, info.cnt, ctx->ax, e,
+					  info.fullCopy);
 	default:
 		break;
 	}

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -58,8 +58,7 @@ generic_kprobe_event(struct pt_regs *ctx)
 				      (unsigned long)ctx->ax, 0, 0);
 	switch (do_copy) {
 	case char_buf:
-		size += __copy_char_buf(&e->args[size], retprobe_buffer,
-					ctx->ax);
+		size += __copy_char_buf(size, retprobe_buffer, ctx->ax, e);
 		break;
 	case char_iovec:
 		size += __copy_char_iovec(&e->args[size], retprobe_buffer, cnt,

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -57,7 +57,7 @@ generic_kprobe_event(struct pt_regs *ctx)
 				      (unsigned long)ctx->ax, 0, 0);
 	switch (do_copy) {
 	case char_buf:
-		size += __copy_char_buf(size, info.ptr, ctx->ax, e);
+		size += __copy_char_buf(size, info.ptr, ctx->ax, e, false);
 		break;
 	case char_iovec:
 		size += __copy_char_iovec(size, info.ptr, info.cnt, ctx->ax, e);

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -198,34 +198,34 @@ __attribute__((section(("kprobe/6")), used)) int
 generic_tracepoint_arg1(void *ctx)
 {
 	return filter_read_arg(ctx, 0, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, (void *)0);
 }
 
 __attribute__((section(("kprobe/7")), used)) int
 generic_tracepoint_arg2(void *ctx)
 {
 	return filter_read_arg(ctx, 1, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, (void *)0);
 }
 
 __attribute__((section(("kprobe/8")), used)) int
 generic_tracepoint_arg3(void *ctx)
 {
 	return filter_read_arg(ctx, 2, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, (void *)0);
 }
 
 __attribute__((section(("kprobe/9")), used)) int
 generic_tracepoint_arg4(void *ctx)
 {
 	return filter_read_arg(ctx, 3, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, (void *)0);
 }
 
 __attribute__((section(("kprobe/10")), used)) int
 generic_tracepoint_arg5(void *ctx)
 {
 	return filter_read_arg(ctx, 4, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0);
+			       (void *)0, (void *)0);
 }
 char _license[] __attribute__((section(("license")), used)) = "GPL";

--- a/bpf/process/data_event.h
+++ b/bpf/process/data_event.h
@@ -1,0 +1,96 @@
+#include "data_msg.h"
+
+static inline __attribute__((always_inline)) long
+__do_bytes(void *ctx, struct msg_data *msg, unsigned long uptr, size_t bytes)
+{
+	size_t max = sizeof(msg->arg) - 1;
+	size_t rd_bytes, size;
+	int err;
+
+	rd_bytes = bytes > max ? max : bytes;
+	msg->common.size = offsetof(struct msg_data, arg) + rd_bytes;
+
+	/* Code movement from clang forces us to inline bounds checks here */
+	asm volatile("%[rd_bytes] &= 0x7fff;\n"
+		     "if %[rd_bytes] < 32736 goto +1\n;"
+		     "%[rd_bytes] = 32736;\n"
+		     :
+		     : [rd_bytes] "+r"(rd_bytes)
+		     :);
+	err = probe_read(&msg->arg[0], rd_bytes, (char *)uptr);
+	if (err < 0)
+		return err;
+
+	size = rd_bytes + offsetof(struct msg_data, arg);
+
+	/* Code movement from clang forces us to inline bounds checks here */
+	asm volatile("%[size] &= 0x7fff;\n" : : [size] "+r"(size) :);
+	perf_event_output(ctx, &tcpmon_map, BPF_F_CURRENT_CPU, msg, size);
+	return rd_bytes;
+}
+
+static long do_bytes(void *ctx, struct msg_data *msg, unsigned long arg,
+		     size_t bytes)
+{
+	size_t rd_bytes = 0;
+	int err, i;
+
+#ifdef __LARGE_BPF_PROG
+#define __CNT 10
+#else
+#define __CNT 8
+#pragma unroll
+#endif
+	for (i = 0; i < __CNT; i++) {
+		err = __do_bytes(ctx, msg, arg + rd_bytes, bytes - rd_bytes);
+		if (err < 0)
+			return err;
+		rd_bytes += err;
+		if (rd_bytes == bytes)
+			return 0;
+	}
+#undef __CNT
+
+	/* leftover */
+	return bytes - rd_bytes;
+}
+
+static int data_event(void *ctx, void *out, unsigned long uptr, size_t size,
+		      struct bpf_map_def *heap,
+		      long (*do_data_event)(void *, struct msg_data *,
+					    unsigned long, size_t))
+{
+	struct data_event_desc *desc = out;
+	struct msg_data *msg;
+	int zero = 0, err;
+
+	msg = map_lookup_elem(heap, &zero);
+	if (!msg)
+		return -1;
+
+	msg->common.op = MSG_OP_DATA;
+	msg->common.flags = 0;
+	msg->common.pad[0] = 0;
+	msg->common.pad[1] = 0;
+
+	msg->id.pid = get_current_pid_tgid();
+	msg->id.time = ktime_get_ns();
+	desc->id = msg->id;
+
+	err = do_data_event(ctx, msg, uptr, size);
+	if (err < 0) {
+		desc->error = err;
+		desc->leftover = 0;
+	} else {
+		desc->error = 0;
+		desc->leftover = err;
+	}
+	return sizeof(*desc);
+}
+
+static inline __attribute__((always_inline)) size_t
+data_event_bytes(void *ctx, void *out, unsigned long uptr, size_t size,
+		 struct bpf_map_def *heap)
+{
+	return data_event(ctx, out, uptr, size, heap, do_bytes);
+}

--- a/bpf/process/data_event.h
+++ b/bpf/process/data_event.h
@@ -56,7 +56,7 @@ static long do_bytes(void *ctx, struct msg_data *msg, unsigned long arg,
 }
 
 static int data_event(void *ctx, void *out, unsigned long uptr, size_t size,
-		      struct bpf_map_def *heap,
+		      bool cont, struct bpf_map_def *heap,
 		      long (*do_data_event)(void *, struct msg_data *,
 					    unsigned long, size_t))
 {
@@ -76,6 +76,7 @@ static int data_event(void *ctx, void *out, unsigned long uptr, size_t size,
 	msg->id.pid = get_current_pid_tgid();
 	msg->id.time = ktime_get_ns();
 	desc->id = msg->id;
+	desc->flags = cont ? DATA_EVENT_DESC_FLAGS_CONT : 0;
 
 	err = do_data_event(ctx, msg, uptr, size);
 	if (err < 0) {
@@ -90,7 +91,7 @@ static int data_event(void *ctx, void *out, unsigned long uptr, size_t size,
 
 static inline __attribute__((always_inline)) size_t
 data_event_bytes(void *ctx, void *out, unsigned long uptr, size_t size,
-		 struct bpf_map_def *heap)
+		 bool cont, struct bpf_map_def *heap)
 {
-	return data_event(ctx, out, uptr, size, heap, do_bytes);
+	return data_event(ctx, out, uptr, size, cont, heap, do_bytes);
 }

--- a/bpf/process/full_copy.h
+++ b/bpf/process/full_copy.h
@@ -1,0 +1,100 @@
+/*
+ * When the fullCopy is enabled for argument (fullCopy: true),
+ * arguments' data pointer/size couples are stored via
+ * full_copy_set function into:
+ *
+ *   struct msg_generic_kprobe::full_copy.data[8]
+ *
+ * This will skip the 'actual' data copy to the kprobe's args,
+ * but instead it stores special id:
+ *
+ *   char_buf_fullcopy_arg = -5
+ *   original argument size
+ *
+ * together with following record describing the status of the
+ * full copy:
+ *
+ *   struct data_event_desc {
+ *     __s32 error;
+ *     __u32 leftover;
+ *     struct data_event_id id;
+ *   }
+ *
+ * The 'actual' argument's data is copied via data_event_bytes
+ * function and delivered to user space via separate data
+ * event(s).
+ *
+ * The user space side sees following data as argument value:
+ *
+ *   value                     |  offset
+ *   -----------------------------------
+ *   char_buf_fullcopy_arg(-5) |       0
+ *   orig size                 |       4
+ *   struct data_event_desc    |
+ *     error                   |       8
+ *     leftover                |      12
+ *     id                      |      16
+ *   next argument data        |      32
+ *
+ * Based on the 'id' we find the 'actual' argument value
+ * from data event.
+ *
+ * All data events are store on the same cpu ring buffer
+ * and *before* the kprobe event is stored. That's because
+ * the cpu can't migrate during kprobe bpf program run.
+ * The user side can rely on that all its data is already
+ * stored.
+ */
+
+static inline __attribute__((always_inline)) struct full_copy_data *
+fullcopy_data(struct msg_generic_kprobe *msg, int idx)
+{
+	struct full_copy_data *data;
+
+	asm volatile("%[idx] &= 0x7;\n" ::[idx] "+r"(idx) :);
+	data = &msg->full_copy.data[idx];
+	return data;
+}
+
+static inline __attribute__((always_inline)) int
+full_copy(void *ctx, struct bpf_map_def *heap_map,
+	  struct bpf_map_def *data_heap)
+{
+	struct msg_generic_kprobe *msg;
+	struct full_copy_data *data;
+	int i = 0, zero = 0;
+	size_t total;
+	char *args;
+	int *s;
+
+	msg = map_lookup_elem(heap_map, &zero);
+	if (!msg)
+		return 0;
+
+	s = (int *)args_off(msg, msg->full_copy.off);
+	s[0] = char_buf_fullcopy_arg;
+	s[1] = msg->full_copy.bytes;
+
+#ifndef __LARGE_BPF_PROG
+#pragma unroll
+#endif
+	for (i = 0; i < 8; i++) {
+		if (i == msg->full_copy.cnt)
+			break;
+
+		data = fullcopy_data(msg, i);
+		args = args_off(msg, data->off);
+		data_event_bytes(ctx, args, data->arg, data->bytes, data_heap);
+	}
+
+	total = msg->common.size + generic_kprobe_common_size();
+	/* Code movement from clang forces us to inline bounds checks here */
+	asm volatile("%[total] &= 0x7fff;\n"
+		     "if %[total] < 9000 goto +1\n;"
+		     "%[total] = 9000;\n"
+		     :
+		     : [total] "+r"(total)
+		     :);
+	perf_event_output(ctx, &tcpmon_map, BPF_F_CURRENT_CPU, msg, total);
+	return 1;
+}

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -49,7 +49,7 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 #ifdef GENERIC_KPROBE
 	ty = bpf_core_enum_value(tetragon_args, argreturn);
 	if (ty > 0)
-		retprobe_map_set(e->thread_id, 1);
+		retprobe_map_set(e->thread_id, 1, false);
 #endif
 
 	/* Read out args1-5 */

--- a/bpf/process/retprobe_map.h
+++ b/bpf/process/retprobe_map.h
@@ -10,21 +10,18 @@ struct bpf_map_def __attribute__((section("maps"), used)) retprobe_map = {
 	.max_entries = 1024,
 };
 
-static inline __attribute__((always_inline)) unsigned long
-retprobe_map_get(__u64 tid, unsigned long *cntp)
+static inline __attribute__((always_inline)) bool
+retprobe_map_get(__u64 tid, struct retprobe_info *bufp)
 {
 	struct retprobe_info *info;
-	unsigned long ptr;
 
 	info = map_lookup_elem(&retprobe_map, &tid);
 	if (!info)
-		return 0;
-
-	ptr = info->ptr;
-	if (cntp)
-		*cntp = info->cnt;
+		return false;
+	if (bufp)
+		*bufp = *info;
 	map_delete_elem(&retprobe_map, &tid);
-	return ptr;
+	return true;
 }
 
 static inline __attribute__((always_inline)) void retprobe_map_clear(__u64 tid)

--- a/bpf/process/retprobe_map.h
+++ b/bpf/process/retprobe_map.h
@@ -1,7 +1,8 @@
 struct retprobe_info {
 	unsigned long ptr;
 	unsigned long cnt;
-};
+	bool fullCopy;
+} __attribute__((packed));
 
 struct bpf_map_def __attribute__((section("maps"), used)) retprobe_map = {
 	.type = BPF_MAP_TYPE_HASH,
@@ -33,22 +34,23 @@ static inline __attribute__((always_inline)) void retprobe_map_clear(__u64 tid)
 }
 
 static inline __attribute__((always_inline)) void
-retprobe_map_set(__u64 tid, unsigned long ptr)
+retprobe_map_set(__u64 tid, unsigned long ptr, bool fullCopy)
 {
 	struct retprobe_info info = {
 		.ptr = ptr,
+		.fullCopy = fullCopy,
 	};
 
 	map_update_elem(&retprobe_map, &tid, &info, BPF_ANY);
 }
 
 static inline __attribute__((always_inline)) void
-retprobe_map_set_iovec(__u64 tid, unsigned long ptr, unsigned long cnt)
+retprobe_map_set_iovec(__u64 tid, unsigned long ptr, unsigned long cnt,
+		       bool fullCopy)
 {
-	struct retprobe_info info = {
-		.ptr = ptr,
-		.cnt = cnt,
-	};
+	struct retprobe_info info = { .ptr = ptr,
+				      .cnt = cnt,
+				      .fullCopy = fullCopy };
 
 	map_update_elem(&retprobe_map, &tid, &info, BPF_ANY);
 }

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -414,11 +414,18 @@ static inline __attribute__((always_inline)) long copy_cred(char *args,
 
 #define ARGM_INDEX_MASK	 ((1 << 4) - 1)
 #define ARGM_RETURN_COPY (1 << 4)
+#define ARGM_FULL_COPY	 (1 << 5)
 
 static inline __attribute__((always_inline)) bool
 hasReturnCopy(unsigned long argm)
 {
 	return (argm & ARGM_RETURN_COPY) != 0;
+}
+
+static inline __attribute__((always_inline)) bool
+hasFullCopy(unsigned long argm)
+{
+	return (argm & ARGM_FULL_COPY) != 0;
 }
 
 static inline __attribute__((always_inline)) unsigned long

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -526,7 +526,7 @@ copy_char_buf(void *ctx, long off, unsigned long arg, int argm,
 
 	if (hasReturnCopy(argm)) {
 		u64 tid = retprobe_map_get_key(ctx);
-		retprobe_map_set(tid, arg);
+		retprobe_map_set(tid, arg, fullCopy);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
 	meta = get_arg_meta(argm, e);
@@ -672,7 +672,7 @@ copy_char_iovec(void *ctx, long off, unsigned long arg, int argm,
 
 	if (hasReturnCopy(argm)) {
 		u64 tid = retprobe_map_get_key(ctx);
-		retprobe_map_set_iovec(tid, arg, meta);
+		retprobe_map_set_iovec(tid, arg, meta, false);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
 	return __copy_char_iovec(off, arg, meta, 0, e);

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -132,9 +132,20 @@ return_stack_error(char *args, int orig, int err)
 	return sizeof(int);
 }
 
+/**
+ * Parse and read single struct iovec data
+ *
+ * @off: offset into msg_generic_kprobe::args
+ * @arg: pointer to iovec data to copy from
+ * @max: maximum bytes to read
+ * @e: pointer to struct msg_generic_kprobe
+ *
+ * Reads iovec data descriptor from @arg pointer
+ * and reads its @bytes bytes into @e->args[@off].
+ */
 static inline __attribute__((always_inline)) int
-parse_iovec_array(char *args, unsigned long arg, int i, __u64 off,
-		  unsigned long max)
+parse_iovec_array(long off, unsigned long arg, int i, unsigned long max,
+		  struct msg_generic_kprobe *e)
 {
 	struct iovec
 		iov; // limit is 1024 using a hack now. For 5.4 kernel we should loop over 1024
@@ -150,11 +161,8 @@ parse_iovec_array(char *args, unsigned long arg, int i, __u64 off,
 		size = max;
 	if (size > 4094)
 		return char_buf_toolarge;
-	asm volatile("%[off] &= 0xfff;\n"
-		     "%[size] &= 0xfff;\n" ::[off] "+r"(off),
-		     [size] "+r"(size)
-		     :);
-	err = probe_read(&args[off], size, (char *)iov.iov_base);
+	asm volatile("%[size] &= 0xfff;\n" ::[size] "+r"(size) :);
+	err = probe_read(args_off(e, off), size, (char *)iov.iov_base);
 	if (err < 0)
 		return char_buf_pagefault;
 	return size;
@@ -167,7 +175,7 @@ parse_iovec_array(char *args, unsigned long arg, int i, __u64 off,
 		/* embedding this in the loop counter breaks verifier */       \
 		if (i >= cnt)                                                  \
 			goto char_iovec_done;                                  \
-		c = parse_iovec_array(args, arg, i, off, max);                 \
+		c = parse_iovec_array(off, arg, i, max, e);                    \
 		if (c < 0)                                                     \
 			return return_stack_error(args, 0, c);                 \
 		size += c;                                                     \
@@ -578,11 +586,12 @@ filter_file_buf(struct selector_arg_filter *filter, char *args)
 }
 
 static inline __attribute__((always_inline)) long
-__copy_char_iovec(char *args, unsigned long arg, unsigned long meta,
-		  unsigned long max)
+__copy_char_iovec(long off, unsigned long arg, unsigned long meta,
+		  unsigned long max, struct msg_generic_kprobe *e)
 {
-	long size, off = 0;
-	int err, i = 0, cnt, *s = (int *)&args[off];
+	char *args = args_off(e, off);
+	long size;
+	int err, i = 0, cnt, *s = (int *)args;
 
 	err = probe_read(&cnt, sizeof(cnt), &meta);
 	if (err < 0) {
@@ -593,17 +602,16 @@ __copy_char_iovec(char *args, unsigned long arg, unsigned long meta,
 	off += 8;
 	PARSE_IOVEC_ENTRIES // may return an error directly
 		/* PARSE_IOVEC_ENTRIES will jump here when done or return error */
-		char_iovec_done : s = (int *)args;
-	s[0] = size;
+		char_iovec_done : s[0] = size;
 	s[1] = size;
 	return size + 8;
 }
 
 static inline __attribute__((always_inline)) long
-copy_char_iovec(void *ctx, char *args, unsigned long arg, int argm,
+copy_char_iovec(void *ctx, long off, unsigned long arg, int argm,
 		struct msg_generic_kprobe *e)
 {
-	int *s = (int *)&args[0];
+	int *s = (int *)args_off(e, off);
 	unsigned long meta;
 
 	meta = get_arg_meta(argm, e);
@@ -613,7 +621,7 @@ copy_char_iovec(void *ctx, char *args, unsigned long arg, int argm,
 		retprobe_map_set_iovec(tid, arg, meta);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
-	return __copy_char_iovec(args, arg, meta, 0);
+	return __copy_char_iovec(off, arg, meta, 0, e);
 }
 
 static inline __attribute__((always_inline)) long
@@ -1220,7 +1228,7 @@ read_call_arg(void *ctx, struct msg_generic_kprobe *e, int index, int type,
 		size = copy_char_buf(ctx, orig_off, arg, argm, e);
 		break;
 	case char_iovec:
-		size = copy_char_iovec(ctx, args, arg, argm, e);
+		size = copy_char_iovec(ctx, orig_off, arg, argm, e);
 		break;
 	default:
 		size = 0;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1120,7 +1120,8 @@ out:
 static inline __attribute__((always_inline)) long
 filter_read_arg(void *ctx, int index, struct bpf_map_def *heap,
 		struct bpf_map_def *filter, struct bpf_map_def *tailcalls,
-		struct bpf_map_def *override_tasks)
+		struct bpf_map_def *override_tasks,
+		struct bpf_map_def *data_heap)
 {
 	struct msg_generic_kprobe *e;
 	int pass, zero = 0;
@@ -1191,6 +1192,11 @@ filter_read_arg(void *ctx, int index, struct bpf_map_def *heap,
 			get_caps(&(enter->caps), task);
 	}
 #endif
+
+	if (data_heap && e->full_copy.cnt) {
+		tail_call(ctx, tailcalls, 11);
+		return 2;
+	}
 
 	total = e->common.size + generic_kprobe_common_size();
 	/* Code movement from clang forces us to inline bounds checks here */

--- a/pkg/api/ops/ops.go
+++ b/pkg/api/ops/ops.go
@@ -19,6 +19,8 @@ const (
 	// MSG_OP_CLONE notifies user-space that a clone() event has occurred.
 	MSG_OP_CLONE = 23
 
+	MSG_OP_DATA = 24
+
 	// just for testing
 	MSG_OP_TEST = 254
 )
@@ -43,6 +45,7 @@ func (op OpCode) String() string {
 		13:  "GenericKprobe",
 		14:  "GenericTracepoint",
 		23:  "Clone",
+		24:  "Data",
 		254: "Test",
 	}[op]
 }

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -36,6 +36,22 @@ type MsgGenericKprobeArgPath struct {
 	Flags uint32
 }
 
+type DataEventId struct {
+	Pid  uint64
+	Time uint64
+}
+
+type DataEventDesc struct {
+	Error    int32
+	Leftover uint32
+	Id       DataEventId
+}
+
+type MsgData struct {
+	Common processapi.MsgCommon
+	Id     DataEventId
+}
+
 func (m MsgGenericKprobeArgPath) GetIndex() uint64 {
 	return m.Index
 }

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -41,9 +41,15 @@ type DataEventId struct {
 	Time uint64
 }
 
+// DataEventDesc flags
+const (
+	DATA_EVENT_DESC_FLAGS_CONT = 0x1
+)
+
 type DataEventDesc struct {
 	Error    int32
 	Leftover uint32
+	Flags    uint32
 	Id       DataEventId
 }
 

--- a/pkg/bpf/loader.go
+++ b/pkg/bpf/loader.go
@@ -357,7 +357,7 @@ static int load_tailcalls(struct bpf_object *obj,
 	map_fd = bpf_map__fd(map_bpf);
 	printf("bpf fgs_kprobe_calls map and progs %s mapfd %d\n", __prog, map_fd);
 	if (map_fd >= 0) {
-		for (i = 0; i < 11; i++) {
+		for (i = 0; i < 12; i++) {
 			struct bpf_program *prog;
 			char prog_name[20];
 			char pin_name[200];

--- a/pkg/bpf/loader.go
+++ b/pkg/bpf/loader.go
@@ -519,8 +519,14 @@ int generic_kprobe_ret_loader(const int version,
 		  const char *genmapdir)
 {
 	struct bpf_object *obj;
+	char map_name[255];
+
 	obj = __loader(version, verbosity, false, btf, prog, mapdir, genmapdir, BPF_PROG_TYPE_KPROBE);
 	if (!obj)
+		return -1;
+
+	snprintf(map_name, sizeof(map_name), "%s-kp-calls", __prog);
+	if (load_tailcalls(obj, prog, __prog, "retkprobe_calls", map_name))
 		return -1;
 
 	return __kprobe_loader(obj, verbosity, false, attach, label, __prog, true);

--- a/pkg/bpf/perf_linux.go
+++ b/pkg/bpf/perf_linux.go
@@ -324,7 +324,7 @@ func DefaultPerfEventConfig() *PerfEventConfig {
 		SampleType:   PERF_SAMPLE_RAW,
 		WakeupEvents: 1,
 		NumCpus:      numCpus,
-		NumPages:     128,
+		NumPages:     16,
 	}
 }
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -44,6 +44,11 @@ spec:
                         trace output.
                       items:
                         properties:
+                          fullCopy:
+                            default: false
+                            description: This field is used only for char_buf and
+                              char_iovec types.
+                            type: boolean
                           index:
                             description: Position of the argument.
                             format: int32
@@ -97,6 +102,11 @@ spec:
                     returnArg:
                       description: A return argument to include in the trace output.
                       properties:
+                        fullCopy:
+                          default: false
+                          description: This field is used only for char_buf and char_iovec
+                            types.
+                          type: boolean
                         index:
                           description: Position of the argument.
                           format: int32
@@ -429,6 +439,11 @@ spec:
                         trace output.
                       items:
                         properties:
+                          fullCopy:
+                            default: false
+                            description: This field is used only for char_buf and
+                              char_iovec types.
+                            type: boolean
                           index:
                             description: Position of the argument.
                             format: int32

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -83,6 +83,10 @@ type KProbeArg struct {
 	// +kubebuilder:default=false
 	// This field is used only for char_buf and char_iovec types.
 	ReturnCopy bool `json:"returnCopy"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// This field is used only for char_buf and char_iovec types.
+	FullCopy bool `json:"fullCopy"`
 }
 
 type BinarySelector struct {

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"syscall"
 	"time"
@@ -35,8 +36,6 @@ const (
 	// limit is required for HTTP/2 parsing to function correctly
 	// which relies on frame ordering (it does limited reordering)
 	maxEventsPerRing = 4
-
-	perCPUBufferBytes = 65535
 
 	// Use cilium/ebpf to read events from the perf ring. Since we're
 	// incrementally rolling this out we're keeping the old code functional
@@ -189,7 +188,7 @@ func (k *Observer) runEventsNew(stopCtx context.Context, ready func()) error {
 	}
 	defer perfMap.Close()
 
-	perfReader, err := perf.NewReader(perfMap, perCPUBufferBytes)
+	perfReader, err := perf.NewReader(perfMap, k.perfConfig.NumPages*os.Getpagesize())
 	if err != nil {
 		return fmt.Errorf("creating perf array reader failed: %w", err)
 	}

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -63,6 +63,7 @@ type testObserverOptions struct {
 	config     string
 	lib        string
 	notestfail bool
+	numPages   int
 }
 
 type testExporterOptions struct {
@@ -110,6 +111,12 @@ func WithLib(lib string) TestOption {
 func withNotestfail(notestfail bool) TestOption {
 	return func(o *TestOptions) {
 		o.observer.notestfail = notestfail
+	}
+}
+
+func WithNumPages(numPages int) TestOption {
+	return func(o *TestOptions) {
+		o.observer.numPages = numPages
 	}
 }
 
@@ -211,10 +218,11 @@ func newDefaultTestOptions(t *testing.T, opts ...TestOption) *TestOptions {
 	// default values
 	options := &TestOptions{
 		observer: testObserverOptions{
-			pretty: false,
-			crd:    false,
-			config: "",
-			lib:    "",
+			pretty:   false,
+			crd:      false,
+			config:   "",
+			lib:      "",
+			numPages: 16,
 		},
 		exporter: testExporterOptions{
 			watcher:     watcher.NewFakeK8sWatcher(nil),
@@ -308,6 +316,7 @@ func getDefaultObserver(t *testing.T, opts ...TestOption) (*Observer, error) {
 
 	obs.perfConfig = bpf.DefaultPerfEventConfig()
 	obs.perfConfig.MapName = filepath.Join(observerTestDir, "tcpmon_map")
+	obs.perfConfig.NumPages = o.observer.numPages
 	return obs, nil
 }
 

--- a/pkg/sensors/bpf.go
+++ b/pkg/sensors/bpf.go
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
-package program
+
+package sensors
 
 import (
 	"fmt"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/sensors/unloader"
 )
 
@@ -31,7 +34,7 @@ type Program struct {
 	// Label is the program section name to load from program.
 	Label string
 	// PinPath is the pinned path to this program. Note this is a relative path
-	// based on the BPF directory FGS is running under.
+	// based on the BPF directory TETRAGON is running under.
 	PinPath string
 
 	// RetProbe indicates whether a kprobe is a kretprobe.
@@ -56,7 +59,7 @@ type Program struct {
 	// for example. The FD is to keep a reference to the tracepoint program in
 	// order to delete it. TODO: This can be moved into loaderData for
 	// tracepoints.
-	TraceFD int
+	traceFD int
 
 	// LoaderData represents per-type specific fields.
 	LoaderData interface{}
@@ -75,13 +78,80 @@ func (p *Program) SetLoaderData(d interface{}) *Program {
 	return p
 }
 
-func (p *Program) Unload() error {
-	if p.unloader == nil {
+// State represents the state of a BPF program or map.
+//
+// NB: Currently there is no case where we attempt to load a program that is
+// already loaded. If this changes, we can use the count as a reference count
+// to track users of a bpf program.
+type State struct {
+	//   0: idle (not loaded)
+	//   >=1: loaded, with N references
+	//  -1: disabled
+	count int
+}
+
+func Idle() State {
+	return State{0}
+}
+
+func (s *State) IsLoaded() bool {
+	return s.count > 0
+}
+
+func (s State) IsDisabled() bool {
+	return s.count == -1
+}
+
+func (s *State) SetDisabled() {
+	if s.IsLoaded() {
+		panic(fmt.Errorf("called SetDisabled() while program is loaded (cnt: %d)", s.count))
+	}
+	s.count = -1
+}
+
+func (s *State) RefInc() {
+	if s.IsDisabled() {
+		panic(fmt.Errorf("called RefInc() while program is disabled (cnt: %d)", s.count))
+	}
+	s.count++
+}
+
+func (s *State) RefDec() int {
+	if s.IsDisabled() {
+		panic(fmt.Errorf("called RefDec() while program is disabled (cnt: %d)", s.count))
+	}
+	s.count--
+	return s.count
+}
+
+// Map represents BPF maps.
+type Map struct {
+	Name      string
+	Prog      *Program
+	PinState  State
+	mapHandle *ebpf.Map
+}
+
+func MapBuilder(name string, ld *Program) *Map {
+	return &Map{name, ld, Idle(), nil}
+}
+
+func (m *Map) Unload() error {
+	log := logger.GetLogger().WithField("map", m.Name)
+	if !m.PinState.IsLoaded() || m.PinState.IsDisabled() {
+		log.WithField("count", m.PinState.count).Debug("Refusing to unload map as it is not loaded or is disabled")
 		return nil
 	}
-	if err := p.unloader.Unload(); err != nil {
-		return fmt.Errorf("Failed to unload: %s", err)
+	if count := m.PinState.RefDec(); count > 0 {
+		log.WithField("count", count).Debug("Reference exists, not unloading map yet")
+		return nil
 	}
-	p.unloader = nil
+	log.Info("map was unloaded")
+	if m.mapHandle != nil {
+		m.mapHandle.Unpin()
+		err := m.mapHandle.Close()
+		m.mapHandle = nil
+		return err
+	}
 	return nil
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -565,6 +565,7 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 			"generic_kprobe").
 			SetLoaderData(kprobeEntry.tableId)
 		load.Override = hasOverride
+		load.FullCopy = hasFullCopy
 		progs = append(progs, load)
 
 		if setRetprobe {
@@ -576,6 +577,7 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec, btfBaseFile string) 
 				"generic_kprobe").
 				SetRetProbe(true).
 				SetLoaderData(kprobeEntry.tableId)
+			loadret.FullCopy = hasFullCopy
 			progs = append(progs, loadret)
 		}
 
@@ -593,7 +595,7 @@ func loadGenericKprobe(bpfDir, mapDir string, version int, p *program.Program, b
 	progpath := filepath.Join(bpfDir, p.PinPath)
 	err, _ := bpf.LoadGenericKprobeProgram(
 		version, option.Config.Verbosity,
-		p.Override, btf,
+		p.Override, p.FullCopy, btf,
 		p.Name,
 		p.Attach,
 		p.Label,
@@ -623,7 +625,7 @@ func loadGenericKprobe(bpfDir, mapDir string, version int, p *program.Program, b
 
 func loadGenericKprobeRet(bpfDir, mapDir string, version int, p *program.Program, btf uintptr, genmapDir string) error {
 	err, _ := bpf.LoadGenericKprobeRetProgram(
-		version, option.Config.Verbosity, btf,
+		version, option.Config.Verbosity, p.FullCopy, btf,
 		p.Name,
 		p.Attach,
 		p.Label,

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2257,3 +2257,167 @@ spec:
 
 	runKprobe_char_iovec_fullCopy(t, configHook, checker, fdw, fdr, buffer)
 }
+
+const (
+	maxSizeLargeKernel = 327350
+	maxSizeSmallKernel = 261880
+)
+
+func fullCopyDataMaxSize() int {
+	if kernels.EnableLargeProgs() {
+		return maxSizeLargeKernel
+	}
+	return maxSizeSmallKernel
+}
+
+func runKprobeFullCopy_char_buf_max(t *testing.T, configHook string,
+	checker ec.MultiEventChecker, fdw, fdr int, buffer *[]byte) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cmdWaitTime)
+	defer cancel()
+
+	testConfigHook := []byte(configHook)
+	err := ioutil.WriteFile(testConfigFile, testConfigHook, 0644)
+	if err != nil {
+		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
+	}
+
+	obs, err := observer.GetDefaultObserverWithWatchers(t, observer.WithConfig(testConfigFile), observer.WithLib(tetragonLib), observer.WithNumPages(128))
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithWatchers error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	n, errno := syscall.Write(fdw, *buffer)
+	if n < 0 {
+		t.Logf("syscall.Write failed: %s\n", errno)
+		t.Fatal()
+	}
+	syscall.Fsync(fdw)
+
+	i, errno := syscall.Read(fdr, *buffer)
+	if i < 0 {
+		t.Logf("syscall.Read failed: %s\n", errno)
+		t.Fatal()
+	}
+
+	err = observer.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobe_char_buf_fullCopy_max(t *testing.T) {
+	fdw, fdr, _ := createTestFile(t)
+	pidStr := strconv.Itoa(int(observer.GetMyPid()))
+
+	configHook := `
+apiVersion: hubble-enterprise.io/v1
+metadata:
+  name: "sys_write_read"
+spec:
+  kprobes:
+  - call: "__x64_sys_write"
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "char_buf"
+      sizeArgIndex: 3
+      fullCopy: true
+    - index: 2
+      type: "size_t"
+    selectors:
+    - matchPIDs:
+      - operator: In
+        followForks: true
+        values:
+        - ` + pidStr + `
+      matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - ` + fmt.Sprint(fdw)
+
+	size := 100 * 4096
+	buffer := make([]byte, size)
+
+	for i := 0; i < size; i++ {
+		buffer[i] = 'A' + byte(i%26)
+	}
+
+	checkSize := fullCopyDataMaxSize()
+	check := buffer[:checkSize]
+
+	kpChecker := ec.NewProcessKprobeChecker().
+		WithFunctionName(sm.Full("__x64_sys_write")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithIntArg(int32(fdw)),
+				ec.NewKprobeArgumentChecker().WithBytesArg(bc.Full(check)),
+				ec.NewKprobeArgumentChecker().WithSizeArg(uint64(size)),
+			))
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	runKprobeFullCopy_char_buf_max(t, configHook, checker, fdw, fdr, &buffer)
+}
+
+func TestKprobe_char_buf_fullCopy_max_returnCopy(t *testing.T) {
+	fdw, fdr, _ := createTestFile(t)
+	pidStr := strconv.Itoa(int(observer.GetMyPid()))
+
+	configHook := `
+apiVersion: hubble-enterprise.io/v1
+metadata:
+  name: "sys_write_read"
+spec:
+  kprobes:
+  - call: "__x64_sys_read"
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "char_buf"
+      returnCopy: true
+      fullCopy: true
+    - index: 2
+      type: "size_t"
+    selectors:
+    - matchPIDs:
+      - operator: In
+        followForks: true
+        values:
+        - ` + pidStr + `
+      matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - ` + fmt.Sprint(fdr)
+
+	size := 100 * 4096
+	buffer := make([]byte, size)
+
+	for i := 0; i < size; i++ {
+		buffer[i] = 'A' + byte(i%26)
+	}
+
+	checkSize := fullCopyDataMaxSize()
+	check := buffer[:checkSize]
+
+	kpChecker := ec.NewProcessKprobeChecker().
+		WithFunctionName(sm.Full("__x64_sys_read")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithIntArg(int32(fdr)),
+				ec.NewKprobeArgumentChecker().WithBytesArg(bc.Full(check)),
+				ec.NewKprobeArgumentChecker().WithSizeArg(uint64(size)),
+			))
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	runKprobeFullCopy_char_buf_max(t, configHook, checker, fdw, fdr, &buffer)
+}

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2091,3 +2091,169 @@ spec:
 
 	runKprobeFullCopy_char_buf(t, configHook, checker, fdw, fdr, &buffer)
 }
+
+func runKprobe_char_iovec_fullCopy(t *testing.T, configHook string,
+	checker ec.MultiEventChecker, fdw, fdr int, buffer []byte) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cmdWaitTime)
+	defer cancel()
+
+	testConfigHook := []byte(configHook)
+	err := ioutil.WriteFile(testConfigFile, testConfigHook, 0644)
+	if err != nil {
+		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
+	}
+
+	obs, err := observer.GetDefaultObserverWithWatchers(t, observer.WithConfig(testConfigFile),
+		observer.WithLib(tetragonLib), observer.WithNumPages(64))
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithWatchers error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	var iovw = make([][]byte, 4)
+	var iovr = make([][]byte, 7)
+
+	// write 200000B
+	iovw[0] = make([]byte, 10000)
+	iovw[1] = make([]byte, 40000)
+	iovw[2] = make([]byte, 50000)
+	iovw[3] = make([]byte, 100000)
+
+	copy(iovw[0], buffer)
+	copy(iovw[1], buffer[10000:])
+	copy(iovw[2], buffer[50000:])
+	copy(iovw[3], buffer[100000:])
+
+	_, err = unix.Writev(fdw, iovw)
+	assert.NoError(t, err)
+
+	syscall.Fsync(fdw)
+
+	// read 210000B
+	iovr[0] = make([]byte, 10000)
+	iovr[1] = make([]byte, 40000)
+	iovr[2] = make([]byte, 50000)
+	iovr[3] = make([]byte, 10000)
+	iovr[4] = make([]byte, 40000)
+	iovr[5] = make([]byte, 50000)
+	iovr[6] = make([]byte, 10000)
+
+	_, err = unix.Readv(fdr, iovr)
+	assert.NoError(t, err)
+
+	err = observer.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobe_char_iovec_fullCopy(t *testing.T) {
+	fdw, fdr, _ := createTestFile(t)
+	pidStr := strconv.Itoa(int(observer.GetMyPid()))
+
+	configHook := `
+apiVersion: hubble-enterprise.io/v1
+metadata:
+  name: "sys_write_writev"
+spec:
+  kprobes:
+  - call: "__x64_sys_writev"
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "char_iovec"
+      sizeArgIndex: 3
+      fullCopy: true
+    - index: 2
+      type: "int"
+    selectors:
+    - matchPIDs:
+      - operator: In
+        followForks: true
+        values:
+        - ` + pidStr + `
+      matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - ` + fmt.Sprint(fdw)
+
+	size := 200000
+	buffer := make([]byte, size)
+
+	for i := 0; i < size; i++ {
+		buffer[i] = 'A' + byte(i%26)
+	}
+
+	kpChecker := ec.NewProcessKprobeChecker().
+		WithFunctionName(sm.Full("__x64_sys_writev")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithIntArg(int32(fdw)),
+				ec.NewKprobeArgumentChecker().WithBytesArg(bc.Full(buffer)),
+				ec.NewKprobeArgumentChecker().WithSizeArg(4),
+			))
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	runKprobe_char_iovec_fullCopy(t, configHook, checker, fdw, fdr, buffer)
+}
+
+func TestKprobe_char_iovec_fullCopy_returnCopy(t *testing.T) {
+	fdw, fdr, _ := createTestFile(t)
+	pidStr := strconv.Itoa(int(observer.GetMyPid()))
+
+	configHook := `
+apiVersion: hubble-enterprise.io/v1
+metadata:
+  name: "sys_write_read"
+spec:
+  kprobes:
+  - call: "__x64_sys_readv"
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "char_iovec"
+      returnCopy: true
+      sizeArgIndex: 3
+      fullCopy: true
+    - index: 2
+      type: "size_t"
+    selectors:
+    - matchPIDs:
+      - operator: In
+        followForks: true
+        values:
+        - ` + pidStr + `
+      matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - ` + fmt.Sprint(fdr)
+
+	size := 200000
+	buffer := make([]byte, size)
+
+	for i := 0; i < size; i++ {
+		buffer[i] = 'A' + byte(i%26)
+	}
+
+	kpChecker := ec.NewProcessKprobeChecker().
+		WithFunctionName(sm.Full("__x64_sys_readv")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithIntArg(int32(fdr)),
+				ec.NewKprobeArgumentChecker().WithBytesArg(bc.Full(buffer)),
+				ec.NewKprobeArgumentChecker().WithSizeArg(7),
+			))
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	runKprobe_char_iovec_fullCopy(t, configHook, checker, fdw, fdr, buffer)
+}


### PR DESCRIPTION


Adding support to send to user space 'full lenght' of arguments
data for char_buf and char_iovec types.

Such argument needs to be marked with 'fullCopy' flag, like:

```
  - call: "__x64_sys_writev"
    syscall: true
    args:
    - index: 0
      type: "int"
    - index: 1
      type: "char_iovec"
      sizeArgIndex: 3
      fullCopy: true
    - index: 2
      type: "int"
```
For each pointer (argument can have more pointers for char_iovec)
we can now download following amount of data:

on large kernel: 327350 bytes
on non-large kernel: 261880 bytes

The copy program is separate tail call bpf program which is loaded
only when the argument is marked with fullCopy.

Signed-off-by: Jiri Olsa [jolsa@kernel.org](mailto:jolsa@kernel.org)
