### PR TITLE
cgroups: add basic cgroups tracking and make it part of the testing framework

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -5,6 +5,7 @@ SHELL=/bin/bash # needed for the *.{o,ll,i,s} pattern in the clean target
 
 ALIGNCHECKERDIR = alignchecker/
 PROCESSDIR := process/
+CGROUPDIR := cgroup/
 BPFTESTDIR := test/
 
 ALIGNCHECKER = bpf_alignchecker.o
@@ -12,6 +13,7 @@ PROCESS = bpf_execve_event.o bpf_execve_event_v53.o bpf_fork.o bpf_exit.o bpf_ge
 	  bpf_generic_kprobe_v53.o bpf_generic_retkprobe.o bpf_generic_retkprobe_v53.o \
 	  bpf_multi_kprobe_v53.o bpf_multi_retkprobe_v53.o \
 	  bpf_generic_tracepoint.o bpf_generic_tracepoint_v53.o
+CGROUP = bpf_cgroup_mkdir.o bpf_cgroup_rmdir.o bpf_cgroup_release.o
 BPFTEST = bpf_lseek.o bpf_globals.o
 
 IDIR = ./include/
@@ -38,9 +40,10 @@ DEPSDIR       := deps/
 TLSOBJ        := $(addprefix $(OBJSDIR),$(TLS))
 NOPOBJ        := $(addprefix $(OBJSDIR),$(NOP))
 PROCESSOBJ    := $(addprefix $(OBJSDIR),$(PROCESS))
+CGROUPOBJ     := $(addprefix $(OBJSDIR),$(CGROUP))
 TESTOBJ       := $(addprefix $(OBJSDIR),$(BPFTEST))
 ALIGNCHECKEROBJ := $(addprefix $(OBJSDIR),$(ALIGNCHECKER))
-OBJS          := $(PROCESSOBJ) $(TESTOBJ) $(NOPOBJ) $(ALIGNCHECKEROBJ)
+OBJS          := $(PROCESSOBJ) $(CGROUPOBJ) $(TESTOBJ) $(NOPOBJ) $(ALIGNCHECKEROBJ)
 LLOBJS        := $(patsubst $(OBJSDIR)%.o,$(OBJSDIR)%.ll,$(OBJS))
 DEPS          := $(patsubst $(OBJSDIR)%.ll,$(DEPSDIR)%.d,$(LLOBJS))
 
@@ -101,6 +104,13 @@ objs/%.ll: $(BPFTESTDIR)%.c
 	$(CLANG) $(CLANG_FLAGS) -c $< -o $@
 
 $(DEPSDIR)%.d: $(BPFTESTDIR)%.c
+	$(CLANG) $(CLANG_FLAGS) -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
+
+# CGROUPDIR
+objs/%.ll: $(CGROUPDIR)%.c
+	$(CLANG) $(CLANG_FLAGS) -c $< -o $@
+
+$(DEPSDIR)%.d: $(CGROUPDIR)%.c
 	$(CLANG) $(CLANG_FLAGS) -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
 
 # Remaining objects are built without mcpu=v2

--- a/bpf/alignchecker/bpf_alignchecker.c
+++ b/bpf/alignchecker/bpf_alignchecker.c
@@ -34,6 +34,7 @@ int main(void)
 	DECLARE(struct, msg_execve_event, iter);
 	DECLARE(struct, msg_exit, iter);
 	DECLARE(struct, msg_test, iter);
+	DECLARE(struct, msg_cgroup_event, iter);
 
 	// from maps
 	DECLARE(struct, event, iter);
@@ -41,6 +42,7 @@ int main(void)
 	DECLARE(struct, execve_map_value, iter);
 	DECLARE(struct, event_config, iter);
 	DECLARE(struct, tetragon_conf, iter);
+	DECLARE(struct, cgroup_tracking_value, iter);
 
 	return 0;
 }

--- a/bpf/cgroup/bpf_cgroup_events.h
+++ b/bpf/cgroup/bpf_cgroup_events.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Tetragon */
+
+#ifndef _BPF_CGROUP_EVENTS__
+#define _BPF_CGROUP_EVENTS__
+
+#include "bpf_helpers.h"
+#include "bpf_events.h"
+#include "environ_conf.h"
+
+/* This function will send the cgroup events to the ring buffer */
+static inline __attribute__((always_inline)) int
+send_cgrp_event(struct bpf_raw_tracepoint_args *ctx,
+		struct cgroup_tracking_value *cgrp_track, __u64 cgrpid,
+		__u32 op)
+{
+	pid_t pid;
+	char *path;
+	int zero = 0;
+	uint64_t size;
+	struct execve_map_value *curr;
+	struct msg_cgroup_event *msg;
+
+	msg = map_lookup_elem(&tg_cgrps_msg_heap, &zero);
+	if (!msg)
+		return 0;
+
+	size = sizeof(struct msg_cgroup_event);
+	msg->common.op = MSG_OP_CGROUP;
+	msg->common.size = size;
+
+	path = (char *)ctx->args[1];
+	pid = (get_current_pid_tgid() >> 32);
+
+	curr = execve_map_get(pid);
+	if (curr) {
+		msg->common.ktime = curr->key.ktime;
+		msg->parent = curr->pkey;
+		msg->flags = curr->flags;
+		msg->ktime = curr->key.ktime;
+	}
+	msg->cgrp_op = op;
+	msg->pid = pid;
+	msg->nspid = get_task_pid_vnr();
+	msg->cgrpid = cgrpid;
+	/* It is same as we are not tracking nested cgroups */
+	msg->cgrpid_tracker = cgrpid;
+	msg->cgrp_data.state = cgrp_track->state;
+	msg->cgrp_data.level = cgrp_track->level;
+	msg->cgrp_data.hierarchy_id = cgrp_track->hierarchy_id;
+	memcpy(&msg->cgrp_data.name, &cgrp_track->name, KN_NAME_LENGTH);
+	probe_read_str(&msg->path, PATH_MAP_SIZE - 1, path);
+
+	perf_event_output(ctx, &tcpmon_map, BPF_F_CURRENT_CPU, msg, size);
+
+	return 0;
+}
+
+#endif

--- a/bpf/cgroup/bpf_cgroup_mkdir.c
+++ b/bpf/cgroup/bpf_cgroup_mkdir.c
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Tetragon */
+
+#include "vmlinux.h"
+#include "api.h"
+
+#include "hubble_msg.h"
+#include "bpf_cgroup.h"
+#include "bpf_events.h"
+#include "bpf_cgroup_events.h"
+
+char _license[] __attribute__((section(("license")), used)) = "GPL";
+#ifdef VMLINUX_KERNEL_VERSION
+int _version __attribute__((section(("version")), used)) =
+	VMLINUX_KERNEL_VERSION;
+#endif
+
+__attribute__((section(("raw_tracepoint/cgroup_mkdir")), used)) int
+tg_tp_cgrp_mkdir(struct bpf_raw_tracepoint_args *ctx)
+{
+	int level, zero = 0;
+	uint64_t cgrpid;
+	struct cgroup *cgrp;
+	struct cgroup_tracking_value *cgrp_heap;
+	struct tetragon_conf *config;
+
+	config = map_lookup_elem(&tg_conf_map, &zero);
+	if (!config || config->tg_cgrp_level == 0)
+		return 0;
+
+	cgrp = (struct cgroup *)ctx->args[0];
+
+	level = get_cgroup_level(cgrp);
+	/* This should never happen as the cgroup hierarchy has already been
+	 * set (e.g., by systemd)
+	 */
+	if (level == 0)
+		return 0;
+
+	cgrpid = get_cgroup_id(cgrp);
+	/* This should never happen unless the bpf helper failed */
+	if (cgrpid == 0)
+		return 0;
+
+	/* We want to track all processes of a container system so that we can
+	 * provide proper identity to events. To do that, we use a certain cgroup
+	 * level. Any cgroups that are created under that level, we ignore.
+	 * That is, if we are monitoring level 5, we do not care about cgroup
+	 * events with level >5.
+	 */
+	if (level <= config->tg_cgrp_level) {
+		cgrp_heap = __init_cgrp_tracking_val_heap(cgrp, CGROUP_NEW);
+		if (!cgrp_heap)
+			return 0;
+
+		/* We track only for now cgroups that are at same or above tetragon
+		 * level (ancestors level)
+		 */
+		map_update_elem(&tg_cgrps_tracking_map, &cgrpid, cgrp_heap,
+				BPF_ANY);
+
+		/* We forward bpf events only under TraceLevel */
+		if (unlikely(config->loglevel == LOG_TRACE_LEVEL))
+			send_cgrp_event(ctx, cgrp_heap, cgrpid,
+					MSG_OP_CGROUP_MKDIR);
+	}
+
+	return 0;
+}

--- a/bpf/cgroup/bpf_cgroup_release.c
+++ b/bpf/cgroup/bpf_cgroup_release.c
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Tetragon */
+
+#include "vmlinux.h"
+#include "api.h"
+
+#include "hubble_msg.h"
+#include "bpf_cgroup.h"
+#include "bpf_events.h"
+#include "bpf_cgroup_events.h"
+
+char _license[] __attribute__((section(("license")), used)) = "GPL";
+#ifdef VMLINUX_KERNEL_VERSION
+int _version __attribute__((section(("version")), used)) =
+	VMLINUX_KERNEL_VERSION;
+#endif
+
+/* Ensure to remove tracked cgroups from bpf map */
+__attribute__((section(("raw_tracepoint/cgroup_release")), used)) int
+tg_tp_cgrp_release(struct bpf_raw_tracepoint_args *ctx)
+{
+	int zero = 0;
+	uint64_t cgrpid;
+	struct cgroup *cgrp;
+	struct tetragon_conf *conf;
+	struct cgroup_tracking_value *cgrp_track;
+
+	cgrp = (struct cgroup *)ctx->args[0];
+	cgrpid = get_cgroup_id(cgrp);
+	/* This should never happen unless our helper failed */
+	if (cgrpid == 0)
+		return 0;
+
+	cgrp_track = map_lookup_elem(&tg_cgrps_tracking_map, &cgrpid);
+	/* TODO: check cgroup level if it is under our tracking level
+	 *   then we probably did miss it and should report this.
+	 *   Otherwise the cgroup was never tracked and let's exit.
+	 */
+	if (!cgrp_track)
+		return 0;
+
+	map_delete_elem(&tg_cgrps_tracking_map, &cgrpid);
+
+	conf = map_lookup_elem(&tg_conf_map, &zero);
+	if (!conf)
+		return 0;
+
+	/* We forward bpf events only under TraceLevel */
+	if (unlikely(conf->loglevel == LOG_TRACE_LEVEL))
+		send_cgrp_event(ctx, cgrp_track, cgrpid, MSG_OP_CGROUP_RELEASE);
+
+	return 0;
+}

--- a/bpf/cgroup/bpf_cgroup_rmdir.c
+++ b/bpf/cgroup/bpf_cgroup_rmdir.c
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Tetragon */
+
+#include "vmlinux.h"
+#include "api.h"
+
+#include "hubble_msg.h"
+#include "bpf_cgroup.h"
+#include "bpf_events.h"
+#include "bpf_cgroup_events.h"
+
+char _license[] __attribute__((section(("license")), used)) = "GPL";
+#ifdef VMLINUX_KERNEL_VERSION
+int _version __attribute__((section(("version")), used)) =
+	VMLINUX_KERNEL_VERSION;
+#endif
+
+/* Remove tracked cgroups from bpf map */
+__attribute__((section(("raw_tracepoint/cgroup_rmdir")), used)) int
+tg_tp_cgrp_rmdir(struct bpf_raw_tracepoint_args *ctx)
+{
+	int zero = 0;
+	uint64_t cgrpid;
+	struct cgroup *cgrp;
+	struct tetragon_conf *conf;
+	struct cgroup_tracking_value *cgrp_track;
+
+	cgrp = (struct cgroup *)ctx->args[0];
+	cgrpid = get_cgroup_id(cgrp);
+	/* This should never happen unless the bpf helper failed */
+	if (cgrpid == 0)
+		return 0;
+
+	cgrp_track = map_lookup_elem(&tg_cgrps_tracking_map, &cgrpid);
+	/* TODO: check cgroup level if it is under our tracking level
+	 *   then we probably did miss it and should report this.
+	 *   Otherwise the cgroup was never tracked and let's exit.
+	 */
+	if (!cgrp_track)
+		return 0;
+
+	map_delete_elem(&tg_cgrps_tracking_map, &cgrpid);
+
+	conf = map_lookup_elem(&tg_conf_map, &zero);
+	if (!conf)
+		return 0;
+
+	/* We forward bpf events only under TraceLevel */
+	if (unlikely(conf->loglevel == LOG_TRACE_LEVEL))
+		send_cgrp_event(ctx, cgrp_track, cgrpid, MSG_OP_CGROUP_RMDIR);
+
+	return 0;
+}

--- a/bpf/lib/bpf_cgroup.h
+++ b/bpf/lib/bpf_cgroup.h
@@ -10,8 +10,29 @@
 
 #define NULL ((void *)0)
 
+#ifndef CGROUP_SUPER_MAGIC
+#define CGROUP_SUPER_MAGIC 0x27e0eb /* Cgroupv1 pseudo FS */
+#endif
+
+#ifndef CGROUP2_SUPER_MAGIC
+#define CGROUP2_SUPER_MAGIC 0x63677270 /* Cgroupv2 pseudo FS */
+#endif
+
 /* Our kernfs node name length, can be made 256? */
 #define KN_NAME_LENGTH 128
+
+/* Max nested cgroups that are tracked. Arbitrary value, nested cgroups
+ * that are at a level greater than 32 will be attached to the cgroup
+ * at level 32.
+ */
+#define CGROUP_MAX_NESTED_LEVEL 32
+
+typedef enum {
+	CGROUP_UNTRACKED = 0, /* Cgroup was created but we did not track it */
+	CGROUP_NEW = 1, /* Cgroup was just created */
+	CGROUP_RUNNING = 2, /* new => running (fork,exec task inside) */
+	CGROUP_RUNNING_PROC = 3, /* Generated from pids of procfs */
+} cgroup_state;
 
 /* Represent old kernfs node with the kernfs_node_id
  * union to read the id in 5.4 kernels and older
@@ -19,6 +40,60 @@
 struct kernfs_node___old {
 	union kernfs_node_id id;
 };
+
+struct cgroup_tracking_value {
+	/* State of cgroup */
+	cgroup_state state;
+
+	/* Unique id for the hierarchy this is mostly for cgroupv1 */
+	__u32 hierarchy_id;
+
+	/* The depth this cgroup is at */
+	__u32 level;
+
+	__u32 pad;
+
+	/* Cgroup kernfs_node name */
+	char name[KN_NAME_LENGTH];
+}; // All fields aligned so no 'packed' attribute.
+
+struct msg_cgroup_event {
+	struct msg_common common;
+	struct msg_execve_key parent;
+	__u32 cgrp_op; /* Current cgroup operation */
+	__u32 pid;
+	__u32 nspid;
+	__u32 flags;
+	__u64 ktime;
+	__u64 cgrpid_tracker; /* Cgroup ID that is used as a tracker for the current cgroup */
+	__u64 cgrpid; /* Current cgroup ID */
+	struct cgroup_tracking_value cgrp_data; /* Current cgroup data */
+	char path[PATH_MAP_SIZE]; /* Current cgroup path */
+}; // All fields aligned so no 'packed' attribute.
+
+/* Map to track cgroups per IDs */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 32768);
+	__type(key, __u64); /* Key is the cgrpid */
+	__type(value, struct cgroup_tracking_value);
+} tg_cgrps_tracking_map SEC(".maps");
+
+/* Heap used to construct a cgroup_tracking_value */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __s32);
+	__type(value, struct cgroup_tracking_value);
+} tg_cgrps_tracking_heap SEC(".maps");
+
+/* Heap used to construct a msg_cgroup_event */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct msg_cgroup_event);
+} tg_cgrps_msg_heap SEC(".maps");
 
 /**
  * get_cgroup_kn_name() Returns a pointer to the kernfs node name

--- a/bpf/lib/environ_conf.h
+++ b/bpf/lib/environ_conf.h
@@ -6,9 +6,15 @@
 
 /* Tetragon runtime configuration */
 struct tetragon_conf {
+	__u32 loglevel; /* Tetragon log level */
+	__u32 pid; /* Tetragon pid for debugging purpose */
+	__u32 nspid; /* Tetragon pid in namespace for debugging purpose */
 	__u32 tg_cgrp_hierarchy; /* Tetragon tracked hierarchy ID */
 	__u32 tg_cgrp_subsys_idx; /* Tetragon tracked cgroup subsystem state index at compile time */
-};
+	__u32 tg_cgrp_level; /* Tetragon cgroup level */
+	__u64 tg_cgrpid; /* Tetragon current cgroup ID to avoid filtering blocking itself */
+	__u64 cgrp_fs_magic; /* Cgroupv1 or Cgroupv2 */
+}; // All fields aligned so no 'packed' attribute.
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);

--- a/bpf/lib/environ_conf.h
+++ b/bpf/lib/environ_conf.h
@@ -4,6 +4,17 @@
 #ifndef __ENVIRON_CONF_
 #define __ENVIRON_CONF_
 
+/* bpf runtime log levels that follow Golang logrus levels
+ * https://pkg.go.dev/github.com/sirupsen/logrus#Level
+ */
+enum {
+	LOG_ERROR_LEVEL = 2,
+	LOG_WARN_LEVEL = 3,
+	LOG_INFO_LEVEL = 4,
+	LOG_DEBUG_LEVEL = 5,
+	LOG_TRACE_LEVEL = 6,
+};
+
 /* Tetragon runtime configuration */
 struct tetragon_conf {
 	__u32 loglevel; /* Tetragon log level */

--- a/bpf/lib/msg_types.h
+++ b/bpf/lib/msg_types.h
@@ -26,6 +26,20 @@ enum msg_ops {
 
 	MSG_OP_DATA = 24,
 
+	MSG_OP_CGROUP = 25,
+
 	MSG_OP_MAX,
 };
+
+enum msg_cgroup_ops {
+	MSG_OP_CGROUP_UNDEF = 0,
+	MSG_OP_CGROUP_MKDIR =
+		1, /* cgroup_mkdir tracepoint, used for debugging */
+	MSG_OP_CGROUP_RMDIR =
+		2, /* cgroup_rmdir tracepoint, used for debugging */
+	MSG_OP_CGROUP_RELEASE =
+		3, /* cgroup_release tracepoint, used for debugging */
+	MSG_OP_CGROUP_ATTACH_TASK = 10, /* cgroup_attach_task tracepoint */
+};
+
 #endif // _MSG_TYPES_

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -29,12 +29,14 @@ func CheckStructAlignments(path string) error {
 	// Validate alignments of C and Go equivalent structs
 	toCheck := map[string][]reflect.Type{
 		// from perf_event_output
-		"msg_exit":         {reflect.TypeOf(processapi.MsgExitEvent{})},
-		"msg_test":         {reflect.TypeOf(testapi.MsgTestEvent{})},
-		"msg_execve_key":   {reflect.TypeOf(processapi.MsgExecveKey{})},
-		"execve_map_value": {reflect.TypeOf(execvemap.ExecveValue{})},
-		"event_config":     {reflect.TypeOf(tracingapi.EventConfig{})},
-		"tetragon_conf":    {reflect.TypeOf(confapi.TetragonConf{})},
+		"msg_exit":              {reflect.TypeOf(processapi.MsgExitEvent{})},
+		"msg_test":              {reflect.TypeOf(testapi.MsgTestEvent{})},
+		"msg_execve_key":        {reflect.TypeOf(processapi.MsgExecveKey{})},
+		"execve_map_value":      {reflect.TypeOf(execvemap.ExecveValue{})},
+		"event_config":          {reflect.TypeOf(tracingapi.EventConfig{})},
+		"tetragon_conf":         {reflect.TypeOf(confapi.TetragonConf{})},
+		"cgroup_tracking_value": {reflect.TypeOf(processapi.MsgCgroupData{})},
+		"msg_cgroup_event":      {reflect.TypeOf(processapi.MsgCgroupEvent{})},
 	}
 
 	confMap := map[string][]reflect.Type{

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/api/testapi"
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
+	"github.com/cilium/tetragon/pkg/sensors/cgroup/cgrouptrackmap"
 	"github.com/cilium/tetragon/pkg/sensors/config/confmap"
 	"github.com/cilium/tetragon/pkg/sensors/exec/execvemap"
 
@@ -43,10 +44,19 @@ func CheckStructAlignments(path string) error {
 		"tetragon_conf": {reflect.TypeOf(confmap.TetragonConfValue{})},
 	}
 
+	cgrpmap := map[string][]reflect.Type{
+		"cgroup_tracking_value": {reflect.TypeOf(cgrouptrackmap.CgrpTrackingValue{})},
+	}
+
 	err := check.CheckStructAlignments(path, toCheck, true)
 	if err != nil {
 		return err
 	}
 
-	return check.CheckStructAlignments(path, confMap, true)
+	err = check.CheckStructAlignments(path, confMap, true)
+	if err != nil {
+		return err
+	}
+
+	return check.CheckStructAlignments(path, cgrpmap, true)
 }

--- a/pkg/api/confapi/confapi.go
+++ b/pkg/api/confapi/confapi.go
@@ -3,6 +3,12 @@
 package confapi
 
 type TetragonConf struct {
+	LogLevel        uint32 `align:"loglevel"`           // Tetragon log level
+	PID             uint32 `align:"pid"`                // Tetragon PID for debugging purpose
+	NSPID           uint32 `align:"nspid"`              // Tetragon PID in namespace for debugging purpose
 	TgCgrpHierarchy uint32 `align:"tg_cgrp_hierarchy"`  // Tetragon Cgroup tracking hierarchy ID
 	TgCgrpSubsysIdx uint32 `align:"tg_cgrp_subsys_idx"` // Tracking Cgroup css idx at compile time
+	TgCgrpLevel     uint32 `align:"tg_cgrp_level"`      // Tetragon cgroup level
+	TgCgrpId        uint64 `align:"tg_cgrpid"`          // Tetragon cgroup ID
+	CgrpFsMagic     uint64 `align:"cgrp_fs_magic"`      // Cgroupv1 or cgroupv2
 }

--- a/pkg/api/ops/ops.go
+++ b/pkg/api/ops/ops.go
@@ -21,8 +21,34 @@ const (
 
 	MSG_OP_DATA = 24
 
+	MSG_OP_CGROUP = 25
+
 	// just for testing
 	MSG_OP_TEST = 254
+)
+
+type CgroupOpCode int
+
+// Cgroup Operations that are sent from BPF side. Right now
+// they are used only for logging and debugging, except for
+// for CGROUP_ATTACH_TASK which will be used to detect
+// cgroup configuration.
+const (
+	MSG_OP_CGROUP_UNDEF       CgroupOpCode = iota
+	MSG_OP_CGROUP_MKDIR       CgroupOpCode = 1
+	MSG_OP_CGROUP_RMDIR       CgroupOpCode = 2
+	MSG_OP_CGROUP_RELEASE     CgroupOpCode = 3
+	MSG_OP_CGROUP_ATTACH_TASK CgroupOpCode = 10
+)
+
+type CgroupState int
+
+// Different cgroup states.
+const (
+	CGROUP_UNTRACKED    CgroupState = iota // Cgroup was created but we did not track it
+	CGROUP_NEW          CgroupState = 1    // Cgroup was just created
+	CGROUP_RUNNING      CgroupState = 2    // Cgroup from new => running (fork,exec task inside)
+	CGROUP_RUNNING_PROC CgroupState = 3    // Cgroups that were generated from pids of procfs
 )
 
 type OpCode int
@@ -46,6 +72,26 @@ func (op OpCode) String() string {
 		14:  "GenericTracepoint",
 		23:  "Clone",
 		24:  "Data",
+		25:  "Cgroup",
 		254: "Test",
 	}[op]
+}
+
+func (op CgroupOpCode) String() string {
+	return [...]string{
+		MSG_OP_CGROUP_UNDEF:       "Undef",
+		MSG_OP_CGROUP_MKDIR:       "CgroupMkdir",
+		MSG_OP_CGROUP_RMDIR:       "CgroupRmdir",
+		MSG_OP_CGROUP_RELEASE:     "CgroupRelease",
+		MSG_OP_CGROUP_ATTACH_TASK: "CgroupAttachTask",
+	}[op]
+}
+
+func (st CgroupState) String() string {
+	return [...]string{
+		CGROUP_UNTRACKED:    "Untracked",
+		CGROUP_NEW:          "New",
+		CGROUP_RUNNING:      "Running",
+		CGROUP_RUNNING_PROC: "RunningProc",
+	}[st]
 }

--- a/pkg/api/ops/ops.go
+++ b/pkg/api/ops/ops.go
@@ -49,6 +49,7 @@ const (
 	CGROUP_NEW          CgroupState = 1    // Cgroup was just created
 	CGROUP_RUNNING      CgroupState = 2    // Cgroup from new => running (fork,exec task inside)
 	CGROUP_RUNNING_PROC CgroupState = 3    // Cgroups that were generated from pids of procfs
+	_CGROUP_STATE_MAX   CgroupState = 4
 )
 
 type OpCode int

--- a/pkg/api/ops/ops_test.go
+++ b/pkg/api/ops/ops_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package ops
+
+import (
+	"testing"
+)
+
+func TestCgroupOpCode(t *testing.T) {
+	testcases := map[CgroupOpCode]string{
+		MSG_OP_CGROUP_UNDEF:       "Undef",
+		MSG_OP_CGROUP_MKDIR:       "CgroupMkdir",
+		MSG_OP_CGROUP_RMDIR:       "CgroupRmdir",
+		MSG_OP_CGROUP_RELEASE:     "CgroupRelease",
+		MSG_OP_CGROUP_ATTACH_TASK: "CgroupAttachTask",
+	}
+
+	for op, str := range testcases {
+		if CgroupOpCode(op).String() != str {
+			t.Errorf("CgroupOpCode mismatch - want:%s  got:%s", str, CgroupOpCode(op).String())
+		}
+	}
+}
+
+func TestCgroupState(t *testing.T) {
+	testcases := map[CgroupState]string{
+		CGROUP_UNTRACKED:    "Untracked",
+		CGROUP_NEW:          "New",
+		CGROUP_RUNNING:      "Running",
+		CGROUP_RUNNING_PROC: "RunningProc",
+	}
+
+	if len(testcases) != int(_CGROUP_STATE_MAX) {
+		t.Errorf("CgroupState values mismatch, missing states")
+	}
+
+	for op, str := range testcases {
+		if CgroupState(op).String() != str {
+			t.Errorf("CgroupState mismatch - want:%s  got:%s", str, CgroupState(op).String())
+		}
+	}
+}

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -148,25 +148,25 @@ type MsgExitEvent struct {
 // MsgCgroupData is complementary cgroup data that is collected from
 // BPF side on various cgroup events.
 type MsgCgroupData struct {
-	State       int32  // State of cgroup
-	HierarchyId uint32 // Unique id for the hierarchy
-	Level       uint32 // The depth this cgroup is at
-	Pad         uint32
-	Name        [CGROUP_NAME_LENGTH]byte // Cgroup kernfs_node name
+	State       int32                    `align:"state"`        // State of cgroup
+	HierarchyId uint32                   `align:"hierarchy_id"` // Unique id for the hierarchy
+	Level       uint32                   `align:"level"`        // The depth this cgroup is at
+	Pad         uint32                   `align:"pad"`
+	Name        [CGROUP_NAME_LENGTH]byte `align:"name"` // Cgroup kernfs_node name
 }
 
 // MsgCgroupEvent is the data that is sent from BPF side on cgroup events
 // into ring buffer.
 type MsgCgroupEvent struct {
-	Common        MsgCommon
-	Parent        MsgExecveKey
-	CgrpOp        uint32 // Current cgroup operation
-	PID           uint32
-	NSPID         uint32
-	Flags         uint32
-	Ktime         uint64
-	CgrpidTracker uint64                   // The tracking cgroup ID
-	Cgrpid        uint64                   // Current cgroup ID
-	CgrpData      MsgCgroupData            // Complementary cgroup data
-	Path          [CGROUP_PATH_LENGTH]byte // Full path of the cgroup on fs
+	Common        MsgCommon                `align:"common"`
+	Parent        MsgExecveKey             `align:"parent"`
+	CgrpOp        uint32                   `align:"cgrp_op"` // Current cgroup operation
+	PID           uint32                   `align:"pid"`
+	NSPID         uint32                   `align:"nspid"`
+	Flags         uint32                   `align:"flags"`
+	Ktime         uint64                   `align:"ktime"`
+	CgrpidTracker uint64                   `align:"cgrpid_tracker"` // The tracking cgroup ID
+	Cgrpid        uint64                   `align:"cgrpid"`         // Current cgroup ID
+	CgrpData      MsgCgroupData            `align:"cgrp_data"`      // Complementary cgroup data
+	Path          [CGROUP_PATH_LENGTH]byte `align:"path"`           // Full path of the cgroup on fs
 }

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -12,6 +12,12 @@ const (
 	// cgroup of the task
 	DOCKER_ID_LENGTH = 128
 
+	// Length of the cgroup name as it is returned from BPF side
+	CGROUP_NAME_LENGTH = 128
+
+	// Length of the cgroup path as it is returned from BPF side
+	CGROUP_PATH_LENGTH = 4096
+
 	MSG_SIZEOF_MAXARG = 100
 	MSG_SIZEOF_EXECVE = 32
 	MSG_SIZEOF_CWD    = 256
@@ -137,4 +143,30 @@ type MsgExitEvent struct {
 	Common     MsgCommon    `align:"common"`
 	ProcessKey MsgExecveKey `align:"current"`
 	Info       MsgExitInfo  `align:"info"`
+}
+
+// MsgCgroupData is complementary cgroup data that is collected from
+// BPF side on various cgroup events.
+type MsgCgroupData struct {
+	State       int32  // State of cgroup
+	HierarchyId uint32 // Unique id for the hierarchy
+	Level       uint32 // The depth this cgroup is at
+	Pad         uint32
+	Name        [CGROUP_NAME_LENGTH]byte // Cgroup kernfs_node name
+}
+
+// MsgCgroupEvent is the data that is sent from BPF side on cgroup events
+// into ring buffer.
+type MsgCgroupEvent struct {
+	Common        MsgCommon
+	Parent        MsgExecveKey
+	CgrpOp        uint32 // Current cgroup operation
+	PID           uint32
+	NSPID         uint32
+	Flags         uint32
+	Ktime         uint64
+	CgrpidTracker uint64                   // The tracking cgroup ID
+	Cgrpid        uint64                   // Current cgroup ID
+	CgrpData      MsgCgroupData            // Complementary cgroup data
+	Path          [CGROUP_PATH_LENGTH]byte // Full path of the cgroup on fs
 }

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -8,6 +8,7 @@ package cgroups
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -660,4 +661,13 @@ func DetectCgroupFSMagic() (uint64, error) {
 	}
 
 	return cgroupFSMagic, nil
+}
+
+// CgroupNameFromCstr() Returns a Golang string from the passed C language format string.
+func CgroupNameFromCStr(cstr []byte) string {
+	i := bytes.IndexByte(cstr, 0)
+	if i == -1 {
+		i = len(cstr)
+	}
+	return string(cstr[:i])
 }

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -157,6 +157,10 @@ func GetCgroupFSMagic() uint64 {
 	return cgroupFSMagic
 }
 
+func GetCgroupFSPath() string {
+	return cgroupFSPath
+}
+
 // DiscoverSubSysIds() Discover Cgroup SubSys IDs and indexes.
 // of the corresponding controllers that we are interested
 // in. We need this dynamic behavior since these controllers are

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -193,6 +193,10 @@ func TestDetectCgroupFSMagic(t *testing.T) {
 	} else {
 		t.Errorf("Test failed to get Cgroup filesystem %s type", cgroupFSPath)
 	}
+
+	assert.NotEqual(t, uint64(CGROUP_UNDEF), GetCgroupFSMagic())
+	assert.NotEmpty(t, CgroupFsMagicStr(fs))
+	assert.NotEmpty(t, GetCgroupFSPath())
 }
 
 // Test discovery of compiled-in Cgroups controllers

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -41,6 +42,63 @@ func isDirMountFsType(path string, mntType string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func TestCgroupNameFromCStr(t *testing.T) {
+	type progTest struct {
+		in   []byte
+		want string
+	}
+
+	containerId := "docker-713516e64fa59fc6c7216b29b25d395a606083232bdaf07e53540cd8252ea3f7.scope"
+	cgroupPath := "/system.slice/docker-713516e64fa59fc6c7216b29b25d395a606083232bdaf07e53540cd8252ea3f7.scope"
+	bempty := []byte{0x00}
+	emptycontainerId := []byte(containerId)
+	emptycontainerId[0] = 0x00
+	bcontainerId := []byte(containerId)
+	cidx := strings.Index(containerId, "6e")
+	bcontainerId[cidx] = 0x00
+	pidx := strings.LastIndex(cgroupPath, "/")
+	bcgroupPath := []byte(cgroupPath)
+	bcgroupPath[pidx] = 0x00
+
+	testcases := []progTest{
+		{
+			in:   []byte(""),
+			want: "",
+		},
+		{
+			in:   bempty,
+			want: "",
+		},
+		{
+			in:   emptycontainerId,
+			want: "",
+		},
+		{
+			in:   []byte(containerId),
+			want: containerId,
+		},
+		{
+			in:   []byte(cgroupPath),
+			want: cgroupPath,
+		},
+		{
+			in:   bcontainerId,
+			want: containerId[:cidx],
+		},
+		{
+			in:   bcgroupPath,
+			want: "/system.slice",
+		},
+	}
+
+	for _, test := range testcases {
+		out := CgroupNameFromCStr(test.in)
+		if out != test.want {
+			t.Errorf("CgroupNameFromCStr() mismatch - want:'%s'  -  got:'%s'\n", test.want, out)
+		}
+	}
 }
 
 // Test cgroup mode detection on an invalid directory

--- a/pkg/logger/log.go
+++ b/pkg/logger/log.go
@@ -96,6 +96,10 @@ func ResetLogOutput() {
 	DefaultLogger.SetOutput(os.Stdout)
 }
 
+func GetLogLevel() logrus.Level {
+	return DefaultLogger.GetLevel()
+}
+
 func setLogLevel(logLevel logrus.Level) {
 	DefaultLogger.SetLevel(logLevel)
 }

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -176,7 +176,7 @@ func (k *Observer) getRBSize(cpus int) int {
 
 func (k *Observer) runEvents(stopCtx context.Context, ready func()) error {
 	/* Probe runtime configuration and do not fail on errors */
-	k.UpdateRuntimeConf()
+	k.UpdateRuntimeConf(option.Config.MapDir)
 
 	pinOpts := ebpf.LoadPinOptions{}
 	perfMap, err := ebpf.LoadPinnedMap(k.perfConfig.MapName, &pinOpts)
@@ -263,14 +263,14 @@ type Observer struct {
 // cgroup context. Use this function in your tests to allow Pod and Containers
 // association to work.
 //
-// The environment and cgroup configuration discovery may fail for several reasons,
-// in such cases errors will be logged.
-// Callers can ignore such errors, but we default print a warning that advanced
-// Cgroups tracking will be disabled which might affect process association
-// with kubernetes pods and containers.
-func (k *Observer) UpdateRuntimeConf() error {
+// The environment and cgroup configuration discovery may fail for several
+// reasons, in such cases errors will be logged.
+// On errors we also print a warning that advanced Cgroups tracking will be
+// disabled which might affect process association with kubernetes pods and
+// containers.
+func (k *Observer) UpdateRuntimeConf(mapDir string) error {
 	pid := os.Getpid()
-	err := confmap.UpdateTgRuntimeConf(option.Config.MapDir, pid)
+	err := confmap.UpdateTgRuntimeConf(mapDir, pid)
 	if err != nil {
 		k.log.WithField("observer", "confmap-update").WithError(err).Warn("Update TetragonConf map failed, advanced Cgroups tracking will be disabled")
 		k.log.WithField("observer", "confmap-update").Warn("Continuing without advanced Cgroups tracking. Process association with Pods and Containers might be limited")

--- a/pkg/sensors/cgroup/cgrouptrackmap/cgrouptrackmap.go
+++ b/pkg/sensors/cgroup/cgrouptrackmap/cgrouptrackmap.go
@@ -20,18 +20,18 @@ type CgrpTrackingKey struct {
 
 type CgrpTrackingValue struct {
 	/* State of cgroup */
-	State int32
+	State int32 `align:"state"`
 
 	/* Unique id for the hierarchy this is mostly for cgroupv1 */
-	HierarchyId uint32
+	HierarchyId uint32 `align:"hierarchy_id"`
 
 	/* The depth this cgroup is at - We don't track ancestors as they may change */
-	Level uint32
+	Level uint32 `align:"level"`
 
-	Pad uint32
+	Pad uint32 `align:"pad"`
 
 	/* Cgroup kernfs_node name */
-	Name [processapi.CGROUP_NAME_LENGTH]byte
+	Name [processapi.CGROUP_NAME_LENGTH]byte `align:"name"`
 }
 
 func (k *CgrpTrackingKey) String() string             { return fmt.Sprintf("key=%d", k.CgrpId) }

--- a/pkg/sensors/cgroup/cgrouptrackmap/cgrouptrackmap.go
+++ b/pkg/sensors/cgroup/cgrouptrackmap/cgrouptrackmap.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package cgrouptrackmap
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/tetragon/pkg/api/processapi"
+	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/logger"
+)
+
+type CgrpTrackingKey struct {
+	CgrpId uint64
+}
+
+type CgrpTrackingValue struct {
+	/* State of cgroup */
+	State int32
+
+	/* Unique id for the hierarchy this is mostly for cgroupv1 */
+	HierarchyId uint32
+
+	/* The depth this cgroup is at - We don't track ancestors as they may change */
+	Level uint32
+
+	Pad uint32
+
+	/* Cgroup kernfs_node name */
+	Name [processapi.CGROUP_NAME_LENGTH]byte
+}
+
+func (k *CgrpTrackingKey) String() string             { return fmt.Sprintf("key=%d", k.CgrpId) }
+func (k *CgrpTrackingKey) GetKeyPtr() unsafe.Pointer  { return unsafe.Pointer(k) }
+func (k *CgrpTrackingKey) DeepCopyMapKey() bpf.MapKey { return &CgrpTrackingKey{k.CgrpId} }
+
+func (k *CgrpTrackingKey) NewValue() bpf.MapValue { return &CgrpTrackingValue{} }
+
+func (v *CgrpTrackingValue) String() string {
+	return fmt.Sprintf("value=%d %s", 0, "")
+}
+func (v *CgrpTrackingValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
+func (v *CgrpTrackingValue) DeepCopyMapValue() bpf.MapValue {
+	val := &CgrpTrackingValue{}
+	val.State = v.State
+	val.HierarchyId = v.HierarchyId
+	val.Level = v.Level
+	copy(val.Name[:processapi.CGROUP_NAME_LENGTH], v.Name[:processapi.CGROUP_NAME_LENGTH])
+	return val
+}
+
+func LookupTrackingCgroup(mapPath string, cgrpid uint64) (*CgrpTrackingValue, error) {
+	if cgrpid == 0 {
+		return nil, fmt.Errorf("invalid CgroupIdTracking")
+	}
+
+	m, err := bpf.OpenMap(mapPath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer m.Close()
+
+	logger.GetLogger().WithFields(logrus.Fields{
+		"cgroup.id": cgrpid,
+		"bpf-map":   m.Name(),
+	}).Trace("Looking for tracking CgroupID inside map")
+
+	k := &CgrpTrackingKey{CgrpId: cgrpid}
+	v, err := m.Lookup(k)
+	if err != nil {
+		return nil, err
+	}
+
+	val := v.DeepCopyMapValue().(*CgrpTrackingValue)
+
+	return val, nil
+}

--- a/pkg/sensors/cgroup/cgrouptrackmap/cgrouptrackmap_test.go
+++ b/pkg/sensors/cgroup/cgrouptrackmap/cgrouptrackmap_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package cgrouptrackmap
+
+import (
+	"testing"
+
+	"github.com/cilium/tetragon/pkg/api/ops"
+	"github.com/cilium/tetragon/pkg/api/processapi"
+	"github.com/cilium/tetragon/pkg/cgroups"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeepCopyMapValue(t *testing.T) {
+	containerId := "docker-6917e69ec552a5b9ff0cd937586d8b7e8d9d77013a12571fa57a53fe681f5c07.scope"
+	k := &CgrpTrackingValue{
+		State:       int32(ops.CGROUP_RUNNING),
+		HierarchyId: 4,
+		Level:       5,
+	}
+	copy(k.Name[:processapi.CGROUP_NAME_LENGTH], containerId)
+
+	val := k.DeepCopyMapValue().(*CgrpTrackingValue)
+	assert.EqualValues(t, val, k)
+	assert.Equal(t, containerId, cgroups.CgroupNameFromCStr(val.Name[:processapi.CGROUP_NAME_LENGTH]))
+}

--- a/pkg/sensors/config/confmap/confmap.go
+++ b/pkg/sensors/config/confmap/confmap.go
@@ -21,8 +21,14 @@ type TetragonConfKey struct {
 }
 
 type TetragonConfValue struct {
+	LogLevel        uint32 `align:"loglevel"`           // Tetragon log level
+	PID             uint32 `align:"pid"`                // Tetragon PID for debugging purpose
+	NSPID           uint32 `align:"nspid"`              // Tetragon PID in namespace for debugging purpose
 	TgCgrpHierarchy uint32 `align:"tg_cgrp_hierarchy"`  // Tetragon Cgroup tracking hierarchy ID
 	TgCgrpSubsysIdx uint32 `align:"tg_cgrp_subsys_idx"` // Tracking Cgroup css idx at compile time
+	TgCgrpLevel     uint32 `align:"tg_cgrp_level"`      // Tetragon cgroup level
+	TgCgrpId        uint64 `align:"tg_cgrpid"`          // Tetragon cgroup ID
+	CgrpFsMagic     uint64 `align:"cgrp_fs_magic"`      // Cgroupv1 or cgroupv2
 }
 
 var (

--- a/pkg/sensors/config/confmap/confmap.go
+++ b/pkg/sensors/config/confmap/confmap.go
@@ -105,8 +105,11 @@ func UpdateTgRuntimeConf(mapDir string, nspid int) error {
 
 	k := &TetragonConfKey{Key: 0}
 	v := &TetragonConfValue{
+		LogLevel:        uint32(logger.GetLogLevel()),
 		TgCgrpHierarchy: cgroups.GetCgrpHierarchyID(),
 		TgCgrpSubsysIdx: cgroups.GetCgrpSubsystemIdx(),
+		NSPID:           uint32(nspid),
+		CgrpFsMagic:     cgroupFsMagic,
 	}
 
 	err = m.Update(k, v)
@@ -119,10 +122,12 @@ func UpdateTgRuntimeConf(mapDir string, nspid int) error {
 	log.WithFields(logrus.Fields{
 		"confmap-update":                configMap.Name,
 		"deployment.mode":               cgroups.DeploymentCode(deployMode).String(),
-		"cgroup.fs.magic":               cgroups.CgroupFsMagicStr(cgroupFsMagic),
+		"log.level":                     logrus.Level(v.LogLevel).String(),
+		"cgroup.fs.magic":               cgroups.CgroupFsMagicStr(v.CgrpFsMagic),
 		"cgroup.controller.name":        cgroups.GetCgrpControllerName(),
 		"cgroup.controller.hierarchyID": v.TgCgrpHierarchy,
 		"cgroup.controller.index":       v.TgCgrpSubsysIdx,
+		"NSPID":                         nspid,
 	}).Info("Updated TetragonConf map successfully")
 
 	return nil

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -4,9 +4,16 @@ package exec
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/cgroups"
+	grpcexec "github.com/cilium/tetragon/pkg/grpc/exec"
+	"github.com/cilium/tetragon/pkg/sensors"
 
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/logger"
@@ -15,10 +22,85 @@ import (
 	"github.com/cilium/tetragon/pkg/sensors/base"
 	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
 	"github.com/cilium/tetragon/pkg/testutils"
+	"github.com/cilium/tetragon/pkg/testutils/perfring"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+const (
+	defaultTimeout = 30 * time.Second
+
+	// Cgroup root directory for tests under /sys/fs/cgroup/...
+	tetragonCgrpRoot = "tetragon-tests"
+)
+
+var (
+	loadedSensors = []*sensors.Sensor{
+		testsensor.GetTestSensor(),
+		testsensor.GetCgroupSensor(),
+	}
+)
+
+func init() {
+	tus.RegisterSensorsAtInit(loadedSensors)
+}
+
+func cgroupMkdir(t *testing.T, cgroupfsPath string, hierarchy string, dir string) error {
+	path := filepath.Join(cgroupfsPath, hierarchy, dir)
+	err := os.MkdirAll(path, 0755)
+	if err != nil {
+		t.Logf("test failed to create cgroup directory '%s': %v", path, err)
+	} else {
+		t.Logf("test created cgroup directory '%s' with success", path)
+	}
+	return err
+}
+
+func cgroupRmdir(t *testing.T, cgroupfsPath string, hierarchy string, dir string) error {
+	path := filepath.Join(cgroupfsPath, hierarchy, dir)
+	err := os.RemoveAll(path)
+	if err != nil {
+		t.Logf("test failed to clean cgroup directory '%s': %v", path, err)
+	} else {
+		t.Logf("test cleaned cgroup directory '%s' with success", path)
+	}
+	return err
+}
+
+func getTestCgroupDirAndHierarchy(t *testing.T) (string, string) {
+	// Do not use random names so we can predict if directory
+	// failed to be removed by previous tests...
+	dir := fmt.Sprintf("/%s/%s", tetragonCgrpRoot, t.Name())
+	cgroupMode := cgroups.GetCgroupMode()
+	assert.NotZero(t, uint32(cgroupMode))
+
+	t.Logf("Test %s is running in '%s'", t.Name(), cgroupMode.String())
+
+	hierarchy := ""
+	if cgroupMode != cgroups.CGROUP_UNIFIED {
+		// In cgroupv1 tracking
+		hierarchy = cgroups.GetCgrpControllerName()
+	}
+
+	return dir, hierarchy
+}
+
+func setupTgRuntimeConf(t *testing.T, trackingCgrpLevel uint32, logLevel uint32) {
+	val, err := testutils.GetTgRuntimeConf()
+	if err != nil {
+		t.Fatalf("GetTgRuntimeConf() failed: %v", err)
+	}
+
+	val.LogLevel = logLevel
+	val.TgCgrpLevel = trackingCgrpLevel
+
+	mapDir := bpf.MapPrefixPath()
+	err = testutils.UpdateTgRuntimeConf(mapDir, val)
+	if err != nil {
+		t.Fatalf("UpdateTgRuntimeConf() failed: %v", err)
+	}
+}
 
 // Test loading bpf cgroups programs
 func TestLoadCgroupsPrograms(t *testing.T) {
@@ -65,4 +147,60 @@ func TestTgRuntimeConf(t *testing.T) {
 	assert.Equal(t, ret.TgCgrpHierarchy, cgroups.GetCgrpHierarchyID())
 	assert.Equal(t, ret.TgCgrpSubsysIdx, cgroups.GetCgrpSubsystemIdx())
 	assert.Equal(t, ret.LogLevel, uint32(logger.GetLogLevel()))
+}
+
+// Test we do not receive any cgroup events from BPF side
+func TestCgroupNoEvents(t *testing.T) {
+	testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	option.Config.Verbosity = 5
+
+	_, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserver error: %s", err)
+	}
+
+	testManager := tus.StartTestSensorManager(ctx, t)
+	observer.SensorManager = testManager.Manager
+
+	testManager.EnableSensors(ctx, t, loadedSensors)
+
+	// Set Cgroup Tracking level to Zero means no tracking and no
+	// cgroup events, all bpf cgroups related programs have no effect
+	trackingCgrpLevel := uint32(0)
+	setupTgRuntimeConf(t, trackingCgrpLevel, uint32(logrus.TraceLevel))
+
+	cgroupFSPath := cgroups.GetCgroupFSPath()
+	assert.NotEmpty(t, cgroupFSPath)
+
+	dir, hierarchy := getTestCgroupDirAndHierarchy(t)
+	cgroupRmdir(t, cgroupFSPath, hierarchy, tetragonCgrpRoot)
+
+	finalpath := filepath.Join(cgroupFSPath, hierarchy, dir)
+	_, err = os.Stat(finalpath)
+	if err == nil {
+		t.Fatalf("Test %s failed cgroup test hierarchy should not exist '%s'", t.Name(), finalpath)
+	}
+
+	t.Cleanup(func() {
+		cgroupRmdir(t, cgroupFSPath, hierarchy, dir)
+	})
+
+	trigger := func() {
+		err = cgroupMkdir(t, cgroupFSPath, hierarchy, dir)
+		assert.NoError(t, err)
+	}
+
+	events := perfring.RunTestEvents(t, ctx, trigger)
+	for _, ev := range events {
+		if msg, ok := ev.(*grpcexec.MsgCgroupEventUnix); ok {
+			if msg.Common.Op == ops.MSG_OP_CGROUP {
+				op := ops.CgroupOpCode(msg.CgrpOp)
+				t.Fatalf("Test failed received a cgroup.event=%s", op)
+			}
+		}
+	}
 }

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package exec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/sensors/base"
+	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
+	"github.com/cilium/tetragon/pkg/testutils"
+	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+	"github.com/sirupsen/logrus"
+)
+
+// Test loading bpf cgroups programs
+func TestLoadCgroupsPrograms(t *testing.T) {
+	testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	option.Config.Verbosity = 5
+	tus.LoadSensor(ctx, t, base.GetInitialSensor())
+	tus.LoadSensor(ctx, t, testsensor.GetTestSensor())
+	tus.LoadSensor(ctx, t, testsensor.GetCgroupSensor())
+}

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -6,13 +6,18 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cilium/tetragon/pkg/cgroups"
+
+	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors/base"
 	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 // Test loading bpf cgroups programs
@@ -26,4 +31,38 @@ func TestLoadCgroupsPrograms(t *testing.T) {
 	tus.LoadSensor(ctx, t, base.GetInitialSensor())
 	tus.LoadSensor(ctx, t, testsensor.GetTestSensor())
 	tus.LoadSensor(ctx, t, testsensor.GetCgroupSensor())
+}
+
+// Test `tg_conf_map` BPF map that it can hold runtime configuration
+func TestTgRuntimeConf(t *testing.T) {
+	testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	option.Config.Verbosity = 5
+
+	_, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserver error: %s", err)
+	}
+
+	val, err := testutils.GetTgRuntimeConf()
+	assert.NoError(t, err)
+
+	assert.NotZero(t, val.NSPID)
+	assert.NotZero(t, val.CgrpFsMagic)
+
+	mapDir := bpf.MapPrefixPath()
+	err = testutils.UpdateTgRuntimeConf(mapDir, val)
+	assert.NoError(t, err)
+
+	ret, err := testutils.ReadTgRuntimeConf(mapDir)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, ret, val)
+
+	assert.Equal(t, ret.TgCgrpHierarchy, cgroups.GetCgrpHierarchyID())
+	assert.Equal(t, ret.TgCgrpSubsysIdx, cgroups.GetCgrpSubsystemIdx())
+	assert.Equal(t, ret.LogLevel, uint32(logger.GetLogLevel()))
 }

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -227,6 +227,16 @@ func handleClone(r *bytes.Reader) ([]observer.Event, error) {
 	return []observer.Event{msgUnix}, nil
 }
 
+func handleCgroupEvent(r *bytes.Reader) ([]observer.Event, error) {
+	m := processapi.MsgCgroupEvent{}
+	err := binary.Read(r, binary.LittleEndian, &m)
+	if err != nil {
+		return nil, err
+	}
+	msgUnix := &exec.MsgCgroupEventUnix{MsgCgroupEvent: m}
+	return []observer.Event{msgUnix}, nil
+}
+
 type execSensor struct {
 	name string
 }
@@ -256,4 +266,5 @@ func AddExec() {
 	observer.RegisterEventHandlerAtInit(ops.MSG_OP_EXECVE, handleExecve)
 	observer.RegisterEventHandlerAtInit(ops.MSG_OP_EXIT, handleExit)
 	observer.RegisterEventHandlerAtInit(ops.MSG_OP_CLONE, handleClone)
+	observer.RegisterEventHandlerAtInit(ops.MSG_OP_CGROUP, handleCgroupEvent)
 }

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/dataapi"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/processapi"
+	"github.com/cilium/tetragon/pkg/cgroups"
 	"github.com/cilium/tetragon/pkg/data"
 	exec "github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/logger"
@@ -22,15 +23,6 @@ import (
 	"github.com/cilium/tetragon/pkg/sensors/program"
 	"github.com/sirupsen/logrus"
 )
-
-func fromCString(cstr []byte) string {
-	for i, c := range cstr {
-		if c == 0 {
-			return string(cstr[:i])
-		}
-	}
-	return string(cstr)
-}
 
 func msgToExecveUnix(m *processapi.MsgExecveEvent) *exec.MsgExecveEventUnix {
 	unix := &exec.MsgExecveEventUnix{}
@@ -65,7 +57,7 @@ func msgToExecveKubeUnix(m *processapi.MsgExecveEvent, exec_id string, filename 
 	// The first byte is set to zero if there is no docker ID for this event.
 	if m.Kube.Docker[0] != 0x00 {
 		// We always get a null terminated buffer from bpf
-		cgroup := fromCString(m.Kube.Docker[:processapi.DOCKER_ID_LENGTH])
+		cgroup := cgroups.CgroupNameFromCStr(m.Kube.Docker[:processapi.CGROUP_NAME_LENGTH])
 		docker, _ := procevents.LookupContainerId(cgroup, true, false)
 		if docker != "" {
 			kube.Docker = docker

--- a/pkg/sensors/test/cgroups.go
+++ b/pkg/sensors/test/cgroups.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package test
+
+import (
+	"github.com/cilium/tetragon/pkg/kernels"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+)
+
+var (
+	CgroupMkdir = program.Builder(
+		"bpf_cgroup_mkdir.o",
+		"cgroup/cgroup_mkdir",
+		"raw_tracepoint/cgroup_mkdir",
+		"tg_tp_cgrp_mkdir",
+		"raw_tracepoint",
+	)
+
+	CgroupRmdir = program.Builder(
+		"bpf_cgroup_rmdir.o",
+		"cgroup/cgroup_rmdir",
+		"raw_tracepoint/cgroup_rmdir",
+		"tg_tp_cgrp_rmdir",
+		"raw_tracepoint",
+	)
+
+	CgroupRelease = program.Builder(
+		"bpf_cgroup_release.o",
+		"cgroup/cgroup_release",
+		"raw_tracepoint/cgroup_release",
+		"tg_tp_cgrp_release",
+		"raw_tracepoint",
+	)
+
+	/* Cgroup tracking maps */
+	CgroupsTrackingMap    = program.MapBuilder("tg_cgrps_tracking_map", CgroupMkdir)
+	CgroupsTrackingMapV53 = program.MapBuilder("tg_cgrps_tracking_map", CgroupMkdir)
+)
+
+func getCgroupsTrackingMap() *program.Map {
+	if kernels.EnableLargeProgs() {
+		return CgroupsTrackingMapV53
+	}
+	return CgroupsTrackingMap
+}
+
+func getCgroupPrograms() []*program.Program {
+	progs := []*program.Program{
+		CgroupMkdir,
+		CgroupRmdir,
+		CgroupRelease,
+	}
+	return progs
+}
+
+func getCgroupMaps() []*program.Map {
+	maps := []*program.Map{
+		getCgroupsTrackingMap(),
+	}
+	return maps
+}
+
+// GetCgroupSensor returns the Cgroups base sensor
+func GetCgroupSensor() *sensors.Sensor {
+	return &sensors.Sensor{
+		Name:  "test-sensor-cgroups",
+		Progs: getCgroupPrograms(),
+		Maps:  getCgroupMaps(),
+	}
+}

--- a/pkg/sensors/test/cgroups.go
+++ b/pkg/sensors/test/cgroups.go
@@ -39,7 +39,7 @@ var (
 	CgroupsTrackingMapV53 = program.MapBuilder("tg_cgrps_tracking_map", CgroupMkdir)
 )
 
-func getCgroupsTrackingMap() *program.Map {
+func GetCgroupsTrackingMap() *program.Map {
 	if kernels.EnableLargeProgs() {
 		return CgroupsTrackingMapV53
 	}
@@ -57,7 +57,7 @@ func getCgroupPrograms() []*program.Program {
 
 func getCgroupMaps() []*program.Map {
 	maps := []*program.Map{
-		getCgroupsTrackingMap(),
+		GetCgroupsTrackingMap(),
 	}
 	return maps
 }

--- a/pkg/testutils/confmap.go
+++ b/pkg/testutils/confmap.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package testutils
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/cgroups"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/sensors/base"
+	"github.com/cilium/tetragon/pkg/sensors/config/confmap"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	log = logger.GetLogger()
+)
+
+func GetTgRuntimeConf() (*confmap.TetragonConfValue, error) {
+	nspid := os.Getpid()
+
+	// First let's detect cgroupfs magic
+	cgroupFsMagic, err := cgroups.DetectCgroupFSMagic()
+	if err != nil {
+		return nil, err
+	}
+
+	// This must be called before probing cgroup configurations
+	err = cgroups.DiscoverSubSysIds()
+	if err != nil {
+		return nil, err
+	}
+
+	// Detect deployment mode
+	_, err = cgroups.DetectDeploymentMode()
+	if err != nil {
+		return nil, err
+	}
+
+	return &confmap.TetragonConfValue{
+		LogLevel:        uint32(logger.GetLogLevel()),
+		TgCgrpHierarchy: cgroups.GetCgrpHierarchyID(),
+		TgCgrpSubsysIdx: cgroups.GetCgrpSubsystemIdx(),
+		NSPID:           uint32(nspid),
+		CgrpFsMagic:     cgroupFsMagic,
+	}, nil
+}
+
+// Test `tg_conf_map` BPF MAP with explicit values
+func UpdateTgRuntimeConf(mapDir string, v *confmap.TetragonConfValue) error {
+	configMap := base.GetTetragonConfMap()
+	mapPath := filepath.Join(mapDir, configMap.Name)
+
+	m, err := bpf.OpenMap(mapPath)
+	for i := 0; err != nil; i++ {
+		m, err = bpf.OpenMap(mapPath)
+		if err != nil {
+			time.Sleep(1 * time.Second)
+		}
+		if i > 4 {
+			log.WithField("confmap-update", configMap.Name).WithError(err).Warn("Failed to update TetragonConf map")
+			return err
+		}
+	}
+
+	defer m.Close()
+
+	k := &confmap.TetragonConfKey{Key: 0}
+	err = m.Update(k, v)
+	if err != nil {
+		log.WithField("confmap-update", configMap.Name).WithError(err).Warn("Failed to update TetragonConf map")
+		return err
+	}
+
+	log.WithFields(logrus.Fields{
+		"confmap-update":                configMap.Name,
+		"log.level":                     logrus.Level(v.LogLevel).String(),
+		"cgroup.fs.magic":               cgroups.CgroupFsMagicStr(v.CgrpFsMagic),
+		"cgroup.controller.name":        cgroups.GetCgrpControllerName(),
+		"cgroup.controller.hierarchyID": v.TgCgrpHierarchy,
+		"cgroup.controller.index":       v.TgCgrpSubsysIdx,
+		"cgroup.ID":                     v.TgCgrpId,
+		"NSPID":                         v.NSPID,
+	}).Debug("Updated TetragonConf map successfully")
+
+	return nil
+}
+
+func ReadTgRuntimeConf(mapDir string) (*confmap.TetragonConfValue, error) {
+	return confmap.ReadTgRuntimeConf(mapDir)
+}

--- a/pkg/testutils/sensors/sensors.go
+++ b/pkg/testutils/sensors/sensors.go
@@ -8,6 +8,12 @@ import (
 	"github.com/cilium/tetragon/pkg/sensors"
 )
 
+func RegisterSensorsAtInit(loaded []*sensors.Sensor) {
+	for _, s := range loaded {
+		sensors.RegisterSensorAtInit(s)
+	}
+}
+
 // LoadSensor is a helper for loading a sensor in tests
 func LoadSensor(ctx context.Context, t *testing.T, sensor *sensors.Sensor) {
 
@@ -69,4 +75,20 @@ func (tsm *TestSensorManager) AddAndEnableSensor(
 	t.Cleanup(func() {
 		tsm.Manager.DisableSensor(ctx, sensorName)
 	})
+}
+
+// EnableSensors is a helper function that enables a list of sensors
+func (tsm *TestSensorManager) EnableSensors(
+	ctx context.Context,
+	t *testing.T,
+	targets []*sensors.Sensor,
+) {
+	for _, s := range targets {
+		if err := tsm.Manager.EnableSensor(ctx, s.Name); err != nil {
+			t.Fatalf("EnableSensor error: %s", err)
+		}
+		t.Cleanup(func() {
+			tsm.Manager.DisableSensor(ctx, s.Name)
+		})
+	}
 }


### PR DESCRIPTION
This PR introduce basic Cgroups tracking. It handles first task of issue: https://github.com/cilium/tetragon/issues/477

The main functionality is `cgroup_mkdir` and `cgroup_rmdir` where we register our bpf programs and expect events to be sent to user space. Note that these programs are not loaded into main Tetragon, we are babysitting them with tests for now, so no new functionality is introduced.

- The patches prefixed with bpf are bpf related parts.
- The following patches are user space handlers for the cgroup events.
- Then we have helpers to make tests easy, followed with tests including bpf unit tests. 