### PR TITLE
tracing: fix multiple selectors support

### DIFF
--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -190,6 +190,9 @@ generic_kprobe_process_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
+// Filter tailcalls: kprobe/6...kprobe/10
+// see also: MIN_FILTER_TAILCALL, MAX_FILTER_TAILCALL
+
 __attribute__((section("kprobe/6"), used)) int
 generic_kprobe_filter_arg1(void *ctx)
 {

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -248,6 +248,9 @@ generic_tracepoint_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
+// Filter tailcalls: tracepoint/6...tracepoint/10
+// see also: MIN_FILTER_TAILCALL, MAX_FILTER_TAILCALL
+
 __attribute__((section("tracepoint/6"), used)) int
 generic_tracepoint_arg1(void *ctx)
 {

--- a/bpf/process/pfilter.h
+++ b/bpf/process/pfilter.h
@@ -398,10 +398,10 @@ selector_process_filter(__u32 *f, __u32 index, struct execve_map_value *enter,
 	index += 4;
 
 	/* read the start offset of the corresponding selector */
-	index = *(__u32 *)((__u64)f + (index & INDEX_MASK));
-
+	/* selector section offset by reading the relative offset in the array */
+	index += *(__u32 *)((__u64)f + (index & INDEX_MASK));
 	index &= INDEX_MASK;
-	index += 8; /* 8: selector value and selector header */
+	index += 4; /* skip selector size field */
 
 	/* matchPid */
 	len = *(__u32 *)((__u64)f +

--- a/bpf/process/pfilter.h
+++ b/bpf/process/pfilter.h
@@ -509,8 +509,6 @@ selector_process_filter(__u32 *f, __u32 index, struct execve_map_value *enter,
 	return res;
 }
 
-#define MAX_SELECTORS 8
-
 static inline __attribute__((always_inline)) int
 process_filter_done(struct msg_selector_data *sel,
 		    struct execve_map_value *enter,

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -968,7 +968,7 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx)
 	}
 
 	/* Making binary selectors fixes size helps on some kernels */
-	asm volatile("%[seloff] &= 0xeff;\n" ::[seloff] "+r"(seloff) :);
+	asm volatile("%[seloff] &= 0xfff;\n" ::[seloff] "+r"(seloff) :);
 	filter = (struct selector_arg_filter *)&f[seloff];
 
 	if (filter->arglen <= 4) // no filters

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -701,33 +701,41 @@ func parseSelector(
 	return nil
 }
 
-// array :=
-// [number][filter1_offset][filter2_offset][...][filtern_offset][filter1][filter2][...][filtern]
-// filter := [length]
+// The byte array storing the selector configuration has the following format
+// array := [N][S1_off][S2_off]...[SN_off][S1][S2][...][SN]
 //
-//	[matchPIDs]
-//	[matchNamespaces]
-//	[matchCapabilities]
-//	[matchNamespaceChanges]
-//	[matchCapabilityChanges]
-//	[matchBinaries]
-//	[matchArgs]
-//	[matchActions]
+//  N: is the number of selectors (u32)
+//  Sx_off: is the relative offset of  selector x (diff of Sx to Sx_off)
+//  Sx: holds the data for the selector
 //
-// matchPIDs := [num][PID1][PID2]...[PIDn]
-// matchBinaries := [num][op][Index]...[Index]
-// matchArgs := [num][ARGx][ARGy]...[ARGn]
-// matchNamespaces := [num][NSx][NSy]...[NSn]
-// matchNamespaceChanges := [num][NCx][NCy]...[NCn]
-// matchCapabilities := [num][CAx][CAy]...[CAn]
-// matchCapabilityChanges := [num][CAx][CAy]...[CAn]
-// PIDn := [op][flags][valueInt]
+// Each selector x starts with its length in bytes, and then stores a number of sections for the
+// different matchers. Each section will typically starts with its length in bytes.
+//
+// Sx := [length]
+//	 [matchPIDs]
+//	 [matchNamespaces]
+//	 [matchCapabilities]
+//	 [matchNamespaceChanges]
+//	 [matchCapabilityChanges]
+//	 [matchBinaries]
+//	 [matchArgs]
+//	 [matchActions]
+// matchPIDs := [length][PID1][PID2]...[PIDn]
+// matchNamespaces := [length][NSx][NSy]...[NSn]
+// matchCapabilities := [length][CAx][CAy]...[CAn]
+// matchNamespaceChanges := [length][NCx][NCy]...[NCn]
+// matchCapabilityChanges := [length][CAx][CAy]...[CAn]
+// matchBinaries := [length][op][Index]...[Index]
+// matchArgs := [length][ARGx][ARGy]...[ARGn]
+// PIDn := [op][flags][nValues][v1]...[vn]
 // Argn := [index][op][valueGen]
 // NSn := [namespace][op][valueInt]
 // NCn := [op][valueInt]
 // CAn := [type][op][namespacecap][valueInt]
 // valueGen := [type][len][v]
 // valueInt := [len][v]
+//
+// For some examples, see kernel_test.go
 func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg) ([4096]byte, error) {
 	kernelSelectors, err := InitKernelSelectorState(selectors, args)
 	if err != nil {

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -5,6 +5,7 @@ package selectors
 
 import (
 	"bytes"
+	"encoding/binary"
 	"strings"
 	"testing"
 
@@ -361,6 +362,68 @@ func TestParseMatchAction(t *testing.T) {
 	ks := &KernelSelectorState{off: 0}
 	if err := parseMatchActions(ks, act); err != nil || bytes.Equal(expected, ks.e[0:ks.off]) == false {
 		t.Errorf("parseMatchActions: error %v expected %v bytes %v parsing %v\n", err, expected, ks.e[0:ks.off], act)
+	}
+}
+
+// NB(kkourt):
+func TestMultipleSelectorsExample(t *testing.T) {
+	args := []v1alpha1.KProbeArg{
+		{Index: 1, Type: "int", SizeArgIndex: 0, ReturnCopy: false},
+	}
+
+	pidSelector := []v1alpha1.PIDSelector{
+		{Operator: "NotIn", Values: []uint32{33, 44}},
+	}
+	matchArgs := []v1alpha1.ArgSelector{
+		{Index: 1, Operator: "Equal", Values: []string{"10", "20"}},
+	}
+	selectors := []v1alpha1.KProbeSelector{
+		{MatchArgs: matchArgs, MatchPIDs: pidSelector},
+		{MatchArgs: matchArgs, MatchPIDs: pidSelector},
+	}
+	b, _ := InitKernelSelectors(selectors, args)
+
+	expected := make([]byte, 4096)
+	expectedLen := 0
+	expU32Push := func(i int) {
+		binary.LittleEndian.PutUint32(expected[expectedLen:], uint32(i))
+		expectedLen += 4
+	}
+
+	// vaue               absolute offset    explanation
+	expU32Push(2)               // off: 0       number of selectors
+	expU32Push(8)               // off: 4       relative ofset of 1st selector (4 + 8 = 12)
+	expU32Push(104)             // off: 8       relative ofset of 2nd selector (8 + 104 = 112)
+	expU32Push(100)             // off: 12      selector1: length (100 + 12 = 112)
+	expU32Push(24)              // off: 16      selector1: MatchPIDs: len
+	expU32Push(selectorOpNotIn) // off: 20      selector1: MatchPIDs[0]: op
+	expU32Push(0)               // off: 24      selector1: MatchPIDs[0]: flags
+	expU32Push(2)               // off: 28      selector1: MatchPIDs[0]: number of values
+	expU32Push(33)              // off: 32      selector1: MatchPIDs[0]: val1
+	expU32Push(44)              // off: 36      selector1: MatchPIDs[0]: val2
+	expU32Push(4)               // off: 40      selector1: MatchNamespaces: len
+	expU32Push(4)               // off: 44      selector1: MatchCapabilities: len
+	expU32Push(4)               // off: 48      selector1: MatchNamespaceChanges: len
+	expU32Push(4)               // off: 52      selector1: MatchCapabilityChanges: len
+	expU32Push(4 + 5*4)         // off: 56      selector1: matchBinaries: len
+	expU32Push(0)               // off: 60      selector1: matchBinaries: 0
+	expU32Push(0)               // off: 64      selector1: matchBinaries: 1
+	expU32Push(0)               // off: 68      selector1: matchBinaries: 2
+	expU32Push(0)               // off: 72      selector1: matchBinaries: 3
+	expU32Push(0)               // off: 76      selector1: matchBinaries: 4
+	expU32Push(28)              // off: 80      selector1: matchArgs: len
+	expU32Push(1)               // off: 84      selector1: matchArgs: arg0: index
+	expU32Push(selectorOpEQ)    // off: 88      selector1: matchArgs: arg0: operator
+	expU32Push(16)              // off: 92      selector1: matchArgs: arg0: len of vals
+	expU32Push(argTypeInt)      // off: 96      selector1: matchArgs: arg0: type
+	expU32Push(10)              // off: 100     selector1: matchArgs: arg0: val0: 10
+	expU32Push(20)              // off: 104     selector1: matchArgs: arg0: val1: 20
+	expU32Push(4)               // off: 108     selector1: matchActions: length
+	expU32Push(100)             // off: 112     selector2: length
+	// ... everything else should be the same as selector1 ...
+
+	if bytes.Equal(expected[:expectedLen], b[:expectedLen]) == false {
+		t.Errorf("\ngot: %v\nexp: %v\n", expected[:expectedLen], b[:expectedLen])
 	}
 }
 

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -93,34 +93,49 @@ var testCases = []struct {
 }{
 	{
 		specOperator:   "Equal",
-		specFilterVals: [][]int{{4443}},
+		specFilterVals: [][]int{{4443}, {9999}},
 		tests: []testCase{
 			{lseekOpsVals: []int{4444, 4443}, expectedArgs: map[uint64]int{4443: 1}},
 			{lseekOpsVals: []int{4443, 4444, 4443}, expectedArgs: map[uint64]int{4443: 2}},
+			{lseekOpsVals: []int{9999, 4443}, expectedArgs: map[uint64]int{4443: 1, 9999: 1}},
+			{lseekOpsVals: []int{9999, 4444}, expectedArgs: map[uint64]int{9999: 1}},
 		},
 	},
 	{
 		specOperator:   "Equal",
-		specFilterVals: [][]int{{4444}},
+		specFilterVals: [][]int{{4444}, {9999}},
 		tests: []testCase{
 			{lseekOpsVals: []int{4444, 4443}, expectedArgs: map[uint64]int{4444: 1}},
 			{lseekOpsVals: []int{4443, 4444, 4443}, expectedArgs: map[uint64]int{4444: 1}},
+			{lseekOpsVals: []int{9999, 4443}, expectedArgs: map[uint64]int{9999: 1}},
+			{lseekOpsVals: []int{9999, 4444}, expectedArgs: map[uint64]int{9999: 1, 4444: 1}},
 		},
 	},
 	{
 		specOperator:   "InMap",
-		specFilterVals: [][]int{{4443}},
+		specFilterVals: [][]int{{4443}, {9999}},
 		tests: []testCase{
 			{lseekOpsVals: []int{4444, 4443}, expectedArgs: map[uint64]int{4443: 1}},
 			{lseekOpsVals: []int{4443, 4444, 4443}, expectedArgs: map[uint64]int{4443: 2}},
+			{lseekOpsVals: []int{9999, 4443}, expectedArgs: map[uint64]int{4443: 1, 9999: 1}},
+			{lseekOpsVals: []int{9999, 4444}, expectedArgs: map[uint64]int{9999: 1}},
 		},
 	},
 	{
 		specOperator:   "InMap",
-		specFilterVals: [][]int{{4444}},
+		specFilterVals: [][]int{{4444}, {9999}},
 		tests: []testCase{
 			{lseekOpsVals: []int{4444, 4443}, expectedArgs: map[uint64]int{4444: 1}},
 			{lseekOpsVals: []int{4443, 4444, 4443}, expectedArgs: map[uint64]int{4444: 1}},
+			{lseekOpsVals: []int{9999, 4443}, expectedArgs: map[uint64]int{9999: 1}},
+			{lseekOpsVals: []int{9999, 4444}, expectedArgs: map[uint64]int{9999: 1, 4444: 1}},
+		},
+	},
+	{
+		specOperator:   "Equal",
+		specFilterVals: [][]int{{8888}, {8889}, {4443}},
+		tests: []testCase{
+			{lseekOpsVals: []int{4444, 4443}, expectedArgs: map[uint64]int{4443: 1}},
 		},
 	},
 }


### PR DESCRIPTION
While the kprobe and tracepoint tracing policies support multiple selectors, they do not work in practice. This PR adds a number of fixes and tests so that multiple selector policies will now work.

Fixes: https://github.com/cilium/tetragon/issues/423