### PR TITLE
Simplify the interaction with the EventCache

### DIFF
--- a/pkg/api/readyapi/readyapi.go
+++ b/pkg/api/readyapi/readyapi.go
@@ -3,10 +3,7 @@
 package readyapi
 
 import (
-	"fmt"
-
 	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/notify"
 )
 
@@ -14,14 +11,6 @@ type MsgTetragonReady struct{}
 
 func (msg *MsgTetragonReady) Notify() bool {
 	return false
-}
-
-func (msg *MsgTetragonReady) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return nil, fmt.Errorf("Unsupported cache event MsgTetragonReady")
-}
-
-func (msg *MsgTetragonReady) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return fmt.Errorf("Unsupported cache retry event MsgTetragonReady")
 }
 
 func (msg *MsgTetragonReady) HandleMessage() *tetragon.GetEventsResponse {

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/pkg/ktime"
+	kt "github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
 	"github.com/cilium/tetragon/pkg/metrics/eventcachemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/mapmetrics"
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/reader/notify"
 	"github.com/cilium/tetragon/pkg/server"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
@@ -31,12 +32,18 @@ var (
 	nodeName string
 )
 
+type retryFn func(notify.Event, *notify.CacheActions, uint32, uint64) error
+type procFn func(*process.ProcessInternal)
+
 type CacheObj struct {
-	internal  *process.ProcessInternal
 	event     notify.Event
-	timestamp uint64
+	pid       uint32 // process pid
+	ktime     uint64 // process ktime
+	timestamp uint64 // event ktime
 	color     int
 	msg       notify.Message
+	actions   *notify.CacheActions
+	retry     retryFn
 }
 
 type Cache struct {
@@ -53,64 +60,158 @@ var (
 	ErrFailedToGetParentInfo  = errors.New("failed to get parent info")
 )
 
-// Generic internal lookup happens when events are received out of order and
-// this event was handled before an exec event so it wasn't able to populate
-// the process info yet.
-func HandleGenericInternal(ev notify.Event, pid uint32, timestamp uint64) (*process.ProcessInternal, error) {
-	internal, parent := process.GetParentProcessInternal(pid, timestamp)
-	var err error
+// We have 2 major caches in Tetragon: (a) processLRU and (b) EventCache.
+// (a) processLRU contains mappings from execID to ProcessInternal structures.
+//     We add new entries from exec/clone events in the processLRU and we remove
+//     them by using reference counting. Exit (and cleanup) events decreases the
+//     reference count.
+// (b) EventCache is responsible to handle OOO events that miss Process, Parent,
+//     or their PodInformation. As handling reference counting is compicated
+//     when we have OOO events functions AddProcessParent and AddProcessParentRefInc
+//     simplify the interaction with the EventCache.
 
-	if parent != nil {
-		ev.SetParent(parent.GetProcessCopy())
-	} else {
-		errormetrics.ErrorTotalInc(errormetrics.EventCacheParentInfoFailed)
-		err = ErrFailedToGetParentInfo
-	}
-
-	if internal != nil {
-		ev.SetProcess(internal.GetProcessCopy())
-	} else {
-		errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
-		err = ErrFailedToGetProcessInfo
-	}
-
-	if err == nil {
-		return internal, err
-	}
-	return nil, err
+// AddProcessParent adds process/parent information to the event e. It does not
+// affect refcnt. This is ideal for events like kprobe/tracepoint that do not
+// come into pairs. This transparently returns the event in the case we don't
+// miss anything or adds the event to the EventCache. In that case it uses processLRU
+// to get process and parent info.
+func AddProcessParent(e notify.Event, msg notify.Message, pid uint32, ktime uint64, timestamp uint64) *tetragon.GetEventsResponse {
+	return addProcInfo(e, msg, pid, ktime, timestamp, func(*process.ProcessInternal) {})
 }
 
-// Generic Event handler without any extra msg specific details or debugging
-// so we only need to wait for the internal link to the process context to
-// resolve PodInfo. This happens when the msg populates the internal state
-// but that event is not fully populated yet.
-func HandleGenericEvent(internal *process.ProcessInternal, ev notify.Event) error {
-	p := internal.UnsafeGetProcess()
-	if option.Config.EnableK8s && p.Pod == nil {
-		errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
-		return ErrFailedToGetPodInfo
+// The AddProcessParentRef{Inc, Dec} functions do the similar to AddProcessParent
+// with the only difference to also increase/decrease the recnt of ProcessInternal.
+// These should be used in pairs.
+//
+// Currently, they are used in exec/clone/exit events. Exec/clone events create a new
+// ProcessInternal with refcnt equals to 1 and increases the reference count of the
+// parent. Exit events descreases the reference count of the process and parent.
+//
+// Other examples can be on file events (i.e. increase on file open and decrease on
+// file close) or networking events (i.e. increase on connect/accept/listen and
+// decrease on close).
+func AddProcessParentRefInc(e notify.Event, msg notify.Message, pid uint32, ktime uint64, timestamp uint64) *tetragon.GetEventsResponse {
+	return addProcInfo(e, msg, pid, ktime, timestamp, func(p *process.ProcessInternal) { p.RefInc() })
+}
+
+func AddProcessParentRefDec(e notify.Event, msg notify.Message, pid uint32, ktime uint64, timestamp uint64) *tetragon.GetEventsResponse {
+	return addProcInfo(e, msg, pid, ktime, timestamp, func(p *process.ProcessInternal) { p.RefDec() })
+}
+
+func addProcInfo(e notify.Event, msg notify.Message, pid uint32, ktime uint64, timestamp uint64, pFn procFn) *tetragon.GetEventsResponse {
+	var tetragonParent, tetragonProcess *tetragon.Process
+
+	proc, parent := process.GetParentProcessInternal(pid, ktime)
+	if proc != nil {
+		tetragonProcess = proc.GetProcessCopy()
+		e.SetProcess(tetragonProcess)
+	}
+	if parent != nil {
+		tetragonParent = parent.GetProcessCopy()
+		e.SetParent(tetragonParent)
 	}
 
-	ev.SetProcess(internal.GetProcessCopy())
-	return nil
+	act := &notify.CacheActions{
+		NeedProcess:    NeededProcess(tetragonProcess),
+		NeedProcessPod: NeededPod(tetragonProcess),
+		NeedParent:     pid > 1 && NeededProcess(tetragonParent),
+		NeedParentPod:  pid > 1 && NeededPod(tetragonParent),
+	}
+
+	if !act.NeedProcess {
+		pFn(proc)
+	}
+
+	if !act.NeedParent {
+		pFn(parent)
+	}
+
+	if ec := Get(); ec != nil && ec.Needed(act) {
+		ec.addWithRetryFn(e, pid, ktime, timestamp, msg, act,
+			func(ev notify.Event, ca *notify.CacheActions, pid uint32, ktime uint64) error {
+				return GenericRetry(ev, ca, pid, ktime, pFn)
+			})
+		return nil
+	}
+
+	return &tetragon.GetEventsResponse{
+		Event:    e.Encapsulate(),
+		NodeName: nodeName,
+		Time:     kt.ToProto(timestamp),
+	}
+}
+
+func GenericRetry(ev notify.Event, ca *notify.CacheActions, pid uint32, ktime uint64, pFn procFn) error {
+	proc, parent := process.GetParentProcessInternal(pid, ktime)
+	var err error
+
+	if ca.NeedProcess {
+		if proc == nil {
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
+			err = ErrFailedToGetProcessInfo
+		} else {
+			pFn(proc)
+			ev.SetProcess(proc.GetProcessCopy())
+			ca.NeedProcess = false
+		}
+	}
+
+	if !ca.NeedProcess && ca.NeedProcessPod {
+		if proc != nil { // we report errors for that in the previous if no need to do that again
+			if option.Config.EnableK8s {
+				if p := proc.UnsafeGetProcess(); p.Docker != "" {
+					if p.Pod == nil {
+						errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
+						err = ErrFailedToGetPodInfo
+					} else {
+						ev.SetProcess(proc.GetProcessCopy())
+						ca.NeedProcessPod = false
+					}
+				}
+			}
+		}
+	}
+
+	if ca.NeedParent {
+		if parent == nil {
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheParentInfoFailed)
+			err = ErrFailedToGetParentInfo
+		} else {
+			pFn(parent)
+			ev.SetParent(parent.GetProcessCopy())
+			ca.NeedParent = false
+		}
+	}
+
+	if !ca.NeedParent && ca.NeedParentPod {
+		if parent != nil { // we report errors for that in the previous if no need to do that again
+			if option.Config.EnableK8s {
+				if p := parent.UnsafeGetProcess(); p.Docker != "" {
+					if p.Pod == nil {
+						errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
+						err = ErrFailedToGetPodInfo
+					} else {
+						ev.SetParent(parent.GetProcessCopy())
+						ca.NeedParentPod = false
+					}
+				}
+			}
+		}
+	}
+
+	return err
 }
 
 func (ec *Cache) handleEvents() {
 	tmp := ec.cache[:0]
 	for _, event := range ec.cache {
-		var err error
 
-		// If the process wasn't found before the Add(), likely because
-		// the execve event was processed after this event, lets look it up
-		// now because it should be available. Otherwise we have a valid
-		// process and lets copy it across.
-		if event.internal == nil {
-			event.internal, err = event.msg.RetryInternal(event.event, event.timestamp)
+		retryFn := event.retry                          // by default we use GenericRetry
+		if c, ok := event.msg.(notify.CacheRetry); ok { // if underlying message implements notify.CacheRetry use that instead
+			retryFn = c.Retry
 		}
-		if err == nil {
-			err = event.msg.Retry(event.internal, event.event)
-		}
-		if err != nil {
+
+		if err := retryFn(event.event, event.actions, event.pid, event.ktime); err != nil {
 			event.color++
 			if event.color < CacheStrikes {
 				tmp = append(tmp, event)
@@ -124,10 +225,26 @@ func (ec *Cache) handleEvents() {
 		}
 
 		if event.msg.Notify() {
+			// Check if we didn't manage to get the process info and add some basic info.
+			// We care for that only when we need to notify.
+			if event.event.GetProcess() == nil {
+				event.event.SetProcess(&tetragon.Process{
+					Pid:       &wrapperspb.UInt32Value{Value: event.pid},
+					StartTime: kt.ToProto(event.ktime),
+				})
+			}
+
 			processedEvent := &tetragon.GetEventsResponse{
 				Event:    event.event.Encapsulate(),
 				NodeName: nodeName,
-				Time:     ktime.ToProto(event.timestamp),
+				Time:     kt.ToProto(event.timestamp),
+			}
+
+			// Do we need to do any further actions after calling
+			// NotifyListener? The user can specify a custom action
+			// by implementing notify.PostProcessing interface.
+			if p, ok := event.msg.(notify.PostProcessing); ok {
+				p.PostProcessing(processedEvent)
 			}
 
 			ec.server.NotifyListeners(event.msg, processedEvent)
@@ -163,26 +280,17 @@ func (ec *Cache) loop() {
 // We handle two race conditions here one where the event races with
 // a Tetragon execve event and the other -- much more common -- where we
 // race with K8s watcher
+func (ec *Cache) Needed(ca *notify.CacheActions) bool {
+	return ca.NeedProcess || ca.NeedProcessPod || ca.NeedParent || ca.NeedParentPod
+}
+
 // case 1 (execve race):
-//
-//	Its possible to receive this Tetragon event before the process event cache
-//	has been populated with a Tetragon execve event. In this case we need to
-//	cache the event until the process cache is populated.
-//
-// case 2 (k8s watcher race):
-//
-//	Its possible to receive an event before the k8s watcher receives the
-//	podInfo event and populates the local cache. If we expect podInfo,
-//	indicated by having a nonZero dockerID we cache the event until the
-//	podInfo arrives.
-func (ec *Cache) Needed(proc *tetragon.Process) bool {
+//  It is possible to receive this Tetragon event before the process event cache
+//  has been populated with a Tetragon execve event. In this case we need to
+//  cache the event until the process cache is populated.
+func NeededProcess(proc *tetragon.Process) bool {
 	if proc == nil {
 		return true
-	}
-	if option.Config.EnableK8s {
-		if proc.Docker != "" && proc.Pod == nil {
-			return true
-		}
 	}
 	if proc.Binary == "" {
 		return true
@@ -190,11 +298,46 @@ func (ec *Cache) Needed(proc *tetragon.Process) bool {
 	return false
 }
 
-func (ec *Cache) Add(internal *process.ProcessInternal,
-	e notify.Event,
-	t uint64,
-	msg notify.Message) {
-	ec.objsChan <- CacheObj{internal: internal, event: e, timestamp: t, msg: msg}
+// case 2 (k8s watcher race):
+//  It is possible to receive an event before the k8s watcher receives the
+//  podInfo event and populates the local cache. If we expect podInfo,
+//  indicated by having a nonZero dockerID we cache the event until the
+//  podInfo arrives.
+func NeededPod(proc *tetragon.Process) bool {
+	if option.Config.EnableK8s {
+		if proc == nil {
+			return true
+		}
+		if proc.Docker != "" && proc.Pod == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (ec *Cache) addWithRetryFn(e notify.Event, pid uint32, ktime uint64, timestamp uint64, msg notify.Message, ca *notify.CacheActions, retry retryFn) {
+	co := CacheObj{
+		event:     e,
+		ktime:     ktime,
+		pid:       pid,
+		timestamp: timestamp,
+		msg:       msg,
+		actions:   ca,
+		retry:     retry,
+	}
+	// if we miss process we also don't have docker ID to check
+	// for this reason we force NeedProcessPod here
+	if option.Config.EnableK8s && ca.NeedProcess {
+		ca.NeedProcessPod = true
+	}
+	if option.Config.EnableK8s && ca.NeedParent {
+		ca.NeedParentPod = true
+	}
+	ec.objsChan <- co
+}
+
+func (ec *Cache) Add(e notify.Event, pid uint32, ktime uint64, timestamp uint64, msg notify.Message, ca *notify.CacheActions) {
+	ec.addWithRetryFn(e, pid, ktime, timestamp, msg, ca, nil)
 }
 
 func NewWithTimer(s *server.Server, dur time.Duration) *Cache {

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/processapi"
-	tetragonAPI "github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/cgroups"
 	"github.com/cilium/tetragon/pkg/eventcache"
 	"github.com/cilium/tetragon/pkg/ktime"
@@ -20,16 +19,10 @@ import (
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/reader/notify"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var (
 	nodeName = node.GetNodeNameForExport()
-)
-
-const (
-	ParentRefCnt  = 0
-	ProcessRefCnt = 1
 )
 
 func (msg *MsgExecveEventUnix) getCleanupEvent() *MsgProcessCleanupEventUnix {
@@ -48,13 +41,13 @@ func GetProcessExec(event *MsgExecveEventUnix, useCache bool) *tetragon.ProcessE
 
 	proc := process.AddExecEvent(&event.MsgExecveEventUnix)
 	tetragonProcess := proc.UnsafeGetProcess()
-
 	parentId := tetragonProcess.ParentExecId
 	processId := tetragonProcess.ExecId
 
 	parent, err := process.Get(parentId)
 	if err == nil {
-		tetragonParent = parent.UnsafeGetProcess()
+		parent.RefInc()
+		tetragonParent = parent.GetProcessCopy()
 	}
 
 	// Set the cap field only if --enable-process-cred flag is set.
@@ -62,22 +55,23 @@ func GetProcessExec(event *MsgExecveEventUnix, useCache bool) *tetragon.ProcessE
 		logger.GetLogger().WithError(err).WithField("processId", processId).WithField("parentId", parentId).Debugf("Failed to annotate process with capabilities and namespaces info")
 	}
 
+	tetragonProcess = proc.GetProcessCopy()
 	tetragonEvent := &tetragon.ProcessExec{
 		Process: tetragonProcess,
 		Parent:  tetragonParent,
 	}
 
 	if useCache {
-		if ec := eventcache.Get(); ec != nil &&
-			(ec.Needed(tetragonEvent.Process) || (tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonEvent.Parent))) {
-			ec.Add(proc, tetragonEvent, event.Common.Ktime, event)
+		act := &notify.CacheActions{
+			NeedProcess:    false,
+			NeedProcessPod: eventcache.NeededPod(tetragonProcess),
+			NeedParent:     event.Process.PID > 1 && eventcache.NeededProcess(tetragonParent),
+			NeedParentPod:  event.Process.PID > 1 && eventcache.NeededPod(tetragonParent),
+		}
+		if ec := eventcache.Get(); ec != nil && ec.Needed(act) {
+			ec.Add(tetragonEvent, event.Process.PID, event.Process.Ktime, event.Common.Ktime, event, act)
 			return nil
 		}
-	}
-
-	if parent != nil {
-		parent.RefInc()
-		tetragonEvent.Parent = parent.GetProcessCopy()
 	}
 
 	// do we need to cleanup anything?
@@ -154,78 +148,90 @@ type MsgExecveEventUnix struct {
 	processapi.MsgExecveEventUnix
 }
 
+var _ notify.CacheRetry = (*MsgExecveEventUnix)(nil)
+
 func (msg *MsgExecveEventUnix) Notify() bool {
-	return true
-}
-
-func (msg *MsgExecveEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return nil, fmt.Errorf("Unreachable state: MsgExecveEventUnix with missing internal")
-}
-
-func (msg *MsgExecveEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	var podInfo *tetragon.Pod
-
-	proc := ev.GetProcess()
-	parent := ev.GetParent()
-
-	containerId := proc.Docker
-	filename := proc.Binary
-	args := proc.Arguments
-	nspid := msg.Process.NSPID
-
-	if option.Config.EnableK8s && containerId != "" {
-		podInfo, _ = process.GetPodInfo(containerId, filename, args, nspid)
-		if podInfo == nil {
-			errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
-			return eventcache.ErrFailedToGetPodInfo
-		}
-	}
-
-	// We can assume that event.internal != nil here since it's being set by AddExecEvent
-	// earlier in the code path. If this invariant ever changes in the future, we probably
-	// want to panic anyway to help us catch the bug faster. So no need to do a nil check
-	// here.
-	internal.AddPodInfo(podInfo)
-	ev.SetProcess(internal.GetProcessCopy())
-
-	// Check we have a parent with exception for pid 1, note we do this last because we want
-	// to ensure the podInfo and process are set before returning any errors.
-	if proc.Pid.Value > 1 && parent == nil {
-		parentId := proc.ParentExecId
-		parent, err := process.Get(parentId)
-		if parent == nil {
-			return err
-		}
-		parent.RefInc()
-		ev.SetParent(parent.GetProcessCopy())
-	}
-
-	// do we need to cleanup anything?
+	// should be done only once
 	if cleanupEvent := msg.getCleanupEvent(); cleanupEvent != nil {
 		// Retry() is going to be executed in the cache loop handling function, but
 		// HandleMessage may enqueue something in the cache channel. To avoid a deadlock,
 		// execute the cleanup message handling in a separate goroutine.
 		go cleanupEvent.HandleMessage()
 	}
+	return true
+}
 
-	return nil
+// Exec events will always have a process entry in the cache. In this case we
+// should check (and add) podInfo if needed. The generic Retry waits for this
+// event to set the correct pod info.
+func (msg *MsgExecveEventUnix) Retry(ev notify.Event, ca *notify.CacheActions, pid uint32, timestamp uint64) error {
+	internal, parent := process.GetParentProcessInternal(pid, timestamp)
+	var err error
+
+	if ca.NeedProcess {
+		return fmt.Errorf("event MsgExecveEventUnix cannot miss process info")
+	}
+
+	if !ca.NeedProcess && ca.NeedProcessPod {
+		if internal != nil {
+			proc := internal.UnsafeGetProcess()
+			if option.Config.EnableK8s && proc.Docker != "" {
+				if podInfo, _ := process.GetPodInfo(proc.Docker, proc.Binary, proc.Arguments, msg.Process.NSPID); podInfo == nil {
+					errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
+					err = eventcache.ErrFailedToGetPodInfo
+				} else {
+					internal.AddPodInfo(podInfo)
+					ev.SetProcess(internal.GetProcessCopy())
+					ca.NeedProcessPod = false
+				}
+			} else {
+				ca.NeedProcessPod = false
+			}
+		} else {
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
+			err = eventcache.ErrFailedToGetProcessInfo
+		}
+	}
+
+	if ca.NeedParent {
+		if parent == nil {
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheParentInfoFailed)
+			err = eventcache.ErrFailedToGetParentInfo
+		} else {
+			parent.RefInc()
+			ev.SetParent(parent.GetProcessCopy())
+			ca.NeedParent = false
+		}
+	}
+
+	if !ca.NeedParent && ca.NeedParentPod {
+		if parent != nil { // we report errors for that in the previous if no need to do that again
+			if option.Config.EnableK8s {
+				if p := parent.UnsafeGetProcess(); p.Docker != "" {
+					if p.Pod == nil {
+						errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
+						err = eventcache.ErrFailedToGetPodInfo
+					} else {
+						ev.SetParent(parent.GetProcessCopy())
+						ca.NeedParentPod = false
+					}
+				}
+			}
+		}
+	}
+
+	return err
 }
 
 func (msg *MsgExecveEventUnix) HandleMessage() *tetragon.GetEventsResponse {
-	var res *tetragon.GetEventsResponse
-	switch msg.Common.Op {
-	case ops.MSG_OP_EXECVE:
-		if e := GetProcessExec(msg, true); e != nil {
-			res = &tetragon.GetEventsResponse{
-				Event:    &tetragon.GetEventsResponse_ProcessExec{ProcessExec: e},
-				NodeName: nodeName,
-				Time:     ktime.ToProto(msg.Common.Ktime),
-			}
+	if e := GetProcessExec(msg, true); e != nil {
+		return &tetragon.GetEventsResponse{
+			Event:    &tetragon.GetEventsResponse_ProcessExec{ProcessExec: e},
+			NodeName: nodeName,
+			Time:     ktime.ToProto(msg.Common.Ktime),
 		}
-	default:
-		logger.GetLogger().WithField("message", msg).Warn("HandleExecveMessage: Unhandled event")
 	}
-	return res
+	return nil
 }
 
 func (msg *MsgExecveEventUnix) Cast(o interface{}) notify.Message {
@@ -237,29 +243,66 @@ type MsgCloneEventUnix struct {
 	processapi.MsgCloneEvent
 }
 
+var _ notify.CacheRetry = (*MsgCloneEventUnix)(nil)
+
 func (msg *MsgCloneEventUnix) Notify() bool {
 	return false
 }
 
-func (msg *MsgCloneEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return nil, process.AddCloneEvent(&msg.MsgCloneEvent)
-}
+// Clone event does not result in a user event. This is a special case as we
+// don't need to find a process. We only need the parent and the process is
+// actually a copy of the parent (with small updates). This is also differs
+// from the generic Retry as it also sets pod info in a similar way to exec
+// events.
+func (msg *MsgCloneEventUnix) Retry(ev notify.Event, ca *notify.CacheActions, pid uint32, timestamp uint64) error {
+	var err error
 
-func (msg *MsgCloneEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return nil
+	if ca.NeedProcess {
+		if internal, _ := process.AddCloneEvent(&msg.MsgCloneEvent); internal == nil {
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
+			err = eventcache.ErrFailedToGetProcessInfo
+		} else {
+			ca.NeedProcess = false
+		}
+	}
+
+	if !ca.NeedProcess && ca.NeedProcessPod {
+		if internal, _ := process.GetParentProcessInternal(pid, timestamp); internal != nil {
+			proc := internal.UnsafeGetProcess()
+			if option.Config.EnableK8s && proc.Docker != "" {
+				if podInfo, _ := process.GetPodInfo(proc.Docker, proc.Binary, proc.Arguments, msg.NSPID); podInfo == nil {
+					errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
+					err = eventcache.ErrFailedToGetPodInfo
+				} else {
+					internal.AddPodInfo(podInfo)
+					ca.NeedProcessPod = false
+				}
+			} else {
+				ca.NeedProcessPod = false
+			}
+		} else {
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
+			err = eventcache.ErrFailedToGetProcessInfo
+		}
+	}
+
+	return err
 }
 
 func (msg *MsgCloneEventUnix) HandleMessage() *tetragon.GetEventsResponse {
-	switch msg.Common.Op {
-	case ops.MSG_OP_CLONE:
-		if err := process.AddCloneEvent(&msg.MsgCloneEvent); err != nil {
-			ec := eventcache.Get()
-			if ec != nil {
-				ec.Add(nil, nil, msg.MsgCloneEvent.Ktime, msg)
-			}
+	internal, err := process.AddCloneEvent(&msg.MsgCloneEvent)
+	if internal == nil || err != nil {
+		act := &notify.CacheActions{
+			NeedProcess:    internal == nil,
+			NeedProcessPod: internal != nil && eventcache.NeededPod(internal.UnsafeGetProcess()),
+			NeedParent:     false,
+			NeedParentPod:  false,
 		}
-	default:
-		logger.GetLogger().WithField("message", msg).Warn("HandleCloneMessage: Unhandled event")
+
+		if ec := eventcache.Get(); ec != nil && ec.Needed(act) {
+			ec.Add(nil, msg.PID, msg.Ktime, 0, msg, act)
+			return nil
+		}
 	}
 	return nil
 }
@@ -269,171 +312,87 @@ func (msg *MsgCloneEventUnix) Cast(o interface{}) notify.Message {
 	return &MsgCloneEventUnix{MsgCloneEvent: t}
 }
 
-// GetProcessExit returns Exit protobuf message for a given process.
-func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
-	var tetragonProcess, tetragonParent *tetragon.Process
-
-	process, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
-	if process != nil {
-		tetragonProcess = process.UnsafeGetProcess()
-	} else {
-		tetragonProcess = &tetragon.Process{
-			Pid:       &wrapperspb.UInt32Value{Value: event.ProcessKey.Pid},
-			StartTime: ktime.ToProto(event.ProcessKey.Ktime),
-		}
-	}
-	if parent != nil {
-		tetragonParent = parent.UnsafeGetProcess()
-	}
-
-	code := event.Info.Code >> 8
-	signal := readerexec.Signal(event.Info.Code & 0xFF)
-
-	tetragonEvent := &tetragon.ProcessExit{
-		Process: tetragonProcess,
-		Parent:  tetragonParent,
-		Signal:  signal,
-		Status:  code,
-		Time:    ktime.ToProto(event.Common.Ktime),
-	}
-	ec := eventcache.Get()
-	if ec != nil &&
-		(ec.Needed(tetragonProcess) ||
-			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
-		ec.Add(nil, tetragonEvent, event.ProcessKey.Ktime, event)
-		return nil
-	}
-	if parent != nil {
-		parent.RefDec()
-		tetragonEvent.Parent = parent.GetProcessCopy()
-	}
-	if process != nil {
-		process.RefDec()
-		tetragonEvent.Process = process.GetProcessCopy()
-	}
-	return tetragonEvent
-}
-
 type MsgExitEventUnix struct {
-	tetragonAPI.MsgExitEvent
-	RefCntDone [2]bool
+	processapi.MsgExitEvent
 }
 
 func (msg *MsgExitEventUnix) Notify() bool {
 	return true
 }
 
-func (msg *MsgExitEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	internal, parent := process.GetParentProcessInternal(msg.ProcessKey.Pid, timestamp)
-	var err error
-
-	if parent != nil {
-		if !msg.RefCntDone[ParentRefCnt] {
-			parent.RefDec()
-			msg.RefCntDone[ParentRefCnt] = true
-		}
-		ev.SetParent(parent.GetProcessCopy())
-	} else {
-		errormetrics.ErrorTotalInc(errormetrics.EventCacheParentInfoFailed)
-		err = eventcache.ErrFailedToGetParentInfo
-	}
-
-	if internal != nil {
-		if !msg.RefCntDone[ProcessRefCnt] {
-			internal.RefDec()
-			msg.RefCntDone[ProcessRefCnt] = true
-		}
-		ev.SetProcess(internal.GetProcessCopy())
-	} else {
-		errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
-		err = eventcache.ErrFailedToGetProcessInfo
-	}
-
-	if err == nil {
-		return internal, err
-	}
-	return nil, err
-}
-
-func (msg *MsgExitEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev)
-}
-
 func (msg *MsgExitEventUnix) HandleMessage() *tetragon.GetEventsResponse {
-	var res *tetragon.GetEventsResponse
+	code := msg.Info.Code >> 8
+	signal := readerexec.Signal(msg.Info.Code & 0xFF)
 
-	switch msg.Common.Op {
-	case ops.MSG_OP_EXIT:
-		msg.RefCntDone = [2]bool{false, false}
-		e := GetProcessExit(msg)
-		if e != nil {
-			res = &tetragon.GetEventsResponse{
-				Event:    &tetragon.GetEventsResponse_ProcessExit{ProcessExit: e},
-				NodeName: nodeName,
-				Time:     ktime.ToProto(msg.Common.Ktime),
-			}
-		}
-	default:
-		logger.GetLogger().WithField("message", msg).Warn("HandleExitMessage: Unhandled event")
+	tetragonEvent := &tetragon.ProcessExit{
+		Signal: signal,
+		Status: code,
 	}
-	return res
+
+	return eventcache.AddProcessParentRefDec(tetragonEvent, msg, msg.ProcessKey.Pid, msg.ProcessKey.Ktime, msg.Common.Ktime)
 }
 
 func (msg *MsgExitEventUnix) Cast(o interface{}) notify.Message {
-	t := o.(tetragonAPI.MsgExitEvent)
+	t := o.(processapi.MsgExitEvent)
 	return &MsgExitEventUnix{MsgExitEvent: t}
 }
 
 type MsgProcessCleanupEventUnix struct {
-	PID        uint32
-	Ktime      uint64
-	RefCntDone [2]bool
+	PID   uint32
+	Ktime uint64
 }
+
+var _ notify.CacheRetry = (*MsgProcessCleanupEventUnix)(nil)
 
 func (msg *MsgProcessCleanupEventUnix) Notify() bool {
 	return false
 }
 
-func (msg *MsgProcessCleanupEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	internal, parent := process.GetParentProcessInternal(msg.PID, timestamp)
+// Cleanup events does not result in a user event. In this case we need a
+// custom Retry function as we only need to decrease the refcnt in both the
+// process and parent.
+func (msg *MsgProcessCleanupEventUnix) Retry(ev notify.Event, ca *notify.CacheActions, pid uint32, timestamp uint64) error {
+	proc, parent := process.GetParentProcessInternal(pid, timestamp)
 	var err error
 
-	if parent != nil {
-		if !msg.RefCntDone[ParentRefCnt] {
+	if ca.NeedProcess {
+		if proc == nil {
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
+			err = eventcache.ErrFailedToGetProcessInfo
+		} else {
+			proc.RefDec()
+			ca.NeedProcess = false
+		}
+	}
+
+	if ca.NeedParent {
+		if parent == nil {
+			errormetrics.ErrorTotalInc(errormetrics.EventCacheParentInfoFailed)
+			err = eventcache.ErrFailedToGetParentInfo
+		} else {
 			parent.RefDec()
-			msg.RefCntDone[ParentRefCnt] = true
+			ca.NeedParent = false
 		}
-	} else {
-		err = eventcache.ErrFailedToGetParentInfo
 	}
 
-	if internal != nil {
-		if !msg.RefCntDone[ProcessRefCnt] {
-			internal.RefDec()
-			msg.RefCntDone[ProcessRefCnt] = true
-		}
-	} else {
-		err = eventcache.ErrFailedToGetProcessInfo
-	}
-
-	if err == nil {
-		return internal, err
-	}
-	return nil, err
-}
-
-func (msg *MsgProcessCleanupEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return nil
+	return err
 }
 
 func (msg *MsgProcessCleanupEventUnix) HandleMessage() *tetragon.GetEventsResponse {
-	msg.RefCntDone = [2]bool{false, false}
-	if process, parent := process.GetParentProcessInternal(msg.PID, msg.Ktime); process != nil && parent != nil {
-		parent.RefDec()
+	process, parent := process.GetParentProcessInternal(msg.PID, msg.Ktime)
+	if process != nil && parent != nil {
 		process.RefDec()
+		parent.RefDec()
 	} else {
-		if ec := eventcache.Get(); ec != nil {
-			ec.Add(nil, nil, msg.Ktime, msg)
+		act := &notify.CacheActions{
+			NeedProcess:    true,
+			NeedProcessPod: false,
+			NeedParent:     true,
+			NeedParentPod:  false,
+		}
+		if ec := eventcache.Get(); ec != nil && ec.Needed(act) {
+			ec.Add(nil, msg.PID, msg.Ktime, 0, msg, act)
+			return nil
 		}
 	}
 	return nil

--- a/pkg/grpc/test/test.go
+++ b/pkg/grpc/test/test.go
@@ -4,12 +4,8 @@ package test
 
 import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/testapi"
-	"github.com/cilium/tetragon/pkg/eventcache"
 	"github.com/cilium/tetragon/pkg/ktime"
-	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/reader/notify"
 )
@@ -26,32 +22,17 @@ func (msg *MsgTestEventUnix) Notify() bool {
 	return true
 }
 
-func (msg *MsgTestEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, 0, timestamp)
-}
-
-func (msg *MsgTestEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev)
-}
-
 func (msg *MsgTestEventUnix) HandleMessage() *tetragon.GetEventsResponse {
-	var res *tetragon.GetEventsResponse
-	switch msg.Common.Op {
-	case ops.MSG_OP_TEST:
-		res = &tetragon.GetEventsResponse{
-			Event: &tetragon.GetEventsResponse_Test{Test: &tetragon.Test{
-				Arg0: msg.Arg0,
-				Arg1: msg.Arg1,
-				Arg2: msg.Arg2,
-				Arg3: msg.Arg3,
-			}},
-			NodeName: nodeName,
-			Time:     ktime.ToProto(msg.Common.Ktime),
-		}
-	default:
-		logger.GetLogger().WithField("message", msg).Warn("HandleTestMessage: Unhandled event")
+	return &tetragon.GetEventsResponse{
+		Event: &tetragon.GetEventsResponse_Test{Test: &tetragon.Test{
+			Arg0: msg.Arg0,
+			Arg1: msg.Arg1,
+			Arg2: msg.Arg2,
+			Arg3: msg.Arg3,
+		}},
+		NodeName: nodeName,
+		Time:     ktime.ToProto(msg.Common.Ktime),
 	}
-	return res
 }
 
 func (msg *MsgTestEventUnix) Cast(o interface{}) notify.Message {

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -6,212 +6,15 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
-	api "github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/eventcache"
-	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/option"
-	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/bpf"
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	"github.com/cilium/tetragon/pkg/reader/network"
-	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/reader/notify"
 	"github.com/cilium/tetragon/pkg/reader/path"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
-
-var (
-	nodeName = node.GetNodeNameForExport()
-)
-
-func kprobeAction(act uint64) tetragon.KprobeAction {
-	switch act {
-	case tracingapi.ActionPost:
-		return tetragon.KprobeAction_KPROBE_ACTION_POST
-	case tracingapi.ActionFollowFd:
-		return tetragon.KprobeAction_KPROBE_ACTION_FOLLOWFD
-	case tracingapi.ActionSigKill:
-		return tetragon.KprobeAction_KPROBE_ACTION_SIGKILL
-	case tracingapi.ActionUnfollowFd:
-		return tetragon.KprobeAction_KPROBE_ACTION_UNFOLLOWFD
-	case tracingapi.ActionOverride:
-		return tetragon.KprobeAction_KPROBE_ACTION_OVERRIDE
-	case tracingapi.ActionCopyFd:
-		return tetragon.KprobeAction_KPROBE_ACTION_COPYFD
-	default:
-		return tetragon.KprobeAction_KPROBE_ACTION_UNKNOWN
-	}
-}
-
-func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
-	var tetragonParent, tetragonProcess *tetragon.Process
-	var tetragonArgs []*tetragon.KprobeArgument
-	var tetragonReturnArg *tetragon.KprobeArgument
-
-	process, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
-	if process == nil {
-		tetragonProcess = &tetragon.Process{
-			Pid:       &wrapperspb.UInt32Value{Value: event.ProcessKey.Pid},
-			StartTime: ktime.ToProto(event.ProcessKey.Ktime),
-		}
-	} else {
-		tetragonProcess = process.UnsafeGetProcess()
-		if err := process.AnnotateProcess(option.Config.EnableProcessCred, option.Config.EnableProcessNs); err != nil {
-			logger.GetLogger().WithError(err).WithField("processId", tetragonProcess.Pid).Debugf("Failed to annotate process with capabilities and namespaces info")
-		}
-	}
-	if parent != nil {
-		tetragonParent = parent.UnsafeGetProcess()
-	}
-
-	for _, arg := range event.Args {
-		a := &tetragon.KprobeArgument{}
-		switch e := arg.(type) {
-		case api.MsgGenericKprobeArgInt:
-			a.Arg = &tetragon.KprobeArgument_IntArg{IntArg: e.Value}
-		case api.MsgGenericKprobeArgUInt:
-			a.Arg = &tetragon.KprobeArgument_UintArg{UintArg: e.Value}
-		case api.MsgGenericKprobeArgSize:
-			a.Arg = &tetragon.KprobeArgument_SizeArg{SizeArg: e.Value}
-		case api.MsgGenericKprobeArgString:
-			a.Arg = &tetragon.KprobeArgument_StringArg{StringArg: e.Value}
-		case api.MsgGenericKprobeArgSock:
-			sockArg := &tetragon.KprobeSock{
-				Family:   network.InetFamily(e.Family),
-				Type:     network.InetType(e.Type),
-				Protocol: network.InetProtocol(e.Protocol),
-				Mark:     e.Mark,
-				Priority: e.Priority,
-				Saddr:    e.Saddr,
-				Daddr:    e.Daddr,
-				Sport:    e.Sport,
-				Dport:    e.Dport,
-			}
-			a.Arg = &tetragon.KprobeArgument_SockArg{SockArg: sockArg}
-		case api.MsgGenericKprobeArgSkb:
-			skbArg := &tetragon.KprobeSkb{
-				Hash:        e.Hash,
-				Len:         e.Len,
-				Priority:    e.Priority,
-				Mark:        e.Mark,
-				Saddr:       e.Saddr,
-				Daddr:       e.Daddr,
-				Sport:       e.Sport,
-				Dport:       e.Dport,
-				Proto:       e.Proto,
-				SecPathLen:  e.SecPathLen,
-				SecPathOlen: e.SecPathOLen,
-			}
-			a.Arg = &tetragon.KprobeArgument_SkbArg{SkbArg: skbArg}
-		case api.MsgGenericKprobeArgCred:
-			capsArg := &tetragon.KprobeCred{
-				Permitted:   caps.GetCapabilitiesTypes(e.Permitted),
-				Effective:   caps.GetCapabilitiesTypes(e.Effective),
-				Inheritable: caps.GetCapabilitiesTypes(e.Inheritable),
-			}
-			a.Arg = &tetragon.KprobeArgument_CredArg{CredArg: capsArg}
-		case api.MsgGenericKprobeArgBytes:
-			if e.OrigSize > uint64(len(e.Value)) {
-				a.Arg = &tetragon.KprobeArgument_TruncatedBytesArg{
-					TruncatedBytesArg: &tetragon.KprobeTruncatedBytes{
-						OrigSize: e.OrigSize,
-						BytesArg: e.Value,
-					},
-				}
-			} else {
-				a.Arg = &tetragon.KprobeArgument_BytesArg{BytesArg: e.Value}
-			}
-		case api.MsgGenericKprobeArgFile:
-			fileArg := &tetragon.KprobeFile{
-				Path:  e.Value,
-				Flags: path.FilePathFlagsToStr(e.Flags),
-			}
-			a.Arg = &tetragon.KprobeArgument_FileArg{FileArg: fileArg}
-		case api.MsgGenericKprobeArgPath:
-			pathArg := &tetragon.KprobePath{
-				Path:  e.Value,
-				Flags: path.FilePathFlagsToStr(e.Flags),
-			}
-			a.Arg = &tetragon.KprobeArgument_PathArg{PathArg: pathArg}
-		case api.MsgGenericKprobeArgBpfAttr:
-			bpfAttrArg := &tetragon.KprobeBpfAttr{
-				ProgType: bpf.GetProgType(e.ProgType),
-				InsnCnt:  e.InsnCnt,
-				ProgName: e.ProgName,
-			}
-			a.Arg = &tetragon.KprobeArgument_BpfAttrArg{BpfAttrArg: bpfAttrArg}
-		case api.MsgGenericKprobeArgPerfEvent:
-			perfEventArg := &tetragon.KprobePerfEvent{
-				KprobeFunc:  e.KprobeFunc,
-				Type:        bpf.GetPerfEventType(e.Type),
-				Config:      e.Config,
-				ProbeOffset: e.ProbeOffset,
-			}
-			a.Arg = &tetragon.KprobeArgument_PerfEventArg{PerfEventArg: perfEventArg}
-		case api.MsgGenericKprobeArgBpfMap:
-			bpfMapArg := &tetragon.KprobeBpfMap{
-				MapType:    bpf.GetBpfMapType(e.MapType),
-				KeySize:    e.KeySize,
-				ValueSize:  e.ValueSize,
-				MaxEntries: e.MaxEntries,
-				MapName:    e.MapName,
-			}
-			a.Arg = &tetragon.KprobeArgument_BpfMapArg{BpfMapArg: bpfMapArg}
-		case api.MsgGenericKprobeArgUserNamespace:
-			nsArg := &tetragon.KprobeUserNamespace{
-				Level: &wrapperspb.Int32Value{Value: e.Level},
-				Owner: &wrapperspb.UInt32Value{Value: e.Owner},
-				Group: &wrapperspb.UInt32Value{Value: e.Group},
-				Ns: &tetragon.Namespace{
-					Inum: e.NsInum,
-				},
-			}
-			if e.Level == 0 {
-				nsArg.Ns.IsHost = true
-			}
-			a.Arg = &tetragon.KprobeArgument_UserNamespaceArg{UserNamespaceArg: nsArg}
-		case api.MsgGenericKprobeArgCapability:
-			cArg := &tetragon.KprobeCapability{
-				Value: &wrapperspb.Int32Value{Value: e.Value},
-			}
-			cArg.Name, _ = caps.GetCapability(e.Value)
-			a.Arg = &tetragon.KprobeArgument_CapabilityArg{CapabilityArg: cArg}
-		default:
-			logger.GetLogger().WithField("arg", e).Warnf("unexpected type: %T", e)
-		}
-		if arg.IsReturnArg() {
-			tetragonReturnArg = a
-		} else {
-			tetragonArgs = append(tetragonArgs, a)
-		}
-	}
-
-	tetragonEvent := &tetragon.ProcessKprobe{
-		Process:      tetragonProcess,
-		Parent:       tetragonParent,
-		FunctionName: event.FuncName,
-		Args:         tetragonArgs,
-		Return:       tetragonReturnArg,
-		Action:       kprobeAction(event.Action),
-	}
-
-	if ec := eventcache.Get(); ec != nil &&
-		(ec.Needed(tetragonProcess) ||
-			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
-		ec.Add(nil, tetragonEvent, event.ProcessKey.Ktime, event)
-		return nil
-	}
-
-	if process != nil {
-		tetragonEvent.Process = process.GetProcessCopy()
-	}
-	if parent != nil {
-		tetragonEvent.Parent = parent.GetProcessCopy()
-	}
-
-	return tetragonEvent
-}
 
 type MsgGenericTracepointUnix struct {
 	Common     processapi.MsgCommon
@@ -226,30 +29,7 @@ func (msg *MsgGenericTracepointUnix) Notify() bool {
 	return true
 }
 
-func (msg *MsgGenericTracepointUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, timestamp)
-}
-
-func (msg *MsgGenericTracepointUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev)
-}
-
 func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse {
-	var tetragonParent, tetragonProcess *tetragon.Process
-
-	process, parent := process.GetParentProcessInternal(msg.ProcessKey.Pid, msg.ProcessKey.Ktime)
-	if process == nil {
-		tetragonProcess = &tetragon.Process{
-			Pid:       &wrapperspb.UInt32Value{Value: msg.ProcessKey.Pid},
-			StartTime: ktime.ToProto(msg.ProcessKey.Ktime),
-		}
-	} else {
-		tetragonProcess = process.UnsafeGetProcess()
-	}
-	if parent != nil {
-		tetragonParent = parent.UnsafeGetProcess()
-	}
-
 	var tetragonArgs []*tetragon.KprobeArgument
 	for _, arg := range msg.Args {
 		switch v := arg.(type) {
@@ -277,32 +57,12 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 	}
 
 	tetragonEvent := &tetragon.ProcessTracepoint{
-		Process: tetragonProcess,
-		Parent:  tetragonParent,
-		Subsys:  msg.Subsys,
-		Event:   msg.Event,
-		Args:    tetragonArgs,
+		Subsys: msg.Subsys,
+		Event:  msg.Event,
+		Args:   tetragonArgs,
 	}
 
-	if ec := eventcache.Get(); ec != nil &&
-		(ec.Needed(tetragonProcess) ||
-			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
-		ec.Add(nil, tetragonEvent, msg.ProcessKey.Ktime, msg)
-		return nil
-	}
-
-	if process != nil {
-		tetragonEvent.Process = process.GetProcessCopy()
-	}
-	if parent != nil {
-		tetragonEvent.Parent = parent.GetProcessCopy()
-	}
-
-	return &tetragon.GetEventsResponse{
-		Event:    &tetragon.GetEventsResponse_ProcessTracepoint{ProcessTracepoint: tetragonEvent},
-		NodeName: nodeName,
-		Time:     ktime.ToProto(msg.Common.Ktime),
-	}
+	return eventcache.AddProcessParent(tetragonEvent, msg, msg.ProcessKey.Pid, msg.ProcessKey.Ktime, msg.Common.Ktime)
 }
 
 func (msg *MsgGenericTracepointUnix) Cast(o interface{}) notify.Message {
@@ -325,24 +85,159 @@ func (msg *MsgGenericKprobeUnix) Notify() bool {
 	return true
 }
 
-func (msg *MsgGenericKprobeUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, timestamp)
-}
-
-func (msg *MsgGenericKprobeUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev)
+func kprobeAction(act uint64) tetragon.KprobeAction {
+	switch act {
+	case tracingapi.ActionPost:
+		return tetragon.KprobeAction_KPROBE_ACTION_POST
+	case tracingapi.ActionFollowFd:
+		return tetragon.KprobeAction_KPROBE_ACTION_FOLLOWFD
+	case tracingapi.ActionSigKill:
+		return tetragon.KprobeAction_KPROBE_ACTION_SIGKILL
+	case tracingapi.ActionUnfollowFd:
+		return tetragon.KprobeAction_KPROBE_ACTION_UNFOLLOWFD
+	case tracingapi.ActionOverride:
+		return tetragon.KprobeAction_KPROBE_ACTION_OVERRIDE
+	case tracingapi.ActionCopyFd:
+		return tetragon.KprobeAction_KPROBE_ACTION_COPYFD
+	default:
+		return tetragon.KprobeAction_KPROBE_ACTION_UNKNOWN
+	}
 }
 
 func (msg *MsgGenericKprobeUnix) HandleMessage() *tetragon.GetEventsResponse {
-	k := GetProcessKprobe(msg)
-	if k == nil {
-		return nil
+	var tetragonArgs []*tetragon.KprobeArgument
+	var tetragonReturnArg *tetragon.KprobeArgument
+
+	for _, arg := range msg.Args {
+		a := &tetragon.KprobeArgument{}
+		switch e := arg.(type) {
+		case tracingapi.MsgGenericKprobeArgInt:
+			a.Arg = &tetragon.KprobeArgument_IntArg{IntArg: e.Value}
+		case tracingapi.MsgGenericKprobeArgUInt:
+			a.Arg = &tetragon.KprobeArgument_UintArg{UintArg: e.Value}
+		case tracingapi.MsgGenericKprobeArgSize:
+			a.Arg = &tetragon.KprobeArgument_SizeArg{SizeArg: e.Value}
+		case tracingapi.MsgGenericKprobeArgString:
+			a.Arg = &tetragon.KprobeArgument_StringArg{StringArg: e.Value}
+		case tracingapi.MsgGenericKprobeArgSock:
+			sockArg := &tetragon.KprobeSock{
+				Family:   network.InetFamily(e.Family),
+				Type:     network.InetType(e.Type),
+				Protocol: network.InetProtocol(e.Protocol),
+				Mark:     e.Mark,
+				Priority: e.Priority,
+				Saddr:    e.Saddr,
+				Daddr:    e.Daddr,
+				Sport:    e.Sport,
+				Dport:    e.Dport,
+			}
+			a.Arg = &tetragon.KprobeArgument_SockArg{SockArg: sockArg}
+		case tracingapi.MsgGenericKprobeArgSkb:
+			skbArg := &tetragon.KprobeSkb{
+				Hash:        e.Hash,
+				Len:         e.Len,
+				Priority:    e.Priority,
+				Mark:        e.Mark,
+				Saddr:       e.Saddr,
+				Daddr:       e.Daddr,
+				Sport:       e.Sport,
+				Dport:       e.Dport,
+				Proto:       e.Proto,
+				SecPathLen:  e.SecPathLen,
+				SecPathOlen: e.SecPathOLen,
+			}
+			a.Arg = &tetragon.KprobeArgument_SkbArg{SkbArg: skbArg}
+		case tracingapi.MsgGenericKprobeArgCred:
+			capsArg := &tetragon.KprobeCred{
+				Permitted:   caps.GetCapabilitiesTypes(e.Permitted),
+				Effective:   caps.GetCapabilitiesTypes(e.Effective),
+				Inheritable: caps.GetCapabilitiesTypes(e.Inheritable),
+			}
+			a.Arg = &tetragon.KprobeArgument_CredArg{CredArg: capsArg}
+		case tracingapi.MsgGenericKprobeArgBytes:
+			if e.OrigSize > uint64(len(e.Value)) {
+				a.Arg = &tetragon.KprobeArgument_TruncatedBytesArg{
+					TruncatedBytesArg: &tetragon.KprobeTruncatedBytes{
+						OrigSize: e.OrigSize,
+						BytesArg: e.Value,
+					},
+				}
+			} else {
+				a.Arg = &tetragon.KprobeArgument_BytesArg{BytesArg: e.Value}
+			}
+		case tracingapi.MsgGenericKprobeArgFile:
+			fileArg := &tetragon.KprobeFile{
+				Path:  e.Value,
+				Flags: path.FilePathFlagsToStr(e.Flags),
+			}
+			a.Arg = &tetragon.KprobeArgument_FileArg{FileArg: fileArg}
+		case tracingapi.MsgGenericKprobeArgPath:
+			pathArg := &tetragon.KprobePath{
+				Path:  e.Value,
+				Flags: path.FilePathFlagsToStr(e.Flags),
+			}
+			a.Arg = &tetragon.KprobeArgument_PathArg{PathArg: pathArg}
+		case tracingapi.MsgGenericKprobeArgBpfAttr:
+			bpfAttrArg := &tetragon.KprobeBpfAttr{
+				ProgType: bpf.GetProgType(e.ProgType),
+				InsnCnt:  e.InsnCnt,
+				ProgName: e.ProgName,
+			}
+			a.Arg = &tetragon.KprobeArgument_BpfAttrArg{BpfAttrArg: bpfAttrArg}
+		case tracingapi.MsgGenericKprobeArgPerfEvent:
+			perfEventArg := &tetragon.KprobePerfEvent{
+				KprobeFunc:  e.KprobeFunc,
+				Type:        bpf.GetPerfEventType(e.Type),
+				Config:      e.Config,
+				ProbeOffset: e.ProbeOffset,
+			}
+			a.Arg = &tetragon.KprobeArgument_PerfEventArg{PerfEventArg: perfEventArg}
+		case tracingapi.MsgGenericKprobeArgBpfMap:
+			bpfMapArg := &tetragon.KprobeBpfMap{
+				MapType:    bpf.GetBpfMapType(e.MapType),
+				KeySize:    e.KeySize,
+				ValueSize:  e.ValueSize,
+				MaxEntries: e.MaxEntries,
+				MapName:    e.MapName,
+			}
+			a.Arg = &tetragon.KprobeArgument_BpfMapArg{BpfMapArg: bpfMapArg}
+		case tracingapi.MsgGenericKprobeArgUserNamespace:
+			nsArg := &tetragon.KprobeUserNamespace{
+				Level: &wrapperspb.Int32Value{Value: e.Level},
+				Owner: &wrapperspb.UInt32Value{Value: e.Owner},
+				Group: &wrapperspb.UInt32Value{Value: e.Group},
+				Ns: &tetragon.Namespace{
+					Inum: e.NsInum,
+				},
+			}
+			if e.Level == 0 {
+				nsArg.Ns.IsHost = true
+			}
+			a.Arg = &tetragon.KprobeArgument_UserNamespaceArg{UserNamespaceArg: nsArg}
+		case tracingapi.MsgGenericKprobeArgCapability:
+			cArg := &tetragon.KprobeCapability{
+				Value: &wrapperspb.Int32Value{Value: e.Value},
+			}
+			cArg.Name, _ = caps.GetCapability(e.Value)
+			a.Arg = &tetragon.KprobeArgument_CapabilityArg{CapabilityArg: cArg}
+		default:
+			logger.GetLogger().WithField("arg", e).Warnf("unexpected type: %T", e)
+		}
+		if arg.IsReturnArg() {
+			tetragonReturnArg = a
+		} else {
+			tetragonArgs = append(tetragonArgs, a)
+		}
 	}
-	return &tetragon.GetEventsResponse{
-		Event:    &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: k},
-		NodeName: nodeName,
-		Time:     ktime.ToProto(msg.Common.Ktime),
+
+	tetragonEvent := &tetragon.ProcessKprobe{
+		FunctionName: msg.FuncName,
+		Args:         tetragonArgs,
+		Return:       tetragonReturnArg,
+		Action:       kprobeAction(msg.Action),
 	}
+
+	return eventcache.AddProcessParent(tetragonEvent, msg, msg.ProcessKey.Pid, msg.ProcessKey.Ktime, msg.Common.Ktime)
 }
 
 func (msg *MsgGenericKprobeUnix) Cast(o interface{}) notify.Message {

--- a/pkg/reader/notify/notify.go
+++ b/pkg/reader/notify/notify.go
@@ -5,15 +5,30 @@ import (
 	"strings"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/pkg/process"
 )
 
+type CacheActions struct {
+	NeedProcess    bool
+	NeedProcessPod bool
+	NeedParent     bool
+	NeedParentPod  bool
+}
+
+// Message is what messages need to implement.
+// Moreover, messages may opt to implement the CacheRetry and PostProcessing interfaces (see below).
 type Message interface {
 	HandleMessage() *tetragon.GetEventsResponse
-	RetryInternal(Event, uint64) (*process.ProcessInternal, error)
-	Retry(*process.ProcessInternal, Event) error
 	Notify() bool
 	Cast(o interface{}) Message
+}
+
+// CacheRetry may (optionaly) be implemented by messages that requiring custom cache retry functionality.
+type CacheRetry interface {
+	Retry(Event, *CacheActions, uint32, uint64) error
+}
+
+type PostProcessing interface {
+	PostProcessing(*tetragon.GetEventsResponse)
 }
 
 type Event interface {


### PR DESCRIPTION
This PR does a cleanup on the way the events interact with the EventCache. It also defines new functions AddProcessParent and AddProcessParentRef{Inc, Dec} that allow events to annotate events with process and parent information and also add them in the eventcache in the case where we miss something.

It also provides ways to use a custom way to interact with the EventCache for special cases like exec and clone events.

The intention of this PR is not to change the functionality but to cleanup the codebase.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>