### PR TITLE
tetragon: refactor eventCache retry logic

### DIFF
--- a/pkg/api/readyapi/readyapi.go
+++ b/pkg/api/readyapi/readyapi.go
@@ -2,9 +2,23 @@
 // Copyright Authors of Tetragon
 package readyapi
 
-import "github.com/cilium/tetragon/api/v1/tetragon"
+import (
+	"fmt"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/reader/notify"
+)
 
 type MsgTETRAGONReady struct{}
+
+func (msg *MsgTETRAGONReady) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
+	return nil, fmt.Errorf("Unsupported cache event MsgTETRAGONReady")
+}
+
+func (msg *MsgTETRAGONReady) Retry(internal *process.ProcessInternal, ev notify.Event) error {
+	return fmt.Errorf("Unsupported cache retry event MsgTETRAGONReady")
+}
 
 func (msg *MsgTETRAGONReady) HandleMessage() *tetragon.GetEventsResponse {
 	return nil

--- a/pkg/grpc/test/test.go
+++ b/pkg/grpc/test/test.go
@@ -6,9 +6,12 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/testapi"
+	"github.com/cilium/tetragon/pkg/eventcache"
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/node"
+	"github.com/cilium/tetragon/pkg/reader/notify"
 )
 
 var (
@@ -17,6 +20,14 @@ var (
 
 type MsgTestEventUnix struct {
 	testapi.MsgTestEvent
+}
+
+func (msg *MsgTestEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
+	return eventcache.HandleGenericInternal(ev, timestamp)
+}
+
+func (msg *MsgTestEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
+	return eventcache.HandleGenericEvent(internal, ev)
 }
 
 func (msg *MsgTestEventUnix) HandleMessage() *tetragon.GetEventsResponse {

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	"github.com/cilium/tetragon/pkg/reader/network"
 	"github.com/cilium/tetragon/pkg/reader/node"
+	"github.com/cilium/tetragon/pkg/reader/notify"
 	"github.com/cilium/tetragon/pkg/reader/path"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -181,6 +182,14 @@ type MsgGenericTracepointUnix struct {
 	Args       []tracingapi.MsgGenericTracepointArg
 }
 
+func (msg *MsgGenericTracepointUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
+	return eventcache.HandleGenericInternal(ev, timestamp)
+}
+
+func (msg *MsgGenericTracepointUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
+	return eventcache.HandleGenericEvent(internal, ev)
+}
+
 func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse {
 	var tetragonParent, tetragonProcess *tetragon.Process
 
@@ -258,6 +267,14 @@ type MsgGenericKprobeUnix struct {
 	Action       uint64
 	FuncName     string
 	Args         []tracingapi.MsgGenericKprobeArg
+}
+
+func (msg *MsgGenericKprobeUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
+	return eventcache.HandleGenericInternal(ev, timestamp)
+}
+
+func (msg *MsgGenericKprobeUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
+	return eventcache.HandleGenericEvent(internal, ev)
 }
 
 func (msg *MsgGenericKprobeUnix) HandleMessage() *tetragon.GetEventsResponse {

--- a/pkg/reader/notify/notify.go
+++ b/pkg/reader/notify/notify.go
@@ -5,10 +5,13 @@ import (
 	"strings"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/process"
 )
 
 type Message interface {
 	HandleMessage() *tetragon.GetEventsResponse
+	RetryInternal(Event, uint64) (*process.ProcessInternal, error)
+	Retry(*process.ProcessInternal, Event) error
 }
 
 type Event interface {


### PR DESCRIPTION
Some objects should never hit retry logic for internal process lookups. One
example here is the exec entries which are the source of the internal
process. But, the exec events can still be missing pod info. Another
example is the test and ready events. These should not be bounced through
the cache and if they are we should get an error. Current implementation
though does not split up internal retries from podInfo retries. Also it
does not allow msg types to specify type specific handlers and instead
did some hard coded exception for exec.

This patch pulls the retry logic into two methods: one to catch missing
internal process and then a second to catch other state such as the
podInfo. Then now that we have a method we can throw exceptions if we
ever catch a cache retry from a test or other event.

Next up I'll add retries for parents, but this requires more specific
message handling so having methods here helps us to do better testing
and debugging as well as handle per message cases without the type
switch reflect logic we previously had.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>