### PR TITLE
exec: fix cache for pod info

### DIFF
--- a/pkg/execcache/execcache.go
+++ b/pkg/execcache/execcache.go
@@ -108,6 +108,16 @@ func (ec *Cache) Add(internal *process.ProcessInternal,
 	cache.objsChan <- cacheObj{internal: internal, process: e, timestamp: t, msg: msg}
 }
 
+func (ec *Cache) Needed(proc *tetragon.Process) bool {
+	if proc == nil {
+		return true
+	}
+	if proc.Docker != "" && proc.Pod == nil {
+		return true
+	}
+	return false
+}
+
 func New(s *server.Server) *Cache {
 	if cache != nil {
 		return cache

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	tetragonAPI "github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/eventcache"
+	"github.com/cilium/tetragon/pkg/execcache"
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
@@ -74,9 +75,9 @@ func (msg *MsgExecveEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 	case ops.MSG_OP_EXECVE:
 		proc := process.AddExecEvent(&msg.MsgExecveEventUnix)
 		procEvent := GetProcessExec(proc)
-		ec := eventcache.Get()
+		ec := execcache.Get()
 		if ec != nil && ec.Needed(procEvent.Process) {
-			ec.Add(proc, procEvent, ktime.ToProto(msg.Common.Ktime), msg)
+			ec.Add(proc, procEvent, ktime.ToProto(msg.Common.Ktime), &msg.MsgExecveEventUnix)
 		} else {
 			procEvent.Process = proc.GetProcessCopy()
 			res = &tetragon.GetEventsResponse{


### PR DESCRIPTION
After 4dac2750a, exec.go was adding events to the wrong cache. This was causing missing
pod info for essentially all events. Fix this by using the execCache again rather than the
eventCache.

Signed-off-by: William Findlay <will@isovalent.com>