### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Request a review from the Tetragon team on any PR
+* @cilium/tetragon
+
+# Request a review from William when codegen is edited
+cmd/protoc-gen-go-tetragon/ @willfindlay
+
+# Request a review from William when CI is edited
+.github/workflows/ @willfindlay


### PR DESCRIPTION
Adding a CODEOWNERS file to make sure the right people get tagged for reviews. For now
I've just added myself for CI and codegen, but others should feel free to add themselves
where it makes sense.

Signed-off-by: William Findlay <will@isovalent.com>