### PR TITLE
Remove dup() test from TestCopyFd

### DIFF
--- a/contrib/tester-progs/dup-tester.c
+++ b/contrib/tester-progs/dup-tester.c
@@ -30,7 +30,7 @@ void read_with_fd(int fd)
 
 int main(int argc, char *argv[])
 {
-    int fd, fd_dup, fd_dup2, fd_dup3;
+    int fd, fd_dup2, fd_dup3;
     const char *pathname = "./strange.txt";
 
     {
@@ -54,12 +54,6 @@ int main(int argc, char *argv[])
 
     read_with_fd(fd);
 
-    fd_dup = dup(fd);
-    if (fd_dup == -1)
-         errExit("dup");
-
-    read_with_fd(fd_dup);
-
     fd_dup2 = dup2(fd, 15); // 15 should be an unused file descriptor
     if (fd_dup2 == -1)
         errExit("dup2");
@@ -74,7 +68,6 @@ int main(int argc, char *argv[])
 
     close(fd_dup3);
     close(fd_dup2);
-    close(fd_dup);
     close(fd);
 
     {

--- a/pkg/sensors/tracing/kprobe_copyfd_test.go
+++ b/pkg/sensors/tracing/kprobe_copyfd_test.go
@@ -50,8 +50,7 @@ func TestCopyFd(t *testing.T) {
 	// makeSpecFile creates a new spec file bsed on the template, and the provided arguments
 	makeSpecFile := func(pid string) string {
 		data := map[string]string{
-			"MatchedPID":   pid,
-			"NamespacePID": "false",
+			"MatchedPID": pid,
 		}
 		specName, err := testutils.GetSpecFromTemplate("copyfd.yaml.tmpl", data)
 		if err != nil {

--- a/pkg/sensors/tracing/kprobe_copyfd_test.go
+++ b/pkg/sensors/tracing/kprobe_copyfd_test.go
@@ -96,7 +96,6 @@ func TestCopyFd(t *testing.T) {
 		kpChecker,
 		kpChecker,
 		kpChecker,
-		kpChecker,
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)

--- a/testdata/specs/copyfd.yaml.tmpl
+++ b/testdata/specs/copyfd.yaml.tmpl
@@ -15,7 +15,6 @@ spec:
     - matchPIDs:
       - operator: In
         followForks: true
-        isNamespacePID: {{.NamespacePID}}
         values:
         - {{.MatchedPID}}
       matchArgs:
@@ -38,7 +37,6 @@ spec:
     - matchPIDs:
       - operator: In
         followForks: true
-        isNamespacePID: {{.NamespacePID}}
         values:
         - {{.MatchedPID}}
       matchArgs:
@@ -63,7 +61,6 @@ spec:
     - matchPIDs:
       - operator: In
         followForks: true
-        isNamespacePID: {{.NamespacePID}}
         values:
         - {{.MatchedPID}}
       matchArgs:
@@ -84,7 +81,6 @@ spec:
     - matchPIDs:
       - operator: In
         followForks: true
-        isNamespacePID: {{.NamespacePID}}
         values:
         - {{.MatchedPID}}
       matchActions:
@@ -105,7 +101,6 @@ spec:
     - matchPIDs:
       - operator: In
         followForks: true
-        isNamespacePID: {{.NamespacePID}}
         values:
         - {{.MatchedPID}}
       matchArgs:


### PR DESCRIPTION
TestCopyFd is failing in older kernels due to missing an event from dup.

`dup` system call is captured by hooking at `fd_install` in a similar way to `open` system call which is not actually the case in CopyFD.

Will fix temporary https://github.com/cilium/tetragon/issues/152 but we have to fix also the `dup` case.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>