### PR TITLE
codegen/eventchecker: fix bug with wrapped protobuf values

### DIFF
--- a/cmd/protoc-gen-go-tetragon/common/common.go
+++ b/cmd/protoc-gen-go-tetragon/common/common.go
@@ -243,10 +243,15 @@ func GetEvents(files []*protogen.File) ([]*protogen.Message, error) {
 
 var fieldsCache []*protogen.Message
 
+// isReservedField marks message types that we don't want to generate event checkers for
 var isReservedField = map[string]struct{}{
-	"Timestamp":   struct{}{},
-	"UInt32Value": struct{}{},
-	"Duration":    struct{}{},
+	"Timestamp":   {},
+	"UInt32Value": {},
+	"Int32Value":  {},
+	"UInt64Value": {},
+	"Int64Value":  {},
+	"StringValue": {},
+	"Duration":    {},
 }
 
 // GetFields returns a list of all messages that are fields


### PR DESCRIPTION
We don't want codegen to try generating an eventchecker struct for protobuf wrapped interger types. To do this, we were keeping a list of reserved fields but this only included Int32Value. Add the other integer types here.

Signed-off-by: William Findlay <will@isovalent.com>