### PR TITLE
Dockerfile: incude tetragon version in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ COPY . ./
 RUN make tetragon-bpf LOCAL_CLANG=1
 
 FROM quay.io/cilium/cilium-builder:a2dc3278c48e1593b1f6c8fd9e5c6a982d56a875@sha256:98c4e694805e9a9d410ed73d555e97e91d77e2ab4529b6b51f5243b33ab411b1 as hubble-builder
+ARG TETRAGON_VERSION
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN apt-get update && apt-get install -y libelf-dev zlib1g-dev
 COPY . ./
-RUN make tetragon-image LOCAL_CLANG=1
+RUN make tetragon-image LOCAL_CLANG=1 VERSION=$TETRAGON_VERSION
 
 FROM docker.io/library/golang:1.18.3-alpine3.15@sha256:b35984144ec2c2dfd6200e112a9b8ecec4a8fd9eff0babaff330f1f82f14cb2a as gops
 RUN apk add --no-cache binutils git \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TESTER_PROGS_DIR = "contrib/tester-progs"
 # Extra flags to pass to test binary
 EXTRA_TESTFLAGS ?=
 
-VERSION=$(shell git describe --tags --always)
+VERSION ?= $(shell git describe --tags --always)
 GO_GCFLAGS ?= ""
 GO_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(VERSION)'"
 GO_IMAGE_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(VERSION)' -linkmode external -extldflags -static"
@@ -160,7 +160,7 @@ lint:
 
 .PHONY: image image-operator image-test image-codegen
 image: image-clang
-	$(CONTAINER_ENGINE) build -t "cilium/tetragon:${DOCKER_IMAGE_TAG}" .
+	$(CONTAINER_ENGINE) build -t "cilium/tetragon:${DOCKER_IMAGE_TAG}" --build-arg TETRAGON_VERSION=$(VERSION) .
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "${CONTAINER_ENGINE} push cilium/tetragon:$(DOCKER_IMAGE_TAG)"
 


### PR DESCRIPTION
Currently, tetragon images do not incude the version. This is because we
generate the version using git, and .git is in .dockerignore so it will
not be copied over when we are bullding the image.

Fix this by passing an appropriate build argument to docker build.

Tested using:
$ make image
$ docker run -it  --entrypoint /bin/sh cilium/tetragon:latest
/ # /usr/bin/tetragon
time="2022-08-17T09:57:07Z" level=info msg="Starting tetragon" version=v0.8.0-478-g30eb03fbf
...

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>