### PR TITLE
Re-enable copyfd test

### DIFF
--- a/tools/split-tetragon-gotests/main.go
+++ b/tools/split-tetragon-gotests/main.go
@@ -49,8 +49,6 @@ var CiBlacklist = []vmtests.GoTest{
 	// was a previous attempt to fix the test, but failed. Ignore it for
 	// now.
 	{PackageProg: "pkg.exporter"},
-	// https://github.com/cilium/tetragon/issues/247
-	{PackageProg: "pkg.sensors.tracing", Test: "TestCopyFd"},
 }
 
 func usage() {


### PR DESCRIPTION
As https://github.com/cilium/tetragon/issues/247 is resolved, this PR
tries to enable this test again.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>