### PR TITLE
tetragon: Add memprofile option

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -40,6 +40,7 @@ const (
 	keyRunStandalone      = "run-standalone"
 	keyIgnoreMissingProgs = "ignore-missing-progs"
 	keyCpuProfile         = "cpuprofile"
+	keyMemProfile         = "memprofile"
 
 	keyExportFilename             = "export-filename"
 	keyExportFileMaxSizeMB        = "export-file-max-size-mb"
@@ -80,6 +81,7 @@ var (
 	exportAggregationBufferSize uint64
 
 	cpuProfile string
+	memProfile string
 )
 
 func readAndSetFlags() {
@@ -122,4 +124,5 @@ func readAndSetFlags() {
 	exportAggregationBufferSize = viper.GetUint64(keyExportAggregationBufferSize)
 
 	cpuProfile = viper.GetString(keyCpuProfile)
+	memProfile = viper.GetString(keyMemProfile)
 }

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -96,12 +96,11 @@ func readConfig(file string) (*config.GenericTracingConf, error) {
 	return cnf, nil
 }
 
-func stopProfile(prof string) {
-	if prof == "" {
-		return
+func stopProfile() {
+	if cpuProfile != "" {
+		log.WithField("file", cpuProfile).Info("Stopping cpu profiling")
+		pprof.StopCPUProfile()
 	}
-	log.WithField("file", prof).Info("Stopping cpu profiling")
-	pprof.StopCPUProfile()
 }
 
 func tetragonExecute() error {
@@ -133,7 +132,6 @@ func tetragonExecute() error {
 			log.Fatal("could not start CPU profile: ", err)
 		}
 		log.WithField("file", cpuProfile).Info("Starting cpu profiling")
-		defer stopProfile(cpuProfile)
 	}
 
 	bpf.CheckOrMountFS("")
@@ -213,9 +211,9 @@ func tetragonExecute() error {
 		<-sigs
 		obs.PrintStats()
 		obs.RemovePrograms()
+		stopProfile()
 		cancel()
 		cancelWg.Wait()
-		stopProfile(cpuProfile)
 		os.Exit(1)
 	}()
 


### PR DESCRIPTION
Adding memprofile option that allows to store go memory profile
into provided file, like:

`  # ./tetragon --memprofile mem.prof`

Tetragon will show the start/stop messagein the log:

```
  time="2022-08-22T23:19:17+02:00" level=info msg="Starting mem profiling" file=prof.mem
  ... 
  time="2022-08-22T23:19:38+02:00" level=info msg="Stopping mem profiling" file=prof.mem

```

you can display the profile in browser with:
`  $ go tool pprof -http=:8080 mem.prof
`

that should spawn new browser tab with memory profile graph
with flamegraph as an option under 'VIEW' menu.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>