### PR TITLE
metrics: add missing process info error metric

### DIFF
--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -38,6 +38,8 @@ var (
 	PidMapMissOnRemove ErrorType = "pid_map_miss_on_remove"
 	// An exec event without parent info.
 	ExecMissingParent ErrorType = "exec_missing_parent"
+	// An event is missing process info.
+	EventMissingProcessInfo ErrorType = "event_missing_process_info"
 )
 
 var (


### PR DESCRIPTION
Add a new error metric that tracks events that are missing process info.

Signed-off-by: William Findlay <will@isovalent.com>