### PR TITLE
Cleanup path resolution code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cscope.po.out
 cscope.out
 cscope.in.out
 strange.txt
+.vscode

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -338,19 +338,11 @@ copy_path(char *args, const struct path *arg)
 	int *s = (int *)args;
 	int size = 0, flags = 0;
 	char *buffer;
-	int zero = 0;
 	void *curr = &args[4];
 
-	buffer = map_lookup_elem(&buffer_heap_map, &zero);
+	buffer = d_path_local(arg, &size, &flags);
 	if (!buffer)
 		return 0;
-
-	size = 256;
-	buffer = __d_path_local(arg, buffer, &size, &flags);
-	if (!buffer)
-		return 0;
-	if (size > 0)
-		size = 256 - size;
 
 	asm volatile("%[size] &= 0xff;\n" ::[size] "+r"(size) :);
 	probe_read(curr, size, buffer);


### PR DESCRIPTION
This PR does not change anything in the path resolution logic.

Tested with running `sudo ./contrib/verify/verify.sh ./bpf/objs/` in 4.19, 5.4, 5.10, 5.13, and 5.15. 

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>