### PR TITLE
Update Chapter 4 Prevention Policies

### DIFF
--- a/docs/security-observability-with-ebpf/04_chapter/01_cilium_tracing_policy/01_privileged_pod.yaml
+++ b/docs/security-observability-with-ebpf/04_chapter/01_cilium_tracing_policy/01_privileged_pod.yaml
@@ -1,12 +1,17 @@
-# Deny a privileged pod start
-apiVersion: cilium.io/v1alpha1
+apiVersion: isovalent.com/v1alpha1
 kind: TracingPolicy
 metadata:
   name: "deny-privileged-pod-start"
 spec:
   kprobes:
-  - call: "<TBD>"
+  # match open fd_install at pod start
+  - call: "fd_install"
     syscall: false
+    args:
+    - index: 0
+      type: int
+    - index: 1
+      type: "file"
     selectors:
     # match all the namespace PIDs including init
     - matchPIDs:
@@ -15,17 +20,23 @@ spec:
         isNamespacePID: true
         values:
         - 0
-    # match a process with CAP_SYS_ADMIN
-    - matchCapabilities:
-      - operator: In
-        isNamespaceCapability: true
+      # match a process with CAP_SYS_ADMIN
+      matchCapabilities:
+      - type: Effective
+        operator: In
         values:
         - "CAP_SYS_ADMIN"
-    # match on containerd-shim binary
-    - matchBinarys:
-      - operator: "In"
+      # match a process with CAP_SYS_ADMIN that gained it later
+      matchCapabilityChanges:
+      - type: Effective
+        operator: In
         values:
-        - "/usr/bin/containerd-shim"
-    # terminate the process
-    - matchActions:
-      - action: Sigkill
+        - "CAP_SYS_ADMIN"
+      # match on containerd-shim binary
+      - matchBinaries:
+        - operator: "In"
+          values:
+          - "/usr/bin/containerd-shim"
+      # terminate the process
+      - matchActions:
+        - action: Sigkill

--- a/docs/security-observability-with-ebpf/04_chapter/01_cilium_tracing_policy/02_nsenter.yaml
+++ b/docs/security-observability-with-ebpf/04_chapter/01_cilium_tracing_policy/02_nsenter.yaml
@@ -5,8 +5,11 @@ metadata:
   name: "deny-nsenter"
 spec:
   kprobes:
-  - call: "<TBD>"
-    syscall: false
+  - call: "__x64_sys_setns"
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
     selectors:
     - matchPIDs:
       # match host processes
@@ -21,15 +24,5 @@ spec:
         isNamespacePID: true
         values:
         - 1
-    # match on mount, network, uts, pid, ipc, user host namespaces
-    - matchNamespaceChanges:
-      - operator: In
-        values:
-        - "mount"
-        - "network"
-        - "uts"
-        - "pid"
-        - "ipc"
-        - "user"
     - matchActions:
       - action: Sigkill


### PR DESCRIPTION
1. Update `01_privileged_pod.yaml`: should block a privileged pod start
2. Update `02_nsenter.yaml`: should block nsenter coming from a container 

Working on: `04_deny_c2_connection.yaml`: need to get the destination addr from sockaddr