### PR TITLE
Add README explaining source of these examples

### DIFF
--- a/docs/security-observability-with-ebpf/README.md
+++ b/docs/security-observability-with-ebpf/README.md
@@ -1,0 +1,4 @@
+# Security Observability with eBPF
+
+This directory contains example TracingPolicies linked from the [O'Reilly report on Security Observability with eBPF](https://www.oreilly.com/library/view/security-observability-with/9781492096719/). 
+These examples were contributed by the report's authors @sharlns and @jedsalazar. 


### PR DESCRIPTION
There are a separate set of example TracingPolicies in this directory associated with Natalia & Jed’s book. This README explains why they are separate from the other examples in the repo. 

Signed-off-by: Liz Rice <liz@lizrice.com>