### PR TITLE
bpf: support raw_tracepoint programs

### DIFF
--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -286,6 +286,15 @@ func loadInstance(bpfDir, mapDir, ciliumDir string, load *program.Program, versi
 			load.Label,
 			filepath.Join(bpfDir, load.PinPath),
 			mapDir)
+	} else if load.Type == "raw_tracepoint" {
+		return loader.LoadRawTracingProgram(
+			version, verbose,
+			btfObj,
+			load.Name,
+			load.Attach,
+			load.Label,
+			filepath.Join(bpfDir, load.PinPath),
+			mapDir)
 	} else if load.Type == "cgrp_socket" {
 		err := cgroup.LoadCgroupProgram(
 			bpfDir,


### PR DESCRIPTION
Add support for loading raw_tracepoint programs which are better compared to classic ones as they allow to access raw data structs. We will need them in following patches to improve our cgroups handling