### PR TITLE
Vagrant on MacOS fix information

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ we provide a standard VagrantFile with the required components enabled. Simply r
  $ vagrant ssh
  ```
 
-This should be sufficient to create a Kind cluster and run Tetragon.
+This should be sufficient to create a Kind cluster and run Tetragon. For more information on the vagrant builds, see the [Development Guide](docs/contributing/development/README.md#local-development-in-vagrant-box).
 
 # FAQ
 

--- a/docs/contributing/development/README.md
+++ b/docs/contributing/development/README.md
@@ -210,6 +210,8 @@ If you are on a Mac, use Vagrant to create a dev VM:
     vagrant ssh
     make
 
+If you are getting an error, you can try to run `sudo launchctl load /Library/LaunchDaemons/org.virtualbox.startup.plist` (from https://stackoverflow.com/questions/18149546/macos-vagrant-up-failed-dev-vboxnetctl-no-such-file-or-directory).
+
 ### Making Changes
 
 1. Make sure the main branch of your fork is up-to-date:


### PR DESCRIPTION
PR adds a hint regarding vagrant/virtualbox fix - from https://stackoverflow.com/questions/18149546/macos-vagrant-up-failed-dev-vboxnetctl-no-such-file-or-directory.

See also
https://cilium.slack.com/archives/C03EV7KJPJ9/p1660806156966189?thread_ts=1660693909.096529&cid=C03EV7KJPJ9

PR is currently cumulative with (the tiny) #33, can rebase if/when #33 is merged.

/cc @kkourt 