### PR TITLE
Make pfilter.h more generic

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -17,6 +17,18 @@
 #define SELECTORS_ACTIVE	 31
 #define MAX_CONFIGURED_SELECTORS MAX_POSSIBLE_SELECTORS + 1
 
+struct msg_selector_data {
+	__u64 curr;
+	__u64 pass;
+	bool active[MAX_CONFIGURED_SELECTORS];
+#ifdef __NS_CHANGES_FILTER
+	__u64 match_ns;
+#endif
+#ifdef __CAP_CHANGES_FILTER
+	__u64 match_cap;
+#endif
+};
+
 struct msg_generic_kprobe {
 	struct msg_common common;
 	struct msg_execve_key current;
@@ -29,15 +41,7 @@ struct msg_generic_kprobe {
 	char args[24000];
 	unsigned long a0, a1, a2, a3, a4;
 	long argsoff[MAX_POSSIBLE_ARGS];
-	__u64 curr;
-	__u64 pass;
-	bool active[MAX_CONFIGURED_SELECTORS];
-#ifdef __NS_CHANGES_FILTER
-	__u64 match_ns;
-#endif
-#ifdef __CAP_CHANGES_FILTER
-	__u64 match_cap;
-#endif
+	struct msg_selector_data sel;
 };
 
 static inline __attribute__((always_inline)) size_t generic_kprobe_common_size()

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -159,11 +159,11 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	});
 
 	msg->common.op = MSG_OP_GENERIC_TRACEPOINT;
-	msg->curr = 0;
+	msg->sel.curr = 0;
 #pragma unroll
 	for (i = 0; i < MAX_CONFIGURED_SELECTORS; i++)
-		msg->active[i] = 0;
-	msg->pass = 0;
+		msg->sel.active[i] = 0;
+	msg->sel.pass = 0;
 	tail_call(ctx, &tp_calls, 5);
 	return 0;
 }
@@ -223,7 +223,8 @@ generic_tracepoint_filter(void *ctx)
 	if (!msg)
 		return 0;
 
-	ret = generic_process_filter(msg, &filter_map, &tp_heap);
+	ret = generic_process_filter(&msg->sel, &msg->current, &msg->ns,
+				     &msg->caps, &filter_map);
 	if (ret == PFILTER_CONTINUE)
 		tail_call(ctx, &tp_calls, 5);
 	else if (ret == PFILTER_ACCEPT)

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -914,9 +914,8 @@ filter_args(struct msg_generic_kprobe *e, int index, void *filter_map)
 	}
 
 	/* No selectors, accept by default */
-	if (!e->active[SELECTORS_ACTIVE]) {
+	if (!e->sel.active[SELECTORS_ACTIVE])
 		return 1;
-	}
 
 	/* We ran process filters early as a prefilter to drop unrelated
 	 * events early. Now we need to ensure that active pid sselectors
@@ -925,7 +924,7 @@ filter_args(struct msg_generic_kprobe *e, int index, void *filter_map)
 	if (index > SELECTORS_ACTIVE)
 		return filter_args_reject();
 
-	if (e->active[index]) {
+	if (e->sel.active[index]) {
 		int pass = selector_arg_offset(f, e, index);
 		if (pass)
 			return pass;
@@ -1134,7 +1133,7 @@ filter_read_arg(void *ctx, int index, struct bpf_map_def *heap,
 	pass = filter_args(e, index, filter);
 	if (!pass) {
 		index++;
-		if (index > MAX_SELECTORS || !e->active[index])
+		if (index > MAX_SELECTORS || !e->sel.active[index])
 			return filter_args_reject();
 		tail_call(ctx, tailcalls, index + 5);
 		return 2;
@@ -1172,7 +1171,7 @@ filter_read_arg(void *ctx, int index, struct bpf_map_def *heap,
 
 #ifdef __NS_CHANGES_FILTER
 	/* update the namespaces if we matched a change on that */
-	if (e->match_ns) {
+	if (e->sel.match_ns) {
 		__u32 pid = (get_current_pid_tgid() >> 32);
 		struct task_struct *task =
 			(struct task_struct *)get_current_task();
@@ -1184,7 +1183,7 @@ filter_read_arg(void *ctx, int index, struct bpf_map_def *heap,
 #endif
 #ifdef __CAP_CHANGES_FILTER
 	/* update the capabilities if we matched a change on that */
-	if (e->match_cap) {
+	if (e->sel.match_cap) {
 		__u32 pid = (get_current_pid_tgid() >> 32);
 		struct task_struct *task =
 			(struct task_struct *)get_current_task();


### PR DESCRIPTION
`bpf/process/pfilter.h` implements several selectors for generic kprobes
and tracepoints. These include `matchPIDs`, `matchNamespaces`,
`matchNamespaceChanges`, `matchCapabilities`, and `matchCapabilityChanges`.

The main function `generic_process_filter()` gets as argument a pointer
to `msg_generic_kprobe`.

This commit changes this function in order to get more generic arguments
in order to be used for other use cases as well.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>