### PR TITLE
eventchecker: fix broken codegen for map checker

### DIFF
--- a/cmd/protoc-gen-go-tetragon/eventchecker/field.go
+++ b/cmd/protoc-gen-go-tetragon/eventchecker/field.go
@@ -209,6 +209,10 @@ func doGetFieldFrom(field *Field, g *protogen.GeneratedFile, handleList, handleO
 		return doListFrom()
 	}
 
+	if handleList && field.Desc.IsMap() {
+		return "// TODO: implement fromMap", nil
+	}
+
 	switch kind {
 	case protoreflect.BoolKind,
 		protoreflect.Int32Kind,
@@ -406,6 +410,10 @@ func doGetFieldCheck(field *Field, g *protogen.GeneratedFile, handleList, handle
 
 	if handleList && field.Desc.IsList() {
 		return doListCheck()
+	}
+
+	if handleList && field.Desc.IsMap() {
+		return "// TODO: implement check for maps", nil
 	}
 
 	switch kind {
@@ -806,7 +814,7 @@ func (field *Field) typeName(g *protogen.GeneratedFile) (string, error) {
 	}
 
 	if field.isMap() {
-		return fmt.Sprintf("map[%s]%s", field.Desc.MapKey(), type_), nil
+		return fmt.Sprintf("map[%s]%s", field.Desc.MapKey().Kind().String(), field.Desc.MapValue().Kind().String()), nil
 	} else if field.isList() {
 		if field.isPrimitive() {
 			return fmt.Sprintf("[]%s", type_), nil


### PR DESCRIPTION
The logic for determining type names from protobuf maps was incorrect because we were
subbing in the FieldDescriptor rather than the underlying type. Fix this for now to get
codegen working. A subsequent commit will fix the eventchecker itself so arbitrary map
key/values will actually work.

Signed-off-by: William Findlay <will@isovalent.com>