### PR TITLE
metrics/eventmetrics: include exec id in event count

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -56,6 +56,8 @@ const (
 	keyExportDenylist  = "export-denylist"
 
 	keyNetnsDir = "netns-dir"
+
+	keyExecIdInMetrics = "exec-id-in-metrics"
 )
 
 var (
@@ -96,6 +98,8 @@ func readAndSetFlags() {
 	option.Config.EnableProcessNs = viper.GetBool(keyEnableProcessNs)
 	option.Config.EnableCilium = viper.GetBool(keyEnableCiliumAPI)
 	option.Config.EnableK8s = viper.GetBool(keyEnableK8sAPI)
+
+	option.Config.ExecIdInMetrics = viper.GetBool(keyExecIdInMetrics)
 
 	logLevel := viper.GetString(keyLogLevel)
 	logFormat := viper.GetString(keyLogFormat)

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -378,6 +378,8 @@ func execute() error {
 	flags.String(keyHubbleLib, "/var/lib/tetragon/", "Location of hubble libs (btf and bpf files)")
 	flags.String(keyBTF, "", "Location of btf")
 
+	flags.Bool(keyExecIdInMetrics, false, "Include process exec ID in some metrics. When set to false this label will be set to empty instead")
+
 	flags.String(keyProcFS, "/proc/", "Location of procfs to consume existing PIDs")
 	flags.String(keyKernelVersion, "", "Kernel version")
 	flags.Int(keyVerbosity, 0, "set verbosity level")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -32,6 +32,8 @@ type config struct {
 	BpfDir    string
 
 	LogOpts map[string]string
+
+	ExecIdInMetrics bool
 }
 
 var (
@@ -46,6 +48,9 @@ var (
 
 		// LogOpts contains logger parameters
 		LogOpts: make(map[string]string),
+
+		// Include exec id in metrics by default and allow users to opt out
+		ExecIdInMetrics: false,
 	}
 )
 


### PR DESCRIPTION
Add an extra label to event count metrics so that we can include exec id of a process.
There is a trade-off here in that this change will introduce extra noise into the metrics
(i.e. we would no longer aggregate multiple runs of a single binary under the same
counter). This can be useful for debugging as well as triaging any suspicious events in
production. Since this can be quite noisy, hide it behind a configuration flag that is
disabled by default.

Signed-off-by: William Findlay <will@isovalent.com>