### PR TITLE
build-images-ci: Remove comments from tags section

### DIFF
--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -58,7 +58,6 @@ jobs:
           platforms: linux/amd64
           tags: |
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
-            # push to latest when we push to main branch.
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest
 
       - name: CI Image Releases digests (main)


### PR DESCRIPTION
They don't handle comments.

https://github.com/cilium/tetragon/runs/8213728526?check_suite_focus=true

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>