### PR TITLE
e2e-framework: fix panic and bump event limit on demo app test

### DIFF
--- a/tests/e2e/checker/multiplexer.go
+++ b/tests/e2e/checker/multiplexer.go
@@ -131,7 +131,6 @@ func (cm *ClientMultiplexer) GetEvents(ctx context.Context, allowList, denyList 
 				select {
 				case <-ctx.Done():
 					klog.V(2).Info("ClientMultiplexer: Context cancelled, stopping GetEvents goroutine")
-					close(c)
 					return
 				default:
 				}

--- a/tests/e2e/tests/labels/labels_test.go
+++ b/tests/e2e/tests/labels/labels_test.go
@@ -88,7 +88,7 @@ func TestMain(m *testing.M) {
 func TestLabelsDemoApp(t *testing.T) {
 	// Grab the minimum kernel version in all cluster nodes and define an RPC checker with it
 	kversion := helpers.GetMinKernelVersion(t, testenv)
-	labelsChecker := labelsEventChecker(kversion).WithEventLimit(2500).WithTimeLimit(2 * time.Minute)
+	labelsChecker := labelsEventChecker(kversion).WithEventLimit(5000).WithTimeLimit(5 * time.Minute)
 
 	// This starts labelsChecker and uses it to run event checks.
 	runEventChecker := features.New("Run Event Checks").


### PR DESCRIPTION
Some bug fixes for e2e framework on GKE clusters. See individual commits. 