### PR TITLE
exec: log results of docker or container ID lookup during execve events

### DIFF
--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	os.Exit(ec)
 }
 
-func Test_msgToExecveUnix(t *testing.T) {
+func Test_msgToExecveKubeUnix(t *testing.T) {
 	event := api.MsgExecveEvent{}
 	idLength := procevents.BpfContainerIdLength
 
@@ -37,53 +37,53 @@ func Test_msgToExecveUnix(t *testing.T) {
 	prefix := "docker-"
 	minikubeID := prefix + "9e123a99b140a6ea4a8d15040ca2c8ee2d5ee9605e81d66ae4e3e29c3f0ef220.scope"
 	copy(event.Kube.Docker[:], minikubeID)
-	result := msgToExecveUnix(&event)
-	assert.Equal(t, strings.Split(minikubeID, "-")[1][:idLength], result.Kube.Docker)
+	kube := msgToExecveKubeUnix(&event, "", "")
+	assert.Equal(t, strings.Split(minikubeID, "-")[1][:idLength], kube.Docker)
 	event.Kube.Docker[0] = 0
-	result = msgToExecveUnix(&event)
-	assert.Empty(t, result.Kube.Docker)
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Empty(t, kube.Docker)
 
 	// GKE doesn't.
 	gkeID := "82836ef3675020258bee5075ace6264b3bc5300e20c975543cbc984bea59638f"
 	copy(event.Kube.Docker[:], gkeID)
-	result = msgToExecveUnix(&event)
-	assert.Equal(t, gkeID[:idLength], result.Kube.Docker)
-	assert.Equal(t, idLength, len(result.Kube.Docker))
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Equal(t, gkeID[:idLength], kube.Docker)
+	assert.Equal(t, idLength, len(kube.Docker))
 	event.Kube.Docker[0] = 0
-	result = msgToExecveUnix(&event)
-	assert.Empty(t, result.Kube.Docker)
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Empty(t, kube.Docker)
 
 	id := "kubepods-burstable-pod29349498_197c_4919_b13f_9a928e7d001b.slice:cri-containerd:0ca2b3cd20e5f55a2bbe8d4aa3f811cf7963b40f0542ad147054b0fcb60fc400"
 	copy(event.Kube.Docker[:], id)
-	result = msgToExecveUnix(&event)
-	assert.Equal(t, id[80:80+idLength], result.Kube.Docker)
-	assert.Equal(t, strings.Split(id, ":")[2][:idLength], result.Kube.Docker)
-	assert.Equal(t, idLength, len(result.Kube.Docker))
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Equal(t, id[80:80+idLength], kube.Docker)
+	assert.Equal(t, strings.Split(id, ":")[2][:idLength], kube.Docker)
+	assert.Equal(t, idLength, len(kube.Docker))
 
 	id = "kubepods-besteffort-pod13cb8437-00ed-40e4-99d8-e17193a58086.slice:cri-containerd:a5a6a3af5d51ad95b915ca948710b90a94abc279e84963b9d22a39f342ce67d9"
 	copy(event.Kube.Docker[:], id)
-	result = msgToExecveUnix(&event)
-	assert.Equal(t, id[81:81+idLength], result.Kube.Docker)
-	assert.Equal(t, strings.Split(id, ":")[2][:idLength], result.Kube.Docker)
-	assert.Equal(t, idLength, len(result.Kube.Docker))
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Equal(t, id[81:81+idLength], kube.Docker)
+	assert.Equal(t, strings.Split(id, ":")[2][:idLength], kube.Docker)
+	assert.Equal(t, idLength, len(kube.Docker))
 
 	id = "cri-containerd-5694f82f44168cc048e014ae14d1b0c8ef673bec49f329dc169911ea638f63c2.scope"
 	copy(event.Kube.Docker[:], id)
-	result = msgToExecveUnix(&event)
-	assert.Equal(t, strings.Split(id, "-")[2][:idLength], result.Kube.Docker)
-	assert.Equal(t, idLength, len(result.Kube.Docker))
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Equal(t, strings.Split(id, "-")[2][:idLength], kube.Docker)
+	assert.Equal(t, idLength, len(kube.Docker))
 
 	id = "libpod-01f3c60cfaadbb51e4d5947dd2ef0480d53551cbcee8f3ada8c3723b2bf03bf4"
 	copy(event.Kube.Docker[:], id)
-	result = msgToExecveUnix(&event)
-	assert.Equal(t, strings.Split(id, "-")[1][:idLength], result.Kube.Docker)
-	assert.Equal(t, idLength, len(result.Kube.Docker))
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Equal(t, strings.Split(id, "-")[1][:idLength], kube.Docker)
+	assert.Equal(t, idLength, len(kube.Docker))
 
 	id = ":a5a6a3af5d51ad95b915ca948710b90a94abc279e84963b9d22a39f342ce67d9"
 	copy(event.Kube.Docker[:], id)
-	result = msgToExecveUnix(&event)
-	assert.Equal(t, strings.Split(id, ":")[1][:idLength], result.Kube.Docker)
-	assert.Equal(t, idLength, len(result.Kube.Docker))
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Equal(t, strings.Split(id, ":")[1][:idLength], kube.Docker)
+	assert.Equal(t, idLength, len(kube.Docker))
 
 	// Empty event so we don't fail tests
 	for i := 0; i < api.DOCKER_ID_LENGTH; i++ {
@@ -92,8 +92,8 @@ func Test_msgToExecveUnix(t *testing.T) {
 	// Not valid
 	id = "ba4c34f800cf9f92881fd55cea8e60d"
 	copy(event.Kube.Docker[:], id)
-	result = msgToExecveUnix(&event)
-	assert.Empty(t, result.Kube.Docker)
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Empty(t, kube.Docker)
 
 	// Empty event so we don't fail tests
 	for i := 0; i < api.DOCKER_ID_LENGTH; i++ {
@@ -101,8 +101,8 @@ func Test_msgToExecveUnix(t *testing.T) {
 	}
 	id = ":ba4c34f800cf9f92881fd55cea8e60d"
 	copy(event.Kube.Docker[:], id)
-	result = msgToExecveUnix(&event)
-	assert.Empty(t, result.Kube.Docker)
+	kube = msgToExecveKubeUnix(&event, "", "")
+	assert.Empty(t, kube.Docker)
 }
 
 func TestNamespaces(t *testing.T) {


### PR DESCRIPTION
During execve events we try to lookup the container ID and fill up the
docker field, however since cgroups implementation has two separate
incompatible implementations, and container runtimes with k8s may use
different one according to their version, not to mention semantics
that change over time. Let's try to log the status of the Container ID
lookup.
    
Logging is at trace level, this will help debug our tests and even correlate
events with exec_id that have a missing docker field.
    
Signed-off-by: Djalal Harouni <tixxdz@gmail.com>