### PR TITLE
chore: move multiplexer into its own package

### DIFF
--- a/pkg/multiplexer/doc.go
+++ b/pkg/multiplexer/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// This package provides a multiplexer for combine one or more gRPC event streams into
+// a single stream. Useful for running the eventchecker across multiple gRPC connections
+// simultaneously, for example in a multi-node cluster.
+package multiplexer

--- a/tests/e2e/checker/rpcchecker.go
+++ b/tests/e2e/checker/rpcchecker.go
@@ -24,6 +24,7 @@ import (
 	eventHelpers "github.com/cilium/tetragon/api/v1/tetragon/codegen/helpers"
 	"github.com/cilium/tetragon/pkg/exporter"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/multiplexer"
 	"github.com/cilium/tetragon/tests/e2e/state"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,7 @@ import (
 type RPCChecker struct {
 	name             string
 	checker          ec.MultiEventChecker
-	getEvents        *ClientMultiplexer
+	getEvents        *multiplexer.ClientMultiplexer
 	eventLimit       uint32
 	timeLimit        time.Duration
 	logs             *bytes.Buffer
@@ -174,7 +175,7 @@ func (rc *RPCChecker) CheckWithFilters(connTimeout time.Duration, allowList, den
 // Connect connects the RPCChecker to one or more gRPC servers. This must be called
 // before calling RPCChecker.Check().
 func (rc *RPCChecker) connect(ctx context.Context, connTimeout time.Duration, addrs ...string) error {
-	cm := &ClientMultiplexer{}
+	cm := multiplexer.NewClientMultiplexer()
 	if err := cm.Connect(ctx, connTimeout, addrs...); err != nil {
 		return err
 	}


### PR DESCRIPTION
The multiplexer previously lived inside the e2e-framework's checker package but it really
should exist independently of the e2e-framework, so let's move it out into its own
package.

Signed-off-by: William Findlay <will@isovalent.com>