### PR TITLE
Add a unit test for missing exec event in the eventcache

### DIFF
--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -19,14 +19,11 @@ import (
 	"github.com/cilium/tetragon/pkg/server"
 )
 
-// garbage collection states
 const (
-	threeStrikes = 3
-)
-
-// garbage collection run interval
-const (
-	eventRetryTimer = time.Second * 10
+	// garbage collection retries
+	cacheStrikes = 15
+	// garbage collection run interval
+	eventRetryTimer = time.Second * 2
 )
 
 var (
@@ -108,7 +105,7 @@ func (ec *Cache) handleEvents() {
 
 		if err != nil {
 			event.color++
-			if event.color < threeStrikes {
+			if event.color < cacheStrikes {
 				tmp = append(tmp, event)
 				continue
 			}

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -21,9 +21,9 @@ import (
 
 const (
 	// garbage collection retries
-	cacheStrikes = 15
+	CacheStrikes = 15
 	// garbage collection run interval
-	eventRetryTimer = time.Second * 2
+	EventRetryTimer = time.Second * 2
 )
 
 var (
@@ -105,7 +105,7 @@ func (ec *Cache) handleEvents() {
 
 		if err != nil {
 			event.color++
-			if event.color < cacheStrikes {
+			if event.color < CacheStrikes {
 				tmp = append(tmp, event)
 				continue
 			}
@@ -129,7 +129,7 @@ func (ec *Cache) loop() {
 	for {
 		select {
 		case <-ticker.C:
-			/* Every 'eventRetryTimer' walk the slice of events pending pod info. If
+			/* Every 'EventRetryTimer' walk the slice of events pending pod info. If
 			 * an event hasn't completed its podInfo after two iterations send the
 			 * event anyways.
 			 */
@@ -198,7 +198,7 @@ func NewWithTimer(s *server.Server, dur time.Duration) *Cache {
 }
 
 func New(s *server.Server) *Cache {
-	return NewWithTimer(s, eventRetryTimer)
+	return NewWithTimer(s, EventRetryTimer)
 }
 
 func Get() *Cache {

--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -24,6 +24,10 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
+const (
+	cacheTimerMs = 100
+)
+
 var (
 	AllEvents []*tetragon.GetEventsResponse
 )
@@ -161,7 +165,7 @@ func initEnv(t *testing.T, cancelWg *sync.WaitGroup) context.CancelFunc {
 	lServer := server.NewServer(ctx, cancelWg, dn, do)
 
 	// Exec cache is always needed to ensure events have an associated Process{}
-	eventcache.NewWithTimer(lServer, time.Millisecond*200)
+	eventcache.NewWithTimer(lServer, time.Millisecond*cacheTimerMs)
 
 	return cancel
 }
@@ -188,7 +192,7 @@ func TestGrpcExecOutOfOrder(t *testing.T) {
 		AllEvents = append(AllEvents, e2)
 	}
 
-	time.Sleep(time.Millisecond * 1000) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * cacheTimerMs)) // wait for cache to do it's work
 
 	assert.Equal(t, len(AllEvents), 2)
 
@@ -230,7 +234,7 @@ func TestGrpcExecInOrder(t *testing.T) {
 		AllEvents = append(AllEvents, e1)
 	}
 
-	time.Sleep(time.Millisecond * 1000) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * cacheTimerMs)) // wait for cache to do it's work
 
 	assert.Equal(t, len(AllEvents), 2)
 
@@ -269,7 +273,7 @@ func TestGrpcMissingExec(t *testing.T) {
 		AllEvents = append(AllEvents, e1)
 	}
 
-	time.Sleep(time.Millisecond * 1000) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * cacheTimerMs)) // wait for cache to do it's work
 
 	assert.Equal(t, len(AllEvents), 1)
 	ev := AllEvents[0]

--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -222,7 +222,7 @@ func TestGrpcExecInOrder(t *testing.T) {
 		cancelWg.Wait()
 	}()
 
-	execMsg, exitMsg := createEvents(46983, 21034975089403)
+	execMsg, exitMsg := createEvents(46984, 21034975089403)
 
 	e2 := execMsg.HandleMessage()
 	if e2 != nil {

--- a/pkg/jsonchecker/jsonchecker.go
+++ b/pkg/jsonchecker/jsonchecker.go
@@ -15,14 +15,15 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/api/v1/tetragon/codegen/helpers"
+	"github.com/cilium/tetragon/pkg/eventcache"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/sirupsen/logrus"
 )
 
 var (
-	Retries    = 20
-	RetryDelay = 2 * time.Second
+	Retries    = 13
+	RetryDelay = eventcache.EventRetryTimer + (1 * time.Second)
 )
 
 // DebugError is an error that will create a debug output message

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -52,7 +52,8 @@ func (pc *Cache) cacheGarbageCollector() {
 			select {
 			case <-pc.stopChan:
 				ticker.Stop()
-				pc.Purge()
+				pc.cache.Purge()
+				pc.pidMap.Purge()
 			case <-ticker.C:
 				newQueue = newQueue[:0]
 				for _, p := range deleteQueue {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -62,7 +62,7 @@ func InitCache(ctx context.Context, w watcher.K8sResourceWatcher, enableCilium b
 	var err error
 
 	if procCache != nil {
-		return nil
+		FreeCache()
 	}
 
 	nodeName = node.GetNodeNameForExport()


### PR DESCRIPTION
This unit-test emulates the case where we get an exit event but we miss the exec event. In that case, we should wait for the cache iterations to end and then produce an exit event with partial process info. In that case we only have the process start time and the process pid.

This PR also fixes https://github.com/cilium/tetragon/issues/285 and https://github.com/cilium/tetragon/issues/247. OOO events was related to these issues and thus I don't use a separate PR for them. To test this I have run 8 successful consecutive runs in the CI while before a kprobe flake appears every ~3 runs. 

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>