### PR TITLE
create symlinks for libbpf.so for podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,9 +168,9 @@ tools-clean:
 libbpf-install:
 	$(eval id=$(shell $(CONTAINER_ENGINE) create $(LIBBPF_IMAGE)))
 	mkdir -p $(LIBBPF_INSTALL_DIR)
-	$(CONTAINER_ENGINE) cp ${id}:/go/src/github.com/covalentio/hubble-fgs/src/libbpf.so $(LIBBPF_INSTALL_DIR)
-	$(CONTAINER_ENGINE) cp ${id}:/go/src/github.com/covalentio/hubble-fgs/src/libbpf.so.0 $(LIBBPF_INSTALL_DIR)
 	$(CONTAINER_ENGINE) cp ${id}:/go/src/github.com/covalentio/hubble-fgs/src/libbpf.so.0.2.0 $(LIBBPF_INSTALL_DIR)
+	ln -s libbpf.so.0.2.0 $(LIBBPF_INSTALL_DIR)/libbpf.so.0
+	ln -s libbpf.so.0 $(LIBBPF_INSTALL_DIR)/libbpf.so
 	$(CONTAINER_ENGINE) stop ${id}
 
 clang-install:


### PR DESCRIPTION
PR is a workaround for the inconsistent behavior of `docker cp` and `podman cp` for the symlinks - docker copies the symlink itself but podman copies the target of the symlink, which leads to the missing symlinks and broken build.

Slack discusion: https://cilium.slack.com/archives/C2B917YHE/p1656948867647459

For reference - build and run with `podman` on rhel8 based on <https://github.com/cilium/tetragon/blob/main/docs/contributing/development/README.md#development-setup>:
```
CONTAINER_ENGINE='sudo podman' make tools-install
CONTAINER_ENGINE='sudo podman' LD_LIBRARY_PATH=$(realpath ./lib) make
sudo LD_LIBRARY_PATH=$(realpath ./lib) ./tetragon --bpf-lib bpf/objs
```

/cc @kkourt 