### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -6,7 +6,6 @@ package btf
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,9 +44,7 @@ func setupfiles() func(*testing.T, string, ...string) {
 func TestObserverFindBTF(t *testing.T) {
 	ctx := context.Background()
 
-	tmpdir, err := ioutil.TempDir("/tmp", fmt.Sprintf("tetragon-%s-*", t.Name()))
-	assert.NoError(t, err, "failed to create temporary directory")
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	old := os.Getenv("TETRAGON_BTF")
 	defer os.Setenv("TETRAGON_BTF", old)

--- a/pkg/bugtool/bugtool_test.go
+++ b/pkg/bugtool/bugtool_test.go
@@ -4,19 +4,20 @@
 package bugtool
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSaveAndLoad(t *testing.T) {
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "tetragon-bugtool-test-")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "tetragon-bugtool-test-")
 	if err != nil {
 		t.Error("failed to create temporary file")
 	}
-	defer os.Remove(tmpFile.Name())
+	defer assert.NoError(t, tmpFile.Close())
 
 	info1 := InitInfo{
 		ExportFname: "1",

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -9,7 +9,6 @@ package cgroups
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -389,7 +388,7 @@ func getValidCgroupv1Path(cgroupPaths []string) (string, error) {
 // Lookup Cgroupv2 active controllers and returns one that we support
 func getCgroupv2Controller(cgroupPath string) (*cgroupController, error) {
 	file := filepath.Join(cgroupPath, "cgroup.controllers")
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %v", file, err)
 	}
@@ -482,7 +481,7 @@ func getValidCgroupv2Path(cgroupPaths []string) (string, error) {
 func getPidCgroupPaths(pid uint32) ([]string, error) {
 	file := filepath.Join(option.Config.ProcFS, fmt.Sprint(pid), "cgroup")
 
-	cgroups, err := ioutil.ReadFile(file)
+	cgroups, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %v", file, err)
 	}

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -5,7 +5,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"sigs.k8s.io/yaml"
@@ -37,7 +37,7 @@ func ReadConfigYaml(data string) (*GenericTracingConf, error) {
 }
 
 func fileConfig(fileName string) (*GenericTracingConf, error) {
-	config, err := ioutil.ReadFile(fileName)
+	config, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kernels/kernels.go
+++ b/pkg/kernels/kernels.go
@@ -4,7 +4,7 @@
 package kernels
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -60,7 +60,7 @@ func GetKernelVersion(kernelVersion, procfs string) (int, string, error) {
 		version = int(KernelStringToNumeric(kernelVersion))
 		verStr = kernelVersion
 	} else {
-		if versionSig, err := ioutil.ReadFile(procfs + "/version_signature"); err == nil {
+		if versionSig, err := os.ReadFile(procfs + "/version_signature"); err == nil {
 			versionStrings := strings.Fields(string(versionSig))
 			version = int(KernelStringToNumeric(versionStrings[len(versionStrings)-1]))
 			verStr = versionStrings[len(versionStrings)-1]

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -519,11 +518,11 @@ func WaitForProcess(process string) error {
 	if procfs == "" {
 		procfs = "/proc/"
 	}
-	procDir, _ := ioutil.ReadDir(procfs)
+	procDir, _ := os.ReadDir(procfs)
 	for i := 0; i < 120; i++ {
 		for _, d := range procDir {
 
-			cmdline, err := ioutil.ReadFile(filepath.Join(procfs, d.Name(), "/cmdline"))
+			cmdline, err := os.ReadFile(filepath.Join(procfs, d.Name(), "/cmdline"))
 			if err != nil {
 				continue
 			}

--- a/pkg/reader/caps/caps.go
+++ b/pkg/reader/caps/caps.go
@@ -5,7 +5,7 @@ package caps
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -359,7 +359,7 @@ func GetPIDCaps(filename string) (uint32, uint64, uint64, uint64) {
 		return uint32(pid), err
 	}
 
-	file, err := ioutil.ReadFile(filename)
+	file, err := os.ReadFile(filename)
 	if err != nil {
 		logger.GetLogger().WithError(err).Warnf("ReadFile failed: %s", filename)
 		return 0, 0, 0, 0

--- a/pkg/reader/namespace/namespace.go
+++ b/pkg/reader/namespace/namespace.go
@@ -4,7 +4,6 @@
 package namespace
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -41,12 +40,12 @@ func GetPidNsInode(pid uint32, nsStr string) uint32 {
 func GetMyPidG() uint32 {
 	selfBinary := filepath.Base(os.Args[0])
 	if procfs := os.Getenv("TETRAGON_PROCFS"); procfs != "" {
-		procFS, _ := ioutil.ReadDir(procfs)
+		procFS, _ := os.ReadDir(procfs)
 		for _, d := range procFS {
 			if d.IsDir() == false {
 				continue
 			}
-			cmdline, err := ioutil.ReadFile(filepath.Join(procfs, d.Name(), "/cmdline"))
+			cmdline, err := os.ReadFile(filepath.Join(procfs, d.Name(), "/cmdline"))
 			if err != nil {
 				continue
 			}

--- a/pkg/reader/proc/proc.go
+++ b/pkg/reader/proc/proc.go
@@ -4,7 +4,7 @@ package proc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -59,7 +59,7 @@ func getProcStatStrings(procStat string) []string {
 }
 
 func GetProcStatStrings(file string) ([]string, error) {
-	statline, err := ioutil.ReadFile(filepath.Join(file, "stat"))
+	statline, err := os.ReadFile(filepath.Join(file, "stat"))
 	if err != nil {
 		return nil, fmt.Errorf("ReadFile: %s /stat error", file)
 	}

--- a/pkg/sensors/exec/procevents/proc.go
+++ b/pkg/sensors/exec/procevents/proc.go
@@ -6,7 +6,7 @@ package procevents
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -44,7 +44,9 @@ func ProcsContainerIdOffset(subdir string) (string, int) {
 // cgroup argument is the full cgroup path
 // bpfSource is set to true if cgroup was obtained from BPF, otherwise false.
 // walkParent if set then walk the parent hierarchy subdirs and try to find the container ID of the process,
-//    this will allow to return the container id of services running inside, example: init.service etc.
+//
+//	this will allow to return the container id of services running inside, example: init.service etc.
+//
 // Returns the container ID as a string of 31 characters and its offset on the full cgroup path,
 // otherwise on errors an empty string and 0 as offset.
 func LookupContainerId(cgroup string, bpfSource bool, walkParent bool) (string, int) {
@@ -145,7 +147,7 @@ func procsFindDockerId(cgroups string) (string, int) {
 // returned.
 func procsDockerId(pid uint32) (string, error) {
 	pidstr := fmt.Sprint(pid)
-	cgroups, err := ioutil.ReadFile(filepath.Join(option.Config.ProcFS, pidstr, "cgroup"))
+	cgroups, err := os.ReadFile(filepath.Join(option.Config.ProcFS, pidstr, "cgroup"))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -5,7 +5,6 @@ package procevents
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -247,7 +246,7 @@ func pushEvents(procs []Procs) {
 func GetRunningProcs() []Procs {
 	var procs []Procs
 
-	procFS, err := ioutil.ReadDir(option.Config.ProcFS)
+	procFS, err := os.ReadDir(option.Config.ProcFS)
 	if err != nil {
 		logger.GetLogger().WithError(err).Errorf("Could not read directory %s", option.Config.ProcFS)
 		return nil
@@ -270,7 +269,7 @@ func GetRunningProcs() []Procs {
 
 		pathName := filepath.Join(option.Config.ProcFS, d.Name())
 
-		cmdline, err := ioutil.ReadFile(filepath.Join(pathName, "cmdline"))
+		cmdline, err := os.ReadFile(filepath.Join(pathName, "cmdline"))
 		if err != nil {
 			continue
 		}
@@ -328,7 +327,7 @@ func GetRunningProcs() []Procs {
 			var err error
 			parentPath := filepath.Join(option.Config.ProcFS, ppid)
 
-			pcmdline, err = ioutil.ReadFile(filepath.Join(parentPath, "cmdline"))
+			pcmdline, err = os.ReadFile(filepath.Join(parentPath, "cmdline"))
 			if err != nil {
 				logger.GetLogger().WithError(err).WithField("path", parentPath).Warn("parent cmdline error")
 				continue

--- a/pkg/sensors/sync.go
+++ b/pkg/sensors/sync.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -245,7 +244,7 @@ func RemoveProgram(bpfDir string, prog *program.Program) {
 			coreFile = splitProg[1]
 		}
 		logger.GetLogger().Debugf("remove strings: %s", coreFile)
-		files, err := ioutil.ReadDir(bpfDir)
+		files, err := os.ReadDir(bpfDir)
 		if err == nil {
 			for _, f := range files {
 				if strings.Contains(f.Name(), coreFile) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -86,7 +85,7 @@ spec:
 	defer cancel()
 
 	writeConfigHook := []byte(writeReadHook)
-	err := ioutil.WriteFile(testConfigFile, writeConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, writeConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -131,7 +130,7 @@ spec:
         - ` + pidStr
 
 	lseekConfigHook := []byte(lseekConfigHook_)
-	err := ioutil.WriteFile(testConfigFile, lseekConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, lseekConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -173,7 +172,7 @@ func runKprobeObjectWriteRead(t *testing.T, writeReadHook string) {
 	defer cancel()
 
 	writeConfigHook := []byte(writeReadHook)
-	err := ioutil.WriteFile(testConfigFile, writeConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, writeConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -426,7 +425,7 @@ func runKprobeObjectRead(t *testing.T, readHook string, checker ec.MultiEventChe
 	defer cancel()
 
 	readConfigHook := []byte(readHook)
-	err := ioutil.WriteFile(testConfigFile, readConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, readConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -605,7 +604,7 @@ func testKprobeObjectFiltered(t *testing.T,
 	syscall.Close(fd)
 
 	readConfigHook := []byte(readHook)
-	err := ioutil.WriteFile(testConfigFile, readConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, readConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -1051,7 +1050,7 @@ spec:
         - 1
 `
 	writeConfigHook := []byte(writeReadHook)
-	err := ioutil.WriteFile(testConfigFile, writeConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, writeConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -1309,7 +1308,7 @@ func corePathTest(t *testing.T, filePath string, readHook string, writeChecker e
 	syscall.Close(fd)
 
 	readConfigHook := []byte(readHook)
-	err := ioutil.WriteFile(testConfigFile, readConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, readConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -1555,7 +1554,7 @@ spec:
 	defer cancel()
 
 	readConfigHook := []byte(readHook)
-	err := ioutil.WriteFile(testConfigFile, readConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, readConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -1608,7 +1607,7 @@ func runKprobeOverride(t *testing.T, hook string, checker ec.MultiEventChecker,
 	defer cancel()
 
 	configHook := []byte(hook)
-	err := ioutil.WriteFile(testConfigFile, configHook, 0644)
+	err := os.WriteFile(testConfigFile, configHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -1640,11 +1639,11 @@ func runKprobeOverride(t *testing.T, hook string, checker ec.MultiEventChecker,
 func TestKprobeOverride(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 
-	file, err := ioutil.TempFile("/tmp", "kprobe-override-")
+	file, err := os.CreateTemp(t.TempDir(), "kprobe-override-")
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer os.Remove(file.Name())
+	defer assert.NoError(t, file.Close())
 
 	openAtHook := `
 apiVersion: cilium.io/v1alpha1
@@ -1715,7 +1714,7 @@ spec:
 `
 
 	configHook := []byte(closeFdHook)
-	err := ioutil.WriteFile(testConfigFile, configHook, 0644)
+	err := os.WriteFile(testConfigFile, configHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -1736,7 +1735,7 @@ func runKprobe_char_iovec(t *testing.T, configHook string,
 	defer cancel()
 
 	testConfigHook := []byte(configHook)
-	err := ioutil.WriteFile(testConfigFile, testConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, testConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -2072,7 +2071,7 @@ func createReadChecker(filename string) *ec.ProcessKprobeChecker {
 
 func createCrdFile(t *testing.T, readHook string) {
 	readConfigHook := []byte(readHook)
-	err := ioutil.WriteFile(testConfigFile, readConfigHook, 0644)
+	err := os.WriteFile(testConfigFile, readConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
@@ -2477,7 +2476,7 @@ spec:
 	var err error
 
 	readConfigHook := []byte(readHook)
-	err = ioutil.WriteFile(testConfigFile, readConfigHook, 0644)
+	err = os.WriteFile(testConfigFile, readConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -6,7 +6,6 @@ package tracing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"syscall"
@@ -460,7 +459,7 @@ spec:
 	var err error
 
 	readConfigHook := []byte(readHook)
-	err = ioutil.WriteFile(testConfigFile, readConfigHook, 0644)
+	err = os.WriteFile(testConfigFile, readConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}

--- a/tests/e2e/helpers/dumpinfo.go
+++ b/tests/e2e/helpers/dumpinfo.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -95,7 +94,7 @@ func CreateExportDir(ctx context.Context, t *testing.T) (context.Context, error)
 		return ctx, nil
 	}
 
-	dir, err = ioutil.TempDir("", fmt.Sprintf("tetragon.e2e.%s.*", t.Name()))
+	dir, err = os.MkdirTemp("", fmt.Sprintf("tetragon.e2e.%s.*", t.Name()))
 	if err != nil {
 		return ctx, err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`)
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`