### PR TITLE
Dockerfile.golangci-lint: remove hubble-libbpf use

### DIFF
--- a/Dockerfile.golangci-lint
+++ b/Dockerfile.golangci-lint
@@ -1,14 +1,4 @@
-FROM ubuntu:21.04 as libbtf
-RUN apt-get -y install
-
-FROM quay.io/isovalent/hubble-libbpf:v0.2.2 as hubble-libbpf
-WORKDIR /go/src/github.com/cilium/tetragon
-
 FROM docker.io/golangci/golangci-lint:v1.45.2
-COPY --from=hubble-libbpf /go/src/github.com/covalentio/hubble-fgs/src/*.h /usr/include/
-COPY --from=hubble-libbpf /go/src/github.com/covalentio/hubble-fgs/src/*.a /usr/local/lib
-COPY --from=hubble-libbpf /go/src/github.com/covalentio/hubble-fgs/src/*.so /usr/local/lib
-COPY --from=hubble-libbpf /go/src/github.com/covalentio/hubble-fgs/src/*.so.* /usr/local/lib
 RUN apt-get -y update
 RUN apt-get -y install libz-dev libelf-dev
 


### PR DESCRIPTION
hubble-libbpf is not needed since we moved to cilium/ebpf.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>