### PR TITLE
Add unit-test for parent and child process refcounts

### DIFF
--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -39,6 +39,8 @@ func GetProcessExec(proc *process.ProcessInternal) *tetragon.ProcessExec {
 		errormetrics.ErrorTotalInc(errormetrics.ExecMissingParent)
 		processexecmetrics.MissingParentInc(parentId)
 		logger.GetLogger().WithField("processId", processId).WithField("parentId", parentId).Debug("Process missing parent")
+	} else {
+		parent.RefInc()
 	}
 
 	// Set the cap field only if --enable-process-cred flag is set.

--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -139,7 +139,7 @@ func createEvents(Pid uint32, Ktime uint64, ParentPid uint32, ParentKtime uint64
 		},
 		Info: tetragonAPI.MsgExitInfo{
 			Code: 0,
-			Pad1: 0, // Cached
+			Pad1: 0,
 		},
 	},
 	}
@@ -248,7 +248,7 @@ func TestGrpcExecOutOfOrder(t *testing.T) {
 		ev1 = AllEvents[1]
 	}
 
-	// fails but we don't expect to have the same Refcnt
+	// success
 	assert.Equal(t, ev1.GetProcessExec().Process, ev2.GetProcessExit().Process)
 
 	// success

--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -281,8 +281,6 @@ func TestGrpcExecInOrder(t *testing.T) {
 		AllEvents = append(AllEvents, e)
 	}
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * cacheTimerMs)) // wait for cache to do it's work
-
 	assert.Equal(t, len(AllEvents), 2)
 
 	var ev1, ev2 *tetragon.GetEventsResponse
@@ -395,8 +393,6 @@ func TestGrpcExecCloneInOrder(t *testing.T) {
 	if e := exitMsg.HandleMessage(); e != nil {
 		AllEvents = append(AllEvents, e)
 	}
-
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * cacheTimerMs)) // wait for cache to do it's work
 
 	checkCloneEvents(t, AllEvents, currentPid, clonePid)
 }

--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -225,14 +225,12 @@ func TestGrpcExecOutOfOrder(t *testing.T) {
 
 	execMsg, exitMsg := createEvents(46983, 21034975089403, 1459, 75200000000)
 
-	e1 := exitMsg.HandleMessage()
-	if e1 != nil {
-		AllEvents = append(AllEvents, e1)
+	if e := exitMsg.HandleMessage(); e != nil {
+		AllEvents = append(AllEvents, e)
 	}
 
-	e2 := execMsg.HandleMessage()
-	if e2 != nil {
-		AllEvents = append(AllEvents, e2)
+	if e := execMsg.HandleMessage(); e != nil {
+		AllEvents = append(AllEvents, e)
 	}
 
 	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * cacheTimerMs)) // wait for cache to do it's work
@@ -267,14 +265,12 @@ func TestGrpcExecInOrder(t *testing.T) {
 
 	execMsg, exitMsg := createEvents(46984, 21034975089403, 1459, 75200000000)
 
-	e2 := execMsg.HandleMessage()
-	if e2 != nil {
-		AllEvents = append(AllEvents, e2)
+	if e := execMsg.HandleMessage(); e != nil {
+		AllEvents = append(AllEvents, e)
 	}
 
-	e1 := exitMsg.HandleMessage()
-	if e1 != nil {
-		AllEvents = append(AllEvents, e1)
+	if e := exitMsg.HandleMessage(); e != nil {
+		AllEvents = append(AllEvents, e)
 	}
 
 	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * cacheTimerMs)) // wait for cache to do it's work
@@ -311,9 +307,8 @@ func TestGrpcMissingExec(t *testing.T) {
 	processPid := uint32(46985)
 	_, exitMsg := createEvents(processPid, 21034975089403, 1459, 75200000000)
 
-	e1 := exitMsg.HandleMessage()
-	if e1 != nil {
-		AllEvents = append(AllEvents, e1)
+	if e := exitMsg.HandleMessage(); e != nil {
+		AllEvents = append(AllEvents, e)
 	}
 
 	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * cacheTimerMs)) // wait for cache to do it's work

--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -89,7 +89,7 @@ func (o DummyObserver) RemoveSensor(ctx context.Context, sensorName string) erro
 	return nil
 }
 
-func createEvents(Pid uint32, Ktime uint64) (*MsgExecveEventUnix, *MsgExitEventUnix) {
+func createEvents(Pid uint32, Ktime uint64, ParentPid uint32, ParentKtime uint64) (*MsgExecveEventUnix, *MsgExitEventUnix) {
 	execMsg := &MsgExecveEventUnix{MsgExecveEventUnix: tetragonAPI.MsgExecveEventUnix{
 		Common: tetragonAPI.MsgCommon{
 			Op:     5,
@@ -105,9 +105,9 @@ func createEvents(Pid uint32, Ktime uint64) (*MsgExecveEventUnix, *MsgExitEventU
 			Docker: "",
 		},
 		Parent: tetragonAPI.MsgExecveKey{
-			Pid:   1459,
+			Pid:   ParentPid,
 			Pad:   0,
-			Ktime: 75200000000,
+			Ktime: ParentKtime,
 		},
 		ParentFlags: 0,
 		Process: tetragonAPI.MsgProcess{
@@ -223,7 +223,7 @@ func TestGrpcExecOutOfOrder(t *testing.T) {
 		cancelWg.Wait()
 	}()
 
-	execMsg, exitMsg := createEvents(46983, 21034975089403)
+	execMsg, exitMsg := createEvents(46983, 21034975089403, 1459, 75200000000)
 
 	e1 := exitMsg.HandleMessage()
 	if e1 != nil {
@@ -265,7 +265,7 @@ func TestGrpcExecInOrder(t *testing.T) {
 		cancelWg.Wait()
 	}()
 
-	execMsg, exitMsg := createEvents(46984, 21034975089403)
+	execMsg, exitMsg := createEvents(46984, 21034975089403, 1459, 75200000000)
 
 	e2 := execMsg.HandleMessage()
 	if e2 != nil {
@@ -309,7 +309,7 @@ func TestGrpcMissingExec(t *testing.T) {
 	}()
 
 	processPid := uint32(46985)
-	_, exitMsg := createEvents(processPid, 21034975089403)
+	_, exitMsg := createEvents(processPid, 21034975089403, 1459, 75200000000)
 
 	e1 := exitMsg.HandleMessage()
 	if e1 != nil {
@@ -370,7 +370,7 @@ func TestGrpcExecCloneInOrder(t *testing.T) {
 		cancelWg.Wait()
 	}()
 
-	execMsg, exitMsg := createEvents(46986, 21034975089403)
+	execMsg, exitMsg := createEvents(46986, 21034975089403, 1459, 75200000000)
 	cloneMsg, exitCloneMsg := createCloneEvents(46987, 21034995089403, 46986, 21034975089403)
 
 	if e := execMsg.HandleMessage(); e != nil {
@@ -402,7 +402,7 @@ func TestGrpcExecCloneOutOfOrder(t *testing.T) {
 		cancelWg.Wait()
 	}()
 
-	execMsg, exitMsg := createEvents(46986, 21034975089403)
+	execMsg, exitMsg := createEvents(46986, 21034975089403, 1459, 75200000000)
 	cloneMsg, exitCloneMsg := createCloneEvents(46987, 21034995089403, 46986, 21034975089403)
 
 	if e := execMsg.HandleMessage(); e != nil {

--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -320,7 +320,7 @@ func TestGrpcMissingExec(t *testing.T) {
 
 	assert.Equal(t, len(AllEvents), 1)
 	ev := AllEvents[0]
-	assert.NotEqual(t, ev.GetProcessExit(), nil)
+	assert.NotNil(t, ev.GetProcessExit())
 
 	// this events misses process info
 	assert.Equal(t, ev.GetProcessExit().Process.ExecId, "")


### PR DESCRIPTION
This PR also include several cleanup, fixes, and optimizations in `pkg/grpc/exec` unit tests. 

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>