### PR TITLE
Make relax_verifier() into one instruction

### DIFF
--- a/bpf/lib/bpf_helpers.h
+++ b/bpf/lib/bpf_helpers.h
@@ -99,7 +99,13 @@ static long (*bpf_probe_read)(void *dst, __u32 size,
  */
 static inline __attribute__((always_inline)) void relax_verifier(void)
 {
-	volatile int __attribute__((__unused__)) id = get_smp_processor_id();
+	/* Calling get_smp_processor_id() in asm saves an instruction as we
+	 * don't have to store the result to ensure the call takes place.
+	 * However, we have to specifiy the call target by number and not
+	 * name, hence 'call 8'. This is unlikely to change, though, so this
+	 * isn't a big issue.
+	 */
+	asm volatile("call 8;\n" ::: "r0", "r1", "r2", "r3", "r4", "r5");
 }
 
 static inline void compiler_barrier(void)


### PR DESCRIPTION
relax_verifier() is used to cause the verifier to add a prune point that
can be helpful in reducing the overall complexity. It does this by
calling get_smp_processor_id(); in order to prevent the call from being
optimised out, its result is stored in a register and marked with the
unused attribute. This results in two assembler instructions, one for
the call and one to store the result. It also potentially causes a
register spill.

This commit changes relax_verifier() into a single assembler instruction
to call the helper. This reduces the overall instruction count and
reduces complexity.

Signed-off-by: Kevin Sheldrake <kevin.sheldrake@isovalent.com>