### PR TITLE
chore: fix capitalization TETRAGON -> Tetragon

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -103,7 +103,7 @@ func stopProfile(prof string) {
 	pprof.StopCPUProfile()
 }
 
-func hubbleTETRAGONExecute() error {
+func tetragonExecute() error {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
@@ -343,7 +343,7 @@ func execute() error {
 			if err := gops.Listen(gops.Options{}); err != nil {
 				log.WithError(err).Fatal("Failed to start gops")
 			}
-			if err := hubbleTETRAGONExecute(); err != nil {
+			if err := tetragonExecute(); err != nil {
 				log.WithError(err).Fatal("Failed to start tetragon")
 			}
 		},
@@ -391,8 +391,8 @@ func execute() error {
 	flags.Int(keyExportRateLimit, -1, "Rate limit (per minute) for event export. Set to -1 to disable")
 	flags.String(keyLogLevel, "info", "Set log level")
 	flags.String(keyLogFormat, "text", "Set log format")
-	flags.Bool(keyEnableK8sAPI, false, "Access Kubernetes API to associate TETRAGON events with Kubernetes pods")
-	flags.Bool(keyEnableCiliumAPI, false, "Access Cilium API to associate TETRAGON events with Cilium endpoints and DNS cache")
+	flags.Bool(keyEnableK8sAPI, false, "Access Kubernetes API to associate Tetragon events with Kubernetes pods")
+	flags.Bool(keyEnableCiliumAPI, false, "Access Cilium API to associate Tetragon events with Cilium endpoints and DNS cache")
 	flags.Bool(keyEnableProcessAncestors, true, "Include ancestors in process exec events")
 	flags.String(keyMetricsServer, "", "Metrics server address (e.g. ':2112'). Set it to an empty string to disable.")
 	flags.String(keyServerAddress, "localhost:54321", "gRPC server address")

--- a/pkg/api/flags.go
+++ b/pkg/api/flags.go
@@ -13,8 +13,8 @@ const (
 	// execveAt syscall
 	EventExecveAt = 0x02
 	// EventProcFS indicates the event is generated from a proc interface.
-	// This happens at TETRAGON init when existing processes are being loaded
-	// into TETRAGON event buffer. All events should have either EventExecve or
+	// This happens at Tetragon init when existing processes are being loaded
+	// into Tetragon event buffer. All events should have either EventExecve or
 	// EventProcFS set.
 	EventProcFS = 0x04
 	// EventTruncFilename indicates we truncated the processes filename
@@ -26,7 +26,7 @@ const (
 	// buffer size to avoid this.
 	EventTruncArgs = 0x10
 	// EventTaskWalk indicates we walked the process hierarchy to find a
-	// parent process in the TETRAGON buffer. This may happen when we did not
+	// parent process in the Tetragon buffer. This may happen when we did not
 	// receive an exec event for the immediate parent of a process.
 	// Typically means we are looking at a fork that in turn did another
 	// fork we don't currently track fork events exactly and instead push
@@ -34,25 +34,25 @@ const (
 	// this insight into the event if needed. Primarily useful for debugging.
 	EventTaskWalk = 0x20
 	// EventMiss is an *error flag* indicating we could not find parent info
-	// in the TETRAGON event buffer. If this is set it should be reported to TETRAGON
-	// developers for debugging. TETRAGON will do its best to recover information
+	// in the Tetragon event buffer. If this is set it should be reported to Tetragon
+	// developers for debugging. Tetragon will do its best to recover information
 	// about the process from available kernel data structures instead of
 	// using cached info in this case. However, args will not be available.
 	EventMiss = 0x40
-	// EventNeedsAUID is an *internal flag* for TETRAGON to indicate the audit
+	// EventNeedsAUID is an *internal flag* for Tetragon to indicate the audit
 	// has not yet been resolved. The BPF hooks look at this flag to
 	// determine if probing the audit system is necessary.
 	EventNeedsAUID = 0x80
 	// EventErrorFilename is an *error flag* indicating an error happened
 	// while reading the filename. If this is set it should be reported to
-	// TETRAGON developers for debugging.
+	// Tetragon developers for debugging.
 	EventErrorFilename = 0x100
 	// EventErrorArgs is an *error flag* indicating an error happened while
 	// reading the process args. If this is set it should be reported to
-	// TETRAGON developers for debugging.
+	// Tetragon developers for debugging.
 	EventErrorArgs = 0x200
-	// EventNeedsCWD is an *internal flag* for TETRAGON to indicate the current
-	// working directory has not yet been resolved. The TETRAGON hooks look at
+	// EventNeedsCWD is an *internal flag* for Tetragon to indicate the current
+	// working directory has not yet been resolved. The Tetragon hooks look at
 	// this flag to determine if probing the CWD is necessary.
 	EventNeedsCWD = 0x400
 	// EventNoCWDSupport indicates we removed the CWD from the event because
@@ -64,7 +64,7 @@ const (
 	EventRootCWD = 0x1000
 	// EventErrorCWD is an *error flag* indicating an error happened while
 	// reading the CWD of a process. If this is set it should be reported to
-	// TETRAGON developers for debugging.
+	// Tetragon developers for debugging.
 	EventErrorCWD = 0x2000
 	// EventClone indicates the process issues a clone before exec* was
 	// issued. This is the general flow to exec* a new process. However,

--- a/pkg/api/readyapi/readyapi.go
+++ b/pkg/api/readyapi/readyapi.go
@@ -10,16 +10,16 @@ import (
 	"github.com/cilium/tetragon/pkg/reader/notify"
 )
 
-type MsgTETRAGONReady struct{}
+type MsgTetragonReady struct{}
 
-func (msg *MsgTETRAGONReady) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return nil, fmt.Errorf("Unsupported cache event MsgTETRAGONReady")
+func (msg *MsgTetragonReady) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
+	return nil, fmt.Errorf("Unsupported cache event MsgTetragonReady")
 }
 
-func (msg *MsgTETRAGONReady) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return fmt.Errorf("Unsupported cache retry event MsgTETRAGONReady")
+func (msg *MsgTetragonReady) Retry(internal *process.ProcessInternal, ev notify.Event) error {
+	return fmt.Errorf("Unsupported cache retry event MsgTetragonReady")
 }
 
-func (msg *MsgTETRAGONReady) HandleMessage() *tetragon.GetEventsResponse {
+func (msg *MsgTetragonReady) HandleMessage() *tetragon.GetEventsResponse {
 	return nil
 }

--- a/pkg/bugtool/bugtool.go
+++ b/pkg/bugtool/bugtool.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
-// TETRAGON bugtool code
+// Tetragon bugtool code
 
 package bugtool
 
@@ -34,7 +34,7 @@ const (
 	initInfoFname = defaults.DefaultRunDir + "tetragon-info.json"
 )
 
-// InitInfo contains information about how TETRAGON was initialized.
+// InitInfo contains information about how Tetragon was initialized.
 type InitInfo struct {
 	ExportFname string `json:"export_fname"`
 	LibDir      string `json:"lib_dir"`

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -18,7 +18,7 @@ const (
 	// DefaultMapRoot is the default path where BPFFS should be mounted
 	DefaultMapRoot = "/sys/fs/bpf"
 
-	// DefaultMapPrefix is the default path prefix where TETRAGON maps should be pinned
+	// DefaultMapPrefix is the default path prefix where Tetragon maps should be pinned
 	DefaultMapPrefix = "tetragon"
 
 	// DefaultEventMap is the default name of the Event map

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -138,7 +138,7 @@ func (k *Observer) __loopEvents(stopCtx context.Context, e *bpf.PerCpuEvents) er
 	pollTimeoutMsec := int(pollTimeout / time.Millisecond)
 
 	k.log.Info("Listening for events...")
-	k.observerListeners(&readyapi.MsgTETRAGONReady{})
+	k.observerListeners(&readyapi.MsgTetragonReady{})
 
 	for !isCtxDone(stopCtx) {
 		_, err := e.Poll(pollTimeoutMsec)
@@ -191,7 +191,7 @@ func (k *Observer) runEventsNew(stopCtx context.Context, ready func()) error {
 	}
 
 	// Inform caller that we're about to start processing events.
-	k.observerListeners(&readyapi.MsgTETRAGONReady{})
+	k.observerListeners(&readyapi.MsgTetragonReady{})
 	ready()
 
 	// Listeners are ready and about to start reading from perf reader, tell

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -296,7 +296,7 @@ func getDefaultObserver(t *testing.T, ctx context.Context, base *sensors.Sensor,
 
 	// There doesn't appear to be a better way to enable the metrics server once and only
 	// once at the beginning of the observer tests. My initial thought was to use the init
-	// function in this file, however that actually ends up interfering with the TETRAGON agent
+	// function in this file, however that actually ends up interfering with the Tetragon agent
 	// since it get compiled into the observer package.
 	//
 	// This is horrifically ugly, so we may want to figure out a better way to do this

--- a/pkg/option/doc.go
+++ b/pkg/option/doc.go
@@ -2,5 +2,5 @@
 // Copyright Authors of Tetragon
 
 // Package option provides global singletons for storing configuration and
-// variables used in Hubble TETRAGON.
+// variables used in Tetragon.
 package option

--- a/pkg/reader/proc/proc.go
+++ b/pkg/reader/proc/proc.go
@@ -14,7 +14,7 @@ const (
 	nanoPerSeconds = 1000000000
 
 	// CLK_TCK is always constant 100 on all architectures except alpha and ia64 which are both
-	// obsolete and not supported by TETRAGON. Also see
+	// obsolete and not supported by Tetragon. Also see
 	// https://lore.kernel.org/lkml/agtlq6$iht$1@penguin.transmeta.com/ and
 	// https://github.com/containerd/cgroups/pull/12
 	clktck = uint64(100)


### PR DESCRIPTION
There was a find and replace error in our initial release that caused a bunch of instances
of Tetragon to be capitalized like TETRAGON. Fix these up since it looks bad.

Signed-off-by: William Findlay <will@isovalent.com>