### PR TITLE
helm/rbac: split crd create permissions

### DIFF
--- a/install/kubernetes/templates/clusterrole.yaml
+++ b/install/kubernetes/templates/clusterrole.yaml
@@ -22,6 +22,14 @@ rules:
       - get
       - list
       - watch
+  # We need to split out the create permission and enforce it without resourceNames since
+  # the name would not be known at resource creation time
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -29,7 +37,6 @@ rules:
     resourceNames:
       - tracingpolicies.cilium.io
     verbs:
-      - create
       - update
       - get
       - list


### PR DESCRIPTION
According to the k8s RBAC documentation:

    Note: You cannot restrict create or deletecollection requests by their resource name.
    For create, this limitation is because the name of the new object may not be known at
    authorization time.

This was causing our operator to fail because it the "create" verb was restricted in the
resource name which was not known ahead of time. To fix this, we need to split out the
"create" permission such that it is not restricted by resourceNames. We can keep the other
CRD permissions as-is.

Logs from operator before this change:

    level=fatal msg="Unable to register CRDs" error="Unable to create custom resource
    definition: customresourcedefinitions.apiextensions.k8s.io is forbidden: User
    \"system:serviceaccount:kube-system:tetragon\" cannot create resource
    \"customresourcedefinitions\" in API group \"apiextensions.k8s.io\" at the cluster
    scope" subsys=tetragon-operator

Signed-off-by: William Findlay <will@isovalent.com>