### PR TITLE
pkg:sensors: simplify GetRunningProcs() when we read running processes

### DIFF
--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -206,7 +206,7 @@ type execSensor struct {
 func (e *execSensor) LoadProbe(args sensors.LoadProbeArgs) error {
 	err := program.LoadTracepointProgram(args.BPFDir, args.MapDir, args.Load, args.Verbose)
 	if err == nil {
-		procevents.GetRunningProcs(true, true)
+		procevents.GetRunningProcs()
 	}
 	return err
 }


### PR DESCRIPTION
GetRunningProcs() that reads process entries from procfs during startup
takes two boolean arguments which we always set to true, then it passes
these arguments down to how we send data to listeners and to write to the
execve_map.

Let's simplify this and remove these arguments as this makes reading code
easier.

Signed-off-by: Djalal Harouni <djalal@isovalent.com>