### PR TITLE
tetragon: Update development docs about tools

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,8 +16,6 @@ Vagrant.configure("2") do |config|
       apt-get update
       apt-get install -y build-essential clang conntrack libcap-dev libelf-dev net-tools
       snap install go --channel=1.17/stable --classic
-      make tools-install LIBBPF_INSTALL_DIR=/usr/local/lib CLANG_INSTALL_DIR=/usr/bin
-      ldconfig /usr/local/
 
       # Install crictl
       VERSION="v1.22.0"

--- a/docs/contributing/development/README.md
+++ b/docs/contributing/development/README.md
@@ -107,29 +107,20 @@ Requirements:
   * `libcap` and `libelf` (in Debian systems, e.g., install `libelf-dev` and
     `libcap-dev`)
 
-Tetragon relies on a permanent fork of libbpf and a fork of clang with some custom patches in order
-to build and load its BPF programs correctly. We first need to get a local copy of both, which can be done
-with:
+You can build Tetragon as follows:
 
 ```
-make tools-install
-```
-
-After running the above command, you are ready to build Tetragon as follows:
-
-```
-LD_LIBRARY_PATH=$(realpath ./lib) make
+make
 ```
 
 You should now have a `./tetragon` binary, which can be run as follows:
 
 ```
-sudo LD_LIBRARY_PATH=$(realpath ./lib) ./tetragon --bpf-lib bpf/objs
+sudo ./tetragon --bpf-lib bpf/objs
 ```
 
-Note that we need to specify the `LD_LIBRARY_PATH` as shown above so that Tetragon can find
-the correct libbpf to use at runtime. The `--bpf-lib` flag tells Tetragon where to look
-for its compiled BPF programs (which were built in the `make` step above).
+The `--bpf-lib` flag tells Tetragon where to look for its compiled BPF programs
+(which were built in the `make` step above).
 
 ### Running Code Generation
 
@@ -160,7 +151,7 @@ Then, run the following commands:
 
 ```
 # Build Tetragon agent and operator images
-LD_LIBRARY_PATH=$(realpath ./lib) make LOCAL_CLANG=0 image image-operator
+make LOCAL_CLANG=0 image image-operator
 
 # Bootstrap the cluster
 contrib/localdev/bootstrap-kind-cluster.sh


### PR DESCRIPTION
Leftover documentation update after removing libbpf
and updating to clang-13.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>