### PR TITLE
Don't truncate Ktime to milliseconds

### DIFF
--- a/pkg/ktime/ktime.go
+++ b/pkg/ktime/ktime.go
@@ -49,5 +49,5 @@ func DecodeKtime(ktime int64, monotonic bool) (time.Time, error) {
 	}
 	diff := ktime - currentTime.Nano()
 	t := time.Now().Add(time.Duration(diff))
-	return t.Truncate(1 * time.Millisecond), nil
+	return t, nil
 }


### PR DESCRIPTION
Don't truncate Ktime to milliseconds and give a higher resolution. Fix for https://github.com/cilium/tetragon/issues/124.