### PR TITLE
fix: (helm) service template now respects defined port and is only templated if prometheus is enabled

### DIFF
--- a/install/kubernetes/templates/service.yaml
+++ b/install/kubernetes/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tetragon.prometheus.enabled -}}
 ---
 apiVersion: v1
 kind: Service
@@ -15,7 +16,7 @@ spec:
     - name: metrics
       port: 2112
       protocol: TCP
-      targetPort: 2112
+      targetPort: {{ .Values.tetragon.prometheus.port }}
   selector:
     {{- with .Values.daemonSetLabelsOverride}}
     {{- toYaml . | nindent 4 }}
@@ -23,3 +24,4 @@ spec:
     {{- include "tetragon.labels" . | nindent 4 }}
     {{- end }}
   type: ClusterIP
+{{- end }}


### PR DESCRIPTION
I've noticed that the service port as defined in `values.yaml` is not respected. As such I created a pull request to respect the value and, by doing so, noticed that the service is only used for metrics. Therefore the service can also be only templated if `prometheus.enabled` is `true`.

Let me know if anything is wrong.
