### PR TITLE
Add a function to load (but not attach) an eBPF program

### DIFF
--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -125,6 +125,16 @@ func KprobeAttach(load *Program) AttachFunc {
 	}
 }
 
+func NoAttach(load *Program) AttachFunc {
+	return func(prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
+		return unloader.ChainUnloader{
+			unloader.PinUnloader{
+				Prog: prog,
+			},
+		}, nil
+	}
+}
+
 func LoadTracepointProgram(bpfDir, mapDir string, load *Program, verbose int) error {
 	ci := &customInstall{fmt.Sprintf("%s-tp-calls", load.PinPath), "tracepoint"}
 	return loadProgram(bpfDir, []string{mapDir}, load, TracepointAttach(load), ci, verbose)
@@ -137,6 +147,10 @@ func LoadRawTracepointProgram(bpfDir, mapDir string, load *Program, verbose int)
 func LoadKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
 	ci := &customInstall{fmt.Sprintf("%s-kp-calls", load.PinPath), "kprobe"}
 	return loadProgram(bpfDir, []string{mapDir}, load, KprobeAttach(load), ci, verbose)
+}
+
+func LoadTailCallProgram(bpfDir, mapDir string, load *Program, verbose int) error {
+	return loadProgram(bpfDir, []string{mapDir}, load, NoAttach(load), nil, verbose)
 }
 
 func slimVerifierError(errStr string) string {


### PR DESCRIPTION
This can be used to load tail call programs.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>