### PR TITLE
tetragon: Force libbpf link creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,8 @@ libbpf-install:
 	$(eval id=$(shell $(CONTAINER_ENGINE) create $(LIBBPF_IMAGE)))
 	mkdir -p $(LIBBPF_INSTALL_DIR)
 	$(CONTAINER_ENGINE) cp ${id}:/go/src/github.com/covalentio/hubble-fgs/src/libbpf.so.0.2.0 $(LIBBPF_INSTALL_DIR)
-	ln -s libbpf.so.0.2.0 $(LIBBPF_INSTALL_DIR)/libbpf.so.0
-	ln -s libbpf.so.0 $(LIBBPF_INSTALL_DIR)/libbpf.so
+	ln -fs libbpf.so.0.2.0 $(LIBBPF_INSTALL_DIR)/libbpf.so.0
+	ln -fs libbpf.so.0 $(LIBBPF_INSTALL_DIR)/libbpf.so
 	$(CONTAINER_ENGINE) stop ${id}
 
 clang-install:


### PR DESCRIPTION
Commit [1] broke libbpf-install target, which fails
if destination files exist:

  $ make libbpf-install
  mkdir -p ./lib
  docker cp 9fb245cca6f49264e1ce716b5db5d6864e734e07b0d1558110880b37f5d0aa85:/go/src/github.com/covalentio/hubble-fgs/src/libbpf.so.0.2.0 ./lib
  ln -s libbpf.so.0.2.0 ./lib/libbpf.so.0
  ln: failed to create symbolic link './lib/libbpf.so.0': File exists
  make: *** [Makefile:176: libbpf-install] Error 1

I need to fix this to get clean update eventhough I'm removing
the whole target in another libbpf remoal PR ;-)

[1] 7c22ff1af9bc create symlinks for libbpf.so for podman

Signed-off-by: Jiri Olsa <jolsa@kernel.org>