### PR TITLE
tests/e2e: dump gops information at the end of failed tests

### DIFF
--- a/tests/e2e/helpers/gops/gops.go
+++ b/tests/e2e/helpers/gops/gops.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// Package gops is a simple gops client implementation to dump gops info from end-to-end
+// tests.
+package gops
+
+import (
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/google/gops/signal"
+)
+
+func DumpHeapProfile(addr net.TCPAddr) ([]byte, error) {
+	out, err := cmd(addr, signal.HeapProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dump heap profile: %w", err)
+	}
+	return out, nil
+}
+
+func DumpBinary(addr net.TCPAddr) ([]byte, error) {
+	out, err := cmd(addr, signal.BinaryDump)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dump binary: %w", err)
+	}
+	return out, nil
+}
+
+func DumpMemStats(addr net.TCPAddr) ([]byte, error) {
+	out, err := cmd(addr, signal.MemStats)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dump memstats: %w", err)
+	}
+	return out, nil
+}
+
+func cmd(addr net.TCPAddr, sig byte) ([]byte, error) {
+	conn, err := net.DialTCP("tcp", nil, &addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := conn.Write([]byte{sig}); err != nil {
+		return nil, err
+	}
+
+	out, err := io.ReadAll(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/tests/e2e/helpers/portforward.go
+++ b/tests/e2e/helpers/portforward.go
@@ -45,10 +45,12 @@ func PortForwardTetragonPods(testenv env.Environment) env.Func {
 		const (
 			grpcPort = 54321
 			promPort = 2112
+			gopsPort = 8118
 		)
 
 		grpcPorts := make(map[string]int)
 		promPorts := make(map[string]int)
+		gopsPorts := make(map[string]int)
 		for i, pod := range podList.Items {
 			if ctx, err = e2ehelpers.PortForwardPod(
 				testenv,
@@ -59,17 +61,20 @@ func PortForwardTetragonPods(testenv env.Environment) env.Func {
 				time.Second,
 				fmt.Sprintf("%d:%d", grpcPort+i, grpcPort),
 				fmt.Sprintf("%d:%d", promPort+i, promPort),
+				fmt.Sprintf("%d:%d", gopsPort+i, gopsPort),
 			)(ctx, cfg); err != nil {
 				return ctx, err
 			}
 			grpcPorts[pod.Name] = grpcPort + i
 			promPorts[pod.Name] = promPort + i
+			gopsPorts[pod.Name] = gopsPort + i
 		}
 
 		ctx = context.WithValue(ctx, state.GrpcForwardedPorts, grpcPorts)
 		ctx = context.WithValue(ctx, state.PromForwardedPorts, promPorts)
+		ctx = context.WithValue(ctx, state.GopsForwardedPorts, gopsPorts)
 
-		klog.InfoS("Successfully forwarded ports for Tetragon pods", "grpcPorts", grpcPorts, "promPorts", promPorts)
+		klog.InfoS("Successfully forwarded ports for Tetragon pods", "grpcPorts", grpcPorts, "promPorts", promPorts, "gopsPorts", gopsPorts)
 
 		return ctx, nil
 	}

--- a/tests/e2e/state/state.go
+++ b/tests/e2e/state/state.go
@@ -15,6 +15,8 @@ var (
 	GrpcForwardedPorts = Key{slug: "GrpcForwardedPorts"}
 	// Key for storing a list of ports we forwarded for prometheus metics
 	PromForwardedPorts = Key{slug: "PromForwardedPorts"}
+	// Key for storing a list of ports we forwarded for the pprof server
+	GopsForwardedPorts = Key{slug: "GopsForwardedPorts"}
 	// Key for storing the minimum kernel version of all nodes in the cluster
 	MinKernelVersion = Key{slug: "MinKernelVersion"}
 	// Stores a list of event checkers that were used in the test


### PR DESCRIPTION
This commit introduces the ability to dump gops debug information at the end of failed
end-to-end tests. We start by dumping memory statics as well as a heap profile for the
application. As with metrics, dumps occur every 30 seconds as well as at the end of
a test, and are discarded unless either the test fails or the user has passed
--tetragon.keep-export=true when running the test.

We also dump a copy of the Tetragon binary running in each Tetragon pod. Unlike the other
dumps, this happens only once at the beginning of a test as it is a costlier operation and
the binary is obviously not expected to change. This binary dump can be used in
cominbation with the heap dump to run it through `go tool pprof`, generating a call graph
that summarizes memory usage throughout Tetragon.

Signed-off-by: William Findlay <will@isovalent.com>