### PR TITLE
tetragon: make gops address configurable

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -32,6 +32,7 @@ const (
 
 	keyMetricsServer     = "metrics-server"
 	keyServerAddress     = "server-address"
+	keyGopsAddr          = "gops-address"
 	keyCiliumBPF         = "cilium-bpf"
 	keyEnableProcessCred = "enable-process-cred"
 	keyEnableProcessNs   = "enable-process-ns"
@@ -98,6 +99,8 @@ func readAndSetFlags() {
 	option.Config.EnableProcessNs = viper.GetBool(keyEnableProcessNs)
 	option.Config.EnableCilium = viper.GetBool(keyEnableCiliumAPI)
 	option.Config.EnableK8s = viper.GetBool(keyEnableK8sAPI)
+
+	option.Config.GopsAddr = viper.GetString(keyGopsAddr)
 
 	logLevel := viper.GetString(keyLogLevel)
 	logFormat := viper.GetString(keyLogFormat)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -27,6 +27,8 @@ type config struct {
 	EnableProcessCred bool
 	EnableK8s         bool
 
+	GopsAddr string
+
 	CiliumDir string
 	MapDir    string
 	BpfDir    string


### PR DESCRIPTION
It would be nice to make the gops address configurable so we can set it to a predictable
value in helm and expose it via the helm chart. That way we can easily get gops data
via a port forward.

Signed-off-by: William Findlay <will@isovalent.com>