### PR TITLE
tests: split json checker out of observer

### DIFF
--- a/pkg/jsonchecker/logcatpure.go
+++ b/pkg/jsonchecker/logcatpure.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package jsonchecker
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+type logCapturer struct {
+	*testing.T
+	origOut io.Writer
+}
+
+func (tl logCapturer) Write(p []byte) (n int, err error) {
+	tl.Logf((string)(p))
+	return len(p), nil
+}
+
+func (tl logCapturer) Release() {
+	logrus.SetOutput(tl.origOut)
+}
+
+// CaptureLog redirects logrus output to testing.Log
+func captureLog(t *testing.T) *logCapturer {
+	lc := &logCapturer{T: t, origOut: logrus.StandardLogger().Out}
+	if !testing.Verbose() {
+		logrus.SetOutput(lc)
+	}
+	return lc
+}

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -50,7 +50,6 @@ var (
 	observerTestDir = "/sys/fs/bpf/testObserver/"
 	metricsAddr     = "localhost:2112"
 	metricsEnabled  = false
-	jsonRetries     = 20
 )
 
 const (

--- a/pkg/sensors/exec/fork_test.go
+++ b/pkg/sensors/exec/fork_test.go
@@ -11,6 +11,7 @@ import (
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	sm "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/stretchr/testify/assert"
@@ -65,7 +66,7 @@ func TestFork(t *testing.T) {
 		WithParent(ec.NewProcessChecker().WithPid(fti.child1Pid))
 	checker := ec.NewUnorderedEventChecker(exitCheck)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 

--- a/pkg/sensors/test/checker_test.go
+++ b/pkg/sensors/test/checker_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/sirupsen/logrus"
@@ -51,7 +52,7 @@ func TestTestChecker(t *testing.T) {
 
 	TestCheckerMarkEnd(t)
 
-	err = observer.JsonTestCheck(t, errorChecker)
+	err = jsonchecker.JsonTestCheck(t, errorChecker)
 	t.Logf("got error: %v", err)
 	if !errors.Is(err, dummyErr) {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/sensors/test/lseek_test.go
+++ b/pkg/sensors/test/lseek_test.go
@@ -15,6 +15,7 @@ import (
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/sensors"
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
@@ -77,7 +78,7 @@ func TestSensorLseekLoad(t *testing.T) {
 	readyWG.Wait()
 	unix.Seek(BogusFd, 0, BogusWhenceVal)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 
@@ -132,6 +133,6 @@ func TestSensorLseekEnable(t *testing.T) {
 	readyWG.Wait()
 	unix.Seek(BogusFd, 0, BogusWhenceVal)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }

--- a/pkg/sensors/tracing/kprobe_copyfd_test.go
+++ b/pkg/sensors/tracing/kprobe_copyfd_test.go
@@ -23,6 +23,7 @@ import (
 	bc "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/bytesmatcher"
 	lc "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/stretchr/testify/assert"
@@ -97,6 +98,6 @@ func TestCopyFd(t *testing.T) {
 		kpChecker,
 	)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }

--- a/pkg/sensors/tracing/kprobe_filterchange_test.go
+++ b/pkg/sensors/tracing/kprobe_filterchange_test.go
@@ -16,6 +16,7 @@ import (
 	bc "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/bytesmatcher"
 	lc "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/testutils"
@@ -99,7 +100,7 @@ func TestKprobeNSChanges(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(
 		kprobeChecker,
 	)
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 
@@ -182,7 +183,7 @@ func testKprobeCapChanges(t *testing.T, spec string, op string, value string) {
 		kprobeChecker,
 	)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 

--- a/pkg/sensors/tracing/kprobe_sigkill_test.go
+++ b/pkg/sensors/tracing/kprobe_sigkill_test.go
@@ -14,6 +14,7 @@ import (
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	lc "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/testutils"
@@ -101,6 +102,6 @@ func TestKprobeSigkill(t *testing.T) {
 		WithAction(tetragon.KprobeAction_KPROBE_ACTION_SIGKILL)
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -22,6 +22,7 @@ import (
 	lc "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/reader/caps"
@@ -173,7 +174,7 @@ func runKprobeObjectWriteRead(t *testing.T, writeReadHook string) {
 	_, err = syscall.Write(1, []byte("hello world"))
 	assert.NoError(t, err)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 
@@ -435,7 +436,7 @@ func runKprobeObjectRead(t *testing.T, readHook string, checker ec.MultiEventChe
 		t.Fatal()
 	}
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 
@@ -634,7 +635,7 @@ func testKprobeObjectFiltered(t *testing.T,
 	n, err := syscall.Write(fd2, []byte(data))
 	assert.Equal(t, len(data), n)
 	assert.NoError(t, err)
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	if expectFailure {
 		assert.Error(t, err)
 	} else {
@@ -1067,7 +1068,7 @@ spec:
 	err = helloIovecWorldWritev()
 	assert.NoError(t, err)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 
@@ -1315,7 +1316,7 @@ func corePathTest(t *testing.T, filePath string, readHook string, writeChecker e
 	n, err := syscall.Write(fd2, []byte(data))
 	assert.Equal(t, len(data), n)
 	assert.NoError(t, err)
-	err = observer.JsonTestCheck(t, writeChecker)
+	err = jsonchecker.JsonTestCheck(t, writeChecker)
 	assert.NoError(t, err)
 }
 
@@ -1597,7 +1598,7 @@ spec:
 		uintptr(newFd), uintptr(unsafe.Pointer(newBytes)),
 		uintptr(flags), 0)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 
@@ -1641,7 +1642,7 @@ func runKprobeOverride(t *testing.T, hook string, checker ec.MultiEventChecker,
 		t.Fatal()
 	}
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 
@@ -1780,7 +1781,7 @@ func runKprobe_char_iovec(t *testing.T, configHook string,
 	_, err = unix.Readv(fdr, iovr)
 	assert.NoError(t, err)
 
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -19,6 +19,7 @@ import (
 	lc "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/listmatcher"
 	smatcher "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/observer"
 	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
@@ -107,7 +108,7 @@ func TestGenericTracepointSimple(t *testing.T) {
 	readyWG.Wait()
 	unix.Seek(-1, 0, whenceBogusValue)
 	time.Sleep(1000 * time.Millisecond)
-	err = observer.JsonTestCheck(t, checker)
+	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }
 
@@ -192,7 +193,7 @@ func doTestGenericTracepointPidFilter(t *testing.T, conf GenericTracepointConf, 
 	}
 	checker := testsensor.NewTestChecker(&checker_)
 
-	if err := observer.JsonTestCheck(t, checker); err != nil {
+	if err := jsonchecker.JsonTestCheck(t, checker); err != nil {
 		t.Logf("error: %s", err)
 		t.Fail()
 	}


### PR DESCRIPTION
JsonTestCheck is used widely by our unit tests, not just in pkg/observer. So let's split
this functionality out of the observer to make things more modular.

Signed-off-by: William Findlay <will@isovalent.com>