### PR TITLE
metrics: add handler error metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mennanov/fmutils v0.2.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/client_model v0.2.1-0.20210607210712-147c58e9608a
 	github.com/sirupsen/logrus v1.9.0
@@ -94,7 +95,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -4,7 +4,8 @@
 package opcodemetrics
 
 import (
-	"github.com/cilium/tetragon/pkg/api/ops"
+	"fmt"
+
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -19,11 +20,11 @@ var (
 )
 
 // Get a new handle on a msgOpsCount metric for an OpCode
-func GetOpTotal(op ops.OpCode) prometheus.Counter {
-	return MsgOpsCount.WithLabelValues(op.String())
+func GetOpTotal(op int) prometheus.Counter {
+	return MsgOpsCount.WithLabelValues(fmt.Sprint(op))
 }
 
 // Increment an msgOpsCount for an OpCode
-func OpTotalInc(op ops.OpCode) {
+func OpTotalInc(op int) {
 	GetOpTotal(op).Inc()
 }

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/reader/notify"
@@ -116,9 +117,9 @@ func HandlePerfData(data []byte) (byte, []Event, error) {
 }
 
 func (k *Observer) receiveEvent(data []byte, cpu int) {
-
 	k.recvCntr++
 	op, events, err := HandlePerfData(data)
+	opcodemetrics.OpTotalInc(int(op))
 	if err != nil {
 		// Increment error metrics
 		errormetrics.ErrorTotalInc(errormetrics.HandlerError)

--- a/pkg/testutils/perfring/perfring.go
+++ b/pkg/testutils/perfring/perfring.go
@@ -68,7 +68,7 @@ func ProcessEvents(t *testing.T, ctx context.Context, eventFn EventFn, wgStarted
 			t.Fatalf("error reading perfring buffer: %v", err)
 		}
 
-		events, err := observer.HandlePerfData(record.RawSample)
+		_, events, err := observer.HandlePerfData(record.RawSample)
 		if err != nil {
 			t.Fatalf("error handling perfring data: %v", err)
 		}


### PR DESCRIPTION
This commit adds error metrics for event handler errors so we can tell when specific handlers are failing without flooding the logs with useless log messages. When more info is needed, debug logging can be enabled.

Signed-off-by: William Findlay <will@isovalent.com>