### PR TITLE
cgroups: select which cgroup hierarchy and subsystem state to use

### DIFF
--- a/bpf/include/vmlinux.h
+++ b/bpf/include/vmlinux.h
@@ -6434,6 +6434,21 @@ struct kernfs_node {
 	struct kernfs_iattrs *iattr;
 };
 
+/* Represent old kernfs node present in 5.4 kernels and older */
+union kernfs_node_id {
+	struct {
+		/*
+		 * blktrace will export this struct as a simplified 'struct
+		 * fid' (which is a big data struction), so userspace can use
+		 * it to find kernfs node. The layout must match the first two
+		 * fields of 'struct fid' exactly.
+		 */
+		u32 ino;
+		u32 generation;
+	};
+	u64 id;
+};
+
 struct kernfs_open_file;
 
 struct kernfs_ops {

--- a/bpf/include/vmlinux.h
+++ b/bpf/include/vmlinux.h
@@ -17203,8 +17203,12 @@ enum cgroup_subsys_id {
 	net_cls_cgrp_id = 7,
 	perf_event_cgrp_id = 8,
 	net_prio_cgrp_id = 9,
-	pids_cgrp_id = 10,
-	CGROUP_SUBSYS_COUNT = 11,
+	hugetlb_cgrp_id = 10,
+	pids_cgrp_id = 11,
+	rdma_cgrp_id = 12,
+	misc_cgrp_id = 13,
+	debug_cgrp_id = 14,
+	CGROUP_SUBSYS_COUNT = 15,
 };
 
 typedef u8 kprobe_opcode_t;

--- a/bpf/lib/bpf_cgroup.h
+++ b/bpf/lib/bpf_cgroup.h
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Tetragon */
+
+#ifndef __BPF_CGROUP_
+#define __BPF_CGROUP_
+
+#include "hubble_msg.h"
+#include "bpf_helpers.h"
+#include "environ_conf.h"
+
+#define NULL ((void *)0)
+
+/* Our kernfs node name length, can be made 256? */
+#define KN_NAME_LENGTH 128
+
+/* Represent old kernfs node with the kernfs_node_id
+ * union to read the id in 5.4 kernels and older
+ */
+struct kernfs_node___old {
+	union kernfs_node_id id;
+};
+
+/**
+ * get_cgroup_kn_name() Returns a pointer to the kernfs node name
+ * @cgrp: target kernfs node
+ *
+ * Returns a pointer to the kernfs node name on success, NULL on failures.
+ */
+static inline __attribute__((always_inline)) const char *
+__get_cgroup_kn_name(const struct kernfs_node *kn)
+{
+	const char *name = NULL;
+
+	if (kn)
+		probe_read(&name, sizeof(name), _(&kn->name));
+
+	return name;
+}
+
+/**
+ * get_cgroup_kn_id() Returns the kernfs node id
+ * @cgrp: target kernfs node
+ *
+ * Returns the kernfs node id on success, zero on failures.
+ */
+static inline __attribute__((always_inline)) __u64
+__get_cgroup_kn_id(const struct kernfs_node *kn)
+{
+	__u64 id = 0;
+	struct kernfs_node___old *old_kn;
+
+	if (!kn)
+		return id;
+
+	/* Kernels prior to 5.5 have the kernfs_node_id */
+	if (!bpf_core_type_exists(union kernfs_node_id)) {
+		probe_read(&id, sizeof(id), _(&kn->id));
+	} else {
+		old_kn = (void *)kn;
+		if (BPF_CORE_READ_INTO(&id, old_kn, id.id) != 0)
+			return 0;
+	}
+
+	return id;
+}
+
+/**
+ * __get_cgroup_kn() Returns the kernfs_node of the cgroup
+ * @cgrp: target cgroup
+ *
+ * Returns the kernfs_node of the cgroup on success, NULL on failures.
+ */
+static inline __attribute__((always_inline)) struct kernfs_node *
+__get_cgroup_kn(const struct cgroup *cgrp)
+{
+	struct kernfs_node *kn = NULL;
+
+	if (cgrp)
+		probe_read(&kn, sizeof(cgrp->kn), _(&cgrp->kn));
+
+	return kn;
+}
+
+/**
+ * get_cgroup_hierarchy_id() Returns the cgroup hierarchy id
+ * @cgrp: target cgroup
+ *
+ * Returns the cgroup hierarchy id. Make sure you pass a valid
+ * cgroup, this can not fail.
+ *
+ * Returning zero means the cgroup is running on the default
+ * hierarchy.
+ */
+static inline __attribute__((always_inline)) __u32
+get_cgroup_hierarchy_id(const struct cgroup *cgrp)
+{
+	__u32 id;
+
+	BPF_CORE_READ_INTO(&id, cgrp, root, hierarchy_id);
+
+	return id;
+}
+
+/**
+ * get_cgroup_name() Returns a pointer to the cgroup name
+ * @cgrp: target cgroup
+ *
+ * Returns a pointer to the cgroup node name on success that can
+ * be read with probe_read(). NULL on failures.
+ */
+static inline __attribute__((always_inline)) const char *
+get_cgroup_name(const struct cgroup *cgrp)
+{
+	const char *name;
+
+	if (unlikely(!cgrp))
+		return NULL;
+
+	if (BPF_CORE_READ_INTO(&name, cgrp, kn, name) != 0)
+		return NULL;
+
+	return name;
+}
+
+/**
+ * get_cgroup_id() Returns cgroup id
+ * @cgrp: target cgroup
+ *
+ * Returns the cgroup id of the target cgroup on success, zero on failures.
+ */
+static inline __attribute__((always_inline)) __u64
+get_cgroup_id(const struct cgroup *cgrp)
+{
+	struct kernfs_node *kn;
+
+	kn = __get_cgroup_kn(cgrp);
+	return __get_cgroup_kn_id(kn);
+}
+
+/**
+ * get_task_cgroup() Returns the accurate or desired cgroup of the css of
+ *    current task that we want to operate on.
+ * @task: must be current task.
+ * @subsys_idx: index of the desired cgroup_subsys_state part of css_set.
+ *    Passing a zero as a subsys_idx is fine assuming you want that.
+ *
+ * Returns the cgroup of the css part of css_set of current task and is
+ * indexed at subsys_idx on success, NULL on failures.
+ *
+ * To get cgroup and kernfs node information we want to operate on the right
+ * cgroup hierarchy which is setup by user space. However due to the
+ * incompatiblity between cgroup v1 and v2; how user space initialize and
+ * install cgroup controllers, etc, it can be difficult.
+ *
+ * Use this helper and pass the css index that you consider accurate and
+ * which can be discovered at runtime in user space.
+ * Usually it is the 'memory' or 'pids' indexes by reading /proc/cgroups
+ * file where each line number is the index starting from zero without
+ * counting first comment line.
+ */
+static inline __attribute__((always_inline)) struct cgroup *
+get_task_cgroup(struct task_struct *task, __u32 subsys_idx)
+{
+	struct cgroup_subsys_state *subsys;
+	struct css_set *cgroups;
+	struct cgroup *cgrp = NULL;
+
+	probe_read(&cgroups, sizeof(cgroups), _(&task->cgroups));
+	if (unlikely(!cgroups))
+		return cgrp;
+
+	/* We are interested only in the cpuset, memory or pids controllers
+	 * which are indexed at 0, 4 and 11 respectively assuming all controllers
+	 * are compiled in.
+	 * When we use the controllers indexes we will first discover these indexes
+	 * dynamically in user space which will work on all setups from reading
+	 * file: /proc/cgroups. If we fail to discover the indexes then passing
+	 * a default index zero should be fine assuming we also want that.
+	 *
+	 * Reference: https://elixir.bootlin.com/linux/v5.19/source/include/linux/cgroup_subsys.h
+	 *
+	 * Notes:
+	 * Newer controllers should be appended at the end. controllers
+	 * that are not upstreamed may mess the calculation here
+	 * especially if they happen to be before the desired subsys_idx,
+	 * we fail.
+	 */
+	if (unlikely(subsys_idx > pids_cgrp_id))
+		return cgrp;
+
+	/* Read css from the passed subsys index to ensure that we operate
+	 * on the desired controller. This allows user space to be flexible
+	 * and chose the right per cgroup subsystem to use in order to
+	 * support as much as workload as possible. It also reduces errors
+	 * in a significant way.
+	 */
+	probe_read(&subsys, sizeof(subsys), _(&cgroups->subsys[subsys_idx]));
+	if (unlikely(!subsys))
+		return cgrp;
+
+	probe_read(&cgrp, sizeof(cgrp), _(&subsys->cgroup));
+	return cgrp;
+}
+
+#endif // __BPF_CGROUP_

--- a/bpf/lib/environ_conf.h
+++ b/bpf/lib/environ_conf.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Tetragon */
+
+#ifndef __ENVIRON_CONF_
+#define __ENVIRON_CONF_
+
+/* Tetragon runtime configuration */
+struct tetragon_conf {
+	__u32 tg_cgrp_hierarchy; /* Tetragon tracked hierarchy ID */
+	__u32 tg_cgrp_subsys_idx; /* Tetragon tracked cgroup subsystem state index at compile time */
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1);
+	__type(key, __s32);
+	__type(value, struct tetragon_conf);
+} tg_conf_map SEC(".maps");
+
+#endif // __ENVIRON_CONF_

--- a/bpf/libbpf/bpf_core_read.h
+++ b/bpf/libbpf/bpf_core_read.h
@@ -19,6 +19,13 @@ enum bpf_field_info_kind {
 	BPF_FIELD_RSHIFT_U64 = 5,
 };
 
+/* second argument to __builtin_preserve_type_info() built-in */
+enum bpf_type_info_kind {
+	BPF_TYPE_EXISTS = 0,		/* type existence in target kernel */
+	BPF_TYPE_SIZE = 1,		/* type size in target kernel */
+	BPF_TYPE_MATCHES = 2,		/* type match in target kernel */
+};
+
 #define __CORE_RELO(src, field, info)					      \
 	__builtin_preserve_field_info((src)->field, BPF_FIELD_##info)
 
@@ -97,6 +104,16 @@ enum bpf_field_info_kind {
  */
 #define bpf_core_field_size(field)					    \
 	__builtin_preserve_field_info(field, BPF_FIELD_BYTE_SIZE)
+
+/*
+ * Convenience macro to check that provided named type
+ * (struct/union/enum/typedef) exists in a target kernel.
+ * Returns:
+ *    1, if such type is present in target kernel's BTF;
+ *    0, if no matching type is found.
+ */
+#define bpf_core_type_exists(type)					    \
+	__builtin_preserve_type_info(*(typeof(type) *)0, BPF_TYPE_EXISTS)
 
 /*
  * bpf_core_read() abstracts away bpf_probe_read() call and captures offset

--- a/pkg/api/confapi/confapi.go
+++ b/pkg/api/confapi/confapi.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package confapi
+
+type TetragonConf struct {
+	TgCgrpHierarchy uint32 `align:"tg_cgrp_hierarchy"`  // Tetragon Cgroup tracking hierarchy ID
+	TgCgrpSubsysIdx uint32 `align:"tg_cgrp_subsys_idx"` // Tracking Cgroup css idx at compile time
+}

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -1,0 +1,664 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build linux
+// +build linux
+
+package cgroups
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/tetragon/pkg/defaults"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// Generic unset value that means undefined or not set
+	CGROUP_UNSET_VALUE = 0
+
+	// Max cgroup subsystems count that is used from BPF side
+	// to define a max index for the default controllers on tasks.
+	// For further documentation check BPF part.
+	CGROUP_SUBSYS_COUNT = 15
+
+	// The default hierarchy for cgroupv2
+	CGROUP_DEFAULT_HIERARCHY = 0
+)
+
+type CgroupModeCode int
+
+const (
+	/* Cgroup Mode:
+	 * https://systemd.io/CGROUP_DELEGATION/
+	 * But this should work also for non-systemd environments: where
+	 * only legacy or unified are available by default.
+	 */
+	CGROUP_UNDEF   CgroupModeCode = iota
+	CGROUP_LEGACY  CgroupModeCode = 1
+	CGROUP_HYBRID  CgroupModeCode = 2
+	CGROUP_UNIFIED CgroupModeCode = 3
+)
+
+type DeploymentCode int
+
+type deploymentEnv struct {
+	id  DeploymentCode
+	str string
+}
+
+const (
+	// Deployment modes
+	DEPLOY_UNKNOWN    DeploymentCode = iota
+	DEPLOY_K8S        DeploymentCode = 1  // K8s deployment
+	DEPLOY_CONTAINER  DeploymentCode = 2  // Container docker, podman, etc
+	DEPLOY_SD_SERVICE DeploymentCode = 10 // Systemd service
+	DEPLOY_SD_USER    DeploymentCode = 11 // Systemd user session
+)
+
+type cgroupController struct {
+	id     uint32 // Hierarchy unique ID
+	idx    uint32 // Cgroup SubSys index
+	name   string // Controller name
+	active bool   // Will be set to true if controller is set and active
+}
+
+var (
+	// Path where default cgroupfs is mounted
+	defaultCgroupRoot = "/sys/fs/cgroup"
+
+	/* Cgroup controllers that we are interested in
+	 * are usually the ones that are setup by systemd
+	 * or other init programs.
+	 */
+	cgroupControllers = []cgroupController{
+		{name: "memory"}, // Memory first
+		{name: "pids"},   // pids second
+		{name: "cpuset"}, // fallback
+	}
+
+	cgroupv2Hierarchy = "0::"
+
+	/* Ordered from nested to top cgroup parents
+	 * For k8s we check also config k8s flags.
+	 */
+	deployments = []deploymentEnv{
+		{id: DEPLOY_K8S, str: "kube"},
+		{id: DEPLOY_CONTAINER, str: "docker"},
+		{id: DEPLOY_CONTAINER, str: "podman"},
+		{id: DEPLOY_CONTAINER, str: "libpod"},
+		{id: DEPLOY_SD_SERVICE, str: "system.slice"},
+		{id: DEPLOY_SD_USER, str: "user.slice"},
+	}
+
+	detectDeploymentOnce sync.Once
+	deploymentMode       DeploymentCode
+
+	detectCgrpModeOnce sync.Once
+	cgroupMode         CgroupModeCode
+
+	detectCgroupFSOnce sync.Once
+	cgroupFSPath       string
+	cgroupFSMagic      uint64
+
+	// Cgroup Migration Path
+	findMigPath       sync.Once
+	cgrpMigrationPath string
+
+	// Cgroup Tracking Hierarchy
+	cgrpHierarchy    uint32
+	cgrpSubsystemIdx uint32
+)
+
+func (code CgroupModeCode) String() string {
+	return [...]string{
+		CGROUP_UNDEF:   "undefined",
+		CGROUP_LEGACY:  "Legacy mode (Cgroupv1)",
+		CGROUP_HYBRID:  "Hybrid mode (Cgroupv1 and Cgroupv2)",
+		CGROUP_UNIFIED: "Unified mode (Cgroupv2)",
+	}[code]
+}
+
+func (op DeploymentCode) String() string {
+	return [...]string{
+		DEPLOY_UNKNOWN:    "unknown",
+		DEPLOY_K8S:        "Kubernetes",
+		DEPLOY_CONTAINER:  "Container",
+		DEPLOY_SD_SERVICE: "systemd service",
+		DEPLOY_SD_USER:    "systemd user session",
+	}[op]
+}
+
+// DetectCgroupFSMagic() runs by default DetectCgroupMode()
+// CgroupFsMagicStr() Returns "Cgroupv2" or "Cgroupv1" based on passed magic.
+func CgroupFsMagicStr(magic uint64) string {
+	if magic == unix.CGROUP2_SUPER_MAGIC {
+		return "Cgroupv2"
+	} else if magic == unix.CGROUP_SUPER_MAGIC {
+		return "Cgroupv1"
+	}
+
+	return ""
+}
+
+func GetCgroupFSMagic() uint64 {
+	return cgroupFSMagic
+}
+
+// DiscoverSubSysIds() Discover Cgroup SubSys IDs and indexes.
+// of the corresponding controllers that we are interested
+// in. We need this dynamic behavior since these controllers are
+// compile config.
+func DiscoverSubSysIds() error {
+	var allcontrollers []string
+
+	path := filepath.Join(option.Config.ProcFS, "cgroups")
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	fscanner := bufio.NewScanner(file)
+	fixed := false
+	idx := 0
+	fscanner.Scan() // ignore first entry
+	for fscanner.Scan() {
+		line := fscanner.Text()
+		fields := strings.Fields(line)
+
+		allcontrollers = append(allcontrollers, fields[0])
+
+		// No need to read enabled field as it can be enabled on
+		// root without having a proper cgroup name to reflect that
+		// or the controller is not active on the unified cgroupv2.
+		for i, controller := range cgroupControllers {
+			if fields[0] == controller.name {
+				/* We care only for the controllers that we want */
+				if idx >= CGROUP_SUBSYS_COUNT {
+					/* Maybe some cgroups are not upstream? */
+					return fmt.Errorf("Cgroup default subsystem '%s' is indexed at idx=%d higher than CGROUP_SUBSYS_COUNT=%d",
+						fields[0], idx, CGROUP_SUBSYS_COUNT)
+				}
+
+				id, err := strconv.ParseUint(fields[1], 10, 32)
+				if err == nil {
+					cgroupControllers[i].id = uint32(id)
+					cgroupControllers[i].idx = uint32(idx)
+					cgroupControllers[i].active = true
+					fixed = true
+				} else {
+					logger.GetLogger().WithFields(logrus.Fields{
+						"cgroup.fs":              cgroupFSPath,
+						"cgroup.controller.name": controller.name,
+					}).WithError(err).Warnf("parsing controller line from '%s' failed", path)
+				}
+			}
+		}
+		idx++
+	}
+
+	logger.GetLogger().WithFields(logrus.Fields{
+		"cgroup.fs":          cgroupFSPath,
+		"cgroup.controllers": fmt.Sprintf("[%s]", strings.Join(allcontrollers, " ")),
+	}).Debugf("Cgroup available controllers")
+
+	// Could not find 'memory', 'pids' nor 'cpuset' controllers, are they compiled in?
+	if fixed == false {
+		err = fmt.Errorf("detect cgroup controllers IDs from '%s' failed", path)
+		logger.GetLogger().WithFields(logrus.Fields{
+			"cgroup.fs": cgroupFSPath,
+		}).WithError(err).Warnf("Cgroup controllers 'memory', 'pids' and 'cpuset' are missing")
+		return err
+	}
+
+	for _, controller := range cgroupControllers {
+		// Print again everything that is available or not
+		if controller.active {
+			logger.GetLogger().WithFields(logrus.Fields{
+				"cgroup.fs":                     cgroupFSPath,
+				"cgroup.controller.name":        controller.name,
+				"cgroup.controller.hierarchyID": controller.id,
+				"cgroup.controller.index":       controller.idx,
+			}).Infof("Supported cgroup controller '%s' is active on the system", controller.name)
+		} else {
+			// Warn with error
+			err = fmt.Errorf("controller '%s' is not active", controller.name)
+			logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warnf("Supported cgroup controller '%s' is not active", controller.name)
+		}
+	}
+
+	return nil
+}
+
+func setDeploymentMode(cgroupPath string) error {
+	if deploymentMode != DEPLOY_UNKNOWN {
+		return nil
+	}
+
+	if option.Config.EnableK8s == true {
+		deploymentMode = DEPLOY_K8S
+		return nil
+	}
+
+	if cgroupPath == "" {
+		// Probably namespaced
+		deploymentMode = DEPLOY_CONTAINER
+		return nil
+	}
+
+	// Last go through the deployments
+	for _, d := range deployments {
+		if strings.Contains(cgroupPath, d.str) {
+			deploymentMode = d.id
+			return nil
+		}
+	}
+
+	return fmt.Errorf("detect deployment mode failed, no match on Cgroup path '%s'", cgroupPath)
+}
+
+func getDeploymentMode() DeploymentCode {
+	return deploymentMode
+}
+
+func GetDeploymentMode() uint32 {
+	return uint32(getDeploymentMode())
+}
+
+func GetCgroupMode() CgroupModeCode {
+	return cgroupMode
+}
+
+func setCgrpHierarchyID(controller *cgroupController) {
+	cgrpHierarchy = controller.id
+}
+
+func setCgrp2HierarchyID() {
+	cgrpHierarchy = CGROUP_DEFAULT_HIERARCHY
+}
+
+func setCgrpSubsystemIdx(controller *cgroupController) {
+	cgrpSubsystemIdx = controller.idx
+}
+
+// GetCgrpHierarchyID() returns the ID of the Cgroup hierarchy
+// that is used to track processes. This is used for Cgroupv1 as for
+// Cgroupv2 we run in the default hierarchy.
+func GetCgrpHierarchyID() uint32 {
+	return cgrpHierarchy
+}
+
+// GetCgrpSubsystemIdx() returns the Index of the subsys
+// or hierarchy to be used to track processes.
+func GetCgrpSubsystemIdx() uint32 {
+	return cgrpSubsystemIdx
+}
+
+// GetCgrpControllerName() returns the name of the controller that is
+// being used as fallback from the css to get cgroup information and
+// track processes.
+func GetCgrpControllerName() string {
+	for _, controller := range cgroupControllers {
+		if controller.active && controller.idx == cgrpSubsystemIdx {
+			return controller.name
+		}
+	}
+	return ""
+}
+
+// Validates cgroupPaths obtained from /proc/self/cgroup based on Cgroupv1
+// and returns it on success
+func getValidCgroupv1Path(cgroupPaths []string) (string, error) {
+	for _, controller := range cgroupControllers {
+		// First lets go again over list of active controllers
+		if controller.active == false {
+			logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).Debugf("Cgroup controller '%s' is not active", controller.name)
+			continue
+		}
+
+		for _, s := range cgroupPaths {
+			if strings.Contains(s, fmt.Sprintf(":%s:", controller.name)) {
+				idx := strings.Index(s, "/")
+				path := s[idx+1:]
+				cgroupPath := filepath.Join(cgroupFSPath, controller.name, path)
+				finalpath := filepath.Join(cgroupPath, "cgroup.procs")
+				_, err := os.Stat(finalpath)
+				if err != nil {
+					// Probably namespaced... run the deployment mode detection
+					err = setDeploymentMode(path)
+					if err == nil {
+						mode := getDeploymentMode()
+						if mode == DEPLOY_K8S || mode == DEPLOY_CONTAINER {
+							// Cgroups are namespaced let's try again
+							cgroupPath = filepath.Join(cgroupFSPath, controller.name)
+							finalpath = filepath.Join(cgroupPath, "cgroup.procs")
+							_, err = os.Stat(finalpath)
+						}
+					}
+				}
+
+				if err != nil {
+					logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warnf("Failed to validate Cgroupv1 path '%s'", finalpath)
+					continue
+				}
+
+				// Run the deployment mode detection last again, fine to rerun.
+				err = setDeploymentMode(path)
+				if err != nil {
+					logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warn("Failed to detect deployment mode from Cgroupv1 path")
+					continue
+				}
+
+				logger.GetLogger().WithFields(logrus.Fields{
+					"cgroup.fs":                     cgroupFSPath,
+					"cgroup.controller.name":        controller.name,
+					"cgroup.controller.hierarchyID": controller.id,
+					"cgroup.controller.index":       controller.idx,
+				}).Infof("Cgroupv1 controller '%s' will be used", controller.name)
+
+				setCgrpHierarchyID(&controller)
+				setCgrpSubsystemIdx(&controller)
+				logger.GetLogger().WithFields(logrus.Fields{
+					"cgroup.fs":   cgroupFSPath,
+					"cgroup.path": cgroupPath,
+				}).Info("Cgroupv1 hierarchy validated successfully")
+				return finalpath, nil
+			}
+		}
+	}
+
+	// Cgroupv1 hierarchy is not properly setup we can not support such systems,
+	// reason should have been logged in above messages.
+	return "", fmt.Errorf("could not validate Cgroupv1 hierarchies")
+}
+
+// Lookup Cgroupv2 active controllers and returns one that we support
+func getCgroupv2Controller(cgroupPath string) (*cgroupController, error) {
+	file := filepath.Join(cgroupPath, "cgroup.controllers")
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %v", file, err)
+	}
+
+	activeControllers := strings.TrimRight(string(data), "\n")
+	if len(activeControllers) == 0 {
+		return nil, fmt.Errorf("no active controllers from '%s'", file)
+	}
+
+	logger.GetLogger().WithFields(logrus.Fields{
+		"cgroup.fs":          cgroupFSPath,
+		"cgroup.controllers": strings.Fields(activeControllers),
+	}).Info("Cgroupv2 supported controllers detected successfully")
+
+	for i, controller := range cgroupControllers {
+		if controller.active && strings.Contains(activeControllers, controller.name) {
+			logger.GetLogger().WithFields(logrus.Fields{
+				"cgroup.fs":                     cgroupFSPath,
+				"cgroup.controller.name":        controller.name,
+				"cgroup.controller.hierarchyID": controller.id,
+				"cgroup.controller.index":       controller.idx,
+			}).Infof("Cgroupv2 controller '%s' will be used as a fallback for the default hierarchy", controller.name)
+			return &cgroupControllers[i], nil
+		}
+	}
+
+	// Cgroupv2 hierarchy does not have the appropriate controllers.
+	// Maybe init system or any other component failed to prepare cgroups properly.
+	return nil, fmt.Errorf("Cgroupv2 no appropriate active controller")
+}
+
+// Validates cgroupPaths obtained from /proc/self/cgroup based on Cgroupv2
+func getValidCgroupv2Path(cgroupPaths []string) (string, error) {
+	for _, s := range cgroupPaths {
+		if strings.Contains(s, cgroupv2Hierarchy) {
+			idx := strings.Index(s, "/")
+			path := s[idx+1:]
+			cgroupPath := filepath.Join(cgroupFSPath, path)
+			finalpath := filepath.Join(cgroupPath, "cgroup.procs")
+			_, err := os.Stat(finalpath)
+			if err != nil {
+				// Namespaced ? let's force the check
+				err = setDeploymentMode(path)
+				if err == nil {
+					mode := getDeploymentMode()
+					if mode == DEPLOY_K8S || mode == DEPLOY_CONTAINER {
+						// Cgroups are namespaced let's try again
+						cgroupPath = cgroupFSPath
+						finalpath = filepath.Join(cgroupPath, "cgroup.procs")
+						_, err = os.Stat(finalpath)
+					}
+				}
+			}
+
+			if err != nil {
+				logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warnf("Failed to validate Cgroupv2 path '%s'", finalpath)
+				break
+			}
+
+			// This should not be necessary but there are broken setups out there
+			// without cgroupv2 default bpf helpers
+			controller, err := getCgroupv2Controller(cgroupPath)
+			if err != nil {
+				logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warnf("Failed to detect current Cgroupv2 active controller")
+				break
+			}
+
+			// Run the deployment mode detection last again, fine to rerun.
+			err = setDeploymentMode(path)
+			if err != nil {
+				logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warn("Failed to detect deployment mode from Cgroupv2 path")
+				break
+			}
+
+			setCgrp2HierarchyID()
+			setCgrpSubsystemIdx(controller)
+			logger.GetLogger().WithFields(logrus.Fields{
+				"cgroup.fs":   cgroupFSPath,
+				"cgroup.path": cgroupPath,
+			}).Info("Cgroupv2 hierarchy validated successfully")
+			return finalpath, nil
+		}
+	}
+
+	// Cgroupv2 hierarchy is not properly setup we can not support such systems,
+	// reason should have been logged in above messages.
+	return "", fmt.Errorf("could not validate Cgroupv2 hierarchy")
+}
+
+func getPidCgroupPaths(pid uint32) ([]string, error) {
+	file := filepath.Join(option.Config.ProcFS, fmt.Sprint(pid), "cgroup")
+
+	cgroups, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %v", file, err)
+	}
+
+	if len(cgroups) == 0 {
+		return nil, fmt.Errorf("no entry from %s", file)
+	}
+
+	return strings.Split(strings.TrimSpace(string(cgroups)), "\n"), nil
+}
+
+func findMigrationPath(pid uint32) (string, error) {
+	if cgrpMigrationPath != "" {
+		return cgrpMigrationPath, nil
+	}
+
+	cgroupPaths, err := getPidCgroupPaths(pid)
+	if err != nil {
+		logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warnf("Unable to get Cgroup paths for pid=%d", pid)
+		return "", err
+	}
+
+	mode, err := DetectCgroupMode()
+	if err != nil {
+		return "", err
+	}
+
+	/* Run the validate and get cgroup migration path once
+	 * as it triggers lot of checks.
+	 */
+	findMigPath.Do(func() {
+		var err error
+		switch mode {
+		case CGROUP_LEGACY, CGROUP_HYBRID:
+			cgrpMigrationPath, err = getValidCgroupv1Path(cgroupPaths)
+		case CGROUP_UNIFIED:
+			cgrpMigrationPath, err = getValidCgroupv2Path(cgroupPaths)
+		default:
+			err = fmt.Errorf("could not detect Cgroup Mode")
+		}
+
+		if err != nil {
+			logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warnf("Unable to find Cgroup migration path for pid=%d", pid)
+		}
+	})
+
+	if cgrpMigrationPath == "" {
+		return "", fmt.Errorf("could not detect Cgroup migration path for pid=%d", pid)
+	}
+
+	return cgrpMigrationPath, nil
+}
+
+func detectCgroupMode(cgroupfs string) (CgroupModeCode, error) {
+	var st syscall.Statfs_t
+
+	if err := syscall.Statfs(cgroupfs, &st); err != nil {
+		return CGROUP_UNDEF, err
+	}
+
+	if st.Type == unix.CGROUP2_SUPER_MAGIC {
+		return CGROUP_UNIFIED, nil
+	} else if st.Type == unix.TMPFS_MAGIC {
+		err := syscall.Statfs(filepath.Join(cgroupfs, "unified"), &st)
+		if err == nil && st.Type == unix.CGROUP2_SUPER_MAGIC {
+			return CGROUP_HYBRID, nil
+		}
+		return CGROUP_LEGACY, nil
+	}
+
+	return CGROUP_UNDEF, fmt.Errorf("wrong type '%d' for cgroupfs '%s'", st.Type, cgroupfs)
+}
+
+// DetectCgroupMode() Returns the current Cgroup mode that is applied to the system
+// This applies to systemd and non-systemd machines, possible values:
+//   - CGROUP_UNDEF: undefined
+//   - CGROUP_LEGACY: Cgroupv1 legacy controllers
+//   - CGROUP_HYBRID: Cgroupv1 and Cgroupv2 set up by systemd
+//   - CGROUP_UNIFIED: Pure Cgroupv2 hierarchy
+//
+// Reference: https://systemd.io/CGROUP_DELEGATION/
+func DetectCgroupMode() (CgroupModeCode, error) {
+	detectCgrpModeOnce.Do(func() {
+		var err error
+		cgroupFSPath = defaultCgroupRoot
+		cgroupMode, err = detectCgroupMode(cgroupFSPath)
+		if err != nil {
+			logger.GetLogger().WithError(err).WithField("cgroup.fs", cgroupFSPath).Debug("Could not detect Cgroup Mode")
+			cgroupMode, err = detectCgroupMode(defaults.Cgroup2Dir)
+			if err != nil {
+				logger.GetLogger().WithError(err).WithField("cgroup.fs", defaults.Cgroup2Dir).Debug("Could not detect Cgroup Mode")
+			} else {
+				cgroupFSPath = defaults.Cgroup2Dir
+			}
+		}
+		if cgroupMode != CGROUP_UNDEF {
+			logger.GetLogger().WithFields(logrus.Fields{
+				"cgroup.fs":   cgroupFSPath,
+				"cgroup.mode": cgroupMode.String(),
+			}).Infof("Cgroup mode detection succeeded")
+		}
+	})
+
+	if cgroupMode == CGROUP_UNDEF {
+		return CGROUP_UNDEF, fmt.Errorf("could not detect Cgroup Mode")
+	}
+
+	return cgroupMode, nil
+}
+
+func detectDeploymentMode() (DeploymentCode, error) {
+	mode := getDeploymentMode()
+	if mode != DEPLOY_UNKNOWN {
+		return mode, nil
+	}
+
+	// Let's call findMigrationPath in case to parse own cgroup
+	// paths and detect the deployment mode.
+	pid := os.Getpid()
+	_, err := findMigrationPath(uint32(pid))
+	if err != nil {
+		return DEPLOY_UNKNOWN, err
+	}
+
+	return getDeploymentMode(), nil
+}
+
+func DetectDeploymentMode() (uint32, error) {
+	detectDeploymentOnce.Do(func() {
+		mode, err := detectDeploymentMode()
+		if err != nil {
+			logger.GetLogger().WithFields(logrus.Fields{
+				"cgroup.fs": cgroupFSPath,
+			}).WithError(err).Warn("Detection of deployment mode failed")
+			return
+		}
+
+		logger.GetLogger().WithFields(logrus.Fields{
+			"cgroup.fs":       cgroupFSPath,
+			"deployment.mode": DeploymentCode(mode).String(),
+		}).Info("Deployment mode detection succeeded")
+	})
+
+	mode := getDeploymentMode()
+	if mode == DEPLOY_UNKNOWN {
+		return uint32(mode), fmt.Errorf("detect deployment mode failed, could not parse process cgroup paths")
+	}
+
+	return uint32(mode), nil
+}
+
+// DetectCgroupFSMagic() runs by default DetectCgroupMode()
+// Return the Cgroupfs v1 or v2 that will be used by bpf programs
+func DetectCgroupFSMagic() (uint64, error) {
+	// Run get cgroup mode again in case
+	mode, err := DetectCgroupMode()
+	if err != nil {
+		return CGROUP_UNSET_VALUE, err
+	}
+
+	// Run this once and log output
+	detectCgroupFSOnce.Do(func() {
+		switch mode {
+		case CGROUP_LEGACY, CGROUP_HYBRID:
+			/* In both legacy or Hybrid modes we switch to Cgroupv1 from bpf side. */
+			logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).Debug("Cgroup BPF helpers will run in raw Cgroup mode")
+			cgroupFSMagic = unix.CGROUP_SUPER_MAGIC
+		case CGROUP_UNIFIED:
+			logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).Debug("Cgroup BPF helpers will run in Cgroupv2 mode or fallback to raw Cgroup on errors")
+			cgroupFSMagic = unix.CGROUP2_SUPER_MAGIC
+		}
+	})
+
+	if cgroupFSMagic == CGROUP_UNSET_VALUE {
+		return CGROUP_UNSET_VALUE, fmt.Errorf("could not detect Cgroup filesystem Magic")
+	}
+
+	return cgroupFSMagic, nil
+}

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -57,6 +57,10 @@ var (
 	NamesMap    = program.MapBuilder("names_map", Execve)
 	NamesMapV53 = program.MapBuilder("names_map", ExecveV53)
 
+	/* Tetragon runtime configuration */
+	TetragonConfMap    = program.MapBuilder("tg_conf_map", Execve)
+	TetragonConfMapV53 = program.MapBuilder("tg_conf_map", ExecveV53)
+
 	/* Internal statistics for debugging */
 	ExecveStats    = program.MapBuilder("execve_map_stats", Execve)
 	ExecveStatsV53 = program.MapBuilder("execve_map_stats", ExecveV53)
@@ -67,6 +71,13 @@ func GetExecveMap() *program.Map {
 		return ExecveMapV53
 	}
 	return ExecveMap
+}
+
+func GetTetragonConfMap() *program.Map {
+	if kernels.EnableLargeProgs() {
+		return TetragonConfMapV53
+	}
+	return TetragonConfMap
 }
 
 func GetDefaultPrograms() []*program.Program {
@@ -91,6 +102,7 @@ func GetDefaultMaps() []*program.Map {
 			ExecveStatsV53,
 			NamesMapV53,
 			TCPMonMapV53,
+			TetragonConfMapV53,
 		)
 	} else {
 		maps = append(maps,
@@ -98,6 +110,7 @@ func GetDefaultMaps() []*program.Map {
 			ExecveStats,
 			NamesMap,
 			TCPMonMap,
+			TetragonConfMap,
 		)
 	}
 	return maps

--- a/pkg/sensors/config/confmap/confmap.go
+++ b/pkg/sensors/config/confmap/confmap.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package confmap
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+	"unsafe"
+
+	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/cgroups"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/sensors/base"
+	"github.com/sirupsen/logrus"
+)
+
+type TetragonConfKey struct {
+	Key uint32
+}
+
+type TetragonConfValue struct {
+	TgCgrpHierarchy uint32 `align:"tg_cgrp_hierarchy"`  // Tetragon Cgroup tracking hierarchy ID
+	TgCgrpSubsysIdx uint32 `align:"tg_cgrp_subsys_idx"` // Tracking Cgroup css idx at compile time
+}
+
+var (
+	log = logger.GetLogger()
+)
+
+func (k *TetragonConfKey) String() string             { return fmt.Sprintf("key=%d", k.Key) }
+func (k *TetragonConfKey) GetKeyPtr() unsafe.Pointer  { return unsafe.Pointer(k) }
+func (k *TetragonConfKey) DeepCopyMapKey() bpf.MapKey { return &TetragonConfKey{k.Key} }
+
+func (k *TetragonConfKey) NewValue() bpf.MapValue { return &TetragonConfValue{} }
+
+func (v *TetragonConfValue) String() string {
+	return fmt.Sprintf("value=%d %s", 0, "")
+}
+func (v *TetragonConfValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
+func (v *TetragonConfValue) DeepCopyMapValue() bpf.MapValue {
+	return &TetragonConfValue{}
+}
+
+// UpdateTgRuntimeConf() Gathers information about Tetragon runtime environment and
+// update the TetragonConfMap that is the BPF `tg_conf_map`.
+//
+// It detects the CgroupFS magic, Cgroup runtime mode, discovers cgroup css's that
+// registered during boot and propagated to all tasks inside their css_set, detects
+// the deployment mode from kubernetes, containers, to standalone or systemd services.
+// All discovered information will also be logged for debugging purpose.
+//
+// On failures it returns an error, and it default prints a warning that advanced
+// Cgroups tracking will be disabled which will affect process association with
+// kubernetes pods and containers.
+func UpdateTgRuntimeConf(mapDir string, nspid int) error {
+	configMap := base.GetTetragonConfMap()
+	mapPath := filepath.Join(mapDir, configMap.Name)
+
+	m, err := bpf.OpenMap(mapPath)
+	for i := 0; err != nil; i++ {
+		m, err = bpf.OpenMap(mapPath)
+		if err != nil {
+			time.Sleep(1 * time.Second)
+		}
+		if i > 4 {
+			log.WithField("confmap-update", configMap.Name).WithError(err).Warn("Failed to update TetragonConf map")
+			log.WithField("confmap-update", configMap.Name).Warn("Update TetragonConf map failed, advanced Cgroups tracking will be disabled")
+			return err
+		}
+	}
+
+	defer m.Close()
+
+	// First let's detect cgroupfs magic
+	cgroupFsMagic, err := cgroups.DetectCgroupFSMagic()
+	if err != nil {
+		log.WithField("confmap-update", configMap.Name).WithError(err).Warnf("Detection of Cgroupfs version failed")
+		log.WithField("confmap-update", configMap.Name).Warn("Cgroupfs magic is unknown, advanced Cgroups tracking will be disabled")
+		return err
+	}
+
+	// This must be called before probing cgroup configurations
+	err = cgroups.DiscoverSubSysIds()
+	if err != nil {
+		log.WithField("confmap-update", configMap.Name).WithError(err).Warnf("Detection of Cgroup Subsystem Controllers failed")
+		log.WithField("confmap-update", configMap.Name).Warn("Cgroup Subsystems IDs are unknown, advanced Cgroups tracking will be disabled")
+		return err
+	}
+
+	// Detect deployment mode
+	deployMode, err := cgroups.DetectDeploymentMode()
+	if err != nil {
+		log.WithField("confmap-update", configMap.Name).WithError(err).Warnf("Detection of deployment mode failed")
+		log.WithField("confmap-update", configMap.Name).Warn("Deployment mode is unknown, advanced Cgroups tracking will be disabled")
+		return err
+	}
+
+	k := &TetragonConfKey{Key: 0}
+	v := &TetragonConfValue{
+		TgCgrpHierarchy: cgroups.GetCgrpHierarchyID(),
+		TgCgrpSubsysIdx: cgroups.GetCgrpSubsystemIdx(),
+	}
+
+	err = m.Update(k, v)
+	if err != nil {
+		log.WithField("confmap-update", configMap.Name).WithError(err).Warn("Failed to update TetragonConf map")
+		log.WithField("confmap-update", configMap.Name).Warn("Update TetragonConf map failed, advanced Cgroups tracking will be disabled")
+		return err
+	}
+
+	log.WithFields(logrus.Fields{
+		"confmap-update":                configMap.Name,
+		"deployment.mode":               cgroups.DeploymentCode(deployMode).String(),
+		"cgroup.fs.magic":               cgroups.CgroupFsMagicStr(cgroupFsMagic),
+		"cgroup.controller.name":        cgroups.GetCgrpControllerName(),
+		"cgroup.controller.hierarchyID": v.TgCgrpHierarchy,
+		"cgroup.controller.index":       v.TgCgrpSubsysIdx,
+	}).Info("Updated TetragonConf map successfully")
+
+	return nil
+}

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -432,6 +432,7 @@ func TestLoadInitialSensor(t *testing.T) {
 
 		// event_execve
 		tus.SensorMap{Name: "names_map", Progs: []uint{0}},
+		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
 
 		// event_wake_up_new_task
 		tus.SensorMap{Name: "execve_val", Progs: []uint{2}},


### PR DESCRIPTION
This was part of https://github.com/cilium/tetragon/pull/225 , it was cleaned in order to improve our logic how we operate on cgroup hierarchies.

bpf:cgroups: pass subsys index when operating on cgroup_subsys_state set
    
Select which cgroup controllers to use at runtime by analyzing current machine
cgroup configuration and adapt the bpf helpers to use the best option.
    
We have experienced events that did not have the proper container ID 'docker' nor the pod fields set. The reason is due to:
    
In Cgroupv1 mode usually systemd only sets up by default the 'cpu, cpuacct, memory, devices and pids' controllers, cpuset which in normal cases indexed at 0 is not installed. Since some container runtimes and different environments may use systemd as a cgroup driver this can cause problems where we won't operate on the right hierarchy. We should also note that these controllers are kernel compile CONFIG_* options, and Tetragon should only work on machines that have the CONFIG_CGROUP_PIDS or CONFIG_CGROUP_MEMORY controllers compiled. Most production machines these days have or must have these compiled in to properly work.
    
Let's be consistent with systemd, Kubernetes and Container runtimes and select by default either the 'memory' or 'pids' to be used as the tracking Cgroup hierarchy for all processes. Usually these two controllers are always present and set. We do this by selecting the right hierarchy ID and the cgroup subsystem state index.
    
In Cgroupv2 mode, systemd successfully sets the related controllers that are safe to be used by default. However we have experienced machines that did not have the cpuset controller. In order to avoid such errors we do same operation for Cgroupv1, we gather the Cgroup subsystem state index and pass it into tetragon_conf struct at startup. To get the Cgroup ID we first use the default Cgroupv2 BPF helpers, if they fail we fallback to the per subsystem index. Last, to get the Cgroup name we always query the subsystem index and read the kernfs node name.
    
This allows Tetragon to work on different environments, regardless of the Cgroup configuration and driver being used.
    
Further reference: https://github.com/systemd/systemd/blob/main/src/basic/cgroup-util.h#L20

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>