### PR TITLE
tetragon: Pull Default loader out of observer

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/ratelimit"
 	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/base"
 	"github.com/cilium/tetragon/pkg/server"
 	"github.com/cilium/tetragon/pkg/version"
 	"github.com/cilium/tetragon/pkg/watcher"
@@ -152,6 +153,9 @@ func hubbleTETRAGONExecute() error {
 	}
 
 	if runStandalone {
+		if err := base.LoadDefault(ctx, observerDir, observerDir, ciliumBPF); err != nil {
+			return err
+		}
 		return obs.StartStandalone(ctx)
 	}
 
@@ -209,6 +213,10 @@ func hubbleTETRAGONExecute() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if err := base.LoadDefault(ctx, observerDir, observerDir, ciliumBPF); err != nil {
+		return err
 	}
 
 	return obs.Start(ctx, startSensors)

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
 	"github.com/cilium/tetragon/pkg/sensors"
-	"github.com/cilium/tetragon/pkg/sensors/base"
 	"github.com/cilium/tetragon/pkg/sensors/config"
 
 	"github.com/sirupsen/logrus"
@@ -261,10 +260,6 @@ type Observer struct {
 }
 
 func (k *Observer) Start(ctx context.Context, sens []*sensors.Sensor) error {
-	if err := base.LoadDefault(ctx, k.bpfDir, k.mapDir, k.ciliumDir); err != nil {
-		return err
-	}
-
 	k.startUpdateMapMetrics()
 
 	if sens != nil {


### PR DESCRIPTION
The observer shouldn't care what programs are being loaded as part of the
default. This allows us to have different commands run different default
setups. One idea here is we can build a stack trace tool with just the
needed stack tracing Or profiling tool with a set of profiling defaults.

This patch moves the default handler out of observer as a first step and
puts it in the cmd that is launching the observer.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>