### PR TITLE
add InMap operator for filtering arguments, and improve eBPF unit testing for kprobes

### DIFF
--- a/bpf/process/argfilter_maps.h
+++ b/bpf/process/argfilter_maps.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Cilium */
+
+#ifndef ARGFILTER_MAPS_H__
+#define ARGFILTER_MAPS_H__
+
+#define ARGFILTER_MAPS_OUTER_MAX_ENTRIES 8
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, ARGFILTER_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_HASH);
+			__uint(max_entries, 1);
+			__type(key, __u64);
+			__type(value, __u8);
+		});
+} argfilter_maps SEC(".maps");
+
+#endif // ARGFILTER_MAPS_H__

--- a/bpf/process/types/operations.h
+++ b/bpf/process/types/operations.h
@@ -17,6 +17,9 @@ enum {
 	op_filter_str_contains = 7,
 	op_filter_str_prefix = 8,
 	op_filter_str_postfix = 9,
+	// map membership ops
+	op_filter_inmap = 10,
+	op_filter_notinmap = 11,
 };
 
 #endif // __OPERATIONS_H__

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -676,6 +676,14 @@ func parseSelector(
 // valueGen := [type][len][v]
 // valueInt := [len][v]
 func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg) ([4096]byte, error) {
+	kernelSelectors, err := InitKernelSelectorState(selectors, args)
+	if err != nil {
+		return [4096]byte{}, err
+	}
+	return kernelSelectors.e, nil
+}
+
+func InitKernelSelectorState(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg) (*KernelSelectorState, error) {
 	kernelSelectors := &KernelSelectorState{}
 
 	WriteSelectorUint32(kernelSelectors, uint32(len(selectors)))
@@ -687,11 +695,11 @@ func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KP
 		WriteSelectorLength(kernelSelectors, soff[i])
 		loff := AdvanceSelectorLength(kernelSelectors)
 		if err := parseSelector(kernelSelectors, &s, args); err != nil {
-			return kernelSelectors.e, err
+			return nil, err
 		}
 		WriteSelectorLength(kernelSelectors, loff)
 	}
-	return kernelSelectors.e, nil
+	return kernelSelectors, nil
 }
 
 func HasOverride(spec *v1alpha1.KProbeSpec) bool {

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -48,8 +48,17 @@ var actionTypeStringTable = map[uint32]string{
 	ActionTypeDnsLookup:  "dnslookup",
 }
 
-func MatchActionSigKill(spec *v1alpha1.KProbeSpec) bool {
-	sels := spec.Selectors
+func MatchActionSigKill(spec interface{}) bool {
+	var sels []v1alpha1.KProbeSelector
+	switch s := spec.(type) {
+	case *v1alpha1.KProbeSpec:
+		sels = s.Selectors
+	case *v1alpha1.TracepointSpec:
+		sels = s.Selectors
+	default:
+		return false
+	}
+
 	for _, s := range sels {
 		for _, act := range s.MatchActions {
 			if strings.ToLower(act.Action) == actionTypeStringTable[ActionTypeSigKill] {

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -306,7 +306,7 @@ func writeMatchValuesInMap(k *KernelSelectorState, values []string, ty uint32) e
 	for _, v := range values {
 		var val [8]byte
 		switch ty {
-		case argTypeS64:
+		case argTypeS64, argTypeInt:
 			i, err := strconv.ParseInt(v, 10, 64)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %x", v, err)

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -12,7 +12,7 @@ type KernelSelectorState struct {
 	e   [4096]byte // kernel encoding of selectors
 }
 
-func GetSelectorBuffer(k *KernelSelectorState) [4096]byte {
+func (k *KernelSelectorState) Buffer() [4096]byte {
 	return k.e
 }
 

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -10,10 +10,17 @@ import (
 type KernelSelectorState struct {
 	off uint32     // offset into encoding
 	e   [4096]byte // kernel encoding of selectors
+
+	// valueMaps are used to populate value maps for InMap and NotInMap operators
+	valueMaps []map[[8]byte]struct{}
 }
 
 func (k *KernelSelectorState) Buffer() [4096]byte {
 	return k.e
+}
+
+func (k *KernelSelectorState) ValueMaps() []map[[8]byte]struct{} {
+	return k.valueMaps
 }
 
 func WriteSelectorInt32(k *KernelSelectorState, v int32) {
@@ -57,4 +64,10 @@ func AdvanceSelectorLength(k *KernelSelectorState) uint32 {
 func ArgSelectorValue(v string) ([]byte, uint32) {
 	b := []byte(v)
 	return b, uint32(len(b))
+}
+
+func (k *KernelSelectorState) newValueMap() (uint32, map[[8]byte]struct{}) {
+	mapid := len(k.valueMaps)
+	k.valueMaps = append(k.valueMaps, map[[8]byte]struct{}{})
+	return uint32(mapid), k.valueMaps[mapid]
 }

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -350,7 +350,7 @@ func doLoadProgram(
 
 	for _, mapLoad := range load.MapLoad {
 		if m, ok := coll.Maps[mapLoad.Name]; ok {
-			if err := m.Update(uint32(0), mapLoad.Data, ebpf.UpdateAny); err != nil {
+			if err := mapLoad.Load(m); err != nil {
 				return nil, err
 			}
 		} else {

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -151,7 +151,13 @@ func LoadRawTracepointProgram(bpfDir, mapDir string, load *Program, verbose int)
 }
 
 func LoadKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
-	ci := &customInstall{fmt.Sprintf("%s-kp-calls", load.PinPath), "kprobe"}
+	var ci *customInstall
+	for mName, mPath := range load.PinMap {
+		if mName == "kprobe_calls" {
+			ci = &customInstall{mPath, "kprobe"}
+			break
+		}
+	}
 	return loadProgram(bpfDir, []string{mapDir}, load, KprobeAttach(load), ci, verbose)
 }
 

--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -5,6 +5,7 @@ package program
 import (
 	"fmt"
 
+	"github.com/cilium/ebpf"
 	"github.com/cilium/tetragon/pkg/sensors/unloader"
 )
 
@@ -35,7 +36,7 @@ func GetProgramInfo(l *Program) (program, label, prog string) {
 
 type MapLoad struct {
 	Name string
-	Data []byte
+	Load func(m *ebpf.Map) error
 }
 
 // Program reprents a BPF program.

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -457,6 +457,55 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 	}, nil
 }
 
+// ReloadGenericKprobeSelectors will reload a kprobe by unlinking it, generating new
+// selector data and updating filter_map, and then relinking the kprobe (entry).
+//
+// This is intentended for speeding up testing, so DO NOT USE elswhere without
+// checking its implementation first because limitations may exist (e.g,. the
+// config map is not updated, the retprobe is not reloaded, userspace return filters are not updated, etc.).
+func ReloadGenericKprobeSelectors(kpSensor *sensors.Sensor, conf *v1alpha1.KProbeSpec) error {
+
+	// The first program should be the (entry) kprobe, and that's the only
+	// one we will reload. We could reload the retprobe, but the assumption
+	// is that we don't need to, because it will never be executed if the
+	// entry probe is not loaded.
+	kprobeProg := kpSensor.Progs[0]
+	if kprobeProg.Label != "kprobe/generic_kprobe" {
+		return fmt.Errorf("first program %+v does not seem to be the entry kprobe", kprobeProg)
+	}
+
+	if err := kprobeProg.Unlink(); err != nil {
+		return fmt.Errorf("unlinking %v failed: %s", kprobeProg, err)
+	}
+
+	kState, err := selectors.InitKernelSelectorState(conf.Selectors, conf.Args)
+	if err != nil {
+		return err
+	}
+
+	filterName, ok := kprobeProg.PinMap["filter_map"]
+	if !ok {
+		return fmt.Errorf("cannot find pinned filter_map")
+	}
+	filterMapPath := filepath.Join(bpf.MapPrefixPath(), filterName)
+	filterMap, err := ebpf.LoadPinnedMap(filterMapPath, nil)
+	if err != nil {
+		return fmt.Errorf("failed to open filter map: %w", err)
+	}
+	defer filterMap.Close()
+
+	selBuff := kState.Buffer()
+	if err := filterMap.Update(uint32(0), selBuff[:], ebpf.UpdateAny); err != nil {
+		return fmt.Errorf("failed to update filter data: %w", err)
+	}
+
+	if err := kprobeProg.Relink(); err != nil {
+		return fmt.Errorf("failed relinking %v: %w", kprobeProg, err)
+	}
+
+	return nil
+}
+
 func loadGenericKprobeSensor(bpfDir, mapDir string, load *program.Program, version, verbose int) error {
 	gk, err := genericKprobeFromBpfLoad(load)
 	if err != nil {

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -436,6 +436,10 @@ func (tp *genericTracepoint) EventConfig() (api.EventConfig, error) {
 		config.ArgM[i] = uint32(0)
 	}
 
+	if selectors.MatchActionSigKill(tp.Spec) {
+		config.Sigkill = 1
+	}
+
 	return config, nil
 }
 

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -506,14 +506,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 	if err != nil {
 		return err
 	}
-	selBuff := kernelSelectors.Buffer()
-	filter := &program.MapLoad{
-		Name: "filter_map",
-		Load: func(m *ebpf.Map) error {
-			return m.Update(uint32(0), selBuff[:], ebpf.UpdateAny)
-		},
-	}
-	load.MapLoad = append(load.MapLoad, filter)
+	load.MapLoad = append(load.MapLoad, selectorsMaploads(kernelSelectors, tp.pinPathPrefix)...)
 
 	config, err := tp.EventConfig()
 	if err != nil {
@@ -528,13 +521,6 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 		},
 	}
 	load.MapLoad = append(load.MapLoad, cfg)
-
-	load.MapLoad = append(load.MapLoad, &program.MapLoad{
-		Name: "argfilter_maps",
-		Load: func(outerMap *ebpf.Map) error {
-			return populateArgFilterMaps(kernelSelectors, tp, outerMap)
-		},
-	})
 
 	return program.LoadTracepointProgram(bpfDir, mapDir, load, verbose)
 }

--- a/pkg/sensors/tracing/selectors.go
+++ b/pkg/sensors/tracing/selectors.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/selectors"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+)
+
+// internal functions for dealing with selectors that are common for kprobes/tracepoints
+
+// updateSelectors will update filter_map and argfilter_maps based on the provided kernel selectors
+func updateSelectors(
+	ks *selectors.KernelSelectorState,
+	pinMap map[string]string,
+	pinPathPrefix string,
+) error {
+
+	filterName, ok := pinMap["filter_map"]
+	if !ok {
+		return fmt.Errorf("cannot find pinned filter_map")
+	}
+	filterMapPath := filepath.Join(bpf.MapPrefixPath(), filterName)
+	filterMap, err := ebpf.LoadPinnedMap(filterMapPath, nil)
+	if err != nil {
+		return fmt.Errorf("failed to open filter map: %w", err)
+	}
+	defer filterMap.Close()
+
+	selBuff := ks.Buffer()
+	if err := filterMap.Update(uint32(0), selBuff[:], ebpf.UpdateAny); err != nil {
+		return fmt.Errorf("failed to update filter data: %w", err)
+	}
+
+	argfilterMapsName, ok := pinMap["argfilter_maps"]
+	if !ok {
+		return fmt.Errorf("cannot find pinned argfilter_maps")
+	}
+	argfilterMapsName = filepath.Join(bpf.MapPrefixPath(), argfilterMapsName)
+	argfilterMaps, err := ebpf.LoadPinnedMap(argfilterMapsName, nil)
+	if err != nil {
+		return fmt.Errorf("failed to open argfilter_map map %s: %w", argfilterMapsName, err)
+	}
+	defer argfilterMaps.Close()
+	if err := populateArgFilterMaps(ks, pinPathPrefix, argfilterMaps); err != nil {
+		return fmt.Errorf("failed to populate argfilter_maps: %w", err)
+	}
+
+	return nil
+}
+
+func populateArgFilterMaps(
+	k *selectors.KernelSelectorState,
+	pinPathPrefix string,
+	outerMap *ebpf.Map,
+) error {
+	for i, vm := range k.ValueMaps() {
+		err := populateArgFilterMap(pinPathPrefix, outerMap, uint32(i), vm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func populateArgFilterMap(
+	pinPathPrefix string,
+	outerMap *ebpf.Map,
+	innerID uint32,
+	innerData map[[8]byte]struct{},
+) error {
+	innerName := fmt.Sprintf("argfilter_map_%d", innerID)
+	innerSpec := &ebpf.MapSpec{
+		Name:       innerName,
+		Type:       ebpf.Hash,
+		KeySize:    8, // NB: hardcoded to 64 bits for now
+		ValueSize:  uint32(1),
+		MaxEntries: uint32(len(innerData)),
+	}
+	innerMap, err := ebpf.NewMapWithOptions(innerSpec, ebpf.MapOptions{
+		PinPath: sensors.PathJoin(pinPathPrefix, innerName),
+	})
+	if err != nil {
+		return fmt.Errorf("creating innerMap %s failed: %w", innerName, err)
+	}
+	defer innerMap.Close()
+
+	one := uint8(1)
+	for val := range innerData {
+		err := innerMap.Update(val[:], one, 0)
+		if err != nil {
+			return fmt.Errorf("failed to insert value into %s: %w", innerName, err)
+		}
+	}
+
+	if err := outerMap.Update(uint32(innerID), uint32(innerMap.FD()), 0); err != nil {
+		return fmt.Errorf("failed to insert %s: %w", innerName, err)
+	}
+
+	return nil
+}

--- a/pkg/sensors/tracing/selectors.go
+++ b/pkg/sensors/tracing/selectors.go
@@ -56,6 +56,23 @@ func updateSelectors(
 	return nil
 }
 
+func selectorsMaploads(ks *selectors.KernelSelectorState, pinPathPrefix string) []*program.MapLoad {
+	selBuff := ks.Buffer()
+	return []*program.MapLoad{
+		{
+			Name: "filter_map",
+			Load: func(m *ebpf.Map) error {
+				return m.Update(uint32(0), selBuff[:], ebpf.UpdateAny)
+			},
+		}, {
+			Name: "argfilter_maps",
+			Load: func(outerMap *ebpf.Map) error {
+				return populateArgFilterMaps(ks, pinPathPrefix, outerMap)
+			},
+		},
+	}
+}
+
 func populateArgFilterMaps(
 	k *selectors.KernelSelectorState,
 	pinPathPrefix string,

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -3,12 +3,17 @@
 
 package tracing
 
+// NB(kkourt): Function(t *testing.T, ctx context.Context) is the reasonable
+// thing to do here even if revive complains.
+//revive:disable:context-as-argument
+
 import (
 	"context"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger"
@@ -38,6 +43,84 @@ func tpSpecReload(t *testing.T, tpSensor *sensors.Sensor, tpSpec *v1alpha1.Trace
 	if len(tpSensor.Progs) != 1 {
 		t.Fatalf("unexpected progs size: %d", len(tpSensor.Progs))
 	}
+}
+
+// loadGenericSensorTest loads a tracing sensor for testing
+func loadGenericSensorTest(t *testing.T, ctx context.Context, spec *v1alpha1.TracingPolicySpec) *sensors.Sensor {
+	ret, err := sensors.GetSensorsFromParserPolicy(spec)
+	if err != nil {
+		t.Fatalf("GetSensorsFromParserPolicy failed: %v", err)
+	} else if len(ret) != 1 {
+		t.Fatalf("GetSensorsFromParserPolicy returned unexpected number of sensors (%d)", len(ret))
+	}
+	tpSensor := ret[0]
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	option.Config.Verbosity = 5
+	tus.LoadSensor(ctx, t, base.GetInitialSensor())
+	tus.LoadSensor(ctx, t, testsensor.GetTestSensor())
+	tus.LoadSensor(ctx, t, tpSensor)
+	return tpSensor
+}
+
+// lseekTestOps retruns a function to perform test lseek operations using the
+// given whence values
+func lseekTestOps(whences []int) func(t *testing.T) {
+	return func(t *testing.T) {
+		for _, whence := range whences {
+			t.Logf("Calling lseek(-1,0,%d)", whence)
+			unix.Seek(-1, 0, whence)
+		}
+	}
+}
+
+type testCase struct {
+	// the test will perform a series of (bogys) lseek cols using the provided values as a whence argumetn
+	lseekOpsVals []int
+	// the expectedArgs are a map from whence values to the frequency they were observed in the events
+	expectedArgs map[uint64]int
+}
+
+// testCases defines the use-cases we want to test
+var testCases = []struct {
+	// specOperator is the operator that will be used in the generated spec
+	specOperator string
+	// specFilterVals is the values that will be used in the generated spec
+	specFilterVals []int
+	// the cases to actually test given the above spec properties
+	tests []testCase
+}{
+	{
+		specOperator:   "Equal",
+		specFilterVals: []int{4443},
+		tests: []testCase{
+			{lseekOpsVals: []int{4444, 4443}, expectedArgs: map[uint64]int{4443: 1}},
+			{lseekOpsVals: []int{4443, 4444, 4443}, expectedArgs: map[uint64]int{4443: 2}},
+		},
+	},
+	{
+		specOperator:   "Equal",
+		specFilterVals: []int{4444},
+		tests: []testCase{
+			{lseekOpsVals: []int{4444, 4443}, expectedArgs: map[uint64]int{4444: 1}},
+			{lseekOpsVals: []int{4443, 4444, 4443}, expectedArgs: map[uint64]int{4444: 1}},
+		},
+	},
+	{
+		specOperator:   "InMap",
+		specFilterVals: []int{4443},
+		tests: []testCase{
+			{lseekOpsVals: []int{4444, 4443}, expectedArgs: map[uint64]int{4443: 1}},
+			{lseekOpsVals: []int{4443, 4444, 4443}, expectedArgs: map[uint64]int{4443: 2}},
+		},
+	},
+	{
+		specOperator:   "InMap",
+		specFilterVals: []int{4444},
+		tests: []testCase{
+			{lseekOpsVals: []int{4444, 4443}, expectedArgs: map[uint64]int{4444: 1}},
+			{lseekOpsVals: []int{4443, 4444, 4443}, expectedArgs: map[uint64]int{4444: 1}},
+		},
+	},
 }
 
 // TestTracepointSelectors tests the tracepoint selectors.
@@ -74,7 +157,7 @@ func TestTracepointSelectors(t *testing.T) {
 	// It will create filters:
 	//  - for our pid, to get more predictable events
 	//  - for the whence values provided as argument (if any)
-	makeSpec := func(t *testing.T, filterWhenceVals []int) *v1alpha1.TracingPolicySpec {
+	makeSpec := func(t *testing.T, filterWhenceVals []int, filterOperator string) *v1alpha1.TracingPolicySpec {
 		mypid := int(observer.GetMyPid())
 		t.Logf("filtering for my pid (%d)", mypid)
 		sels := []v1alpha1.KProbeSelector{{
@@ -93,7 +176,7 @@ func TestTracepointSelectors(t *testing.T) {
 			sels[0].MatchArgs = []v1alpha1.ArgSelector{
 				{
 					Index:    whenceIdx,
-					Operator: "Equal",
+					Operator: filterOperator,
 					Values:   whences,
 				},
 			}
@@ -111,38 +194,10 @@ func TestTracepointSelectors(t *testing.T) {
 		return &spec
 	}
 
-	// loadSensor loads a sensor
-	loadSensor := func(t *testing.T, spec *v1alpha1.TracingPolicySpec) *sensors.Sensor {
-		ret, err := sensors.GetSensorsFromParserPolicy(spec)
-		if err != nil {
-			t.Fatalf("GetSensorsFromParserPolicy failed: %v", err)
-		} else if len(ret) != 1 {
-			t.Fatalf("GetSensorsFromParserPolicy returned unexpected number of sensors (%d)", len(ret))
-		}
-		tpSensor := ret[0]
-		option.Config.HubbleLib = tus.Conf().TetragonLib
-		option.Config.Verbosity = 5
-		tus.LoadSensor(ctx, t, base.GetInitialSensor())
-		tus.LoadSensor(ctx, t, testsensor.GetTestSensor())
-		tus.LoadSensor(ctx, t, tpSensor)
-		return tpSensor
-	}
-
-	// lseekOps retruns a function to perform test lseek operations using the given whence
-	// values
-	lseekOps := func(whences []int) func(t *testing.T) {
-		return func(t *testing.T) {
-			for _, whence := range whences {
-				t.Logf("Calling lseek(-1,0,%d)", whence)
-				unix.Seek(-1, 0, whence)
-			}
-		}
-	}
-
 	// runAndCheck runs perfring test where op is exected and events are collected.
-	// expectedArgs is a counter for the whence values seen by events, and is checked at the end
-	// of the test.
-	runAndCheck := func(t *testing.T, name string, op func(t *testing.T), expectedArgs map[uint64]int) {
+	// expectedArgs is a counter for the whence values seen by events, and is
+	// checked at the end of the test.
+	runAndCheck := func(t *testing.T, ctx context.Context, name string, op func(t *testing.T), expectedArgs map[uint64]int) {
 		ret := make(map[uint64]int)
 		perfring.RunSubTest(t, ctx, name, op, func(ev notify.Message) error {
 			if tpEvent, ok := ev.(*tracing.MsgGenericTracepointUnix); ok {
@@ -172,20 +227,141 @@ func TestTracepointSelectors(t *testing.T) {
 		}
 	}
 
+	tpSensor := loadGenericSensorTest(t, ctx, makeSpec(t, testCases[0].specFilterVals, testCases[0].specOperator))
 	t0 := time.Now()
-	tpSensor := loadSensor(t, makeSpec(t, []int{4443}))
 	loadElapsed := time.Since(t0)
 	t.Logf("loading sensors took: %s\n", loadElapsed)
+	for i, tcs := range testCases {
+		tName := fmt.Sprintf("spec:%s%v", tcs.specOperator, tcs.specFilterVals)
+		t.Run(tName, func(t *testing.T) {
+			t.Logf("%d", i)
+			testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
+			spec := makeSpec(t, tcs.specFilterVals, tcs.specOperator)
+			if i == 0 {
+			} else {
+				tpSpecReload(t, tpSensor, &spec.Tracepoints[0])
+			}
 
-	t.Run("initial sensor", func(t *testing.T) {
-		testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
-		runAndCheck(t, "two events", lseekOps([]int{4444, 4443}), map[uint64]int{4443: 1})
-	})
+			for _, tc := range tcs.tests {
+				runAndCheck(t, ctx, fmt.Sprintf("lseekValls:%v", tc.lseekOpsVals), lseekTestOps(tc.lseekOpsVals), tc.expectedArgs)
+			}
+		})
+	}
 
-	t.Run("sensor with filter for 4443", func(t *testing.T) {
-		testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
-		spec := makeSpec(t, []int{4444})
-		tpSpecReload(t, tpSensor, &spec.Tracepoints[0])
-		runAndCheck(t, "one event", lseekOps([]int{4444, 4443}), map[uint64]int{4444: 1})
-	})
+}
+
+func TestKprobeSelectors(t *testing.T) {
+	testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	makeSpec := func(t *testing.T, filterWhenceVals []int, filterOperator string) *v1alpha1.TracingPolicySpec {
+		mypid := int(observer.GetMyPid())
+		t.Logf("filtering for my pid (%d)", mypid)
+		sels := []v1alpha1.KProbeSelector{{
+			MatchPIDs: []v1alpha1.PIDSelector{{
+				Operator:       "In",
+				IsNamespacePID: false,
+				FollowForks:    true,
+				Values:         []uint32{uint32(mypid)},
+			}}}}
+
+		if len(filterWhenceVals) > 0 {
+			whences := make([]string, len(filterWhenceVals))
+			for i := range filterWhenceVals {
+				whences[i] = fmt.Sprintf("%d", filterWhenceVals[i])
+			}
+			sels[0].MatchArgs = []v1alpha1.ArgSelector{
+				{
+					Index:    2,
+					Operator: filterOperator,
+					Values:   whences,
+				},
+			}
+		}
+
+		spec := v1alpha1.TracingPolicySpec{
+			KProbes: []v1alpha1.KProbeSpec{{
+				Call:    "__x64_sys_lseek",
+				Return:  true,
+				Syscall: true,
+				ReturnArg: v1alpha1.KProbeArg{
+					Type: "int",
+				},
+				Args: []v1alpha1.KProbeArg{{
+					Index: 2,
+					Type:  "int",
+				}},
+				Selectors: sels,
+			}},
+		}
+
+		return &spec
+	}
+
+	// runAndCheck runs perfring test where op is exected and events are collected.
+	// expectedArgs is a counter for the whence values seen by events, and is
+	// checked at the end of the test.
+	runAndCheck := func(t *testing.T, ctx context.Context, name string, op func(t *testing.T), expectedArgs map[uint64]int) {
+		ret := make(map[uint64]int)
+		perfring.RunSubTest(t, ctx, name, op, func(ev notify.Message) error {
+			if kpEvent, ok := ev.(*tracing.MsgGenericKprobeUnix); ok {
+				if kpEvent.FuncName != "__x64_sys_lseek" {
+					return fmt.Errorf("unexpected kprobe event, func:%s", kpEvent.FuncName)
+				}
+				if len(kpEvent.Args) != 2 {
+					return fmt.Errorf("unexpected kprobe arguments: %+v", kpEvent.Args)
+				}
+				whenceArg, ok := kpEvent.Args[0].(tracingapi.MsgGenericKprobeArgInt)
+				if !ok {
+					return fmt.Errorf("unexpected kprobe arguments %+v", kpEvent.Args[0])
+				}
+
+				retArg, ok := kpEvent.Args[1].(tracingapi.MsgGenericKprobeArgInt)
+				if !ok {
+					return fmt.Errorf("unexpected kprobe arguments %+v", kpEvent.Args[0])
+				}
+				if retArg.Value != -9 { // -EBADF
+					return fmt.Errorf("unexpected return value: %+v", retArg)
+				}
+
+				whence := uint64(whenceArg.Value)
+				// the test sensor also uses the same trick: an lseek call with a
+				// bogus whence value. Ignore those events
+				if whence == uint64(testsensor.BogusWhenceVal) {
+					return nil
+				}
+
+				ret[whence] = ret[whence] + 1
+				return nil
+			}
+			return nil
+		})
+		if diff := cmp.Diff(expectedArgs, ret); diff != "" {
+			t.Fatalf("expecting %v but got %v, diff:%s", expectedArgs, ret, diff)
+		}
+	}
+
+	t0 := time.Now()
+	kpSensor := loadGenericSensorTest(t, ctx, makeSpec(t, testCases[0].specFilterVals, testCases[0].specOperator))
+	loadElapsed := time.Since(t0)
+	t.Logf("loading sensors (kpSensor: %p)  took: %s\n", kpSensor, loadElapsed)
+	for i, tcs := range testCases {
+		tName := fmt.Sprintf("spec:%s%v", tcs.specOperator, tcs.specFilterVals)
+		t.Run(tName, func(t *testing.T) {
+			t.Logf("%d", i)
+			testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
+			spec := makeSpec(t, tcs.specFilterVals, tcs.specOperator)
+			if i == 0 {
+			} else {
+				if err := ReloadGenericKprobeSelectors(kpSensor, &spec.KProbes[0]); err != nil {
+					t.Fatalf("failed to reload kprobe prog: %s", err)
+				}
+			}
+
+			for _, tc := range tcs.tests {
+				runAndCheck(t, ctx, fmt.Sprintf("lseekValls:%v", tc.lseekOpsVals), lseekTestOps(tc.lseekOpsVals), tc.expectedArgs)
+			}
+		})
+	}
 }

--- a/pkg/syscallinfo/syscallinfo.go
+++ b/pkg/syscallinfo/syscallinfo.go
@@ -402,6 +402,24 @@ var syscallNames = map[int]string{
 	// unix.SYS_SET_MEMPOLICY_HOME_NODE: "sys_set_mempolicy_home_node",
 }
 
+var syscallIDs = func() map[string]int {
+	ret := make(map[string]int, len(syscallNames))
+	for k, v := range syscallNames {
+		ret[v] = k
+	}
+	return ret
+}()
+
+// GetSyscallID returns the id of a syscall based on its name
+// returns -1, if no system call was found
+func GetSyscallID(sysName string) int {
+	k := fmt.Sprintf("sys_%s", sysName)
+	if id, ok := syscallIDs[k]; ok {
+		return id
+	}
+	return -1
+}
+
 // GetSyscallName returns the name of a syscall based on its i d
 func GetSyscallName(sysID int) string {
 	if name, ok := syscallNames[sysID]; ok {

--- a/pkg/testutils/sensors/testrun.go
+++ b/pkg/testutils/sensors/testrun.go
@@ -113,12 +113,20 @@ func TestSensorsRun(m *testing.M, sensorName string) int {
 
 	bpf.SetMapPrefix(testMapDir)
 	defer func() {
+		log := logger.GetLogger()
 		path := bpf.MapPrefixPath()
 		_, err := os.Stat(path)
 		if os.IsNotExist(err) {
 			return
 		}
-		fmt.Printf("map dir `%s` still exists after test. Removing it.\n", path)
+
+		if entries, err := os.ReadDir(path); err == nil {
+			for _, entry := range entries {
+				log.Printf("`%s` still exists after test", entry.Name())
+			}
+		}
+
+		log.Printf("map dir `%s` still exists after test. Removing it.", path)
 		os.RemoveAll(path)
 	}()
 	if err := btf.InitCachedBTF(context.Background(), config.TetragonLib, ""); err != nil {


### PR DESCRIPTION
Mainly, this PR adds an InMap (and NotInMap) argument operator for generic tracepoints and kprobes. InMap acts as a filter based on whether the value of an argument exists on a map or not. It works similar to the Equal operator, but it does not have the constrains on the number of values of the latter.

Secondly, this PR improves upon #415, by adding support for testing different selectors without reloading (and re-verifying) the program to generic kprobes.

Thirdly, it improves the implementation for both generic kprobes and tracepoints. Please review commit-by-commit.
