### PR TITLE
gitignore .vagrant directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ cscope.po.out
 cscope.out
 cscope.in.out
 strange.txt
+.vagrant/
 .vscode


### PR DESCRIPTION
PR adds `.vagrant/` to `.gitignore` for less spurious red on the `git status` command (after playing with vagrant in this repo).

Signed-off-by: Dmitry Savintsev <dsavints@gmail.com>