### PR TITLE
tests/exec: bump longpath version check to 5.16

### DIFF
--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -203,9 +203,9 @@ func TestEventExecveLongPath(t *testing.T) {
 
 	dirNum := 14
 
-	// kernels < v.5.15 won't trigger tracepoints for data bigger
+	// kernels < v.5.16 won't trigger tracepoints for data bigger
 	// than 2048 bytes, so making the path smaller for them
-	if kernels.IsKernelVersionLessThan("5.15.0") {
+	if kernels.IsKernelVersionLessThan("5.16.0") {
 		dirNum = 6
 	}
 
@@ -334,9 +334,9 @@ func TestEventExecveLongPathLongArgs(t *testing.T) {
 
 	dirNum := 14
 
-	// kernels < v.5.15 won't trigger tracepoints for data bigger
+	// kernels < v.5.16 won't trigger tracepoints for data bigger
 	// than 2048 bytes, so making the path smaller for them
-	if kernels.IsKernelVersionLessThan("5.15.0") {
+	if kernels.IsKernelVersionLessThan("5.16.0") {
 		dirNum = 6
 	}
 


### PR DESCRIPTION
The longpath execve tests were relying on detecting a specific kernel feature that enables
longer tracepoint arguments. The checks are currently looking for 5.15+ kernels, however
this feature actually was not included until 5.16. This causes the longpath tests to fail
on 5.15 kernels.

Fix the problem by bumping the version check to 5.16.

Signed-off-by: William Findlay <will@isovalent.com>