### PR TITLE
Update Tetragon Clusterrole

### DIFF
--- a/install/kubernetes/templates/clusterrole.yaml
+++ b/install/kubernetes/templates/clusterrole.yaml
@@ -17,17 +17,18 @@ rules:
   - apiGroups:
       - cilium.io
     resources:
-      - '*'
+      - tracingpolicies
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
   - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
+    resourceNames:
+      - tracingpolicies.cilium.io
     verbs:
       - create
-      - get
-      - list
       - update
-      - watch
 {{- end }}


### PR DESCRIPTION
Tetragon daemonset should be only allowed to get/list/watch TracingPolicy objects
Tetragon daemonset should be only allowed to create/update the TracingPolicy CRD definition

Signed-off-by: Natalia Reka Ivanko <natalia@isovalent.com>