### PR TITLE
tests/e2e: dump extra checker info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,11 @@ test:
 e2e-test: image image-operator
 	$(GO) test -p 1 -parallel 1 $(GOFLAGS) -gcflags=$(GO_GCFLAGS) -timeout 20m -failfast -cover ./tests/e2e/tests/... ${EXTRA_TESTFLAGS} -fail-fast -tetragon.helm.set tetragon.image.override="cilium/tetragon:${DOCKER_IMAGE_TAG}" -tetragon.helm.set tetragonOperator.image.override="cilium/tetragon-operator:${DOCKER_IMAGE_TAG}" -tetragon.helm.url="" -tetragon.helm.chart="$(realpath ./install/kubernetes)"
 
+TEST_COMPILE ?= ./...
 .PHONY: test-compile
 test-compile:
 	mkdir -p go-tests
-	for pkg in $$($(GO) list ./...); do \
+	for pkg in $$($(GO) list "$(TEST_COMPILE)"); do \
 		localpkg=$$(echo $$pkg | sed -e 's:github.com/cilium/tetragon/::'); \
 		localtestfile=$$(echo $$localpkg | sed -e 's:/:.:g'); \
 		numtests=$$(ls -l ./$$localpkg/*_test.go 2> /dev/null | wc -l); \

--- a/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -112,6 +112,11 @@ func (checker *OrderedEventChecker) GetChecks() []EventChecker {
 	return checker.checks
 }
 
+// GetRemainingChecks returns this checker's list of remaining checks
+func (checker *OrderedEventChecker) GetRemainingChecks() []EventChecker {
+	return checker.checks[checker.idx:]
+}
+
 // UnorderedEventChecker checks a series of events in arbitrary order
 type UnorderedEventChecker struct {
 	pendingChecks *list.List
@@ -207,6 +212,19 @@ func (checker *UnorderedEventChecker) GetChecks() []EventChecker {
 	var checks []EventChecker
 
 	for e := checker.allChecks.Front(); e != nil; e = e.Next() {
+		if check, ok := e.Value.(EventChecker); ok {
+			checks = append(checks, check)
+		}
+	}
+
+	return checks
+}
+
+// GetRemainingChecks returns this checker's list of remaining checks
+func (checker *UnorderedEventChecker) GetRemainingChecks() []EventChecker {
+	var checks []EventChecker
+
+	for e := checker.pendingChecks.Front(); e != nil; e = e.Next() {
 		if check, ok := e.Value.(EventChecker); ok {
 			checks = append(checks, check)
 		}

--- a/cmd/protoc-gen-go-tetragon/eventchecker/multichecker.go
+++ b/cmd/protoc-gen-go-tetragon/eventchecker/multichecker.go
@@ -100,6 +100,11 @@ func generateOrderedEventChecker(g *protogen.GeneratedFile) error {
         return checker.checks
     }`)
 
+	g.P(`// GetRemainingChecks returns this checker's list of remaining checks
+    func (checker *OrderedEventChecker) GetRemainingChecks() []EventChecker {
+        return checker.checks[checker.idx:]
+    }`)
+
 	return nil
 }
 
@@ -204,6 +209,19 @@ func generateUnorderedEventChecker(g *protogen.GeneratedFile) error {
         var checks []EventChecker
 
         for e := checker.allChecks.Front(); e != nil; e = e.Next() {
+            if check, ok := e.Value.(EventChecker); ok {
+                checks = append(checks, check)
+            }
+        }
+
+        return checks
+    }`)
+
+	g.P(`// GetRemainingChecks returns this checker's list of remaining checks
+    func (checker *UnorderedEventChecker) GetRemainingChecks() []EventChecker {
+        var checks []EventChecker
+
+        for e := checker.pendingChecks.Front(); e != nil; e = e.Next() {
             if check, ok := e.Value.(EventChecker); ok {
                 checks = append(checks, check)
             }

--- a/tests/e2e/checker/rpcchecker.go
+++ b/tests/e2e/checker/rpcchecker.go
@@ -258,16 +258,16 @@ func (rc *RPCChecker) check(ctx context.Context, allowList, denyList []*tetragon
 
 			done, err := ec.NextResponseCheck(rc.checker, event, log)
 			if done && err == nil {
-				klog.Infof("%s => FINAL MATCH ", prefix)
-				klog.Infof("DONE!")
+				log.Infof("%s => FINAL MATCH ", prefix)
+				log.Infof("DONE!")
 				return nil
 			} else if err == nil {
-				klog.Infof("%s => MATCH, continuing", prefix)
+				log.Infof("%s => MATCH, continuing", prefix)
 			} else if done {
-				klog.Errorf("%s => terminating error: %s", prefix, err)
+				log.Errorf("%s => terminating error: %s", prefix, err)
 				return err
 			} else {
-				klog.Infof("%s => no match: %s, continuing", prefix, err)
+				log.Infof("%s => no match: %s, continuing", prefix, err)
 			}
 		}
 	}

--- a/tests/e2e/state/state.go
+++ b/tests/e2e/state/state.go
@@ -21,4 +21,6 @@ var (
 	EventCheckers = Key{slug: "EventCheckers"}
 	// Stores the most recent *testing.T
 	Test = Key{slug: "Test"}
+	// Key for storing the export directory for this test
+	ExportDir = Key{slug: "ExportDir"}
 )

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -112,6 +112,11 @@ func (checker *OrderedEventChecker) GetChecks() []EventChecker {
 	return checker.checks
 }
 
+// GetRemainingChecks returns this checker's list of remaining checks
+func (checker *OrderedEventChecker) GetRemainingChecks() []EventChecker {
+	return checker.checks[checker.idx:]
+}
+
 // UnorderedEventChecker checks a series of events in arbitrary order
 type UnorderedEventChecker struct {
 	pendingChecks *list.List
@@ -207,6 +212,19 @@ func (checker *UnorderedEventChecker) GetChecks() []EventChecker {
 	var checks []EventChecker
 
 	for e := checker.allChecks.Front(); e != nil; e = e.Next() {
+		if check, ok := e.Value.(EventChecker); ok {
+			checks = append(checks, check)
+		}
+	}
+
+	return checks
+}
+
+// GetRemainingChecks returns this checker's list of remaining checks
+func (checker *UnorderedEventChecker) GetRemainingChecks() []EventChecker {
+	var checks []EventChecker
+
+	for e := checker.pendingChecks.Front(); e != nil; e = e.Next() {
 		if check, ok := e.Value.(EventChecker); ok {
 			checks = append(checks, check)
 		}


### PR DESCRIPTION
This PR makes two critical additions to the e2e test export. In particular, we will now dump a list of all events encountered by the checker in order as well as all unmatched checks from the event checker in JSON format. Combined, these two additions will help us debug failing tests by enabling us to match events 1:1 with the checker logs. See individual commits.