### PR TITLE
tetragon: Add -cpuprofile option

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -39,6 +39,7 @@ const (
 
 	keyRunStandalone      = "run-standalone"
 	keyIgnoreMissingProgs = "ignore-missing-progs"
+	keyCpuProfile         = "cpuprofile"
 
 	keyExportFilename             = "export-filename"
 	keyExportFileMaxSizeMB        = "export-file-max-size-mb"
@@ -77,6 +78,8 @@ var (
 	enableExportAggregation     bool
 	exportAggregationWindowSize time.Duration
 	exportAggregationBufferSize uint64
+
+	cpuProfile string
 )
 
 func readAndSetFlags() {
@@ -117,4 +120,6 @@ func readAndSetFlags() {
 	enableExportAggregation = viper.GetBool(keyEnableExportAggregation)
 	exportAggregationWindowSize = viper.GetDuration(keyExportAggregationWindowSize)
 	exportAggregationBufferSize = viper.GetUint64(keyExportAggregationBufferSize)
+
+	cpuProfile = viper.GetString(keyCpuProfile)
 }


### PR DESCRIPTION
Adding -cpuprofile option that allows to store go cpu profile
into provided file, like:

`  # ./tetragon --cpuprofile krava.prof`

Tetragon will show the start/stop messagein the log:

```
  time="2022-07-28T13:39:12+02:00" level=info msg="Starting cpu profiling" file=krava.prof
  ...
  time="2022-07-28T13:39:22+02:00" level=info msg="Stopping cpu profiling" file=krava.prof
```
you can display the profile in browser with:
` $ go tool pprof -http=:8080 krava.prof`

that should spawn new browser tab, go on 'VIEW' menu,
click on 'Flame Graph' and be amazed ;-)

Signed-off-by: Jiri Olsa <jolsa@kernel.org>