### PR TITLE
Test checker

### DIFF
--- a/pkg/jsonchecker/jsonchecker.go
+++ b/pkg/jsonchecker/jsonchecker.go
@@ -115,10 +115,8 @@ func JsonCheck(jsonFile *os.File, checker ec.MultiEventChecker, log *logrus.Logg
 }
 
 // JsonTestCheck checks a JSON file using the new eventchecker library.
-func JsonTestCheck(t *testing.T, checker ec.MultiEventChecker) error {
+func JsonTestCheckFile(t *testing.T, checker ec.MultiEventChecker, jsonFname string) error {
 	var err error
-
-	jsonFname := testutils.GetExportFilename(t)
 
 	// cleanup function: if test fails, mark export file to be kept
 	defer func() {
@@ -168,4 +166,9 @@ func JsonTestCheck(t *testing.T, checker ec.MultiEventChecker) error {
 	}
 
 	return err
+}
+
+func JsonTestCheck(t *testing.T, checker ec.MultiEventChecker) error {
+	jsonFname := testutils.GetExportFilename(t)
+	return JsonTestCheckFile(t, checker, jsonFname)
 }


### PR DESCRIPTION
We have 2 kprobe events with __x64_sys_read function name, and both of
these have the same path: "/etc/passwd".

Next we create 2 checkers:
1. __x64_sys_read with path "/etc/passwd"
2. __x64_sys_read with path "/etc/group"

So this test should fail. But it passes.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>