### PR TITLE
chore: use proper sha256 values for go images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y libelf-dev zlib1g-dev
 COPY . ./
 RUN make tetragon-image LOCAL_CLANG=1
 
-FROM docker.io/library/golang:1.18.3-alpine3.15@sha256:b35984144ec2c2dfd6200e112a9b8ecec4a8fd9eff0babaff330f1f82f14cb2a as gops
+FROM docker.io/library/golang:1.18.3-alpine3.15@sha256:f9181168749690bddb6751b004e976bf5d427425e0cfb50522e92c06f761def7 as gops
 RUN apk add --no-cache binutils git \
  && git clone https://github.com/google/gops /go/src/github.com/google/gops \
  && cd /go/src/github.com/google/gops \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -15,7 +15,7 @@ FROM quay.io/isovalent/hubble-libbpf:v0.2.3 as hubble-libbpf
 WORKDIR /go/src/github.com/cilium/tetragon
 COPY . ./
 
-FROM docker.io/library/golang:1.18.3@sha256:0168c352a2be96f4bcc5856fe6e03ee665b187593f574cecb5cd2712c2b20cab
+FROM docker.io/library/golang:1.18.3@sha256:1650c170f3c55c158431cd35906cb6faf25f5c93b9d8850341c81e1236eaa745
 RUN apt-get update
 RUN apt-get install -y linux-libc-dev rpm2cpio cpio git flex bison autoconf libelf-dev bc netcat-traditional
 WORKDIR /go/src/github.com/cilium/tetragon


### PR DESCRIPTION
Commit 8bd6295af79599489c8244faa75f64a2f04bd0a6 updated the image tags
of Dockerfile and Dockerfile.test but not the sha256 hashes. This meant
that the old version was used since the tag is ignored in the present of
the hash.

Add the correct hashes:
$ ~/src/cilium/images/scripts/get-image-digest.sh docker.io/library/golang:1.18.3-alpine3.15
sha256:f9181168749690bddb6751b004e976bf5d427425e0cfb50522e92c06f761def7
$ ~/src/cilium/images/scripts/get-image-digest.sh docker.io/library/golang:1.18.3
sha256:1650c170f3c55c158431cd35906cb6faf25f5c93b9d8850341c81e1236eaa745

fixes: 8bd6295af79599489c8244faa75f64a2f04bd0a6

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>