### PR TITLE
Fix for NotIn operator in matchCapabilities selector

### DIFF
--- a/bpf/process/pfilter.h
+++ b/bpf/process/pfilter.h
@@ -258,11 +258,10 @@ process_filter_capabilities(__u32 ty, __u32 op, __u32 ns, __u64 val, void *heap)
 
 	caps = msg->caps.c[ty];
 
-	/* if op == op_filter_in we care for all bits in vals that are set */
-	if (op == op_filter_notin)
-		val = ~val; /* for op_filter_notin we care for all the rest bits */
-
-	return (caps & val) ? PFILTER_ACCEPT : PFILTER_REJECT;
+	if (op == op_filter_in)
+		return (caps & val) ? PFILTER_ACCEPT : PFILTER_REJECT;
+	return (caps & val) ? PFILTER_REJECT :
+			      PFILTER_ACCEPT; /* op_filter_notin */
 }
 
 #ifdef __CAP_CHANGES_FILTER

--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -2,3 +2,4 @@ capabilities-tester
 fork-tester
 namespace-tester
 sigkill-tester
+dup-tester

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -274,6 +274,39 @@ spec:
 	runKprobeObjectWriteRead(t, writeReadHook)
 }
 
+func TestKprobeObjectWriteCapsNotIn(t *testing.T) {
+	writeReadHook := `
+apiVersion: cilium.io/v1alpha1
+metadata:
+  name: "sys_write"
+spec:
+  kprobes:
+  - call: "__x64_sys_write"
+    return: false
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "char_buf"
+      sizeArgIndex: 3
+    - index: 2
+      type: "size_t"
+    selectors:
+    - matchCapabilities:
+      - type: Inheritable # these are 0x00 for root
+        operator: NotIn
+        values:
+        - "CAP_SYS_ADMIN"
+      matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "1"
+`
+	runKprobeObjectWriteRead(t, writeReadHook)
+}
+
 func TestKprobeObjectWriteReadNsOnly(t *testing.T) {
 	myPid := observer.GetMyPid()
 	mntNsStr := strconv.FormatUint(uint64(namespace.GetPidNsInode(myPid, "mnt")), 10)


### PR DESCRIPTION
Add a test for `NotIn` operator in `matchCapabilities` selector and fix an issue with that. 

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>