### PR TITLE
Fix for verifier issue in 5.4 with clang-13

### DIFF
--- a/bpf/lib/data_msg.h
+++ b/bpf/lib/data_msg.h
@@ -4,6 +4,8 @@
 #ifndef __DATA_MSG_
 #define __DATA_MSG_
 
+#define MSG_DATA_ARG_LEN 32736
+
 struct data_event_id {
 	__u64 pid;
 	__u64 time;
@@ -18,13 +20,13 @@ struct data_event_desc {
 struct msg_data {
 	struct msg_common common;
 	struct data_event_id id;
-	/* To have a fast way to check buffer size we use 32736
+	/* To have a fast way to check buffer size we use 32736 (MSG_DATA_ARG_LEN)
 	 * as arg size, which is:
 	 *   0x8000 - offsetof(struct msg_kprobe_arg, arg)
 	 * so we can make verifier happy with:
 	 *   'size &= 0x7fff' check
 	 */
-	char arg[32736];
+	char arg[MSG_DATA_ARG_LEN];
 } __attribute__((packed));
 
 #endif /* __DATA_MSG_ */


### PR DESCRIPTION
FIXES: https://github.com/cilium/tetragon/issues/220

Tested over https://github.com/cilium/tetragon/pull/171 for clang-13 support.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>