### PR TITLE
Fix runtime panic when config file is empty

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -198,14 +198,20 @@ func hubbleTETRAGONExecute() error {
 	if enableK8sAPI {
 		go crd.WatchTracePolicy(ctx, observer.SensorManager)
 	}
-	cnf, err := readConfig(configFile)
-	if err != nil {
-		return err
+
+	var startSensors []*sensors.Sensor
+	if len(configFile) > 0 {
+		cnf, err := readConfig(configFile)
+		if err != nil {
+			return err
+		}
+
+		startSensors, err = sensors.GetSensorsFromParserPolicy(&cnf.Spec)
+		if err != nil {
+			return err
+		}
 	}
-	startSensors, err := sensors.GetSensorsFromParserPolicy(&cnf.Spec)
-	if err != nil {
-		return err
-	}
+
 	return obs.Start(ctx, startSensors)
 }
 


### PR DESCRIPTION
When the config file is not specified a runtime panic occcured, as
we tried to dereference the nil config object.

Signed-off-by: Thomas Schubart <thomas@gitpod.io>

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x17d16ca]

goroutine 1 [running]:
main.hubbleTETRAGONExecute()
	/go/src/github.com/cilium/tetragon/cmd/tetragon/main.go:208 +0xa0a
main.execute.func1(0xc00011a780, {0x1d78f14, 0x1, 0x1})
	/go/src/github.com/cilium/tetragon/cmd/tetragon/main.go:314 +0x8a
github.com/spf13/cobra.(*Command).execute(0xc00011a780, {0xc000132010, 0x1, 0x1})
	/go/src/github.com/cilium/tetragon/vendor/github.com/spf13/cobra/command.go:856 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc00011a780)
	/go/src/github.com/cilium/tetragon/vendor/github.com/spf13/cobra/command.go:960 +0x3ad
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/cilium/tetragon/vendor/github.com/spf13/cobra/command.go:897
main.execute()
	/go/src/github.com/cilium/tetragon/cmd/tetragon/main.go:394 +0x9be
main.main()
	/go/src/github.com/cilium/tetragon/cmd/tetragon/tetragon.go:11 +0x19ru
```