### PR TITLE
README: Remove --release-channel GKE flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Run the following command to create a GKE cluster:
 export NAME="$(whoami)-$RANDOM"
 gcloud container clusters create "${NAME}" \
   --zone us-west2-a \
-  --release-channel rapid \
   --num-nodes 1
 ```
 


### PR DESCRIPTION
The default channel now comes with BTF file.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>