### PR TITLE
eventcache: remove event.internal nil check for exec events

### DIFF
--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -68,10 +68,10 @@ func handleExecEvent(event *cacheObj, nspid uint32) error {
 		}
 	}
 
-	if event.internal == nil {
-		errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
-		return ErrFailedToGetProcessInfo
-	}
+	// We can assume that event.internal != nil here since it's being set by AddExecEvent
+	// earlier in the code path. If this invariant ever changes in the future, we probably
+	// want to panic anyway to help us catch the bug faster. So no need to do a nil check
+	// here.
 
 	event.internal.AddPodInfo(podInfo)
 	event.event.SetProcess(event.internal.GetProcessCopy())


### PR DESCRIPTION
It was rightly pointed out that event.internal not being nil is an invariant here. If this
ever changes accidentally we would probably want to know and in any case the panic would
happen much earlier in the code path. So let's remove the nil check here.

Signed-off-by: William Findlay <will@isovalent.com>