### PR TITLE
doc: remove invalid whitespaces in proto file

### DIFF
--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -164,9 +164,7 @@ AggregationOptions defines configuration options for aggregating events.
 | image | [Image](#tetragon-Image) |  |  |
 | start_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Start time of the container. |
 | pid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | PID in the container namespace. |
-| maybe_exec_probe | [bool](#bool) |  | If this is set true, it means that the process might have been originated from a Kubernetes exec probe. For this field to be true, the following must be true:
-
-1. The binary field matches the first element of the exec command list for either liveness or readiness probe excluding the basename. For example, &#34;/bin/ls&#34; and &#34;ls&#34; are considered a match. 2. The arguments field exactly matches the rest of the exec command list. |
+| maybe_exec_probe | [bool](#bool) |  | If this is set true, it means that the process might have been originated from a Kubernetes exec probe. For this field to be true, the following must be true: 1. The binary field matches the first element of the exec command list for either liveness or readiness probe excluding the basename. For example, &#34;/bin/ls&#34; and &#34;ls&#34; are considered a match. 2. The arguments field exactly matches the rest of the exec command list. |
 
 
 
@@ -298,12 +296,8 @@ AggregationOptions defines configuration options for aggregating events.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | allow_list | [Filter](#tetragon-Filter) | repeated | allow_list specifies a list of filters to apply to only return certain events. If multiple filters are specified, at least one of them has to match for an event to be included in the results. |
-| deny_list | [Filter](#tetragon-Filter) | repeated | deny_list specifies a list of filters to apply to exclude certain events from the results. If multiple filters are specified, at least one of them has to match for an event to be excluded.
-
-If both allow_list and deny_list are specified, the results contain the set difference allow_list - deny_list. |
-| aggregation_options | [AggregationOptions](#tetragon-AggregationOptions) |  | aggregation_options configures aggregation options for this request. If this field is not set, responses will not be aggregated.
-
-Note that currently only process_accept and process_connect events are aggregated. Other events remain unaggregated. |
+| deny_list | [Filter](#tetragon-Filter) | repeated | deny_list specifies a list of filters to apply to exclude certain events from the results. If multiple filters are specified, at least one of them has to match for an event to be excluded. If both allow_list and deny_list are specified, the results contain the set difference allow_list - deny_list. |
+| aggregation_options | [AggregationOptions](#tetragon-AggregationOptions) |  | aggregation_options configures aggregation options for this request. If this field is not set, responses will not be aggregated. Note that currently only process_accept and process_connect events are aggregated. Other events remain unaggregated. |
 
 
 
@@ -325,9 +319,7 @@ Note that currently only process_accept and process_connect events are aggregate
 | process_dns | [ProcessDns](#tetragon-ProcessDns) |  |  |
 | test | [Test](#tetragon-Test) |  |  |
 | node_name | [string](#string) |  | Name of the node where this event was observed. |
-| time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Timestamp at which this event was observed.
-
-For an aggregated response, this field to set to the timestamp at which the event was observed for the first time in a given aggregation time window. |
+| time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Timestamp at which this event was observed. For an aggregated response, this field to set to the timestamp at which the event was observed for the first time in a given aggregation time window. |
 | aggregation_info | [AggregationInfo](#tetragon-AggregationInfo) |  | aggregation_info contains information about aggregation results. This field is set only for aggregated responses. |
 
 
@@ -988,57 +980,47 @@ For an aggregated response, this field to set to the timestamp at which the even
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| CAP_CHOWN | 0 | In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this overrides the restriction of changing file ownership and group ownership.
-
-Override all DAC access, including ACL execute access if [_POSIX_ACL] is defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE. |
-| DAC_OVERRIDE | 1 |  |
+| CAP_CHOWN | 0 | In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this overrides the restriction of changing file ownership and group ownership. |
+| DAC_OVERRIDE | 1 | Override all DAC access, including ACL execute access if [_POSIX_ACL] is defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE. |
 | CAP_DAC_READ_SEARCH | 2 | Overrides all DAC restrictions regarding read and search on files and directories, including ACL restrictions if [_POSIX_ACL] is defined. Excluding DAC access covered by &#34;$1&#34;_LINUX_IMMUTABLE. |
-| CAP_FOWNER | 3 |  |
-| CAP_FSETID | 4 |  |
-| CAP_KILL | 5 |  |
-| CAP_SETGID | 6 |  |
-| CAP_SETUID | 7 |  |
-| CAP_SETPCAP | 8 |  |
-| CAP_LINUX_IMMUTABLE | 9 |  |
-| CAP_NET_BIND_SERVICE | 10 |  |
-| CAP_NET_BROADCAST | 11 |  |
-| CAP_NET_ADMIN | 12 |  |
-| CAP_NET_RAW | 13 |  |
-| CAP_IPC_LOCK | 14 |  |
-| CAP_IPC_OWNER | 15 |  |
+| CAP_FOWNER | 3 | Overrides all restrictions about allowed operations on files, where file owner ID must be equal to the user ID, except where CAP_FSETID is applicable. It doesn&#39;t override MAC and DAC restrictions. |
+| CAP_FSETID | 4 | Overrides the following restrictions that the effective user ID shall match the file owner ID when setting the S_ISUID and S_ISGID bits on that file; that the effective group ID (or one of the supplementary group IDs) shall match the file owner ID when setting the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are cleared on successful return from chown(2) (not implemented). |
+| CAP_KILL | 5 | Overrides the restriction that the real or effective user ID of a process sending a signal must match the real or effective user ID of the process receiving the signal. |
+| CAP_SETGID | 6 | Allows forged gids on socket credentials passing. |
+| CAP_SETUID | 7 | Allows forged pids on socket credentials passing. |
+| CAP_SETPCAP | 8 | Without VFS support for capabilities: Transfer any capability in your permitted set to any pid, remove any capability in your permitted set from any pid With VFS support for capabilities (neither of above, but) Add any capability from current&#39;s capability bounding set to the current process&#39; inheritable set Allow taking bits out of capability bounding set Allow modification of the securebits for a process |
+| CAP_LINUX_IMMUTABLE | 9 | Allow modification of S_IMMUTABLE and S_APPEND file attributes |
+| CAP_NET_BIND_SERVICE | 10 | Allows binding to ATM VCIs below 32 |
+| CAP_NET_BROADCAST | 11 | Allow broadcasting, listen to multicast |
+| CAP_NET_ADMIN | 12 | Allow activation of ATM control sockets |
+| CAP_NET_RAW | 13 | Allow binding to any address for transparent proxying (also via NET_ADMIN) |
+| CAP_IPC_LOCK | 14 | Allow mlock and mlockall (which doesn&#39;t really have anything to do with IPC) |
+| CAP_IPC_OWNER | 15 | Override IPC ownership checks |
 | CAP_SYS_MODULE | 16 | Insert and remove kernel modules - modify kernel without limit |
-| CAP_SYS_RAWIO | 17 |  |
-| CAP_SYS_CHROOT | 18 |  |
-| CAP_SYS_PTRACE | 19 | Allow configuration of process accounting |
-| CAP_SYS_PACCT | 20 |  |
-| CAP_SYS_ADMIN | 21 |  |
-| CAP_SYS_BOOT | 22 |  |
-| CAP_SYS_NICE | 23 |  |
-| CAP_SYS_RESOURCE | 24 |  |
-| CAP_SYS_TIME | 25 |  |
-| CAP_SYS_TTY_CONFIG | 26 |  |
-| CAP_MKNOD | 27 |  |
-| CAP_LEASE | 28 |  |
-| CAP_AUDIT_WRITE | 29 |  |
-| CAP_AUDIT_CONTROL | 30 |  |
-| CAP_SETFCAP | 31 |  |
-| CAP_MAC_OVERRIDE | 32 |  |
-| CAP_MAC_ADMIN | 33 |  |
-| CAP_SYSLOG | 34 |  |
-| CAP_WAKE_ALARM | 35 |  |
-| CAP_BLOCK_SUSPEND | 36 |  |
-| CAP_AUDIT_READ | 37 |  |
-| CAP_PERFMON | 38 |  |
-| CAP_BPF | 39 | CAP_BPF allows the following BPF operations: - Creating all types of BPF maps - Advanced verifier features - Indirect variable access - Bounded loops - BPF to BPF function calls - Scalar precision tracking - Larger complexity limits - Dead code elimination - And potentially other features - Loading BPF Type Format (BTF) data - Retrieve xlated and JITed code of BPF programs - Use bpf_spin_lock() helper
-
-CAP_PERFMON relaxes the verifier checks further: - BPF progs can use of pointer-to-integer conversions - speculation attack hardening measures are bypassed - bpf_probe_read to read arbitrary kernel memory is allowed - bpf_trace_printk to print kernel memory is allowed
-
-CAP_SYS_ADMIN is required to use bpf_probe_write_user.
-
-CAP_SYS_ADMIN is required to iterate system wide loaded programs, maps, links, BTFs and convert their IDs to file descriptors.
-
-CAP_PERFMON and CAP_BPF are required to load tracing programs. CAP_NET_ADMIN and CAP_BPF are required to load networking programs. |
-| CAP_CHECKPOINT_RESTORE | 40 |  |
+| CAP_SYS_RAWIO | 17 | Allow sending USB messages to any device via /dev/bus/usb |
+| CAP_SYS_CHROOT | 18 | Allow use of chroot() |
+| CAP_SYS_PTRACE | 19 | Allow ptrace() of any process |
+| CAP_SYS_PACCT | 20 | Allow configuration of process accounting |
+| CAP_SYS_ADMIN | 21 | Allow everything under CAP_BPF and CAP_PERFMON for backward compatibility |
+| CAP_SYS_BOOT | 22 | Allow use of reboot() |
+| CAP_SYS_NICE | 23 | Allow setting cpu affinity on other processes |
+| CAP_SYS_RESOURCE | 24 | Control memory reclaim behavior |
+| CAP_SYS_TIME | 25 | Allow setting the real-time clock |
+| CAP_SYS_TTY_CONFIG | 26 | Allow vhangup() of tty |
+| CAP_MKNOD | 27 | Allow the privileged aspects of mknod() |
+| CAP_LEASE | 28 | Allow taking of leases on files |
+| CAP_AUDIT_WRITE | 29 | Allow writing the audit log via unicast netlink socket |
+| CAP_AUDIT_CONTROL | 30 | Allow configuration of audit via unicast netlink socket |
+| CAP_SETFCAP | 31 | Set or remove capabilities on files |
+| CAP_MAC_OVERRIDE | 32 | Override MAC access. The base kernel enforces no MAC policy. An LSM may enforce a MAC policy, and if it does and it chooses to implement capability based overrides of that policy, this is the capability it should use to do so. |
+| CAP_MAC_ADMIN | 33 | Allow MAC configuration or state changes. The base kernel requires no MAC configuration. An LSM may enforce a MAC policy, and if it does and it chooses to implement capability based checks on modifications to that policy or the data required to maintain it, this is the capability it should use to do so. |
+| CAP_SYSLOG | 34 | Allow configuring the kernel&#39;s syslog (printk behaviour) |
+| CAP_WAKE_ALARM | 35 | Allow triggering something that will wake the system |
+| CAP_BLOCK_SUSPEND | 36 | Allow preventing system suspends |
+| CAP_AUDIT_READ | 37 | Allow reading the audit log via multicast netlink socket |
+| CAP_PERFMON | 38 | Allow system performance and observability privileged operations using perf_events, i915_perf and other kernel subsystems |
+| CAP_BPF | 39 | CAP_BPF allows the following BPF operations: - Creating all types of BPF maps - Advanced verifier features - Indirect variable access - Bounded loops - BPF to BPF function calls - Scalar precision tracking - Larger complexity limits - Dead code elimination - And potentially other features - Loading BPF Type Format (BTF) data - Retrieve xlated and JITed code of BPF programs - Use bpf_spin_lock() helper CAP_PERFMON relaxes the verifier checks further: - BPF progs can use of pointer-to-integer conversions - speculation attack hardening measures are bypassed - bpf_probe_read to read arbitrary kernel memory is allowed - bpf_trace_printk to print kernel memory is allowed CAP_SYS_ADMIN is required to use bpf_probe_write_user. CAP_SYS_ADMIN is required to iterate system wide loaded programs, maps, links, BTFs and convert their IDs to file descriptors. CAP_PERFMON and CAP_BPF are required to load tracing programs. CAP_NET_ADMIN and CAP_BPF are required to load networking programs. |
+| CAP_CHECKPOINT_RESTORE | 40 | Allow writing to ns_last_pid |
 
 
 

--- a/api/v1/tetragon/tetragon.pb.go
+++ b/api/v1/tetragon/tetragon.pb.go
@@ -264,49 +264,115 @@ const (
 	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
 	//overrides the restriction of changing file ownership and group
 	//ownership.
-	CapabilitiesType_CAP_CHOWN    CapabilitiesType = 0
+	CapabilitiesType_CAP_CHOWN CapabilitiesType = 0
+	// Override all DAC access, including ACL execute access if
+	//[_POSIX_ACL] is defined. Excluding DAC access covered by
+	//CAP_LINUX_IMMUTABLE.
 	CapabilitiesType_DAC_OVERRIDE CapabilitiesType = 1
 	// Overrides all DAC restrictions regarding read and search on files
 	//and directories, including ACL restrictions if [_POSIX_ACL] is
 	//defined. Excluding DAC access covered by "$1"_LINUX_IMMUTABLE.
-	CapabilitiesType_CAP_DAC_READ_SEARCH  CapabilitiesType = 2
-	CapabilitiesType_CAP_FOWNER           CapabilitiesType = 3
-	CapabilitiesType_CAP_FSETID           CapabilitiesType = 4
-	CapabilitiesType_CAP_KILL             CapabilitiesType = 5
-	CapabilitiesType_CAP_SETGID           CapabilitiesType = 6
-	CapabilitiesType_CAP_SETUID           CapabilitiesType = 7
-	CapabilitiesType_CAP_SETPCAP          CapabilitiesType = 8
-	CapabilitiesType_CAP_LINUX_IMMUTABLE  CapabilitiesType = 9
+	CapabilitiesType_CAP_DAC_READ_SEARCH CapabilitiesType = 2
+	// Overrides all restrictions about allowed operations on files, where
+	//file owner ID must be equal to the user ID, except where CAP_FSETID
+	//is applicable. It doesn't override MAC and DAC restrictions.
+	CapabilitiesType_CAP_FOWNER CapabilitiesType = 3
+	// Overrides the following restrictions that the effective user ID
+	//shall match the file owner ID when setting the S_ISUID and S_ISGID
+	//bits on that file; that the effective group ID (or one of the
+	//supplementary group IDs) shall match the file owner ID when setting
+	//the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+	//cleared on successful return from chown(2) (not implemented).
+	CapabilitiesType_CAP_FSETID CapabilitiesType = 4
+	// Overrides the restriction that the real or effective user ID of a
+	//process sending a signal must match the real or effective user ID
+	//of the process receiving the signal.
+	CapabilitiesType_CAP_KILL CapabilitiesType = 5
+	// Allows forged gids on socket credentials passing.
+	CapabilitiesType_CAP_SETGID CapabilitiesType = 6
+	// Allows forged pids on socket credentials passing.
+	CapabilitiesType_CAP_SETUID CapabilitiesType = 7
+	// Without VFS support for capabilities:
+	//   Transfer any capability in your permitted set to any pid,
+	//   remove any capability in your permitted set from any pid
+	// With VFS support for capabilities (neither of above, but)
+	//   Add any capability from current's capability bounding set
+	//       to the current process' inheritable set
+	//   Allow taking bits out of capability bounding set
+	//   Allow modification of the securebits for a process
+	CapabilitiesType_CAP_SETPCAP CapabilitiesType = 8
+	// Allow modification of S_IMMUTABLE and S_APPEND file attributes
+	CapabilitiesType_CAP_LINUX_IMMUTABLE CapabilitiesType = 9
+	// Allows binding to ATM VCIs below 32
 	CapabilitiesType_CAP_NET_BIND_SERVICE CapabilitiesType = 10
-	CapabilitiesType_CAP_NET_BROADCAST    CapabilitiesType = 11
-	CapabilitiesType_CAP_NET_ADMIN        CapabilitiesType = 12
-	CapabilitiesType_CAP_NET_RAW          CapabilitiesType = 13
-	CapabilitiesType_CAP_IPC_LOCK         CapabilitiesType = 14
-	CapabilitiesType_CAP_IPC_OWNER        CapabilitiesType = 15
+	// Allow broadcasting, listen to multicast
+	CapabilitiesType_CAP_NET_BROADCAST CapabilitiesType = 11
+	// Allow activation of ATM control sockets
+	CapabilitiesType_CAP_NET_ADMIN CapabilitiesType = 12
+	// Allow binding to any address for transparent proxying (also via NET_ADMIN)
+	CapabilitiesType_CAP_NET_RAW CapabilitiesType = 13
+	// Allow mlock and mlockall (which doesn't really have anything to do
+	//with IPC)
+	CapabilitiesType_CAP_IPC_LOCK CapabilitiesType = 14
+	// Override IPC ownership checks
+	CapabilitiesType_CAP_IPC_OWNER CapabilitiesType = 15
 	// Insert and remove kernel modules - modify kernel without limit
-	CapabilitiesType_CAP_SYS_MODULE     CapabilitiesType = 16
-	CapabilitiesType_CAP_SYS_RAWIO      CapabilitiesType = 17
-	CapabilitiesType_CAP_SYS_CHROOT     CapabilitiesType = 18
-	CapabilitiesType_CAP_SYS_PTRACE     CapabilitiesType = 19 // Allow configuration of process accounting
-	CapabilitiesType_CAP_SYS_PACCT      CapabilitiesType = 20
-	CapabilitiesType_CAP_SYS_ADMIN      CapabilitiesType = 21
-	CapabilitiesType_CAP_SYS_BOOT       CapabilitiesType = 22
-	CapabilitiesType_CAP_SYS_NICE       CapabilitiesType = 23
-	CapabilitiesType_CAP_SYS_RESOURCE   CapabilitiesType = 24
-	CapabilitiesType_CAP_SYS_TIME       CapabilitiesType = 25
+	CapabilitiesType_CAP_SYS_MODULE CapabilitiesType = 16
+	// Allow sending USB messages to any device via /dev/bus/usb
+	CapabilitiesType_CAP_SYS_RAWIO CapabilitiesType = 17
+	// Allow use of chroot()
+	CapabilitiesType_CAP_SYS_CHROOT CapabilitiesType = 18
+	// Allow ptrace() of any process
+	CapabilitiesType_CAP_SYS_PTRACE CapabilitiesType = 19
+	// Allow configuration of process accounting
+	CapabilitiesType_CAP_SYS_PACCT CapabilitiesType = 20
+	// Allow everything under CAP_BPF and CAP_PERFMON for backward compatibility
+	CapabilitiesType_CAP_SYS_ADMIN CapabilitiesType = 21
+	// Allow use of reboot()
+	CapabilitiesType_CAP_SYS_BOOT CapabilitiesType = 22
+	// Allow setting cpu affinity on other processes
+	CapabilitiesType_CAP_SYS_NICE CapabilitiesType = 23
+	// Control memory reclaim behavior
+	CapabilitiesType_CAP_SYS_RESOURCE CapabilitiesType = 24
+	// Allow setting the real-time clock
+	CapabilitiesType_CAP_SYS_TIME CapabilitiesType = 25
+	// Allow vhangup() of tty
 	CapabilitiesType_CAP_SYS_TTY_CONFIG CapabilitiesType = 26
-	CapabilitiesType_CAP_MKNOD          CapabilitiesType = 27
-	CapabilitiesType_CAP_LEASE          CapabilitiesType = 28
-	CapabilitiesType_CAP_AUDIT_WRITE    CapabilitiesType = 29
-	CapabilitiesType_CAP_AUDIT_CONTROL  CapabilitiesType = 30
-	CapabilitiesType_CAP_SETFCAP        CapabilitiesType = 31
-	CapabilitiesType_CAP_MAC_OVERRIDE   CapabilitiesType = 32
-	CapabilitiesType_CAP_MAC_ADMIN      CapabilitiesType = 33
-	CapabilitiesType_CAP_SYSLOG         CapabilitiesType = 34
-	CapabilitiesType_CAP_WAKE_ALARM     CapabilitiesType = 35
-	CapabilitiesType_CAP_BLOCK_SUSPEND  CapabilitiesType = 36
-	CapabilitiesType_CAP_AUDIT_READ     CapabilitiesType = 37
-	CapabilitiesType_CAP_PERFMON        CapabilitiesType = 38
+	// Allow the privileged aspects of mknod()
+	CapabilitiesType_CAP_MKNOD CapabilitiesType = 27
+	// Allow taking of leases on files
+	CapabilitiesType_CAP_LEASE CapabilitiesType = 28
+	// Allow writing the audit log via unicast netlink socket
+	CapabilitiesType_CAP_AUDIT_WRITE CapabilitiesType = 29
+	// Allow configuration of audit via unicast netlink socket
+	CapabilitiesType_CAP_AUDIT_CONTROL CapabilitiesType = 30
+	// Set or remove capabilities on files
+	CapabilitiesType_CAP_SETFCAP CapabilitiesType = 31
+	// Override MAC access.
+	//The base kernel enforces no MAC policy.
+	//An LSM may enforce a MAC policy, and if it does and it chooses
+	//to implement capability based overrides of that policy, this is
+	//the capability it should use to do so.
+	CapabilitiesType_CAP_MAC_OVERRIDE CapabilitiesType = 32
+	// Allow MAC configuration or state changes.
+	//The base kernel requires no MAC configuration.
+	//An LSM may enforce a MAC policy, and if it does and it chooses
+	//to implement capability based checks on modifications to that
+	//policy or the data required to maintain it, this is the
+	//capability it should use to do so.
+	CapabilitiesType_CAP_MAC_ADMIN CapabilitiesType = 33
+	// Allow configuring the kernel's syslog (printk behaviour)
+	CapabilitiesType_CAP_SYSLOG CapabilitiesType = 34
+	// Allow triggering something that will wake the system
+	CapabilitiesType_CAP_WAKE_ALARM CapabilitiesType = 35
+	// Allow preventing system suspends
+	CapabilitiesType_CAP_BLOCK_SUSPEND CapabilitiesType = 36
+	// Allow reading the audit log via multicast netlink socket
+	CapabilitiesType_CAP_AUDIT_READ CapabilitiesType = 37
+	//
+	// Allow system performance and observability privileged operations
+	// using perf_events, i915_perf and other kernel subsystems
+	CapabilitiesType_CAP_PERFMON CapabilitiesType = 38
 	//
 	// CAP_BPF allows the following BPF operations:
 	// - Creating all types of BPF maps
@@ -321,21 +387,18 @@ const (
 	// - Loading BPF Type Format (BTF) data
 	// - Retrieve xlated and JITed code of BPF programs
 	// - Use bpf_spin_lock() helper
-	//
 	// CAP_PERFMON relaxes the verifier checks further:
 	// - BPF progs can use of pointer-to-integer conversions
 	// - speculation attack hardening measures are bypassed
 	// - bpf_probe_read to read arbitrary kernel memory is allowed
 	// - bpf_trace_printk to print kernel memory is allowed
-	//
 	// CAP_SYS_ADMIN is required to use bpf_probe_write_user.
-	//
 	// CAP_SYS_ADMIN is required to iterate system wide loaded
 	// programs, maps, links, BTFs and convert their IDs to file descriptors.
-	//
 	// CAP_PERFMON and CAP_BPF are required to load tracing programs.
 	// CAP_NET_ADMIN and CAP_BPF are required to load networking programs.
-	CapabilitiesType_CAP_BPF                CapabilitiesType = 39
+	CapabilitiesType_CAP_BPF CapabilitiesType = 39
+	// Allow writing to ns_last_pid
 	CapabilitiesType_CAP_CHECKPOINT_RESTORE CapabilitiesType = 40
 )
 
@@ -525,7 +588,6 @@ type Container struct {
 	Pid *wrapperspb.UInt32Value `protobuf:"bytes,5,opt,name=pid,proto3" json:"pid,omitempty"`
 	// If this is set true, it means that the process might have been originated from
 	// a Kubernetes exec probe. For this field to be true, the following must be true:
-	//
 	// 1. The binary field matches the first element of the exec command list for either
 	//    liveness or readiness probe excluding the basename. For example, "/bin/ls"
 	//    and "ls" are considered a match.
@@ -3708,13 +3770,11 @@ type GetEventsRequest struct {
 	// deny_list specifies a list of filters to apply to exclude certain events
 	// from the results. If multiple filters are specified, at least one of
 	// them has to match for an event to be excluded.
-	//
 	// If both allow_list and deny_list are specified, the results contain the
 	// set difference allow_list - deny_list.
 	DenyList []*Filter `protobuf:"bytes,2,rep,name=deny_list,json=denyList,proto3" json:"deny_list,omitempty"`
 	// aggregation_options configures aggregation options for this request.
 	// If this field is not set, responses will not be aggregated.
-	//
 	// Note that currently only process_accept and process_connect events are
 	// aggregated. Other events remain unaggregated.
 	AggregationOptions *AggregationOptions `protobuf:"bytes,3,opt,name=aggregation_options,json=aggregationOptions,proto3" json:"aggregation_options,omitempty"`
@@ -3838,7 +3898,6 @@ type GetEventsResponse struct {
 	// Name of the node where this event was observed.
 	NodeName string `protobuf:"bytes,1000,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
 	// Timestamp at which this event was observed.
-	//
 	// For an aggregated response, this field to set to the timestamp at which
 	// the event was observed for the first time in a given aggregation time window.
 	Time *timestamppb.Timestamp `protobuf:"bytes,1001,opt,name=time,proto3" json:"time,omitempty"`

--- a/api/v1/tetragon/tetragon.proto
+++ b/api/v1/tetragon/tetragon.proto
@@ -38,7 +38,6 @@ message Container {
 
     // If this is set true, it means that the process might have been originated from
     // a Kubernetes exec probe. For this field to be true, the following must be true:
-    //
     // 1. The binary field matches the first element of the exec command list for either
     //    liveness or readiness probe excluding the basename. For example, "/bin/ls"
     //    and "ls" are considered a match.
@@ -387,13 +386,11 @@ message GetEventsRequest {
     // deny_list specifies a list of filters to apply to exclude certain events
     // from the results. If multiple filters are specified, at least one of
     // them has to match for an event to be excluded.
-    //
     // If both allow_list and deny_list are specified, the results contain the
     // set difference allow_list - deny_list.
     repeated Filter deny_list = 2;
     // aggregation_options configures aggregation options for this request.
     // If this field is not set, responses will not be aggregated.
-    //
     // Note that currently only process_accept and process_connect events are
     // aggregated. Other events remain unaggregated.
     AggregationOptions aggregation_options = 3;
@@ -418,7 +415,6 @@ message GetEventsResponse {
     // Name of the node where this event was observed.
     string node_name = 1000;
     // Timestamp at which this event was observed.
-    //
     // For an aggregated response, this field to set to the timestamp at which
     // the event was observed for the first time in a given aggregation time window.
     google.protobuf.Timestamp time = 1001;
@@ -457,7 +453,6 @@ enum CapabilitiesType {
 	/* Override all DAC access, including ACL execute access if
 	   [_POSIX_ACL] is defined. Excluding DAC access covered by
 	   CAP_LINUX_IMMUTABLE. */
-
  DAC_OVERRIDE = 1;
 
 	/* Overrides all DAC restrictions regarding read and search on files
@@ -468,7 +463,6 @@ enum CapabilitiesType {
 	/* Overrides all restrictions about allowed operations on files, where
 	   file owner ID must be equal to the user ID, except where CAP_FSETID
 	   is applicable. It doesn't override MAC and DAC restrictions. */
-
  CAP_FOWNER = 3;
 
 	/* Overrides the following restrictions that the effective user ID
@@ -477,24 +471,20 @@ enum CapabilitiesType {
 	   supplementary group IDs) shall match the file owner ID when setting
 	   the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
 	   cleared on successful return from chown(2) (not implemented). */
-
  CAP_FSETID = 4;
 
 	/* Overrides the restriction that the real or effective user ID of a
 	   process sending a signal must match the real or effective user ID
 	   of the process receiving the signal. */
-
  CAP_KILL = 5;
 
 	/* Allows setgid(2) manipulation */
 	/* Allows setgroups(2) */
 	/* Allows forged gids on socket credentials passing. */
-
  CAP_SETGID = 6;
 
 	/* Allows set*uid(2) manipulation (including fsuid). */
 	/* Allows forged pids on socket credentials passing. */
-
  CAP_SETUID = 7;
 
 	/**
@@ -510,20 +500,16 @@ enum CapabilitiesType {
 	 *   Allow taking bits out of capability bounding set
 	 *   Allow modification of the securebits for a process
 	 */
-
  CAP_SETPCAP = 8;
 
 	/* Allow modification of S_IMMUTABLE and S_APPEND file attributes */
-
  CAP_LINUX_IMMUTABLE = 9;
 
 	/* Allows binding to TCP/UDP sockets below 1024 */
 	/* Allows binding to ATM VCIs below 32 */
-
  CAP_NET_BIND_SERVICE = 10;
 
 	/* Allow broadcasting, listen to multicast */
-
  CAP_NET_BROADCAST = 11;
 
 	/* Allow interface configuration */
@@ -539,23 +525,19 @@ enum CapabilitiesType {
 	/* Allow multicasting */
 	/* Allow read/write of device-specific registers */
 	/* Allow activation of ATM control sockets */
-
  CAP_NET_ADMIN = 12;
 
 	/* Allow use of RAW sockets */
 	/* Allow use of PACKET sockets */
 	/* Allow binding to any address for transparent proxying (also via NET_ADMIN) */
-
  CAP_NET_RAW = 13;
 
 	/* Allow locking of shared memory segments */
 	/* Allow mlock and mlockall (which doesn't really have anything to do
 	   with IPC) */
-
  CAP_IPC_LOCK = 14;
 
 	/* Override IPC ownership checks */
-
  CAP_IPC_OWNER = 15;
 
 	/* Insert and remove kernel modules - modify kernel without limit */
@@ -563,18 +545,14 @@ enum CapabilitiesType {
 
 	/* Allow ioperm/iopl access */
 	/* Allow sending USB messages to any device via /dev/bus/usb */
-
  CAP_SYS_RAWIO = 17;
 
 	/* Allow use of chroot() */
-
  CAP_SYS_CHROOT = 18;
 
 	/* Allow ptrace() of any process */
-
  CAP_SYS_PTRACE = 19;
 	/* Allow configuration of process accounting */
-
  CAP_SYS_PACCT = 20;
 
 	/* Allow configuration of the secure attention key */
@@ -612,11 +590,9 @@ enum CapabilitiesType {
 	/* Allow setting encryption key on loopback filesystem */
 	/* Allow setting zone reclaim policy */
 	/* Allow everything under CAP_BPF and CAP_PERFMON for backward compatibility */
-
  CAP_SYS_ADMIN = 21;
 
 	/* Allow use of reboot() */
-
  CAP_SYS_BOOT = 22;
 
 	/* Allow raising priority and setting priority on other (different
@@ -625,7 +601,6 @@ enum CapabilitiesType {
 	   processes and setting the scheduling algorithm used by another
 	   process. */
 	/* Allow setting cpu affinity on other processes */
-
  CAP_SYS_NICE = 23;
 
 	/* Override resource limits. Set resource limits. */
@@ -640,38 +615,30 @@ enum CapabilitiesType {
 	/* Override max number of consoles on console allocation */
 	/* Override max number of keymaps */
 	/* Control memory reclaim behavior */
-
  CAP_SYS_RESOURCE = 24;
 
 	/* Allow manipulation of system clock */
 	/* Allow irix_stime on mips */
 	/* Allow setting the real-time clock */
-
  CAP_SYS_TIME = 25;
 
 	/* Allow configuration of tty devices */
 	/* Allow vhangup() of tty */
-
  CAP_SYS_TTY_CONFIG = 26;
 
 	/* Allow the privileged aspects of mknod() */
-
  CAP_MKNOD = 27;
 
 	/* Allow taking of leases on files */
-
  CAP_LEASE = 28;
 
 	/* Allow writing the audit log via unicast netlink socket */
-
  CAP_AUDIT_WRITE = 29;
 
 	/* Allow configuration of audit via unicast netlink socket */
-
  CAP_AUDIT_CONTROL = 30;
 
 	/* Set or remove capabilities on files */
-
  CAP_SETFCAP = 31;
 
 	/* Override MAC access.
@@ -679,7 +646,6 @@ enum CapabilitiesType {
 	   An LSM may enforce a MAC policy, and if it does and it chooses
 	   to implement capability based overrides of that policy, this is
 	   the capability it should use to do so. */
-
  CAP_MAC_OVERRIDE = 32;
 
 	/* Allow MAC configuration or state changes.
@@ -688,30 +654,24 @@ enum CapabilitiesType {
 	   to implement capability based checks on modifications to that
 	   policy or the data required to maintain it, this is the
 	   capability it should use to do so. */
-
  CAP_MAC_ADMIN = 33;
 
 	/* Allow configuring the kernel's syslog (printk behaviour) */
-
  CAP_SYSLOG = 34;
 
 	/* Allow triggering something that will wake the system */
-
  CAP_WAKE_ALARM = 35;
 
 	/* Allow preventing system suspends */
-
  CAP_BLOCK_SUSPEND = 36;
 
 	/* Allow reading the audit log via multicast netlink socket */
-
  CAP_AUDIT_READ = 37;
 
 	/*
 	 * Allow system performance and observability privileged operations
 	 * using perf_events, i915_perf and other kernel subsystems
 	 */
-
  CAP_PERFMON = 38;
 
 	/*
@@ -728,18 +688,14 @@ enum CapabilitiesType {
 	 * - Loading BPF Type Format (BTF) data
 	 * - Retrieve xlated and JITed code of BPF programs
 	 * - Use bpf_spin_lock() helper
-	 *
 	 * CAP_PERFMON relaxes the verifier checks further:
 	 * - BPF progs can use of pointer-to-integer conversions
 	 * - speculation attack hardening measures are bypassed
 	 * - bpf_probe_read to read arbitrary kernel memory is allowed
 	 * - bpf_trace_printk to print kernel memory is allowed
-	 *
 	 * CAP_SYS_ADMIN is required to use bpf_probe_write_user.
-	 *
 	 * CAP_SYS_ADMIN is required to iterate system wide loaded
 	 * programs, maps, links, BTFs and convert their IDs to file descriptors.
-	 *
 	 * CAP_PERFMON and CAP_BPF are required to load tracing programs.
 	 * CAP_NET_ADMIN and CAP_BPF are required to load networking programs.
 	 */
@@ -748,6 +704,5 @@ enum CapabilitiesType {
 	/* Allow checkpoint/restore related operations */
 	/* Allow PID selection during clone3() */
 	/* Allow writing to ns_last_pid */
-
  CAP_CHECKPOINT_RESTORE = 40;
 }


### PR DESCRIPTION
the invalid whitespaces in api/v1/tetragon.proto makes generated markdown document unreadable

remove invalid whitespaces in tetragon.proto and regenerate related files

Signed-off-by: Peihao Yang <peihao.young@gmail.com>