### PR TITLE
change Vagrant image to ubuntu/jammy64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/impish64"
+  config.vm.box = "ubuntu/jammy64"
   config.vm.disk :disk, size: "50GB"
   config.vm.provision :docker
   config.vm.network "private_network", ip: "192.168.56.11"


### PR DESCRIPTION
https://lists.ubuntu.com/archives/ubuntu-announce/2022-July/000281.html indicates July 14, 2002 as the EOL date for ubuntu Impish release, therefore change it to Jammy Jellifish one https://lists.ubuntu.com/archives/ubuntu-announce/2022-April/000279.html.