### PR TITLE
tetragon: Use lru.Cache for data events storage

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -21,6 +21,7 @@ const (
 	keyKernelVersion    = "kernel"
 	keyVerbosity        = "verbose"
 	keyProcessCacheSize = "process-cache-size"
+	keyDataCacheSize    = "data-cache-size"
 	keyForceSmallProgs  = "force-small-progs"
 
 	keyLogLevel  = "log-level"
@@ -72,6 +73,7 @@ const (
 
 var (
 	processCacheSize int
+	dataCacheSize    int
 
 	metricsServer string
 	serverAddress string
@@ -120,6 +122,7 @@ func readAndSetFlags() {
 	logger.PopulateLogOpts(option.Config.LogOpts, logLevel, logFormat)
 
 	processCacheSize = viper.GetInt(keyProcessCacheSize)
+	dataCacheSize = viper.GetInt(keyDataCacheSize)
 
 	metricsServer = viper.GetString(keyMetricsServer)
 	serverAddress = viper.GetString(keyServerAddress)

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -239,6 +239,10 @@ func tetragonExecute() error {
 		return err
 	}
 
+	if err := observer.InitDataCache(dataCacheSize); err != nil {
+		return err
+	}
+
 	if metricsServer != "" {
 		go metrics.EnableMetrics(metricsServer)
 	}
@@ -546,6 +550,7 @@ func execute() error {
 	flags.String(keyKernelVersion, "", "Kernel version")
 	flags.Int(keyVerbosity, 0, "set verbosity level for eBPF verifier dumps. Pass 0 for silent, 1 for truncated logs, 2 for a full dump")
 	flags.Int(keyProcessCacheSize, 65536, "Size of the process cache")
+	flags.Int(keyDataCacheSize, 1024, "Size of the data events cache")
 	flags.Bool(keyForceSmallProgs, false, "Force loading small programs, even in kernels with >= 5.3 versions")
 	flags.String(keyExportFilename, "", "Filename for JSON export. Disabled by default")
 	flags.Int(keyExportFileMaxSizeMB, 10, "Size in MB for rotating JSON export files")

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -216,12 +216,17 @@ func startBenchmarkExporter(ctx context.Context, obs *observer.Observer, summary
 	var wg sync.WaitGroup
 
 	processCacheSize := 32768
+	dataCacheSize := 1024
 	enableCiliumAPI := false
 
 	if _, err := cilium.InitCiliumState(ctx, enableCiliumAPI); err != nil {
 		return err
 	}
 	if err := process.InitCache(ctx, watcher.NewFakeK8sWatcher(nil), enableCiliumAPI, processCacheSize); err != nil {
+		return err
+	}
+
+	if err := observer.InitDataCache(dataCacheSize); err != nil {
 		return err
 	}
 

--- a/pkg/observer/data.go
+++ b/pkg/observer/data.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/dataapi"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/logger"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 func init() {
@@ -16,8 +17,15 @@ func init() {
 }
 
 var (
-	dataMap map[dataapi.DataEventId][]byte = make(map[dataapi.DataEventId][]byte)
+	dataMap *lru.Cache[dataapi.DataEventId, []byte]
 )
+
+func InitDataCache(size int) error {
+	var err error
+
+	dataMap, err = lru.New[dataapi.DataEventId, []byte](size)
+	return err
+}
 
 func add(r *bytes.Reader, m *dataapi.MsgData) error {
 	size := m.Common.Size - uint32(unsafe.Sizeof(*m))
@@ -29,12 +37,12 @@ func add(r *bytes.Reader, m *dataapi.MsgData) error {
 		return err
 	}
 
-	data := dataMap[m.Id]
-	if data == nil {
-		dataMap[m.Id] = msgData
+	data, ok := dataMap.Get(m.Id)
+	if !ok {
+		dataMap.Add(m.Id, msgData)
 	} else {
 		data = append(data, msgData...)
-		dataMap[m.Id] = data
+		dataMap.Add(m.Id, data)
 	}
 
 	logger.GetLogger().Debugf("Data message received id %v, size %v, total %v", m.Id, size, len(data))
@@ -42,12 +50,12 @@ func add(r *bytes.Reader, m *dataapi.MsgData) error {
 }
 
 func DataGet(id dataapi.DataEventId) ([]byte, error) {
-	data := dataMap[id]
-	if data == nil {
+	data, ok := dataMap.Get(id)
+	if !ok {
 		return nil, fmt.Errorf("failed to find data for id: %v", id)
 	}
 
-	delete(dataMap, id)
+	dataMap.Remove(id)
 	logger.GetLogger().Debugf("Data message used id %v, data len %v", id, len(data))
 	return data, nil
 }

--- a/pkg/observer/data.go
+++ b/pkg/observer/data.go
@@ -1,4 +1,4 @@
-package data
+package observer
 
 import (
 	"bytes"
@@ -9,11 +9,10 @@ import (
 	"github.com/cilium/tetragon/pkg/api/dataapi"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/observer"
 )
 
 func init() {
-	observer.RegisterEventHandlerAtInit(ops.MSG_OP_DATA, HandleData)
+	RegisterEventHandlerAtInit(ops.MSG_OP_DATA, HandleData)
 }
 
 var (
@@ -42,7 +41,7 @@ func add(r *bytes.Reader, m *dataapi.MsgData) error {
 	return nil
 }
 
-func Get(id dataapi.DataEventId) ([]byte, error) {
+func DataGet(id dataapi.DataEventId) ([]byte, error) {
 	data := dataMap[id]
 	if data == nil {
 		return nil, fmt.Errorf("failed to find data for id: %v", id)
@@ -53,7 +52,7 @@ func Get(id dataapi.DataEventId) ([]byte, error) {
 	return data, nil
 }
 
-func HandleData(r *bytes.Reader) ([]observer.Event, error) {
+func HandleData(r *bytes.Reader) ([]Event, error) {
 	m := dataapi.MsgData{}
 	err := binary.Read(r, binary.LittleEndian, &m)
 	if err != nil {

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -363,6 +363,7 @@ func loadExporter(t *testing.T, ctx context.Context, obs *Observer, opts *testEx
 	watcher := opts.watcher
 	ciliumState := opts.ciliumState
 	processCacheSize := 32768
+	dataCacheSize := 1024
 
 	if err := obs.InitSensorManager(); err != nil {
 		return err
@@ -377,6 +378,10 @@ func loadExporter(t *testing.T, ctx context.Context, obs *Observer, opts *testEx
 	}
 
 	if err := process.InitCache(ctx, watcher, false, processCacheSize); err != nil {
+		return err
+	}
+
+	if err := InitDataCache(dataCacheSize); err != nil {
 		return err
 	}
 

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -587,6 +587,16 @@ func setupTgRuntimeConf(t *testing.T, trackingCgrpLevel, logLevel, hierarchyId, 
 	}
 }
 
+func setupObserver(ctx context.Context, t *testing.T) *tus.TestSensorManager {
+	testManager := tus.StartTestSensorManager(ctx, t)
+	observer.SensorManager = testManager.Manager
+
+	if err := observer.InitDataCache(1024); err != nil {
+		t.Fatalf("failed to call observer.InitDataCache %s", err)
+	}
+	return testManager
+}
+
 // Test loading bpf cgroups programs
 func TestLoadCgroupsPrograms(t *testing.T) {
 	testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
@@ -642,8 +652,7 @@ func TestCgroupNoEvents(t *testing.T) {
 
 	tus.LoadSensor(ctx, t, base.GetInitialSensor())
 
-	testManager := tus.StartTestSensorManager(ctx, t)
-	observer.SensorManager = testManager.Manager
+	testManager := setupObserver(ctx, t)
 
 	testManager.AddAndEnableSensors(ctx, t, loadedSensors)
 
@@ -695,8 +704,7 @@ func TestCgroupEventMkdirRmdir(t *testing.T) {
 
 	tus.LoadSensor(ctx, t, base.GetInitialSensor())
 
-	testManager := tus.StartTestSensorManager(ctx, t)
-	observer.SensorManager = testManager.Manager
+	testManager := setupObserver(ctx, t)
 
 	testManager.AddAndEnableSensors(ctx, t, loadedSensors)
 	t.Cleanup(func() {
@@ -875,8 +883,7 @@ func testCgroupv2HierarchyInUnified(ctx context.Context, t *testing.T,
 // Test Cgroupv2 tries to emulate k8s hierarchy without exec context
 // Works in systemd unified and hybrid mode according to parameter
 func testCgroupv2K8sHierarchy(ctx context.Context, t *testing.T, mode cgroups.CgroupModeCode, withExec bool) {
-	testManager := tus.StartTestSensorManager(ctx, t)
-	observer.SensorManager = testManager.Manager
+	testManager := setupObserver(ctx, t)
 
 	testManager.AddAndEnableSensors(ctx, t, loadedSensors)
 	t.Cleanup(func() {
@@ -1090,8 +1097,7 @@ func testCgroupv1K8sHierarchyInHybrid(t *testing.T, withExec bool, selectedContr
 
 	tus.LoadSensor(ctx, t, base.GetInitialSensor())
 
-	testManager := tus.StartTestSensorManager(ctx, t)
-	observer.SensorManager = testManager.Manager
+	testManager := setupObserver(ctx, t)
 
 	testManager.AddAndEnableSensors(ctx, t, loadedSensors)
 

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/cgroups"
-	"github.com/cilium/tetragon/pkg/data"
 	exec "github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/observer"
@@ -132,7 +131,7 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, bool, error) {
 			proc.Filename = "enomem"
 			return proc, false, err
 		}
-		data, err := data.Get(desc.Id)
+		data, err := observer.DataGet(desc.Id)
 		if err != nil {
 			return proc, false, err
 		}
@@ -159,7 +158,7 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, bool, error) {
 			proc.Filename = "enomem"
 			return proc, false, err
 		}
-		data, err := data.Get(desc.Id)
+		data, err := observer.DataGet(desc.Id)
 		if err != nil {
 			return proc, false, err
 		}

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -524,6 +524,10 @@ func TestExecPerfring(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
+	if err := observer.InitDataCache(1024); err != nil {
+		t.Fatalf("observer.InitDataCache: %s", err)
+	}
+
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 	tus.LoadSensor(ctx, t, base.GetInitialSensor())
 	tus.LoadSensor(ctx, t, testsensor.GetTestSensor())

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -47,6 +47,9 @@ func tpSpecReload(t *testing.T, tpSensor *sensors.Sensor, tpSpec *v1alpha1.Trace
 
 // loadGenericSensorTest loads a tracing sensor for testing
 func loadGenericSensorTest(t *testing.T, ctx context.Context, spec *v1alpha1.TracingPolicySpec) *sensors.Sensor {
+	if err := observer.InitDataCache(1024); err != nil {
+		t.Fatalf("observer.InitDataCache: %s", err)
+	}
 	ret, err := sensors.GetSensorsFromParserPolicy(spec)
 	if err != nil {
 		t.Fatalf("GetSensorsFromParserPolicy failed: %v", err)


### PR DESCRIPTION
There's a chance that by losing events (in perf ring buffer)
we would never use data stored by data events. Adding the data
into lru cache so we eventually remove unused entries to make
space for new ones and don't grow endlessly.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>