### PR TITLE
tetragon: Disable long path/args retrieval for 4.19 kernels

### DIFF
--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -195,6 +195,10 @@ func TestEventExecveLongPath(t *testing.T) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
+	if !kernels.EnableLargeProgs() {
+		t.Skip()
+	}
+
 	testNop := testutils.ContribPath("tester-progs/nop")
 
 	// create dir portion of path
@@ -279,6 +283,10 @@ func TestEventExecveLongArgs(t *testing.T) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
+	if !kernels.EnableLargeProgs() {
+		t.Skip()
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), cmdWaitTime)
 	defer cancel()
 
@@ -325,6 +333,10 @@ func TestEventExecveLongArgs(t *testing.T) {
 func TestEventExecveLongPathLongArgs(t *testing.T) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
+
+	if !kernels.EnableLargeProgs() {
+		t.Skip()
+	}
 
 	testNop := testutils.ContribPath("tester-progs/nop")
 


### PR DESCRIPTION
Disabling long path/args retrieval for 4.19 kernels,
because it breaks probe loading at the moment with
program too long error.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>