### PR TITLE
tetragon: Revert "observer_test_helper: do not pass the base sensor"

### DIFF
--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -251,7 +251,7 @@ func readConfig(file string) (*yaml.GenericTracingConf, error) {
 	return cnf, nil
 }
 
-func getDefaultObserverSensors(t *testing.T, ctx context.Context, opts ...TestOption) (*Observer, []*sensors.Sensor, error) {
+func getDefaultObserverSensors(t *testing.T, ctx context.Context, base *sensors.Sensor, opts ...TestOption) (*Observer, []*sensors.Sensor, error) {
 	var cnfSensor *sensors.Sensor
 	var ret []*sensors.Sensor
 
@@ -277,8 +277,6 @@ func getDefaultObserverSensors(t *testing.T, ctx context.Context, opts ...TestOp
 		return nil, ret, err
 	}
 
-	baseSensor := base.GetInitialSensor()
-
 	cnf, _ := readConfig(o.observer.config)
 	if cnf != nil {
 		var err error
@@ -289,7 +287,7 @@ func getDefaultObserverSensors(t *testing.T, ctx context.Context, opts ...TestOp
 		ret = append(ret, cnfSensor)
 	}
 
-	if err := loadObserver(t, ctx, baseSensor, cnfSensor, o.observer.notestfail); err != nil {
+	if err := loadObserver(t, ctx, base, cnfSensor, o.observer.notestfail); err != nil {
 		return nil, ret, err
 	}
 
@@ -316,19 +314,19 @@ func getDefaultObserverSensors(t *testing.T, ctx context.Context, opts ...TestOp
 		testDone(t, obs)
 	})
 
-	ret = append(ret, baseSensor)
+	ret = append(ret, base)
 
 	obs.perfConfig = bpf.DefaultPerfEventConfig()
 	obs.perfConfig.MapName = filepath.Join(bpf.MapPrefixPath(), "tcpmon_map")
 	return obs, ret, nil
 }
 
-func getDefaultObserver(t *testing.T, ctx context.Context, opts ...TestOption) (*Observer, error) {
-	obs, _, err := getDefaultObserverSensors(t, ctx, opts...)
+func getDefaultObserver(t *testing.T, ctx context.Context, base *sensors.Sensor, opts ...TestOption) (*Observer, error) {
+	obs, _, err := getDefaultObserverSensors(t, ctx, base, opts...)
 	return obs, err
 }
 
-func GetDefaultObserverWithWatchers(t *testing.T, ctx context.Context, opts ...TestOption) (*Observer, error) {
+func GetDefaultObserverWithWatchers(t *testing.T, ctx context.Context, base *sensors.Sensor, opts ...TestOption) (*Observer, error) {
 	const (
 		testPod       = "pod-1"
 		testNamespace = "ns-1"
@@ -339,20 +337,27 @@ func GetDefaultObserverWithWatchers(t *testing.T, ctx context.Context, opts ...T
 
 	opts = append(opts, withK8sWatcher(w))
 	opts = append(opts, withCiliumState(s))
-	return getDefaultObserver(t, ctx, opts...)
+	return getDefaultObserver(t, ctx, base, opts...)
+}
+
+func GetDefaultObserverWithBase(t *testing.T, ctx context.Context, b *sensors.Sensor, file, lib string) (*Observer, error) {
+	return GetDefaultObserverWithWatchers(t, ctx, b, WithConfig(file), withPretty(), WithLib(lib))
 }
 
 func GetDefaultObserverWithFile(t *testing.T, ctx context.Context, file, lib string) (*Observer, error) {
-	return GetDefaultObserverWithWatchers(t, ctx, WithConfig(file), withPretty(), WithLib(lib))
+	b := base.GetInitialSensor()
+	return GetDefaultObserverWithWatchers(t, ctx, b, WithConfig(file), withPretty(), WithLib(lib))
 }
 
 func GetDefaultSensorsWithFile(t *testing.T, ctx context.Context, file, lib string) ([]*sensors.Sensor, error) {
-	_, sens, err := getDefaultObserverSensors(t, ctx, WithConfig(file), withPretty(), WithLib(lib))
+	b := base.GetInitialSensor()
+	_, sens, err := getDefaultObserverSensors(t, ctx, b, WithConfig(file), withPretty(), WithLib(lib))
 	return sens, err
 }
 
 func GetDefaultObserverWithFileNoTest(t *testing.T, ctx context.Context, file, lib string, fail bool) (*Observer, error) {
-	return GetDefaultObserverWithWatchers(t, ctx, WithConfig(file), withPretty(), WithLib(lib), withNotestfail(fail))
+	b := base.GetInitialSensor()
+	return GetDefaultObserverWithWatchers(t, ctx, b, WithConfig(file), withPretty(), WithLib(lib), withNotestfail(fail))
 }
 
 func loadExporter(t *testing.T, ctx context.Context, obs *Observer, opts *testExporterOptions, oo *testObserverOptions) error {
@@ -545,11 +550,13 @@ func WriteConfigFile(fileName, config string) error {
 }
 
 func GetDefaultObserver(t *testing.T, ctx context.Context, lib string) (*Observer, error) {
-	return GetDefaultObserverWithWatchers(t, ctx, withPretty(), WithLib(lib))
+	b := base.GetInitialSensor()
+	return GetDefaultObserverWithWatchers(t, ctx, b, withPretty(), WithLib(lib))
 }
 
 func GetDefaultObserverWithLib(t *testing.T, ctx context.Context, config, lib string) (*Observer, error) {
-	return GetDefaultObserverWithWatchers(t, ctx, WithConfig(config), WithLib(lib))
+	b := base.GetInitialSensor()
+	return GetDefaultObserverWithWatchers(t, ctx, b, WithConfig(config), WithLib(lib))
 }
 
 func GetMyPid() uint32 {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -1741,7 +1741,8 @@ func runKprobe_char_iovec(t *testing.T, configHook string,
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	obs, err := observer.GetDefaultObserverWithWatchers(t, ctx, observer.WithConfig(testConfigFile), observer.WithLib(tus.Conf().TetragonLib))
+	b := base.GetInitialSensor()
+	obs, err := observer.GetDefaultObserverWithWatchers(t, ctx, b, observer.WithConfig(testConfigFile), observer.WithLib(tus.Conf().TetragonLib))
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithWatchers error: %s", err)
 	}


### PR DESCRIPTION
This reverts commit 2dc54da6a84df9346e8753d67c5219b504b4933c.

I sometimes pass a set of programs into observer test framework for running debug tests. I don't want to lose the capability so lets revert this for now and we can work to add some users. Or maybe improve the API so its not as clunky, but lets not just drop it.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>