### PR TITLE
chore: add event_config alignment check

### DIFF
--- a/bpf/alignchecker/bpf_alignchecker.c
+++ b/bpf/alignchecker/bpf_alignchecker.c
@@ -3,6 +3,8 @@
 #include "include/vmlinux.h"
 #include "include/api.h"
 #include "lib/hubble_msg.h"
+#include "process/retprobe_map.h"
+#include "process/types/basic.h"
 
 /* DECLARE declares a unique usage of the union or struct 'x' on the stack.
  *
@@ -36,6 +38,7 @@ int main(void)
 	// from maps
 	DECLARE(struct, event, iter);
 	DECLARE(struct, execve_map_value, iter);
+	DECLARE(struct, event_config, iter);
 
 	return 0;
 }

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/api/testapi"
+	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/sensors/exec/execvemap"
 
 	check "github.com/cilium/cilium/pkg/alignchecker"
@@ -29,6 +30,7 @@ func CheckStructAlignments(path string) error {
 		"msg_exit":         {reflect.TypeOf(processapi.MsgExitEvent{})},
 		"msg_test":         {reflect.TypeOf(testapi.MsgTestEvent{})},
 		"execve_map_value": {reflect.TypeOf(execvemap.ExecveValue{})},
+		"event_config":     {reflect.TypeOf(tracingapi.EventConfig{})},
 	}
 	return check.CheckStructAlignments(path, toCheck, true)
 }

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -228,12 +228,12 @@ type KprobeArgs struct {
 }
 
 type EventConfig struct {
-	FuncId        uint32
-	Arg           [5]int32
-	ArgM          [5]uint32
-	ArgTpCtxOff   [5]uint32
-	Sigkill       uint32
-	Syscall       uint32
-	ArgReturnCopy int32
-	ArgReturn     int32
+	FuncId        uint32    `align:"func_id"`
+	Arg           [5]int32  `align:"arg0"`
+	ArgM          [5]uint32 `align:"arg0m"`
+	ArgTpCtxOff   [5]uint32 `align:"t_arg0_ctx_off"`
+	Sigkill       uint32    `align:"sigkill"`
+	Syscall       uint32    `align:"syscall"`
+	ArgReturnCopy int32     `align:"argreturncopy"`
+	ArgReturn     int32     `align:"argreturn"`
 }


### PR DESCRIPTION
Take the issue #108 . Have tested locally.

--- 
BTW, the alignment-checker reminds me that 
```
C and Go structs alignment check failed: execvemap.ExecveValue(48) size does not match execve_map_value(112)
```

Is this expected? I found that they are defined as 
```C
// bpf/lib/process.h
struct execve_map_value {
	struct msg_execve_key key;
	struct msg_execve_key pkey;
	__u32 flags;
	__u32 nspid;
	__u32 binary;
	__u32 pad;
	struct msg_ns ns;
	struct msg_capabilities caps;
} __attribute__((packed)) __attribute__((aligned(8)));
```

and 

```go
// pkg/sensors/exec/execvemap/execve.go
type ExecveValue struct {
	Process processapi.MsgExecveKey
	Parent  processapi.MsgExecveKey
	Flags   uint32
	Nspid   uint32
	Buffer  uint64
}
```
Apparently, they are not the same...
And another related `ExecveValueL` struct in `pkg/sensors/exec/execvemap/execve.go` seems deprectated.