### PR TITLE
codegen: implement UnwrapGetEventsResponse helper

### DIFF
--- a/api/v1/tetragon/types.pb.go
+++ b/api/v1/tetragon/types.pb.go
@@ -112,3 +112,24 @@ func (event *Test) Encapsulate() IsGetEventsResponse_Event {
 		Test: event,
 	}
 }
+
+// UnwrapGetEventsResponse gets the inner event type from a GetEventsResponse
+func UnwrapGetEventsResponse(response *GetEventsResponse) interface{} {
+	event := response.GetEvent()
+	if event == nil {
+		return nil
+	}
+	switch ev := event.(type) {
+	case *GetEventsResponse_ProcessExec:
+		return ev.ProcessExec
+	case *GetEventsResponse_ProcessExit:
+		return ev.ProcessExit
+	case *GetEventsResponse_ProcessKprobe:
+		return ev.ProcessKprobe
+	case *GetEventsResponse_ProcessTracepoint:
+		return ev.ProcessTracepoint
+	case *GetEventsResponse_Test:
+		return ev.Test
+	}
+	return nil
+}

--- a/cmd/protoc-gen-go-tetragon/types/types.go
+++ b/cmd/protoc-gen-go-tetragon/types/types.go
@@ -67,5 +67,21 @@ func Generate(gen *protogen.Plugin, files []*protogen.File) error {
 		}
 	}
 
+	// Generate UnwrapGetEventsResponse
+	g.P(`// UnwrapGetEventsResponse gets the inner event type from a GetEventsResponse
+    func UnwrapGetEventsResponse(response *GetEventsResponse) interface{} {
+        event := response.GetEvent()
+        if event == nil {
+            return nil
+        }
+        switch ev := event.(type) {`)
+	for _, event := range events {
+		g.P(`case *GetEventsResponse_` + event.GoIdent.GoName + `:
+            return ev.` + event.GoIdent.GoName)
+	}
+	g.P(`}
+        return nil
+    }`)
+
 	return nil
 }

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/types.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/types.pb.go
@@ -112,3 +112,24 @@ func (event *Test) Encapsulate() IsGetEventsResponse_Event {
 		Test: event,
 	}
 }
+
+// UnwrapGetEventsResponse gets the inner event type from a GetEventsResponse
+func UnwrapGetEventsResponse(response *GetEventsResponse) interface{} {
+	event := response.GetEvent()
+	if event == nil {
+		return nil
+	}
+	switch ev := event.(type) {
+	case *GetEventsResponse_ProcessExec:
+		return ev.ProcessExec
+	case *GetEventsResponse_ProcessExit:
+		return ev.ProcessExit
+	case *GetEventsResponse_ProcessKprobe:
+		return ev.ProcessKprobe
+	case *GetEventsResponse_ProcessTracepoint:
+		return ev.ProcessTracepoint
+	case *GetEventsResponse_Test:
+		return ev.Test
+	}
+	return nil
+}


### PR DESCRIPTION
This commit adds a code generated UnwrapGetEventsResponse helper that returns the inner event type from a GetEventsResponse. This enables us to do type matching directly on the inner event, for example to see whether it implements a particular interface, thus avoiding the need for long and complex switch statements when we only care about one or two possible event types.

In subsequent patches, I will start to refactor existing parts of our codebase to use this new helper. But for now let's get this in as it should be useful in the future as well.

Signed-off-by: William Findlay <will@isovalent.com>