### PR TITLE
tetragon: Avoid passing dir options around and add them to option

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -62,7 +62,6 @@ var (
 
 	metricsServer string
 	serverAddress string
-	ciliumBPF     string
 	configFile    string
 
 	runStandalone bool
@@ -103,7 +102,7 @@ func readAndSetFlags() {
 
 	metricsServer = viper.GetString(keyMetricsServer)
 	serverAddress = viper.GetString(keyServerAddress)
-	ciliumBPF = viper.GetString(keyCiliumBPF)
+	option.Config.CiliumDir = viper.GetString(keyCiliumBPF)
 	configFile = viper.GetString(keyConfigFile)
 
 	runStandalone = viper.GetBool(keyRunStandalone)

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -120,12 +120,9 @@ func hubbleTETRAGONExecute() error {
 
 	bpf.ConfigureResourceLimits()
 	observerDir := getObserverDir()
-	obs := observer.NewObserver(
-		observerDir,
-		observerDir,
-		ciliumBPF,
-		configFile,
-	)
+	option.Config.BpfDir = observerDir
+	option.Config.MapDir = observerDir
+	obs := observer.NewObserver(configFile)
 	if err := obs.InitSensorManager(); err != nil {
 		return err
 	}
@@ -148,7 +145,7 @@ func hubbleTETRAGONExecute() error {
 	}
 
 	if runStandalone {
-		if err := base.LoadDefault(ctx, observerDir, observerDir, ciliumBPF); err != nil {
+		if err := base.LoadDefault(ctx, observerDir, observerDir, option.Config.CiliumDir); err != nil {
 			return err
 		}
 		return obs.StartStandalone(ctx)
@@ -217,7 +214,7 @@ func hubbleTETRAGONExecute() error {
 		}
 	}
 
-	if err := base.LoadDefault(ctx, observerDir, observerDir, ciliumBPF); err != nil {
+	if err := base.LoadDefault(ctx, observerDir, observerDir, option.Config.CiliumDir); err != nil {
 		return err
 	}
 

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/reader/notify"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/config"
@@ -237,9 +238,6 @@ func (k *Observer) runEventsNew(stopCtx context.Context, ready func()) error {
 // notified of their corresponding events.
 type Observer struct {
 	/* Configuration */
-	bpfDir     string
-	mapDir     string
-	ciliumDir  string
 	listeners  map[Listener]struct{}
 	perfConfig *bpf.PerfEventConfig
 	/* Statistics */
@@ -259,7 +257,7 @@ func (k *Observer) Start(ctx context.Context, sens []*sensors.Sensor) error {
 	k.startUpdateMapMetrics()
 
 	if sens != nil {
-		if err := config.LoadConfig(ctx, k.bpfDir, k.mapDir, k.ciliumDir, sens); err != nil {
+		if err := config.LoadConfig(ctx, option.Config.BpfDir, option.Config.MapDir, option.Config.CiliumDir, sens); err != nil {
 			return err
 		}
 	}
@@ -287,15 +285,12 @@ func (k *Observer) Start(ctx context.Context, sens []*sensors.Sensor) error {
 // InitSensorManager starts the sensor controller and stt manager.
 func (k *Observer) InitSensorManager() error {
 	var err error
-	SensorManager, err = sensors.StartSensorManager(k.bpfDir, k.mapDir, k.ciliumDir)
+	SensorManager, err = sensors.StartSensorManager(option.Config.BpfDir, option.Config.MapDir, option.Config.CiliumDir)
 	return err
 }
 
-func NewObserver(bpfDir, mapDir, ciliumDir, configFile string) *Observer {
+func NewObserver(configFile string) *Observer {
 	o := &Observer{
-		bpfDir:     bpfDir,
-		mapDir:     mapDir,
-		ciliumDir:  ciliumDir,
 		listeners:  make(map[Listener]struct{}),
 		log:        logger.GetLogger(),
 		configFile: configFile,
@@ -319,5 +314,5 @@ func (k *Observer) PrintStats() {
 }
 
 func (k *Observer) RemovePrograms() {
-	RemovePrograms(k.bpfDir, k.mapDir)
+	RemovePrograms(option.Config.BpfDir, option.Config.MapDir)
 }

--- a/pkg/observer/observer_stats.go
+++ b/pkg/observer/observer_stats.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/metrics/mapmetrics"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors"
 )
 
@@ -49,7 +50,7 @@ func (s *statValue) DeepCopyMapValue() bpf.MapValue {
 func (k *Observer) startUpdateMapMetrics() {
 	update := func() {
 		for _, m := range sensors.AllMaps {
-			pin := filepath.Join(k.mapDir, m.Name)
+			pin := filepath.Join(option.Config.MapDir, m.Name)
 			pinStats := pin + "_stats"
 
 			mapLinkStats, err := bpf.OpenMap(pinStats)

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -229,10 +229,10 @@ func newDefaultTestOptions(t *testing.T, opts ...TestOption) *TestOptions {
 }
 
 func newDefaultObserver(t *testing.T, oo *testObserverOptions) *Observer {
-	return NewObserver(observerTestDir,
-		observerTestDir,
-		"",
-		oo.config)
+	option.Config.BpfDir = observerTestDir
+	option.Config.MapDir = observerTestDir
+	option.Config.CiliumDir = ""
+	return NewObserver(oo.config)
 }
 
 func readConfig(file string) (*yaml.GenericTracingConf, error) {
@@ -282,7 +282,7 @@ func getDefaultObserver(t *testing.T, base *sensors.Sensor, opts ...TestOption) 
 		}
 	}
 
-	if err := loadObserver(t, obs, base, sens, o.observer.notestfail); err != nil {
+	if err := loadObserver(t, base, sens, o.observer.notestfail); err != nil {
 		return nil, err
 	}
 
@@ -398,15 +398,15 @@ func loadExporter(t *testing.T, obs *Observer, opts *testExporterOptions, oo *te
 	return nil
 }
 
-func loadObserver(t *testing.T, obs *Observer, base *sensors.Sensor, sens []*sensors.Sensor, notestfail bool) error {
-	if err := base.Load(context.TODO(), obs.bpfDir, obs.mapDir, obs.ciliumDir); err != nil {
+func loadObserver(t *testing.T, base *sensors.Sensor, sens []*sensors.Sensor, notestfail bool) error {
+	if err := base.Load(context.TODO(), option.Config.BpfDir, option.Config.MapDir, option.Config.CiliumDir); err != nil {
 		t.Fatalf("Load base error: %s\n", err)
 	}
 	if err := config.LoadConfig(
 		context.TODO(),
-		obs.bpfDir,
-		obs.mapDir,
-		obs.ciliumDir,
+		option.Config.BpfDir,
+		option.Config.MapDir,
+		option.Config.CiliumDir,
 		sens,
 	); err != nil {
 		if notestfail {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -21,10 +21,15 @@ type config struct {
 	Verbosity          int
 	IgnoreMissingProgs bool
 	ForceSmallProgs    bool
-	EnableCilium       bool
-	EnableProcessNs    bool
-	EnableProcessCred  bool
-	EnableK8s          bool
+
+	EnableCilium      bool
+	EnableProcessNs   bool
+	EnableProcessCred bool
+	EnableK8s         bool
+
+	CiliumDir string
+	MapDir    string
+	BpfDir    string
 
 	LogOpts map[string]string
 }


### PR DESCRIPTION
Dir variables are passed around and embedded in the observer even though
they are set once and fixed. Further they are not part of the observer
object at all. The fallout is then random pkgs reach into observer
just to lookup directories. This can then cause cycles and makes dev
work more difficult.

Lets skip passing them around and read them directly through the option
pkg.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>