### PR TITLE
ci/vmtest: disable fail-fast on test matrix

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -61,6 +61,7 @@ jobs:
          retention-days: 5
   test:
     strategy:
+        fail-fast: false
         matrix:
            kernel:
               - '5.10'


### PR DESCRIPTION
GA defaults to fail-fast on matrix strategies. This means that if one of our test groups
fails, it will cancel all the others. I think we really don't want this because 1. most of
the other jobs will probably be almost completed anyways so cancelling them is not worth
it and 2. more cancelled jobs means more jobs we need to re-run on flakes.

Let's disable fail-fast for the reasons stated above.

Signed-off-by: William Findlay <will@isovalent.com>