### PR TITLE
tetragon: Switch to BTF defined maps

### DIFF
--- a/bpf/lib/bpf_helpers.h
+++ b/bpf/lib/bpf_helpers.h
@@ -116,4 +116,11 @@ static inline void compiler_barrier(void)
 {
 	asm volatile("" ::: "memory");
 }
+
+#define __uint(name, val)  int(*name)[val]
+#define __type(name, val)  typeof(val) *name
+#define __array(name, val) typeof(val) *name[]
+
+#define SEC(name) __attribute__((section(name), used))
+
 #endif //__BPF_HELPERS_

--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -57,11 +57,16 @@ struct sched_execve_args {
 };
 
 #ifndef ALIGNCHECKER
-struct bpf_map_def __attribute__((section("maps"), used)) names_map = {
-	.type = BPF_MAP_TYPE_HASH,
-	.key_size = sizeof(char) * 256,
-	.value_size = sizeof(__u32),
-	.max_entries = 64,
+struct names_map_key {
+	char path[256];
 };
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 64);
+	__type(key, struct names_map_key);
+	__type(value, __u32);
+} names_map SEC(".maps");
+
 #endif // ALIGNCHECKER
 #endif // _GENERIC__

--- a/bpf/lib/hubble_msg.h
+++ b/bpf/lib/hubble_msg.h
@@ -18,9 +18,10 @@ struct event {
 	int event;
 };
 
-struct bpf_map_def __attribute__((section("maps"), used)) tcpmon_map = {
-	.type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,
-	.key_size = sizeof(int),
-	.value_size = sizeof(struct event),
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__type(key, int);
+	__type(value, struct event);
+} tcpmon_map SEC(".maps");
+
 #endif // __HUBBLE_MSG_

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -275,34 +275,33 @@ struct execve_map_value {
 	struct msg_capabilities caps;
 } __attribute__((packed)) __attribute__((aligned(8)));
 
-struct bpf_map_def __attribute__((section("maps"), used))
-execve_msg_heap_map = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(__u32),
-	.value_size = sizeof(struct msg_execve_event),
-	.max_entries = 1,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct msg_execve_event);
+} execve_msg_heap_map SEC(".maps");
 
-struct bpf_map_def __attribute__((section("maps"), used)) execve_map = {
-	.type = BPF_MAP_TYPE_HASH,
-	.key_size = sizeof(__u32),
-	.value_size = sizeof(struct execve_map_value),
-	.max_entries = 32768,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 32768);
+	__type(key, __u32);
+	__type(value, struct execve_map_value);
+} execve_map SEC(".maps");
 
-struct bpf_map_def __attribute__((section("maps"), used)) execve_map_stats = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(__s32),
-	.value_size = sizeof(__s64),
-	.max_entries = 1,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __s32);
+	__type(value, __s64);
+} execve_map_stats SEC(".maps");
 
-struct bpf_map_def __attribute__((section("maps"), used)) execve_val = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(__s32),
-	.value_size = sizeof(struct execve_map_value),
-	.max_entries = 1,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __s32);
+	__type(value, struct execve_map_value);
+} execve_val SEC(".maps");
 
 struct execve_heap {
 	union {
@@ -311,12 +310,12 @@ struct execve_heap {
 	};
 };
 
-struct bpf_map_def __attribute__((section("maps"), used)) execve_heap = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(__s32),
-	.value_size = sizeof(struct execve_heap),
-	.max_entries = 1,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __s32);
+	__type(value, struct execve_heap);
+} execve_heap SEC(".maps");
 
 static inline __attribute__((always_inline)) int64_t
 validate_msg_execve_size(int64_t size)

--- a/bpf/process/bpf_exit.h
+++ b/bpf/process/bpf_exit.h
@@ -7,12 +7,12 @@
 #include "hubble_msg.h"
 #include "bpf_events.h"
 
-struct bpf_map_def __attribute__((section("maps"), used)) exit_heap_map = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(int),
-	.value_size = sizeof(struct msg_exit),
-	.max_entries = 1,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct msg_exit);
+} exit_heap_map SEC(".maps");
 
 static inline __attribute__((always_inline)) void
 event_exit_send(struct sched_execve_args *ctx, __u64 current)

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -14,19 +14,19 @@
 
 char _license[] __attribute__((section("license"), used)) = "GPL";
 
-struct bpf_map_def __attribute__((section("maps"), used)) process_call_heap = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(__u32),
-	.value_size = sizeof(struct msg_generic_kprobe),
-	.max_entries = 1,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct msg_generic_kprobe);
+} process_call_heap SEC(".maps");
 
-struct bpf_map_def __attribute__((section("maps"), used)) config_map = {
-	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(int),
-	.value_size = sizeof(struct event_config),
-	.max_entries = 1,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct event_config);
+} config_map SEC(".maps");
 
 __attribute__((section("kprobe/generic_retkprobe"), used)) int
 BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -12,34 +12,38 @@
 #include "generic_calls.h"
 #include "pfilter.h"
 
-struct bpf_map_def __attribute__((section("maps"), used)) tp_calls = {
-	.type = BPF_MAP_TYPE_PROG_ARRAY,
-	.key_size = sizeof(__u32),
-	.value_size = sizeof(__u32),
-	.max_entries = 11,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(max_entries, 11);
+	__type(key, __u32);
+	__type(value, __u32);
+} tp_calls SEC(".maps");
 
-struct bpf_map_def __attribute__((section("maps"), used)) tp_heap = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(__u32),
-	.value_size = sizeof(struct msg_generic_kprobe),
-	.max_entries = 1,
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct msg_generic_kprobe);
+} tp_heap SEC(".maps");
+
+struct filter_map_value {
+	unsigned char buf[FILTER_SIZE];
 };
 
 /* Arrays of size 1 will be rewritten to direct loads in verifier */
-struct bpf_map_def __attribute__((section("maps"), used)) filter_map = {
-	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(int),
-	.value_size = FILTER_SIZE,
-	.max_entries = 1,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct filter_map_value);
+} filter_map SEC(".maps");
 
-struct bpf_map_def __attribute__((section("maps"), used)) config_map = {
-	.type = BPF_MAP_TYPE_ARRAY,
-	.key_size = sizeof(int),
-	.value_size = sizeof(struct event_config),
-	.max_entries = 1,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct event_config);
+} config_map SEC(".maps");
 
 struct generic_tracepoint_event_arg {
 	/* common header */
@@ -167,36 +171,46 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 __attribute__((section("tracepoint/0"), used)) int
 generic_tracepoint_event0(void *ctx)
 {
-	return generic_process_event0(ctx, &tp_heap, &filter_map, &tp_calls,
-				      &config_map);
+	return generic_process_event0(ctx, (struct bpf_map_def *)&tp_heap,
+				      (struct bpf_map_def *)&filter_map,
+				      (struct bpf_map_def *)&tp_calls,
+				      (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/1"), used)) int
 generic_tracepoint_event1(void *ctx)
 {
-	return generic_process_event1(ctx, &tp_heap, &filter_map, &tp_calls,
-				      &config_map);
+	return generic_process_event1(ctx, (struct bpf_map_def *)&tp_heap,
+				      (struct bpf_map_def *)&filter_map,
+				      (struct bpf_map_def *)&tp_calls,
+				      (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/2"), used)) int
 generic_tracepoint_event2(void *ctx)
 {
-	return generic_process_event2(ctx, &tp_heap, &filter_map, &tp_calls,
-				      &config_map);
+	return generic_process_event2(ctx, (struct bpf_map_def *)&tp_heap,
+				      (struct bpf_map_def *)&filter_map,
+				      (struct bpf_map_def *)&tp_calls,
+				      (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/3"), used)) int
 generic_tracepoint_event3(void *ctx)
 {
-	return generic_process_event3(ctx, &tp_heap, &filter_map, &tp_calls,
-				      &config_map);
+	return generic_process_event3(ctx, (struct bpf_map_def *)&tp_heap,
+				      (struct bpf_map_def *)&filter_map,
+				      (struct bpf_map_def *)&tp_calls,
+				      (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/4"), used)) int
 generic_tracepoint_event4(void *ctx)
 {
-	return generic_process_event4(ctx, &tp_heap, &filter_map, &tp_calls,
-				      &config_map);
+	return generic_process_event4(ctx, (struct bpf_map_def *)&tp_heap,
+				      (struct bpf_map_def *)&filter_map,
+				      (struct bpf_map_def *)&tp_calls,
+				      (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/5"), used)) int
@@ -223,36 +237,46 @@ generic_tracepoint_filter(void *ctx)
 __attribute__((section("tracepoint/6"), used)) int
 generic_tracepoint_arg1(void *ctx)
 {
-	return filter_read_arg(ctx, 0, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0, &config_map);
+	return filter_read_arg(ctx, 0, (struct bpf_map_def *)&tp_heap,
+			       (struct bpf_map_def *)&filter_map,
+			       (struct bpf_map_def *)&tp_calls, (void *)0,
+			       (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/7"), used)) int
 generic_tracepoint_arg2(void *ctx)
 {
-	return filter_read_arg(ctx, 1, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0, &config_map);
+	return filter_read_arg(ctx, 1, (struct bpf_map_def *)&tp_heap,
+			       (struct bpf_map_def *)&filter_map,
+			       (struct bpf_map_def *)&tp_calls, (void *)0,
+			       (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/8"), used)) int
 generic_tracepoint_arg3(void *ctx)
 {
-	return filter_read_arg(ctx, 2, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0, &config_map);
+	return filter_read_arg(ctx, 2, (struct bpf_map_def *)&tp_heap,
+			       (struct bpf_map_def *)&filter_map,
+			       (struct bpf_map_def *)&tp_calls, (void *)0,
+			       (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/9"), used)) int
 generic_tracepoint_arg4(void *ctx)
 {
-	return filter_read_arg(ctx, 3, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0, &config_map);
+	return filter_read_arg(ctx, 3, (struct bpf_map_def *)&tp_heap,
+			       (struct bpf_map_def *)&filter_map,
+			       (struct bpf_map_def *)&tp_calls, (void *)0,
+			       (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/10"), used)) int
 generic_tracepoint_arg5(void *ctx)
 {
-	return filter_read_arg(ctx, 4, &tp_heap, &filter_map, &tp_calls,
-			       (void *)0, &config_map);
+	return filter_read_arg(ctx, 4, (struct bpf_map_def *)&tp_heap,
+			       (struct bpf_map_def *)&filter_map,
+			       (struct bpf_map_def *)&tp_calls, (void *)0,
+			       (struct bpf_map_def *)&config_map);
 }
 
 char _license[] __attribute__((section("license"), used)) = "GPL";

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -4,14 +4,20 @@
 #ifndef _BPF_PROCESS_EVENT__
 #define _BPF_PROCESS_EVENT__
 
+#include "bpf_helpers.h"
+
 #define ENAMETOOLONG 36 /* File name too long */
 
-struct bpf_map_def __attribute__((section("maps"), used)) buffer_heap_map = {
-	.type = BPF_MAP_TYPE_PERCPU_ARRAY,
-	.key_size = sizeof(int),
-	.value_size = PATH_MAP_SIZE * sizeof(char),
-	.max_entries = 1,
+struct buffer_heap_map_value {
+	unsigned char buf[PATH_MAP_SIZE];
 };
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct buffer_heap_map_value);
+} buffer_heap_map SEC(".maps");
 
 static inline __attribute__((always_inline)) __u64
 __get_auid(struct task_struct *task)

--- a/bpf/process/retprobe_map.h
+++ b/bpf/process/retprobe_map.h
@@ -7,12 +7,12 @@ struct retprobe_info {
 	unsigned long cnt;
 };
 
-struct bpf_map_def __attribute__((section("maps"), used)) retprobe_map = {
-	.type = BPF_MAP_TYPE_HASH,
-	.key_size = sizeof(__u64),
-	.value_size = sizeof(struct retprobe_info),
-	.max_entries = 1024,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, __u64);
+	__type(value, struct retprobe_info);
+} retprobe_map SEC(".maps");
 
 static inline __attribute__((always_inline)) unsigned long
 retprobe_map_get(__u64 tid, unsigned long *cntp)

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -943,12 +943,12 @@ struct fdinstall_value {
 	char file[264]; // 256B paths + 4B length + 4B flags
 };
 
-struct bpf_map_def __attribute__((section("maps"), used)) fdinstall_map = {
-	.type = BPF_MAP_TYPE_LRU_HASH,
-	.key_size = sizeof(struct fdinstall_key),
-	.value_size = sizeof(struct fdinstall_value),
-	.max_entries = 32000,
-};
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 32000);
+	__type(key, struct fdinstall_key);
+	__type(value, struct fdinstall_value);
+} fdinstall_map SEC(".maps");
 
 static inline __attribute__((always_inline)) int
 installfd(struct msg_generic_kprobe *e, int fd, int name, bool follow)


### PR DESCRIPTION
Switching to BTF defined maps. This allows to dump map values nicely, like:


```
# bpftool map dump pinned execve_map | head -10
[{
        "key": 431671,
        "value": {
            "key": {
                "pid": 431671,
                "pad": [0,0,0,0
                ],
                "ktime": 171231811545404
            },
            "pkey": {
...
```
Signed-off-by: Jiri Olsa <jolsa@kernel.org>
