### PR TITLE
tetragon: Do not fail because of the empty map ids

### DIFF
--- a/pkg/sensors/program/coll.go
+++ b/pkg/sensors/program/coll.go
@@ -108,11 +108,11 @@ func copyLoadedCollection(coll *ebpf.Collection) (*LoadedCollection, error) {
 			return nil, fmt.Errorf("failed to get id")
 		}
 		mapIDs, ok := info.MapIDs()
-		if !ok {
-			return nil, fmt.Errorf("failed to get map ids")
-		}
+
 		lp := &LoadedProgram{ID: id}
-		lp.MapIDs = mapIDs
+		if ok {
+			lp.MapIDs = mapIDs
+		}
 		lp.Type = p.Type()
 		lc.Programs[name] = lp
 	}


### PR DESCRIPTION
Add program even with no maps.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>