### PR TITLE
add volume mounting ':Z' label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ tetragon-bpf-local:
 
 tetragon-bpf-container:
 	$(CONTAINER_ENGINE) rm tetragon-clang || true
-	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon -u $$(id -u) --name tetragon-clang $(CLANG_IMAGE) $(MAKE) -C /tetragon/bpf
+	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon:Z -u $$(id -u) --name tetragon-clang $(CLANG_IMAGE) $(MAKE) -C /tetragon/bpf
 	$(CONTAINER_ENGINE) rm tetragon-clang
 
 .PHONY: verify
@@ -213,7 +213,7 @@ check:
 else
 check:
 	$(CONTAINER_ENGINE) build -t golangci-lint:tetragon . -f Dockerfile.golangci-lint
-	$(CONTAINER_ENGINE) run --rm -v `pwd`:/app -w /app golangci-lint:tetragon golangci-lint run
+	$(CONTAINER_ENGINE) run --rm -v `pwd`:/app:Z -w /app golangci-lint:tetragon golangci-lint run
 endif
 
 .PHONY: clang-format


### PR DESCRIPTION
PR adds the volume mount `:Z` option for the `docker run` (or `podman run`) command to work properly with SELinux.  This is to prevent the following error with the current code:
```
$ CONTAINER_ENGINE='sudo podman' make tetragon-bpf-container
/bin/sh: docker: command not found
sudo podman rm tetragon-clang || true
a53e97d50c0bd557ddaa234c835d62c5af982415688743fcff30d3022e1c5de4
sudo podman run -v /home/dmitris/dev/hack/gh/cilium/tetragon:/tetragon -u $(id -u) --name tetragon-clang quay.io/cilium/clang:7ea8dd5b610a8864ce7b56e10ffeb61030a0c50e@sha256:02ad7cc1d08d85c027557099b88856945be5124b5c31aeabce326e7983e3913b make -C /tetragon/bpf
make: *** /tetragon/bpf: Permission denied.  Stop.
make: *** [Makefile:71: tetragon-bpf-container] Error 2
```

`sealert` shows:
```
SELinux is preventing /usr/bin/make from read access on the file Makefile.
```

With the added `:Z` label, the `make` command works:
```
$ CONTAINER_ENGINE='sudo podman' make tetragon-bpf-container
/bin/sh: docker: command not found
sudo podman rm tetragon-clang || true
a2869369ae2a45e08ede410dda2337e4deefe1f4ddf4155e29ae1d89f3a82d8e
sudo podman run -v /home/dmitris/dev/hack/gh/cilium/tetragon:/tetragon:Z -u $(id -u) --name tetragon-clang quay.io/cilium/clang:7ea8dd5b610a8864ce7b56e10ffeb61030a0c50e@sha256:02ad7cc1d08d85c027557099b88856945be5124b5c31aeabce326e7983e3913b make -C /tetragon/bpf
make: Entering directory '/tetragon/bpf'
make: Nothing to be done for 'all'.
make: Leaving directory '/tetragon/bpf'
sudo podman rm tetragon-clang
15110f581bf8c5762686d8516833dd52f192c78a74a4bf3aa723d9dc1717d61f
```

Credit to @maditya for suggesting to use the `:Z` label.