### PR TITLE
Build tetra CLI for linux arm64 and windows amd64/arm64

### DIFF
--- a/Makefile.cli
+++ b/Makefile.cli
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Tetragon
 
-GO_BUILD = CGO_ENABLED=0 $(GO) build
+GO_BUILD = CGO_ENABLED=0 $(GO) build -tags standalone
 TARGET=tetra
 
 RELEASE_UID ?= $(shell id -u)
@@ -17,10 +17,9 @@ cli-release:
 			adduser -u $(RELEASE_UID) -D -G release release && \
 			su release -c 'make cli-local-release VERSION=${VERSION}'"
 
-# TODO: Build darwin / windows / linux arm64 binaries
 cli-local-release: cli-clean
 	set -o errexit; \
-	for OS in darwin linux; do \
+	for OS in darwin linux windows; do \
 		EXT=; \
 		ARCHS=; \
 		case $$OS in \
@@ -28,7 +27,10 @@ cli-local-release: cli-clean
 				ARCHS='arm64 amd64'; \
 				;; \
 			linux) \
-				ARCHS='amd64'; \
+				ARCHS='arm64 amd64'; \
+				;; \
+			windows) \
+				ARCHS='arm64 amd64'; \
 				;; \
 		esac; \
 		for ARCH in $$ARCHS; do \

--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -6,18 +6,18 @@ package common
 import (
 	"context"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/spf13/viper"
-	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 func CliRunErr(fn func(ctx context.Context, cli tetragon.FineGuidanceSensorsClient), fnErr func(err error)) {
-	ctx, cancel := signal.NotifyContext(context.Background(), unix.SIGINT, unix.SIGTERM)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	connCtx, connCancel := context.WithTimeout(ctx, 10*time.Second)

--- a/cmd/tetra/full_commands.go
+++ b/cmd/tetra/full_commands.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !standalone
+
+package main
+
+import (
+	"github.com/cilium/tetragon/cmd/tetra/bugtool"
+	"github.com/cilium/tetragon/cmd/tetra/getevents"
+	"github.com/cilium/tetragon/cmd/tetra/sensors"
+	"github.com/cilium/tetragon/cmd/tetra/stacktracetree"
+	"github.com/cilium/tetragon/cmd/tetra/status"
+	"github.com/cilium/tetragon/cmd/tetra/tracingpolicy"
+	"github.com/cilium/tetragon/cmd/tetra/version"
+	"github.com/spf13/cobra"
+)
+
+func addCommands(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(getevents.New())
+	rootCmd.AddCommand(version.New())
+	rootCmd.AddCommand(bugtool.New())
+	rootCmd.AddCommand(sensors.New())
+	rootCmd.AddCommand(stacktracetree.New())
+	rootCmd.AddCommand(status.New())
+	rootCmd.AddCommand(tracingpolicy.New())
+}

--- a/cmd/tetra/main.go
+++ b/cmd/tetra/main.go
@@ -6,14 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cilium/tetragon/cmd/tetra/bugtool"
 	"github.com/cilium/tetragon/cmd/tetra/common"
-	"github.com/cilium/tetragon/cmd/tetra/getevents"
-	"github.com/cilium/tetragon/cmd/tetra/sensors"
-	"github.com/cilium/tetragon/cmd/tetra/stacktracetree"
-	"github.com/cilium/tetragon/cmd/tetra/status"
-	"github.com/cilium/tetragon/cmd/tetra/tracingpolicy"
-	"github.com/cilium/tetragon/cmd/tetra/version"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -45,14 +38,7 @@ func new() *cobra.Command {
 		},
 	}
 
-	rootCmd.AddCommand(bugtool.New())
-	rootCmd.AddCommand(getevents.New())
-	rootCmd.AddCommand(sensors.New())
-	rootCmd.AddCommand(stacktracetree.New())
-	rootCmd.AddCommand(status.New())
-	rootCmd.AddCommand(tracingpolicy.New())
-	rootCmd.AddCommand(version.New())
-
+	addCommands(rootCmd)
 	flags := rootCmd.PersistentFlags()
 	flags.BoolP(common.KeyDebug, "d", false, "Enable debug messages")
 	flags.String(common.KeyServerAddress, "localhost:54321", "gRPC server address")

--- a/cmd/tetra/standalone_commands.go
+++ b/cmd/tetra/standalone_commands.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build standalone
+
+package main
+
+import (
+	"github.com/cilium/tetragon/cmd/tetra/getevents"
+	"github.com/cilium/tetragon/cmd/tetra/version"
+	"github.com/spf13/cobra"
+)
+
+// addCommands in standalone mode only supports getevents and version subcommands.
+func addCommands(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(getevents.New())
+	rootCmd.AddCommand(version.New())
+}

--- a/pkg/syscallinfo/syscallnames_windows.go
+++ b/pkg/syscallinfo/syscallnames_windows.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build windows && (arm64 || amd64)
+
+package syscallinfo
+
+// Define syscalNames variable so that we can compile tetra CLI for windows.
+var syscallNames = map[int]string{}


### PR DESCRIPTION
- Add "standalone" build tag for only exposing version and getevents
  subcommands in the standalone tetra CLI.
- Update make cli-local-release target to build linux arm64 and windows
  amd64/arm64 binaries.
- Use syscall instead of unix for SIGINT and SIGTERM for windows build.
- Define an empty syscallNames for windows.

Ref: #438
Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>