### PR TITLE
Cleanup in selectors/kernel.go

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -642,13 +642,11 @@ func InitTracepointSelectors(spec *v1alpha1.TracepointSpec) ([4096]byte, error) 
 	selectors := spec.Selectors
 	args := spec.Args
 	kernelSelectors := &KernelSelectorState{}
-	totaloff := 2
 
 	WriteSelectorUint32(kernelSelectors, uint32(len(selectors)))
 	soff := make([]uint32, len(selectors))
 	for i := range selectors {
 		soff[i] = AdvanceSelectorLength(kernelSelectors)
-		totaloff++
 	}
 	for i, s := range selectors {
 		WriteSelectorLength(kernelSelectors, soff[i])

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -617,30 +617,7 @@ func parseSelector(
 // CAn := [type][op][namespacecap][valueInt]
 // valueGen := [type][len][v]
 // valueInt := [len][v]
-func InitKernelSelectors(spec *v1alpha1.KProbeSpec) ([4096]byte, error) {
-	selectors := spec.Selectors
-	args := spec.Args
-	kernelSelectors := &KernelSelectorState{}
-
-	WriteSelectorUint32(kernelSelectors, uint32(len(selectors)))
-	soff := make([]uint32, len(selectors))
-	for i := range selectors {
-		soff[i] = AdvanceSelectorLength(kernelSelectors)
-	}
-	for i, s := range selectors {
-		WriteSelectorLength(kernelSelectors, soff[i])
-		loff := AdvanceSelectorLength(kernelSelectors)
-		if err := parseSelector(kernelSelectors, &s, args); err != nil {
-			return kernelSelectors.e, err
-		}
-		WriteSelectorLength(kernelSelectors, loff)
-	}
-	return kernelSelectors.e, nil
-}
-
-func InitTracepointSelectors(spec *v1alpha1.TracepointSpec) ([4096]byte, error) {
-	selectors := spec.Selectors
-	args := spec.Args
+func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg) ([4096]byte, error) {
 	kernelSelectors := &KernelSelectorState{}
 
 	WriteSelectorUint32(kernelSelectors, uint32(len(selectors)))

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -556,11 +556,7 @@ func TestInitKernelSelectors(t *testing.T) {
 		v1alpha1.KProbeArg{Index: 3, Type: "char_buf", SizeArgIndex: 0, ReturnCopy: false},
 		v1alpha1.KProbeArg{Index: 4, Type: "char_iovec", SizeArgIndex: 0, ReturnCopy: false},
 	}
-	spec := v1alpha1.KProbeSpec{
-		Selectors: selectors,
-		Args:      args,
-	}
-	b, _ := InitKernelSelectors(&spec)
+	b, _ := InitKernelSelectors(selectors, args)
 	if bytes.Equal(expected[0:len(expected)], b[0:len(expected)]) == false {
 		t.Errorf("InitKernelSelectors: expected %v bytes %v\n", expected, b[0:len(expected)])
 	}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -290,7 +290,7 @@ func addGenericKprobeSensors(kprobes []v1alpha1.KProbeSpec) (*sensors.Sensor, er
 		}
 
 		// Parse Filters into kernel filter logic
-		kernelSelectors, err := selectors.InitKernelSelectors(f)
+		kernelSelectors, err := selectors.InitKernelSelectors(f.Selectors, f.Args)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -426,7 +426,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 		}
 	}
 
-	kernelSelectors, err := selectors.InitTracepointSelectors(tp.Selectors)
+	kernelSelectors, err := selectors.InitKernelSelectors(tp.Selectors.Selectors, tp.Selectors.Args)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`InitKernelSelectors` and `InitTracepointSelectors` functions are almost the same. So we removed the second one.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>