### PR TITLE
Call go test only for directories that contain at least one test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ test-compile:
 	for pkg in $$($(GO) list ./...); do \
 		localpkg=$$(echo $$pkg | sed -e 's:github.com/cilium/tetragon/::'); \
 		localtestfile=$$(echo $$localpkg | sed -e 's:/:.:g'); \
+		numtests=$$(ls -l ./$$localpkg/*_test.go 2> /dev/null | wc -l); \
+		if [ $$numtests -le 0 ]; then \
+			continue; \
+		fi; \
 		echo -c ./$$localpkg -o go-tests/$$localtestfile; \
 	done | xargs -P $$(nproc) -L 1 $(GO) test -gcflags=$(GO_GCFLAGS)
 


### PR DESCRIPTION
`make test-compile` iterates all directories with Go code and calls go test to build the executable. In many of the directories there are no tests which introduces delays in the make process.

This commit calls go test only for directories that contain at least one test file (i.e. `*_test.go`).

Before the fix:
```
$ rm  -rf go-tests/ && time make test-compile > /dev/null

real	0m41.261s
user	2m10.735s
sys	0m24.337s
$ ls -la go-tests/ | wc -l
36
```

After the fix:
```
$ rm  -rf go-tests/ && time make test-compile > /dev/null

real	0m22.878s
user	1m16.238s
sys	0m10.950s
$ ls -la go-tests/ | wc -l
36
```

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>