### PR TITLE
tetragon: Return pid value get_task_pid_vnr for zero level

### DIFF
--- a/bpf/lib/bpf_events.h
+++ b/bpf/lib/bpf_events.h
@@ -106,8 +106,6 @@ static inline __attribute__((always_inline)) __u32 get_task_pid_vnr(void)
 	}
 	upid_sz = bpf_core_field_size(pid->numbers[0]);
 	probe_read(&level, sizeof(level), _(&pid->level));
-	if (level < 1)
-		return 0;
 	probe_read(&upid, upid_sz,
 		   (void *)_(&pid->numbers) + (level * upid_sz));
 	return upid.nr;


### PR DESCRIPTION
We take /proc/PID/status NStgid last value when we scan procfs,
which does not match get_task_pid_vnr retrieval where we return
zero if there's no extra namespace level.

Changing get_task_pid_vnr to return pid value for zero level.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>