### PR TITLE
tetragon: Add bpf program loader tests

### DIFF
--- a/pkg/sensors/program/coll.go
+++ b/pkg/sensors/program/coll.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package program
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/logger"
+)
+
+// The idea of LoadedCollection is to keep loaded programs and maps
+// from ebpf.Collection to be used later for 'TestLoad*' tests to
+// verify loaded programs and maps.
+//
+// We can't just iterate all existing programs and maps for 2 reasons:
+//   - we could race with others loading bpf programs
+//   - we get limited name (16 bytes), which we usually cross with
+//     our names for maps and programs
+//
+// The process of loading LoadedCollection is following:
+//
+//   - ebpf collection is loaded
+//
+//     coll := NewCollectionWithOptions
+//
+//   - copy all programs/maps from ebpf collection
+//
+//     copyLoadedCollection(lc, coll)
+//
+//   - collection is removed and only 'used' programs and maps stay loaded
+//     so we filter out unused programs/maps with (based on their IDs)
+//
+//     load.LC = filterLoadedCollection(lc)
+//
+// This way we have only programs/maps realted to our test and with
+// original long names.
+//
+// All this is happening only when program.KeepCollection is set true,
+// so it's enabled only for testing code.
+
+var (
+	KeepCollection bool
+)
+
+type LoadedMap struct {
+	ID ebpf.MapID
+}
+
+type LoadedProgram struct {
+	ID     ebpf.ProgramID
+	MapIDs []ebpf.MapID
+	Type   ebpf.ProgramType
+}
+
+type LoadedCollection struct {
+	Programs map[string]*LoadedProgram
+	Maps     map[string]*LoadedMap
+}
+
+func newLoadedCollection() *LoadedCollection {
+	lc := &LoadedCollection{}
+	lc.Maps = map[string]*LoadedMap{}
+	lc.Programs = map[string]*LoadedProgram{}
+	return lc
+}
+
+func printLoadedCollection(str string, lc *LoadedCollection) {
+	logger.GetLogger().Infof("Programs (%s):", str)
+	for name, lp := range lc.Programs {
+		logger.GetLogger().Infof("%d: %s - %v", lp.ID, name, lp.MapIDs)
+	}
+	logger.GetLogger().Infof("Maps (%s):", str)
+	for name, lm := range lc.Maps {
+		logger.GetLogger().Infof("%d: %s", lm.ID, name)
+	}
+}
+
+func copyLoadedCollection(coll *ebpf.Collection) (*LoadedCollection, error) {
+	if coll == nil {
+		return nil, fmt.Errorf("failed to get collection")
+	}
+	lc := newLoadedCollection()
+	// copy all loaded maps
+	for name, m := range coll.Maps {
+		info, err := m.Info()
+		if err != nil {
+			return nil, err
+		}
+		id, ok := info.ID()
+		if !ok {
+			return nil, fmt.Errorf("failed to get id")
+		}
+		lm := &LoadedMap{id}
+		lc.Maps[name] = lm
+	}
+	// copy all loaded programs with assigned map ids
+	for name, p := range coll.Programs {
+		info, err := p.Info()
+		if err != nil {
+			return nil, err
+		}
+		id, ok := info.ID()
+		if !ok {
+			return nil, fmt.Errorf("failed to get id")
+		}
+		mapIDs, ok := info.MapIDs()
+		if !ok {
+			return nil, fmt.Errorf("failed to get map ids")
+		}
+		lp := &LoadedProgram{ID: id}
+		lp.MapIDs = mapIDs
+		lp.Type = p.Type()
+		lc.Programs[name] = lp
+	}
+	return lc, nil
+}
+
+// Gets all the programs/maps and removes any non existent ones
+// from passed collection
+func filterLoadedCollection(lc *LoadedCollection) *LoadedCollection {
+	ret := newLoadedCollection()
+
+	// filter out non existing programs
+	lastProg := ebpf.ProgramID(0)
+	for {
+		next, err := ebpf.ProgramGetNextID(lastProg)
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		for name, lp := range lc.Programs {
+			if lp.ID == next {
+				ret.Programs[name] = lp
+			}
+		}
+		lastProg = next
+	}
+
+	// filter out non existing maps
+	lastMap := ebpf.MapID(0)
+	for {
+		next, err := ebpf.MapGetNextID(lastMap)
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		for name, lm := range lc.Maps {
+			if lm.ID == next {
+				ret.Maps[name] = lm
+			}
+		}
+		lastMap = next
+	}
+	for _, lp := range lc.Programs {
+		var mapIDs []ebpf.MapID
+
+		for _, mi := range lp.MapIDs {
+			for _, lm := range lc.Maps {
+				if lm.ID == mi {
+					mapIDs = append(mapIDs, mi)
+					break
+				}
+			}
+		}
+		lp.MapIDs = mapIDs
+	}
+	return ret
+}

--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -76,6 +76,9 @@ type Program struct {
 	unloaderOverride unloader.Unloader
 
 	PinMap map[string]string
+
+	// available when program.KeepCollection is true
+	LC *LoadedCollection
 }
 
 func (p *Program) SetRetProbe(ret bool) *Program {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/cilium/ebpf"
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/bpf"
@@ -2399,4 +2400,103 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
+}
+
+func TestLoadKprobeSensor(t *testing.T) {
+	var sensorProgs = []tus.SensorProg{
+		// kprobe
+		0:  tus.SensorProg{Name: "generic_kprobe_event", Type: ebpf.Kprobe},
+		1:  tus.SensorProg{Name: "generic_kprobe_process_event0", Type: ebpf.Kprobe},
+		2:  tus.SensorProg{Name: "generic_kprobe_process_event1", Type: ebpf.Kprobe},
+		3:  tus.SensorProg{Name: "generic_kprobe_process_event2", Type: ebpf.Kprobe},
+		4:  tus.SensorProg{Name: "generic_kprobe_process_event3", Type: ebpf.Kprobe},
+		5:  tus.SensorProg{Name: "generic_kprobe_process_event4", Type: ebpf.Kprobe},
+		6:  tus.SensorProg{Name: "generic_kprobe_filter_arg1", Type: ebpf.Kprobe},
+		7:  tus.SensorProg{Name: "generic_kprobe_filter_arg2", Type: ebpf.Kprobe},
+		8:  tus.SensorProg{Name: "generic_kprobe_filter_arg3", Type: ebpf.Kprobe},
+		9:  tus.SensorProg{Name: "generic_kprobe_filter_arg4", Type: ebpf.Kprobe},
+		10: tus.SensorProg{Name: "generic_kprobe_filter_arg5", Type: ebpf.Kprobe},
+		11: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
+		// retkprobe
+		12: tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
+
+		// base sensor
+		13: tus.SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
+		14: tus.SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
+		15: tus.SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
+	}
+
+	var sensorMaps = []tus.SensorMap{
+		// all kprobe programs
+		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+		tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+
+		// only retkprobe
+		tus.SensorMap{Name: "process_call_heap", Progs: []uint{12}},
+
+		// generic_kprobe_process_filter,generic_kprobe_filter_arg*
+		tus.SensorMap{Name: "filter_map", Progs: []uint{6, 7, 8, 9, 10, 11}},
+
+		// generic_kprobe_filter_arg*
+		tus.SensorMap{Name: "override_tasks", Progs: []uint{6, 7, 8, 9, 10}},
+
+		// generic_kprobe_filter_arg*,generic_retkprobe_event,base
+		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{6, 7, 8, 9, 10, 12, 13, 14, 15}},
+
+		// only retkprobe
+		tus.SensorMap{Name: "config_map", Progs: []uint{12}},
+
+		// shared with base sensor
+		tus.SensorMap{Name: "execve_map", Progs: []uint{13, 14, 15, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+		tus.SensorMap{Name: "execve_map_stats", Progs: []uint{13, 14, 15, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+
+		// generic_kprobe_process_event*,generic_kprobe_filter_arg*,retkprobe
+		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12}},
+	}
+
+	if kernels.EnableLargeProgs() {
+		// all kprobe but generic_kprobe_process_filter,generic_kprobe_event
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}})
+	} else {
+		// all kprobe but generic_kprobe_process_filter,generic_kprobe_event
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{1, 2, 3, 4, 5}})
+	}
+
+	readHook := `
+apiVersion: cilium.io/v1alpha1
+metadata:
+  name: "sys_read"
+spec:
+  kprobes:
+  - call: "__x64_sys_read"
+    syscall: true
+    return: true
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "char_buf"
+      returnCopy: true
+    - index: 2
+      type: "size_t"
+    returnArg:
+      type: "size_t"
+`
+
+	var sens []*sensors.Sensor
+	var err error
+
+	readConfigHook := []byte(readHook)
+	err = ioutil.WriteFile(testConfigFile, readConfigHook, 0644)
+	if err != nil {
+		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
+	}
+	sens, err = observer.GetDefaultSensorsWithFile(t, context.TODO(), testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+
+	tus.CheckSensorLoad(sens, sensorMaps, sensorProgs, t)
+
+	sensors.UnloadAll(tus.Conf().TetragonLib)
 }

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package sensors
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+)
+
+type SensorProg struct {
+	Name  string
+	Type  ebpf.ProgramType
+	NotIn bool
+}
+
+type SensorMap struct {
+	Name  string
+	Progs []uint
+}
+
+func findMapForProg(coll *program.LoadedCollection, nam string, p *program.LoadedProgram, t *testing.T) *program.LoadedMap {
+	for name, m := range coll.Maps {
+		if nam != name {
+			continue
+		}
+		for _, id := range p.MapIDs {
+			if m.ID == id {
+				return m
+			}
+		}
+	}
+	return nil
+}
+
+type prog struct {
+	name string
+	prog *program.LoadedProgram
+	coll *program.LoadedCollection
+	mark bool
+}
+
+func findProgram(cache []*prog, name string, typ ebpf.ProgramType, t *testing.T) *prog {
+	for _, c := range cache {
+		if c.prog.Type != typ {
+			continue
+		}
+		if c.name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func CheckSensorLoad(sensors []*sensors.Sensor, sensorMaps []SensorMap, sensorProgs []SensorProg, t *testing.T) {
+
+	var cache []*prog
+
+	// make programs cache 'name/type/coll'
+	for _, sensor := range sensors {
+		for _, load := range sensor.Progs {
+			c := load.LC
+			for n, p := range c.Programs {
+				c := &prog{name: n, prog: p, coll: c, mark: false}
+				cache = append(cache, c)
+			}
+		}
+	}
+
+	// check that we loaded expected programs
+	for _, tp := range sensorProgs {
+		c := findProgram(cache, tp.Name, tp.Type, t)
+		if c == nil {
+			t.Fatalf("could not find program %v in sensor", tp.Name)
+		}
+		c.mark = true
+		t.Logf("Found prog %v type %s\n", c.name, c.prog.Type)
+	}
+
+	var extra bool
+
+	// check that we did not load anything else
+	for _, c := range cache {
+		if !c.mark {
+			t.Logf("found extra program loaded: %v type %s", c.name, c.prog.Type)
+			extra = true
+		}
+	}
+
+	if extra {
+		t.Fatalf("found extra program loaded")
+	}
+
+	// check user provided maps
+	for _, tm := range sensorMaps {
+		var sharedId ebpf.MapID
+
+		t.Logf("Checking map %v\n", tm.Name)
+
+		for _, c := range cache {
+			c.mark = false
+		}
+
+		// check that tm.Progs programs DO share the map
+		for _, idx := range tm.Progs {
+			tp := sensorProgs[idx]
+
+			c := findProgram(cache, tp.Name, tp.Type, t)
+			if c == nil {
+				t.Fatalf("could not find program %v in sensor\n", tp.Name)
+			}
+
+			m := findMapForProg(c.coll, tm.Name, c.prog, t)
+			if m == nil {
+				t.Fatalf("could not find map %v in program %v\n", tm.Name, tp.Name)
+			}
+
+			t.Logf("\tFound map %v id %v in prog %v\n", tm.Name, m.ID, tp.Name)
+
+			if sharedId == 0 {
+				sharedId = m.ID
+			}
+
+			if m.ID != sharedId {
+				t.Fatalf("map %v has wrong shared id %v != %v\n", tm.Name, m.ID, sharedId)
+			}
+			c.mark = true
+		}
+
+		// check that rest of the loaded programs DO NOT share the map
+		for _, c := range cache {
+			if c.mark {
+				continue
+			}
+
+			m := findMapForProg(c.coll, tm.Name, c.prog, t)
+			if m == nil {
+				continue
+			}
+
+			if m.ID == sharedId {
+				t.Fatalf("Map %s[%d] is shared also with program %s", tm.Name, m.ID, c.name)
+			}
+		}
+	}
+}

--- a/pkg/testutils/sensors/testrun.go
+++ b/pkg/testutils/sensors/testrun.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/sensors/program"
 )
 
 var config *Config
@@ -52,6 +53,9 @@ func TetragonBpfPath() string {
 func TestSensorsRun(m *testing.M, sensorName string) int {
 	c := ConfigDefaults
 	config = &c
+
+	// instruct loader to keep the loaded collection for TestLoad* tests
+	program.KeepCollection = true
 
 	// some tests require the name of the current binary.
 	config.SelfBinary = filepath.Base(os.Args[0])

--- a/pkg/testutils/sensors/testrun.go
+++ b/pkg/testutils/sensors/testrun.go
@@ -4,6 +4,7 @@
 package sensors
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/sensors/program"
 )
 
@@ -99,5 +101,8 @@ func TestSensorsRun(m *testing.M, sensorName string) int {
 		fmt.Printf("map dir `%s` still exists after test. Removing it.\n", path)
 		os.RemoveAll(path)
 	}()
+	if err := btf.InitCachedBTF(context.Background(), config.TetragonLib, ""); err != nil {
+		fmt.Printf("InitCachedBTF failed: %v", err)
+	}
 	return m.Run()
 }


### PR DESCRIPTION
Adding CheckSensorLoad function that takes array of programs
and maps and checks they are loaded and share specified maps.

Plus related changes to allow that.
    
Signed-off-by: Jiri Olsa <jolsa@kernel.org>

