### PR TITLE
ci/checkpatch: remove SPDX warning

### DIFF
--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -13,4 +13,4 @@ jobs:
       - name: Run checkpatch.pl
         uses: docker://quay.io/cilium/cilium-checkpatch:2f0f4f512e795d5668ea4e7ef0ba85abc75eb225@sha256:f307bf0315954e8b8c31edc1864d949bf211b0c6522346359317d757b5a6cea0
         with:
-          args: "-- --ignore PREFER_DEFINED_ATTRIBUTE_MACRO,C99_COMMENTS,OPEN_ENDED_LINE,PREFER_KERNEL_TYPES,REPEATED_WORD"
+          args: "-- --ignore PREFER_DEFINED_ATTRIBUTE_MACRO,C99_COMMENTS,OPEN_ENDED_LINE,PREFER_KERNEL_TYPES,REPEATED_WORD,SPDX_LICENSE_TAG"


### PR DESCRIPTION
This was flagging new files following our current convention for SPDX license tag. This is
annoying so turn it off.

Signed-off-by: William Findlay <will@isovalent.com>