### PR TITLE
tests/kprobe: remove unused const

### DIFF
--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -37,7 +37,6 @@ import (
 )
 
 const (
-	mountPath      = "/tmp2"
 	testConfigFile = "/tmp/tetragon.gotest.yaml"
 )
 


### PR DESCRIPTION
mountPath was unused and our static checks were complaining. Let's get rid of it.

Signed-off-by: William Findlay <will@isovalent.com>