### PR TITLE
sensor pinning fixes (and misc updates)

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -601,8 +601,17 @@ func parseSelector(
 	return nil
 }
 
-// array := [number][filter1][filter2][...][filtern]
-// filter := [length][matchPIDs][matchBinaries][matchArgs][matchNamespaces][matchCapabilities][matchNamespaceChanges][matchCapabilityChanges]
+// array :=
+// [number][filter1_offset][filter2_offset][...][filtern_offset][filter1][filter2][...][filtern]
+// filter := [length]
+//           [matchPIDs]
+//           [matchNamespaces]
+//           [matchCapabilities]
+//           [matchNamespaceChanges]
+//           [matchCapabilityChanges]
+//           [matchBinaries]
+//           [matchArgs]
+//           [matchActions]
 // matchPIDs := [num][PID1][PID2]...[PIDn]
 // matchBinaries := [num][op][Index]...[Index]
 // matchArgs := [num][ARGx][ARGy]...[ARGn]

--- a/pkg/sensors/path.go
+++ b/pkg/sensors/path.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package sensors
+
+import (
+	"strings"
+)
+
+// PathJoin creates a path meant for sensor filenames in /sys/fs/bpf.
+//
+// At some point, we would like to have a file hierarchy under /sys/fs/bpf for each sensor.
+// see: https://github.com/cilium/tetragon/issues/408
+//
+// Unfortunately, this requires changes, for properly creating and deleting
+// these directories requires. As an intermediate step, we use this function
+// that uses dashes instead of / to create unique files in flat hierarchy,
+// without needeing to manage directories.
+func PathJoin(elem ...string) string {
+	return strings.Join(elem, "-")
+}

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -313,8 +313,8 @@ func doLoadProgram(
 		if err != nil {
 			// Log the error directly using the logger so that the verifier log
 			// gets properly pretty-printed.
-			logger.GetLogger().Infof("Opening collection failed, dumping verifier log.")
 			if verbose != 0 {
+				logger.GetLogger().Infof("Opening collection failed, dumping verifier log.")
 				fmt.Println(slimVerifierError(err.Error()))
 			}
 

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -126,7 +126,13 @@ func KprobeAttach(load *Program) AttachFunc {
 }
 
 func LoadTracepointProgram(bpfDir, mapDir string, load *Program, verbose int) error {
-	ci := &customInstall{fmt.Sprintf("%s-tp-calls", load.PinPath), "tracepoint"}
+	var ci *customInstall
+	for mName, mPath := range load.PinMap {
+		if mName == "tp_calls" {
+			ci = &customInstall{mPath, "tracepoint"}
+			break
+		}
+	}
 	return loadProgram(bpfDir, []string{mapDir}, load, TracepointAttach(load), ci, verbose)
 }
 

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -107,7 +107,7 @@ func TestKprobeLseek(t *testing.T) {
 	defer cancel()
 
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
-	fmt.Printf("pid=%s\n", pidStr)
+	t.Logf("tester pid=%s\n", pidStr)
 
 	lseekConfigHook_ := `
 apiVersion: cilium.io/v1alpha1

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -66,7 +66,7 @@ func TestGenericTracepointSimple(t *testing.T) {
 
 	sm := tus.StartTestSensorManager(ctx, t)
 	// create and add sensor
-	sensor, err := createGenericTracepointSensor([]GenericTracepointConf{lseekConf})
+	sensor, err := createGenericTracepointSensor("GtpLseekTest", []GenericTracepointConf{lseekConf})
 	if err != nil {
 		t.Fatalf("failed to create generic tracepoint sensor: %s", err)
 	}
@@ -125,7 +125,7 @@ func doTestGenericTracepointPidFilter(t *testing.T, conf GenericTracepointConf, 
 
 	sm := tus.StartTestSensorManager(ctx, t)
 	// create and add sensor
-	sensor, err := createGenericTracepointSensor([]GenericTracepointConf{conf})
+	sensor, err := createGenericTracepointSensor("GtpLseekTest", []GenericTracepointConf{conf})
 	if err != nil {
 		t.Fatalf("failed to create generic tracepoint sensor: %s", err)
 	}


### PR DESCRIPTION
This PR aims to sanitize pinning and meant as an intermediate step towards https://github.com/cilium/tetragon/issues/408. It also includes some simple (first 3) patches.

One of the immediate effects of this PR is that generic tracepoints have unique map names and collisions that may  cause problems are avoided.

See patches for more information.