### PR TITLE
release: Add a job to create a release draft

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -37,11 +37,11 @@ assignees: ''
       - https://quay.io/repository/cilium/tetragon?tab=tags
       - https://quay.io/repository/cilium/tetragon-operator?tab=tags
 
-- [ ] After creating the tag, [create the release] using the GitHub UI
-      - Click the link above to draft a new release
-      - Select the tag you created in the previous step
-      - Click on "Generate Release Notes" on the right-hand side
-      - Click on "Publish Release" at the bottom
+- [ ] When a tag is pushed, a GitHub Action job takes care of creating a new GitHub
+      draft release, building artifacts and attaching them to the draft release. Once
+      the draft is available in the [releases page]:
+  - [ ] Use the "Auto-generate release notes" button to generate the release notes.
+  - [ ] Review the release notes and click on "Publish Release" at the bottom.
 
 - [ ] Publish Helm chart
       - Follow [cilium/charts RELEASE.md] to publish the Helm chart.
@@ -52,5 +52,5 @@ assignees: ''
 [Image CI Releases workflow]: https://github.com/cilium/tetragon/actions/workflows/build-images-releases.yml
 [cilium/charts RELEASE.md]: https://github.com/cilium/charts/blob/master/RELEASE.md
 [cilium/charts GKE workflow]: https://github.com/cilium/charts/actions/workflows/conformance-tetragon-gke.yaml
-[create the release]: https://github.com/cilium/tetragon/releases/new
+[releases page]: https://github.com/cilium/tetragon/releases
 [a Tetragon maintainer]: https://github.com/orgs/cilium/teams/tetragon-maintainers/members

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*
+      - test*
 
 jobs:
   build-and-push:
@@ -43,7 +44,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          push: true
+          push: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
           platforms: linux/amd64
           tags: |
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
@@ -92,3 +93,41 @@ jobs:
         run: |
           cd image-digest/
           find -type f | sort | xargs -d '\n' cat
+
+  draft-github-release:
+    name: Create Release
+    if: github.repository == 'cilium/tetragon'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+
+      - name: Set up Go
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: 1.19.1
+
+      - name: Generate tetra CLI artifacts
+        run: make cli-release
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+          body: |
+            Note for maintainers:: Please update the description with the actual release notes (see RELEASE.md for instructions).
+
+      - name: Upload the artifacts
+        id: upload-release-artifacts
+        uses: skx/github-action-publish-binaries@b9ca5643b2f1d7371a6cba7f35333f1461bbc703
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          releaseId: ${{ steps.create_release.outputs.id }}
+          args: 'release/*'


### PR DESCRIPTION
- Create a GitHub release draft as a part of the Image CI Releases workflow.
- Trigger the workflow when a tag with "test" prefix is pushed. It runs the Image CI Releases workflow for testing without actually pushing release images for testing.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>