### PR TITLE
codegen/helpers: fix name inference for oneof codegen

### DIFF
--- a/api/v1/tetragon/codegen/helpers/helpers.pb.go
+++ b/api/v1/tetragon/codegen/helpers/helpers.pb.go
@@ -31,10 +31,10 @@ func EventTypeString(event event) (string, error) {
 		return tetragon.EventType_PROCESS_KPROBE.String(), nil
 	case *tetragon.GetEventsResponse_ProcessTracepoint:
 		return tetragon.EventType_PROCESS_TRACEPOINT.String(), nil
-	case *tetragon.GetEventsResponse_Test:
-		return tetragon.EventType_TEST.String(), nil
 	case *tetragon.GetEventsResponse_ProcessDns:
 		return tetragon.EventType_PROCESS_DNS.String(), nil
+	case *tetragon.GetEventsResponse_Test:
+		return tetragon.EventType_TEST.String(), nil
 
 	}
 	return "", fmt.Errorf("Unhandled event type %T", event)

--- a/cmd/protoc-gen-go-tetragon/common/common.go
+++ b/cmd/protoc-gen-go-tetragon/common/common.go
@@ -110,6 +110,46 @@ func StructTag(tag string) string {
 
 var eventsCache []*protogen.Message
 
+type GetEventsResponseOneofInfo struct {
+	TypeName  string
+	FieldName string
+}
+
+func GetEventsResponseOneofs(f *protogen.File) ([]GetEventsResponseOneofInfo, error) {
+	// find the GetEventsResponse type
+	var getEventsResponse *protogen.Message
+	for _, msg := range f.Messages {
+		if msg.GoIdent.GoName == "GetEventsResponse" {
+			getEventsResponse = msg
+			break
+		}
+	}
+	if getEventsResponse == nil {
+		return nil, fmt.Errorf("Unable to find GetEventsResponse message")
+	}
+
+	var eventOneof *protogen.Oneof
+	for _, oneof := range getEventsResponse.Oneofs {
+		if oneof.Desc.Name() == "event" {
+			eventOneof = oneof
+			break
+		}
+	}
+	if eventOneof == nil {
+		return nil, fmt.Errorf("Unable to find GetEventsResponse.event")
+	}
+
+	var info []GetEventsResponseOneofInfo
+	for _, oneof := range eventOneof.Fields {
+		info = append(info, GetEventsResponseOneofInfo{
+			TypeName:  strings.TrimPrefix(oneof.GoIdent.GoName, "GetEventsResponse_"),
+			FieldName: oneof.Desc.TextName(),
+		})
+	}
+
+	return info, nil
+}
+
 // GetEvents returns a list of all messages that are events
 func GetEvents(f *protogen.File) ([]*protogen.Message, error) {
 	if len(eventsCache) == 0 {

--- a/cmd/protoc-gen-go-tetragon/helpers/helpers.go
+++ b/cmd/protoc-gen-go-tetragon/helpers/helpers.go
@@ -5,24 +5,23 @@ package helpers
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cilium/tetragon/cmd/protoc-gen-go-tetragon/common"
-	"github.com/iancoleman/strcase"
 	"google.golang.org/protobuf/compiler/protogen"
 )
 
 func generateEventTypeString(g *protogen.GeneratedFile, f *protogen.File) error {
-	events, err := common.GetEvents(f)
+	oneofs, err := common.GetEventsResponseOneofs(f)
 	if err != nil {
 		return err
 	}
 
 	doCases := func() string {
 		var ret string
-		for _, msg := range events {
-			resGoIdent := common.TetragonApiIdent(g, fmt.Sprintf("GetEventsResponse_%s", msg.GoIdent.GoName))
-			typeName := strcase.ToScreamingSnake(msg.GoIdent.GoName)
-			typeGoIdent := common.TetragonApiIdent(g, fmt.Sprintf("EventType_%s", typeName))
+		for _, oneof := range oneofs {
+			resGoIdent := common.TetragonApiIdent(g, fmt.Sprintf("GetEventsResponse_%s", oneof.TypeName))
+			typeGoIdent := common.TetragonApiIdent(g, fmt.Sprintf("EventType_%s", strings.ToUpper(oneof.FieldName)))
 
 			ret += `case *` + resGoIdent + `:
                 return ` + typeGoIdent + `.String(), nil


### PR DESCRIPTION
The approach we were using, converting the Oneof field type using
strcase.ToScreamingSnake() was fundamentally broken for types that include e.g. a number
immediately next to a letter in the type name.

For example, consider something like:

message FooEvent42 { /* ... */ }

oneof event {
    ProcessExec process_exec = 1;
    ProcessExit process_exit = 5;
    ProcessKprobe process_kprobe = 9;
    ProcessTracepoint process_tracepoint = 10;
    ProcessDns process_dns = 14;
    FooEvent42 foo_event42 = 15;

    Test test = 40000;
}

The name for the oneof according to our codegen would be wrong: FOO_EVENT_42 instead of
FOO_EVENT42. To fix this, we can just grab the name of the actual oneof field and apply
a simple strings.ToUpper() transformation to it. This then results in the correct name
FOO_EVENT42.

Signed-off-by: William Findlay <will@isovalent.com>