### PR TITLE
tetragon: Process Manager args cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ endif
 
 .PHONY: go-format
 go-format:
-	find . -name '*.go' -not -path './vendor/*' | xargs gofmt -w
+	find . -name '*.go' -not -path './vendor/*' -not -path './api/vendor/*' | xargs gofmt -w
 
 .PHONY: format
 format: go-format clang-format

--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -60,15 +60,10 @@ const (
 var (
 	processCacheSize int
 
-	enableK8sAPI    bool
-	enableCiliumAPI bool
-
-	metricsServer     string
-	serverAddress     string
-	ciliumBPF         string
-	enableProcessCred bool
-	enableProcessNs   bool
-	configFile        string
+	metricsServer string
+	serverAddress string
+	ciliumBPF     string
+	configFile    string
 
 	runStandalone bool
 
@@ -95,20 +90,20 @@ func readAndSetFlags() {
 	option.Config.ForceSmallProgs = viper.GetBool(keyForceSmallProgs)
 	option.Config.Debug = viper.GetBool(keyDebug)
 
+	option.Config.EnableProcessCred = viper.GetBool(keyEnableProcessCred)
+	option.Config.EnableProcessNs = viper.GetBool(keyEnableProcessNs)
+	option.Config.EnableCilium = viper.GetBool(keyEnableCiliumAPI)
+	option.Config.EnableK8s = viper.GetBool(keyEnableK8sAPI)
+
 	logLevel := viper.GetString(keyLogLevel)
 	logFormat := viper.GetString(keyLogFormat)
 	logger.PopulateLogOpts(option.Config.LogOpts, logLevel, logFormat)
 
 	processCacheSize = viper.GetInt(keyProcessCacheSize)
 
-	enableK8sAPI = viper.GetBool(keyEnableK8sAPI)
-	enableCiliumAPI = viper.GetBool(keyEnableCiliumAPI)
-
 	metricsServer = viper.GetString(keyMetricsServer)
 	serverAddress = viper.GetString(keyServerAddress)
 	ciliumBPF = viper.GetString(keyCiliumBPF)
-	enableProcessCred = viper.GetBool(keyEnableProcessCred)
-	enableProcessNs = viper.GetBool(keyEnableProcessNs)
 	configFile = viper.GetString(keyConfigFile)
 
 	runStandalone = viper.GetBool(keyRunStandalone)

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -178,7 +178,6 @@ func hubbleTETRAGONExecute() error {
 		observer.SensorManager,
 		option.Config.EnableProcessCred,
 		option.Config.EnableProcessNs,
-		option.Config.EnableK8s,
 		option.Config.EnableCilium)
 	if err != nil {
 		return err

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -175,10 +175,7 @@ func hubbleTETRAGONExecute() error {
 		ctx,
 		&cancelWg,
 		ciliumState,
-		observer.SensorManager,
-		option.Config.EnableProcessCred,
-		option.Config.EnableProcessNs,
-		option.Config.EnableCilium)
+		observer.SensorManager)
 	if err != nil {
 		return err
 	}

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -158,16 +158,16 @@ func hubbleTETRAGONExecute() error {
 		go metrics.EnableMetrics(metricsServer)
 	}
 
-	watcher, err := getWatcher(enableK8sAPI)
+	watcher, err := getWatcher()
 	if err != nil {
 		return err
 	}
-	ciliumState, err := cilium.InitCiliumState(ctx, enableCiliumAPI)
+	ciliumState, err := cilium.InitCiliumState(ctx, option.Config.EnableCilium)
 	if err != nil {
 		return err
 	}
 
-	if err := process.InitCache(ctx, watcher, enableCiliumAPI, processCacheSize); err != nil {
+	if err := process.InitCache(ctx, watcher, option.Config.EnableCilium, processCacheSize); err != nil {
 		return err
 	}
 
@@ -176,10 +176,10 @@ func hubbleTETRAGONExecute() error {
 		&cancelWg,
 		ciliumState,
 		observer.SensorManager,
-		enableProcessCred,
-		enableProcessNs,
-		enableK8sAPI,
-		enableCiliumAPI)
+		option.Config.EnableProcessCred,
+		option.Config.EnableProcessNs,
+		option.Config.EnableK8s,
+		option.Config.EnableCilium)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func hubbleTETRAGONExecute() error {
 	log.WithField("enabled", exportFilename != "").WithField("fileName", exportFilename).Info("Exporter configuration")
 	obs.AddListener(pm)
 	saveInitInfo()
-	if enableK8sAPI {
+	if option.Config.EnableK8s {
 		go crd.WatchTracePolicy(ctx, observer.SensorManager)
 	}
 
@@ -303,8 +303,8 @@ func Serve(ctx context.Context, address string, server *server.Server) error {
 	return nil
 }
 
-func getWatcher(enableK8sAPI bool) (watcher.K8sResourceWatcher, error) {
-	if enableK8sAPI {
+func getWatcher() (watcher.K8sResourceWatcher, error) {
+	if option.Config.EnableK8s {
 		log.Info("Enabling Kubernetes API")
 		config, err := rest.InClusterConfig()
 		if err != nil {

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -23,9 +23,8 @@ import (
 
 // ProcessManager maintains a cache of processes from tetragon exec events.
 type ProcessManager struct {
-	execCache *execcache.Cache
-	nodeName  string
-	Server    *server.Server
+	nodeName string
+	Server   *server.Server
 	// synchronize access to the listeners map.
 	mux         sync.Mutex
 	listeners   map[server.Listener]struct{}
@@ -53,7 +52,8 @@ func NewProcessManager(
 		eventcache.New(pm.Server)
 	}
 
-	pm.execCache = execcache.New(pm.Server)
+	// Exec cache is always needed to ensure events have an associated Process{}
+	execcache.New(pm.Server)
 
 	logger.GetLogger().WithField("enableCilium", option.Config.EnableCilium).WithFields(logrus.Fields{
 		"enableK8s":         option.Config.EnableK8s,

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -34,7 +34,6 @@ type ProcessManager struct {
 	ciliumState       *cilium.State
 	enableProcessCred bool
 	enableProcessNs   bool
-	enableEventCache  bool
 	enableCilium      bool
 }
 
@@ -46,7 +45,6 @@ func NewProcessManager(
 	manager *sensors.Manager,
 	enableProcessCred bool,
 	enableProcessNs bool,
-	enableEventCache bool,
 	enableCilium bool,
 ) (*ProcessManager, error) {
 	pm := &ProcessManager{
@@ -55,7 +53,6 @@ func NewProcessManager(
 		listeners:         make(map[server.Listener]struct{}),
 		enableProcessCred: enableProcessCred,
 		enableProcessNs:   enableProcessNs,
-		enableEventCache:  enableEventCache,
 		enableCilium:      enableCilium,
 	}
 
@@ -67,7 +64,6 @@ func NewProcessManager(
 	exec.New(pm.execCache, pm.eventCache, enableProcessCred, enableProcessNs)
 
 	logger.GetLogger().WithField("enableCilium", enableCilium).WithFields(logrus.Fields{
-		"enableEventCache":  enableEventCache,
 		"enableProcessCred": enableProcessCred,
 		"enableProcessNs":   enableProcessNs,
 	}).Info("Starting process manager")

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/tetragon/pkg/eventcache"
 	"github.com/cilium/tetragon/pkg/execcache"
 	"github.com/cilium/tetragon/pkg/grpc/exec"
-	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/reader/node"
@@ -60,7 +59,6 @@ func NewProcessManager(
 	pm.eventCache = eventcache.New(pm.Server)
 	pm.execCache = execcache.New(pm.Server)
 
-	tracing.New(enableCilium, enableProcessCred, enableProcessNs)
 	exec.New(pm.execCache, pm.eventCache, enableProcessCred, enableProcessNs)
 
 	logger.GetLogger().WithField("enableCilium", enableCilium).WithFields(logrus.Fields{

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/eventcache"
 	"github.com/cilium/tetragon/pkg/execcache"
-	"github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/reader/node"
@@ -58,8 +57,6 @@ func NewProcessManager(
 	pm.Server = server.NewServer(ctx, wg, pm, manager)
 	pm.eventCache = eventcache.New(pm.Server)
 	pm.execCache = execcache.New(pm.Server)
-
-	exec.New(pm.execCache, pm.eventCache, enableProcessCred, enableProcessNs)
 
 	logger.GetLogger().WithField("enableCilium", enableCilium).WithFields(logrus.Fields{
 		"enableProcessCred": enableProcessCred,

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -168,12 +168,10 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 		},
 	})
 
-	exec.New(pm.execCache, pm.eventCache, pm.enableProcessCred, pm.enableProcessNs)
 	assert.Nil(t, exec.GetProcessExec(procInternal).Process.Cap)
 
 	// cap field should be set with enable-process-cred flag.
 	pm.enableProcessCred = true
-	exec.New(pm.execCache, pm.eventCache, pm.enableProcessCred, pm.enableProcessNs)
 	assert.Equal(t,
 		&tetragon.Capabilities{
 			Permitted:   []tetragon.CapabilitiesType{tetragon.CapabilitiesType_CAP_CHOWN},

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/pkg/grpc/exec"
+	"github.com/cilium/tetragon/pkg/option"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/api/processapi"
@@ -147,12 +148,15 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 	assert.NoError(t, err)
 	defer process.FreeCache()
 	var wg sync.WaitGroup
-	pm, err := NewProcessManager(
+
+	option.Config.EnableProcessNs = false
+	option.Config.EnableProcessCred = false
+	option.Config.EnableCilium = false
+	_, err = NewProcessManager(
 		context.Background(),
 		&wg,
 		cilium.GetFakeCiliumState(),
-		nil,
-		false, false, false)
+		nil)
 	assert.NoError(t, err)
 	procInternal := process.AddExecEvent(&processapi.MsgExecveEventUnix{
 		Common: processapi.MsgCommon{
@@ -171,7 +175,7 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 	assert.Nil(t, exec.GetProcessExec(procInternal).Process.Cap)
 
 	// cap field should be set with enable-process-cred flag.
-	pm.enableProcessCred = true
+	option.Config.EnableProcessCred = true
 	assert.Equal(t,
 		&tetragon.Capabilities{
 			Permitted:   []tetragon.CapabilitiesType{tetragon.CapabilitiesType_CAP_CHOWN},

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -152,7 +152,7 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 		&wg,
 		cilium.GetFakeCiliumState(),
 		nil,
-		false, false, false, false)
+		false, false, false)
 	assert.NoError(t, err)
 	procInternal := process.AddExecEvent(&processapi.MsgExecveEventUnix{
 		Common: processapi.MsgCommon{

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -369,7 +369,10 @@ func loadExporter(t *testing.T, obs *Observer, opts *testExporterOptions, oo *te
 	// to bounce events through the cache waiting for Cilium to reply with endpoints
 	// and K8s cache data to be completed. We currently only stub them enough to
 	// report nil or a pre-defined value. So no cache needed.
-	processManager, err := tetragonGrpc.NewProcessManager(context.Background(), &cancelWg, ciliumState, SensorManager, true, true, false)
+	option.Config.EnableProcessNs = true
+	option.Config.EnableProcessCred = true
+	option.Config.EnableCilium = false
+	processManager, err := tetragonGrpc.NewProcessManager(context.Background(), &cancelWg, ciliumState, SensorManager)
 	if err != nil {
 		return err
 	}

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -369,7 +369,7 @@ func loadExporter(t *testing.T, obs *Observer, opts *testExporterOptions, oo *te
 	// to bounce events through the cache waiting for Cilium to reply with endpoints
 	// and K8s cache data to be completed. We currently only stub them enough to
 	// report nil or a pre-defined value. So no cache needed.
-	processManager, err := tetragonGrpc.NewProcessManager(context.Background(), &cancelWg, ciliumState, SensorManager, true, true, true, false)
+	processManager, err := tetragonGrpc.NewProcessManager(context.Background(), &cancelWg, ciliumState, SensorManager, true, true, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -21,6 +21,10 @@ type config struct {
 	Verbosity          int
 	IgnoreMissingProgs bool
 	ForceSmallProgs    bool
+	EnableCilium       bool
+	EnableProcessNs    bool
+	EnableProcessCred  bool
+	EnableK8s          bool
 
 	LogOpts map[string]string
 }
@@ -28,7 +32,7 @@ type config struct {
 var (
 	log = logger.GetLogger()
 
-	// Config contains all the configuration used by FGS.
+	// Config contains all the configuration used by Tetragon.
 	Config = config{
 		// Initialize global defaults below.
 


### PR DESCRIPTION
This simplifies Process manager and arg handling creating common pkg to handle getting/setting args. After this series ./pkg/option is also used for standard configuration options such as ProcessNS and ProcessCreds.

With this we can simplify Process Manager arg passing and avoid pushing args down through multiple layers of calls. And additionally logs can pretty print the args at any debug or info point we need them.

Finally fixes up cache init flow to only enable the eventCache when the K8s watcher is also enabled. This further simplifies bringing the ProcessManager up because we no longer need to pass the arg through. And finally, we can drop storing the cache in the process manager object. Caches are singular objects you can't have multiple caches of the same type. Historically, we allowed this but it was thoroughly confusing and when some poor person had to debug it you end up asking questions like -- which cache is not working, is the event in the other cache , and so on--  so we removed this logic long ago, but process manager never came along with it until now.