### PR TITLE
Add tests for pkg/grpc/exec

### DIFF
--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -74,12 +74,6 @@ func handleExecEvent(event *cacheObj, nspid uint32) error {
 func handleEvent(event *cacheObj) error {
 	p := event.event.GetProcess()
 
-	endpoint := process.GetProcessEndpoint(p)
-	if p.Docker != "" && (endpoint == nil || p.Pod == nil) {
-		errormetrics.ErrorTotalInc(errormetrics.EventCacheEndpointRetryFailed)
-		return fmt.Errorf("failed to get process endpoint ifno")
-	}
-
 	// If the process wasn't found before the Add(), likely because
 	// the execve event was processed after this event, lets look it up
 	// now because it should be available. Otherwise we have a valid

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -91,6 +91,11 @@ func handleEvent(event *cacheObj) error {
 		}
 	}
 
+	p = event.internal.UnsafeGetProcess()
+	if option.Config.EnableK8s && p.Pod == nil {
+		return fmt.Errorf("Process missing PodInfo")
+	}
+
 	event.event.SetProcess(event.internal.GetProcessCopy())
 	return nil
 }

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -61,12 +61,8 @@ func handleExecEvent(event *cacheObj, nspid uint32) error {
 		return fmt.Errorf("failed to get pod info")
 	}
 
-	if event.internal != nil {
-		event.internal.AddPodInfo(podInfo)
-		event.event.SetProcess(event.internal.GetProcessCopy())
-	} else {
-		event.internal.GetProcess().Pod = podInfo
-	}
+	event.internal.AddPodInfo(podInfo)
+	event.event.SetProcess(event.internal.GetProcessCopy())
 
 	return nil
 }

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -166,6 +166,9 @@ func (ec *Cache) Needed(proc *tetragon.Process) bool {
 	if proc.Docker != "" && proc.Pod == nil {
 		return true
 	}
+	if proc.Binary == "" {
+		return true
+	}
 	return false
 }
 

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -76,7 +76,7 @@ func (msg *MsgExecveEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 		procEvent := GetProcessExec(proc)
 		ec := eventcache.Get()
 		if ec != nil && ec.Needed(procEvent.Process) {
-			ec.Add(proc, procEvent, ktime.ToProto(msg.Common.Ktime), msg)
+			ec.Add(proc, procEvent, msg.MsgExecveEventUnix.Process.Ktime, msg)
 		} else {
 			procEvent.Process = proc.GetProcessCopy()
 			res = &tetragon.GetEventsResponse{
@@ -139,7 +139,7 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 	}
 	ec := eventcache.Get()
 	if ec != nil && ec.Needed(tetragonProcess) {
-		ec.Add(process, tetragonEvent, ktime.ToProto(event.Common.Ktime), event)
+		ec.Add(process, tetragonEvent, event.ProcessKey.Ktime, event)
 		return nil
 	}
 	if process != nil {

--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// CGO_LDFLAGS=-L$(realpath ./lib) go test -gcflags="" -c ./pkg/grpc/exec/ -o go-tests/grpc-exec.test
+// sudo LD_LIBRARY_PATH=$(realpath ./lib) ./go-tests/grpc-exec.test  [ -test.run TestGrpcExec ]
+
+package exec
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	tetragonAPI "github.com/cilium/tetragon/pkg/api/processapi"
+	"github.com/cilium/tetragon/pkg/cilium"
+	"github.com/cilium/tetragon/pkg/eventcache"
+	"github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/server"
+	"github.com/cilium/tetragon/pkg/watcher"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	AllEvents []*tetragon.GetEventsResponse
+)
+
+type DummyNotifier struct {
+	t *testing.T
+}
+
+func (n DummyNotifier) AddListener(listener server.Listener) {}
+
+func (n DummyNotifier) RemoveListener(listener server.Listener) {}
+
+func (n DummyNotifier) NotifyListener(original interface{}, processed *tetragon.GetEventsResponse) {
+	switch v := original.(type) {
+	case *MsgExitEventUnix:
+		e := v.HandleMessage()
+		if e != nil {
+			AllEvents = append(AllEvents, e)
+		}
+	case *MsgExecveEventUnix:
+		e := v.HandleMessage()
+		if e != nil {
+			AllEvents = append(AllEvents, e)
+		}
+	default:
+		n.t.Fatalf("Unknown type in NotifyListener = %T", v)
+	}
+}
+
+type DummyObserver struct {
+	t *testing.T
+}
+
+func (o DummyObserver) AddTracingPolicy(ctx context.Context, sensorName string, spec interface{}) error {
+	return nil
+}
+
+func (o DummyObserver) DelTracingPolicy(ctx context.Context, sensorName string) error {
+	return nil
+}
+
+func (o DummyObserver) EnableSensor(ctx context.Context, name string) error {
+	return nil
+}
+
+func (o DummyObserver) DisableSensor(ctx context.Context, name string) error {
+	return nil
+}
+
+func (o DummyObserver) ListSensors(ctx context.Context) (*[]sensors.SensorStatus, error) {
+	return nil, nil
+}
+
+func (o DummyObserver) GetSensorConfig(ctx context.Context, name string, cfgkey string) (string, error) {
+	return "<dummy>", nil
+}
+
+func (o DummyObserver) SetSensorConfig(ctx context.Context, name string, cfgkey string, cfgval string) error {
+	return nil
+}
+
+func (o DummyObserver) RemoveSensor(ctx context.Context, sensorName string) error {
+	return nil
+}
+
+func createEvents(Pid uint32, Ktime uint64) (*MsgExecveEventUnix, *MsgExitEventUnix) {
+	execMsg := &MsgExecveEventUnix{MsgExecveEventUnix: tetragonAPI.MsgExecveEventUnix{
+		Common: tetragonAPI.MsgCommon{
+			Op:     5,
+			Flags:  0,
+			Pad_v2: [2]uint8{0, 0},
+			Size:   326,
+			Ktime:  21034975106173,
+		},
+		Kube: tetragonAPI.MsgK8sUnix{
+			NetNS:  4026531992,
+			Cid:    0,
+			Cgrpid: 0,
+			Docker: "",
+		},
+		Parent: tetragonAPI.MsgExecveKey{
+			Pid:   1459,
+			Pad:   0,
+			Ktime: 75200000000,
+		},
+		ParentFlags: 0,
+		Process: tetragonAPI.MsgProcess{
+			Size:     78,
+			PID:      Pid,
+			NSPID:    0,
+			UID:      1010,
+			AUID:     1010,
+			Flags:    16385,
+			Ktime:    Ktime,
+			Filename: "/usr/bin/ls",
+			Args:     "--color=auto\x00/home/apapag/tetragon",
+		},
+	},
+	}
+
+	exitMsg := &MsgExitEventUnix{MsgExitEvent: tetragonAPI.MsgExitEvent{
+		Common: tetragonAPI.MsgCommon{
+			Op:     7,
+			Flags:  0,
+			Pad_v2: [2]uint8{0, 0},
+			Size:   40,
+			Ktime:  21034976281104,
+		},
+		ProcessKey: tetragonAPI.MsgExecveKey{
+			Pid:   Pid,
+			Pad:   0,
+			Ktime: Ktime,
+		},
+		Info: tetragonAPI.MsgExitInfo{
+			Code: 0,
+			Pad1: 0, // Cached
+		},
+	},
+	}
+
+	return execMsg, exitMsg
+}
+
+func initEnv(t *testing.T, cancelWg *sync.WaitGroup) context.CancelFunc {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	watcher := watcher.NewFakeK8sWatcher(nil)
+	_, err := cilium.InitCiliumState(ctx, false)
+	if err != nil {
+		t.Fatalf("failed to call cilium.InitCiliumState %s", err)
+	}
+
+	if err := process.InitCache(ctx, watcher, false, 65536); err != nil {
+		t.Fatalf("failed to call process.InitCache %s", err)
+	}
+
+	dn := DummyNotifier{t}
+	do := DummyObserver{t}
+	lServer := server.NewServer(ctx, cancelWg, dn, do)
+
+	// Exec cache is always needed to ensure events have an associated Process{}
+	eventcache.NewWithTimer(lServer, time.Millisecond*200)
+
+	return cancel
+}
+
+func TestGrpcExecOutOfOrder(t *testing.T) {
+	var cancelWg sync.WaitGroup
+
+	AllEvents = nil
+	cancel := initEnv(t, &cancelWg)
+	defer func() {
+		cancel()
+		cancelWg.Wait()
+	}()
+
+	execMsg, exitMsg := createEvents(46983, 21034975089403)
+
+	e1 := exitMsg.HandleMessage()
+	if e1 != nil {
+		AllEvents = append(AllEvents, e1)
+	}
+
+	e2 := execMsg.HandleMessage()
+	if e2 != nil {
+		AllEvents = append(AllEvents, e2)
+	}
+
+	time.Sleep(time.Millisecond * 1000) // wait for cache to do it's work
+
+	assert.Equal(t, len(AllEvents), 2)
+
+	var ev1, ev2 *tetragon.GetEventsResponse
+	if AllEvents[0].GetProcessExec() != nil {
+		ev1 = AllEvents[0]
+		ev2 = AllEvents[1]
+	} else {
+		ev2 = AllEvents[0]
+		ev1 = AllEvents[1]
+	}
+
+	// fails but we don't expect to have the same Refcnt
+	ev1.GetProcessExec().Process.Refcnt = 0 // hardcode that to make the following pass
+	assert.Equal(t, ev1.GetProcessExec().Process, ev2.GetProcessExit().Process)
+
+	// success
+	assert.Equal(t, ev1.GetProcessExec().Parent, ev2.GetProcessExit().Parent)
+}
+
+func TestGrpcExecInOrder(t *testing.T) {
+	var cancelWg sync.WaitGroup
+
+	AllEvents = nil
+	cancel := initEnv(t, &cancelWg)
+	defer func() {
+		cancel()
+		cancelWg.Wait()
+	}()
+
+	execMsg, exitMsg := createEvents(46983, 21034975089403)
+
+	e2 := execMsg.HandleMessage()
+	if e2 != nil {
+		AllEvents = append(AllEvents, e2)
+	}
+
+	e1 := exitMsg.HandleMessage()
+	if e1 != nil {
+		AllEvents = append(AllEvents, e1)
+	}
+
+	time.Sleep(time.Millisecond * 1000) // wait for cache to do it's work
+
+	assert.Equal(t, len(AllEvents), 2)
+
+	var ev1, ev2 *tetragon.GetEventsResponse
+	if AllEvents[0].GetProcessExec() != nil {
+		ev1 = AllEvents[0]
+		ev2 = AllEvents[1]
+	} else {
+		ev2 = AllEvents[0]
+		ev1 = AllEvents[1]
+	}
+
+	// fails but we don't expect to have the same Refcnt
+	ev1.GetProcessExec().Process.Refcnt = 0 // hardcode that to make the following pass
+	assert.Equal(t, ev1.GetProcessExec().Process, ev2.GetProcessExit().Process)
+
+	// success
+	assert.Equal(t, ev1.GetProcessExec().Parent, ev2.GetProcessExit().Parent)
+}

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -162,7 +162,7 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 
 	ec := eventcache.Get()
 	if ec != nil && ec.Needed(tetragonProcess) {
-		ec.Add(process, tetragonEvent, ktime.ToProto(event.Common.Ktime), event)
+		ec.Add(process, tetragonEvent, event.ProcessKey.Ktime, event)
 		return nil
 	}
 
@@ -235,7 +235,7 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 
 	ec := eventcache.Get()
 	if ec != nil && ec.Needed(tetragonProcess) {
-		ec.Add(process, tetragonEvent, ktime.ToProto(msg.Common.Ktime), msg)
+		ec.Add(process, tetragonEvent, msg.ProcessKey.Ktime, msg)
 		return nil
 	}
 	if process != nil {

--- a/tests/e2e/tests/skeleton/skeleton_test.go
+++ b/tests/e2e/tests/skeleton/skeleton_test.go
@@ -89,7 +89,7 @@ func TestSkeletonBasic(t *testing.T) {
 	// Grab the minimum kernel version in all cluster nodes and define an RPC checker with it
 	kversion := helpers.GetMinKernelVersion(t, testenv)
 	// Create an curl event checker with a limit or 10 events or 30 seconds, whichever comes first
-	curlChecker := curlEventChecker(kversion).WithEventLimit(10).WithTimeLimit(30 * time.Second)
+	curlChecker := curlEventChecker(kversion).WithEventLimit(100).WithTimeLimit(30 * time.Second)
 
 	// Define test features here. These can be used to perform actions like:
 	// - Spawning an event checker and running checks


### PR DESCRIPTION
An exec and exit event can be delivered out of order to the agent. For this reason, we have a cache that keeps the un populated events for a small period of time to wait for the exec event.

There are also other caches that deal with this situations.

This commit adds tests for pkg/grpc/exec. For now it only contains 2 different cases:
1. exec and exit events in order (TestGrpcExecInOrder)
2. exec and exit events out of order (TestGrpcExecOutOfOrder)

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>