### PR TITLE
Vagrantfile: bump Go version to 1.17

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
       cd /home/vagrant/go/src/github.com/cilium/tetragon
       apt-get update
       apt-get install -y build-essential clang conntrack libcap-dev libelf-dev net-tools
-      snap install go --channel=1.16/stable --classic
+      snap install go --channel=1.17/stable --classic
       make tools-install LIBBPF_INSTALL_DIR=/usr/local/lib CLANG_INSTALL_DIR=/usr/bin
       ldconfig /usr/local/
 


### PR DESCRIPTION
Small fix, I was using the Vagrantfile, and recently the build of tetragon failed with Go 1.16, and `make vendor` was not working because the `go mod tidy -compat` flag was added in 1.17. I don't use snap but with a Go 1.17 version, it worked, I guess it's only mirroring what is used here https://github.com/cilium/tetragon/blob/main/.github/workflows/gotests.yml.

I guess you could directly install Go (I put 1.17.8 because you use it in the test workflow) with something like what I use in my Vagrantfiles and that looks like what you did with the rest:
```
GO_VERSION=1.17.8
curl -OL https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz
rm -rf /usr/local/go && tar -C /usr/local -xzf go$GO_VERSION.linux-amd64.tar.gz
rm -f go$GO_VERSION.linux-amd64.tar.gz
echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bashrc
```