### PR TITLE
tetragon: before parsing environment vars replace "-" with "_"

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/pprof"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -368,6 +369,8 @@ func execute() error {
 			}
 			log.WithField(keyConfigDir, configDir).Info("Loaded config from directory")
 		}
+		replacer := strings.NewReplacer("-", "_")
+		viper.SetEnvKeyReplacer(replacer)
 		viper.AutomaticEnv()
 	})
 


### PR DESCRIPTION
Before parsing environment variables we have to replace every "-" by "_"
in variable names.

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>