### PR TITLE
tetragon: Check the returned data length for exec arguments

### DIFF
--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -110,10 +110,12 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, bool, error) {
 		}
 		proc.Filename = string(data[:])
 		args = args[unsafe.Sizeof(desc):]
-	} else {
+	} else if exec.Flags&api.EventErrorFilename == 0 {
 		n := bytes.Index(args, []byte{0x00})
-		proc.Filename = string(args[:n])
-		args = args[n+1:]
+		if n != -1 {
+			proc.Filename = string(args[:n])
+			args = args[n+1:]
+		}
 	}
 
 	var cmdArgs [][]byte
@@ -134,8 +136,10 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, bool, error) {
 			return proc, false, err
 		}
 		// cut the zero byte
-		n := len(data) - 1
-		cmdArgs = bytes.Split(data[:n], []byte{0x00})
+		if len(data) > 0 {
+			n := len(data) - 1
+			cmdArgs = bytes.Split(data[:n], []byte{0x00})
+		}
 
 		cwd := args[unsafe.Sizeof(desc):]
 		cmdArgs = append(cmdArgs, cwd)


### PR DESCRIPTION
It can actually happen that there will be no arguments
or filename, in which case we need to check the data
length and api.EventErrorFilename flag.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>