### PR TITLE
Docs: Use URLs for kubectl apply demo commands instead of relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ specify additional directories or specific files if needed.
 As a first step, let's apply the following `TracingPolicy`:
 
 ```bash
-kubectl apply -f ./crds/examples/sys_write_follow_fd_prefix.yaml
+kubectl apply -f https://raw.githubusercontent.com/cilium/tetragon/main/crds/examples/sys_write_follow_fd_prefix.yaml
 ```
 
 As a second step, let's start monitoring the events from the `xwing` pod:
@@ -532,7 +532,7 @@ kubectl delete -f ./crds/examples/sys_write_follow_fd_prefix.yaml
 To view TCP connect events apply the example TCP connect `TracingPolicy`:
 
 ```bash
-kubectl apply -f ./crds/examples/tcp-connect.yaml
+kubectl apply -f https://raw.githubusercontent.com/cilium/tetragon/main/crds/examples/tcp-connect.yaml
 ```
 
 To start monitoring events in the `xwing` pod run the Tetragon CLI:
@@ -584,7 +584,7 @@ kubectl logs -n kube-system ds/tetragon -c export-stdout -f | tetragon observe -
 
 In another terminal let's apply the privileged PodSpec:
 ```bash
-kubectl apply -f ./testdata/specs/testpod.yaml
+kubectl apply -f https://raw.githubusercontent.com/cilium/tetragon/main/testdata/specs/testpod.yaml
 ```
 
 If you observe the output in the first terminal, you can see the container start with `CAP_SYS_ADMIN`:


### PR DESCRIPTION
## Problem to solve

We've tested the Tetragon deployment for the first time in our #EveryoneCanContribute cafe meetup: https://everyonecancontribute.com/post/2022-06-16-cafe-52-learned-at-kubecon-eu-coffee-chat/  

Some of the kubectl commands use relative paths which only work when you have the project cloned locally. 

This PR changes all kubectl commands to using raw URLs and help smoothen the first impression, allowing to deploy and play < 15 minutes. 