### PR TITLE
tetragon: extract protobuf from the dns cache

### DIFF
--- a/pkg/dns/dns_cache.go
+++ b/pkg/dns/dns_cache.go
@@ -5,7 +5,6 @@ package dns
 import (
 	"fmt"
 
-	"github.com/cilium/tetragon/api/v1/tetragon"
 	lru "github.com/hashicorp/golang-lru"
 )
 
@@ -36,13 +35,9 @@ func (c *Cache) GetIp(ip string) ([]string, error) {
 	return entry.([]string), nil
 }
 
-func (c *Cache) AddIp(dns *tetragon.DnsInfo) {
-	if !dns.Response {
-		return
-	}
-
-	for _, ip := range dns.Ips {
-		c.cache.Add(ip, dns.Names)
+func (c *Cache) AddIp(ips, names []string) {
+	for _, ip := range ips {
+		c.cache.Add(ip, names)
 	}
 }
 


### PR DESCRIPTION
Preparing to use Cilium to fetch DNS names (lost in conversion to OSS) we
have the dns pkg pulling in protobufs. This is a bit odd and not ideal
because Cilium certainly doesn't care about Tetragon protobufs and
importing them and using them in Cilium side is awkward.

For now do some simple refactoring to clean up the API.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>