### PR TITLE
tetragon: Add bench application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 lib/*
 /tetragon
 /tetragon-alignchecker
+/tetragon-bench
 /tetra
 /parsertest
 /checkerpc

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
 
 .PHONY: all
-all: tetragon-bpf tetragon tetra tetragon-alignchecker test-compile tester-progs protoc-gen-go-tetragon
+all: tetragon-bpf tetragon tetra tetragon-alignchecker test-compile tester-progs protoc-gen-go-tetragon tetragon-bench
 
 -include Makefile.docker
 
@@ -75,12 +75,15 @@ tetragon-bpf-container:
 verify: tetragon-bpf
 	sudo contrib/verify/verify.sh bpf/objs
 
-.PHONY: tetragon tetra tetragon-operator tetragon-alignchecker
+.PHONY: tetragon tetra tetragon-operator tetragon-alignchecker tetragon-bench
 tetragon:
 	$(GO) build -gcflags=$(GO_GCFLAGS) -ldflags=$(GO_LDFLAGS) -mod=vendor ./cmd/tetragon/
 
 tetra:
 	$(GO) build -gcflags=$(GO_GCFLAGS) -ldflags=$(GO_LDFLAGS) -mod=vendor ./cmd/tetra/
+
+tetragon-bench:
+	$(GO) build -gcflags=$(GO_GCFLAGS) -ldflags=$(GO_LDFLAGS) -mod=vendor ./cmd/tetragon-bench/
 
 tetragon-operator:
 	$(GO) build -gcflags=$(GO_GCFLAGS) -ldflags=$(GO_LDFLAGS) -mod=vendor -o $@ ./operator

--- a/cmd/tetragon-bench/bench.go
+++ b/cmd/tetragon-bench/bench.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/cilium/tetragon/pkg/bench"
+	"github.com/spf13/viper"
+	"golang.org/x/sys/unix"
+)
+
+// Command-line flags
+var (
+	debug       *bool
+	jsonEncode  *bool
+	baseline    *bool
+	printEvents *bool
+
+	traceBench *string
+)
+
+func init() {
+	debug = flag.Bool("debug", false, "enable debugging")
+	jsonEncode = flag.Bool("json-encode", false, "JSON encode the events and measure overhead")
+	baseline = flag.Bool("baseline", false, "run a baseline benchmark without tetragon")
+	printEvents = flag.Bool("print", false, "print events in JSON to stdout")
+	traceBench = flag.String("trace", "none", "trace benchmark to run, one of: "+strings.Join(bench.TraceBenchSupported(), ", "))
+}
+
+func main() {
+	if unix.Getuid() != 0 {
+		log.Fatalf("You need to run fgs-bench as root.")
+	}
+
+	flag.Parse()
+	log.SetOutput(os.Stderr)
+
+	if *debug {
+		viper.Set("log-level", "debug")
+	}
+
+	args := &bench.Arguments{
+		Debug:       *debug,
+		JSONEncode:  *jsonEncode || *printEvents,
+		PrintEvents: *printEvents,
+		Baseline:    *baseline,
+		Trace:       bench.TraceBenchNameOrPanic(*traceBench),
+	}
+
+	summary := bench.RunTraceBench(args)
+
+	summary.PrettyPrint()
+	if summary.Error != "" {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mennanov/fmutils v0.2.0
 	github.com/prometheus/client_golang v1.12.2
+	github.com/prometheus/client_model v0.2.1-0.20210607210712-147c58e9608a
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
@@ -94,7 +95,6 @@ require (
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.2.1-0.20210607210712-147c58e9608a // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -41,6 +41,8 @@ import (
 
 type Arguments struct {
 	Trace       string
+	Crd         string
+	CmdArgs     []string
 	Debug       bool
 	PrintEvents bool
 	JSONEncode  bool

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bench
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/api/readyapi"
+	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/btf"
+	"github.com/cilium/tetragon/pkg/cilium"
+	"github.com/cilium/tetragon/pkg/config"
+	"github.com/cilium/tetragon/pkg/defaults"
+	"github.com/cilium/tetragon/pkg/exporter"
+	"github.com/cilium/tetragon/pkg/grpc"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/reader/notify"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/base"
+	"github.com/cilium/tetragon/pkg/watcher"
+
+	// Imported to allow sensors to be initialized inside init().
+	_ "github.com/cilium/tetragon/pkg/sensors/exec"
+	_ "github.com/cilium/tetragon/pkg/sensors/tracing"
+)
+
+type Arguments struct {
+	Trace       string
+	Debug       bool
+	PrintEvents bool
+	JSONEncode  bool
+	Baseline    bool
+}
+
+func readConfig(file string) (*config.GenericTracingConf, error) {
+	if file == "" {
+		return nil, nil
+	}
+
+	yamlData, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read yaml file %s: %w", file, err)
+	}
+	cnf, err := config.ReadConfigYaml(string(yamlData))
+	if err != nil {
+		return nil, err
+	}
+
+	return cnf, nil
+}
+
+func (args *Arguments) String() string {
+	return fmt.Sprintf("Trace=%s, Debug=%v, PrintEvents=%v, JSONEncode=%v, Baseline=%v",
+		args.Trace, args.Debug, args.PrintEvents, args.JSONEncode, args.Baseline)
+}
+
+func runTetragon(ctx context.Context, configFile string, args *Arguments, summary *Summary, ready chan bool) {
+	bpf.ConfigureResourceLimits()
+	bpf.CheckOrMountFS("")
+	bpf.CheckOrMountDebugFS()
+	bpf.CheckOrMountCgroup2()
+
+	if args.Debug {
+		option.Config.Verbosity = 5
+	}
+
+	if _, err := os.Stat("../../bpf/objs"); err == nil {
+		option.Config.HubbleLib = "../../bpf/objs"
+	} else {
+		exePath, err := os.Executable()
+		if err != nil {
+			log.Fatal(err)
+		}
+		option.Config.HubbleLib = path.Join(path.Dir(exePath), "bpf/objs")
+
+		if _, err := os.Stat(option.Config.HubbleLib); err != nil {
+			// Running outside the source tree, fall back to default location.
+			option.Config.HubbleLib = defaults.DefaultTetragonLib
+		}
+	}
+
+	option.Config.BpfDir = bpf.MapPrefixPath()
+	option.Config.MapDir = bpf.MapPrefixPath()
+	obs := observer.NewObserver(configFile)
+
+	if err := obs.InitSensorManager(); err != nil {
+		logger.GetLogger().Fatalf("InitSensorManager failed: %v", err)
+	}
+
+	if err := btf.InitCachedBTF(ctx, option.Config.HubbleLib, ""); err != nil {
+		log.Fatal(err)
+	}
+
+	listener := &benchmarkListener{
+		ctx:      ctx,
+		observer: obs,
+		ready:    ready,
+	}
+	obs.AddListener(listener)
+
+	if args.JSONEncode {
+		if err := startBenchmarkExporter(ctx, obs, summary); err != nil {
+			log.Fatalf("Starting exporter failed: %v", err)
+		}
+	}
+
+	cnf, err := readConfig(configFile)
+	if err != nil {
+		log.Fatalf("readConfig error: %v", err)
+	}
+
+	benchSensors, err := sensors.GetMergedSensorFromParserPolicy(cnf.Name(), &cnf.Spec)
+	if err != nil {
+		log.Fatalf("GetMergedSensorFromParserPolicy error: %v", err)
+	}
+
+	baseSensors := base.GetInitialSensor()
+
+	if err := baseSensors.Load(ctx, option.Config.BpfDir, option.Config.MapDir, option.Config.CiliumDir); err != nil {
+		log.Fatalf("Load base error: %s\n", err)
+	}
+
+	if err := benchSensors.Load(ctx, option.Config.BpfDir, option.Config.MapDir, option.Config.CiliumDir); err != nil {
+		log.Fatalf("Load sensors error: %s\n", err)
+	}
+
+	if err := obs.Start(ctx); err != nil {
+		log.Fatalf("Starting observer failed: %v", err)
+	}
+
+	<-ctx.Done()
+	obs.RemovePrograms()
+}
+
+func sigHandler(ctx context.Context, cancel context.CancelFunc) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case <-ctx.Done():
+		close(sigs)
+		return
+	case sig := <-sigs:
+		log.Printf("Signal '%s' received, stopping...\n", sig)
+		cancel()
+		return
+	}
+}
+
+type benchmarkListener struct {
+	ready    chan bool
+	ctx      context.Context
+	observer *observer.Observer
+}
+
+func (bl *benchmarkListener) Notify(msg notify.Message) error {
+	switch msg.(type) {
+	case *readyapi.MsgTetragonReady:
+		bl.ready <- true
+	}
+
+	return nil
+}
+
+func (bl *benchmarkListener) Close() error {
+	return nil
+}
+
+type timingEncoder struct {
+	totalDuration uint64
+	inner         exporter.ExportEncoder
+}
+
+func (te *timingEncoder) Encode(v interface{}) error {
+	t0 := time.Now()
+	err := te.inner.Encode(v)
+	atomic.AddUint64(&te.totalDuration, uint64(time.Since(t0)))
+	return err
+}
+
+type CountingDiscardWriter struct {
+	nbytes  int64
+	nwrites int64
+}
+
+func (cw *CountingDiscardWriter) Write(p []byte) (n int, err error) {
+	cw.nbytes += int64(len(p))
+	cw.nwrites++
+	return len(p), nil
+}
+
+func (cw *CountingDiscardWriter) String() string {
+	return fmt.Sprintf("bytes=%v, writes=%v", cw.nbytes, cw.nwrites)
+}
+
+func startBenchmarkExporter(ctx context.Context, obs *observer.Observer, summary *Summary) error {
+	var wg sync.WaitGroup
+
+	processCacheSize := 32768
+	enableCiliumAPI := false
+
+	if _, err := cilium.InitCiliumState(ctx, enableCiliumAPI); err != nil {
+		return err
+	}
+	if err := process.InitCache(ctx, watcher.NewFakeK8sWatcher(nil), enableCiliumAPI, processCacheSize); err != nil {
+		return err
+	}
+
+	processManager, err := grpc.NewProcessManager(
+		ctx,
+		&wg,
+		cilium.GetFakeCiliumState(),
+		observer.SensorManager)
+	if err != nil {
+		return err
+	}
+
+	var encoder exporter.ExportEncoder
+	if summary.Args.PrintEvents {
+		encoder = json.NewEncoder(os.Stdout)
+	} else {
+		encoder = json.NewEncoder(&summary.ExportStats)
+	}
+
+	timingEncoder := timingEncoder{inner: encoder}
+	go func() {
+		// FIXME I'm racy, someone might read summary before this is written.
+		// Likely not an issue since we wait for slower things to exit.
+		<-ctx.Done()
+		summary.JSONEncodingDurationNanos = time.Duration(timingEncoder.totalDuration)
+	}()
+
+	req := tetragon.GetEventsRequest{AllowList: nil, DenyList: nil, AggregationOptions: nil}
+	exporter := exporter.NewExporter(ctx, &req, processManager.Server, &timingEncoder, nil, nil)
+	exporter.Start()
+	obs.AddListener(processManager)
+	return nil
+}

--- a/pkg/bench/bpfstats.go
+++ b/pkg/bench/bpfstats.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bench
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func EnableBpfStats() {
+	err := os.WriteFile("/proc/sys/kernel/bpf_stats_enabled", []byte("1"), 0666)
+	if err != nil {
+		log.Fatalf("failed to enable bpf stats: %v", err)
+	}
+}
+
+type BpfProgStats struct {
+	Id     int64  `json:"id"`
+	Type   string `json:"type"`
+	Name   string `json:"name"`
+	RunNs  int64  `json:"run_time_ns"`
+	RunCnt int64  `json:"run_cnt"`
+	// ...
+}
+
+func (bps *BpfProgStats) String() string {
+	duration := time.Duration(0)
+	if bps.RunCnt > 0 {
+		duration = time.Duration(bps.RunNs / bps.RunCnt)
+	}
+	name := bps.Name
+	if len(name) == 0 {
+		name = "<unnamed>"
+	}
+
+	lbl := fmt.Sprintf("%-30s [%s/%d]", name, bps.Type, bps.Id)
+
+	return fmt.Sprintf("%-50s:\t%.2fµs (%d)",
+		lbl, float64(duration)/float64(time.Microsecond), bps.RunCnt)
+}
+
+func GetBpfStatsSince(oldStats map[int64]*BpfProgStats) map[int64]*BpfProgStats {
+	newStats := GetBpfStats()
+	for id, newStat := range newStats {
+		if oldStat, ok := oldStats[id]; ok {
+			newStat.RunNs -= oldStat.RunNs
+			newStat.RunCnt -= oldStat.RunCnt
+		}
+	}
+	return newStats
+}
+
+func GetBpfStats() map[int64]*BpfProgStats {
+	out, err := exec.Command("/bin/sh", "-c", "bpftool prog show -j").Output()
+	if err != nil {
+		log.Printf("Failed to query bpf stats: %s\n", err)
+		return nil
+	}
+
+	var stats []BpfProgStats
+	err = json.Unmarshal(out, &stats)
+	if err != nil {
+		log.Printf("Failed to parse bpf stats: %s\n", err)
+		return nil
+	}
+
+	m := make(map[int64]*BpfProgStats)
+	for id := range stats {
+		var s = &stats[id]
+		m[s.Id] = s
+	}
+	return m
+}

--- a/pkg/bench/cpuusage.go
+++ b/pkg/bench/cpuusage.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bench
+
+import (
+	"fmt"
+	"log"
+	"syscall"
+	"time"
+)
+
+type CPUUsage struct {
+	SystemTime      time.Duration
+	UserTime        time.Duration
+	MaxRss          int64
+	ContextSwitches int64
+}
+
+type CPUUsageTarget int
+
+const (
+	CPU_USAGE_ALL_THREADS = syscall.RUSAGE_SELF
+	CPU_USAGE_THIS_THREAD = syscall.RUSAGE_THREAD
+)
+
+func CPUUsageFromRusage(rusage *syscall.Rusage) (cpuUsage CPUUsage) {
+	cpuUsage.UserTime = timevalToDuration(rusage.Utime)
+	cpuUsage.SystemTime = timevalToDuration(rusage.Stime)
+	cpuUsage.MaxRss = rusage.Maxrss
+	cpuUsage.ContextSwitches = rusage.Nivcsw + rusage.Nvcsw
+	return
+}
+
+func GetCPUUsage(tgt CPUUsageTarget) CPUUsage {
+	var rusage syscall.Rusage
+	if err := syscall.Getrusage(int(tgt), &rusage); err != nil {
+		log.Printf("Getrusage failed: %v", err)
+		return CPUUsage{}
+	}
+	return CPUUsageFromRusage(&rusage)
+}
+
+func timevalToDuration(tv syscall.Timeval) time.Duration {
+	return time.Duration(tv.Sec)*time.Second +
+		time.Duration(tv.Usec)*time.Microsecond
+}
+
+func (cu CPUUsage) Sub(cu2 CPUUsage) CPUUsage {
+	cu.UserTime -= cu2.UserTime
+	cu.SystemTime -= cu2.SystemTime
+	cu.ContextSwitches -= cu2.ContextSwitches
+	return cu
+}
+
+func (cu CPUUsage) Add(cu2 CPUUsage) CPUUsage {
+	cu.UserTime += cu2.UserTime
+	cu.SystemTime += cu2.SystemTime
+	cu.ContextSwitches += cu2.ContextSwitches
+	return cu
+}
+
+func (cu CPUUsage) String() string {
+	return fmt.Sprintf("system=%s, user=%s, rss=%d, ctxsw=%d", cu.SystemTime, cu.UserTime, cu.MaxRss, cu.ContextSwitches)
+}

--- a/pkg/bench/summary.go
+++ b/pkg/bench/summary.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bench
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
+	"github.com/fatih/color"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Summary gathers benchmark results. Serializes to JSON.
+// This is updated from multiple places concurrently (ExportStats
+// are from tetragon process), but currently there is no overlap on
+// writes, so this isn't yet protected by a mutex.
+type Summary struct {
+	Args *Arguments
+
+	ExitEvents, ExecEvents int64
+
+	StartTime          time.Time
+	EndTime            time.Time
+	RunTime            time.Time
+	SetupDurationNanos time.Duration
+	TestDurationNanos  time.Duration
+
+	JSONEncodingDurationNanos time.Duration
+	ExportStats               CountingDiscardWriter
+
+	TetragonCPUUsage CPUUsage
+
+	// key is the bpf program id
+	BpfStats map[int64]*BpfProgStats
+
+	Error string
+}
+
+func (s *Summary) Dump() {
+	err := json.NewEncoder(os.Stdout).Encode(s)
+	if err != nil {
+		log.Fatalf("json.Encode: %v", err)
+	}
+}
+
+func getGaugeValue(gauge prometheus.Gauge) int {
+	// Yep, this does seem to be the only way to read it.
+	var d dto.Metric
+	gauge.Write(&d)
+	return int(*d.Gauge.Value)
+}
+
+func (s *Summary) PrettyPrint() {
+	color.Set(color.FgBlue)
+	fmt.Println("Benchmark summary")
+	fmt.Println("-----------------")
+	color.Unset()
+	fmt.Printf("Test started:       %s\n", s.StartTime)
+	fmt.Printf("Test ended:         %s\n", s.EndTime)
+	fmt.Printf("Workload start:     %s\n", s.EndTime)
+	fmt.Printf("Arguments:          %v\n", s.Args)
+	fmt.Printf("Total duration:     %s\n", s.EndTime.Sub(s.StartTime))
+	fmt.Printf("Setup duration:     %s\n", s.SetupDurationNanos)
+	fmt.Printf("Workload duration:  %s\n", s.EndTime.Sub(s.RunTime))
+	fmt.Printf("Test duration:      %s\n", s.TestDurationNanos)
+	fmt.Printf("Export duration:    %s\n", s.JSONEncodingDurationNanos)
+	fmt.Printf("Export stats:       %s\n", s.ExportStats.String())
+	fmt.Printf("Tetragon cpu usage: %s\n", s.TetragonCPUUsage)
+
+	if !s.Args.Baseline {
+		fmt.Printf("Ring buffer:       received=%d, lost=%d, errors=%d\n",
+			getGaugeValue(ringbufmetrics.PerfEventReceived.WithLabelValues()),
+			getGaugeValue(ringbufmetrics.PerfEventLost.WithLabelValues()),
+			getGaugeValue(ringbufmetrics.PerfEventErrors.WithLabelValues()))
+	}
+
+	fmt.Println("BPF statistics:")
+	for _, bps := range s.BpfStats {
+		if bps.RunCnt > 0 {
+			fmt.Printf("  %s\n", bps)
+		}
+	}
+
+	if s.Error != "" {
+		color.Set(color.FgRed)
+		fmt.Printf("Error:             %s\n", s.Error)
+		color.Unset()
+	}
+}
+
+func (s *Summary) WriteFile(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return json.NewEncoder(f).Encode(s)
+}
+
+func newSummary(args *Arguments) *Summary {
+	return &Summary{
+		StartTime: time.Now(),
+		Args:      args,
+	}
+}

--- a/pkg/bench/trace.go
+++ b/pkg/bench/trace.go
@@ -17,7 +17,7 @@ type TraceBench interface {
 }
 
 var (
-	traceBenches = []string{"rw"}
+	traceBenches = []string{"rw", "open"}
 )
 
 func TraceBenchSupported() []string {
@@ -53,6 +53,8 @@ func RunTraceBench(args *Arguments) (summary *Summary) {
 	switch args.Trace {
 	case "rw":
 		bench = newTraceBenchRw()
+	case "open":
+		bench = newTraceBenchOpen()
 	default:
 		panic("unknown benchmark")
 	}

--- a/pkg/bench/trace.go
+++ b/pkg/bench/trace.go
@@ -17,7 +17,7 @@ type TraceBench interface {
 }
 
 var (
-	traceBenches = []string{}
+	traceBenches = []string{"rw"}
 )
 
 func TraceBenchSupported() []string {
@@ -51,6 +51,8 @@ func RunTraceBench(args *Arguments) (summary *Summary) {
 	var bench TraceBench
 
 	switch args.Trace {
+	case "rw":
+		bench = newTraceBenchRw()
 	default:
 		panic("unknown benchmark")
 	}

--- a/pkg/bench/trace.go
+++ b/pkg/bench/trace.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bench
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+type TraceBench interface {
+	ConfigFilename(ctx context.Context, args *Arguments) string
+	Run(ctx context.Context, args *Arguments, summary *Summary) error
+}
+
+var (
+	traceBenches = []string{}
+)
+
+func TraceBenchSupported() []string {
+	keys := make([]string, 0, len(traceBenches))
+	for _, k := range traceBenches {
+		keys = append(keys, string(k))
+	}
+	return keys
+}
+
+func TraceBenchNameOrPanic(s string) string {
+	for _, k := range traceBenches {
+		if k == s {
+			return s
+		}
+	}
+	log.Fatalf("Unknown bench '%s', use one of: %s", s, strings.Join(TraceBenchSupported(), ", "))
+	return string("")
+}
+
+func RunTraceBench(args *Arguments) (summary *Summary) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go sigHandler(ctx, cancel)
+
+	summary = newSummary(args)
+	summary.StartTime = time.Now()
+
+	EnableBpfStats()
+	oldBpfStats := GetBpfStats()
+
+	var bench TraceBench
+
+	switch args.Trace {
+	default:
+		panic("unknown benchmark")
+	}
+
+	configFile := bench.ConfigFilename(ctx, args)
+	defer os.Remove(configFile)
+
+	// Start tetragon if requested.
+	tetragonFinished := make(chan bool, 1)
+	if !args.Baseline {
+		ready := make(chan bool)
+		log.Printf("Starting tetragon...\n")
+		go func() {
+			runTetragon(ctx, configFile, args, summary, ready)
+			tetragonFinished <- true
+		}()
+		// Wait for tetragon to initialize.
+		<-ready
+	} else {
+		tetragonFinished <- true
+	}
+	summary.SetupDurationNanos = time.Since(summary.StartTime)
+
+	log.Printf("Benchmark start [%s]", args.Trace)
+
+	cpuUsageBefore := GetCPUUsage(CPU_USAGE_ALL_THREADS)
+
+	summary.RunTime = time.Now()
+
+	err := bench.Run(ctx, args, summary)
+	if err != nil {
+		cancel()
+		return
+	}
+
+	summary.EndTime = time.Now()
+
+	cpuUsageAfter := GetCPUUsage(CPU_USAGE_ALL_THREADS)
+
+	summary.BpfStats = GetBpfStatsSince(oldBpfStats)
+	summary.TestDurationNanos = summary.EndTime.Sub(summary.StartTime)
+
+	log.Printf("Benchmark finished, cleaning..")
+
+	// Now that the source finished, cancel the context to stop everything and collect stats.
+	cancel()
+	// Wait for tetragon to finish cleaning up.
+	<-tetragonFinished
+
+	summary.TetragonCPUUsage = cpuUsageAfter.Sub(cpuUsageBefore)
+	return
+}

--- a/pkg/bench/trace.go
+++ b/pkg/bench/trace.go
@@ -17,7 +17,7 @@ type TraceBench interface {
 }
 
 var (
-	traceBenches = []string{"rw", "open"}
+	traceBenches = []string{"rw", "open", "custom"}
 )
 
 func TraceBenchSupported() []string {
@@ -55,12 +55,17 @@ func RunTraceBench(args *Arguments) (summary *Summary) {
 		bench = newTraceBenchRw()
 	case "open":
 		bench = newTraceBenchOpen()
+	case "custom":
+		bench = newTraceBenchCustom()
 	default:
 		panic("unknown benchmark")
 	}
 
 	configFile := bench.ConfigFilename(ctx, args)
-	defer os.Remove(configFile)
+
+	if args.Trace != "custom" {
+		defer os.Remove(configFile)
+	}
 
 	// Start tetragon if requested.
 	tetragonFinished := make(chan bool, 1)

--- a/pkg/bench/trace_bench_custom.go
+++ b/pkg/bench/trace_bench_custom.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bench
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type traceBenchCustom struct {
+}
+
+func (src traceBenchCustom) Run(ctx context.Context, args *Arguments, summary *Summary) error {
+	fmt.Printf("running %v\n", args.CmdArgs)
+
+	// run the benchmark
+	cmd := exec.Command(args.CmdArgs[0], args.CmdArgs[1:]...)
+
+	// get the result
+	var out []byte
+	var err error
+
+	out, err = cmd.Output()
+	if err != nil {
+		fmt.Printf("%s\n", err)
+	}
+	fmt.Printf("%s\n", out)
+	return err
+}
+
+func (src traceBenchCustom) ConfigFilename(ctx context.Context, args *Arguments) string {
+	return args.Crd
+}
+
+func newTraceBenchCustom() *traceBenchCustom {
+	return &traceBenchCustom{}
+}

--- a/pkg/bench/trace_bench_open.go
+++ b/pkg/bench/trace_bench_open.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bench
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Command-line flags
+var (
+	openLoops   *uint
+	openThreads *uint
+	openSleep   *uint
+)
+
+func init() {
+	openSleep = flag.Uint("bench-open-sleep", 1, "bench open sleep between open syscalls (us)")
+	openLoops = flag.Uint("bench-open-loops", 1000000, "bench open number of loops")
+	openThreads = flag.Uint("bench-open-threads", 4, "bench open number of threads")
+}
+
+type traceBenchOpen struct {
+}
+
+func (src traceBenchOpen) benchWorker(ctx context.Context) {
+	name := "/tmp/non-existing-file"
+
+	var loop uint
+
+	for ctx.Err() == nil {
+		var err error
+
+		_, err = syscall.Open(name, 0, 0)
+		if err == nil {
+			fmt.Printf("failed: open did not fail\n")
+			break
+		}
+
+		loop++
+		if loop == *openLoops {
+			break
+		}
+
+		if *openSleep != 0 {
+			time.Sleep(time.Duration(*openSleep) * time.Microsecond)
+		}
+	}
+}
+
+func (src traceBenchOpen) Run(ctx context.Context, args *Arguments, summary *Summary) error {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	fmt.Printf("threads %v, loops %v, sleep %v(us)\n", *openThreads, *openLoops, *openSleep)
+
+	var i uint
+
+	for i = 0; i < *openThreads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			src.benchWorker(ctx)
+		}()
+	}
+
+	return nil
+}
+
+func (src traceBenchOpen) ConfigFilename(ctx context.Context, args *Arguments) string {
+	tmpl := `
+apiVersion: cilium.io/v1alpha1
+metadata:
+  name: "sys_write_writev"
+spec:
+  kprobes:
+  - call: "__x64_sys_openat"
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "char_buf"
+    - index: 2
+      type: "int"
+`
+
+	f, err := os.CreateTemp("/tmp", "fgs-bench-hubble-crd-*.yaml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	f.Write([]byte(tmpl))
+	return f.Name()
+}
+
+func newTraceBenchOpen() *traceBenchOpen {
+	return &traceBenchOpen{}
+}

--- a/pkg/bench/trace_bench_rw.go
+++ b/pkg/bench/trace_bench_rw.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bench
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"strconv"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/cilium/tetragon/pkg/observer"
+)
+
+// Command-line flags
+var (
+	rwLoops   *uint
+	rwSize    *uint
+	rwCount   *uint
+	rwThreads *uint
+	rwSleep   *uint
+)
+
+func init() {
+	rwLoops = flag.Uint("bench-rw-loops", 100, "bench rw number of loops")
+	rwSize = flag.Uint("bench-rw-size", 1024, "bench rw buffer size")
+	rwCount = flag.Uint("bench-rw-count", 100, "bench rw read/write count")
+	rwThreads = flag.Uint("bench-rw-threads", 4, "bench rw number of threads")
+	rwSleep = flag.Uint("bench-rw-sleep", 1, "bench rw sleep in ms")
+}
+
+type traceBenchRw struct {
+}
+
+func (src traceBenchRw) benchRwWorker(ctx context.Context) {
+	f, err := os.CreateTemp("/tmp", "fgs-bench-hubble-crd-*.data")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	var loop uint
+	var syscall uint
+
+	buffer := make([]byte, *rwSize)
+
+	for ctx.Err() == nil {
+		syscall = 0
+
+		for {
+			n, errno := f.Write(buffer)
+			if n < 0 {
+				log.Fatalf("syscall.Write failed: %s\n", errno)
+			}
+
+			// give us a chance to catch up
+			time.Sleep(time.Duration(*rwSleep) * time.Microsecond)
+
+			syscall++
+			if syscall == *rwCount {
+				break
+			}
+		}
+
+		f.Seek(0, 0)
+		syscall = 0
+
+		for {
+			n, errno := f.Read(buffer)
+			if n < 0 {
+				log.Fatalf("syscall.Read failed: %s\n", errno)
+			}
+
+			// give us a chance to catch up
+			time.Sleep(time.Duration(*rwSleep) * time.Microsecond)
+
+			syscall++
+			if syscall == *rwCount {
+				break
+			}
+		}
+
+		loop++
+		if loop == *rwLoops {
+			break
+		}
+	}
+}
+
+func (src traceBenchRw) Run(ctx context.Context, args *Arguments, summary *Summary) error {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	var i uint
+
+	for i = 0; i < *rwThreads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			src.benchRwWorker(ctx)
+		}()
+	}
+
+	return nil
+}
+
+func (src traceBenchRw) ConfigFilename(ctx context.Context, args *Arguments) string {
+	matchPid := strconv.Itoa(int(observer.GetMyPid()))
+
+	tmpl := `
+apiVersion: cilium.io/v1alpha1
+metadata:
+  name: "sys_write_writev"
+spec:
+  kprobes:
+  - call: "__x64_sys_write"
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "char_buf"
+      sizeArgIndex: 3
+    - index: 2
+      type: "int"
+  - call: "__x64_sys_read"
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "char_buf"
+      returnCopy: true
+    - index: 2
+      type: "size_t"
+    selectors:
+    - matchPIDs:
+      - operator: In
+        followForks: true
+        values:
+        - {{.MatchPid}}
+`
+
+	f, err := os.CreateTemp("/tmp", "fgs-bench-hubble-crd-*.yaml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	templateArgs :=
+		struct {
+			MatchPid string
+		}{
+			MatchPid: matchPid,
+		}
+
+	err = template.Must(template.New("crd").Parse(tmpl)).Execute(f, templateArgs)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return f.Name()
+}
+
+func newTraceBenchRw() *traceBenchRw {
+	return &traceBenchRw{}
+}


### PR DESCRIPTION
Adding benchmark application to measure tracing workloads. 

The tetragon-bench application starts tetragon (or not for -baseline option)
for given CRD file and runs workload.

At the end it displays some stats, like:

```
Benchmark summary
-----------------
Test started:      2022-09-08 15:04:28.04513503 +0200 CEST m=+0.016539427
Test ended:        2022-09-08 15:04:38.268072909 +0200 CEST m=+10.239477312
Workload start:    2022-09-08 15:04:38.268072909 +0200 CEST m=+10.239477312
Arguments:         
Total duration:    10.222937885s
Setup duration:    1.743823005s
Workload duration: 8.479094472s
Test duration:     10.222937885s
Export duration:   0s
Export stats:      bytes=0, writes=0
FGS cpu usage:     system=15.170223s, user=17.522276s, rss=230504, ctxsw=1231909
Ring buffer:       received=3958406, lost=41842, errors=0
BPF statistics:
  event_execve                   [tracepoint/212]   :   8.89µs (2)
  event_wake_up_new_task         [kprobe/211]       :   1.41µs (6)
  generic_kprobe_event           [kprobe/205]       :   1.54µs (4001580)
  restrict_filesystems           [lsm/58]           :   0.13µs (1569)
  event_exit                     [tracepoint/210]   :   0.49µs (32)
```

It's possible to run predefined workloads with builtin CRD files,
or run specific custom benchmark.

The predefined benchmarks are rw and open and can be run with:

```
# ./tetragon-bench -trace rw
# ./tetragon-bench -trace open
```
They do and monitor some simple read/write open operations and they are there
mainly to show the possibility of builtin benchmark if we think it's good idea ;-)

The custom benchmark is what I'm using most at the moment and
it allows to pass CRD file to start tetragon with and specify workload, like:


```
# ./tetragon-bench -crd crds/examples/names.yaml  -- perf bench sched pipe
```

I'm doing perf profiles to check on CRD stuff with:

```
# perf record -g -e cycles:k ./tetragon-bench -crd ./read_write.yaml -json-encode -- perf bench sched pipe
```

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
