### PR TITLE
tetragon: Allow retry logic for clone events

### DIFF
--- a/pkg/api/readyapi/readyapi.go
+++ b/pkg/api/readyapi/readyapi.go
@@ -12,6 +12,10 @@ import (
 
 type MsgTetragonReady struct{}
 
+func (msg *MsgTetragonReady) Notify() bool {
+	return false
+}
+
 func (msg *MsgTetragonReady) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
 	return nil, fmt.Errorf("Unsupported cache event MsgTetragonReady")
 }

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -109,13 +109,15 @@ func (ec *Cache) handleEvents() {
 			}
 		}
 
-		processedEvent := &tetragon.GetEventsResponse{
-			Event:    event.event.Encapsulate(),
-			NodeName: nodeName,
-			Time:     ktime.ToProto(event.timestamp),
-		}
+		if event.msg.Notify() {
+			processedEvent := &tetragon.GetEventsResponse{
+				Event:    event.event.Encapsulate(),
+				NodeName: nodeName,
+				Time:     ktime.ToProto(event.timestamp),
+			}
 
-		ec.server.NotifyListeners(event.msg, processedEvent)
+			ec.server.NotifyListeners(event.msg, processedEvent)
+		}
 	}
 	ec.cache = tmp
 }

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -67,6 +67,10 @@ type MsgExecveEventUnix struct {
 	processapi.MsgExecveEventUnix
 }
 
+func (msg *MsgExecveEventUnix) Notify() bool {
+	return true
+}
+
 func (msg *MsgExecveEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
 	return nil, fmt.Errorf("Unreachable state: MsgExecveEventUnix with missing internal")
 }
@@ -142,6 +146,10 @@ type MsgCloneEventUnix struct {
 	processapi.MsgCloneEvent
 }
 
+func (msg *MsgCloneEventUnix) Notify() bool {
+	return false
+}
+
 func (msg *MsgCloneEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
 	return nil, fmt.Errorf("Unreachable state: MsgCloneEventUnix with missing internal")
 }
@@ -205,6 +213,10 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 
 type MsgExitEventUnix struct {
 	tetragonAPI.MsgExitEvent
+}
+
+func (msg *MsgExitEventUnix) Notify() bool {
+	return true
 }
 
 func (msg *MsgExitEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {

--- a/pkg/grpc/test/test.go
+++ b/pkg/grpc/test/test.go
@@ -22,6 +22,10 @@ type MsgTestEventUnix struct {
 	testapi.MsgTestEvent
 }
 
+func (msg *MsgTestEventUnix) Notify() bool {
+	return true
+}
+
 func (msg *MsgTestEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
 	return eventcache.HandleGenericInternal(ev, timestamp)
 }

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -193,6 +193,10 @@ type MsgGenericTracepointUnix struct {
 	Args       []tracingapi.MsgGenericTracepointArg
 }
 
+func (msg *MsgGenericTracepointUnix) Notify() bool {
+	return true
+}
+
 func (msg *MsgGenericTracepointUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
 	return eventcache.HandleGenericInternal(ev, timestamp)
 }
@@ -280,6 +284,10 @@ type MsgGenericKprobeUnix struct {
 	Action       uint64
 	FuncName     string
 	Args         []tracingapi.MsgGenericKprobeArg
+}
+
+func (msg *MsgGenericKprobeUnix) Notify() bool {
+	return true
 }
 
 func (msg *MsgGenericKprobeUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -268,12 +268,12 @@ func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 }
 
 // AddCloneEvent adds a new process into the cache from a CloneEvent
-func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) {
+func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 	parentExecId := GetProcessID(event.Parent.Pid, event.Parent.Ktime)
 	parent, err := Get(parentExecId)
 	if err != nil {
 		logger.GetLogger().WithField("parent-exec-id", parentExecId).Debug("AddCloneEvent: process not found in cache")
-		return
+		return err
 	}
 	pi := parent.GetProcessInternalCopy()
 	if pi.process != nil {
@@ -288,6 +288,7 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) {
 		}
 	}
 	procCache.Add(pi)
+	return nil
 }
 
 func Get(execId string) (*ProcessInternal, error) {

--- a/pkg/reader/notify/notify.go
+++ b/pkg/reader/notify/notify.go
@@ -12,6 +12,7 @@ type Message interface {
 	HandleMessage() *tetragon.GetEventsResponse
 	RetryInternal(Event, uint64) (*process.ProcessInternal, error)
 	Retry(*process.ProcessInternal, Event) error
+	Notify() bool
 }
 
 type Event interface {


### PR DESCRIPTION
The AddCloneEvent fails to add process the the cache if
the parent does not exist - there's no record of it. 

This can happen for example in TestFork test where fork events
can be delievered out of order and tetragon sees the child fork
event before the parent's one.

Adding retry logic for clone events, which will retry the fork
event processing and adding the hild process entry after the 
timeout. During the timeout the parent is updated and following
retry logic will add the child's entry properly.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
