### PR TITLE
tetragon: Teach file writer to exit gracefully

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -138,13 +138,6 @@ func hubbleTETRAGONExecute() error {
 	 */
 	obs.RemovePrograms()
 	os.Mkdir(defaults.DefaultRunDir, os.ModeDir)
-	go func() {
-		<-sigs
-		obs.PrintStats()
-		obs.RemovePrograms()
-		cancel()
-		os.Exit(1)
-	}()
 
 	err := btf.InitCachedBTF(ctx, option.Config.HubbleLib, option.Config.BTF)
 	if err != nil {
@@ -176,6 +169,7 @@ func hubbleTETRAGONExecute() error {
 	}
 
 	pm, err := tetragonGrpc.NewProcessManager(
+		ctx,
 		ciliumState,
 		observer.SensorManager,
 		enableProcessCred,
@@ -193,6 +187,14 @@ func hubbleTETRAGONExecute() error {
 			return err
 		}
 	}
+
+	go func() {
+		<-sigs
+		obs.PrintStats()
+		obs.RemovePrograms()
+		cancel()
+		os.Exit(1)
+	}()
 
 	log.WithField("enabled", exportFilename != "").WithField("fileName", exportFilename).Info("Exporter configuration")
 	obs.AddListener(pm)

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -60,6 +60,7 @@ type ProcessManager struct {
 // NewProcessManager returns a pointer to an initialized ProcessManager struct.
 func NewProcessManager(
 	ctx context.Context,
+	wg *sync.WaitGroup,
 	ciliumState *cilium.State,
 	manager *sensors.Manager,
 	enableProcessCred bool,
@@ -83,7 +84,7 @@ func NewProcessManager(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DNS cache %w", err)
 	}
-	pm.Server = server.NewServer(ctx, pm, manager)
+	pm.Server = server.NewServer(ctx, wg, pm, manager)
 	pm.eventCache = eventcache.New(pm.Server, pm.dns)
 	pm.execCache = execcache.New(pm.Server, pm.dns)
 

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -4,6 +4,7 @@
 package grpc
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -58,6 +59,7 @@ type ProcessManager struct {
 
 // NewProcessManager returns a pointer to an initialized ProcessManager struct.
 func NewProcessManager(
+	ctx context.Context,
 	ciliumState *cilium.State,
 	manager *sensors.Manager,
 	enableProcessCred bool,
@@ -81,7 +83,7 @@ func NewProcessManager(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DNS cache %w", err)
 	}
-	pm.Server = server.NewServer(pm, manager)
+	pm.Server = server.NewServer(ctx, pm, manager)
 	pm.eventCache = eventcache.New(pm.Server, pm.dns)
 	pm.execCache = execcache.New(pm.Server, pm.dns)
 

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -145,7 +146,10 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 	err := process.InitCache(context.Background(), watcher.NewFakeK8sWatcher(nil), false, 10)
 	assert.NoError(t, err)
 	defer process.FreeCache()
+	var wg sync.WaitGroup
 	pm, err := NewProcessManager(
+		context.Background(),
+		&wg,
 		cilium.GetFakeCiliumState(),
 		nil,
 		false, false, false, false)

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -358,7 +358,7 @@ func loadExporter(t *testing.T, obs *Observer, opts *testExporterOptions, oo *te
 	// to bounce events through the cache waiting for Cilium to reply with endpoints
 	// and K8s cache data to be completed. We currently only stub them enough to
 	// report nil or a pre-defined value. So no cache needed.
-	processManager, err := tetragonGrpc.NewProcessManager(ciliumState, SensorManager, true, true, true, false)
+	processManager, err := tetragonGrpc.NewProcessManager(context.Background(), ciliumState, SensorManager, true, true, true, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We observed that rarely if we SIGTERM Tetragon (e.g. what pod restart and destroy do before SIGKILL it) that a corrupted json file might get left behind. The theory is this is do to writers being killed in the middle of an operation. 

To fix we do two things. First propagate a single context through the processManager and Server objects instead of just using context.Backgroun(). This allows the cancel() call from our SIGTERM handler to be handled by ctx.Done() in the respective go routines. Then we add a waitGroup to the signal handler to ensure it waits until the writer has exited.

I only fix the go routine responsible for writes here. We should audit the other routines as well.

And second I started thinking about how we nest the various objects, at the moment we pass a lot of input types through the New() constructors. But this looked bigger than a fix so held off for now on this.