### PR TITLE
tetragon: Add --rb-size/--rb-size-total options to setup perf ring buffer size

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -58,6 +58,9 @@ const (
 	keyNetnsDir = "netns-dir"
 
 	keyDisableKprobeMulti = "disable-kprobe-multi"
+
+	keyRBSize      = "rb-size"
+	keyRBSizeTotal = "rb-size-total"
 )
 
 var (
@@ -98,6 +101,9 @@ func readAndSetFlags() {
 	option.Config.EnableK8s = viper.GetBool(keyEnableK8sAPI)
 
 	option.Config.DisableKprobeMulti = viper.GetBool(keyDisableKprobeMulti)
+
+	option.Config.RBSize = viper.GetInt(keyRBSize)
+	option.Config.RBSizeTotal = viper.GetInt(keyRBSizeTotal)
 
 	option.Config.GopsAddr = viper.GetString(keyGopsAddr)
 

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -127,6 +127,10 @@ func tetragonExecute() error {
 		log.Fatal(err)
 	}
 
+	if option.Config.RBSize != 0 && option.Config.RBSizeTotal != 0 {
+		log.Fatalf("Can't specify --rb-size and --rb-size-total together")
+	}
+
 	// enable extra programs/maps loading debug output
 	if logger.DefaultLogger.IsLevelEnabled(logrus.DebugLevel) {
 		program.KeepCollection = true
@@ -456,6 +460,10 @@ func execute() error {
 
 	// Allow to disable kprobe multi interface
 	flags.Bool(keyDisableKprobeMulti, false, "Allow to disable kprobe multi interface")
+
+	// Allow to specify perf ring buffer size
+	flags.Int(keyRBSizeTotal, 0, "Set perf ring buffer size in total for all cpus (default 65k per cpu)")
+	flags.Int(keyRBSize, 0, "Set perf ring buffer size for single cpu (default 65k)")
 
 	viper.BindPFlags(flags)
 	return rootCmd.Execute()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -35,6 +35,9 @@ type config struct {
 	BpfDir    string
 
 	LogOpts map[string]string
+
+	RBSize      int
+	RBSizeTotal int
 }
 
 var (


### PR DESCRIPTION
Adding new options to configure the size of perf ring buffer, which is used to get events from ebpf programs to user space.

Adding two new options:
`  --rb-size <BYTES>` specifies number of bytes to allocate for perf ring buffer for each cpu


`  --rb-size-total <BYTES>` specifies number of bytes to allocate for perf ring buffer in summary for all cpus

Adding new log message that displays how much memory is actually allocated for ring buffer:

for default case:
`  time="2022-10-17T15:53:04+02:00" level=info msg="Perf ring buffer size (bytes)" percpu=69632 total=278528`

for '--rb-size 128000' (on 4 cpu server):
`  time="2022-10-17T15:53:39+02:00" level=info msg="Perf ring buffer size (bytes)" percpu=135168 total=540672`

for  '--rb-size-total 128000' (on 4 cpus server):
`  time="2022-10-17T15:54:43+02:00" level=info msg="Perf ring buffer size (bytes)" percpu=36864 total=147456`

Note that the final size might be different than what's specified, because the final perf ring buffer needs to have power of two number of pages (+1 extra), so the final number will be rounded to it.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>