### PR TITLE
tetragon: Separate execve sensor into taill called programs

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -262,6 +262,10 @@ struct msg_execve_event {
 		struct msg_process process;
 		char buffer[PADDED_BUFFER];
 	};
+	/* below fields are not part of the event, serve just as
+	 * heap for execve programs
+	 */
+	__u32 binary;
 }; // All fields aligned so no 'packed' attribute.
 
 struct execve_map_value {

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -50,6 +50,9 @@ var (
 	ExecveMap    = program.MapBuilder("execve_map", Execve)
 	ExecveMapV53 = program.MapBuilder("execve_map", ExecveV53)
 
+	ExecveTailCallsMap    = program.MapBuilderPin("execve_calls", "execve_calls", Execve)
+	ExecveTailCallsMapV53 = program.MapBuilderPin("execve_calls", "execve_calls", ExecveV53)
+
 	/* Policy maps populated from base programs */
 	NamesMap    = program.MapBuilder("names_map", Execve)
 	NamesMapV53 = program.MapBuilder("names_map", ExecveV53)
@@ -104,6 +107,7 @@ func GetDefaultMaps() []*program.Map {
 		maps = append(maps,
 			ExecveMapV53,
 			ExecveStatsV53,
+			ExecveTailCallsMapV53,
 			NamesMapV53,
 			TCPMonMapV53,
 			TetragonConfMapV53,
@@ -112,6 +116,7 @@ func GetDefaultMaps() []*program.Map {
 		maps = append(maps,
 			ExecveMap,
 			ExecveStats,
+			ExecveTailCallsMap,
 			NamesMap,
 			TCPMonMap,
 			TetragonConfMap,

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -418,25 +418,8 @@ func TestEventExecveLongPathLongArgs(t *testing.T) {
 
 func TestLoadInitialSensor(t *testing.T) {
 
-	var sensorProgs = []tus.SensorProg{
-		0: tus.SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
-		1: tus.SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
-		2: tus.SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
-	}
-
-	var sensorMaps = []tus.SensorMap{
-		// all programs
-		tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 2}},
-		tus.SensorMap{Name: "execve_map_stats", Progs: []uint{0, 1, 2}},
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{0, 1, 2}},
-
-		// event_execve
-		tus.SensorMap{Name: "names_map", Progs: []uint{0}},
-		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
-
-		// event_wake_up_new_task
-		tus.SensorMap{Name: "execve_val", Progs: []uint{2}},
-	}
+	var sensorProgs = []tus.SensorProg{}
+	var sensorMaps = []tus.SensorMap{}
 
 	sensor := base.GetInitialSensor()
 

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -137,7 +137,7 @@ func NoAttach(load *Program) AttachFunc {
 func LoadTracepointProgram(bpfDir, mapDir string, load *Program, verbose int) error {
 	var ci *customInstall
 	for mName, mPath := range load.PinMap {
-		if mName == "tp_calls" {
+		if mName == "tp_calls" || mName == "execve_calls" {
 			ci = &customInstall{mPath, "tracepoint"}
 			break
 		}

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2406,11 +2406,6 @@ func TestLoadKprobeSensor(t *testing.T) {
 		11: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
 		// retkprobe
 		12: tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
-
-		// base sensor
-		13: tus.SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
-		14: tus.SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
-		15: tus.SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
 	}
 
 	var sensorMaps = []tus.SensorMap{
@@ -2428,16 +2423,13 @@ func TestLoadKprobeSensor(t *testing.T) {
 		tus.SensorMap{Name: "override_tasks", Progs: []uint{6, 7, 8, 9, 10}},
 
 		// generic_kprobe_filter_arg*,generic_retkprobe_event,base
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{6, 7, 8, 9, 10, 12, 13, 14, 15}},
+		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{6, 7, 8, 9, 10, 12}},
 
 		// only retkprobe
 		tus.SensorMap{Name: "config_map", Progs: []uint{12}},
 
 		// shared with base sensor
-		tus.SensorMap{Name: "execve_map", Progs: []uint{13, 14, 15, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
-
-		// base only
-		tus.SensorMap{Name: "execve_map_stats", Progs: []uint{13, 14, 15}},
+		tus.SensorMap{Name: "execve_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
 
 		// generic_kprobe_process_event*,generic_kprobe_filter_arg*,retkprobe
 		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12}},

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -405,11 +405,6 @@ func TestLoadTracepointSensor(t *testing.T) {
 		9:  tus.SensorProg{Name: "generic_tracepoint_event3", Type: ebpf.TracePoint},
 		10: tus.SensorProg{Name: "generic_tracepoint_event4", Type: ebpf.TracePoint},
 		11: tus.SensorProg{Name: "generic_tracepoint_filter", Type: ebpf.TracePoint},
-
-		// base sensor
-		12: tus.SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
-		13: tus.SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
-		14: tus.SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
 	}
 
 	var sensorMaps = []tus.SensorMap{
@@ -424,13 +419,10 @@ func TestLoadTracepointSensor(t *testing.T) {
 		tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 
 		// generic_tracepoint_arg**,base
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 3, 4, 5, 12, 13, 14}},
+		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 3, 4, 5}},
 
 		// shared with base sensor
-		tus.SensorMap{Name: "execve_map", Progs: []uint{12, 13, 14, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
-
-		// base only
-		tus.SensorMap{Name: "execve_map_stats", Progs: []uint{12, 13, 14}},
+		tus.SensorMap{Name: "execve_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
 	}
 
 	if kernels.EnableLargeProgs() {

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/program"
 )
@@ -117,12 +118,13 @@ func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []S
 		0: SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
 		1: SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
 		2: SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
+		3: SensorProg{Name: "execve_send", Type: ebpf.TracePoint},
 	}
+
 	var baseMaps = []SensorMap{
 		// all programs
-		SensorMap{Name: "execve_map", Progs: []uint{0, 1, 2}},
-		SensorMap{Name: "execve_map_stats", Progs: []uint{0, 1, 2}},
-		SensorMap{Name: "tcpmon_map", Progs: []uint{0, 1, 2}},
+		SensorMap{Name: "execve_map", Progs: []uint{0, 1, 2, 3}},
+		SensorMap{Name: "execve_map_stats", Progs: []uint{1, 2, 3}},
 
 		// event_execve
 		SensorMap{Name: "names_map", Progs: []uint{0}},
@@ -130,6 +132,12 @@ func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []S
 
 		// event_wake_up_new_task
 		SensorMap{Name: "execve_val", Progs: []uint{2}},
+	}
+
+	if kernels.EnableLargeProgs() {
+		baseMaps = append(baseMaps, SensorMap{Name: "tcpmon_map", Progs: []uint{0, 1, 2, 3}})
+	} else {
+		baseMaps = append(baseMaps, SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 3}})
 	}
 
 	return mergeSensorMaps(t, sensorMaps, baseMaps, sensorProgs, baseProgs)

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -112,7 +112,32 @@ func mergeSensorMaps(t *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []Se
 	return mapsReturn, progsReturn
 }
 
+func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []SensorProg) ([]SensorMap, []SensorProg) {
+	var baseProgs = []SensorProg{
+		0: SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
+		1: SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
+		2: SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
+	}
+	var baseMaps = []SensorMap{
+		// all programs
+		SensorMap{Name: "execve_map", Progs: []uint{0, 1, 2}},
+		SensorMap{Name: "execve_map_stats", Progs: []uint{0, 1, 2}},
+		SensorMap{Name: "tcpmon_map", Progs: []uint{0, 1, 2}},
+
+		// event_execve
+		SensorMap{Name: "names_map", Progs: []uint{0}},
+		SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
+
+		// event_wake_up_new_task
+		SensorMap{Name: "execve_val", Progs: []uint{2}},
+	}
+
+	return mergeSensorMaps(t, sensorMaps, baseMaps, sensorProgs, baseProgs)
+}
+
 func CheckSensorLoad(sensors []*sensors.Sensor, sensorMaps []SensorMap, sensorProgs []SensorProg, t *testing.T) {
+
+	sensorMaps, sensorProgs = mergeInBaseSensorMaps(t, sensorMaps, sensorProgs)
 
 	var cache []*prog
 


### PR DESCRIPTION
The execve is getting more complex and on 4.19 it's reaching
the maximum program size.

Splitting execve sensor into 2 (so far) tail called programs and
adjusting TestLoad* tests.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
