### PR TITLE
build: use upstream clang instead of forked version for BPF programs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,11 @@
 # Ignore VCS
 .git/
 
+# Ignore dockerignore and Dockerfiles
+.dockerignore
+Dockerfile
+Dockerfile.*
+
 # Ignore compiled binaries and libraries
 go-tests/
 lib/

--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -1,0 +1,96 @@
+name: Build Clang Image
+
+on:
+  push:
+    branches:
+      - main
+      - v*
+    paths:
+    - 'Dockerfile.clang'
+  pull_request:
+    paths:
+    - 'Dockerfile.clang'
+
+jobs:
+  build-and-push:
+    environment: release-clang
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Login to quay.io
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_CLANG_RELEASE_USERNAME }}
+          password: ${{ secrets.QUAY_CLANG_RELEASE_PASSWORD }}
+
+      - name: Getting image tag
+        id: tag
+        run: |
+          if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
+            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+          else
+            echo ::set-output name=tag::${{ github.sha }}
+          fi
+
+      - name: Checkout Source Code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Release Build clang
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+        id: docker_build_release
+        with:
+          context: .
+          file: ./Dockerfile.clang
+          push: true
+          platforms: linux/amd64
+          tags: |
+            quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}
+
+      - name: Image Release Digest
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          job_name=clang
+          job_name_capital=${job_name^^}
+          job_name_underscored=${job_name_capital//-/_}
+          echo "${job_name_underscored}_DIGEST := \"${{ steps.docker_build_release.outputs.digest }}\"" > image-digest/makefile-digest.txt
+
+          echo "### clang" > image-digest/clang.txt
+          echo "" >> image-digest/clang.txt
+          echo "\`quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/clang.txt
+          echo "" >> image-digest/clang.txt
+
+      # Upload artifact digests
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
+        with:
+          name: image-digest clang
+          path: image-digest
+          retention-days: 1
+
+  image-digests:
+    if: ${{ github.repository == 'cilium/tetragon' }}
+    name: Display Digests
+    runs-on: ubuntu-20.04
+    needs: build-and-push
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+
+      - name: Download digests of all images built
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          path: image-digest/
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat
+

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -24,10 +24,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt install libelf-dev netcat-traditional libcap-dev gcc
+        sudo apt-get install libelf-dev netcat-traditional libcap-dev gcc
 
         cd go/src/github.com/cilium/tetragon/
-        sudo -E make tools-install LIBBPF_INSTALL_DIR=/usr/local/lib CLANG_INSTALL_DIR=/usr/bin
+        sudo -E make tools-install LIBBPF_INSTALL_DIR=/usr/local/lib
         sudo -E ldconfig /usr/local/
 
         sudo sed -i '/secure_path/d' /etc/sudoers

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/isovalent/hubble-llvm:2022-01-03-a6dfdaf as bpf-builder
+FROM quay.io/cilium/clang:7ea8dd5b610a8864ce7b56e10ffeb61030a0c50e@sha256:02ad7cc1d08d85c027557099b88856945be5124b5c31aeabce326e7983e3913b as bpf-builder
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN apt-get update
 RUN apt-get install -y linux-libc-dev

--- a/Dockerfile.clang
+++ b/Dockerfile.clang
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+WORKDIR /go/src/github.com/cilium/tetragon
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get install -y --no-install-recommends clang-13 llvm-13 make
+RUN ln -vsnf /usr/lib/llvm-13/bin/clang /usr/bin/clang
+RUN ln -vsnf /usr/lib/llvm-13/bin/llc /usr/bin/llc
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,10 +1,9 @@
-FROM quay.io/isovalent/hubble-llvm:2022-01-03-a6dfdaf as bpf-builder
+FROM quay.io/cilium/clang:7ea8dd5b610a8864ce7b56e10ffeb61030a0c50e@sha256:02ad7cc1d08d85c027557099b88856945be5124b5c31aeabce326e7983e3913b as bpf-builder
 WORKDIR /go/src/github.com/cilium/tetragon
-RUN apt-get update  -y && \
-    apt-get upgrade -y && \
-    apt-get install -y linux-libc-dev
+RUN apt-get update
+RUN apt-get install -y linux-libc-dev
 COPY . ./
-RUN make tetragon-bpf
+RUN make tetragon-bpf LOCAL_CLANG=1
 
 FROM quay.io/isovalent/hubble-libbpf:v0.2.3 as hubble-libbpf
 WORKDIR /go/src/github.com/cilium/tetragon

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,9 @@
-FROM quay.io/isovalent/hubble-llvm:2022-01-03-a6dfdaf as bpf-builder
+FROM quay.io/cilium/clang:7ea8dd5b610a8864ce7b56e10ffeb61030a0c50e@sha256:02ad7cc1d08d85c027557099b88856945be5124b5c31aeabce326e7983e3913b as bpf-builder
+WORKDIR /go/src/github.com/cilium/tetragon
+RUN apt-get update
+RUN apt-get install -y linux-libc-dev
+COPY . ./
+RUN make tetragon-bpf LOCAL_CLANG=1
 
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN apt-get update

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,11 @@ LOCAL_CLANG_FORMAT ?= 0
 FORMAT_FIND_FLAGS ?= -name '*.c' -o -name '*.h' -not -path 'bpf/include/vmlinux.h' -not -path 'bpf/include/api.h' -not -path 'bpf/libbpf/*'
 NOOPT ?= 0
 LIBBPF_IMAGE = quay.io/isovalent/hubble-libbpf:v0.2.3
-CLANG_IMAGE  = quay.io/isovalent/hubble-llvm:2020-12-29-45f6aa2
+CLANG_IMAGE  = quay.io/cilium/clang:7ea8dd5b610a8864ce7b56e10ffeb61030a0c50e@sha256:02ad7cc1d08d85c027557099b88856945be5124b5c31aeabce326e7983e3913b
 METADATA_IMAGE = quay.io/isovalent/tetragon-metadata
 TESTER_PROGS_DIR = "contrib/tester-progs"
 
 LIBBPF_INSTALL_DIR ?= ./lib
-CLANG_INSTALL_DIR  ?= ./bin
 VERSION=$(shell git describe --tags --always)
 GO_GCFLAGS ?= ""
 GO_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(VERSION)'"
@@ -48,9 +47,9 @@ verify: tetragon-bpf
 	sudo contrib/verify/verify.sh bpf/objs
 
 tetragon-bpf-container:
-	$(CONTAINER_ENGINE) rm hubble-llvm || true
-	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon -u $$(id -u)  --name hubble-llvm $(CLANG_IMAGE) $(MAKE) -C /tetragon/bpf
-	$(CONTAINER_ENGINE) rm hubble-llvm
+	$(CONTAINER_ENGINE) rm tetragon-clang || true
+	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon -u $$(id -u) --name tetragon-clang $(CLANG_IMAGE) $(MAKE) -C /tetragon/bpf
+	$(CONTAINER_ENGINE) rm tetragon-clang
 
 tetragon:
 	$(GO) build -gcflags=$(GO_GCFLAGS) -ldflags=$(GO_LDFLAGS) -mod=vendor ./cmd/tetragon/
@@ -116,7 +115,7 @@ update-copyright:
 lint:
 	golint -set_exit_status $$(go list ./...)
 
-image:
+image: image-clang
 	$(CONTAINER_ENGINE) build -t "cilium/tetragon:${DOCKER_IMAGE_TAG}" .
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "${CONTAINER_ENGINE} push cilium/tetragon:$(DOCKER_IMAGE_TAG)"
@@ -126,7 +125,7 @@ image-operator:
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "${CONTAINER_ENGINE} push cilium/tetragon-operator:$(DOCKER_IMAGE_TAG)"
 
-image-test:
+image-test: image-clang
 	$(CONTAINER_ENGINE) build -f Dockerfile.test -t "cilium/tetragon-test:${DOCKER_IMAGE_TAG}" .
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "${CONTAINER_ENGINE} push cilium/tetragon-test:$(DOCKER_IMAGE_TAG)"
@@ -136,24 +135,22 @@ image-codegen:
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "${CONTAINER_ENGINE} push cilium/tetragon-codegen:$(DOCKER_IMAGE_TAG)"
 
-.PHONY: tools-install tools-clean libbpf-install clang-install
-tools-install: libbpf-install clang-install
+.PHONY: image-clang
+image-clang:
+	$(CONTAINER_ENGINE) build -f Dockerfile.clang -t "cilium/clang:${DOCKER_IMAGE_TAG}" .
+	$(QUIET)echo "Push like this when ready:"
+	$(QUIET)echo "${CONTAINER_ENGINE} push cilium/clang:$(DOCKER_IMAGE_TAG)"
+
+.PHONY: tools-install tools-clean libbpf-install
+tools-install: libbpf-install
 tools-clean:
 	rm -rf $(LIBBPF_INSTALL_DIR)
-	rm -rf $(CLANG_INSTALL_DIR)
 libbpf-install:
 	$(eval id=$(shell $(CONTAINER_ENGINE) create $(LIBBPF_IMAGE)))
 	mkdir -p $(LIBBPF_INSTALL_DIR)
 	$(CONTAINER_ENGINE) cp ${id}:/go/src/github.com/covalentio/hubble-fgs/src/libbpf.so $(LIBBPF_INSTALL_DIR)
 	$(CONTAINER_ENGINE) cp ${id}:/go/src/github.com/covalentio/hubble-fgs/src/libbpf.so.0 $(LIBBPF_INSTALL_DIR)
 	$(CONTAINER_ENGINE) cp ${id}:/go/src/github.com/covalentio/hubble-fgs/src/libbpf.so.0.2.0 $(LIBBPF_INSTALL_DIR)
-	$(CONTAINER_ENGINE) stop ${id}
-
-clang-install:
-	$(eval id=$(shell $(CONTAINER_ENGINE) create $(CLANG_IMAGE)))
-	mkdir -p $(CLANG_INSTALL_DIR)
-	$(CONTAINER_ENGINE) cp ${id}:/usr/local/bin/clang-11 $(CLANG_INSTALL_DIR)/clang
-	$(CONTAINER_ENGINE) cp ${id}:/usr/local/bin/llc $(CLANG_INSTALL_DIR)/llc
 	$(CONTAINER_ENGINE) stop ${id}
 
 generate:

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -7,7 +7,7 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 {
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
-	unsigned long a0, a1, a2, a3, a4;
+	unsigned long a0;
 	struct event_config *config;
 	bool walker = 0;
 	__u32 ppid;
@@ -31,10 +31,6 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 		return 0;
 
 	a0 = e->a0;
-	a1 = e->a1;
-	a2 = e->a2;
-	a3 = e->a3;
-	a4 = e->a4;
 
 	e->common.flags = 0;
 	e->common.pad[0] = 0;
@@ -146,7 +142,7 @@ generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)
 {
-	unsigned long a0, a1, a2, a3, a4;
+	unsigned long a1;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
 	struct event_config *config;
@@ -170,11 +166,7 @@ generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
 
 	total = e->common.size;
 
-	a0 = e->a0;
 	a1 = e->a1;
-	a2 = e->a2;
-	a3 = e->a3;
-	a4 = e->a4;
 
 	ty = config->arg1;
 	if (total < MAX_TOTAL) {
@@ -200,7 +192,7 @@ generic_process_event2(void *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)
 {
-	unsigned long a0, a1, a2, a3, a4;
+	unsigned long a2;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
 	struct event_config *config;
@@ -224,11 +216,7 @@ generic_process_event2(void *ctx, struct bpf_map_def *heap_map,
 
 	total = e->common.size;
 
-	a0 = e->a0;
-	a1 = e->a1;
 	a2 = e->a2;
-	a3 = e->a3;
-	a4 = e->a4;
 
 	ty = config->arg2;
 	if (total < MAX_TOTAL) {
@@ -254,7 +242,7 @@ generic_process_event3(void *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)
 {
-	unsigned long a0, a1, a2, a3, a4;
+	unsigned long a3;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
 	struct event_config *config;
@@ -278,11 +266,7 @@ generic_process_event3(void *ctx, struct bpf_map_def *heap_map,
 
 	total = e->common.size;
 
-	a0 = e->a0;
-	a1 = e->a1;
-	a2 = e->a2;
 	a3 = e->a3;
-	a4 = e->a4;
 
 	/* Arg filter and copy logic */
 	ty = config->arg3;
@@ -309,7 +293,7 @@ generic_process_event4(void *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)
 {
-	unsigned long a0, a1, a2, a3, a4;
+	unsigned long a4;
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;
 	struct event_config *config;
@@ -333,10 +317,6 @@ generic_process_event4(void *ctx, struct bpf_map_def *heap_map,
 
 	total = e->common.size;
 
-	a0 = e->a0;
-	a1 = e->a1;
-	a2 = e->a2;
-	a3 = e->a3;
 	a4 = e->a4;
 
 	ty = config->arg4;

--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -4,3 +4,4 @@ namespace-tester
 sigkill-tester
 dup-tester
 trigger-test-events
+nop


### PR DESCRIPTION
Use an upstreamed version of clang (clang-13) instead of our forked version. We provide a Docker image for convenience, but any distribution's clang should work provided it is >= clang-13. See individual commits.

Fixes #142