### PR TITLE
Podman-friendly CONTAINER_ENGINE setting

### DIFF
--- a/docs/contributing/development/README.md
+++ b/docs/contributing/development/README.md
@@ -215,3 +215,6 @@ If you are on a Mac, use Vagrant to create a dev VM:
 6. Run `git diff --check` to catch obvious white space violations
 
 7. Build Tetragon with your changes included.
+
+### Running Tests
+See <https://github.com/cilium/tetragon/blob/main/tests/vmtests/README.md>.

--- a/tests/vmtests/fetch-data.sh
+++ b/tests/vmtests/fetch-data.sh
@@ -6,7 +6,7 @@ set -eu -o pipefail
 OCIORG=quay.io/lvh-images
 ROOTIMG=$OCIORG/root-images
 KERNIMG=$OCIORG/kernel-images
-CONTAINER_ENGINE=docker
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
 KERNEL_VERS="$@"
 DEST_DIR="tests/vmtests/test-data"
 


### PR DESCRIPTION
PR changes the setting of `CONTAINER_ENGINE` in tests/vmtests/fetch-data.sh to allow overwriting the variable with for example `sudo podman` while keeping `docker` as the default.  It also adds a link to the vmtests README in the contributor guide.  

Based on the Slack conversation https://cilium.slack.com/archives/C2B917YHE/p1660856168376349?thread_ts=1660843012.876959&cid=C2B917YHE - thanks @kkourt!