### PR TITLE
eventcachemetrics: fix eventcache and add error metrics

### DIFF
--- a/pkg/metrics/eventcachemetrics/eventcachemetrics.go
+++ b/pkg/metrics/eventcachemetrics/eventcachemetrics.go
@@ -10,9 +10,14 @@ import (
 )
 
 var (
-	ProcessInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "process_info_errors",
+	processInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "event_cache_process_info_errors",
 		Help:        "The total of times we failed to fetch cached process info for a given event type.",
+		ConstLabels: nil,
+	}, []string{"event_type"})
+	podInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "event_cache_pod_info_errors",
+		Help:        "The total of times we failed to fetch cached pod info for a given event type.",
 		ConstLabels: nil,
 	}, []string{"event_type"})
 	EventCacheCount = promauto.NewCounter(prometheus.CounterOpts{
@@ -23,11 +28,11 @@ var (
 )
 
 // Get a new handle on an processInfoErrors metric for an eventType
-func GetProcessInfoError(eventType string) prometheus.Counter {
-	return ProcessInfoErrors.WithLabelValues(eventType)
+func ProcessInfoError(eventType string) prometheus.Counter {
+	return processInfoErrors.WithLabelValues(eventType)
 }
 
-// Increment an errorsTotal for an eventType
-func ProcessInfoErrorInc(eventType string) {
-	GetProcessInfoError(eventType).Inc()
+// Get a new handle on an processInfoErrors metric for an eventType
+func PodInfoError(eventType string) prometheus.Counter {
+	return podInfoErrors.WithLabelValues(eventType)
 }

--- a/pkg/reader/notify/notify.go
+++ b/pkg/reader/notify/notify.go
@@ -1,6 +1,11 @@
 package notify
 
-import "github.com/cilium/tetragon/api/v1/tetragon"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+)
 
 type Message interface {
 	HandleMessage() *tetragon.GetEventsResponse
@@ -10,4 +15,13 @@ type Event interface {
 	GetProcess() *tetragon.Process
 	SetProcess(*tetragon.Process)
 	Encapsulate() tetragon.IsGetEventsResponse_Event
+}
+
+func EventTypeString(event Event) string {
+	// Get the concrete type of the event
+	ty := fmt.Sprintf("%T", event)
+	// Take only what comes after the last "."
+	tys := strings.Split(ty, ".")
+	ty = tys[len(tys)-1]
+	return ty
 }


### PR DESCRIPTION
Minor fixes to event cache handlers so that they deal with missing pod info separately
from missing process info.

Also update the event cache to increment pod and process info errors by event type when we
hit our cache strikes limit.

Signed-off-by: William Findlay <will@isovalent.com>