### PR TITLE
ci/codeql: change runner version

### DIFF
--- a/.github/workflows/lint-codeql.yml
+++ b/.github/workflows/lint-codeql.yml
@@ -16,7 +16,7 @@ jobs:
   check_changes:
     name: Deduce required tests from code changes
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       go-changes: ${{ steps.go-changes.outputs.src }}
     steps:
@@ -41,7 +41,7 @@ jobs:
   analyze:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.go-changes == 'true' || github.event_name != 'pull_request' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       security-events: write
     steps:


### PR DESCRIPTION
Ubuntu 18.04 is deprecated and is now being severely throttled by GA. So let's update the
runner to Ubuntu 20.04.

Signed-off-by: William Findlay <will@isovalent.com>