### PR TITLE
ci/dependabot: add release blocker label on dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
       - dependency-name: "sigs.k8s.io/*"
     labels:
     - enhancement
+    - release-blocker
 
   - package-ecosystem: github-actions
     directory: /
@@ -23,6 +24,7 @@ updates:
     rebase-strategy: disabled
     labels:
     - enhancement
+    - release-blocker
 
   - package-ecosystem: docker
     directory: /
@@ -32,3 +34,4 @@ updates:
     rebase-strategy: disabled
     labels:
     - enhancement
+    - release-blocker


### PR DESCRIPTION
We want our releases to include important security updates for dependencies, so make these
PRs release-blockers.

Signed-off-by: William Findlay <will@isovalent.com>