### PR TITLE
tetragon: avoid segfault of eventcache is disabled

### DIFF
--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -75,7 +75,7 @@ func (msg *MsgExecveEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 		proc := process.AddExecEvent(&msg.MsgExecveEventUnix)
 		procEvent := GetProcessExec(proc)
 		ec := eventcache.Get()
-		if ec.Needed(procEvent.Process) {
+		if ec != nil && ec.Needed(procEvent.Process) {
 			ec.Add(proc, procEvent, ktime.ToProto(msg.Common.Ktime), msg)
 		} else {
 			procEvent.Process = proc.GetProcessCopy()
@@ -134,7 +134,7 @@ func GetProcessExit(event *tetragonAPI.MsgExitEvent) *tetragon.ProcessExit {
 		Status:  code,
 	}
 	ec := eventcache.Get()
-	if ec.Needed(tetragonProcess) {
+	if ec != nil && ec.Needed(tetragonProcess) {
 		ec.Add(process, tetragonEvent, ktime.ToProto(event.Common.Ktime), event)
 		return nil
 	}

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -153,7 +153,7 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 	}
 
 	ec := eventcache.Get()
-	if ec.Needed(tetragonProcess) {
+	if ec != nil && ec.Needed(tetragonProcess) {
 		ec.Add(process, tetragonEvent, ktime.ToProto(event.Common.Ktime), event)
 		return nil
 	}
@@ -226,7 +226,7 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 	}
 
 	ec := eventcache.Get()
-	if ec.Needed(tetragonProcess) {
+	if ec != nil && ec.Needed(tetragonProcess) {
 		ec.Add(process, tetragonEvent, ktime.ToProto(msg.Common.Ktime), msg)
 		return nil
 	}


### PR DESCRIPTION
Exec sensor missed check for execcache != nil and attempts to query the
execcache even though its a nil pointer.

To fix simply check ptr for nil. Perhaps we should hide these behind a
fake interface, but not sure its worth it really.

This fixes the following,

panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x15835df]

goroutine 68 [running]:
testing.tRunner.func1.2({0x170cf40, 0x27c6850})
	/usr/local/go/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1392 +0x39f
panic({0x170cf40, 0x27c6850})
	/usr/local/go/src/runtime/panic.go:838 +0x207
github.com/cilium/tetragon/pkg/eventcache.(*Cache).Add(...)
	/home/john/go/src/github.com/cilium/tetragon/pkg/eventcache/eventcache.go:181
github.com/cilium/tetragon/pkg/grpc/exec.(*MsgExecveEventUnix).HandleMessage(0xc000239ad0)
	/home/john/go/src/github.com/cilium/tetragon/pkg/grpc/exec/exec.go:79 +0x1ff
github.com/cilium/tetragon/pkg/grpc.(*ProcessManager).Notify(0xf?, {0x1bc9640, 0xc000239ad0})
	/home/john/go/src/github.com/cilium/tetragon/pkg/grpc/process_manager.go:68 +0x2c
github.com/cilium/tetragon/pkg/observer.(*Observer).observerListeners(0xc000b0a240, {0x1bc9640, 0xc000239ad0})
	/home/john/go/src/github.com/cilium/tetragon/pkg/observer/observer.go:64 +0xb3

Signed-off-by: John Fastabend <john.fastabend@gmail.com>