### PR TITLE
metrics: reintroduce opcode metrics

### DIFF
--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -4,7 +4,8 @@
 package opcodemetrics
 
 import (
-	"github.com/cilium/tetragon/pkg/api/ops"
+	"fmt"
+
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -19,11 +20,11 @@ var (
 )
 
 // Get a new handle on a msgOpsCount metric for an OpCode
-func GetOpTotal(op ops.OpCode) prometheus.Counter {
-	return MsgOpsCount.WithLabelValues(op.String())
+func GetOpTotal(op int) prometheus.Counter {
+	return MsgOpsCount.WithLabelValues(fmt.Sprint(op))
 }
 
 // Increment an msgOpsCount for an OpCode
-func OpTotalInc(op ops.OpCode) {
+func OpTotalInc(op int) {
 	GetOpTotal(op).Inc()
 }

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/reader/notify"
@@ -116,9 +117,9 @@ func HandlePerfData(data []byte) (byte, []Event, error) {
 }
 
 func (k *Observer) receiveEvent(data []byte, cpu int) {
-
 	k.recvCntr++
 	op, events, err := HandlePerfData(data)
+	opcodemetrics.OpTotalInc(int(op))
 	if err != nil {
 		// Increment error metrics
 		errormetrics.ErrorTotalInc(errormetrics.HandlerError)


### PR DESCRIPTION
opcode metrics were erroneously removed during refactoring some time ago. Let's reintroduce them here to get a sense of what handlers are being called for which event opcodes. (N.B. we are already tracking events per process as metrics but the per-opcode counters here include hidden perf events that don't get pushed to userspace on their own. Thus, we get a higher level of detail here for debugging.)

Signed-off-by: William Findlay <will@isovalent.com>