### PR TITLE
tetragon: Fix cache usage of logger

### DIFF
--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -17,7 +17,6 @@ import (
 )
 
 type Cache struct {
-	log        logrus.FieldLogger
 	cache      *lru.Cache
 	deleteChan chan *ProcessInternal
 	stopChan   chan bool
@@ -213,7 +212,7 @@ func (pc *Cache) getFromPidMap(pid uint32) string {
 	}
 	execID, ok := entry.(string)
 	if !ok {
-		pc.log.WithFields(logrus.Fields{"pid": pid, "execID": execID}).Warn("Invalid entry in pidMap")
+		logger.GetLogger().WithFields(logrus.Fields{"pid": pid, "execID": execID}).Warn("Invalid entry in pidMap")
 		errormetrics.ErrorTotalInc(errormetrics.PidMapInvalidEntry)
 		return ""
 	}
@@ -223,7 +222,7 @@ func (pc *Cache) getFromPidMap(pid uint32) string {
 func (pc *Cache) AddToPidMap(pid uint32, execID string) bool {
 	evicted := pc.pidMap.Add(pid, execID)
 	if evicted {
-		pc.log.Warn("Entry evicted from pidMap")
+		logger.GetLogger().Warn("Entry evicted from pidMap")
 		errormetrics.ErrorTotalInc(errormetrics.PidMapEvicted)
 	}
 	return evicted


### PR DESCRIPTION
We observed a panic from cache code when trying to print a log message. The issue
is the pkg has not been completely converted over to the new logging scheme. Seems
like we missed some bits when refactoring.

To fix remove log from Cache and use GetLogger() api.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>