### PR TITLE
Add UnloadHook to Sensors

### DIFF
--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -43,6 +43,10 @@ type Sensor struct {
 	Loaded bool
 	// Ops contains an implementation to perform on this sensor.
 	Ops Operations
+	// UnloadHook can optionally contain a pointer to a function to be
+	// called during sensor unloading, prior to the programs and maps being
+	// unloaded.
+	UnloadHook SensorUnloadHook
 }
 
 // Operations is the interface to the underlying sensor implementations.
@@ -53,6 +57,10 @@ type Operations interface {
 	GetConfig(cfg string) (string, error)
 	SetConfig(cfg string, val string) error
 }
+
+// SensorUnloadHook is the function signature for an optional function
+// that can be called during sensor unloading.
+type SensorUnloadHook func() error
 
 func SensorCombine(name string, sensors ...*Sensor) *Sensor {
 	progs := []*program.Program{}

--- a/pkg/sensors/sync.go
+++ b/pkg/sensors/sync.go
@@ -276,6 +276,12 @@ func UnloadSensor(ctx context.Context, bpfDir, mapDir string, sensor *Sensor) er
 		return fmt.Errorf("unload of sensor %s failed: sensor not loaded", sensor.Name)
 	}
 
+	if sensor.UnloadHook != nil {
+		if err := sensor.UnloadHook(); err != nil {
+			logger.GetLogger().Warnf("Sensor %s unload hook failed: %s", sensor.Name, err)
+		}
+	}
+
 	for _, p := range sensor.Progs {
 		RemoveProgram(bpfDir, p)
 	}


### PR DESCRIPTION
Some sensors need to perform additional work when unloaded, in order to
leave the system in a clean state, as part of facilitating the
capability to load and unload sensors repeatedly. A clear example would
be if a sensor installed a timer (an implementation of a stopable
ticker) in an enable function.

This commit adds an UnloadHook that can optionally be set by a sensor to
point to a function to call, prior to the programs and maps being
unloaded, when the sensor is being unloaded.

Signed-off-by: Kevin Sheldrake <kevin.sheldrake@isovalent.com>