### PR TITLE
Update the current clusterrole

### DIFF
--- a/install/kubernetes/templates/clusterrole.yaml
+++ b/install/kubernetes/templates/clusterrole.yaml
@@ -26,9 +26,14 @@ rules:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
+    verbs:
+      - create
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
     resourceNames:
       - tracingpolicies.cilium.io
     verbs:
-      - create
       - update
 {{- end }}


### PR DESCRIPTION
Tetragon daemonset should be only allowed to get/list/watch TracingPolicy objects
Tetragon daemonset should be only allowed to create/update the TracingPolicy CRD definition

Signed-off-by: Natalia Reka Ivanko <natalia@isovalent.com>