### PR TITLE
checkpatch: ignore OPEN_ENDED_LINE and PREFER_KERNEL_TYPES

### DIFF
--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -13,4 +13,4 @@ jobs:
       - name: Run checkpatch.pl
         uses: docker://quay.io/cilium/cilium-checkpatch:2f0f4f512e795d5668ea4e7ef0ba85abc75eb225@sha256:f307bf0315954e8b8c31edc1864d949bf211b0c6522346359317d757b5a6cea0
         with:
-          args: "-- --ignore PREFER_DEFINED_ATTRIBUTE_MACRO,C99_COMMENTS"
+          args: "-- --ignore PREFER_DEFINED_ATTRIBUTE_MACRO,C99_COMMENTS,OPEN_ENDED_LINE,PREFER_KERNEL_TYPES"


### PR DESCRIPTION
OPEN_ENDED_LINE is a false positive since our clang-format job is what really lays down
the law here. PREFER_KERNEL_TYPES trips up a lot since we tend to use things like uint64_t
in our BPF code quite a bit.

Let's ignore both of these for the reasons stated above.

Signed-off-by: William Findlay <will@isovalent.com>