### PR TITLE
Make events with missing parents go through eventcache

### DIFF
--- a/api/v1/tetragon/tetragon_ext.go
+++ b/api/v1/tetragon/tetragon_ext.go
@@ -47,3 +47,19 @@ func (x *ProcessKprobe) SetProcess(p *Process) {
 func (x *ProcessTracepoint) SetProcess(p *Process) {
 	x.Process = p
 }
+
+func (x *ProcessExec) SetParent(p *Process) {
+	x.Parent = p
+}
+
+func (x *ProcessExit) SetParent(p *Process) {
+	x.Parent = p
+}
+
+func (x *ProcessKprobe) SetParent(p *Process) {
+	x.Parent = p
+}
+
+func (x *ProcessTracepoint) SetParent(p *Process) {
+	x.Parent = p
+}

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -50,6 +50,7 @@ type Cache struct {
 var (
 	ErrFailedToGetPodInfo     = errors.New("failed to get pod info")
 	ErrFailedToGetProcessInfo = errors.New("failed to get process info")
+	ErrFailedToGetParentInfo  = errors.New("failed to get parent info")
 )
 
 // Generic internal lookup happens when events are received out of order and

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
-	"github.com/cilium/tetragon/pkg/metrics/processexecmetrics"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
 	readerexec "github.com/cilium/tetragon/pkg/reader/exec"
@@ -37,11 +36,7 @@ func GetProcessExec(proc *process.ProcessInternal) *tetragon.ProcessExec {
 	processId := tetragonProcess.ExecId
 
 	parent, err := process.Get(parentId)
-	if err != nil {
-		errormetrics.ErrorTotalInc(errormetrics.ExecMissingParent)
-		processexecmetrics.MissingParentInc(parentId)
-		logger.GetLogger().WithField("processId", processId).WithField("parentId", parentId).Debug("Process missing parent")
-	} else {
+	if err == nil {
 		parent.RefInc()
 	}
 

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -166,7 +166,6 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 
 	process, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
 	if process != nil {
-		process.RefDec()
 		tetragonProcess = process.UnsafeGetProcess()
 	} else {
 		tetragonProcess = &tetragon.Process{
@@ -175,7 +174,6 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 		}
 	}
 	if parent != nil {
-		parent.RefDec()
 		tetragonParent = parent.GetProcessCopy()
 	}
 
@@ -195,7 +193,11 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 		ec.Add(process, tetragonEvent, event.ProcessKey.Ktime, event)
 		return nil
 	}
+	if parent != nil {
+		parent.RefDec()
+	}
 	if process != nil {
+		process.RefDec()
 		tetragonEvent.Process = process.GetProcessCopy()
 	}
 	return tetragonEvent

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -79,10 +79,12 @@ func (msg *MsgExecveEventUnix) RetryInternal(ev notify.Event, timestamp uint64) 
 func (msg *MsgExecveEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
 	var podInfo *tetragon.Pod
 
-	p := ev.GetProcess()
-	containerId := p.Docker
-	filename := p.Binary
-	args := p.Arguments
+	proc := ev.GetProcess()
+	parent := ev.GetParent()
+
+	containerId := proc.Docker
+	filename := proc.Binary
+	args := proc.Arguments
 	nspid := msg.Process.NSPID
 
 	if option.Config.EnableK8s && containerId != "" {
@@ -99,6 +101,20 @@ func (msg *MsgExecveEventUnix) Retry(internal *process.ProcessInternal, ev notif
 	// here.
 	internal.AddPodInfo(podInfo)
 	ev.SetProcess(internal.GetProcessCopy())
+
+	// Check we have a parent with exception for pid 1, note we do this last because we want
+	// to ensure the podInfo and process are set before returning any errors.
+	if proc.Pid.Value > 1 && parent == nil {
+		parentId := proc.ParentExecId
+		parent, err := process.Get(parentId)
+		if parent == nil {
+			return err
+		}
+		if strings.Contains(proc.Flags, "clone") == true {
+			parent.RefInc()
+		}
+	}
+
 	return nil
 }
 
@@ -109,7 +125,9 @@ func (msg *MsgExecveEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 		proc := process.AddExecEvent(&msg.MsgExecveEventUnix)
 		procEvent := GetProcessExec(proc)
 		ec := eventcache.Get()
-		if ec != nil && ec.Needed(procEvent.Process) {
+		if ec != nil &&
+			(ec.Needed(procEvent.Process) ||
+				(procEvent.Process.Pid.Value > 1 && ec.Needed(procEvent.Parent))) {
 			ec.Add(proc, procEvent, msg.MsgExecveEventUnix.Process.Ktime, msg)
 		} else {
 			procEvent.Process = proc.GetProcessCopy()
@@ -176,7 +194,9 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 		Status:  code,
 	}
 	ec := eventcache.Get()
-	if ec != nil && ec.Needed(tetragonProcess) {
+	if ec != nil &&
+		(ec.Needed(tetragonProcess) ||
+			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
 		ec.Add(process, tetragonEvent, event.ProcessKey.Ktime, event)
 		return nil
 	}
@@ -191,7 +211,26 @@ type MsgExitEventUnix struct {
 }
 
 func (msg *MsgExitEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, timestamp)
+	p := ev.GetProcess()
+	internal, parent := process.GetParentProcessInternal(p.Pid.Value, timestamp)
+	var err error
+
+	if parent != nil {
+		ev.SetParent(parent.GetProcessCopy())
+		parent.RefDec()
+	} else {
+		errormetrics.ErrorTotalInc(errormetrics.EventCacheParentInfoFailed)
+		err = eventcache.ErrFailedToGetParentInfo
+	}
+
+	if internal != nil {
+		internal.RefDec()
+	} else {
+		errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
+		err = eventcache.ErrFailedToGetProcessInfo
+	}
+
+	return internal, err
 }
 
 func (msg *MsgExitEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {

--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -764,7 +764,7 @@ func TestGrpcParentRefcntInOrder(t *testing.T) {
 	assert.Equal(t, currentExitEv.Process.Pid.Value, currentPid)
 	assert.Equal(t, currentExitEv.Process.Refcnt, uint32(0))
 	assert.Equal(t, currentExitEv.Parent.Pid.Value, parentPid)
-	assert.Equal(t, currentExitEv.Parent.Refcnt, uint32(1))
+	assert.Equal(t, currentExitEv.Parent.Refcnt, uint32(2))
 
 	// 4th event: exit from parent
 	// 1. should match pid of parent

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -162,7 +162,9 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 	}
 
 	ec := eventcache.Get()
-	if ec != nil && ec.Needed(tetragonProcess) {
+	if ec != nil &&
+		(ec.Needed(tetragonProcess) ||
+			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
 		ec.Add(process, tetragonEvent, event.ProcessKey.Ktime, event)
 		return nil
 	}
@@ -243,7 +245,9 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 	}
 
 	ec := eventcache.Get()
-	if ec != nil && ec.Needed(tetragonProcess) {
+	if ec != nil &&
+		(ec.Needed(tetragonProcess) ||
+			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
 		ec.Add(process, tetragonEvent, msg.ProcessKey.Ktime, msg)
 		return nil
 	}

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -28,6 +28,8 @@ var (
 	EventCacheEndpointRetryFailed ErrorType = "event_cache_endpoint_retry_failed"
 	// Event cache failed to set process information for an event.
 	EventCacheProcessInfoFailed ErrorType = "event_cache_process_info_failed"
+	// Event cache failed to set parent information for an event.
+	EventCacheParentInfoFailed ErrorType = "event_cache_parent_info_failed"
 	// There was an invalid entry in the pid map.
 	PidMapInvalidEntry ErrorType = "pid_map_invalid_entry"
 	// An entry was evicted from the pid map because the map was full.

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -151,6 +151,11 @@ func (pi *ProcessInternal) RefInc() {
 	procCache.refInc(pi)
 }
 
+func (pi *ProcessInternal) RefGet() uint32 {
+	ref := atomic.LoadUint32(&pi.refcnt)
+	return ref
+}
+
 func GetProcessID(pid uint32, ktime uint64) string {
 	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%d:%d", nodeName, ktime, pid)))
 }

--- a/pkg/reader/notify/notify.go
+++ b/pkg/reader/notify/notify.go
@@ -16,7 +16,9 @@ type Message interface {
 
 type Event interface {
 	GetProcess() *tetragon.Process
+	GetParent() *tetragon.Process
 	SetProcess(*tetragon.Process)
+	SetParent(*tetragon.Process)
 	Encapsulate() tetragon.IsGetEventsResponse_Event
 }
 

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon_ext.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon_ext.go
@@ -47,3 +47,19 @@ func (x *ProcessKprobe) SetProcess(p *Process) {
 func (x *ProcessTracepoint) SetProcess(p *Process) {
 	x.Process = p
 }
+
+func (x *ProcessExec) SetParent(p *Process) {
+	x.Parent = p
+}
+
+func (x *ProcessExit) SetParent(p *Process) {
+	x.Parent = p
+}
+
+func (x *ProcessKprobe) SetParent(p *Process) {
+	x.Parent = p
+}
+
+func (x *ProcessTracepoint) SetParent(p *Process) {
+	x.Parent = p
+}


### PR DESCRIPTION
When we bounce through the event cache its possible we never found the
parent process. In this case we also get a ref cnt imbalance because
the exit event will dec the ref but the exec does not.

To fix this update the Retry logic to also search for the parent
and if its missing populate it plus do refInc. And similarly
on exit check for parent and if its not handled yet similarly
go to the cache and wait, but this time do a refDec.

Now its still possible the dec happens before the inc in this
scenario,

```
  exec -> cache ------------------> parentFound IncRef
              exit -> decRef
```

But, in this case its OK that the ref briefly was incorrect because
the GC will wait for at minimum two iterations before removing it
to account for this eventually consistent logic.

Finally, there is the corner case where the exec is delayed for
some extreme amount of time, the GC interval * 3, and then the
exit is handled with its decRef. Now we've go an imbalance. But
we tried really hard here and the system is not responsive so
best we can do is carry on and let the cache reconcile this later.
It could cause some entries to get froze in the cache until the
LRU evicts them. This should be exceedingly rare and we will
add counters for this case which would indicate the GC interval
should be extended.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>
Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>