### PR TITLE
tests/e2e: only install cilium if it is missing

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -110,9 +110,6 @@ jobs:
           -kubeconfig ~/.kube/config \
           -args -v=4
 
-          # -tetragon.helm.set enterprise.metadataImage.override=btf:latest \
-          # -tetragon.helm.set enterprise.metadataImage.imagePullPolicy=Never \
-
     - name: Upload Tetragon Logs
       if: failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8


### PR DESCRIPTION
Update the default runner config so that it only installs Cilium if it is not already
installed in the cluster.

Signed-off-by: William Findlay <will@isovalent.com>