### PR TITLE
tetragon: Warn on sensor bug can flood the logs make it debug

### DIFF
--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -118,11 +118,11 @@ func (k *Observer) receiveEvent(data []byte, cpu int) {
 	if err != nil {
 		switch e := err.(type) {
 		case handlePerfUnknownOp:
-			k.log.WithField("opcode", e.op).WithField("event_type", tetragon.EventType(e.op).String()).Warn("unknown opcode ignored")
+			k.log.WithField("opcode", e.op).WithField("event_type", tetragon.EventType(e.op).String()).Debug("unknown opcode ignored")
 		case *handlePerfHandlerErr:
-			k.log.WithError(e.err).WithField("event_type", tetragon.EventType(e.op).String()).Warn("error occurred in event handler")
+			k.log.WithError(e.err).WithField("event_type", tetragon.EventType(e.op).String()).Debug("error occurred in event handler")
 		default:
-			k.log.WithError(err).Warn("error occurred in event handler")
+			k.log.WithError(err).Debug("error occurred in event handler")
 		}
 	}
 	for _, event := range events {


### PR DESCRIPTION
Flooding the logs with Warnings when a sensors have an error can be rather noisy. Instead these should be behind metrics that we can collected. Anyways lets make it Debug fow now and prode sensor owners to add proper error metrics for each type.

Signed-off-by: John Fastabend <john.fastabend@gmail.com