### PR TITLE
tetragon: Fix merged kprobe events

### DIFF
--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -55,10 +55,13 @@ BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 	if (!retprobe_map_get(e->thread_id, &info))
 		return 0;
 
+	*(unsigned long *)e->args = info.ktime_enter;
+	size += sizeof(info.ktime_enter);
+
 	ty_arg = config->argreturn;
 	do_copy = config->argreturncopy;
 	if (ty_arg)
-		size += read_call_arg(ctx, e, 0, ty_arg, 0, ret, 0, 0);
+		size += read_call_arg(ctx, e, 0, ty_arg, size, ret, 0, 0);
 
 	/*
 	 * 0x1000 should be maximum argument length, so masking

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -54,7 +54,7 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 #ifdef GENERIC_KPROBE
 	ty = config->argreturn;
 	if (ty > 0)
-		retprobe_map_set(e->thread_id, 1);
+		retprobe_map_set(e->thread_id, e->common.ktime, 1);
 #endif
 
 	/* Read out args1-5 */

--- a/bpf/process/retprobe_map.h
+++ b/bpf/process/retprobe_map.h
@@ -14,21 +14,18 @@ struct {
 	__type(value, struct retprobe_info);
 } retprobe_map SEC(".maps");
 
-static inline __attribute__((always_inline)) unsigned long
-retprobe_map_get(__u64 tid, unsigned long *cntp)
+static inline __attribute__((always_inline)) bool
+retprobe_map_get(__u64 tid, struct retprobe_info *bufp)
 {
 	struct retprobe_info *info;
-	unsigned long ptr;
 
 	info = map_lookup_elem(&retprobe_map, &tid);
 	if (!info)
-		return 0;
-
-	ptr = info->ptr;
-	if (cntp)
-		*cntp = info->cnt;
+		return false;
+	if (bufp)
+		*bufp = *info;
 	map_delete_elem(&retprobe_map, &tid);
-	return ptr;
+	return true;
 }
 
 static inline __attribute__((always_inline)) void retprobe_map_clear(__u64 tid)

--- a/bpf/process/retprobe_map.h
+++ b/bpf/process/retprobe_map.h
@@ -3,6 +3,7 @@
 #include "bpf_tracing.h"
 
 struct retprobe_info {
+	unsigned long ktime_enter;
 	unsigned long ptr;
 	unsigned long cnt;
 };
@@ -37,9 +38,10 @@ static inline __attribute__((always_inline)) void retprobe_map_clear(__u64 tid)
 }
 
 static inline __attribute__((always_inline)) void
-retprobe_map_set(__u64 tid, unsigned long ptr)
+retprobe_map_set(__u64 tid, __u64 ktime, unsigned long ptr)
 {
 	struct retprobe_info info = {
+		.ktime_enter = ktime,
 		.ptr = ptr,
 	};
 
@@ -47,9 +49,11 @@ retprobe_map_set(__u64 tid, unsigned long ptr)
 }
 
 static inline __attribute__((always_inline)) void
-retprobe_map_set_iovec(__u64 tid, unsigned long ptr, unsigned long cnt)
+retprobe_map_set_iovec(__u64 tid, __u64 ktime, unsigned long ptr,
+		       unsigned long cnt)
 {
 	struct retprobe_info info = {
+		.ktime_enter = ktime,
 		.ptr = ptr,
 		.cnt = cnt,
 	};

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -493,7 +493,7 @@ copy_char_buf(void *ctx, long off, unsigned long arg, int argm,
 
 	if (hasReturnCopy(argm)) {
 		u64 tid = retprobe_map_get_key(ctx);
-		retprobe_map_set(tid, arg);
+		retprobe_map_set(tid, e->common.ktime, arg);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
 	meta = get_arg_meta(argm, e);
@@ -641,7 +641,7 @@ copy_char_iovec(void *ctx, long off, unsigned long arg, int argm,
 
 	if (hasReturnCopy(argm)) {
 		u64 tid = retprobe_map_get_key(ctx);
-		retprobe_map_set_iovec(tid, arg, meta);
+		retprobe_map_set_iovec(tid, e->common.ktime, arg, meta);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
 	return __copy_char_iovec(off, arg, meta, 0, e);

--- a/cmd/tetragon-bench/bench.go
+++ b/cmd/tetragon-bench/bench.go
@@ -20,6 +20,7 @@ var (
 	jsonEncode  *bool
 	baseline    *bool
 	printEvents *bool
+	storeEvents *bool
 
 	traceBench *string
 	crd        *string
@@ -30,6 +31,7 @@ func init() {
 	jsonEncode = flag.Bool("json-encode", false, "JSON encode the events and measure overhead")
 	baseline = flag.Bool("baseline", false, "run a baseline benchmark without tetragon")
 	printEvents = flag.Bool("print", false, "print events in JSON to stdout")
+	storeEvents = flag.Bool("store", false, "store events in JSON to stdout")
 	traceBench = flag.String("trace", "none", "trace benchmark to run, one of: "+strings.Join(bench.TraceBenchSupported(), ", "))
 	crd = flag.String("crd", "none", "crd to start tetragon with")
 }
@@ -74,10 +76,15 @@ func main() {
 		*traceBench = "custom"
 	}
 
+	if *printEvents && *storeEvents {
+		log.Fatalf("Can't specify together -print and -store options.")
+	}
+
 	args := &bench.Arguments{
 		Debug:       *debug,
-		JSONEncode:  *jsonEncode || *printEvents,
+		JSONEncode:  *jsonEncode || *printEvents || *storeEvents,
 		PrintEvents: *printEvents,
+		StoreEvents: *storeEvents,
 		Baseline:    *baseline,
 		Trace:       bench.TraceBenchNameOrPanic(*traceBench),
 		Crd:         *crd,

--- a/pkg/bench/trace_bench_rw.go
+++ b/pkg/bench/trace_bench_rw.go
@@ -129,6 +129,7 @@ spec:
       type: "int"
   - call: "__x64_sys_read"
     syscall: true
+    return: true
     args:
     - index: 0
       type: "int"
@@ -136,6 +137,8 @@ spec:
       type: "char_buf"
       returnCopy: true
     - index: 2
+      type: "size_t"
+    returnArg:
       type: "size_t"
     selectors:
     - matchPIDs:

--- a/pkg/metrics/kprobemetrics/kprobemetrics.go
+++ b/pkg/metrics/kprobemetrics/kprobemetrics.go
@@ -15,6 +15,11 @@ var (
 		Help:        "The total number of failed attempts to merge a kprobe and kretprobe event.",
 		ConstLabels: nil,
 	}, []string{"curr_fn", "curr_type", "prev_fn", "prev_type"})
+	MergeOkTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "generic_kprobe_merge_ok_total",
+		Help:        "The total number of successful attempts to merge a kprobe and kretprobe event.",
+		ConstLabels: nil,
+	})
 )
 
 // Get a new handle on the mergeErrors metric for a current and previous function
@@ -27,4 +32,8 @@ func GetMergeErrors(currFn, currType, prevFn, prevType string) prometheus.Counte
 // name and probe type
 func MergeErrorsInc(currFn, currType, prevFn, prevType string) {
 	GetMergeErrors(currFn, currType, prevFn, prevType).Inc()
+}
+
+func MergeOkTotalInc() {
+	MergeOkTotal.Inc()
 }

--- a/pkg/metrics/kprobemetrics/kprobemetrics.go
+++ b/pkg/metrics/kprobemetrics/kprobemetrics.go
@@ -20,6 +20,11 @@ var (
 		Help:        "The total number of successful attempts to merge a kprobe and kretprobe event.",
 		ConstLabels: nil,
 	})
+	MergePushed = promauto.NewCounter(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "generic_kprobe_merge_pushed",
+		Help:        "The total number of pushed events for later merge.",
+		ConstLabels: nil,
+	})
 )
 
 // Get a new handle on the mergeErrors metric for a current and previous function
@@ -36,4 +41,8 @@ func MergeErrorsInc(currFn, currType, prevFn, prevType string) {
 
 func MergeOkTotalInc() {
 	MergeOkTotal.Inc()
+}
+
+func MergePushedInc() {
+	MergePushed.Inc()
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -753,6 +753,7 @@ func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
 			unix, retArg = retprobeMerge(prev, curr)
 		} else {
 			gk.pendingEvents[m.ThreadId] = curr
+			kprobemetrics.MergePushedInc()
 			unix = nil
 		}
 	}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -872,6 +872,8 @@ func retprobeMerge(prev pendingEvent, curr pendingEvent) (*tracing.MsgGenericKpr
 		return nil, nil
 	}
 
+	kprobemetrics.MergeOkTotalInc()
+
 	for _, retArg := range retEv.Args {
 		index := retArg.GetIndex()
 		if uint64(len(enterEv.Args)) > index {


### PR DESCRIPTION
Fixing merging of kprobe events (returnCopy case) by adding 'ktime' to the merged key.

At the moment we merge kprobe events by matching the 'thread_id',
which can lead to wrong events in case we have LOST events like in
following sequence of received events:

```
 -  read/kprobe
 -  read/kreptprobe (LOST)
 -  read/kprobe (LOST)
 -  read/kretprobe
```

having 'ktime' part of the key eliminates such cases

This patchset:
  - adds metrics for merged events
  - adds support to 'rw' benchmark to generate case above
  -  store events in tetragon-bench for post processing
  - adds ktime to the key in kprobe merge map

With the fix and some post processing of the benchmark output data,
we can see more better numbers for correctly merged events:

We generated 'random sys_read' events and verified in the generated
output.json that the sys_read size argument matches with the length
of the retrieved data (it's the 'changed false' case in the output below).

with the fix:

```
        Ring buffer:        received=1829323, lost=58838568, errors=0
        Merged events:      pushed=1252435, ok=230527, errors=1021908

        [root@krava tetragon]# cat out | grep  'changed false' | wc -l
        229583
        [root@krava tetragon]# cat out | grep  'changed true' | wc -l
        912
```

base:

```
        Ring buffer:        received=1876130, lost=58814126, errors=0
        Merged events:      pushed=763227, ok=247434, errors=515793

        [root@krava tetragon]# cat out | grep  'changed true' | wc -l
        125061
        [root@krava tetragon]# cat out | grep  'changed false' | wc -l
        122337
```

We can see much better stats for the fix. The extra '912' bad events
seems is the other 'sys_read' traffic, where sys_read syscall did not
return full amount of bytes, because the 'rw' benchmark is system wide.  

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
