### PR TITLE
test improvements, and avoiding retries in event tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO := go
+GO ?= go
 INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
 CONTAINER_ENGINE ?= docker

--- a/bpf/test/bpf_lseek.c
+++ b/bpf/test/bpf_lseek.c
@@ -48,6 +48,7 @@ test_lseek(struct sys_enter_lseek_args *ctx)
 		msg.common.op = MSG_OP_TEST;
 		msg.common.ktime = ktime_get_ns();
 		msg.common.size = size;
+		msg.arg0 = get_smp_processor_id();
 		perf_event_output(ctx, &tcpmon_map, BPF_F_CURRENT_CPU, &msg,
 				  size);
 	}

--- a/bpf/test/bpf_lseek.c
+++ b/bpf/test/bpf_lseek.c
@@ -42,7 +42,7 @@ test_lseek(struct sys_enter_lseek_args *ctx)
 {
 	// NB: this values should match BogusFd and  BogusWhenceVal in
 	// pkg/sensrors/test
-	if (ctx->fd == -1 && ctx->whence == 4444) {
+	if (ctx->fd == -1 && ctx->whence == 4729) {
 		struct msg_test msg = { 0 };
 		size_t size = sizeof(msg);
 		msg.common.op = MSG_OP_TEST;

--- a/bpf/test/bpf_lseek.c
+++ b/bpf/test/bpf_lseek.c
@@ -40,6 +40,8 @@ char _license[] __attribute__((section(("license")), used)) = "GPL";
 __attribute__((section(("tracepoint/sys_enter_lseek")), used)) int
 test_lseek(struct sys_enter_lseek_args *ctx)
 {
+	// NB: this values should match BogusFd and  BogusWhenceVal in
+	// pkg/sensrors/test
 	if (ctx->fd == -1 && ctx->whence == 4444) {
 		struct msg_test msg = { 0 };
 		size_t size = sizeof(msg);

--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -3,3 +3,4 @@ fork-tester
 namespace-tester
 sigkill-tester
 dup-tester
+trigger-test-events

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -5,7 +5,8 @@ PROGS = sigkill-tester \
 	capabilities-tester \
 	namespace-tester \
 	fork-tester \
-	dup-tester
+	dup-tester \
+	trigger-test-events
 
 all: $(PROGS)
 

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -1,24 +1,19 @@
 
 GCC ?= gcc
 
-PROGS = sigkill-tester capabilities-tester namespace-tester fork-tester dup-tester
+PROGS = sigkill-tester \
+	capabilities-tester \
+	namespace-tester \
+	fork-tester \
+	dup-tester
 
 all: $(PROGS)
 
-sigkill-tester: sigkill-tester.c
-	$(GCC) -Wall -o sigkill-tester sigkill-tester.c
+%: %.c
+	$(GCC) -Wall $< -o $@
 
 capabilities-tester: capabilities-tester.c
 	$(GCC) -Wall $< -o $@ -lcap
-
-namespace-tester: namespace-tester.c
-	$(GCC) -Wall $< -o $@
-
-fork-tester: fork-tester.c
-	$(GCC) -Wall $< -o $@
-
-dup-tester: dup-tester.c
-	$(GCC) -Wall $< -o $@
 
 .PHONY: clean
 clean:

--- a/contrib/tester-progs/trigger-test-events.c
+++ b/contrib/tester-progs/trigger-test-events.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
 			if (CPU_ISSET(c, &mask)) {
 				printf("cpu:%d\n", c);
 				setaffinity_oncpu(c);
-				syscall(SYS_lseek, (uintptr_t)-1, 0, 4444);
+				syscall(SYS_lseek, (uintptr_t)-1, 0, 4729);
 				break;
 			}
 		}

--- a/contrib/tester-progs/trigger-test-events.c
+++ b/contrib/tester-progs/trigger-test-events.c
@@ -1,0 +1,51 @@
+/*
+ * trigger-test-event: trigger a test event on all CPUs
+ */
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <stdio.h>
+#include <sched.h>
+#include <string.h>
+#include <unistd.h>
+#include <syscall.h>
+#include <inttypes.h>
+
+void setaffinity_oncpu(unsigned int cpu)
+{
+	cpu_set_t cpu_mask;
+	int err;
+
+	CPU_ZERO(&cpu_mask);
+	CPU_SET(cpu, &cpu_mask);
+
+	err = sched_setaffinity(0, sizeof(cpu_set_t), &cpu_mask);
+	if (err) {
+		perror("sched_setaffinity");
+		exit(1);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	cpu_set_t mask;
+	int err = sched_getaffinity(0, sizeof(cpu_set_t), &mask);
+	if (err < 0) {
+		perror("sched_getaffinity");
+		exit(1);
+	}
+
+	unsigned int ncpus = CPU_COUNT(&mask);
+	unsigned int cpu_cur = 0;
+	printf("ncpus:%d\n", ncpus);
+	for (unsigned int i=0; i<ncpus; i++) {
+		while (1) {
+			unsigned int c = cpu_cur++;
+			if (CPU_ISSET(c, &mask)) {
+				printf("cpu:%d\n", c);
+				setaffinity_oncpu(c);
+				syscall(SYS_lseek, (uintptr_t)-1, 0, 4444);
+				break;
+			}
+		}
+	}
+}

--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -73,11 +73,6 @@ func SetMapPrefix(path string) {
 	mapPrefix = path
 }
 
-func GetMapPrefix() string {
-	once.Do(lockDown)
-	return mapPrefix
-}
-
 func MapPrefixPath() string {
 	once.Do(lockDown)
 	return filepath.Join(mapRoot, mapPrefix)

--- a/pkg/observer/observer_test_json.go
+++ b/pkg/observer/observer_test_json.go
@@ -64,7 +64,7 @@ func JsonCheck(jsonFile *os.File, checker ec.MultiEventChecker, log *logrus.Logg
 		matchPrefix := fmt.Sprintf("%sevent:%s", prefix, eType)
 		done, err := ec.NextResponseCheck(checker, &ev, log)
 		if done && err == nil {
-			log.Infof("%s =>  FINAL MATCH ", matchPrefix)
+			log.Infof("%s =>  FINAL MATCH", matchPrefix)
 			log.Infof("jsonTestCheck: DONE!")
 			return nil
 		} else if err == nil {

--- a/pkg/sensors/sync.go
+++ b/pkg/sensors/sync.go
@@ -107,7 +107,6 @@ func StartSensorManager(bpfDir, mapDir, ciliumDir string) (*Manager, error) {
 				err = nil
 				for _, s := range sensors {
 					if s.Loaded {
-						fmt.Printf("s.Loaded failed: %s\n", op.name)
 						err = fmt.Errorf("sensor %s enabled, please disable it before removing", op.name)
 						break
 					}

--- a/pkg/sensors/test/checker.go
+++ b/pkg/sensors/test/checker.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package test
+
+import (
+	"runtime"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/sirupsen/logrus"
+
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+)
+
+//revive:disable
+
+// TestChecker is a checker that relies on:
+//  - the test sensor being loaded
+//  - user-space executing hooks that trigger the test sensor on all cores
+//  (see contrib/tester-progs/trigger-test-events).
+//
+// The typical structure of a test is:
+//   1. start observer
+//   2. do some things on user-space
+//   3. check that we get the expected events from tetragon
+//
+// The above approach requires retries for step 3 if the events we are looking
+// for are not there. These retry counts are large so that we can deal with
+// worst case scenarios, and, subsequently, they induce a significant time cost
+// in failing tests. Furthermore, for some tests we also need to check for the
+// absence of events (e.g., when doing filtering), which also requires waiting
+// on timeouts.
+//
+// The TestChecker enables testing without timeouts. We still use timeouts for
+// robustness, but if the TestChecker works correctly, they are not needed.
+// TestChecker offers a way to end the test even if we have not receive the
+// expected events.
+//
+// The idea is simple: after step 2, we trigger the hook of the test sensor on
+// all CPUs. Once we 've seen all the test events (on all CPUs), then we know
+// that if we expect any events, they are not there.
+type TestChecker struct {
+	checker       ec.MultiEventChecker
+	testDone      map[uint64]bool
+	testDoneCount int
+}
+
+//revive:enable
+
+func NewTestChecker(c ec.MultiEventChecker) *TestChecker {
+	ncpus := runtime.NumCPU()
+	ret := TestChecker{
+		checker:  c,
+		testDone: make(map[uint64]bool, ncpus),
+	}
+
+	// NB: We assume CPU ids are consecutive. There are systems where this
+	// is not the caes (e.g., cores getting offline), but we ignore them
+	// for now.
+	ret.testDoneCount = ncpus
+	for i := 0; i < ncpus; i++ {
+		ret.testDone[uint64(i)] = false
+	}
+
+	return &ret
+}
+
+// update updates the state bsaed on the given event
+func (tc *TestChecker) update(ev ec.Event) {
+	switch ev := ev.(type) {
+	case *tetragon.Test:
+		cpu := ev.Arg0
+		prev := tc.testDone[cpu]
+		tc.testDone[cpu] = true
+		if !prev && tc.testDoneCount > 0 {
+			tc.testDoneCount--
+		}
+	default:
+	}
+}
+
+// reset resets internal state
+func (tc *TestChecker) reset() {
+	for i := range tc.testDone {
+		tc.testDone[i] = false
+	}
+	tc.testDoneCount = len(tc.testDone)
+}
+
+func (tc *TestChecker) seenAllTestEvents() bool {
+	return tc.testDoneCount == 0
+}
+
+func (tc *TestChecker) NextEventCheck(ev ec.Event, l *logrus.Logger) (bool, error) {
+	if tc.seenAllTestEvents() {
+		l.Info("seen events on all CPUs, finalizing test")
+		return true, tc.checker.FinalCheck(l)
+	}
+
+	done, err := tc.checker.NextEventCheck(ev, l)
+	if done {
+		// underlying checker done, just return its values
+		return true, err
+	}
+
+	// just update the state. In the next event, we wil check
+	// whether it's time to terminate or not.
+	tc.update(ev)
+
+	return false, err
+}
+
+func (tc *TestChecker) FinalCheck(l *logrus.Logger) error {
+	// this means that we run out of events before seeing all test events.
+	// Just return what the underlying checker returns
+	tc.reset()
+	return tc.checker.FinalCheck(l)
+}

--- a/pkg/sensors/test/checker.go
+++ b/pkg/sensors/test/checker.go
@@ -4,9 +4,12 @@
 package test
 
 import (
+	"os/exec"
 	"runtime"
+	"testing"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/sirupsen/logrus"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
@@ -43,6 +46,16 @@ type TestChecker struct {
 	checker       ec.MultiEventChecker
 	testDone      map[uint64]bool
 	testDoneCount int
+}
+
+// TestCheckerMarkEnd executes the proper code to mark the end of event stream on all CPUs
+func TestCheckerMarkEnd(t *testing.T) {
+	testBin := testutils.ContribPath("tester-progs/trigger-test-events")
+	testCmd := exec.Command(testBin)
+	err := testCmd.Run()
+	if err != nil {
+		t.Fatalf("error executing command: %v", err)
+	}
 }
 
 //revive:enable

--- a/pkg/sensors/test/checker_test.go
+++ b/pkg/sensors/test/checker_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/sirupsen/logrus"
+)
+
+// TestTestChecker tests the test checker
+func TestTestChecker(t *testing.T) {
+	if _, err := os.Stat("/sys/kernel/debug/tracing/events/syscalls"); os.IsNotExist(err) {
+		t.Skip("cannot use syscall tracepoints (consider enabling CONFIG_FTRACE_SYSCALLS)")
+	}
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cmdWaitTime)
+	defer cancel()
+
+	dummyErr := errors.New("dummy error")
+	dummyChecker := ec.FnEventChecker{
+		NextCheckFn: func(ev ec.Event, log *logrus.Logger) (bool, error) {
+			return false, nil
+		},
+		FinalCheckFn: func(log *logrus.Logger) error {
+			return dummyErr
+		},
+	}
+	errorChecker := NewTestChecker(&dummyChecker)
+
+	obs, err := observer.GetDefaultObserver(t, tetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserver error: %s", err)
+	}
+	sensor := GetTestSensor()
+	if err := sensor.FindPrograms(ctx); err != nil {
+		t.Fatalf("ObserverFindProgs error: %s", err)
+	}
+	mapDir := bpf.MapPrefixPath()
+	if err := sensor.Load(ctx, mapDir, mapDir, ""); err != nil {
+		t.Fatalf("observerLoadSensor error: %s", err)
+	}
+	defer sensors.UnloadSensor(ctx, mapDir, mapDir, sensor)
+
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	TestCheckerMarkEnd(t)
+
+	err = observer.JsonTestCheck(t, errorChecker)
+	t.Logf("got error: %v", err)
+	if !errors.Is(err, dummyErr) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/sensors/test/checker_test.go
+++ b/pkg/sensors/test/checker_test.go
@@ -11,9 +11,7 @@ import (
 	"testing"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
-	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/observer"
-	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/sirupsen/logrus"
 )
@@ -46,14 +44,7 @@ func TestTestChecker(t *testing.T) {
 		t.Fatalf("GetDefaultObserver error: %s", err)
 	}
 	sensor := GetTestSensor()
-	if err := sensor.FindPrograms(ctx); err != nil {
-		t.Fatalf("ObserverFindProgs error: %s", err)
-	}
-	mapDir := bpf.MapPrefixPath()
-	if err := sensor.Load(ctx, mapDir, mapDir, ""); err != nil {
-		t.Fatalf("observerLoadSensor error: %s", err)
-	}
-	defer sensors.UnloadSensor(ctx, mapDir, mapDir, sensor)
+	testutils.LoadSensor(ctx, t, sensor)
 
 	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()

--- a/pkg/sensors/test/checker_test.go
+++ b/pkg/sensors/test/checker_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -64,4 +65,6 @@ func TestTestChecker(t *testing.T) {
 	if !errors.Is(err, dummyErr) {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	// NB: we expect a failure, so mark the file to be removed.
+	testutils.DontKeepExportFile(t)
 }

--- a/pkg/sensors/test/lseek_test.go
+++ b/pkg/sensors/test/lseek_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/sensors"
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
+	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 )
@@ -71,21 +72,13 @@ func TestSensorLseekLoad(t *testing.T) {
 		t.Fatalf("GetDefaultObserver error: %s", err)
 	}
 	sensor := GetTestSensor()
-	if err := sensor.FindPrograms(ctx); err != nil {
-		t.Fatalf("ObserverFindProgs error: %s", err)
-	}
-	mapDir := bpf.MapPrefixPath()
-	if err := sensor.Load(ctx, mapDir, mapDir, ""); err != nil {
-		t.Fatalf("observerLoadSensor error: %s", err)
-	}
+	testutils.LoadSensor(ctx, t, sensor)
 	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()
 	unix.Seek(BogusFd, 0, BogusWhenceVal)
 
 	err = observer.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
-
-	sensors.UnloadSensor(ctx, mapDir, mapDir, sensor)
 }
 
 func TestSensorLseekEnable(t *testing.T) {

--- a/pkg/sensors/test/test.go
+++ b/pkg/sensors/test/test.go
@@ -28,7 +28,7 @@ var (
 	// BogusFd is the fd value required to trigger the lseek test probe
 	BogusFd = -1
 	// BogusWhenceVal is the whence value required to trigger the lseek test probe
-	BogusWhenceVal = 4444
+	BogusWhenceVal = 4729
 )
 
 func init() {

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -86,7 +86,7 @@ func TestGenericTracepointSimple(t *testing.T) {
 	defer func() {
 		err := sm.StopSensorManager(ctx)
 		if err != nil {
-			fmt.Printf("stopSensorController failed: %s\n", err)
+			t.Logf("stopSensorController failed: %s\n", err)
 		}
 	}()
 
@@ -128,6 +128,9 @@ func TestGenericTracepointSimple(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// doTestGenericTracepointPidFilter is a utility function for doing generic
+// tracepoint tests. It filters events based on the test program's pid, so that
+// we get more predictable results.
 func doTestGenericTracepointPidFilter(t *testing.T, conf GenericTracepointConf, selfOp func(), checkFn func(*tetragon.ProcessTracepoint) error) {
 	if _, err := os.Stat("/sys/kernel/debug/tracing/events/syscalls"); os.IsNotExist(err) {
 		t.Skip("cannot use syscall tracepoints (consider enabling CONFIG_FTRACE_SYSCALLS)")
@@ -164,7 +167,7 @@ func doTestGenericTracepointPidFilter(t *testing.T, conf GenericTracepointConf, 
 	defer func() {
 		err := sm.StopSensorManager(ctx)
 		if err != nil {
-			fmt.Printf("stopSensorController failed: %s\n", err)
+			t.Logf("stopSensorController failed: %s\n", err)
 		}
 	}()
 
@@ -237,7 +240,7 @@ func TestGenericTracepointPidFilterLseek(t *testing.T) {
 	}
 
 	op := func() {
-		fmt.Printf("Calling lseek...\n")
+		t.Logf("Calling lseek...\n")
 		unix.Seek(-1, 0, 4444)
 	}
 
@@ -280,7 +283,7 @@ func TestGenericTracepointArgFilterLseek(t *testing.T) {
 	}
 
 	op := func() {
-		fmt.Printf("Calling lseek...\n")
+		t.Logf("Calling lseek...\n")
 		unix.Seek(fd, 0, whence)
 		unix.Seek(fd, 0, whence+1)
 	}

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/sensors"
-	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
@@ -130,12 +129,6 @@ func TestGenericTracepointSimple(t *testing.T) {
 }
 
 func doTestGenericTracepointPidFilter(t *testing.T, conf GenericTracepointConf, selfOp func(), checkFn func(*tetragon.ProcessTracepoint) error) {
-	defer func() {
-		if t.Failed() {
-			testutils.KeepExportFile(t)
-		}
-	}()
-
 	if _, err := os.Stat("/sys/kernel/debug/tracing/events/syscalls"); os.IsNotExist(err) {
 		t.Skip("cannot use syscall tracepoints (consider enabling CONFIG_FTRACE_SYSCALLS)")
 	}

--- a/pkg/testutils/filenames.go
+++ b/pkg/testutils/filenames.go
@@ -90,3 +90,17 @@ func KeepExportFile(t *testing.T) {
 	ef.keep = true
 	exportFiles[testName] = ef
 }
+
+// DontKeepExportFile: unmarks export file to be kept. This is meant for tests
+// that are expected to fail.
+func DontKeepExportFile(t *testing.T) {
+	exportFilesLock.Lock()
+	defer exportFilesLock.Unlock()
+	testName := t.Name()
+	ef, ok := exportFiles[testName]
+	if !ok {
+		t.Fatalf("file for test %s does not exist", testName)
+	}
+	ef.keep = false
+	exportFiles[testName] = ef
+}

--- a/pkg/testutils/sensors.go
+++ b/pkg/testutils/sensors.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package testutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/sensors"
+)
+
+// LoadSensor is a helper for loading a sensor in tests
+func LoadSensor(ctx context.Context, t *testing.T, sensor *sensors.Sensor) {
+
+	if err := sensor.FindPrograms(ctx); err != nil {
+		t.Fatalf("ObserverFindProgs error: %s", err)
+	}
+	mapDir := bpf.MapPrefixPath()
+	if err := sensor.Load(ctx, mapDir, mapDir, ""); err != nil {
+		t.Fatalf("observerLoadSensor error: %s", err)
+	}
+
+	t.Cleanup(func() {
+		sensors.UnloadSensor(ctx, mapDir, mapDir, sensor)
+	})
+}


### PR DESCRIPTION
Please review commit-by-commit

This PR contains a number of  improvements for testing. Most of them are small, but there is one which is notable: allowing testing without retries.

The idea is the following:

The typical structure of our tests is:
  1. start observer
  2. do some things on user-space
  3. check that we get the expected events from tetragon

The above approach requires retries for step 3 if the events we are looking
for are not there. These retry counts are large so that we can deal with
worst case scenarios, and, subsequently, they induce a significant time cost
in failing tests. Furthermore, for some tests we also need to check for the
absence of events (e.g., when doing filtering), which also requires waiting
on timeouts.

This patch introduces the first steps to avoid having to wait on
timeouts.

We use pkg/sensors/test, which is a simpler sensor that hooks into the
lseek call, and generates a MSG_TEST event when lseek is called with
bogus arguments (fd=-1, whence=4444).

The idea is simple: after step 2 in our tests, can we trigger events
from test sensor on all CPUs. Once we have seen all the test events (on
all CPUs), then we know that if we expect any events, they are not
there, and, subsequently, there is no need for retries.

This patch:
 * introduces the user-space component for above functionality:
 TestChecker
 * modifies the BPF hook to also record the current CPU
 * adds a trigger-test-events program that triggers the test events on
   all CPUs

TestChecker works by wrapping another MultiEventChecker and looking for
TEST messages. Once it has seen one such message in all CPUs, it will
terminate the test by calling FinalCheck of the underlying
MultiEventChecker.