### PR TITLE
Fix bugtool upload

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -73,5 +73,5 @@ jobs:
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
       with:
         name: tetragon-bugtool
-        path: /tmp/tetragon-bugtool-*
+        path: /tmp/tetragon-bugtool*
         retention-days: 5


### PR DESCRIPTION
From a failed test:
`level=info msg="Dumped bugtool info" file=/tmp/tetragon-bugtool.tar.gz test=TestKprobeObjectReadReturn`

So the the bugtool tarball is /tmp/tetragon-bugtool.tar.gz. The current action
uploads /tmp/tetragon-bugtool-* which does not match anything.

This commit fixes the action to upload the bugtool report.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>