### PR TITLE
Fixes to pass VSCode Intellisence checks

### DIFF
--- a/bpf/lib/bpf_helpers.h
+++ b/bpf/lib/bpf_helpers.h
@@ -35,6 +35,9 @@
 #define XSTR(s) STR(s)
 #define STR(s)	#s
 
+#ifdef VSCODE
+const void * __builtin_preserve_access_index(void *);
+#endif
 #define _(P) (__builtin_preserve_access_index(P))
 
 /*

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -8,7 +8,7 @@
 #include "bpf_events.h"
 #include "bpf_process_event.h"
 
-char _license[] __attribute__((section(("license")), used)) = "GPL";
+char _license[] __attribute__((section("license"), used)) = "GPL";
 
 #ifdef __LARGE_BPF_PROG
 #include "data_event.h"
@@ -145,7 +145,7 @@ event_filename_builder(void *ctx, struct msg_process *curr, __u32 curr_pid,
 	return bin;
 }
 
-__attribute__((section(("tracepoint/sys_execve")), used)) int
+__attribute__((section("tracepoint/sys_execve"), used)) int
 event_execve(struct sched_execve_args *ctx)
 {
 	struct task_struct *task = (struct task_struct *)get_current_task();

--- a/bpf/process/bpf_exit.c
+++ b/bpf/process/bpf_exit.c
@@ -3,9 +3,9 @@
 
 #include "bpf_exit.h"
 
-char _license[] __attribute__((section(("license")), used)) = "GPL";
+char _license[] __attribute__((section("license"), used)) = "GPL";
 
-__attribute__((section(("tracepoint/sys_exit")), used)) int
+__attribute__((section("tracepoint/sys_exit"), used)) int
 event_exit(struct sched_execve_args *ctx)
 {
 	__u64 pid_tgid;

--- a/bpf/process/bpf_fork.c
+++ b/bpf/process/bpf_fork.c
@@ -8,13 +8,13 @@
 #include "bpf_events.h"
 #include "bpf_process_event.h"
 
-char _license[] __attribute__((section(("license")), used)) = "GPL";
+char _license[] __attribute__((section("license"), used)) = "GPL";
 #ifdef VMLINUX_KERNEL_VERSION
 int _version __attribute__((section(("version")), used)) =
 	VMLINUX_KERNEL_VERSION;
 #endif
 
-__attribute__((section(("kprobe/wake_up_new_task")), used)) int
+__attribute__((section("kprobe/wake_up_new_task"), used)) int
 event_wake_up_new_task(struct pt_regs *ctx)
 {
 	struct execve_map_value *curr, *parent;

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -14,7 +14,7 @@
 #include "generic_calls.h"
 #include "pfilter.h"
 
-char _license[] __attribute__((section(("license")), used)) = "GPL";
+char _license[] __attribute__((section("license"), used)) = "GPL";
 
 struct bpf_map_def __attribute__((section("maps"), used)) process_call_heap = {
 	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
@@ -108,13 +108,13 @@ generic_kprobe_start_process_filter(void *ctx)
  * to get below 4k insns. For 5.x+ kernels with 1m.insns its not
  * an issue.
  */
-__attribute__((section(("kprobe/generic_kprobe")), used)) int
+__attribute__((section("kprobe/generic_kprobe"), used)) int
 generic_kprobe_event(struct pt_regs *ctx)
 {
 	return generic_kprobe_start_process_filter(ctx);
 }
 
-__attribute__((section(("kprobe/0")), used)) int
+__attribute__((section("kprobe/0"), used)) int
 generic_kprobe_process_event0(void *ctx)
 {
 	return generic_process_event_and_setup(ctx, &process_call_heap,
@@ -122,35 +122,35 @@ generic_kprobe_process_event0(void *ctx)
 					       &config_map);
 }
 
-__attribute__((section(("kprobe/1")), used)) int
+__attribute__((section("kprobe/1"), used)) int
 generic_kprobe_process_event1(void *ctx)
 {
 	return generic_process_event1(ctx, &process_call_heap, &filter_map,
 				      &kprobe_calls, &config_map);
 }
 
-__attribute__((section(("kprobe/2")), used)) int
+__attribute__((section("kprobe/2"), used)) int
 generic_kprobe_process_event2(void *ctx)
 {
 	return generic_process_event2(ctx, &process_call_heap, &filter_map,
 				      &kprobe_calls, &config_map);
 }
 
-__attribute__((section(("kprobe/3")), used)) int
+__attribute__((section("kprobe/3"), used)) int
 generic_kprobe_process_event3(void *ctx)
 {
 	return generic_process_event3(ctx, &process_call_heap, &filter_map,
 				      &kprobe_calls, &config_map);
 }
 
-__attribute__((section(("kprobe/4")), used)) int
+__attribute__((section("kprobe/4"), used)) int
 generic_kprobe_process_event4(void *ctx)
 {
 	return generic_process_event4(ctx, &process_call_heap, &filter_map,
 				      &kprobe_calls, &config_map);
 }
 
-__attribute__((section(("kprobe/5")), used)) int
+__attribute__((section("kprobe/5"), used)) int
 generic_kprobe_process_filter(void *ctx)
 {
 	struct msg_generic_kprobe *msg;
@@ -171,42 +171,42 @@ generic_kprobe_process_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
-__attribute__((section(("kprobe/6")), used)) int
+__attribute__((section("kprobe/6"), used)) int
 generic_kprobe_filter_arg1(void *ctx)
 {
 	return filter_read_arg(ctx, 0, &process_call_heap, &filter_map,
 			       &kprobe_calls, &override_tasks, &config_map);
 }
 
-__attribute__((section(("kprobe/7")), used)) int
+__attribute__((section("kprobe/7"), used)) int
 generic_kprobe_filter_arg2(void *ctx)
 {
 	return filter_read_arg(ctx, 1, &process_call_heap, &filter_map,
 			       &kprobe_calls, &override_tasks, &config_map);
 }
 
-__attribute__((section(("kprobe/8")), used)) int
+__attribute__((section("kprobe/8"), used)) int
 generic_kprobe_filter_arg3(void *ctx)
 {
 	return filter_read_arg(ctx, 2, &process_call_heap, &filter_map,
 			       &kprobe_calls, &override_tasks, &config_map);
 }
 
-__attribute__((section(("kprobe/9")), used)) int
+__attribute__((section("kprobe/9"), used)) int
 generic_kprobe_filter_arg4(void *ctx)
 {
 	return filter_read_arg(ctx, 3, &process_call_heap, &filter_map,
 			       &kprobe_calls, &override_tasks, &config_map);
 }
 
-__attribute__((section(("kprobe/10")), used)) int
+__attribute__((section("kprobe/10"), used)) int
 generic_kprobe_filter_arg5(void *ctx)
 {
 	return filter_read_arg(ctx, 4, &process_call_heap, &filter_map,
 			       &kprobe_calls, &override_tasks, &config_map);
 }
 
-__attribute__((section(("kprobe/override")), used)) int
+__attribute__((section("kprobe/override"), used)) int
 generic_kprobe_override(void *ctx)
 {
 	__u64 id = get_current_pid_tgid();

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -11,7 +11,7 @@
 
 #define MAX_FILENAME 8096
 
-char _license[] __attribute__((section(("license")), used)) = "GPL";
+char _license[] __attribute__((section("license"), used)) = "GPL";
 
 struct bpf_map_def __attribute__((section("maps"), used)) process_call_heap = {
 	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
@@ -27,7 +27,7 @@ struct bpf_map_def __attribute__((section("maps"), used)) config_map = {
 	.max_entries = 1,
 };
 
-__attribute__((section(("kprobe/generic_retkprobe")), used)) int
+__attribute__((section("kprobe/generic_retkprobe"), used)) int
 generic_kprobe_event(struct pt_regs *ctx)
 {
 	struct execve_map_value *enter;

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -99,7 +99,7 @@ static inline __attribute__((always_inline)) unsigned long get_ctx_ul(void *src,
 	}
 }
 
-__attribute__((section(("tracepoint/generic_tracepoint")), used)) int
+__attribute__((section("tracepoint/generic_tracepoint"), used)) int
 generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 {
 	struct msg_generic_kprobe *msg;
@@ -164,41 +164,41 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	return 0;
 }
 
-__attribute__((section(("kprobe/0")), used)) int
+__attribute__((section("kprobe/0"), used)) int
 generic_tracepoint_event0(void *ctx)
 {
 	return generic_process_event0(ctx, &tp_heap, &filter_map, &tp_calls,
 				      &config_map);
 }
-__attribute__((section(("kprobe/1")), used)) int
+__attribute__((section("kprobe/1"), used)) int
 generic_tracepoint_event1(void *ctx)
 {
 	return generic_process_event1(ctx, &tp_heap, &filter_map, &tp_calls,
 				      &config_map);
 }
 
-__attribute__((section(("kprobe/2")), used)) int
+__attribute__((section("kprobe/2"), used)) int
 generic_tracepoint_event2(void *ctx)
 {
 	return generic_process_event2(ctx, &tp_heap, &filter_map, &tp_calls,
 				      &config_map);
 }
 
-__attribute__((section(("kprobe/3")), used)) int
+__attribute__((section("kprobe/3"), used)) int
 generic_tracepoint_event3(void *ctx)
 {
 	return generic_process_event3(ctx, &tp_heap, &filter_map, &tp_calls,
 				      &config_map);
 }
 
-__attribute__((section(("kprobe/4")), used)) int
+__attribute__((section("kprobe/4"), used)) int
 generic_tracepoint_event4(void *ctx)
 {
 	return generic_process_event4(ctx, &tp_heap, &filter_map, &tp_calls,
 				      &config_map);
 }
 
-__attribute__((section(("kprobe/5")), used)) int
+__attribute__((section("kprobe/5"), used)) int
 generic_tracepoint_filter(void *ctx)
 {
 	struct msg_generic_kprobe *msg;
@@ -219,38 +219,38 @@ generic_tracepoint_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
-__attribute__((section(("kprobe/6")), used)) int
+__attribute__((section("kprobe/6"), used)) int
 generic_tracepoint_arg1(void *ctx)
 {
 	return filter_read_arg(ctx, 0, &tp_heap, &filter_map, &tp_calls,
 			       (void *)0, &config_map);
 }
 
-__attribute__((section(("kprobe/7")), used)) int
+__attribute__((section("kprobe/7"), used)) int
 generic_tracepoint_arg2(void *ctx)
 {
 	return filter_read_arg(ctx, 1, &tp_heap, &filter_map, &tp_calls,
 			       (void *)0, &config_map);
 }
 
-__attribute__((section(("kprobe/8")), used)) int
+__attribute__((section("kprobe/8"), used)) int
 generic_tracepoint_arg3(void *ctx)
 {
 	return filter_read_arg(ctx, 2, &tp_heap, &filter_map, &tp_calls,
 			       (void *)0, &config_map);
 }
 
-__attribute__((section(("kprobe/9")), used)) int
+__attribute__((section("kprobe/9"), used)) int
 generic_tracepoint_arg4(void *ctx)
 {
 	return filter_read_arg(ctx, 3, &tp_heap, &filter_map, &tp_calls,
 			       (void *)0, &config_map);
 }
 
-__attribute__((section(("kprobe/10")), used)) int
+__attribute__((section("kprobe/10"), used)) int
 generic_tracepoint_arg5(void *ctx)
 {
 	return filter_read_arg(ctx, 4, &tp_heap, &filter_map, &tp_calls,
 			       (void *)0, &config_map);
 }
-char _license[] __attribute__((section(("license")), used)) = "GPL";
+char _license[] __attribute__((section("license"), used)) = "GPL";

--- a/bpf/test/bpf_globals.c
+++ b/bpf/test/bpf_globals.c
@@ -8,7 +8,7 @@
 #include "bpf_events.h"
 #include "globals.h"
 
-char _license[] __attribute__((section(("license")), used)) = "GPL";
+char _license[] __attribute__((section("license"), used)) = "GPL";
 
 GLOBAL_U16 g_u16;
 GLOBAL_I16 g_i16;
@@ -17,7 +17,7 @@ GLOBAL_I32 g_i32;
 GLOBAL_U64 g_u64;
 GLOBAL_I64 g_i64;
 
-__attribute__((section(("socket_filter/read_globals_test")), used)) int
+__attribute__((section("socket_filter/read_globals_test"), used)) int
 read_globals_test(void *ctx)
 {
 	if (READ_GLOBAL(g_u16) != 65535)

--- a/bpf/test/bpf_lseek.c
+++ b/bpf/test/bpf_lseek.c
@@ -35,9 +35,9 @@ struct sys_enter_lseek_args {
 	__u64 whence;
 };
 
-char _license[] __attribute__((section(("license")), used)) = "GPL";
+char _license[] __attribute__((section("license"), used)) = "GPL";
 
-__attribute__((section(("tracepoint/sys_enter_lseek")), used)) int
+__attribute__((section("tracepoint/sys_enter_lseek"), used)) int
 test_lseek(struct sys_enter_lseek_args *ctx)
 {
 	// NB: this values should match BogusFd and  BogusWhenceVal in


### PR DESCRIPTION
Often, the attribute((section())) statement was used with an extra
set of parentheses around the section name. This caused issues for
VSCode and resulted in the files being marked as having errors, making
it harder to spot actual errors.

This commit removes the extra parentheses. It also adds a #define for
'''__builtin_preserve_access_index()''' if VSCODE has been defined. This
allows developers to define VSCODE in their VSCODE C/C++ settings in
order to stop Intellisense complaining about the _(P) macro which is
used in probe_read() calls.

Signed-off-by: Kevin Sheldrake <kevin.sheldrake@isovalent.com>