### PR TITLE
hubble-fgs: event cache doesn't use endpoint for anything drop the query

### DIFF
--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -74,12 +74,6 @@ func handleExecEvent(event *cacheObj, nspid uint32) error {
 func handleEvent(event *cacheObj) error {
 	p := event.event.GetProcess()
 
-	endpoint := process.GetProcessEndpoint(p)
-	if p.Docker != "" && (endpoint == nil || p.Pod == nil) {
-		errormetrics.ErrorTotalInc(errormetrics.EventCacheEndpointRetryFailed)
-		return fmt.Errorf("failed to get process endpoint ifno")
-	}
-
 	// If the process wasn't found before the Add(), likely because
 	// the execve event was processed after this event, lets look it up
 	// now because it should be available. Otherwise we have a valid

--- a/tests/e2e/tests/skeleton/skeleton_test.go
+++ b/tests/e2e/tests/skeleton/skeleton_test.go
@@ -89,7 +89,7 @@ func TestSkeletonBasic(t *testing.T) {
 	// Grab the minimum kernel version in all cluster nodes and define an RPC checker with it
 	kversion := helpers.GetMinKernelVersion(t, testenv)
 	// Create an curl event checker with a limit or 10 events or 30 seconds, whichever comes first
-	curlChecker := curlEventChecker(kversion).WithEventLimit(10).WithTimeLimit(30 * time.Second)
+	curlChecker := curlEventChecker(kversion).WithEventLimit(100).WithTimeLimit(30 * time.Second)
 
 	// Define test features here. These can be used to perform actions like:
 	// - Spawning an event checker and running checks


### PR DESCRIPTION
Collecting enpoint does not do anything here so lets drop it for now.
Presumably, we lost the code that used this in one of our refactors so
we can add it back if we have a need for it later.

We also need to update the skeleton e2e test since we are now receiving more events than
initially expected which would cause the test to cross the event limit. To fix this, bump
the limit up to a conservative 100 events.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>
Signed-off-by: William Findlay <will@isovalent.com>