### PR TITLE
add support for bpf_attr type

### DIFF
--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -14,6 +14,7 @@
     - [HealthStatus](#tetragon-HealthStatus)
     - [Image](#tetragon-Image)
     - [KprobeArgument](#tetragon-KprobeArgument)
+    - [KprobeBpfAttr](#tetragon-KprobeBpfAttr)
     - [KprobeCred](#tetragon-KprobeCred)
     - [KprobeFile](#tetragon-KprobeFile)
     - [KprobePath](#tetragon-KprobePath)
@@ -272,6 +273,24 @@
 | sock_arg | [KprobeSock](#tetragon-KprobeSock) |  |  |
 | cred_arg | [KprobeCred](#tetragon-KprobeCred) |  |  |
 | long_arg | [int64](#int64) |  |  |
+| bpf_attr_arg | [KprobeBpfAttr](#tetragon-KprobeBpfAttr) |  |  |
+
+
+
+
+
+
+<a name="tetragon-KprobeBpfAttr"></a>
+
+### KprobeBpfAttr
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ProgType | [string](#string) |  |  |
+| InsnCnt | [uint32](#uint32) |  |  |
+| ProgName | [string](#string) |  |  |
 
 
 

--- a/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -2690,6 +2690,74 @@ func (checker *KprobeCredChecker) FromKprobeCred(event *tetragon.KprobeCred) *Kp
 	return checker
 }
 
+// KprobeBpfAttrChecker implements a checker struct to check a KprobeBpfAttr field
+type KprobeBpfAttrChecker struct {
+	ProgType *stringmatcher.StringMatcher `json:"ProgType,omitempty"`
+	InsnCnt  *uint32                      `json:"InsnCnt,omitempty"`
+	ProgName *stringmatcher.StringMatcher `json:"ProgName,omitempty"`
+}
+
+// NewKprobeBpfAttrChecker creates a new KprobeBpfAttrChecker
+func NewKprobeBpfAttrChecker() *KprobeBpfAttrChecker {
+	return &KprobeBpfAttrChecker{}
+}
+
+// Check checks a KprobeBpfAttr field
+func (checker *KprobeBpfAttrChecker) Check(event *tetragon.KprobeBpfAttr) error {
+	if event == nil {
+		return fmt.Errorf("KprobeBpfAttrChecker: KprobeBpfAttr field is nil")
+	}
+
+	if checker.ProgType != nil {
+		if err := checker.ProgType.Match(event.ProgType); err != nil {
+			return fmt.Errorf("KprobeBpfAttrChecker: ProgType check failed: %w", err)
+		}
+	}
+	if checker.InsnCnt != nil {
+		if *checker.InsnCnt != event.InsnCnt {
+			return fmt.Errorf("KprobeBpfAttrChecker: InsnCnt has value %d which does not match expected value %d", event.InsnCnt, *checker.InsnCnt)
+		}
+	}
+	if checker.ProgName != nil {
+		if err := checker.ProgName.Match(event.ProgName); err != nil {
+			return fmt.Errorf("KprobeBpfAttrChecker: ProgName check failed: %w", err)
+		}
+	}
+	return nil
+}
+
+// WithProgType adds a ProgType check to the KprobeBpfAttrChecker
+func (checker *KprobeBpfAttrChecker) WithProgType(check *stringmatcher.StringMatcher) *KprobeBpfAttrChecker {
+	checker.ProgType = check
+	return checker
+}
+
+// WithInsnCnt adds a InsnCnt check to the KprobeBpfAttrChecker
+func (checker *KprobeBpfAttrChecker) WithInsnCnt(check uint32) *KprobeBpfAttrChecker {
+	checker.InsnCnt = &check
+	return checker
+}
+
+// WithProgName adds a ProgName check to the KprobeBpfAttrChecker
+func (checker *KprobeBpfAttrChecker) WithProgName(check *stringmatcher.StringMatcher) *KprobeBpfAttrChecker {
+	checker.ProgName = check
+	return checker
+}
+
+//FromKprobeBpfAttr populates the KprobeBpfAttrChecker using data from a KprobeBpfAttr field
+func (checker *KprobeBpfAttrChecker) FromKprobeBpfAttr(event *tetragon.KprobeBpfAttr) *KprobeBpfAttrChecker {
+	if event == nil {
+		return checker
+	}
+	checker.ProgType = stringmatcher.Full(event.ProgType)
+	{
+		val := event.InsnCnt
+		checker.InsnCnt = &val
+	}
+	checker.ProgName = stringmatcher.Full(event.ProgName)
+	return checker
+}
+
 // KprobeArgumentChecker implements a checker struct to check a KprobeArgument field
 type KprobeArgumentChecker struct {
 	StringArg         *stringmatcher.StringMatcher `json:"stringArg,omitempty"`
@@ -2703,6 +2771,7 @@ type KprobeArgumentChecker struct {
 	SockArg           *KprobeSockChecker           `json:"sockArg,omitempty"`
 	CredArg           *KprobeCredChecker           `json:"credArg,omitempty"`
 	LongArg           *int64                       `json:"longArg,omitempty"`
+	BpfAttrArg        *KprobeBpfAttrChecker        `json:"bpfAttrArg,omitempty"`
 }
 
 // NewKprobeArgumentChecker creates a new KprobeArgumentChecker
@@ -2826,6 +2895,16 @@ func (checker *KprobeArgumentChecker) Check(event *tetragon.KprobeArgument) erro
 			return fmt.Errorf("KprobeArgumentChecker: LongArg check failed: %T is not a LongArg", event)
 		}
 	}
+	if checker.BpfAttrArg != nil {
+		switch event := event.Arg.(type) {
+		case *tetragon.KprobeArgument_BpfAttrArg:
+			if err := checker.BpfAttrArg.Check(event.BpfAttrArg); err != nil {
+				return fmt.Errorf("KprobeArgumentChecker: BpfAttrArg check failed: %w", err)
+			}
+		default:
+			return fmt.Errorf("KprobeArgumentChecker: BpfAttrArg check failed: %T is not a BpfAttrArg", event)
+		}
+	}
 	return nil
 }
 
@@ -2892,6 +2971,12 @@ func (checker *KprobeArgumentChecker) WithCredArg(check *KprobeCredChecker) *Kpr
 // WithLongArg adds a LongArg check to the KprobeArgumentChecker
 func (checker *KprobeArgumentChecker) WithLongArg(check int64) *KprobeArgumentChecker {
 	checker.LongArg = &check
+	return checker
+}
+
+// WithBpfAttrArg adds a BpfAttrArg check to the KprobeArgumentChecker
+func (checker *KprobeArgumentChecker) WithBpfAttrArg(check *KprobeBpfAttrChecker) *KprobeArgumentChecker {
+	checker.BpfAttrArg = check
 	return checker
 }
 
@@ -2963,6 +3048,12 @@ func (checker *KprobeArgumentChecker) FromKprobeArgument(event *tetragon.KprobeA
 		{
 			val := event.LongArg
 			checker.LongArg = &val
+		}
+	}
+	switch event := event.Arg.(type) {
+	case *tetragon.KprobeArgument_BpfAttrArg:
+		if event.BpfAttrArg != nil {
+			checker.BpfAttrArg = NewKprobeBpfAttrChecker().FromKprobeBpfAttr(event.BpfAttrArg)
 		}
 	}
 	return checker

--- a/api/v1/tetragon/tetragon.pb.go
+++ b/api/v1/tetragon/tetragon.pb.go
@@ -1440,6 +1440,69 @@ func (x *KprobeCred) GetInheritable() []CapabilitiesType {
 	return nil
 }
 
+type KprobeBpfAttr struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	ProgType string `protobuf:"bytes,1,opt,name=ProgType,proto3" json:"ProgType,omitempty"`
+	InsnCnt  uint32 `protobuf:"varint,2,opt,name=InsnCnt,proto3" json:"InsnCnt,omitempty"`
+	ProgName string `protobuf:"bytes,3,opt,name=ProgName,proto3" json:"ProgName,omitempty"`
+}
+
+func (x *KprobeBpfAttr) Reset() {
+	*x = KprobeBpfAttr{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tetragon_tetragon_proto_msgTypes[15]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *KprobeBpfAttr) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KprobeBpfAttr) ProtoMessage() {}
+
+func (x *KprobeBpfAttr) ProtoReflect() protoreflect.Message {
+	mi := &file_tetragon_tetragon_proto_msgTypes[15]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KprobeBpfAttr.ProtoReflect.Descriptor instead.
+func (*KprobeBpfAttr) Descriptor() ([]byte, []int) {
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *KprobeBpfAttr) GetProgType() string {
+	if x != nil {
+		return x.ProgType
+	}
+	return ""
+}
+
+func (x *KprobeBpfAttr) GetInsnCnt() uint32 {
+	if x != nil {
+		return x.InsnCnt
+	}
+	return 0
+}
+
+func (x *KprobeBpfAttr) GetProgName() string {
+	if x != nil {
+		return x.ProgName
+	}
+	return ""
+}
+
 type KprobeArgument struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1457,13 +1520,14 @@ type KprobeArgument struct {
 	//	*KprobeArgument_SockArg
 	//	*KprobeArgument_CredArg
 	//	*KprobeArgument_LongArg
+	//	*KprobeArgument_BpfAttrArg
 	Arg isKprobeArgument_Arg `protobuf_oneof:"arg"`
 }
 
 func (x *KprobeArgument) Reset() {
 	*x = KprobeArgument{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[15]
+		mi := &file_tetragon_tetragon_proto_msgTypes[16]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1476,7 +1540,7 @@ func (x *KprobeArgument) String() string {
 func (*KprobeArgument) ProtoMessage() {}
 
 func (x *KprobeArgument) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[15]
+	mi := &file_tetragon_tetragon_proto_msgTypes[16]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1489,7 +1553,7 @@ func (x *KprobeArgument) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeArgument.ProtoReflect.Descriptor instead.
 func (*KprobeArgument) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{15}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{16}
 }
 
 func (m *KprobeArgument) GetArg() isKprobeArgument_Arg {
@@ -1576,6 +1640,13 @@ func (x *KprobeArgument) GetLongArg() int64 {
 	return 0
 }
 
+func (x *KprobeArgument) GetBpfAttrArg() *KprobeBpfAttr {
+	if x, ok := x.GetArg().(*KprobeArgument_BpfAttrArg); ok {
+		return x.BpfAttrArg
+	}
+	return nil
+}
+
 type isKprobeArgument_Arg interface {
 	isKprobeArgument_Arg()
 }
@@ -1624,6 +1695,10 @@ type KprobeArgument_LongArg struct {
 	LongArg int64 `protobuf:"varint,11,opt,name=long_arg,json=longArg,proto3,oneof"`
 }
 
+type KprobeArgument_BpfAttrArg struct {
+	BpfAttrArg *KprobeBpfAttr `protobuf:"bytes,12,opt,name=bpf_attr_arg,json=bpfAttrArg,proto3,oneof"`
+}
+
 func (*KprobeArgument_StringArg) isKprobeArgument_Arg() {}
 
 func (*KprobeArgument_IntArg) isKprobeArgument_Arg() {}
@@ -1646,6 +1721,8 @@ func (*KprobeArgument_CredArg) isKprobeArgument_Arg() {}
 
 func (*KprobeArgument_LongArg) isKprobeArgument_Arg() {}
 
+func (*KprobeArgument_BpfAttrArg) isKprobeArgument_Arg() {}
+
 type ProcessKprobe struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1662,7 +1739,7 @@ type ProcessKprobe struct {
 func (x *ProcessKprobe) Reset() {
 	*x = ProcessKprobe{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[16]
+		mi := &file_tetragon_tetragon_proto_msgTypes[17]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1675,7 +1752,7 @@ func (x *ProcessKprobe) String() string {
 func (*ProcessKprobe) ProtoMessage() {}
 
 func (x *ProcessKprobe) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[16]
+	mi := &file_tetragon_tetragon_proto_msgTypes[17]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1688,7 +1765,7 @@ func (x *ProcessKprobe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessKprobe.ProtoReflect.Descriptor instead.
 func (*ProcessKprobe) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{16}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ProcessKprobe) GetProcess() *Process {
@@ -1749,7 +1826,7 @@ type ProcessTracepoint struct {
 func (x *ProcessTracepoint) Reset() {
 	*x = ProcessTracepoint{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[17]
+		mi := &file_tetragon_tetragon_proto_msgTypes[18]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1762,7 +1839,7 @@ func (x *ProcessTracepoint) String() string {
 func (*ProcessTracepoint) ProtoMessage() {}
 
 func (x *ProcessTracepoint) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[17]
+	mi := &file_tetragon_tetragon_proto_msgTypes[18]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1775,7 +1852,7 @@ func (x *ProcessTracepoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessTracepoint.ProtoReflect.Descriptor instead.
 func (*ProcessTracepoint) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{17}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ProcessTracepoint) GetProcess() *Process {
@@ -1827,7 +1904,7 @@ type Test struct {
 func (x *Test) Reset() {
 	*x = Test{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[18]
+		mi := &file_tetragon_tetragon_proto_msgTypes[19]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1840,7 +1917,7 @@ func (x *Test) String() string {
 func (*Test) ProtoMessage() {}
 
 func (x *Test) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[18]
+	mi := &file_tetragon_tetragon_proto_msgTypes[19]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1853,7 +1930,7 @@ func (x *Test) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Test.ProtoReflect.Descriptor instead.
 func (*Test) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{18}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *Test) GetArg0() uint64 {
@@ -1895,7 +1972,7 @@ type GetHealthStatusRequest struct {
 func (x *GetHealthStatusRequest) Reset() {
 	*x = GetHealthStatusRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[19]
+		mi := &file_tetragon_tetragon_proto_msgTypes[20]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1908,7 +1985,7 @@ func (x *GetHealthStatusRequest) String() string {
 func (*GetHealthStatusRequest) ProtoMessage() {}
 
 func (x *GetHealthStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[19]
+	mi := &file_tetragon_tetragon_proto_msgTypes[20]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1921,7 +1998,7 @@ func (x *GetHealthStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHealthStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetHealthStatusRequest) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{19}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetHealthStatusRequest) GetEventSet() []HealthStatusType {
@@ -1944,7 +2021,7 @@ type HealthStatus struct {
 func (x *HealthStatus) Reset() {
 	*x = HealthStatus{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[20]
+		mi := &file_tetragon_tetragon_proto_msgTypes[21]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1957,7 +2034,7 @@ func (x *HealthStatus) String() string {
 func (*HealthStatus) ProtoMessage() {}
 
 func (x *HealthStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[20]
+	mi := &file_tetragon_tetragon_proto_msgTypes[21]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1970,7 +2047,7 @@ func (x *HealthStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthStatus.ProtoReflect.Descriptor instead.
 func (*HealthStatus) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{20}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *HealthStatus) GetEvent() HealthStatusType {
@@ -2005,7 +2082,7 @@ type GetHealthStatusResponse struct {
 func (x *GetHealthStatusResponse) Reset() {
 	*x = GetHealthStatusResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[21]
+		mi := &file_tetragon_tetragon_proto_msgTypes[22]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2018,7 +2095,7 @@ func (x *GetHealthStatusResponse) String() string {
 func (*GetHealthStatusResponse) ProtoMessage() {}
 
 func (x *GetHealthStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[21]
+	mi := &file_tetragon_tetragon_proto_msgTypes[22]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2031,7 +2108,7 @@ func (x *GetHealthStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHealthStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetHealthStatusResponse) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{21}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetHealthStatusResponse) GetHealthStatus() []*HealthStatus {
@@ -2241,38 +2318,48 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x68, 0x65, 0x72, 0x69, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0e, 0x32,
 	0x1a, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x43, 0x61, 0x70, 0x61, 0x62,
 	0x69, 0x6c, 0x69, 0x74, 0x69, 0x65, 0x73, 0x54, 0x79, 0x70, 0x65, 0x52, 0x0b, 0x69, 0x6e, 0x68,
-	0x65, 0x72, 0x69, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x22, 0xfa, 0x03, 0x0a, 0x0e, 0x4b, 0x70, 0x72,
-	0x6f, 0x62, 0x65, 0x41, 0x72, 0x67, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x12, 0x1f, 0x0a, 0x0a, 0x73,
-	0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x48,
-	0x00, 0x52, 0x09, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x41, 0x72, 0x67, 0x12, 0x19, 0x0a, 0x07,
-	0x69, 0x6e, 0x74, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x48, 0x00, 0x52,
-	0x06, 0x69, 0x6e, 0x74, 0x41, 0x72, 0x67, 0x12, 0x2e, 0x0a, 0x07, 0x73, 0x6b, 0x62, 0x5f, 0x61,
-	0x72, 0x67, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61,
-	0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53, 0x6b, 0x62, 0x48, 0x00, 0x52,
-	0x06, 0x73, 0x6b, 0x62, 0x41, 0x72, 0x67, 0x12, 0x1b, 0x0a, 0x08, 0x73, 0x69, 0x7a, 0x65, 0x5f,
-	0x61, 0x72, 0x67, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x48, 0x00, 0x52, 0x07, 0x73, 0x69, 0x7a,
-	0x65, 0x41, 0x72, 0x67, 0x12, 0x1d, 0x0a, 0x09, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x61, 0x72,
-	0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0c, 0x48, 0x00, 0x52, 0x08, 0x62, 0x79, 0x74, 0x65, 0x73,
-	0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x70, 0x61, 0x74, 0x68, 0x5f, 0x61, 0x72, 0x67, 0x18,
-	0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e,
-	0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x50, 0x61, 0x74, 0x68, 0x48, 0x00, 0x52, 0x07, 0x70,
-	0x61, 0x74, 0x68, 0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x66, 0x69, 0x6c, 0x65, 0x5f, 0x61,
-	0x72, 0x67, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61,
-	0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x48, 0x00,
-	0x52, 0x07, 0x66, 0x69, 0x6c, 0x65, 0x41, 0x72, 0x67, 0x12, 0x50, 0x0a, 0x13, 0x74, 0x72, 0x75,
-	0x6e, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x61, 0x72, 0x67,
-	0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f,
-	0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x54, 0x72, 0x75, 0x6e, 0x63, 0x61, 0x74, 0x65,
-	0x64, 0x42, 0x79, 0x74, 0x65, 0x73, 0x48, 0x00, 0x52, 0x11, 0x74, 0x72, 0x75, 0x6e, 0x63, 0x61,
-	0x74, 0x65, 0x64, 0x42, 0x79, 0x74, 0x65, 0x73, 0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x73,
-	0x6f, 0x63, 0x6b, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e,
-	0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53,
-	0x6f, 0x63, 0x6b, 0x48, 0x00, 0x52, 0x07, 0x73, 0x6f, 0x63, 0x6b, 0x41, 0x72, 0x67, 0x12, 0x31,
-	0x0a, 0x08, 0x63, 0x72, 0x65, 0x64, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x0b,
+	0x65, 0x72, 0x69, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x22, 0x61, 0x0a, 0x0d, 0x4b, 0x70, 0x72, 0x6f,
+	0x62, 0x65, 0x42, 0x70, 0x66, 0x41, 0x74, 0x74, 0x72, 0x12, 0x1a, 0x0a, 0x08, 0x50, 0x72, 0x6f,
+	0x67, 0x54, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x50, 0x72, 0x6f,
+	0x67, 0x54, 0x79, 0x70, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x49, 0x6e, 0x73, 0x6e, 0x43, 0x6e, 0x74,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x07, 0x49, 0x6e, 0x73, 0x6e, 0x43, 0x6e, 0x74, 0x12,
+	0x1a, 0x0a, 0x08, 0x50, 0x72, 0x6f, 0x67, 0x4e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x08, 0x50, 0x72, 0x6f, 0x67, 0x4e, 0x61, 0x6d, 0x65, 0x22, 0xb7, 0x04, 0x0a, 0x0e,
+	0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x41, 0x72, 0x67, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x12, 0x1f,
+	0x0a, 0x0a, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x09, 0x48, 0x00, 0x52, 0x09, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x41, 0x72, 0x67, 0x12,
+	0x19, 0x0a, 0x07, 0x69, 0x6e, 0x74, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05,
+	0x48, 0x00, 0x52, 0x06, 0x69, 0x6e, 0x74, 0x41, 0x72, 0x67, 0x12, 0x2e, 0x0a, 0x07, 0x73, 0x6b,
+	0x62, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x74, 0x65,
+	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53, 0x6b, 0x62,
+	0x48, 0x00, 0x52, 0x06, 0x73, 0x6b, 0x62, 0x41, 0x72, 0x67, 0x12, 0x1b, 0x0a, 0x08, 0x73, 0x69,
+	0x7a, 0x65, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x48, 0x00, 0x52, 0x07,
+	0x73, 0x69, 0x7a, 0x65, 0x41, 0x72, 0x67, 0x12, 0x1d, 0x0a, 0x09, 0x62, 0x79, 0x74, 0x65, 0x73,
+	0x5f, 0x61, 0x72, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0c, 0x48, 0x00, 0x52, 0x08, 0x62, 0x79,
+	0x74, 0x65, 0x73, 0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x70, 0x61, 0x74, 0x68, 0x5f, 0x61,
+	0x72, 0x67, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61,
+	0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x50, 0x61, 0x74, 0x68, 0x48, 0x00,
+	0x52, 0x07, 0x70, 0x61, 0x74, 0x68, 0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x66, 0x69, 0x6c,
+	0x65, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65,
+	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x46, 0x69, 0x6c,
+	0x65, 0x48, 0x00, 0x52, 0x07, 0x66, 0x69, 0x6c, 0x65, 0x41, 0x72, 0x67, 0x12, 0x50, 0x0a, 0x13,
+	0x74, 0x72, 0x75, 0x6e, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f,
+	0x61, 0x72, 0x67, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x74, 0x65, 0x74, 0x72,
+	0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x54, 0x72, 0x75, 0x6e, 0x63,
+	0x61, 0x74, 0x65, 0x64, 0x42, 0x79, 0x74, 0x65, 0x73, 0x48, 0x00, 0x52, 0x11, 0x74, 0x72, 0x75,
+	0x6e, 0x63, 0x61, 0x74, 0x65, 0x64, 0x42, 0x79, 0x74, 0x65, 0x73, 0x41, 0x72, 0x67, 0x12, 0x31,
+	0x0a, 0x08, 0x73, 0x6f, 0x63, 0x6b, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0b,
 	0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f,
-	0x62, 0x65, 0x43, 0x72, 0x65, 0x64, 0x48, 0x00, 0x52, 0x07, 0x63, 0x72, 0x65, 0x64, 0x41, 0x72,
-	0x67, 0x12, 0x1b, 0x0a, 0x08, 0x6c, 0x6f, 0x6e, 0x67, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x0b, 0x20,
-	0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x07, 0x6c, 0x6f, 0x6e, 0x67, 0x41, 0x72, 0x67, 0x42, 0x05,
+	0x62, 0x65, 0x53, 0x6f, 0x63, 0x6b, 0x48, 0x00, 0x52, 0x07, 0x73, 0x6f, 0x63, 0x6b, 0x41, 0x72,
+	0x67, 0x12, 0x31, 0x0a, 0x08, 0x63, 0x72, 0x65, 0x64, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x0a, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b,
+	0x70, 0x72, 0x6f, 0x62, 0x65, 0x43, 0x72, 0x65, 0x64, 0x48, 0x00, 0x52, 0x07, 0x63, 0x72, 0x65,
+	0x64, 0x41, 0x72, 0x67, 0x12, 0x1b, 0x0a, 0x08, 0x6c, 0x6f, 0x6e, 0x67, 0x5f, 0x61, 0x72, 0x67,
+	0x18, 0x0b, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x07, 0x6c, 0x6f, 0x6e, 0x67, 0x41, 0x72,
+	0x67, 0x12, 0x3b, 0x0a, 0x0c, 0x62, 0x70, 0x66, 0x5f, 0x61, 0x74, 0x74, 0x72, 0x5f, 0x61, 0x72,
+	0x67, 0x18, 0x0c, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67,
+	0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x42, 0x70, 0x66, 0x41, 0x74, 0x74, 0x72,
+	0x48, 0x00, 0x52, 0x0a, 0x62, 0x70, 0x66, 0x41, 0x74, 0x74, 0x72, 0x41, 0x72, 0x67, 0x42, 0x05,
 	0x0a, 0x03, 0x61, 0x72, 0x67, 0x22, 0x9c, 0x02, 0x0a, 0x0d, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73,
 	0x73, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x12, 0x2b, 0x0a, 0x07, 0x70, 0x72, 0x6f, 0x63, 0x65,
 	0x73, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x11, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61,
@@ -2371,7 +2458,7 @@ func file_tetragon_tetragon_proto_rawDescGZIP() []byte {
 }
 
 var file_tetragon_tetragon_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_tetragon_tetragon_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_tetragon_tetragon_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_tetragon_tetragon_proto_goTypes = []interface{}{
 	(KprobeAction)(0),               // 0: tetragon.KprobeAction
 	(HealthStatusType)(0),           // 1: tetragon.HealthStatusType
@@ -2391,27 +2478,28 @@ var file_tetragon_tetragon_proto_goTypes = []interface{}{
 	(*KprobeFile)(nil),              // 15: tetragon.KprobeFile
 	(*KprobeTruncatedBytes)(nil),    // 16: tetragon.KprobeTruncatedBytes
 	(*KprobeCred)(nil),              // 17: tetragon.KprobeCred
-	(*KprobeArgument)(nil),          // 18: tetragon.KprobeArgument
-	(*ProcessKprobe)(nil),           // 19: tetragon.ProcessKprobe
-	(*ProcessTracepoint)(nil),       // 20: tetragon.ProcessTracepoint
-	(*Test)(nil),                    // 21: tetragon.Test
-	(*GetHealthStatusRequest)(nil),  // 22: tetragon.GetHealthStatusRequest
-	(*HealthStatus)(nil),            // 23: tetragon.HealthStatus
-	(*GetHealthStatusResponse)(nil), // 24: tetragon.GetHealthStatusResponse
-	nil,                             // 25: tetragon.Pod.PodLabelsEntry
-	(*timestamppb.Timestamp)(nil),   // 26: google.protobuf.Timestamp
-	(*wrapperspb.UInt32Value)(nil),  // 27: google.protobuf.UInt32Value
-	(CapabilitiesType)(0),           // 28: tetragon.CapabilitiesType
+	(*KprobeBpfAttr)(nil),           // 18: tetragon.KprobeBpfAttr
+	(*KprobeArgument)(nil),          // 19: tetragon.KprobeArgument
+	(*ProcessKprobe)(nil),           // 20: tetragon.ProcessKprobe
+	(*ProcessTracepoint)(nil),       // 21: tetragon.ProcessTracepoint
+	(*Test)(nil),                    // 22: tetragon.Test
+	(*GetHealthStatusRequest)(nil),  // 23: tetragon.GetHealthStatusRequest
+	(*HealthStatus)(nil),            // 24: tetragon.HealthStatus
+	(*GetHealthStatusResponse)(nil), // 25: tetragon.GetHealthStatusResponse
+	nil,                             // 26: tetragon.Pod.PodLabelsEntry
+	(*timestamppb.Timestamp)(nil),   // 27: google.protobuf.Timestamp
+	(*wrapperspb.UInt32Value)(nil),  // 28: google.protobuf.UInt32Value
+	(CapabilitiesType)(0),           // 29: tetragon.CapabilitiesType
 }
 var file_tetragon_tetragon_proto_depIdxs = []int32{
 	3,  // 0: tetragon.Container.image:type_name -> tetragon.Image
-	26, // 1: tetragon.Container.start_time:type_name -> google.protobuf.Timestamp
-	27, // 2: tetragon.Container.pid:type_name -> google.protobuf.UInt32Value
+	27, // 1: tetragon.Container.start_time:type_name -> google.protobuf.Timestamp
+	28, // 2: tetragon.Container.pid:type_name -> google.protobuf.UInt32Value
 	4,  // 3: tetragon.Pod.container:type_name -> tetragon.Container
-	25, // 4: tetragon.Pod.pod_labels:type_name -> tetragon.Pod.PodLabelsEntry
-	28, // 5: tetragon.Capabilities.permitted:type_name -> tetragon.CapabilitiesType
-	28, // 6: tetragon.Capabilities.effective:type_name -> tetragon.CapabilitiesType
-	28, // 7: tetragon.Capabilities.inheritable:type_name -> tetragon.CapabilitiesType
+	26, // 4: tetragon.Pod.pod_labels:type_name -> tetragon.Pod.PodLabelsEntry
+	29, // 5: tetragon.Capabilities.permitted:type_name -> tetragon.CapabilitiesType
+	29, // 6: tetragon.Capabilities.effective:type_name -> tetragon.CapabilitiesType
+	29, // 7: tetragon.Capabilities.inheritable:type_name -> tetragon.CapabilitiesType
 	7,  // 8: tetragon.Namespaces.uts:type_name -> tetragon.Namespace
 	7,  // 9: tetragon.Namespaces.ipc:type_name -> tetragon.Namespace
 	7,  // 10: tetragon.Namespaces.mnt:type_name -> tetragon.Namespace
@@ -2422,10 +2510,10 @@ var file_tetragon_tetragon_proto_depIdxs = []int32{
 	7,  // 15: tetragon.Namespaces.time_for_children:type_name -> tetragon.Namespace
 	7,  // 16: tetragon.Namespaces.cgroup:type_name -> tetragon.Namespace
 	7,  // 17: tetragon.Namespaces.user:type_name -> tetragon.Namespace
-	27, // 18: tetragon.Process.pid:type_name -> google.protobuf.UInt32Value
-	27, // 19: tetragon.Process.uid:type_name -> google.protobuf.UInt32Value
-	26, // 20: tetragon.Process.start_time:type_name -> google.protobuf.Timestamp
-	27, // 21: tetragon.Process.auid:type_name -> google.protobuf.UInt32Value
+	28, // 18: tetragon.Process.pid:type_name -> google.protobuf.UInt32Value
+	28, // 19: tetragon.Process.uid:type_name -> google.protobuf.UInt32Value
+	27, // 20: tetragon.Process.start_time:type_name -> google.protobuf.Timestamp
+	28, // 21: tetragon.Process.auid:type_name -> google.protobuf.UInt32Value
 	5,  // 22: tetragon.Process.pod:type_name -> tetragon.Pod
 	6,  // 23: tetragon.Process.cap:type_name -> tetragon.Capabilities
 	8,  // 24: tetragon.Process.ns:type_name -> tetragon.Namespaces
@@ -2434,32 +2522,33 @@ var file_tetragon_tetragon_proto_depIdxs = []int32{
 	9,  // 27: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
 	9,  // 28: tetragon.ProcessExit.process:type_name -> tetragon.Process
 	9,  // 29: tetragon.ProcessExit.parent:type_name -> tetragon.Process
-	28, // 30: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
-	28, // 31: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
-	28, // 32: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
+	29, // 30: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
+	29, // 31: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
+	29, // 32: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
 	13, // 33: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
 	14, // 34: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
 	15, // 35: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
 	16, // 36: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
 	12, // 37: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
 	17, // 38: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
-	9,  // 39: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
-	9,  // 40: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
-	18, // 41: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
-	18, // 42: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
-	0,  // 43: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
-	9,  // 44: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
-	9,  // 45: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
-	18, // 46: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
-	1,  // 47: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
-	1,  // 48: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
-	2,  // 49: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
-	23, // 50: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
-	51, // [51:51] is the sub-list for method output_type
-	51, // [51:51] is the sub-list for method input_type
-	51, // [51:51] is the sub-list for extension type_name
-	51, // [51:51] is the sub-list for extension extendee
-	0,  // [0:51] is the sub-list for field type_name
+	18, // 39: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
+	9,  // 40: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
+	9,  // 41: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
+	19, // 42: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
+	19, // 43: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
+	0,  // 44: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
+	9,  // 45: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
+	9,  // 46: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
+	19, // 47: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
+	1,  // 48: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
+	1,  // 49: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
+	2,  // 50: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
+	24, // 51: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
+	52, // [52:52] is the sub-list for method output_type
+	52, // [52:52] is the sub-list for method input_type
+	52, // [52:52] is the sub-list for extension type_name
+	52, // [52:52] is the sub-list for extension extendee
+	0,  // [0:52] is the sub-list for field type_name
 }
 
 func init() { file_tetragon_tetragon_proto_init() }
@@ -2650,7 +2739,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeArgument); i {
+			switch v := v.(*KprobeBpfAttr); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2662,7 +2751,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessKprobe); i {
+			switch v := v.(*KprobeArgument); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2674,7 +2763,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessTracepoint); i {
+			switch v := v.(*ProcessKprobe); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2686,7 +2775,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Test); i {
+			switch v := v.(*ProcessTracepoint); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2698,7 +2787,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetHealthStatusRequest); i {
+			switch v := v.(*Test); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2710,7 +2799,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*HealthStatus); i {
+			switch v := v.(*GetHealthStatusRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2722,6 +2811,18 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*HealthStatus); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tetragon_tetragon_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*GetHealthStatusResponse); i {
 			case 0:
 				return &v.state
@@ -2734,7 +2835,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 	}
-	file_tetragon_tetragon_proto_msgTypes[15].OneofWrappers = []interface{}{
+	file_tetragon_tetragon_proto_msgTypes[16].OneofWrappers = []interface{}{
 		(*KprobeArgument_StringArg)(nil),
 		(*KprobeArgument_IntArg)(nil),
 		(*KprobeArgument_SkbArg)(nil),
@@ -2746,6 +2847,7 @@ func file_tetragon_tetragon_proto_init() {
 		(*KprobeArgument_SockArg)(nil),
 		(*KprobeArgument_CredArg)(nil),
 		(*KprobeArgument_LongArg)(nil),
+		(*KprobeArgument_BpfAttrArg)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2753,7 +2855,7 @@ func file_tetragon_tetragon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_tetragon_tetragon_proto_rawDesc,
 			NumEnums:      3,
-			NumMessages:   23,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/v1/tetragon/tetragon.pb.json.go
+++ b/api/v1/tetragon/tetragon.pb.json.go
@@ -248,6 +248,22 @@ func (msg *KprobeCred) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
+func (msg *KprobeBpfAttr) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseEnumNumbers:  false,
+		EmitUnpopulated: false,
+		UseProtoNames:   true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *KprobeBpfAttr) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{
+		DiscardUnknown: false,
+	}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
 func (msg *KprobeArgument) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseEnumNumbers:  false,

--- a/api/v1/tetragon/tetragon.proto
+++ b/api/v1/tetragon/tetragon.proto
@@ -160,6 +160,12 @@ message KprobeCred {
     repeated CapabilitiesType inheritable = 3;
 }
 
+message KprobeBpfAttr {
+    string  ProgType = 1;
+    uint32  InsnCnt = 2;
+    string  ProgName = 3;
+}
+
 message KprobeArgument {
     oneof arg {
 	string    string_arg = 1;
@@ -173,6 +179,7 @@ message KprobeArgument {
 	KprobeSock sock_arg = 9;
 	KprobeCred cred_arg = 10;
 	int64 long_arg = 11;
+	KprobeBpfAttr bpf_attr_arg = 12;
     }
 }
 

--- a/bpf/process/types/bpfattr.h
+++ b/bpf/process/types/bpfattr.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Cilium */
+
+#ifndef __BPFATTR_H__
+#define __BPFATTR_H__
+
+struct bpf_info_type {
+	__u32 prog_type;
+	__u32 insn_cnt;
+	char prog_name[16U];
+};
+
+#endif

--- a/crds/examples/bpf_check.yaml
+++ b/crds/examples/bpf_check.yaml
@@ -1,0 +1,11 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+ name: "bpf-check"
+spec:
+ kprobes:
+ - call: "bpf_check"
+   syscall: false
+   args:
+   - index: 1
+     type: "bpf_attr"

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -203,6 +203,27 @@ func (m MsgGenericKprobeArgCred) IsReturnArg() bool {
 	return m.Index == ReturnArgIndex
 }
 
+type MsgGenericKprobeBpfAttr struct {
+	ProgType uint32
+	InsnCnt  uint32
+	ProgName [16]byte
+}
+
+type MsgGenericKprobeArgBpfAttr struct {
+	Index    uint64
+	ProgType uint32
+	InsnCnt  uint32
+	ProgName string
+}
+
+func (m MsgGenericKprobeArgBpfAttr) GetIndex() uint64 {
+	return m.Index
+}
+
+func (m MsgGenericKprobeArgBpfAttr) IsReturnArg() bool {
+	return m.Index == ReturnArgIndex
+}
+
 type MsgGenericKprobeArg interface {
 	GetIndex() uint64
 	IsReturnArg() bool

--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -205,6 +205,11 @@ func typesCompatible(specTy string, kernelTy string) bool {
 		case "struct file *":
 			return true
 		}
+	case "bpf_attr":
+		switch kernelTy {
+		case "union bpf_attr *":
+			return true
+		}
 	}
 
 	return false

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -25,6 +25,7 @@ const (
 
 	// GenericConstBuffer is a buffer type whose size is static (and known).
 	GenericConstBuffer = 18
+	GenericBpfAttr     = 19
 
 	GenericNopType     = -1
 	GenericInvalidType = -2
@@ -68,6 +69,8 @@ func GenericTypeFromString(arg string) int {
 		return GenericConstBuffer
 	case "nop":
 		return GenericNopType
+	case "bpf_attr":
+		return GenericBpfAttr
 	default:
 		return GenericInvalidType
 	}

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/reader/bpfattr"
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	"github.com/cilium/tetragon/pkg/reader/network"
 	"github.com/cilium/tetragon/pkg/reader/node"
@@ -133,6 +134,13 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 				Flags: path.FilePathFlagsToStr(e.Flags),
 			}
 			a.Arg = &tetragon.KprobeArgument_PathArg{PathArg: pathArg}
+		case api.MsgGenericKprobeArgBpfAttr:
+			bpfAttrArg := &tetragon.KprobeBpfAttr{
+				ProgType: bpfattr.GetProgType(e.ProgType),
+				InsnCnt:  e.InsnCnt,
+				ProgName: e.ProgName,
+			}
+			a.Arg = &tetragon.KprobeArgument_BpfAttrArg{BpfAttrArg: bpfAttrArg}
 		default:
 			logger.GetLogger().WithField("arg", e).Warnf("unexpected type: %T", e)
 		}

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -80,6 +80,7 @@ spec:
                             - filename
                             - path
                             - nop
+                            - bpf_attr
                             type: string
                         required:
                         - index
@@ -133,6 +134,7 @@ spec:
                           - filename
                           - path
                           - nop
+                          - bpf_attr
                           type: string
                       required:
                       - index
@@ -467,6 +469,7 @@ spec:
                             - filename
                             - path
                             - nop
+                            - bpf_attr
                             type: string
                         required:
                         - index

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -71,7 +71,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;
+	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;
 	// Argument type.
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional

--- a/pkg/reader/bpfattr/bpfattr.go
+++ b/pkg/reader/bpfattr/bpfattr.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bpfattr
+
+import (
+	"fmt"
+)
+
+/*uapi/linux/bpf.h */
+var progTypeString = map[uint32]string{
+	0:  "BPF_PROG_TYPE_UNSPEC",
+	1:  "BPF_PROG_TYPE_SOCKET_FILTER",
+	2:  "BPF_PROG_TYPE_KPROBE",
+	3:  "BPF_PROG_TYPE_SCHED_CLS",
+	4:  "BPF_PROG_TYPE_SCHED_ACT",
+	5:  "BPF_PROG_TYPE_TRACEPOINT",
+	6:  "BPF_PROG_TYPE_XDP",
+	7:  "BPF_PROG_TYPE_PERF_EVENT",
+	8:  "BPF_PROG_TYPE_CGROUP_SKB",
+	9:  "BPF_PROG_TYPE_CGROUP_SOCK",
+	10: "BPF_PROG_TYPE_LWT_IN",
+	11: "BPF_PROG_TYPE_LWT_OUT",
+	12: "BPF_PROG_TYPE_LWT_XMIT",
+	13: "BPF_PROG_TYPE_SOCK_OPS",
+	14: "BPF_PROG_TYPE_SK_SKB",
+	15: "BPF_PROG_TYPE_CGROUP_DEVICE",
+	16: "BPF_PROG_TYPE_SK_MSG",
+	17: "BPF_PROG_TYPE_RAW_TRACEPOINT",
+	18: "BPF_PROG_TYPE_CGROUP_SOCK_ADDR",
+	19: "BPF_PROG_TYPE_LWT_SEG6LOCAL",
+	20: "BPF_PROG_TYPE_LIRC_MODE2",
+	21: "BPF_PROG_TYPE_SK_REUSEPORT",
+	22: "BPF_PROG_TYPE_FLOW_DISSECTOR",
+	23: "BPF_PROG_TYPE_CGROUP_SYSCTL",
+	24: "BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE",
+	25: "BPF_PROG_TYPE_CGROUP_SOCKOPT",
+	26: "BPF_PROG_TYPE_TRACING",
+	27: "BPF_PROG_TYPE_STRUCT_OPS",
+	28: "BPF_PROG_TYPE_EXT",
+	29: "BPF_PROG_TYPE_LSM",
+	30: "BPF_PROG_TYPE_SK_LOOKUP",
+	31: "BPF_PROG_TYPE_SYSCALL", /* a program that can execute syscalls */
+}
+
+func GetProgType(t uint32) string {
+	if t, ok := progTypeString[t]; ok {
+		return t
+	}
+	return fmt.Sprintf("%d", t)
+}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -690,6 +690,18 @@ func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
 			unix.Args = append(unix.Args, arg)
 		case gt.GenericNopType:
 			// do nothing
+		case gt.GenericBpfAttr:
+			var output api.MsgGenericKprobeBpfAttr
+			var arg api.MsgGenericKprobeArgBpfAttr
+
+			err := binary.Read(r, binary.LittleEndian, &output)
+			if err != nil {
+				logger.GetLogger().WithError(err).Warnf("bpf_attr type error")
+			}
+			arg.ProgType = output.ProgType
+			arg.InsnCnt = output.InsnCnt
+			arg.ProgName = string(output.ProgName[:15]) // don't include last null byte
+			unix.Args = append(unix.Args, arg)
 		default:
 			logger.GetLogger().WithError(err).WithField("event", a).Warnf("Unknown type event")
 		}

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -2690,6 +2690,74 @@ func (checker *KprobeCredChecker) FromKprobeCred(event *tetragon.KprobeCred) *Kp
 	return checker
 }
 
+// KprobeBpfAttrChecker implements a checker struct to check a KprobeBpfAttr field
+type KprobeBpfAttrChecker struct {
+	ProgType *stringmatcher.StringMatcher `json:"ProgType,omitempty"`
+	InsnCnt  *uint32                      `json:"InsnCnt,omitempty"`
+	ProgName *stringmatcher.StringMatcher `json:"ProgName,omitempty"`
+}
+
+// NewKprobeBpfAttrChecker creates a new KprobeBpfAttrChecker
+func NewKprobeBpfAttrChecker() *KprobeBpfAttrChecker {
+	return &KprobeBpfAttrChecker{}
+}
+
+// Check checks a KprobeBpfAttr field
+func (checker *KprobeBpfAttrChecker) Check(event *tetragon.KprobeBpfAttr) error {
+	if event == nil {
+		return fmt.Errorf("KprobeBpfAttrChecker: KprobeBpfAttr field is nil")
+	}
+
+	if checker.ProgType != nil {
+		if err := checker.ProgType.Match(event.ProgType); err != nil {
+			return fmt.Errorf("KprobeBpfAttrChecker: ProgType check failed: %w", err)
+		}
+	}
+	if checker.InsnCnt != nil {
+		if *checker.InsnCnt != event.InsnCnt {
+			return fmt.Errorf("KprobeBpfAttrChecker: InsnCnt has value %d which does not match expected value %d", event.InsnCnt, *checker.InsnCnt)
+		}
+	}
+	if checker.ProgName != nil {
+		if err := checker.ProgName.Match(event.ProgName); err != nil {
+			return fmt.Errorf("KprobeBpfAttrChecker: ProgName check failed: %w", err)
+		}
+	}
+	return nil
+}
+
+// WithProgType adds a ProgType check to the KprobeBpfAttrChecker
+func (checker *KprobeBpfAttrChecker) WithProgType(check *stringmatcher.StringMatcher) *KprobeBpfAttrChecker {
+	checker.ProgType = check
+	return checker
+}
+
+// WithInsnCnt adds a InsnCnt check to the KprobeBpfAttrChecker
+func (checker *KprobeBpfAttrChecker) WithInsnCnt(check uint32) *KprobeBpfAttrChecker {
+	checker.InsnCnt = &check
+	return checker
+}
+
+// WithProgName adds a ProgName check to the KprobeBpfAttrChecker
+func (checker *KprobeBpfAttrChecker) WithProgName(check *stringmatcher.StringMatcher) *KprobeBpfAttrChecker {
+	checker.ProgName = check
+	return checker
+}
+
+//FromKprobeBpfAttr populates the KprobeBpfAttrChecker using data from a KprobeBpfAttr field
+func (checker *KprobeBpfAttrChecker) FromKprobeBpfAttr(event *tetragon.KprobeBpfAttr) *KprobeBpfAttrChecker {
+	if event == nil {
+		return checker
+	}
+	checker.ProgType = stringmatcher.Full(event.ProgType)
+	{
+		val := event.InsnCnt
+		checker.InsnCnt = &val
+	}
+	checker.ProgName = stringmatcher.Full(event.ProgName)
+	return checker
+}
+
 // KprobeArgumentChecker implements a checker struct to check a KprobeArgument field
 type KprobeArgumentChecker struct {
 	StringArg         *stringmatcher.StringMatcher `json:"stringArg,omitempty"`
@@ -2703,6 +2771,7 @@ type KprobeArgumentChecker struct {
 	SockArg           *KprobeSockChecker           `json:"sockArg,omitempty"`
 	CredArg           *KprobeCredChecker           `json:"credArg,omitempty"`
 	LongArg           *int64                       `json:"longArg,omitempty"`
+	BpfAttrArg        *KprobeBpfAttrChecker        `json:"bpfAttrArg,omitempty"`
 }
 
 // NewKprobeArgumentChecker creates a new KprobeArgumentChecker
@@ -2826,6 +2895,16 @@ func (checker *KprobeArgumentChecker) Check(event *tetragon.KprobeArgument) erro
 			return fmt.Errorf("KprobeArgumentChecker: LongArg check failed: %T is not a LongArg", event)
 		}
 	}
+	if checker.BpfAttrArg != nil {
+		switch event := event.Arg.(type) {
+		case *tetragon.KprobeArgument_BpfAttrArg:
+			if err := checker.BpfAttrArg.Check(event.BpfAttrArg); err != nil {
+				return fmt.Errorf("KprobeArgumentChecker: BpfAttrArg check failed: %w", err)
+			}
+		default:
+			return fmt.Errorf("KprobeArgumentChecker: BpfAttrArg check failed: %T is not a BpfAttrArg", event)
+		}
+	}
 	return nil
 }
 
@@ -2892,6 +2971,12 @@ func (checker *KprobeArgumentChecker) WithCredArg(check *KprobeCredChecker) *Kpr
 // WithLongArg adds a LongArg check to the KprobeArgumentChecker
 func (checker *KprobeArgumentChecker) WithLongArg(check int64) *KprobeArgumentChecker {
 	checker.LongArg = &check
+	return checker
+}
+
+// WithBpfAttrArg adds a BpfAttrArg check to the KprobeArgumentChecker
+func (checker *KprobeArgumentChecker) WithBpfAttrArg(check *KprobeBpfAttrChecker) *KprobeArgumentChecker {
+	checker.BpfAttrArg = check
 	return checker
 }
 
@@ -2963,6 +3048,12 @@ func (checker *KprobeArgumentChecker) FromKprobeArgument(event *tetragon.KprobeA
 		{
 			val := event.LongArg
 			checker.LongArg = &val
+		}
+	}
+	switch event := event.Arg.(type) {
+	case *tetragon.KprobeArgument_BpfAttrArg:
+		if event.BpfAttrArg != nil {
+			checker.BpfAttrArg = NewKprobeBpfAttrChecker().FromKprobeBpfAttr(event.BpfAttrArg)
 		}
 	}
 	return checker

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
@@ -1440,6 +1440,69 @@ func (x *KprobeCred) GetInheritable() []CapabilitiesType {
 	return nil
 }
 
+type KprobeBpfAttr struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	ProgType string `protobuf:"bytes,1,opt,name=ProgType,proto3" json:"ProgType,omitempty"`
+	InsnCnt  uint32 `protobuf:"varint,2,opt,name=InsnCnt,proto3" json:"InsnCnt,omitempty"`
+	ProgName string `protobuf:"bytes,3,opt,name=ProgName,proto3" json:"ProgName,omitempty"`
+}
+
+func (x *KprobeBpfAttr) Reset() {
+	*x = KprobeBpfAttr{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tetragon_tetragon_proto_msgTypes[15]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *KprobeBpfAttr) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KprobeBpfAttr) ProtoMessage() {}
+
+func (x *KprobeBpfAttr) ProtoReflect() protoreflect.Message {
+	mi := &file_tetragon_tetragon_proto_msgTypes[15]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KprobeBpfAttr.ProtoReflect.Descriptor instead.
+func (*KprobeBpfAttr) Descriptor() ([]byte, []int) {
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *KprobeBpfAttr) GetProgType() string {
+	if x != nil {
+		return x.ProgType
+	}
+	return ""
+}
+
+func (x *KprobeBpfAttr) GetInsnCnt() uint32 {
+	if x != nil {
+		return x.InsnCnt
+	}
+	return 0
+}
+
+func (x *KprobeBpfAttr) GetProgName() string {
+	if x != nil {
+		return x.ProgName
+	}
+	return ""
+}
+
 type KprobeArgument struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1457,13 +1520,14 @@ type KprobeArgument struct {
 	//	*KprobeArgument_SockArg
 	//	*KprobeArgument_CredArg
 	//	*KprobeArgument_LongArg
+	//	*KprobeArgument_BpfAttrArg
 	Arg isKprobeArgument_Arg `protobuf_oneof:"arg"`
 }
 
 func (x *KprobeArgument) Reset() {
 	*x = KprobeArgument{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[15]
+		mi := &file_tetragon_tetragon_proto_msgTypes[16]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1476,7 +1540,7 @@ func (x *KprobeArgument) String() string {
 func (*KprobeArgument) ProtoMessage() {}
 
 func (x *KprobeArgument) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[15]
+	mi := &file_tetragon_tetragon_proto_msgTypes[16]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1489,7 +1553,7 @@ func (x *KprobeArgument) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeArgument.ProtoReflect.Descriptor instead.
 func (*KprobeArgument) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{15}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{16}
 }
 
 func (m *KprobeArgument) GetArg() isKprobeArgument_Arg {
@@ -1576,6 +1640,13 @@ func (x *KprobeArgument) GetLongArg() int64 {
 	return 0
 }
 
+func (x *KprobeArgument) GetBpfAttrArg() *KprobeBpfAttr {
+	if x, ok := x.GetArg().(*KprobeArgument_BpfAttrArg); ok {
+		return x.BpfAttrArg
+	}
+	return nil
+}
+
 type isKprobeArgument_Arg interface {
 	isKprobeArgument_Arg()
 }
@@ -1624,6 +1695,10 @@ type KprobeArgument_LongArg struct {
 	LongArg int64 `protobuf:"varint,11,opt,name=long_arg,json=longArg,proto3,oneof"`
 }
 
+type KprobeArgument_BpfAttrArg struct {
+	BpfAttrArg *KprobeBpfAttr `protobuf:"bytes,12,opt,name=bpf_attr_arg,json=bpfAttrArg,proto3,oneof"`
+}
+
 func (*KprobeArgument_StringArg) isKprobeArgument_Arg() {}
 
 func (*KprobeArgument_IntArg) isKprobeArgument_Arg() {}
@@ -1646,6 +1721,8 @@ func (*KprobeArgument_CredArg) isKprobeArgument_Arg() {}
 
 func (*KprobeArgument_LongArg) isKprobeArgument_Arg() {}
 
+func (*KprobeArgument_BpfAttrArg) isKprobeArgument_Arg() {}
+
 type ProcessKprobe struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1662,7 +1739,7 @@ type ProcessKprobe struct {
 func (x *ProcessKprobe) Reset() {
 	*x = ProcessKprobe{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[16]
+		mi := &file_tetragon_tetragon_proto_msgTypes[17]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1675,7 +1752,7 @@ func (x *ProcessKprobe) String() string {
 func (*ProcessKprobe) ProtoMessage() {}
 
 func (x *ProcessKprobe) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[16]
+	mi := &file_tetragon_tetragon_proto_msgTypes[17]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1688,7 +1765,7 @@ func (x *ProcessKprobe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessKprobe.ProtoReflect.Descriptor instead.
 func (*ProcessKprobe) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{16}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ProcessKprobe) GetProcess() *Process {
@@ -1749,7 +1826,7 @@ type ProcessTracepoint struct {
 func (x *ProcessTracepoint) Reset() {
 	*x = ProcessTracepoint{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[17]
+		mi := &file_tetragon_tetragon_proto_msgTypes[18]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1762,7 +1839,7 @@ func (x *ProcessTracepoint) String() string {
 func (*ProcessTracepoint) ProtoMessage() {}
 
 func (x *ProcessTracepoint) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[17]
+	mi := &file_tetragon_tetragon_proto_msgTypes[18]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1775,7 +1852,7 @@ func (x *ProcessTracepoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessTracepoint.ProtoReflect.Descriptor instead.
 func (*ProcessTracepoint) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{17}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ProcessTracepoint) GetProcess() *Process {
@@ -1827,7 +1904,7 @@ type Test struct {
 func (x *Test) Reset() {
 	*x = Test{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[18]
+		mi := &file_tetragon_tetragon_proto_msgTypes[19]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1840,7 +1917,7 @@ func (x *Test) String() string {
 func (*Test) ProtoMessage() {}
 
 func (x *Test) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[18]
+	mi := &file_tetragon_tetragon_proto_msgTypes[19]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1853,7 +1930,7 @@ func (x *Test) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Test.ProtoReflect.Descriptor instead.
 func (*Test) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{18}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *Test) GetArg0() uint64 {
@@ -1895,7 +1972,7 @@ type GetHealthStatusRequest struct {
 func (x *GetHealthStatusRequest) Reset() {
 	*x = GetHealthStatusRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[19]
+		mi := &file_tetragon_tetragon_proto_msgTypes[20]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1908,7 +1985,7 @@ func (x *GetHealthStatusRequest) String() string {
 func (*GetHealthStatusRequest) ProtoMessage() {}
 
 func (x *GetHealthStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[19]
+	mi := &file_tetragon_tetragon_proto_msgTypes[20]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1921,7 +1998,7 @@ func (x *GetHealthStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHealthStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetHealthStatusRequest) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{19}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetHealthStatusRequest) GetEventSet() []HealthStatusType {
@@ -1944,7 +2021,7 @@ type HealthStatus struct {
 func (x *HealthStatus) Reset() {
 	*x = HealthStatus{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[20]
+		mi := &file_tetragon_tetragon_proto_msgTypes[21]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1957,7 +2034,7 @@ func (x *HealthStatus) String() string {
 func (*HealthStatus) ProtoMessage() {}
 
 func (x *HealthStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[20]
+	mi := &file_tetragon_tetragon_proto_msgTypes[21]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1970,7 +2047,7 @@ func (x *HealthStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthStatus.ProtoReflect.Descriptor instead.
 func (*HealthStatus) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{20}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *HealthStatus) GetEvent() HealthStatusType {
@@ -2005,7 +2082,7 @@ type GetHealthStatusResponse struct {
 func (x *GetHealthStatusResponse) Reset() {
 	*x = GetHealthStatusResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[21]
+		mi := &file_tetragon_tetragon_proto_msgTypes[22]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2018,7 +2095,7 @@ func (x *GetHealthStatusResponse) String() string {
 func (*GetHealthStatusResponse) ProtoMessage() {}
 
 func (x *GetHealthStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[21]
+	mi := &file_tetragon_tetragon_proto_msgTypes[22]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2031,7 +2108,7 @@ func (x *GetHealthStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHealthStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetHealthStatusResponse) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{21}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetHealthStatusResponse) GetHealthStatus() []*HealthStatus {
@@ -2241,38 +2318,48 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x68, 0x65, 0x72, 0x69, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0e, 0x32,
 	0x1a, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x43, 0x61, 0x70, 0x61, 0x62,
 	0x69, 0x6c, 0x69, 0x74, 0x69, 0x65, 0x73, 0x54, 0x79, 0x70, 0x65, 0x52, 0x0b, 0x69, 0x6e, 0x68,
-	0x65, 0x72, 0x69, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x22, 0xfa, 0x03, 0x0a, 0x0e, 0x4b, 0x70, 0x72,
-	0x6f, 0x62, 0x65, 0x41, 0x72, 0x67, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x12, 0x1f, 0x0a, 0x0a, 0x73,
-	0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x48,
-	0x00, 0x52, 0x09, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x41, 0x72, 0x67, 0x12, 0x19, 0x0a, 0x07,
-	0x69, 0x6e, 0x74, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05, 0x48, 0x00, 0x52,
-	0x06, 0x69, 0x6e, 0x74, 0x41, 0x72, 0x67, 0x12, 0x2e, 0x0a, 0x07, 0x73, 0x6b, 0x62, 0x5f, 0x61,
-	0x72, 0x67, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61,
-	0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53, 0x6b, 0x62, 0x48, 0x00, 0x52,
-	0x06, 0x73, 0x6b, 0x62, 0x41, 0x72, 0x67, 0x12, 0x1b, 0x0a, 0x08, 0x73, 0x69, 0x7a, 0x65, 0x5f,
-	0x61, 0x72, 0x67, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x48, 0x00, 0x52, 0x07, 0x73, 0x69, 0x7a,
-	0x65, 0x41, 0x72, 0x67, 0x12, 0x1d, 0x0a, 0x09, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x61, 0x72,
-	0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0c, 0x48, 0x00, 0x52, 0x08, 0x62, 0x79, 0x74, 0x65, 0x73,
-	0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x70, 0x61, 0x74, 0x68, 0x5f, 0x61, 0x72, 0x67, 0x18,
-	0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e,
-	0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x50, 0x61, 0x74, 0x68, 0x48, 0x00, 0x52, 0x07, 0x70,
-	0x61, 0x74, 0x68, 0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x66, 0x69, 0x6c, 0x65, 0x5f, 0x61,
-	0x72, 0x67, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61,
-	0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x46, 0x69, 0x6c, 0x65, 0x48, 0x00,
-	0x52, 0x07, 0x66, 0x69, 0x6c, 0x65, 0x41, 0x72, 0x67, 0x12, 0x50, 0x0a, 0x13, 0x74, 0x72, 0x75,
-	0x6e, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f, 0x61, 0x72, 0x67,
-	0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f,
-	0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x54, 0x72, 0x75, 0x6e, 0x63, 0x61, 0x74, 0x65,
-	0x64, 0x42, 0x79, 0x74, 0x65, 0x73, 0x48, 0x00, 0x52, 0x11, 0x74, 0x72, 0x75, 0x6e, 0x63, 0x61,
-	0x74, 0x65, 0x64, 0x42, 0x79, 0x74, 0x65, 0x73, 0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x73,
-	0x6f, 0x63, 0x6b, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e,
-	0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53,
-	0x6f, 0x63, 0x6b, 0x48, 0x00, 0x52, 0x07, 0x73, 0x6f, 0x63, 0x6b, 0x41, 0x72, 0x67, 0x12, 0x31,
-	0x0a, 0x08, 0x63, 0x72, 0x65, 0x64, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x0b,
+	0x65, 0x72, 0x69, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x22, 0x61, 0x0a, 0x0d, 0x4b, 0x70, 0x72, 0x6f,
+	0x62, 0x65, 0x42, 0x70, 0x66, 0x41, 0x74, 0x74, 0x72, 0x12, 0x1a, 0x0a, 0x08, 0x50, 0x72, 0x6f,
+	0x67, 0x54, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x50, 0x72, 0x6f,
+	0x67, 0x54, 0x79, 0x70, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x49, 0x6e, 0x73, 0x6e, 0x43, 0x6e, 0x74,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x07, 0x49, 0x6e, 0x73, 0x6e, 0x43, 0x6e, 0x74, 0x12,
+	0x1a, 0x0a, 0x08, 0x50, 0x72, 0x6f, 0x67, 0x4e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x08, 0x50, 0x72, 0x6f, 0x67, 0x4e, 0x61, 0x6d, 0x65, 0x22, 0xb7, 0x04, 0x0a, 0x0e,
+	0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x41, 0x72, 0x67, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x12, 0x1f,
+	0x0a, 0x0a, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x09, 0x48, 0x00, 0x52, 0x09, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x41, 0x72, 0x67, 0x12,
+	0x19, 0x0a, 0x07, 0x69, 0x6e, 0x74, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x02, 0x20, 0x01, 0x28, 0x05,
+	0x48, 0x00, 0x52, 0x06, 0x69, 0x6e, 0x74, 0x41, 0x72, 0x67, 0x12, 0x2e, 0x0a, 0x07, 0x73, 0x6b,
+	0x62, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x74, 0x65,
+	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53, 0x6b, 0x62,
+	0x48, 0x00, 0x52, 0x06, 0x73, 0x6b, 0x62, 0x41, 0x72, 0x67, 0x12, 0x1b, 0x0a, 0x08, 0x73, 0x69,
+	0x7a, 0x65, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x48, 0x00, 0x52, 0x07,
+	0x73, 0x69, 0x7a, 0x65, 0x41, 0x72, 0x67, 0x12, 0x1d, 0x0a, 0x09, 0x62, 0x79, 0x74, 0x65, 0x73,
+	0x5f, 0x61, 0x72, 0x67, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0c, 0x48, 0x00, 0x52, 0x08, 0x62, 0x79,
+	0x74, 0x65, 0x73, 0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x70, 0x61, 0x74, 0x68, 0x5f, 0x61,
+	0x72, 0x67, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61,
+	0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x50, 0x61, 0x74, 0x68, 0x48, 0x00,
+	0x52, 0x07, 0x70, 0x61, 0x74, 0x68, 0x41, 0x72, 0x67, 0x12, 0x31, 0x0a, 0x08, 0x66, 0x69, 0x6c,
+	0x65, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65,
+	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x46, 0x69, 0x6c,
+	0x65, 0x48, 0x00, 0x52, 0x07, 0x66, 0x69, 0x6c, 0x65, 0x41, 0x72, 0x67, 0x12, 0x50, 0x0a, 0x13,
+	0x74, 0x72, 0x75, 0x6e, 0x63, 0x61, 0x74, 0x65, 0x64, 0x5f, 0x62, 0x79, 0x74, 0x65, 0x73, 0x5f,
+	0x61, 0x72, 0x67, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x74, 0x65, 0x74, 0x72,
+	0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x54, 0x72, 0x75, 0x6e, 0x63,
+	0x61, 0x74, 0x65, 0x64, 0x42, 0x79, 0x74, 0x65, 0x73, 0x48, 0x00, 0x52, 0x11, 0x74, 0x72, 0x75,
+	0x6e, 0x63, 0x61, 0x74, 0x65, 0x64, 0x42, 0x79, 0x74, 0x65, 0x73, 0x41, 0x72, 0x67, 0x12, 0x31,
+	0x0a, 0x08, 0x73, 0x6f, 0x63, 0x6b, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x09, 0x20, 0x01, 0x28, 0x0b,
 	0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f,
-	0x62, 0x65, 0x43, 0x72, 0x65, 0x64, 0x48, 0x00, 0x52, 0x07, 0x63, 0x72, 0x65, 0x64, 0x41, 0x72,
-	0x67, 0x12, 0x1b, 0x0a, 0x08, 0x6c, 0x6f, 0x6e, 0x67, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x0b, 0x20,
-	0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x07, 0x6c, 0x6f, 0x6e, 0x67, 0x41, 0x72, 0x67, 0x42, 0x05,
+	0x62, 0x65, 0x53, 0x6f, 0x63, 0x6b, 0x48, 0x00, 0x52, 0x07, 0x73, 0x6f, 0x63, 0x6b, 0x41, 0x72,
+	0x67, 0x12, 0x31, 0x0a, 0x08, 0x63, 0x72, 0x65, 0x64, 0x5f, 0x61, 0x72, 0x67, 0x18, 0x0a, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4b,
+	0x70, 0x72, 0x6f, 0x62, 0x65, 0x43, 0x72, 0x65, 0x64, 0x48, 0x00, 0x52, 0x07, 0x63, 0x72, 0x65,
+	0x64, 0x41, 0x72, 0x67, 0x12, 0x1b, 0x0a, 0x08, 0x6c, 0x6f, 0x6e, 0x67, 0x5f, 0x61, 0x72, 0x67,
+	0x18, 0x0b, 0x20, 0x01, 0x28, 0x03, 0x48, 0x00, 0x52, 0x07, 0x6c, 0x6f, 0x6e, 0x67, 0x41, 0x72,
+	0x67, 0x12, 0x3b, 0x0a, 0x0c, 0x62, 0x70, 0x66, 0x5f, 0x61, 0x74, 0x74, 0x72, 0x5f, 0x61, 0x72,
+	0x67, 0x18, 0x0c, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67,
+	0x6f, 0x6e, 0x2e, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x42, 0x70, 0x66, 0x41, 0x74, 0x74, 0x72,
+	0x48, 0x00, 0x52, 0x0a, 0x62, 0x70, 0x66, 0x41, 0x74, 0x74, 0x72, 0x41, 0x72, 0x67, 0x42, 0x05,
 	0x0a, 0x03, 0x61, 0x72, 0x67, 0x22, 0x9c, 0x02, 0x0a, 0x0d, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73,
 	0x73, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x12, 0x2b, 0x0a, 0x07, 0x70, 0x72, 0x6f, 0x63, 0x65,
 	0x73, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x11, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61,
@@ -2371,7 +2458,7 @@ func file_tetragon_tetragon_proto_rawDescGZIP() []byte {
 }
 
 var file_tetragon_tetragon_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_tetragon_tetragon_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_tetragon_tetragon_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_tetragon_tetragon_proto_goTypes = []interface{}{
 	(KprobeAction)(0),               // 0: tetragon.KprobeAction
 	(HealthStatusType)(0),           // 1: tetragon.HealthStatusType
@@ -2391,27 +2478,28 @@ var file_tetragon_tetragon_proto_goTypes = []interface{}{
 	(*KprobeFile)(nil),              // 15: tetragon.KprobeFile
 	(*KprobeTruncatedBytes)(nil),    // 16: tetragon.KprobeTruncatedBytes
 	(*KprobeCred)(nil),              // 17: tetragon.KprobeCred
-	(*KprobeArgument)(nil),          // 18: tetragon.KprobeArgument
-	(*ProcessKprobe)(nil),           // 19: tetragon.ProcessKprobe
-	(*ProcessTracepoint)(nil),       // 20: tetragon.ProcessTracepoint
-	(*Test)(nil),                    // 21: tetragon.Test
-	(*GetHealthStatusRequest)(nil),  // 22: tetragon.GetHealthStatusRequest
-	(*HealthStatus)(nil),            // 23: tetragon.HealthStatus
-	(*GetHealthStatusResponse)(nil), // 24: tetragon.GetHealthStatusResponse
-	nil,                             // 25: tetragon.Pod.PodLabelsEntry
-	(*timestamppb.Timestamp)(nil),   // 26: google.protobuf.Timestamp
-	(*wrapperspb.UInt32Value)(nil),  // 27: google.protobuf.UInt32Value
-	(CapabilitiesType)(0),           // 28: tetragon.CapabilitiesType
+	(*KprobeBpfAttr)(nil),           // 18: tetragon.KprobeBpfAttr
+	(*KprobeArgument)(nil),          // 19: tetragon.KprobeArgument
+	(*ProcessKprobe)(nil),           // 20: tetragon.ProcessKprobe
+	(*ProcessTracepoint)(nil),       // 21: tetragon.ProcessTracepoint
+	(*Test)(nil),                    // 22: tetragon.Test
+	(*GetHealthStatusRequest)(nil),  // 23: tetragon.GetHealthStatusRequest
+	(*HealthStatus)(nil),            // 24: tetragon.HealthStatus
+	(*GetHealthStatusResponse)(nil), // 25: tetragon.GetHealthStatusResponse
+	nil,                             // 26: tetragon.Pod.PodLabelsEntry
+	(*timestamppb.Timestamp)(nil),   // 27: google.protobuf.Timestamp
+	(*wrapperspb.UInt32Value)(nil),  // 28: google.protobuf.UInt32Value
+	(CapabilitiesType)(0),           // 29: tetragon.CapabilitiesType
 }
 var file_tetragon_tetragon_proto_depIdxs = []int32{
 	3,  // 0: tetragon.Container.image:type_name -> tetragon.Image
-	26, // 1: tetragon.Container.start_time:type_name -> google.protobuf.Timestamp
-	27, // 2: tetragon.Container.pid:type_name -> google.protobuf.UInt32Value
+	27, // 1: tetragon.Container.start_time:type_name -> google.protobuf.Timestamp
+	28, // 2: tetragon.Container.pid:type_name -> google.protobuf.UInt32Value
 	4,  // 3: tetragon.Pod.container:type_name -> tetragon.Container
-	25, // 4: tetragon.Pod.pod_labels:type_name -> tetragon.Pod.PodLabelsEntry
-	28, // 5: tetragon.Capabilities.permitted:type_name -> tetragon.CapabilitiesType
-	28, // 6: tetragon.Capabilities.effective:type_name -> tetragon.CapabilitiesType
-	28, // 7: tetragon.Capabilities.inheritable:type_name -> tetragon.CapabilitiesType
+	26, // 4: tetragon.Pod.pod_labels:type_name -> tetragon.Pod.PodLabelsEntry
+	29, // 5: tetragon.Capabilities.permitted:type_name -> tetragon.CapabilitiesType
+	29, // 6: tetragon.Capabilities.effective:type_name -> tetragon.CapabilitiesType
+	29, // 7: tetragon.Capabilities.inheritable:type_name -> tetragon.CapabilitiesType
 	7,  // 8: tetragon.Namespaces.uts:type_name -> tetragon.Namespace
 	7,  // 9: tetragon.Namespaces.ipc:type_name -> tetragon.Namespace
 	7,  // 10: tetragon.Namespaces.mnt:type_name -> tetragon.Namespace
@@ -2422,10 +2510,10 @@ var file_tetragon_tetragon_proto_depIdxs = []int32{
 	7,  // 15: tetragon.Namespaces.time_for_children:type_name -> tetragon.Namespace
 	7,  // 16: tetragon.Namespaces.cgroup:type_name -> tetragon.Namespace
 	7,  // 17: tetragon.Namespaces.user:type_name -> tetragon.Namespace
-	27, // 18: tetragon.Process.pid:type_name -> google.protobuf.UInt32Value
-	27, // 19: tetragon.Process.uid:type_name -> google.protobuf.UInt32Value
-	26, // 20: tetragon.Process.start_time:type_name -> google.protobuf.Timestamp
-	27, // 21: tetragon.Process.auid:type_name -> google.protobuf.UInt32Value
+	28, // 18: tetragon.Process.pid:type_name -> google.protobuf.UInt32Value
+	28, // 19: tetragon.Process.uid:type_name -> google.protobuf.UInt32Value
+	27, // 20: tetragon.Process.start_time:type_name -> google.protobuf.Timestamp
+	28, // 21: tetragon.Process.auid:type_name -> google.protobuf.UInt32Value
 	5,  // 22: tetragon.Process.pod:type_name -> tetragon.Pod
 	6,  // 23: tetragon.Process.cap:type_name -> tetragon.Capabilities
 	8,  // 24: tetragon.Process.ns:type_name -> tetragon.Namespaces
@@ -2434,32 +2522,33 @@ var file_tetragon_tetragon_proto_depIdxs = []int32{
 	9,  // 27: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
 	9,  // 28: tetragon.ProcessExit.process:type_name -> tetragon.Process
 	9,  // 29: tetragon.ProcessExit.parent:type_name -> tetragon.Process
-	28, // 30: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
-	28, // 31: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
-	28, // 32: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
+	29, // 30: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
+	29, // 31: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
+	29, // 32: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
 	13, // 33: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
 	14, // 34: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
 	15, // 35: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
 	16, // 36: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
 	12, // 37: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
 	17, // 38: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
-	9,  // 39: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
-	9,  // 40: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
-	18, // 41: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
-	18, // 42: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
-	0,  // 43: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
-	9,  // 44: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
-	9,  // 45: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
-	18, // 46: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
-	1,  // 47: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
-	1,  // 48: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
-	2,  // 49: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
-	23, // 50: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
-	51, // [51:51] is the sub-list for method output_type
-	51, // [51:51] is the sub-list for method input_type
-	51, // [51:51] is the sub-list for extension type_name
-	51, // [51:51] is the sub-list for extension extendee
-	0,  // [0:51] is the sub-list for field type_name
+	18, // 39: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
+	9,  // 40: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
+	9,  // 41: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
+	19, // 42: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
+	19, // 43: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
+	0,  // 44: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
+	9,  // 45: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
+	9,  // 46: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
+	19, // 47: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
+	1,  // 48: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
+	1,  // 49: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
+	2,  // 50: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
+	24, // 51: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
+	52, // [52:52] is the sub-list for method output_type
+	52, // [52:52] is the sub-list for method input_type
+	52, // [52:52] is the sub-list for extension type_name
+	52, // [52:52] is the sub-list for extension extendee
+	0,  // [0:52] is the sub-list for field type_name
 }
 
 func init() { file_tetragon_tetragon_proto_init() }
@@ -2650,7 +2739,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeArgument); i {
+			switch v := v.(*KprobeBpfAttr); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2662,7 +2751,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessKprobe); i {
+			switch v := v.(*KprobeArgument); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2674,7 +2763,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessTracepoint); i {
+			switch v := v.(*ProcessKprobe); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2686,7 +2775,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Test); i {
+			switch v := v.(*ProcessTracepoint); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2698,7 +2787,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetHealthStatusRequest); i {
+			switch v := v.(*Test); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2710,7 +2799,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*HealthStatus); i {
+			switch v := v.(*GetHealthStatusRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2722,6 +2811,18 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*HealthStatus); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tetragon_tetragon_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*GetHealthStatusResponse); i {
 			case 0:
 				return &v.state
@@ -2734,7 +2835,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 	}
-	file_tetragon_tetragon_proto_msgTypes[15].OneofWrappers = []interface{}{
+	file_tetragon_tetragon_proto_msgTypes[16].OneofWrappers = []interface{}{
 		(*KprobeArgument_StringArg)(nil),
 		(*KprobeArgument_IntArg)(nil),
 		(*KprobeArgument_SkbArg)(nil),
@@ -2746,6 +2847,7 @@ func file_tetragon_tetragon_proto_init() {
 		(*KprobeArgument_SockArg)(nil),
 		(*KprobeArgument_CredArg)(nil),
 		(*KprobeArgument_LongArg)(nil),
+		(*KprobeArgument_BpfAttrArg)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -2753,7 +2855,7 @@ func file_tetragon_tetragon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_tetragon_tetragon_proto_rawDesc,
 			NumEnums:      3,
-			NumMessages:   23,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.json.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.json.go
@@ -248,6 +248,22 @@ func (msg *KprobeCred) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
+func (msg *KprobeBpfAttr) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseEnumNumbers:  false,
+		EmitUnpopulated: false,
+		UseProtoNames:   true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *KprobeBpfAttr) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{
+		DiscardUnknown: false,
+	}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
 func (msg *KprobeArgument) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseEnumNumbers:  false,

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
@@ -160,6 +160,12 @@ message KprobeCred {
     repeated CapabilitiesType inheritable = 3;
 }
 
+message KprobeBpfAttr {
+    string  ProgType = 1;
+    uint32  InsnCnt = 2;
+    string  ProgName = 3;
+}
+
 message KprobeArgument {
     oneof arg {
 	string    string_arg = 1;
@@ -173,6 +179,7 @@ message KprobeArgument {
 	KprobeSock sock_arg = 9;
 	KprobeCred cred_arg = 10;
 	int64 long_arg = 11;
+	KprobeBpfAttr bpf_attr_arg = 12;
     }
 }
 

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -80,6 +80,7 @@ spec:
                             - filename
                             - path
                             - nop
+                            - bpf_attr
                             type: string
                         required:
                         - index
@@ -133,6 +134,7 @@ spec:
                           - filename
                           - path
                           - nop
+                          - bpf_attr
                           type: string
                       required:
                       - index
@@ -467,6 +469,7 @@ spec:
                             - filename
                             - path
                             - nop
+                            - bpf_attr
                             type: string
                         required:
                         - index

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -71,7 +71,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;
+	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;
 	// Argument type.
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
This patch allows us to collect name, program type, and instruction
count of eBPF programs when they are verified.

Signed-off-by: Sarah Fujimori <sarah.fujimori@isovalent.com>