### PR TITLE
kprobes: matchArgs improvements (for fd/file)

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -122,22 +122,6 @@ generic_process_event_and_setup(struct pt_regs *ctx,
 }
 
 static inline __attribute__((always_inline)) int
-generic_filter_submit(void *ctx, struct msg_generic_kprobe *e, long total)
-{
-	/* Post event */
-	total += generic_kprobe_common_size();
-	/* Code movement from clang forces us to inline bounds checks here */
-	asm volatile("%[total] &= 0x7fff;\n"
-		     "if %[total] < 9000 goto +1\n;"
-		     "%[total] = 9000;\n"
-		     :
-		     : [total] "+r"(total)
-		     :);
-	perf_event_output(ctx, &tcpmon_map, BPF_F_CURRENT_CPU, e, total);
-	return 0;
-}
-
-static inline __attribute__((always_inline)) int
 generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
 		       struct bpf_map_def *map, struct bpf_map_def *tailcals,
 		       struct bpf_map_def *config_map)

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -567,15 +567,18 @@ __filter_file_buf(char *value, char *args, __u32 op)
 		if (a < v)
 			goto skip_string;
 	} else if (op == op_filter_str_postfix) {
-#ifdef __LARGE_BPF_PROG
-		err = cmpbytes(&value[4], &args[4], v - 1);
-#else
-		err = cmpbytes_small(&value[4], &args[4], v - 1);
-#endif
+		/* Due to the lack of followfd we get a kprobe with empty path. This is not a match */
+		if (a == 0)
+			goto skip_string;
+		err = rcmpbytes(&value[4], &args[4], v - 1, a - 1);
 		if (!err)
 			return 0;
 	}
-	err = rcmpbytes(&value[4], &args[4], v - 1, a - 1);
+#ifdef __LARGE_BPF_PROG
+	err = cmpbytes(&value[4], &args[4], v - 1);
+#else
+	err = cmpbytes_small(&value[4], &args[4], v - 1);
+#endif
 	if (!err)
 		return 0;
 skip_string:
@@ -583,12 +586,9 @@ skip_string:
 }
 
 /* filter_file_buf: runs a comparison between the file path in args against the
- * filter file path. This is slightly different from a string compare because
- * files are stored in reverse order. We could swap them in kernel but this is
- * problematic as well from a complexity angle. At the moment it seems easiest
- * to simply special case filepaths and do a reverse search over them. Notice
- * for 'equals' operatore either direction would work. But for prefix and
- * postfix mappings direction matters.
+ * filter file path. For 'equal' and 'prefix' operators we compare the file path
+ * and the filter file path in the normal order. For the 'postfix' operator we do
+ * a reverse search.
  */
 static inline __attribute__((always_inline)) long
 filter_file_buf(struct selector_arg_filter *filter, char *args)

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -225,6 +225,7 @@ func (k *Observer) runEventsNew(stopCtx context.Context, ready func()) error {
 				}
 			}
 		}
+		k.log.WithError(stopCtx.Err()).Info("Listening for events completed.")
 	}()
 
 	// Wait for context to be cancelled and then stop.

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -36,9 +36,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var mountPath = "/tmp2"
-
 const (
+	mountPath      = "/tmp2"
 	testConfigFile = "/tmp/tetragon.gotest.yaml"
 )
 

--- a/pkg/testutils/sensors/testrun.go
+++ b/pkg/testutils/sensors/testrun.go
@@ -52,7 +52,7 @@ func TestSensorsRun(m *testing.M, sensorName string) int {
 		"tetragon lib directory (location of btf file and bpf objs). Will be overridden by an TETRAGON_LIB env variable.")
 	flag.DurationVar(&config.CmdWaitTime,
 		"command-wait",
-		20000*time.Millisecond,
+		60000*time.Millisecond,
 		"duration to wait for tetragon to gather logs from commands")
 	flag.IntVar(
 		&config.VerboseLevel,


### PR DESCRIPTION
In kprobes, we support `matchArgs` selector for `fd` and `file` types with `Equal`, `Prefix`, and `Postfix` operators.

This PR first introduces unit-tests for all of these cases. These tests show an issue in the case of `Postfix` operator and we also fix this issue.

Currently, `matchArgs` for `fd/file` types support up to 2 values. This PR also increases this number for newer kernels (5.3+) to 8. It keeps that to 2 for older kernels. 

Finally, we also update unit-tests to check these.

ps. Tested locally on 4.19, 5.4, 5.10, and 5.13.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>