### PR TITLE
clusterrole: add get and list verbs

### DIFF
--- a/install/kubernetes/templates/clusterrole.yaml
+++ b/install/kubernetes/templates/clusterrole.yaml
@@ -31,4 +31,6 @@ rules:
     verbs:
       - create
       - update
+      - get
+      - list
 {{- end }}


### PR DESCRIPTION
A prior broke our operator since it is no longer able to create the tracingpolicy CRD with
the permissions we gave it. Add get/list verbs for customresource so that it works again.

Signed-off-by: William Findlay <will@isovalent.com>