### PR TITLE
Add Verbose Value To Cgroup Program Loader

### DIFF
--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -291,7 +291,8 @@ func loadInstance(bpfDir, mapDir, ciliumDir string, load *program.Program, versi
 			bpfDir,
 			mapDir,
 			ciliumDir,
-			load)
+			load,
+			verbose)
 		return err
 	} else {
 		if s, ok := registeredProbeLoad[load.Type]; ok {

--- a/pkg/sensors/program/cgroup/cgroup.go
+++ b/pkg/sensors/program/cgroup/cgroup.go
@@ -17,14 +17,14 @@ var (
 
 func LoadSockOpt(
 	bpfDir, mapDir, ciliumDir string,
-	load *program.Program,
+	load *program.Program, verbose int,
 ) error {
-	return LoadCgroupProgram(bpfDir, mapDir, ciliumDir, load)
+	return LoadCgroupProgram(bpfDir, mapDir, ciliumDir, load, verbose)
 }
 
 func LoadCgroupProgram(
 	bpfDir, mapDir, ciliumDir string,
-	load *program.Program) error {
+	load *program.Program, verbose int) error {
 	if fgsCgroupFD < 0 {
 		fd, err := unix.Open(fgsCgroupPath, unix.O_RDONLY, 0)
 		if err != nil {
@@ -32,5 +32,5 @@ func LoadCgroupProgram(
 		}
 		fgsCgroupFD = fd
 	}
-	return program.LoadProgram(bpfDir, []string{mapDir, ciliumDir}, load, program.RawAttach(fgsCgroupFD))
+	return program.LoadProgram(bpfDir, []string{mapDir, ciliumDir}, load, program.RawAttach(fgsCgroupFD), verbose)
 }

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -450,6 +450,7 @@ func LoadProgram(
 	mapDirs []string,
 	load *Program,
 	withProgram AttachFunc,
+	verbose int,
 ) error {
-	return loadProgram(bpfDir, mapDirs, load, withProgram, nil, 0)
+	return loadProgram(bpfDir, mapDirs, load, withProgram, nil, verbose)
 }


### PR DESCRIPTION
Most program types have a verbose flag passed to the loader to indicate the level of output to provide for debugging purposes.

The loader used for CGroup programs passed a literal 0 instead of a configurable argument.

This commit adds the verbose int so that the CGroup program loader can provide verbose output.

Signed-off-by: Kevin Sheldrake <kevin.sheldrake@isovalent.com>