### PR TITLE
.github: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+    rebase-strategy: disabled
+    ignore:
+      - dependency-name: "github.com/cilium/cilium"
+      - dependency-name: "github.com/cilium/hubble"
+        # k8s dependencies will be updated manually all at once
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/*"
+    labels:
+    - enhancement
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+    rebase-strategy: disabled
+    labels:
+    - enhancement


### PR DESCRIPTION
Let dependabot update Go modules and GH actions automatically. Exclude
cilium, hubble and the k8s Go modules though. These should be bumped in
lockstep, manually and explicitly because they likely also need
additional changes.