### PR TITLE
Run alignchecker as part of unit tests

### DIFF
--- a/pkg/alignchecker/alignchecker_test.go
+++ b/pkg/alignchecker/alignchecker_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package alignchecker
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var tetragonLib string
+
+func init() {
+	flag.StringVar(&tetragonLib, "bpf-lib", "../../../bpf/objs/", "tetragon lib directory (location of btf file and bpf objs). Will be overridden by an TETRAGON_LIB env variable.")
+
+	tetragonLibEnv := os.Getenv("TETRAGON_LIB")
+	if tetragonLibEnv != "" {
+		tetragonLib = tetragonLibEnv
+	}
+}
+
+func TestStructAlignments(t *testing.T) {
+	bpfObjPath := filepath.Join(tetragonLib, "bpf_alignchecker.o")
+	if _, err := os.Stat(bpfObjPath); err != nil {
+		t.Fatalf("Cannot check alignment against %s: %s\n", bpfObjPath, err)
+	}
+	if err := CheckStructAlignments(bpfObjPath); err != nil {
+		t.Fatalf("C and Go structs alignment check failed: %s\n", err)
+	}
+}


### PR DESCRIPTION
In order to run the aligncheker (i.e. compare the Go and C structs that are shared between user and kernel space) the user has to issue it manually:
```
$ sudo ./tetragon-alignchecker ./bpf/objs/bpf_alignchecker.o
OK
```

This commit adds a new unit test in `pkg/alignchecker/` that calls the alignchecker as part of the Go tests.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>