### PR TITLE
metrics: export raw metric maps

### DIFF
--- a/api/v1/tetragon/codegen/eventcache/eventcache.pb.go
+++ b/api/v1/tetragon/codegen/eventcache/eventcache.pb.go
@@ -25,7 +25,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessExec")
+			eventcachemetrics.ProcessInfoErrorInc("ProcessExec")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
@@ -38,7 +38,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessExit")
+			eventcachemetrics.ProcessInfoErrorInc("ProcessExit")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
@@ -51,7 +51,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessKprobe")
+			eventcachemetrics.ProcessInfoErrorInc("ProcessKprobe")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
@@ -64,7 +64,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessTracepoint")
+			eventcachemetrics.ProcessInfoErrorInc("ProcessTracepoint")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{
@@ -77,7 +77,7 @@ func DoHandleEvent(event eventObj, internal *process.ProcessInternal, labels []s
 		if internal != nil {
 			e.Process = internal.GetProcessCopy()
 		} else {
-			eventcachemetrics.ProcessInfoErrorTotalInc("ProcessDns")
+			eventcachemetrics.ProcessInfoErrorInc("ProcessDns")
 			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		}
 		return &tetragon.GetEventsResponse{

--- a/cmd/protoc-gen-go-tetragon/eventcache/eventcache.go
+++ b/cmd/protoc-gen-go-tetragon/eventcache/eventcache.go
@@ -29,7 +29,7 @@ func generateDoHandleEvents(g *protogen.GeneratedFile, f *protogen.File) error {
 
 	incErrorCount := common.TetragonIdent(g, "pkg/metrics/errormetrics", "ErrorTotalInc")
 	mInfoFailed := common.TetragonIdent(g, "pkg/metrics/errormetrics", "EventCacheProcessInfoFailed")
-	incProcessInfoErrors := common.TetragonIdent(g, "pkg/metrics/eventcachemetrics", "ProcessInfoErrorTotalInc")
+	incProcessInfoErrors := common.TetragonIdent(g, "pkg/metrics/eventcachemetrics", "ProcessInfoErrorInc")
 
 	g.P(`func DoHandleEvent(event eventObj, internal *` + tetragonProcessInternal + `, labels []string, nodeName string, timestamp *` + timestamp + `) (*` + tetragonGER + `, error) {
         switch e := event.(type) {`)

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -42,35 +42,35 @@ var (
 	ExecMissingParent ErrorType = "exec_missing_parent"
 )
 
-// Get a new handle on an errorsTotal metric for an ErrorType
-func ErrorTotal(t ErrorType) prometheus.Counter {
-	return errorsTotal.WithLabelValues(string(t))
-}
-
-// Increment an errorsTotal for an ErrorType
-func ErrorTotalInc(t ErrorType) {
-	ErrorTotal(t).Inc()
-}
-
-// Get a new handle on an eventCacheCount metric for an ErrorType
-func EventCache(t ErrorType) prometheus.Counter {
-	return eventCacheCount.WithLabelValues(string(t))
-}
-
-// Increment an eventCacheCount for an ErrorType
-func EventCacheInc(t ErrorType) {
-	ErrorTotal(t).Inc()
-}
-
 var (
-	errorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	ErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "errors_total",
 		Help:        "The total number of Tetragon errors. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
-	eventCacheCount = promauto.NewCounterVec(prometheus.CounterOpts{
+	EventCacheCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "event_cache",
 		Help:        "The total number of Tetragon event cache access/errors. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
 )
+
+// Get a new handle on an errorsTotal metric for an ErrorType
+func GetErrorTotal(t ErrorType) prometheus.Counter {
+	return ErrorTotal.WithLabelValues(string(t))
+}
+
+// Increment an errorsTotal for an ErrorType
+func ErrorTotalInc(t ErrorType) {
+	GetErrorTotal(t).Inc()
+}
+
+// Get a new handle on an eventCacheCount metric for an ErrorType
+func EventCache(t ErrorType) prometheus.Counter {
+	return EventCacheCount.WithLabelValues(string(t))
+}
+
+// Increment an eventCacheCount for an ErrorType
+func EventCacheInc(t ErrorType) {
+	EventCache(t).Inc()
+}

--- a/pkg/metrics/eventcachemetrics/eventcachemetrics.go
+++ b/pkg/metrics/eventcachemetrics/eventcachemetrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	processInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+	ProcessInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "process_info_errors",
 		Help:        "The total of times we failed to fetch cached process info for a given event type.",
 		ConstLabels: nil,
@@ -18,11 +18,11 @@ var (
 )
 
 // Get a new handle on an processInfoErrors metric for an eventType
-func ProcessInfoErrorTotal(eventType string) prometheus.Counter {
-	return processInfoErrors.WithLabelValues(eventType)
+func GetProcessInfoError(eventType string) prometheus.Counter {
+	return ProcessInfoErrors.WithLabelValues(eventType)
 }
 
 // Increment an errorsTotal for an eventType
-func ProcessInfoErrorTotalInc(eventType string) {
-	ProcessInfoErrorTotal(eventType).Inc()
+func ProcessInfoErrorInc(eventType string) {
+	GetProcessInfoError(eventType).Inc()
 }

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -20,17 +20,17 @@ import (
 )
 
 var (
-	eventsProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
+	EventsProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "events_total",
 		Help:        "The total number of Tetragon events",
 		ConstLabels: nil,
 	}, []string{"type", "namespace", "pod", "binary"})
-	flagCount = promauto.NewCounterVec(prometheus.CounterOpts{
+	FlagCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "flags_total",
 		Help:        "The total number of Tetragon flags. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
-	dnsRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	DnsRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: consts.MetricNamePrefix + "dns_total",
 		Help: "Dns request/response statistics",
 	}, []string{"namespace", "pod", "binary", "names", "rcodes", "response"})
@@ -54,7 +54,7 @@ func handleOriginalEvent(originalEvent interface{}) {
 		flags = msg.Process.Flags
 	}
 	for _, flag := range exec.DecodeCommonFlags(flags) {
-		flagCount.WithLabelValues(flag).Inc()
+		FlagCount.WithLabelValues(flag).Inc()
 	}
 }
 
@@ -73,7 +73,7 @@ func postDnsMetric(ev *tetragon.GetEventsResponse, res *tetragon.ProcessDns) {
 		rr = "Request"
 	}
 
-	dnsRequestTotal.WithLabelValues(ns, pod, binary, names, codes, rr).Inc()
+	DnsRequestTotal.WithLabelValues(ns, pod, binary, names, codes, rr).Inc()
 }
 
 func handleDnsEvent(processedEvent interface{}) {
@@ -100,7 +100,7 @@ func handleProcessedEvent(processedEvent interface{}) {
 	default:
 		eventType = "unknown"
 	}
-	eventsProcessed.WithLabelValues(eventType, namespace, pod, binary).Inc()
+	EventsProcessed.WithLabelValues(eventType, namespace, pod, binary).Inc()
 }
 
 func ProcessEvent(originalEvent interface{}, processedEvent interface{}) {

--- a/pkg/metrics/eventmetrics/eventmetrics_test.go
+++ b/pkg/metrics/eventmetrics/eventmetrics_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHandleProcessedEvent(t *testing.T) {
-	assert.NoError(t, testutil.CollectAndCompare(eventsProcessed, strings.NewReader("")))
+	assert.NoError(t, testutil.CollectAndCompare(EventsProcessed, strings.NewReader("")))
 	handleProcessedEvent(nil)
 	// empty process
 	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: &tetragon.ProcessKprobe{}}})
@@ -92,13 +92,13 @@ tetragon_events_total{binary="binary_d",namespace="namespace_d",pod="pod_d",type
 tetragon_events_total{binary="binary_e",namespace="",pod="",type="PROCESS_EXIT"} 1
 tetragon_events_total{binary="binary_e",namespace="namespace_e",pod="pod_e",type="PROCESS_EXIT"} 1
 `)
-	assert.NoError(t, testutil.CollectAndCompare(eventsProcessed, expected))
+	assert.NoError(t, testutil.CollectAndCompare(EventsProcessed, expected))
 }
 
 func TestHandleOriginalEvent(t *testing.T) {
 	handleOriginalEvent(nil)
 	handleOriginalEvent(&processapi.MsgExecveEventUnix{})
-	assert.NoError(t, testutil.CollectAndCompare(flagCount, strings.NewReader("")))
+	assert.NoError(t, testutil.CollectAndCompare(FlagCount, strings.NewReader("")))
 	handleOriginalEvent(&processapi.MsgExecveEventUnix{
 		Process: processapi.MsgProcess{
 			Flags: api.EventClone | api.EventExecve,
@@ -109,5 +109,5 @@ func TestHandleOriginalEvent(t *testing.T) {
 tetragon_flags_total{type="clone"} 1
 tetragon_flags_total{type="execve"} 1
 `)
-	assert.NoError(t, testutil.CollectAndCompare(flagCount, expected))
+	assert.NoError(t, testutil.CollectAndCompare(FlagCount, expected))
 }

--- a/pkg/metrics/kprobemetrics/kprobemetrics.go
+++ b/pkg/metrics/kprobemetrics/kprobemetrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	mergeErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+	MergeErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "generic_kprobe_merge_errors",
 		Help:        "The total number of failed attempts to merge a kprobe and kretprobe event.",
 		ConstLabels: nil,
@@ -19,12 +19,12 @@ var (
 
 // Get a new handle on the mergeErrors metric for a current and previous function
 // name and probe type
-func MergeErrors(currFn, currType, prevFn, prevType string) prometheus.Counter {
-	return mergeErrors.WithLabelValues(currFn, currType, prevFn, prevType)
+func GetMergeErrors(currFn, currType, prevFn, prevType string) prometheus.Counter {
+	return MergeErrors.WithLabelValues(currFn, currType, prevFn, prevType)
 }
 
 // Increment the mergeErrors metric for a current and previous function
 // name and probe type
 func MergeErrorsInc(currFn, currType, prevFn, prevType string) {
-	MergeErrors(currFn, currType, prevFn, prevType).Inc()
+	GetMergeErrors(currFn, currType, prevFn, prevType).Inc()
 }

--- a/pkg/metrics/mapmetrics/mapmetrics.go
+++ b/pkg/metrics/mapmetrics/mapmetrics.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	mapSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	MapSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        consts.MetricNamePrefix + "map_in_use_gauge",
 		Help:        "The total number of in-use entries per map.",
 		ConstLabels: nil,
@@ -20,16 +20,16 @@ var (
 )
 
 // Get a new handle on a mapSize metric for a mapName and totalCapacity
-func MapSize(mapName string, totalCapacity int) prometheus.Gauge {
-	return mapSize.WithLabelValues(mapName, fmt.Sprint(totalCapacity))
+func GetMapSize(mapName string, totalCapacity int) prometheus.Gauge {
+	return MapSize.WithLabelValues(mapName, fmt.Sprint(totalCapacity))
 }
 
 // Increment a mapSize metric for a mapName and totalCapacity
 func MapSizeInc(mapName string, totalCapacity int) {
-	MapSize(mapName, totalCapacity).Inc()
+	GetMapSize(mapName, totalCapacity).Inc()
 }
 
 // Set a mapSize metric to size for a mapName and totalCapacity
 func MapSizeSet(mapName string, totalCapacity int, size float64) {
-	MapSize(mapName, totalCapacity).Set(size)
+	GetMapSize(mapName, totalCapacity).Set(size)
 }

--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	msgOpsCount = promauto.NewCounterVec(prometheus.CounterOpts{
+	MsgOpsCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "msg_op_total",
 		Help:        "The total number of times we encounter a given message opcode. For internal use only.",
 		ConstLabels: nil,
@@ -19,11 +19,11 @@ var (
 )
 
 // Get a new handle on a msgOpsCount metric for an OpCode
-func OpTotal(op ops.OpCode) prometheus.Counter {
-	return msgOpsCount.WithLabelValues(op.String())
+func GetOpTotal(op ops.OpCode) prometheus.Counter {
+	return MsgOpsCount.WithLabelValues(op.String())
 }
 
 // Increment an msgOpsCount for an OpCode
 func OpTotalInc(op ops.OpCode) {
-	OpTotal(op).Inc()
+	GetOpTotal(op).Inc()
 }

--- a/pkg/metrics/processexecmetrics/processexecmetrics.go
+++ b/pkg/metrics/processexecmetrics/processexecmetrics.go
@@ -10,12 +10,12 @@ import (
 )
 
 var (
-	missingParentErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+	MissingParentErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "exec_missing_parent_errors",
 		Help:        "The total of times a given parent exec id could not be found in an exec event.",
 		ConstLabels: nil,
 	}, []string{"parent_exec_id"})
-	sameExecIdErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+	SameExecIdErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        consts.MetricNamePrefix + "exec_parent_child_same_id_errors",
 		Help:        "The total of times an error occurs due to a parent and child process have the same exec id.",
 		ConstLabels: nil,
@@ -23,21 +23,21 @@ var (
 )
 
 // Get a new handle on the missingParentErrors metric for an execId
-func MissingParent(execId string) prometheus.Counter {
-	return missingParentErrors.WithLabelValues(execId)
+func GetMissingParent(execId string) prometheus.Counter {
+	return MissingParentErrors.WithLabelValues(execId)
 }
 
 // Increment the missingParentErrors metric for an execId
 func MissingParentInc(execId string) {
-	MissingParent(execId).Inc()
+	GetMissingParent(execId).Inc()
 }
 
 // Get a new handle on the sameExecIdErrors metric for an execId
-func SameExecId(execId string) prometheus.Counter {
-	return sameExecIdErrors.WithLabelValues(execId)
+func GetSameExecId(execId string) prometheus.Counter {
+	return SameExecIdErrors.WithLabelValues(execId)
 }
 
 // Increment the sameExecIdErrors metric for an execId
 func SameExecIdInc(execId string) {
-	SameExecId(execId).Inc()
+	GetSameExecId(execId).Inc()
 }

--- a/pkg/metrics/ringbufmetrics/ringbufmetrics.go
+++ b/pkg/metrics/ringbufmetrics/ringbufmetrics.go
@@ -10,17 +10,17 @@ import (
 )
 
 var (
-	ringbufPerfEventReceived = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	PerfEventReceived = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_received",
 		Help:        "The total number of Tetragon ringbuf perf events received.",
 		ConstLabels: nil,
 	}, nil)
-	ringbufPerfEventLost = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	PerfEventLost = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_lost",
 		Help:        "The total number of Tetragon ringbuf perf events lost.",
 		ConstLabels: nil,
 	}, nil)
-	ringbufPerfEventErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	PerfEventErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_errors",
 		Help:        "The total number of Tetragon ringbuf perf event error count.",
 		ConstLabels: nil,
@@ -28,31 +28,31 @@ var (
 )
 
 // Get a new handle on the metric for received events
-func Received() prometheus.Gauge {
-	return ringbufPerfEventReceived.WithLabelValues()
+func GetReceived() prometheus.Gauge {
+	return PerfEventReceived.WithLabelValues()
 }
 
 // Get a new handle on the metric for received events
 func ReceivedSet(val float64) {
-	Received().Set(val)
+	GetReceived().Set(val)
 }
 
 // Get a new handle on the metric for lost events
-func Lost() prometheus.Gauge {
-	return ringbufPerfEventLost.WithLabelValues()
+func GetLost() prometheus.Gauge {
+	return PerfEventLost.WithLabelValues()
 }
 
 // Get a new handle on the metric for lost events
 func LostSet(val float64) {
-	Lost().Set(val)
+	GetLost().Set(val)
 }
 
 // Get a new handle on the metric for ringbuf errors
-func Errors() prometheus.Gauge {
-	return ringbufPerfEventErrors.WithLabelValues()
+func GetErrors() prometheus.Gauge {
+	return PerfEventErrors.WithLabelValues()
 }
 
 // Get a new handle on the metric for ringbuf errors
 func ErrorsSet(val float64) {
-	Errors().Set(val)
+	GetErrors().Set(val)
 }


### PR DESCRIPTION
It's useful to export raw metric maps in case we need to do any more complex operations
that are not already exposed by helpers. So let's export them. This also matches the old
behaviour before bd4aada1.

Signed-off-by: William Findlay <will@isovalent.com>