### PR TITLE
Remove pidMap

### DIFF
--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -34,12 +34,6 @@ var (
 	EventCacheProcessInfoFailed ErrorType = "event_cache_process_info_failed"
 	// Event cache failed to set parent information for an event.
 	EventCacheParentInfoFailed ErrorType = "event_cache_parent_info_failed"
-	// There was an invalid entry in the pid map.
-	PidMapInvalidEntry ErrorType = "pid_map_invalid_entry"
-	// An entry was evicted from the pid map because the map was full.
-	PidMapEvicted ErrorType = "pid_map_evicted"
-	// PID not found in the pid map on remove() call.
-	PidMapMissOnRemove ErrorType = "pid_map_miss_on_remove"
 	// An exec event without parent info.
 	ExecMissingParent ErrorType = "exec_missing_parent"
 	// An event is missing process info.

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -169,7 +169,7 @@ func (pc *Cache) get(processID string) (*ProcessInternal, error) {
 		errormetrics.ErrorTotalInc(errormetrics.ProcessCacheMissOnGet)
 		return nil, fmt.Errorf("invalid entry for process ID: %s", processID)
 	}
-	process, _ := entry.(*ProcessInternal)
+	process, ok := entry.(*ProcessInternal)
 	if !ok {
 		logger.GetLogger().WithField("process entry", entry).Debug("invalid entry in process cache")
 		errormetrics.ErrorTotalInc(errormetrics.ProcessCacheMissOnGet)

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -32,19 +32,15 @@ func TestProcessCache(t *testing.T) {
 	}
 	cache.Add(&proc)
 	assert.Equal(t, cache.len(), 1)
-	cache.AddToPidMap(pid.Value, execID)
 
 	result, err := cache.get(proc.process.ExecId)
 	assert.NoError(t, err)
 	assert.Equal(t, proc.process.ExecId, result.process.ExecId)
 	assert.Equal(t, proc.capabilities, result.capabilities)
-	assert.Equal(t, cache.getFromPidMap(pid.Value), execID)
 
 	// remove the entry from cache.
 	assert.True(t, cache.remove(proc.process))
 	assert.Equal(t, cache.len(), 0)
-	assert.Equal(t, cache.pidMap.Len(), 0)
 	_, err = cache.get(proc.process.ExecId)
 	assert.Error(t, err)
-	assert.Equal(t, cache.getFromPidMap(pid.Value), "")
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/tetragon/pkg/cilium"
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	"github.com/cilium/tetragon/pkg/reader/exec"
 	"github.com/cilium/tetragon/pkg/reader/namespace"
@@ -264,6 +265,11 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 		pi.process.Refcnt = 1
 		if pi.process.Pod != nil && pi.process.Pod.Container != nil {
 			pi.process.Pod.Container.Pid = &wrapperspb.UInt32Value{Value: event.NSPID}
+		}
+		if option.Config.EnableK8s && pi.process.Docker != "" && pi.process.Pod == nil {
+			if podInfo, _ := GetPodInfo(pi.process.Docker, pi.process.Binary, pi.process.Arguments, event.NSPID); podInfo != nil {
+				pi.AddPodInfo(podInfo)
+			}
 		}
 		procCache.Add(pi)
 	}


### PR DESCRIPTION
pidMap holds mappings from PID to the most recent exec ID for the PID. This is used to find the parent of exec events that come after another exec event (i.e. not a clone). This can be racy as events can come OOO to the user space.

This information is also available in the execve_map inside the kernel where all events happen in-order.

https://github.com/cilium/tetragon/commit/45745a0a93c65811495f82deb9314a1c849e1403 introduced a new field in msg_execve_event (cleanup_key) that keeps the parent of the execve event. In that case this was needed for cleanup.

We can use the same information for the parent and remove entirely the pidMap. If there is a case where we cannot find the entry in the execve_map, we use as a parent the view of Linux (i.e. the process that clones the current process and not the previous execve).

This PR also contains small fixes to other components in the execve path.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>