### PR TITLE
tetragon: Rename entry point of retkprobe function

### DIFF
--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -29,7 +29,7 @@ struct bpf_map_def __attribute__((section("maps"), used)) config_map = {
 };
 
 __attribute__((section("kprobe/generic_retkprobe"), used)) int
-BPF_KRETPROBE(generic_kprobe_event, unsigned long ret)
+BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 {
 	struct execve_map_value *enter;
 	struct msg_generic_kprobe *e;


### PR DESCRIPTION
Renaming entry point of retkprobe function so it won't get
confused in bpftool stats output with the regular kprobe
program.

We used the 'generic_kprobe_event' to make things easier
in previous libbpf loader code. Now when it's gone we can
have unique name for retkprobe program.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>