### PR TITLE
chore: sample memfd_create rule

### DIFF
--- a/crds/examples/fd_memfd_kill.yaml
+++ b/crds/examples/fd_memfd_kill.yaml
@@ -1,0 +1,34 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "demo-memfd"
+spec:
+  kprobes:
+  - call: "fd_install"
+    syscall: false
+    args:
+    - index: 0
+      type: int
+    - index: 1
+      type: "file"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Prefix"
+        values:
+        - "/proc/self/fd/"
+      matchActions:
+      - action: FollowFD
+        argFd: 0
+        argName: 1
+  # int memfd_create(const char *name, unsigned int flags);
+  - call: "__x64_sys_memfd_create"
+    syscall: true
+    args:
+    - index: 0
+      type: "string"
+    - index: 1
+      type: "int"
+    # selectors:
+    # - matchActions:
+    #   - action: Sigkill

--- a/crds/examples/fd_memfd_kill.yaml
+++ b/crds/examples/fd_memfd_kill.yaml
@@ -4,23 +4,24 @@ metadata:
   name: "demo-memfd"
 spec:
   kprobes:
-  - call: "fd_install"
-    syscall: false
+# int close(int fd);
+  - call: "__x64_sys_close"
+    syscall: true
     args:
     - index: 0
-      type: int
-    - index: 1
-      type: "file"
+      type: "int"
     selectors:
-    - matchArgs:
-      - index: 1
-        operator: "Prefix"
+    - matchPIDs:
+      - operator: NotIn
+        followForks: true
+        isNamespacePID: true
         values:
-        - "/proc/self/fd/"
+        - 0
+        - 1
       matchActions:
-      - action: FollowFD
+      - action: UnfollowFD
         argFd: 0
-        argName: 1
+        argName: 0
   # int memfd_create(const char *name, unsigned int flags);
   - call: "__x64_sys_memfd_create"
     syscall: true
@@ -29,6 +30,32 @@ spec:
       type: "string"
     - index: 1
       type: "int"
-    # selectors:
-    # - matchActions:
-    #   - action: Sigkill
+    selectors:
+    - matchPIDs:
+      - operator: NotIn
+        followForks: true
+        isNamespacePID: true
+        values:
+        - 0
+        - 1
+# int execve(const char *pathname, char *const argv[],char *const envp[]);
+  - call: "__x64_sys_execve"
+    syscall: true
+    args:
+    - index: 0
+      type: "string"
+    selectors:
+    - matchPIDs:
+      - operator: NotIn
+        followForks: false
+        isNamespacePID: true
+        values:
+        - 0
+        - 1
+      matchArgs:
+      - index: 0
+        operator: "Prefix"
+        values:
+        - "/proc/self/fd/"
+      matchActions:
+      - action: Sigkill


### PR DESCRIPTION
Hi! I would like to validate about how detect memfd_call and use the file descriptor to execute.

More notes about the output of this policy and the image test, [here](https://hackmd.io/@krol/HJ3UiFSmi) 