### PR TITLE
tetragon: eventcache Needed() is incomplete

### DIFF
--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -165,6 +165,9 @@ func (ec *Cache) Needed(proc *tetragon.Process) bool {
 	if proc.Docker != "" && proc.Pod == nil {
 		return true
 	}
+	if proc.Binary == "" {
+		return true
+	}
 	return false
 }
 

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -49,15 +49,19 @@ type Cache struct {
 }
 
 func handleExecEvent(event *cacheObj, nspid uint32) error {
+	var podInfo *tetragon.Pod
+
 	p := event.event.GetProcess()
 	containerId := p.Docker
 	filename := p.Binary
 	args := p.Arguments
 
-	podInfo, _ := process.GetPodInfo(containerId, filename, args, nspid)
-	if podInfo == nil {
-		errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
-		return fmt.Errorf("failed to get pod info")
+	if option.Config.EnableK8s {
+		podInfo, _ = process.GetPodInfo(containerId, filename, args, nspid)
+		if podInfo == nil {
+			errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
+			return fmt.Errorf("failed to get pod info")
+		}
 	}
 
 	event.internal.AddPodInfo(podInfo)
@@ -67,11 +71,6 @@ func handleExecEvent(event *cacheObj, nspid uint32) error {
 }
 
 func handleEvent(event *cacheObj) error {
-	// No need to fetch endpoint info if we don't have the watcher to do so.
-	if !option.Config.EnableK8s {
-		return nil
-	}
-
 	p := event.event.GetProcess()
 
 	if event.internal != nil {
@@ -152,8 +151,10 @@ func (ec *Cache) Needed(proc *tetragon.Process) bool {
 	if proc == nil {
 		return true
 	}
-	if proc.Docker != "" && proc.Pod == nil {
-		return true
+	if option.Config.EnableK8s {
+		if proc.Docker != "" && proc.Pod == nil {
+			return true
+		}
 	}
 	if proc.Binary == "" {
 		return true

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -73,14 +73,18 @@ func handleExecEvent(event *cacheObj, nspid uint32) error {
 func handleEvent(event *cacheObj) error {
 	p := event.event.GetProcess()
 
-	if event.internal != nil {
-		event.event.SetProcess(event.internal.GetProcessCopy())
-	} else {
-		typeName := fmt.Sprintf("%T", event.event)
-		eventcachemetrics.ProcessInfoErrorInc(typeName)
-		errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
+	// If the process wasn't found before the Add(), likely because
+	// the execve event was processed after this event, lets look it up
+	// now because it should be available. Otherwise we have a valid
+	// process and lets copy it across.
+	if event.internal == nil {
+		event.internal, _ = process.GetParentProcessInternal(p.Pid.Value, p.StartTime.Value) //tbd StartTime needs to be the correct uint64 not the mangled timestamp.
+		if event.internal == nil {
+			return fmt.Errorf("Process lookup failed")
+		}
 	}
 
+	event.event.SetProcess(event.internal.GetProcessCopy())
 	return nil
 }
 

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -60,12 +60,8 @@ func handleExecEvent(event *cacheObj, nspid uint32) error {
 		return fmt.Errorf("failed to get pod info")
 	}
 
-	if event.internal != nil {
-		event.internal.AddPodInfo(podInfo)
-		event.event.SetProcess(event.internal.GetProcessCopy())
-	} else {
-		event.internal.GetProcess().Pod = podInfo
-	}
+	event.internal.AddPodInfo(podInfo)
+	event.event.SetProcess(event.internal.GetProcessCopy())
 
 	return nil
 }

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -78,12 +78,6 @@ func handleEvent(event *cacheObj) error {
 
 	p := event.event.GetProcess()
 
-	endpoint := process.GetProcessEndpoint(p)
-	if p.Docker != "" && (endpoint == nil || p.Pod == nil) {
-		errormetrics.ErrorTotalInc(errormetrics.EventCacheEndpointRetryFailed)
-		return fmt.Errorf("failed to get process endpoint ifno")
-	}
-
 	if event.internal != nil {
 		event.event.SetProcess(event.internal.GetProcessCopy())
 	} else {

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -84,6 +84,11 @@ func handleEvent(event *cacheObj) error {
 		}
 	}
 
+	p = event.internal.UnsafeGetProcess()
+	if option.Config.EnableK8s && p.Pod == nil {
+		return fmt.Errorf("Process missing PodInfo")
+	}
+
 	event.event.SetProcess(event.internal.GetProcessCopy())
 	return nil
 }


### PR DESCRIPTION
Resolve obvious cases for Needed() where we have a process pointer, but
are missing binary and other information. This happens through common
paths for example when exit events are received before their exec event.

To fix just extend the Needed() check to search for Binary name. I
introduced this while preparing initial release and doing some
refactoring.

Fixes: 931b70f2c9878 "Tetragon: Cilium developers happily contribute Tetragon"
Signed-off-by: John Fastabend <john.fastabend@gmail.com>