### PR TITLE
Do not increase open file descriptors limit

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -39,9 +39,6 @@ jobs:
         cd go/src/github.com/cilium/tetragon/
         make verify
 
-    - name: Increase open file descriptors limit
-      run: echo fs.file-max=1048576 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-
     - name: Run go tests
       env:
         GOPATH: /home/runner/work/tetragon/tetragon/go

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ clean:
 
 .PHONY: test
 test:
-	ulimit -n 1048576 && $(GO) test -p 1 -parallel 1 $(GOFLAGS) -gcflags=$(GO_GCFLAGS) -timeout 20m -failfast -cover ./pkg/... ${EXTRA_TESTFLAGS}
+	$(GO) test -p 1 -parallel 1 $(GOFLAGS) -gcflags=$(GO_GCFLAGS) -timeout 20m -failfast -cover ./pkg/... ${EXTRA_TESTFLAGS}
 
 
 .PHONY: e2e-test


### PR DESCRIPTION
When we are using libbpf we had some issues with open fd when running
unit tests. By moving to cilium/ebpf this should not be still an issue.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>