### PR TITLE
fix(helm): Support command override in exporter container #118

### DIFF
--- a/install/kubernetes/templates/_container_export_stdout.tpl
+++ b/install/kubernetes/templates/_container_export_stdout.tpl
@@ -8,10 +8,18 @@
   resources:
     {{- toYaml .Values.export.resources | nindent 4 }}
   command:
+{{- with .Values.export.commandOverride }}
+  {{- toYaml . | nindent 2 }}
+{{- else }}
     - hubble-export-stdout
+{{- end }}
   args:
+{{- with .Values.export.argsOverride }}
+  {{- toYaml . | nindent 2 }}
+{{- else }}
 {{- range .Values.export.filenames }}
     - {{ $.Values.exportDirectory }}/{{ . }}
+{{- end }}
 {{- end }}
   volumeMounts:
     - name: export-logs


### PR DESCRIPTION
Resolve https://github.com/cilium/tetragon/issues/118
Supports plugging in another exporter container.