### PR TITLE
tetragon: detect execve of anonymous binaries

### DIFF
--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -14,10 +14,12 @@
     - [Container](#tetragon-Container)
     - [CreateContainer](#tetragon-CreateContainer)
     - [CreateContainer.AnnotationsEntry](#tetragon-CreateContainer-AnnotationsEntry)
+    - [FileProperties](#tetragon-FileProperties)
     - [GetHealthStatusRequest](#tetragon-GetHealthStatusRequest)
     - [GetHealthStatusResponse](#tetragon-GetHealthStatusResponse)
     - [HealthStatus](#tetragon-HealthStatus)
     - [Image](#tetragon-Image)
+    - [Inode](#tetragon-Inode)
     - [KernelModule](#tetragon-KernelModule)
     - [KprobeArgument](#tetragon-KprobeArgument)
     - [KprobeBpfAttr](#tetragon-KprobeBpfAttr)
@@ -222,6 +224,7 @@ Reasons of why the process privileges changed.
 | setuid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | If set then this is the set user ID used for execution |
 | setgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | If set then this is the set group ID used for execution |
 | privileges_changed | [ProcessPrivilegesChanged](#tetragon-ProcessPrivilegesChanged) | repeated | The reasons why this binary execution changed privileges. Usually this happens when the process executes a binary with the set-user-ID to root or file capability sets. The final granted privileges can be listed inside the `process_credentials` or capabilities fields part of of the `process` object. |
+| file | [FileProperties](#tetragon-FileProperties) |  | File properties in case the executed binary is: 1. An anonymous shared memory file https://man7.org/linux/man-pages/man7/shm_overview.7.html. 2. An anonymous file obtained with memfd API https://man7.org/linux/man-pages/man2/memfd_create.2.html. 3. Or it was deleted from the file system. |
 
 
 
@@ -301,6 +304,22 @@ https://github.com/opencontainers/runtime-spec/blob/main/config.md#createcontain
 
 
 
+<a name="tetragon-FileProperties"></a>
+
+### FileProperties
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| inode | [Inode](#tetragon-Inode) |  | Inode of the file |
+| path | [string](#string) |  | Path of the file |
+
+
+
+
+
+
 <a name="tetragon-GetHealthStatusRequest"></a>
 
 ### GetHealthStatusRequest
@@ -358,6 +377,22 @@ https://github.com/opencontainers/runtime-spec/blob/main/config.md#createcontain
 | ----- | ---- | ----- | ----------- |
 | id | [string](#string) |  | Identifier of the container image composed of the registry path and the sha256. |
 | name | [string](#string) |  | Name of the container image composed of the registry path and the tag. |
+
+
+
+
+
+
+<a name="tetragon-Inode"></a>
+
+### Inode
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| number | [uint64](#uint64) |  | The inode number |
+| links | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The inode links on the file system. If zero means the file is only in memory |
 
 
 

--- a/api/v1/tetragon/tetragon.pb.go
+++ b/api/v1/tetragon/tetragon.pb.go
@@ -1018,6 +1018,120 @@ func (x *ProcessCredentials) GetUserNs() *UserNamespace {
 	return nil
 }
 
+type Inode struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// The inode number
+	Number uint64 `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"`
+	// The inode links on the file system. If zero means the file is only in memory
+	Links *wrapperspb.UInt32Value `protobuf:"bytes,2,opt,name=links,proto3" json:"links,omitempty"`
+}
+
+func (x *Inode) Reset() {
+	*x = Inode{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tetragon_tetragon_proto_msgTypes[8]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Inode) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Inode) ProtoMessage() {}
+
+func (x *Inode) ProtoReflect() protoreflect.Message {
+	mi := &file_tetragon_tetragon_proto_msgTypes[8]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Inode.ProtoReflect.Descriptor instead.
+func (*Inode) Descriptor() ([]byte, []int) {
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *Inode) GetNumber() uint64 {
+	if x != nil {
+		return x.Number
+	}
+	return 0
+}
+
+func (x *Inode) GetLinks() *wrapperspb.UInt32Value {
+	if x != nil {
+		return x.Links
+	}
+	return nil
+}
+
+type FileProperties struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Inode of the file
+	Inode *Inode `protobuf:"bytes,1,opt,name=inode,proto3" json:"inode,omitempty"`
+	// Path of the file
+	Path string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+}
+
+func (x *FileProperties) Reset() {
+	*x = FileProperties{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tetragon_tetragon_proto_msgTypes[9]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *FileProperties) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FileProperties) ProtoMessage() {}
+
+func (x *FileProperties) ProtoReflect() protoreflect.Message {
+	mi := &file_tetragon_tetragon_proto_msgTypes[9]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FileProperties.ProtoReflect.Descriptor instead.
+func (*FileProperties) Descriptor() ([]byte, []int) {
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *FileProperties) GetInode() *Inode {
+	if x != nil {
+		return x.Inode
+	}
+	return nil
+}
+
+func (x *FileProperties) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
 type BinaryProperties struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1031,12 +1145,17 @@ type BinaryProperties struct {
 	// a binary with the set-user-ID to root or file capability sets.
 	// The final granted privileges can be listed inside the `process_credentials` or capabilities fields part of of the `process` object.
 	PrivilegesChanged []ProcessPrivilegesChanged `protobuf:"varint,3,rep,packed,name=privileges_changed,json=privilegesChanged,proto3,enum=tetragon.ProcessPrivilegesChanged" json:"privileges_changed,omitempty"`
+	// File properties in case the executed binary is:
+	// 1. An anonymous shared memory file https://man7.org/linux/man-pages/man7/shm_overview.7.html.
+	// 2. An anonymous file obtained with memfd API https://man7.org/linux/man-pages/man2/memfd_create.2.html.
+	// 3. Or it was deleted from the file system.
+	File *FileProperties `protobuf:"bytes,4,opt,name=file,proto3" json:"file,omitempty"`
 }
 
 func (x *BinaryProperties) Reset() {
 	*x = BinaryProperties{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[8]
+		mi := &file_tetragon_tetragon_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1049,7 +1168,7 @@ func (x *BinaryProperties) String() string {
 func (*BinaryProperties) ProtoMessage() {}
 
 func (x *BinaryProperties) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[8]
+	mi := &file_tetragon_tetragon_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1062,7 +1181,7 @@ func (x *BinaryProperties) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BinaryProperties.ProtoReflect.Descriptor instead.
 func (*BinaryProperties) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{8}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *BinaryProperties) GetSetuid() *wrapperspb.UInt32Value {
@@ -1082,6 +1201,13 @@ func (x *BinaryProperties) GetSetgid() *wrapperspb.UInt32Value {
 func (x *BinaryProperties) GetPrivilegesChanged() []ProcessPrivilegesChanged {
 	if x != nil {
 		return x.PrivilegesChanged
+	}
+	return nil
+}
+
+func (x *BinaryProperties) GetFile() *FileProperties {
+	if x != nil {
+		return x.File
 	}
 	return nil
 }
@@ -1188,7 +1314,7 @@ type Process struct {
 func (x *Process) Reset() {
 	*x = Process{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[9]
+		mi := &file_tetragon_tetragon_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1201,7 +1327,7 @@ func (x *Process) String() string {
 func (*Process) ProtoMessage() {}
 
 func (x *Process) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[9]
+	mi := &file_tetragon_tetragon_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1214,7 +1340,7 @@ func (x *Process) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Process.ProtoReflect.Descriptor instead.
 func (*Process) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{9}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Process) GetExecId() string {
@@ -1359,7 +1485,7 @@ type ProcessExec struct {
 func (x *ProcessExec) Reset() {
 	*x = ProcessExec{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[10]
+		mi := &file_tetragon_tetragon_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1372,7 +1498,7 @@ func (x *ProcessExec) String() string {
 func (*ProcessExec) ProtoMessage() {}
 
 func (x *ProcessExec) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[10]
+	mi := &file_tetragon_tetragon_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1385,7 +1511,7 @@ func (x *ProcessExec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessExec.ProtoReflect.Descriptor instead.
 func (*ProcessExec) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{10}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ProcessExec) GetProcess() *Process {
@@ -1433,7 +1559,7 @@ type ProcessExit struct {
 func (x *ProcessExit) Reset() {
 	*x = ProcessExit{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[11]
+		mi := &file_tetragon_tetragon_proto_msgTypes[13]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1446,7 +1572,7 @@ func (x *ProcessExit) String() string {
 func (*ProcessExit) ProtoMessage() {}
 
 func (x *ProcessExit) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[11]
+	mi := &file_tetragon_tetragon_proto_msgTypes[13]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1459,7 +1585,7 @@ func (x *ProcessExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessExit.ProtoReflect.Descriptor instead.
 func (*ProcessExit) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{11}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ProcessExit) GetProcess() *Process {
@@ -1518,7 +1644,7 @@ type KprobeSock struct {
 func (x *KprobeSock) Reset() {
 	*x = KprobeSock{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[12]
+		mi := &file_tetragon_tetragon_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1531,7 +1657,7 @@ func (x *KprobeSock) String() string {
 func (*KprobeSock) ProtoMessage() {}
 
 func (x *KprobeSock) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[12]
+	mi := &file_tetragon_tetragon_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1544,7 +1670,7 @@ func (x *KprobeSock) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeSock.ProtoReflect.Descriptor instead.
 func (*KprobeSock) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{12}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *KprobeSock) GetFamily() string {
@@ -1647,7 +1773,7 @@ type KprobeSkb struct {
 func (x *KprobeSkb) Reset() {
 	*x = KprobeSkb{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[13]
+		mi := &file_tetragon_tetragon_proto_msgTypes[15]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1660,7 +1786,7 @@ func (x *KprobeSkb) String() string {
 func (*KprobeSkb) ProtoMessage() {}
 
 func (x *KprobeSkb) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[13]
+	mi := &file_tetragon_tetragon_proto_msgTypes[15]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1673,7 +1799,7 @@ func (x *KprobeSkb) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeSkb.ProtoReflect.Descriptor instead.
 func (*KprobeSkb) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{13}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *KprobeSkb) GetHash() uint32 {
@@ -1780,7 +1906,7 @@ type KprobePath struct {
 func (x *KprobePath) Reset() {
 	*x = KprobePath{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[14]
+		mi := &file_tetragon_tetragon_proto_msgTypes[16]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1793,7 +1919,7 @@ func (x *KprobePath) String() string {
 func (*KprobePath) ProtoMessage() {}
 
 func (x *KprobePath) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[14]
+	mi := &file_tetragon_tetragon_proto_msgTypes[16]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1806,7 +1932,7 @@ func (x *KprobePath) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobePath.ProtoReflect.Descriptor instead.
 func (*KprobePath) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{14}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *KprobePath) GetMount() string {
@@ -1843,7 +1969,7 @@ type KprobeFile struct {
 func (x *KprobeFile) Reset() {
 	*x = KprobeFile{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[15]
+		mi := &file_tetragon_tetragon_proto_msgTypes[17]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1856,7 +1982,7 @@ func (x *KprobeFile) String() string {
 func (*KprobeFile) ProtoMessage() {}
 
 func (x *KprobeFile) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[15]
+	mi := &file_tetragon_tetragon_proto_msgTypes[17]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1869,7 +1995,7 @@ func (x *KprobeFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeFile.ProtoReflect.Descriptor instead.
 func (*KprobeFile) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{15}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *KprobeFile) GetMount() string {
@@ -1905,7 +2031,7 @@ type KprobeTruncatedBytes struct {
 func (x *KprobeTruncatedBytes) Reset() {
 	*x = KprobeTruncatedBytes{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[16]
+		mi := &file_tetragon_tetragon_proto_msgTypes[18]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1918,7 +2044,7 @@ func (x *KprobeTruncatedBytes) String() string {
 func (*KprobeTruncatedBytes) ProtoMessage() {}
 
 func (x *KprobeTruncatedBytes) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[16]
+	mi := &file_tetragon_tetragon_proto_msgTypes[18]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1931,7 +2057,7 @@ func (x *KprobeTruncatedBytes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeTruncatedBytes.ProtoReflect.Descriptor instead.
 func (*KprobeTruncatedBytes) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{16}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *KprobeTruncatedBytes) GetBytesArg() []byte {
@@ -1961,7 +2087,7 @@ type KprobeCred struct {
 func (x *KprobeCred) Reset() {
 	*x = KprobeCred{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[17]
+		mi := &file_tetragon_tetragon_proto_msgTypes[19]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1974,7 +2100,7 @@ func (x *KprobeCred) String() string {
 func (*KprobeCred) ProtoMessage() {}
 
 func (x *KprobeCred) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[17]
+	mi := &file_tetragon_tetragon_proto_msgTypes[19]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1987,7 +2113,7 @@ func (x *KprobeCred) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeCred.ProtoReflect.Descriptor instead.
 func (*KprobeCred) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{17}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *KprobeCred) GetPermitted() []CapabilitiesType {
@@ -2023,7 +2149,7 @@ type KprobeCapability struct {
 func (x *KprobeCapability) Reset() {
 	*x = KprobeCapability{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[18]
+		mi := &file_tetragon_tetragon_proto_msgTypes[20]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2036,7 +2162,7 @@ func (x *KprobeCapability) String() string {
 func (*KprobeCapability) ProtoMessage() {}
 
 func (x *KprobeCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[18]
+	mi := &file_tetragon_tetragon_proto_msgTypes[20]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2049,7 +2175,7 @@ func (x *KprobeCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeCapability.ProtoReflect.Descriptor instead.
 func (*KprobeCapability) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{18}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *KprobeCapability) GetValue() *wrapperspb.Int32Value {
@@ -2080,7 +2206,7 @@ type KprobeUserNamespace struct {
 func (x *KprobeUserNamespace) Reset() {
 	*x = KprobeUserNamespace{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[19]
+		mi := &file_tetragon_tetragon_proto_msgTypes[21]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2093,7 +2219,7 @@ func (x *KprobeUserNamespace) String() string {
 func (*KprobeUserNamespace) ProtoMessage() {}
 
 func (x *KprobeUserNamespace) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[19]
+	mi := &file_tetragon_tetragon_proto_msgTypes[21]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2106,7 +2232,7 @@ func (x *KprobeUserNamespace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeUserNamespace.ProtoReflect.Descriptor instead.
 func (*KprobeUserNamespace) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{19}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *KprobeUserNamespace) GetLevel() *wrapperspb.Int32Value {
@@ -2150,7 +2276,7 @@ type KprobeBpfAttr struct {
 func (x *KprobeBpfAttr) Reset() {
 	*x = KprobeBpfAttr{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[20]
+		mi := &file_tetragon_tetragon_proto_msgTypes[22]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2163,7 +2289,7 @@ func (x *KprobeBpfAttr) String() string {
 func (*KprobeBpfAttr) ProtoMessage() {}
 
 func (x *KprobeBpfAttr) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[20]
+	mi := &file_tetragon_tetragon_proto_msgTypes[22]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2176,7 +2302,7 @@ func (x *KprobeBpfAttr) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeBpfAttr.ProtoReflect.Descriptor instead.
 func (*KprobeBpfAttr) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{20}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *KprobeBpfAttr) GetProgType() string {
@@ -2214,7 +2340,7 @@ type KprobePerfEvent struct {
 func (x *KprobePerfEvent) Reset() {
 	*x = KprobePerfEvent{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[21]
+		mi := &file_tetragon_tetragon_proto_msgTypes[23]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2227,7 +2353,7 @@ func (x *KprobePerfEvent) String() string {
 func (*KprobePerfEvent) ProtoMessage() {}
 
 func (x *KprobePerfEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[21]
+	mi := &file_tetragon_tetragon_proto_msgTypes[23]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2240,7 +2366,7 @@ func (x *KprobePerfEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobePerfEvent.ProtoReflect.Descriptor instead.
 func (*KprobePerfEvent) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{21}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *KprobePerfEvent) GetKprobeFunc() string {
@@ -2286,7 +2412,7 @@ type KprobeBpfMap struct {
 func (x *KprobeBpfMap) Reset() {
 	*x = KprobeBpfMap{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[22]
+		mi := &file_tetragon_tetragon_proto_msgTypes[24]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2299,7 +2425,7 @@ func (x *KprobeBpfMap) String() string {
 func (*KprobeBpfMap) ProtoMessage() {}
 
 func (x *KprobeBpfMap) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[22]
+	mi := &file_tetragon_tetragon_proto_msgTypes[24]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2312,7 +2438,7 @@ func (x *KprobeBpfMap) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeBpfMap.ProtoReflect.Descriptor instead.
 func (*KprobeBpfMap) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{22}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *KprobeBpfMap) GetMapType() string {
@@ -2384,7 +2510,7 @@ type KprobeArgument struct {
 func (x *KprobeArgument) Reset() {
 	*x = KprobeArgument{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[23]
+		mi := &file_tetragon_tetragon_proto_msgTypes[25]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2397,7 +2523,7 @@ func (x *KprobeArgument) String() string {
 func (*KprobeArgument) ProtoMessage() {}
 
 func (x *KprobeArgument) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[23]
+	mi := &file_tetragon_tetragon_proto_msgTypes[25]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2410,7 +2536,7 @@ func (x *KprobeArgument) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeArgument.ProtoReflect.Descriptor instead.
 func (*KprobeArgument) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{23}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{25}
 }
 
 func (m *KprobeArgument) GetArg() isKprobeArgument_Arg {
@@ -2723,7 +2849,7 @@ type ProcessKprobe struct {
 func (x *ProcessKprobe) Reset() {
 	*x = ProcessKprobe{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[24]
+		mi := &file_tetragon_tetragon_proto_msgTypes[26]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2736,7 +2862,7 @@ func (x *ProcessKprobe) String() string {
 func (*ProcessKprobe) ProtoMessage() {}
 
 func (x *ProcessKprobe) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[24]
+	mi := &file_tetragon_tetragon_proto_msgTypes[26]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2749,7 +2875,7 @@ func (x *ProcessKprobe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessKprobe.ProtoReflect.Descriptor instead.
 func (*ProcessKprobe) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{24}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ProcessKprobe) GetProcess() *Process {
@@ -2849,7 +2975,7 @@ type ProcessTracepoint struct {
 func (x *ProcessTracepoint) Reset() {
 	*x = ProcessTracepoint{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[25]
+		mi := &file_tetragon_tetragon_proto_msgTypes[27]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2862,7 +2988,7 @@ func (x *ProcessTracepoint) String() string {
 func (*ProcessTracepoint) ProtoMessage() {}
 
 func (x *ProcessTracepoint) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[25]
+	mi := &file_tetragon_tetragon_proto_msgTypes[27]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2875,7 +3001,7 @@ func (x *ProcessTracepoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessTracepoint.ProtoReflect.Descriptor instead.
 func (*ProcessTracepoint) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{25}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ProcessTracepoint) GetProcess() *Process {
@@ -2954,7 +3080,7 @@ type ProcessUprobe struct {
 func (x *ProcessUprobe) Reset() {
 	*x = ProcessUprobe{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[26]
+		mi := &file_tetragon_tetragon_proto_msgTypes[28]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2967,7 +3093,7 @@ func (x *ProcessUprobe) String() string {
 func (*ProcessUprobe) ProtoMessage() {}
 
 func (x *ProcessUprobe) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[26]
+	mi := &file_tetragon_tetragon_proto_msgTypes[28]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2980,7 +3106,7 @@ func (x *ProcessUprobe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessUprobe.ProtoReflect.Descriptor instead.
 func (*ProcessUprobe) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{26}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ProcessUprobe) GetProcess() *Process {
@@ -3049,7 +3175,7 @@ type KernelModule struct {
 func (x *KernelModule) Reset() {
 	*x = KernelModule{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[27]
+		mi := &file_tetragon_tetragon_proto_msgTypes[29]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3062,7 +3188,7 @@ func (x *KernelModule) String() string {
 func (*KernelModule) ProtoMessage() {}
 
 func (x *KernelModule) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[27]
+	mi := &file_tetragon_tetragon_proto_msgTypes[29]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3075,7 +3201,7 @@ func (x *KernelModule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KernelModule.ProtoReflect.Descriptor instead.
 func (*KernelModule) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{27}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *KernelModule) GetName() string {
@@ -3113,7 +3239,7 @@ type Test struct {
 func (x *Test) Reset() {
 	*x = Test{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[28]
+		mi := &file_tetragon_tetragon_proto_msgTypes[30]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3126,7 +3252,7 @@ func (x *Test) String() string {
 func (*Test) ProtoMessage() {}
 
 func (x *Test) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[28]
+	mi := &file_tetragon_tetragon_proto_msgTypes[30]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3139,7 +3265,7 @@ func (x *Test) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Test.ProtoReflect.Descriptor instead.
 func (*Test) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{28}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *Test) GetArg0() uint64 {
@@ -3181,7 +3307,7 @@ type GetHealthStatusRequest struct {
 func (x *GetHealthStatusRequest) Reset() {
 	*x = GetHealthStatusRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[29]
+		mi := &file_tetragon_tetragon_proto_msgTypes[31]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3194,7 +3320,7 @@ func (x *GetHealthStatusRequest) String() string {
 func (*GetHealthStatusRequest) ProtoMessage() {}
 
 func (x *GetHealthStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[29]
+	mi := &file_tetragon_tetragon_proto_msgTypes[31]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3207,7 +3333,7 @@ func (x *GetHealthStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHealthStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetHealthStatusRequest) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{29}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetHealthStatusRequest) GetEventSet() []HealthStatusType {
@@ -3230,7 +3356,7 @@ type HealthStatus struct {
 func (x *HealthStatus) Reset() {
 	*x = HealthStatus{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[30]
+		mi := &file_tetragon_tetragon_proto_msgTypes[32]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3243,7 +3369,7 @@ func (x *HealthStatus) String() string {
 func (*HealthStatus) ProtoMessage() {}
 
 func (x *HealthStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[30]
+	mi := &file_tetragon_tetragon_proto_msgTypes[32]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3256,7 +3382,7 @@ func (x *HealthStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthStatus.ProtoReflect.Descriptor instead.
 func (*HealthStatus) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{30}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *HealthStatus) GetEvent() HealthStatusType {
@@ -3291,7 +3417,7 @@ type GetHealthStatusResponse struct {
 func (x *GetHealthStatusResponse) Reset() {
 	*x = GetHealthStatusResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[31]
+		mi := &file_tetragon_tetragon_proto_msgTypes[33]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3304,7 +3430,7 @@ func (x *GetHealthStatusResponse) String() string {
 func (*GetHealthStatusResponse) ProtoMessage() {}
 
 func (x *GetHealthStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[31]
+	mi := &file_tetragon_tetragon_proto_msgTypes[33]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3317,7 +3443,7 @@ func (x *GetHealthStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHealthStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetHealthStatusResponse) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{31}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetHealthStatusResponse) GetHealthStatus() []*HealthStatus {
@@ -3341,7 +3467,7 @@ type ProcessLoader struct {
 func (x *ProcessLoader) Reset() {
 	*x = ProcessLoader{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[32]
+		mi := &file_tetragon_tetragon_proto_msgTypes[34]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3354,7 +3480,7 @@ func (x *ProcessLoader) String() string {
 func (*ProcessLoader) ProtoMessage() {}
 
 func (x *ProcessLoader) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[32]
+	mi := &file_tetragon_tetragon_proto_msgTypes[34]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3367,7 +3493,7 @@ func (x *ProcessLoader) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessLoader.ProtoReflect.Descriptor instead.
 func (*ProcessLoader) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{32}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ProcessLoader) GetProcess() *Process {
@@ -3406,7 +3532,7 @@ type RuntimeHookRequest struct {
 func (x *RuntimeHookRequest) Reset() {
 	*x = RuntimeHookRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[33]
+		mi := &file_tetragon_tetragon_proto_msgTypes[35]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3419,7 +3545,7 @@ func (x *RuntimeHookRequest) String() string {
 func (*RuntimeHookRequest) ProtoMessage() {}
 
 func (x *RuntimeHookRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[33]
+	mi := &file_tetragon_tetragon_proto_msgTypes[35]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3432,7 +3558,7 @@ func (x *RuntimeHookRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeHookRequest.ProtoReflect.Descriptor instead.
 func (*RuntimeHookRequest) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{33}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{35}
 }
 
 func (m *RuntimeHookRequest) GetEvent() isRuntimeHookRequest_Event {
@@ -3468,7 +3594,7 @@ type RuntimeHookResponse struct {
 func (x *RuntimeHookResponse) Reset() {
 	*x = RuntimeHookResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[34]
+		mi := &file_tetragon_tetragon_proto_msgTypes[36]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3481,7 +3607,7 @@ func (x *RuntimeHookResponse) String() string {
 func (*RuntimeHookResponse) ProtoMessage() {}
 
 func (x *RuntimeHookResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[34]
+	mi := &file_tetragon_tetragon_proto_msgTypes[36]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3494,7 +3620,7 @@ func (x *RuntimeHookResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeHookResponse.ProtoReflect.Descriptor instead.
 func (*RuntimeHookResponse) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{34}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{36}
 }
 
 // CreateContainer informs the agent that a container was created
@@ -3520,7 +3646,7 @@ type CreateContainer struct {
 func (x *CreateContainer) Reset() {
 	*x = CreateContainer{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[35]
+		mi := &file_tetragon_tetragon_proto_msgTypes[37]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3533,7 +3659,7 @@ func (x *CreateContainer) String() string {
 func (*CreateContainer) ProtoMessage() {}
 
 func (x *CreateContainer) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[35]
+	mi := &file_tetragon_tetragon_proto_msgTypes[37]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3546,7 +3672,7 @@ func (x *CreateContainer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateContainer.ProtoReflect.Descriptor instead.
 func (*CreateContainer) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{35}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CreateContainer) GetCgroupsPath() string {
@@ -3586,7 +3712,7 @@ type StackTraceEntry struct {
 func (x *StackTraceEntry) Reset() {
 	*x = StackTraceEntry{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[36]
+		mi := &file_tetragon_tetragon_proto_msgTypes[38]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3599,7 +3725,7 @@ func (x *StackTraceEntry) String() string {
 func (*StackTraceEntry) ProtoMessage() {}
 
 func (x *StackTraceEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[36]
+	mi := &file_tetragon_tetragon_proto_msgTypes[38]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3612,7 +3738,7 @@ func (x *StackTraceEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StackTraceEntry.ProtoReflect.Descriptor instead.
 func (*StackTraceEntry) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{36}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *StackTraceEntry) GetAddress() uint64 {
@@ -3776,20 +3902,33 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x74, 0x69, 0x65, 0x73, 0x52, 0x04, 0x63, 0x61, 0x70, 0x73, 0x12, 0x30, 0x0a, 0x07, 0x75, 0x73,
 	0x65, 0x72, 0x5f, 0x6e, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x74, 0x65,
 	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x55, 0x73, 0x65, 0x72, 0x4e, 0x61, 0x6d, 0x65, 0x73,
-	0x70, 0x61, 0x63, 0x65, 0x52, 0x06, 0x75, 0x73, 0x65, 0x72, 0x4e, 0x73, 0x22, 0xd1, 0x01, 0x0a,
-	0x10, 0x42, 0x69, 0x6e, 0x61, 0x72, 0x79, 0x50, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x69, 0x65,
-	0x73, 0x12, 0x34, 0x0a, 0x06, 0x73, 0x65, 0x74, 0x75, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
-	0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
-	0x62, 0x75, 0x66, 0x2e, 0x55, 0x49, 0x6e, 0x74, 0x33, 0x32, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52,
-	0x06, 0x73, 0x65, 0x74, 0x75, 0x69, 0x64, 0x12, 0x34, 0x0a, 0x06, 0x73, 0x65, 0x74, 0x67, 0x69,
-	0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
-	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x49, 0x6e, 0x74, 0x33, 0x32,
-	0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x06, 0x73, 0x65, 0x74, 0x67, 0x69, 0x64, 0x12, 0x51, 0x0a,
-	0x12, 0x70, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x5f, 0x63, 0x68, 0x61, 0x6e,
-	0x67, 0x65, 0x64, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x22, 0x2e, 0x74, 0x65, 0x74, 0x72,
-	0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x50, 0x72, 0x69, 0x76,
-	0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x64, 0x52, 0x11, 0x70,
-	0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x64,
+	0x70, 0x61, 0x63, 0x65, 0x52, 0x06, 0x75, 0x73, 0x65, 0x72, 0x4e, 0x73, 0x22, 0x53, 0x0a, 0x05,
+	0x49, 0x6e, 0x6f, 0x64, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x32, 0x0a,
+	0x05, 0x6c, 0x69, 0x6e, 0x6b, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67,
+	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55,
+	0x49, 0x6e, 0x74, 0x33, 0x32, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x05, 0x6c, 0x69, 0x6e, 0x6b,
+	0x73, 0x22, 0x4b, 0x0a, 0x0e, 0x46, 0x69, 0x6c, 0x65, 0x50, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74,
+	0x69, 0x65, 0x73, 0x12, 0x25, 0x0a, 0x05, 0x69, 0x6e, 0x6f, 0x64, 0x65, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x49, 0x6e,
+	0x6f, 0x64, 0x65, 0x52, 0x05, 0x69, 0x6e, 0x6f, 0x64, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x70, 0x61,
+	0x74, 0x68, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x22, 0xff,
+	0x01, 0x0a, 0x10, 0x42, 0x69, 0x6e, 0x61, 0x72, 0x79, 0x50, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74,
+	0x69, 0x65, 0x73, 0x12, 0x34, 0x0a, 0x06, 0x73, 0x65, 0x74, 0x75, 0x69, 0x64, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x49, 0x6e, 0x74, 0x33, 0x32, 0x56, 0x61, 0x6c, 0x75,
+	0x65, 0x52, 0x06, 0x73, 0x65, 0x74, 0x75, 0x69, 0x64, 0x12, 0x34, 0x0a, 0x06, 0x73, 0x65, 0x74,
+	0x67, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
+	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x49, 0x6e, 0x74,
+	0x33, 0x32, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x06, 0x73, 0x65, 0x74, 0x67, 0x69, 0x64, 0x12,
+	0x51, 0x0a, 0x12, 0x70, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x5f, 0x63, 0x68,
+	0x61, 0x6e, 0x67, 0x65, 0x64, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x22, 0x2e, 0x74, 0x65,
+	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x50, 0x72,
+	0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x64, 0x52,
+	0x11, 0x70, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x43, 0x68, 0x61, 0x6e, 0x67,
+	0x65, 0x64, 0x12, 0x2c, 0x0a, 0x04, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x18, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x46, 0x69, 0x6c, 0x65,
+	0x50, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x69, 0x65, 0x73, 0x52, 0x04, 0x66, 0x69, 0x6c, 0x65,
 	0x22, 0xdc, 0x05, 0x0a, 0x07, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x12, 0x17, 0x0a, 0x07,
 	0x65, 0x78, 0x65, 0x63, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x65,
 	0x78, 0x65, 0x63, 0x49, 0x64, 0x12, 0x2e, 0x0a, 0x03, 0x70, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01,
@@ -4240,7 +4379,7 @@ func file_tetragon_tetragon_proto_rawDescGZIP() []byte {
 }
 
 var file_tetragon_tetragon_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_tetragon_tetragon_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
+var file_tetragon_tetragon_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_tetragon_tetragon_proto_goTypes = []interface{}{
 	(KprobeAction)(0),               // 0: tetragon.KprobeAction
 	(HealthStatusType)(0),           // 1: tetragon.HealthStatusType
@@ -4254,148 +4393,153 @@ var file_tetragon_tetragon_proto_goTypes = []interface{}{
 	(*Namespaces)(nil),              // 9: tetragon.Namespaces
 	(*UserNamespace)(nil),           // 10: tetragon.UserNamespace
 	(*ProcessCredentials)(nil),      // 11: tetragon.ProcessCredentials
-	(*BinaryProperties)(nil),        // 12: tetragon.BinaryProperties
-	(*Process)(nil),                 // 13: tetragon.Process
-	(*ProcessExec)(nil),             // 14: tetragon.ProcessExec
-	(*ProcessExit)(nil),             // 15: tetragon.ProcessExit
-	(*KprobeSock)(nil),              // 16: tetragon.KprobeSock
-	(*KprobeSkb)(nil),               // 17: tetragon.KprobeSkb
-	(*KprobePath)(nil),              // 18: tetragon.KprobePath
-	(*KprobeFile)(nil),              // 19: tetragon.KprobeFile
-	(*KprobeTruncatedBytes)(nil),    // 20: tetragon.KprobeTruncatedBytes
-	(*KprobeCred)(nil),              // 21: tetragon.KprobeCred
-	(*KprobeCapability)(nil),        // 22: tetragon.KprobeCapability
-	(*KprobeUserNamespace)(nil),     // 23: tetragon.KprobeUserNamespace
-	(*KprobeBpfAttr)(nil),           // 24: tetragon.KprobeBpfAttr
-	(*KprobePerfEvent)(nil),         // 25: tetragon.KprobePerfEvent
-	(*KprobeBpfMap)(nil),            // 26: tetragon.KprobeBpfMap
-	(*KprobeArgument)(nil),          // 27: tetragon.KprobeArgument
-	(*ProcessKprobe)(nil),           // 28: tetragon.ProcessKprobe
-	(*ProcessTracepoint)(nil),       // 29: tetragon.ProcessTracepoint
-	(*ProcessUprobe)(nil),           // 30: tetragon.ProcessUprobe
-	(*KernelModule)(nil),            // 31: tetragon.KernelModule
-	(*Test)(nil),                    // 32: tetragon.Test
-	(*GetHealthStatusRequest)(nil),  // 33: tetragon.GetHealthStatusRequest
-	(*HealthStatus)(nil),            // 34: tetragon.HealthStatus
-	(*GetHealthStatusResponse)(nil), // 35: tetragon.GetHealthStatusResponse
-	(*ProcessLoader)(nil),           // 36: tetragon.ProcessLoader
-	(*RuntimeHookRequest)(nil),      // 37: tetragon.RuntimeHookRequest
-	(*RuntimeHookResponse)(nil),     // 38: tetragon.RuntimeHookResponse
-	(*CreateContainer)(nil),         // 39: tetragon.CreateContainer
-	(*StackTraceEntry)(nil),         // 40: tetragon.StackTraceEntry
-	nil,                             // 41: tetragon.Pod.PodLabelsEntry
-	nil,                             // 42: tetragon.CreateContainer.AnnotationsEntry
-	(*timestamppb.Timestamp)(nil),   // 43: google.protobuf.Timestamp
-	(*wrapperspb.UInt32Value)(nil),  // 44: google.protobuf.UInt32Value
-	(CapabilitiesType)(0),           // 45: tetragon.CapabilitiesType
-	(*wrapperspb.Int32Value)(nil),   // 46: google.protobuf.Int32Value
-	(SecureBitsType)(0),             // 47: tetragon.SecureBitsType
-	(ProcessPrivilegesChanged)(0),   // 48: tetragon.ProcessPrivilegesChanged
-	(*wrapperspb.BoolValue)(nil),    // 49: google.protobuf.BoolValue
+	(*Inode)(nil),                   // 12: tetragon.Inode
+	(*FileProperties)(nil),          // 13: tetragon.FileProperties
+	(*BinaryProperties)(nil),        // 14: tetragon.BinaryProperties
+	(*Process)(nil),                 // 15: tetragon.Process
+	(*ProcessExec)(nil),             // 16: tetragon.ProcessExec
+	(*ProcessExit)(nil),             // 17: tetragon.ProcessExit
+	(*KprobeSock)(nil),              // 18: tetragon.KprobeSock
+	(*KprobeSkb)(nil),               // 19: tetragon.KprobeSkb
+	(*KprobePath)(nil),              // 20: tetragon.KprobePath
+	(*KprobeFile)(nil),              // 21: tetragon.KprobeFile
+	(*KprobeTruncatedBytes)(nil),    // 22: tetragon.KprobeTruncatedBytes
+	(*KprobeCred)(nil),              // 23: tetragon.KprobeCred
+	(*KprobeCapability)(nil),        // 24: tetragon.KprobeCapability
+	(*KprobeUserNamespace)(nil),     // 25: tetragon.KprobeUserNamespace
+	(*KprobeBpfAttr)(nil),           // 26: tetragon.KprobeBpfAttr
+	(*KprobePerfEvent)(nil),         // 27: tetragon.KprobePerfEvent
+	(*KprobeBpfMap)(nil),            // 28: tetragon.KprobeBpfMap
+	(*KprobeArgument)(nil),          // 29: tetragon.KprobeArgument
+	(*ProcessKprobe)(nil),           // 30: tetragon.ProcessKprobe
+	(*ProcessTracepoint)(nil),       // 31: tetragon.ProcessTracepoint
+	(*ProcessUprobe)(nil),           // 32: tetragon.ProcessUprobe
+	(*KernelModule)(nil),            // 33: tetragon.KernelModule
+	(*Test)(nil),                    // 34: tetragon.Test
+	(*GetHealthStatusRequest)(nil),  // 35: tetragon.GetHealthStatusRequest
+	(*HealthStatus)(nil),            // 36: tetragon.HealthStatus
+	(*GetHealthStatusResponse)(nil), // 37: tetragon.GetHealthStatusResponse
+	(*ProcessLoader)(nil),           // 38: tetragon.ProcessLoader
+	(*RuntimeHookRequest)(nil),      // 39: tetragon.RuntimeHookRequest
+	(*RuntimeHookResponse)(nil),     // 40: tetragon.RuntimeHookResponse
+	(*CreateContainer)(nil),         // 41: tetragon.CreateContainer
+	(*StackTraceEntry)(nil),         // 42: tetragon.StackTraceEntry
+	nil,                             // 43: tetragon.Pod.PodLabelsEntry
+	nil,                             // 44: tetragon.CreateContainer.AnnotationsEntry
+	(*timestamppb.Timestamp)(nil),   // 45: google.protobuf.Timestamp
+	(*wrapperspb.UInt32Value)(nil),  // 46: google.protobuf.UInt32Value
+	(CapabilitiesType)(0),           // 47: tetragon.CapabilitiesType
+	(*wrapperspb.Int32Value)(nil),   // 48: google.protobuf.Int32Value
+	(SecureBitsType)(0),             // 49: tetragon.SecureBitsType
+	(ProcessPrivilegesChanged)(0),   // 50: tetragon.ProcessPrivilegesChanged
+	(*wrapperspb.BoolValue)(nil),    // 51: google.protobuf.BoolValue
 }
 var file_tetragon_tetragon_proto_depIdxs = []int32{
-	4,  // 0: tetragon.Container.image:type_name -> tetragon.Image
-	43, // 1: tetragon.Container.start_time:type_name -> google.protobuf.Timestamp
-	44, // 2: tetragon.Container.pid:type_name -> google.protobuf.UInt32Value
-	5,  // 3: tetragon.Pod.container:type_name -> tetragon.Container
-	41, // 4: tetragon.Pod.pod_labels:type_name -> tetragon.Pod.PodLabelsEntry
-	45, // 5: tetragon.Capabilities.permitted:type_name -> tetragon.CapabilitiesType
-	45, // 6: tetragon.Capabilities.effective:type_name -> tetragon.CapabilitiesType
-	45, // 7: tetragon.Capabilities.inheritable:type_name -> tetragon.CapabilitiesType
-	8,  // 8: tetragon.Namespaces.uts:type_name -> tetragon.Namespace
-	8,  // 9: tetragon.Namespaces.ipc:type_name -> tetragon.Namespace
-	8,  // 10: tetragon.Namespaces.mnt:type_name -> tetragon.Namespace
-	8,  // 11: tetragon.Namespaces.pid:type_name -> tetragon.Namespace
-	8,  // 12: tetragon.Namespaces.pid_for_children:type_name -> tetragon.Namespace
-	8,  // 13: tetragon.Namespaces.net:type_name -> tetragon.Namespace
-	8,  // 14: tetragon.Namespaces.time:type_name -> tetragon.Namespace
-	8,  // 15: tetragon.Namespaces.time_for_children:type_name -> tetragon.Namespace
-	8,  // 16: tetragon.Namespaces.cgroup:type_name -> tetragon.Namespace
-	8,  // 17: tetragon.Namespaces.user:type_name -> tetragon.Namespace
-	46, // 18: tetragon.UserNamespace.level:type_name -> google.protobuf.Int32Value
-	44, // 19: tetragon.UserNamespace.uid:type_name -> google.protobuf.UInt32Value
-	44, // 20: tetragon.UserNamespace.gid:type_name -> google.protobuf.UInt32Value
-	8,  // 21: tetragon.UserNamespace.ns:type_name -> tetragon.Namespace
-	44, // 22: tetragon.ProcessCredentials.uid:type_name -> google.protobuf.UInt32Value
-	44, // 23: tetragon.ProcessCredentials.gid:type_name -> google.protobuf.UInt32Value
-	44, // 24: tetragon.ProcessCredentials.euid:type_name -> google.protobuf.UInt32Value
-	44, // 25: tetragon.ProcessCredentials.egid:type_name -> google.protobuf.UInt32Value
-	44, // 26: tetragon.ProcessCredentials.suid:type_name -> google.protobuf.UInt32Value
-	44, // 27: tetragon.ProcessCredentials.sgid:type_name -> google.protobuf.UInt32Value
-	44, // 28: tetragon.ProcessCredentials.fsuid:type_name -> google.protobuf.UInt32Value
-	44, // 29: tetragon.ProcessCredentials.fsgid:type_name -> google.protobuf.UInt32Value
-	47, // 30: tetragon.ProcessCredentials.securebits:type_name -> tetragon.SecureBitsType
-	7,  // 31: tetragon.ProcessCredentials.caps:type_name -> tetragon.Capabilities
-	10, // 32: tetragon.ProcessCredentials.user_ns:type_name -> tetragon.UserNamespace
-	44, // 33: tetragon.BinaryProperties.setuid:type_name -> google.protobuf.UInt32Value
-	44, // 34: tetragon.BinaryProperties.setgid:type_name -> google.protobuf.UInt32Value
-	48, // 35: tetragon.BinaryProperties.privileges_changed:type_name -> tetragon.ProcessPrivilegesChanged
-	44, // 36: tetragon.Process.pid:type_name -> google.protobuf.UInt32Value
-	44, // 37: tetragon.Process.uid:type_name -> google.protobuf.UInt32Value
-	43, // 38: tetragon.Process.start_time:type_name -> google.protobuf.Timestamp
-	44, // 39: tetragon.Process.auid:type_name -> google.protobuf.UInt32Value
-	6,  // 40: tetragon.Process.pod:type_name -> tetragon.Pod
-	7,  // 41: tetragon.Process.cap:type_name -> tetragon.Capabilities
-	9,  // 42: tetragon.Process.ns:type_name -> tetragon.Namespaces
-	44, // 43: tetragon.Process.tid:type_name -> google.protobuf.UInt32Value
-	11, // 44: tetragon.Process.process_credentials:type_name -> tetragon.ProcessCredentials
-	12, // 45: tetragon.Process.binary_properties:type_name -> tetragon.BinaryProperties
-	13, // 46: tetragon.ProcessExec.process:type_name -> tetragon.Process
-	13, // 47: tetragon.ProcessExec.parent:type_name -> tetragon.Process
-	13, // 48: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
-	13, // 49: tetragon.ProcessExit.process:type_name -> tetragon.Process
-	13, // 50: tetragon.ProcessExit.parent:type_name -> tetragon.Process
-	43, // 51: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
-	45, // 52: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
-	45, // 53: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
-	45, // 54: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
-	46, // 55: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
-	46, // 56: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
-	44, // 57: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
-	44, // 58: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
-	8,  // 59: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
-	17, // 60: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
-	18, // 61: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
-	19, // 62: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
-	20, // 63: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
-	16, // 64: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
-	21, // 65: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
-	24, // 66: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
-	25, // 67: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
-	26, // 68: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
-	23, // 69: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
-	22, // 70: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
-	11, // 71: tetragon.KprobeArgument.process_credentials_arg:type_name -> tetragon.ProcessCredentials
-	10, // 72: tetragon.KprobeArgument.user_ns_arg:type_name -> tetragon.UserNamespace
-	31, // 73: tetragon.KprobeArgument.module_arg:type_name -> tetragon.KernelModule
-	13, // 74: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
-	13, // 75: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
-	27, // 76: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
-	27, // 77: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
-	0,  // 78: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
-	40, // 79: tetragon.ProcessKprobe.stack_trace:type_name -> tetragon.StackTraceEntry
-	0,  // 80: tetragon.ProcessKprobe.return_action:type_name -> tetragon.KprobeAction
-	13, // 81: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
-	13, // 82: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
-	27, // 83: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
-	0,  // 84: tetragon.ProcessTracepoint.action:type_name -> tetragon.KprobeAction
-	13, // 85: tetragon.ProcessUprobe.process:type_name -> tetragon.Process
-	13, // 86: tetragon.ProcessUprobe.parent:type_name -> tetragon.Process
-	27, // 87: tetragon.ProcessUprobe.args:type_name -> tetragon.KprobeArgument
-	49, // 88: tetragon.KernelModule.signature_ok:type_name -> google.protobuf.BoolValue
-	3,  // 89: tetragon.KernelModule.tainted:type_name -> tetragon.TaintedBitsType
-	1,  // 90: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
-	1,  // 91: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
-	2,  // 92: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
-	34, // 93: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
-	13, // 94: tetragon.ProcessLoader.process:type_name -> tetragon.Process
-	39, // 95: tetragon.RuntimeHookRequest.createContainer:type_name -> tetragon.CreateContainer
-	42, // 96: tetragon.CreateContainer.annotations:type_name -> tetragon.CreateContainer.AnnotationsEntry
-	97, // [97:97] is the sub-list for method output_type
-	97, // [97:97] is the sub-list for method input_type
-	97, // [97:97] is the sub-list for extension type_name
-	97, // [97:97] is the sub-list for extension extendee
-	0,  // [0:97] is the sub-list for field type_name
+	4,   // 0: tetragon.Container.image:type_name -> tetragon.Image
+	45,  // 1: tetragon.Container.start_time:type_name -> google.protobuf.Timestamp
+	46,  // 2: tetragon.Container.pid:type_name -> google.protobuf.UInt32Value
+	5,   // 3: tetragon.Pod.container:type_name -> tetragon.Container
+	43,  // 4: tetragon.Pod.pod_labels:type_name -> tetragon.Pod.PodLabelsEntry
+	47,  // 5: tetragon.Capabilities.permitted:type_name -> tetragon.CapabilitiesType
+	47,  // 6: tetragon.Capabilities.effective:type_name -> tetragon.CapabilitiesType
+	47,  // 7: tetragon.Capabilities.inheritable:type_name -> tetragon.CapabilitiesType
+	8,   // 8: tetragon.Namespaces.uts:type_name -> tetragon.Namespace
+	8,   // 9: tetragon.Namespaces.ipc:type_name -> tetragon.Namespace
+	8,   // 10: tetragon.Namespaces.mnt:type_name -> tetragon.Namespace
+	8,   // 11: tetragon.Namespaces.pid:type_name -> tetragon.Namespace
+	8,   // 12: tetragon.Namespaces.pid_for_children:type_name -> tetragon.Namespace
+	8,   // 13: tetragon.Namespaces.net:type_name -> tetragon.Namespace
+	8,   // 14: tetragon.Namespaces.time:type_name -> tetragon.Namespace
+	8,   // 15: tetragon.Namespaces.time_for_children:type_name -> tetragon.Namespace
+	8,   // 16: tetragon.Namespaces.cgroup:type_name -> tetragon.Namespace
+	8,   // 17: tetragon.Namespaces.user:type_name -> tetragon.Namespace
+	48,  // 18: tetragon.UserNamespace.level:type_name -> google.protobuf.Int32Value
+	46,  // 19: tetragon.UserNamespace.uid:type_name -> google.protobuf.UInt32Value
+	46,  // 20: tetragon.UserNamespace.gid:type_name -> google.protobuf.UInt32Value
+	8,   // 21: tetragon.UserNamespace.ns:type_name -> tetragon.Namespace
+	46,  // 22: tetragon.ProcessCredentials.uid:type_name -> google.protobuf.UInt32Value
+	46,  // 23: tetragon.ProcessCredentials.gid:type_name -> google.protobuf.UInt32Value
+	46,  // 24: tetragon.ProcessCredentials.euid:type_name -> google.protobuf.UInt32Value
+	46,  // 25: tetragon.ProcessCredentials.egid:type_name -> google.protobuf.UInt32Value
+	46,  // 26: tetragon.ProcessCredentials.suid:type_name -> google.protobuf.UInt32Value
+	46,  // 27: tetragon.ProcessCredentials.sgid:type_name -> google.protobuf.UInt32Value
+	46,  // 28: tetragon.ProcessCredentials.fsuid:type_name -> google.protobuf.UInt32Value
+	46,  // 29: tetragon.ProcessCredentials.fsgid:type_name -> google.protobuf.UInt32Value
+	49,  // 30: tetragon.ProcessCredentials.securebits:type_name -> tetragon.SecureBitsType
+	7,   // 31: tetragon.ProcessCredentials.caps:type_name -> tetragon.Capabilities
+	10,  // 32: tetragon.ProcessCredentials.user_ns:type_name -> tetragon.UserNamespace
+	46,  // 33: tetragon.Inode.links:type_name -> google.protobuf.UInt32Value
+	12,  // 34: tetragon.FileProperties.inode:type_name -> tetragon.Inode
+	46,  // 35: tetragon.BinaryProperties.setuid:type_name -> google.protobuf.UInt32Value
+	46,  // 36: tetragon.BinaryProperties.setgid:type_name -> google.protobuf.UInt32Value
+	50,  // 37: tetragon.BinaryProperties.privileges_changed:type_name -> tetragon.ProcessPrivilegesChanged
+	13,  // 38: tetragon.BinaryProperties.file:type_name -> tetragon.FileProperties
+	46,  // 39: tetragon.Process.pid:type_name -> google.protobuf.UInt32Value
+	46,  // 40: tetragon.Process.uid:type_name -> google.protobuf.UInt32Value
+	45,  // 41: tetragon.Process.start_time:type_name -> google.protobuf.Timestamp
+	46,  // 42: tetragon.Process.auid:type_name -> google.protobuf.UInt32Value
+	6,   // 43: tetragon.Process.pod:type_name -> tetragon.Pod
+	7,   // 44: tetragon.Process.cap:type_name -> tetragon.Capabilities
+	9,   // 45: tetragon.Process.ns:type_name -> tetragon.Namespaces
+	46,  // 46: tetragon.Process.tid:type_name -> google.protobuf.UInt32Value
+	11,  // 47: tetragon.Process.process_credentials:type_name -> tetragon.ProcessCredentials
+	14,  // 48: tetragon.Process.binary_properties:type_name -> tetragon.BinaryProperties
+	15,  // 49: tetragon.ProcessExec.process:type_name -> tetragon.Process
+	15,  // 50: tetragon.ProcessExec.parent:type_name -> tetragon.Process
+	15,  // 51: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
+	15,  // 52: tetragon.ProcessExit.process:type_name -> tetragon.Process
+	15,  // 53: tetragon.ProcessExit.parent:type_name -> tetragon.Process
+	45,  // 54: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
+	47,  // 55: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
+	47,  // 56: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
+	47,  // 57: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
+	48,  // 58: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
+	48,  // 59: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
+	46,  // 60: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
+	46,  // 61: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
+	8,   // 62: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
+	19,  // 63: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
+	20,  // 64: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
+	21,  // 65: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
+	22,  // 66: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
+	18,  // 67: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
+	23,  // 68: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
+	26,  // 69: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
+	27,  // 70: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
+	28,  // 71: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
+	25,  // 72: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
+	24,  // 73: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
+	11,  // 74: tetragon.KprobeArgument.process_credentials_arg:type_name -> tetragon.ProcessCredentials
+	10,  // 75: tetragon.KprobeArgument.user_ns_arg:type_name -> tetragon.UserNamespace
+	33,  // 76: tetragon.KprobeArgument.module_arg:type_name -> tetragon.KernelModule
+	15,  // 77: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
+	15,  // 78: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
+	29,  // 79: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
+	29,  // 80: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
+	0,   // 81: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
+	42,  // 82: tetragon.ProcessKprobe.stack_trace:type_name -> tetragon.StackTraceEntry
+	0,   // 83: tetragon.ProcessKprobe.return_action:type_name -> tetragon.KprobeAction
+	15,  // 84: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
+	15,  // 85: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
+	29,  // 86: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
+	0,   // 87: tetragon.ProcessTracepoint.action:type_name -> tetragon.KprobeAction
+	15,  // 88: tetragon.ProcessUprobe.process:type_name -> tetragon.Process
+	15,  // 89: tetragon.ProcessUprobe.parent:type_name -> tetragon.Process
+	29,  // 90: tetragon.ProcessUprobe.args:type_name -> tetragon.KprobeArgument
+	51,  // 91: tetragon.KernelModule.signature_ok:type_name -> google.protobuf.BoolValue
+	3,   // 92: tetragon.KernelModule.tainted:type_name -> tetragon.TaintedBitsType
+	1,   // 93: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
+	1,   // 94: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
+	2,   // 95: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
+	36,  // 96: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
+	15,  // 97: tetragon.ProcessLoader.process:type_name -> tetragon.Process
+	41,  // 98: tetragon.RuntimeHookRequest.createContainer:type_name -> tetragon.CreateContainer
+	44,  // 99: tetragon.CreateContainer.annotations:type_name -> tetragon.CreateContainer.AnnotationsEntry
+	100, // [100:100] is the sub-list for method output_type
+	100, // [100:100] is the sub-list for method input_type
+	100, // [100:100] is the sub-list for extension type_name
+	100, // [100:100] is the sub-list for extension extendee
+	0,   // [0:100] is the sub-list for field type_name
 }
 
 func init() { file_tetragon_tetragon_proto_init() }
@@ -4502,7 +4646,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*BinaryProperties); i {
+			switch v := v.(*Inode); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4514,7 +4658,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Process); i {
+			switch v := v.(*FileProperties); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4526,7 +4670,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessExec); i {
+			switch v := v.(*BinaryProperties); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4538,7 +4682,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessExit); i {
+			switch v := v.(*Process); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4550,7 +4694,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeSock); i {
+			switch v := v.(*ProcessExec); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4562,7 +4706,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeSkb); i {
+			switch v := v.(*ProcessExit); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4574,7 +4718,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobePath); i {
+			switch v := v.(*KprobeSock); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4586,7 +4730,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeFile); i {
+			switch v := v.(*KprobeSkb); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4598,7 +4742,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeTruncatedBytes); i {
+			switch v := v.(*KprobePath); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4610,7 +4754,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeCred); i {
+			switch v := v.(*KprobeFile); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4622,7 +4766,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeCapability); i {
+			switch v := v.(*KprobeTruncatedBytes); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4634,7 +4778,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeUserNamespace); i {
+			switch v := v.(*KprobeCred); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4646,7 +4790,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeBpfAttr); i {
+			switch v := v.(*KprobeCapability); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4658,7 +4802,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobePerfEvent); i {
+			switch v := v.(*KprobeUserNamespace); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4670,7 +4814,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeBpfMap); i {
+			switch v := v.(*KprobeBpfAttr); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4682,7 +4826,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeArgument); i {
+			switch v := v.(*KprobePerfEvent); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4694,7 +4838,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessKprobe); i {
+			switch v := v.(*KprobeBpfMap); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4706,7 +4850,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessTracepoint); i {
+			switch v := v.(*KprobeArgument); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4718,7 +4862,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessUprobe); i {
+			switch v := v.(*ProcessKprobe); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4730,7 +4874,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KernelModule); i {
+			switch v := v.(*ProcessTracepoint); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4742,7 +4886,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Test); i {
+			switch v := v.(*ProcessUprobe); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4754,7 +4898,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetHealthStatusRequest); i {
+			switch v := v.(*KernelModule); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4766,7 +4910,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*HealthStatus); i {
+			switch v := v.(*Test); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4778,7 +4922,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetHealthStatusResponse); i {
+			switch v := v.(*GetHealthStatusRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4790,7 +4934,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[32].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessLoader); i {
+			switch v := v.(*HealthStatus); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4802,7 +4946,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[33].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RuntimeHookRequest); i {
+			switch v := v.(*GetHealthStatusResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4814,7 +4958,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[34].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RuntimeHookResponse); i {
+			switch v := v.(*ProcessLoader); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4826,7 +4970,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[35].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CreateContainer); i {
+			switch v := v.(*RuntimeHookRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4838,6 +4982,30 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[36].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*RuntimeHookResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tetragon_tetragon_proto_msgTypes[37].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CreateContainer); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tetragon_tetragon_proto_msgTypes[38].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*StackTraceEntry); i {
 			case 0:
 				return &v.state
@@ -4850,7 +5018,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 	}
-	file_tetragon_tetragon_proto_msgTypes[23].OneofWrappers = []interface{}{
+	file_tetragon_tetragon_proto_msgTypes[25].OneofWrappers = []interface{}{
 		(*KprobeArgument_StringArg)(nil),
 		(*KprobeArgument_IntArg)(nil),
 		(*KprobeArgument_SkbArg)(nil),
@@ -4872,7 +5040,7 @@ func file_tetragon_tetragon_proto_init() {
 		(*KprobeArgument_UserNsArg)(nil),
 		(*KprobeArgument_ModuleArg)(nil),
 	}
-	file_tetragon_tetragon_proto_msgTypes[33].OneofWrappers = []interface{}{
+	file_tetragon_tetragon_proto_msgTypes[35].OneofWrappers = []interface{}{
 		(*RuntimeHookRequest_CreateContainer)(nil),
 	}
 	type x struct{}
@@ -4881,7 +5049,7 @@ func file_tetragon_tetragon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_tetragon_tetragon_proto_rawDesc,
 			NumEnums:      4,
-			NumMessages:   39,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/v1/tetragon/tetragon.pb.json.go
+++ b/api/v1/tetragon/tetragon.pb.json.go
@@ -136,6 +136,38 @@ func (msg *ProcessCredentials) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
+func (msg *Inode) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseEnumNumbers:  false,
+		EmitUnpopulated: false,
+		UseProtoNames:   true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *Inode) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{
+		DiscardUnknown: false,
+	}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
+func (msg *FileProperties) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseEnumNumbers:  false,
+		EmitUnpopulated: false,
+		UseProtoNames:   true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *FileProperties) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{
+		DiscardUnknown: false,
+	}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
 func (msg *BinaryProperties) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseEnumNumbers:  false,

--- a/api/v1/tetragon/tetragon.proto
+++ b/api/v1/tetragon/tetragon.proto
@@ -136,6 +136,20 @@ message ProcessCredentials {
 	UserNamespace user_ns = 11;
 }
 
+message Inode {
+	// The inode number
+	uint64 number = 1;
+	// The inode links on the file system. If zero means the file is only in memory
+	google.protobuf.UInt32Value links = 2;
+}
+
+message FileProperties {
+	// Inode of the file
+	Inode inode = 1;
+	// Path of the file
+	string path = 2;
+}
+
 message BinaryProperties {
 	// If set then this is the set user ID used for execution
 	google.protobuf.UInt32Value setuid = 1;
@@ -145,6 +159,11 @@ message BinaryProperties {
 	// a binary with the set-user-ID to root or file capability sets.
 	// The final granted privileges can be listed inside the `process_credentials` or capabilities fields part of of the `process` object.
 	repeated ProcessPrivilegesChanged privileges_changed = 3;
+	// File properties in case the executed binary is:
+	// 1. An anonymous shared memory file https://man7.org/linux/man-pages/man7/shm_overview.7.html.
+	// 2. An anonymous file obtained with memfd API https://man7.org/linux/man-pages/man2/memfd_create.2.html.
+	// 3. Or it was deleted from the file system.
+	FileProperties file = 4;
 }
 
 message Process {

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -94,7 +94,7 @@
  */
 #define CWD_MAX	     256
 #define BUFFER	     1024
-#define SIZEOF_EVENT 40
+#define SIZEOF_EVENT 56
 #define PADDED_BUFFER \
 	(BUFFER + MAXARGLENGTH + SIZEOF_EVENT + SIZEOF_EVENT + CWD_MAX)
 /* This is the usable buffer size for args and filenames. It is calculated
@@ -178,7 +178,8 @@ struct execve_info {
 	 *   EXEC_SETUID or EXEC_SETGID
 	 */
 	__u32 secureexec;
-	__u32 pad;
+	__u32 i_nlink; /* inode links */
+	__u64 i_ino; /* inode number */
 };
 
 /* process information
@@ -195,6 +196,9 @@ struct msg_process {
 	__u32 uid;
 	__u32 auid;
 	__u32 flags;
+	__u32 i_nlink;
+	__u32 pad;
+	__u64 i_ino;
 	__u64 ktime;
 	char *args;
 }; // All fields aligned so no 'packed' attribute.

--- a/docs/content/en/docs/reference/grpc-api.md
+++ b/docs/content/en/docs/reference/grpc-api.md
@@ -107,6 +107,7 @@ Reasons of why the process privileges changed.
 | setuid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | If set then this is the set user ID used for execution |
 | setgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | If set then this is the set group ID used for execution |
 | privileges_changed | [ProcessPrivilegesChanged](#tetragon-ProcessPrivilegesChanged) | repeated | The reasons why this binary execution changed privileges. Usually this happens when the process executes a binary with the set-user-ID to root or file capability sets. The final granted privileges can be listed inside the `process_credentials` or capabilities fields part of of the `process` object. |
+| file | [FileProperties](#tetragon-FileProperties) |  | File properties in case the executed binary is: 1. An anonymous shared memory file https://man7.org/linux/man-pages/man7/shm_overview.7.html. 2. An anonymous file obtained with memfd API https://man7.org/linux/man-pages/man2/memfd_create.2.html. 3. Or it was deleted from the file system. |
 
 <a name="tetragon-Capabilities"></a>
 
@@ -154,6 +155,15 @@ https://github.com/opencontainers/runtime-spec/blob/main/config.md#createcontain
 | key | [string](#string) |  |  |
 | value | [string](#string) |  |  |
 
+<a name="tetragon-FileProperties"></a>
+
+### FileProperties
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| inode | [Inode](#tetragon-Inode) |  | Inode of the file |
+| path | [string](#string) |  | Path of the file |
+
 <a name="tetragon-GetHealthStatusRequest"></a>
 
 ### GetHealthStatusRequest
@@ -188,6 +198,15 @@ https://github.com/opencontainers/runtime-spec/blob/main/config.md#createcontain
 | ----- | ---- | ----- | ----------- |
 | id | [string](#string) |  | Identifier of the container image composed of the registry path and the sha256. |
 | name | [string](#string) |  | Name of the container image composed of the registry path and the tag. |
+
+<a name="tetragon-Inode"></a>
+
+### Inode
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| number | [uint64](#uint64) |  | The inode number |
+| links | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The inode links on the file system. If zero means the file is only in memory |
 
 <a name="tetragon-KernelModule"></a>
 

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -20,7 +20,7 @@ const (
 	CGROUP_PATH_LENGTH = 4096
 
 	MSG_SIZEOF_MAXARG = 100
-	MSG_SIZEOF_EXECVE = 40
+	MSG_SIZEOF_EXECVE = 56
 	MSG_SIZEOF_CWD    = 256
 	MSG_SIZEOF_ARGS   = 1024
 	MSG_SIZEOF_BUFFER = MSG_SIZEOF_ARGS +
@@ -55,6 +55,9 @@ type MsgExec struct {
 	UID        uint32
 	AUID       uint32
 	Flags      uint32
+	Nlink      uint32
+	Pad        uint32
+	Ino        uint64
 	Ktime      uint64
 }
 
@@ -177,6 +180,8 @@ type MsgProcess struct {
 	UID        uint32
 	AUID       uint32
 	Flags      uint32
+	Nlink      uint32
+	Ino        uint64
 	Ktime      uint64
 	Filename   string
 	Args       string

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -107,6 +107,8 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, bool, error) {
 	proc.Ktime = exec.Ktime
 	proc.AUID = exec.AUID
 	proc.SecureExec = exec.SecureExec
+	proc.Nlink = exec.Nlink
+	proc.Ino = exec.Ino
 
 	size := exec.Size - processapi.MSG_SIZEOF_EXECVE
 	if size > processapi.MSG_SIZEOF_BUFFER-processapi.MSG_SIZEOF_EXECVE {

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
@@ -1018,6 +1018,120 @@ func (x *ProcessCredentials) GetUserNs() *UserNamespace {
 	return nil
 }
 
+type Inode struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// The inode number
+	Number uint64 `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"`
+	// The inode links on the file system. If zero means the file is only in memory
+	Links *wrapperspb.UInt32Value `protobuf:"bytes,2,opt,name=links,proto3" json:"links,omitempty"`
+}
+
+func (x *Inode) Reset() {
+	*x = Inode{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tetragon_tetragon_proto_msgTypes[8]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Inode) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Inode) ProtoMessage() {}
+
+func (x *Inode) ProtoReflect() protoreflect.Message {
+	mi := &file_tetragon_tetragon_proto_msgTypes[8]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Inode.ProtoReflect.Descriptor instead.
+func (*Inode) Descriptor() ([]byte, []int) {
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *Inode) GetNumber() uint64 {
+	if x != nil {
+		return x.Number
+	}
+	return 0
+}
+
+func (x *Inode) GetLinks() *wrapperspb.UInt32Value {
+	if x != nil {
+		return x.Links
+	}
+	return nil
+}
+
+type FileProperties struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Inode of the file
+	Inode *Inode `protobuf:"bytes,1,opt,name=inode,proto3" json:"inode,omitempty"`
+	// Path of the file
+	Path string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+}
+
+func (x *FileProperties) Reset() {
+	*x = FileProperties{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tetragon_tetragon_proto_msgTypes[9]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *FileProperties) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FileProperties) ProtoMessage() {}
+
+func (x *FileProperties) ProtoReflect() protoreflect.Message {
+	mi := &file_tetragon_tetragon_proto_msgTypes[9]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FileProperties.ProtoReflect.Descriptor instead.
+func (*FileProperties) Descriptor() ([]byte, []int) {
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *FileProperties) GetInode() *Inode {
+	if x != nil {
+		return x.Inode
+	}
+	return nil
+}
+
+func (x *FileProperties) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
 type BinaryProperties struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1031,12 +1145,17 @@ type BinaryProperties struct {
 	// a binary with the set-user-ID to root or file capability sets.
 	// The final granted privileges can be listed inside the `process_credentials` or capabilities fields part of of the `process` object.
 	PrivilegesChanged []ProcessPrivilegesChanged `protobuf:"varint,3,rep,packed,name=privileges_changed,json=privilegesChanged,proto3,enum=tetragon.ProcessPrivilegesChanged" json:"privileges_changed,omitempty"`
+	// File properties in case the executed binary is:
+	// 1. An anonymous shared memory file https://man7.org/linux/man-pages/man7/shm_overview.7.html.
+	// 2. An anonymous file obtained with memfd API https://man7.org/linux/man-pages/man2/memfd_create.2.html.
+	// 3. Or it was deleted from the file system.
+	File *FileProperties `protobuf:"bytes,4,opt,name=file,proto3" json:"file,omitempty"`
 }
 
 func (x *BinaryProperties) Reset() {
 	*x = BinaryProperties{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[8]
+		mi := &file_tetragon_tetragon_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1049,7 +1168,7 @@ func (x *BinaryProperties) String() string {
 func (*BinaryProperties) ProtoMessage() {}
 
 func (x *BinaryProperties) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[8]
+	mi := &file_tetragon_tetragon_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1062,7 +1181,7 @@ func (x *BinaryProperties) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BinaryProperties.ProtoReflect.Descriptor instead.
 func (*BinaryProperties) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{8}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *BinaryProperties) GetSetuid() *wrapperspb.UInt32Value {
@@ -1082,6 +1201,13 @@ func (x *BinaryProperties) GetSetgid() *wrapperspb.UInt32Value {
 func (x *BinaryProperties) GetPrivilegesChanged() []ProcessPrivilegesChanged {
 	if x != nil {
 		return x.PrivilegesChanged
+	}
+	return nil
+}
+
+func (x *BinaryProperties) GetFile() *FileProperties {
+	if x != nil {
+		return x.File
 	}
 	return nil
 }
@@ -1188,7 +1314,7 @@ type Process struct {
 func (x *Process) Reset() {
 	*x = Process{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[9]
+		mi := &file_tetragon_tetragon_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1201,7 +1327,7 @@ func (x *Process) String() string {
 func (*Process) ProtoMessage() {}
 
 func (x *Process) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[9]
+	mi := &file_tetragon_tetragon_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1214,7 +1340,7 @@ func (x *Process) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Process.ProtoReflect.Descriptor instead.
 func (*Process) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{9}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Process) GetExecId() string {
@@ -1359,7 +1485,7 @@ type ProcessExec struct {
 func (x *ProcessExec) Reset() {
 	*x = ProcessExec{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[10]
+		mi := &file_tetragon_tetragon_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1372,7 +1498,7 @@ func (x *ProcessExec) String() string {
 func (*ProcessExec) ProtoMessage() {}
 
 func (x *ProcessExec) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[10]
+	mi := &file_tetragon_tetragon_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1385,7 +1511,7 @@ func (x *ProcessExec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessExec.ProtoReflect.Descriptor instead.
 func (*ProcessExec) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{10}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ProcessExec) GetProcess() *Process {
@@ -1433,7 +1559,7 @@ type ProcessExit struct {
 func (x *ProcessExit) Reset() {
 	*x = ProcessExit{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[11]
+		mi := &file_tetragon_tetragon_proto_msgTypes[13]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1446,7 +1572,7 @@ func (x *ProcessExit) String() string {
 func (*ProcessExit) ProtoMessage() {}
 
 func (x *ProcessExit) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[11]
+	mi := &file_tetragon_tetragon_proto_msgTypes[13]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1459,7 +1585,7 @@ func (x *ProcessExit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessExit.ProtoReflect.Descriptor instead.
 func (*ProcessExit) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{11}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ProcessExit) GetProcess() *Process {
@@ -1518,7 +1644,7 @@ type KprobeSock struct {
 func (x *KprobeSock) Reset() {
 	*x = KprobeSock{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[12]
+		mi := &file_tetragon_tetragon_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1531,7 +1657,7 @@ func (x *KprobeSock) String() string {
 func (*KprobeSock) ProtoMessage() {}
 
 func (x *KprobeSock) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[12]
+	mi := &file_tetragon_tetragon_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1544,7 +1670,7 @@ func (x *KprobeSock) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeSock.ProtoReflect.Descriptor instead.
 func (*KprobeSock) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{12}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *KprobeSock) GetFamily() string {
@@ -1647,7 +1773,7 @@ type KprobeSkb struct {
 func (x *KprobeSkb) Reset() {
 	*x = KprobeSkb{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[13]
+		mi := &file_tetragon_tetragon_proto_msgTypes[15]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1660,7 +1786,7 @@ func (x *KprobeSkb) String() string {
 func (*KprobeSkb) ProtoMessage() {}
 
 func (x *KprobeSkb) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[13]
+	mi := &file_tetragon_tetragon_proto_msgTypes[15]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1673,7 +1799,7 @@ func (x *KprobeSkb) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeSkb.ProtoReflect.Descriptor instead.
 func (*KprobeSkb) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{13}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *KprobeSkb) GetHash() uint32 {
@@ -1780,7 +1906,7 @@ type KprobePath struct {
 func (x *KprobePath) Reset() {
 	*x = KprobePath{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[14]
+		mi := &file_tetragon_tetragon_proto_msgTypes[16]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1793,7 +1919,7 @@ func (x *KprobePath) String() string {
 func (*KprobePath) ProtoMessage() {}
 
 func (x *KprobePath) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[14]
+	mi := &file_tetragon_tetragon_proto_msgTypes[16]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1806,7 +1932,7 @@ func (x *KprobePath) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobePath.ProtoReflect.Descriptor instead.
 func (*KprobePath) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{14}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *KprobePath) GetMount() string {
@@ -1843,7 +1969,7 @@ type KprobeFile struct {
 func (x *KprobeFile) Reset() {
 	*x = KprobeFile{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[15]
+		mi := &file_tetragon_tetragon_proto_msgTypes[17]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1856,7 +1982,7 @@ func (x *KprobeFile) String() string {
 func (*KprobeFile) ProtoMessage() {}
 
 func (x *KprobeFile) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[15]
+	mi := &file_tetragon_tetragon_proto_msgTypes[17]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1869,7 +1995,7 @@ func (x *KprobeFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeFile.ProtoReflect.Descriptor instead.
 func (*KprobeFile) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{15}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *KprobeFile) GetMount() string {
@@ -1905,7 +2031,7 @@ type KprobeTruncatedBytes struct {
 func (x *KprobeTruncatedBytes) Reset() {
 	*x = KprobeTruncatedBytes{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[16]
+		mi := &file_tetragon_tetragon_proto_msgTypes[18]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1918,7 +2044,7 @@ func (x *KprobeTruncatedBytes) String() string {
 func (*KprobeTruncatedBytes) ProtoMessage() {}
 
 func (x *KprobeTruncatedBytes) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[16]
+	mi := &file_tetragon_tetragon_proto_msgTypes[18]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1931,7 +2057,7 @@ func (x *KprobeTruncatedBytes) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeTruncatedBytes.ProtoReflect.Descriptor instead.
 func (*KprobeTruncatedBytes) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{16}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *KprobeTruncatedBytes) GetBytesArg() []byte {
@@ -1961,7 +2087,7 @@ type KprobeCred struct {
 func (x *KprobeCred) Reset() {
 	*x = KprobeCred{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[17]
+		mi := &file_tetragon_tetragon_proto_msgTypes[19]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1974,7 +2100,7 @@ func (x *KprobeCred) String() string {
 func (*KprobeCred) ProtoMessage() {}
 
 func (x *KprobeCred) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[17]
+	mi := &file_tetragon_tetragon_proto_msgTypes[19]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1987,7 +2113,7 @@ func (x *KprobeCred) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeCred.ProtoReflect.Descriptor instead.
 func (*KprobeCred) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{17}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *KprobeCred) GetPermitted() []CapabilitiesType {
@@ -2023,7 +2149,7 @@ type KprobeCapability struct {
 func (x *KprobeCapability) Reset() {
 	*x = KprobeCapability{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[18]
+		mi := &file_tetragon_tetragon_proto_msgTypes[20]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2036,7 +2162,7 @@ func (x *KprobeCapability) String() string {
 func (*KprobeCapability) ProtoMessage() {}
 
 func (x *KprobeCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[18]
+	mi := &file_tetragon_tetragon_proto_msgTypes[20]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2049,7 +2175,7 @@ func (x *KprobeCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeCapability.ProtoReflect.Descriptor instead.
 func (*KprobeCapability) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{18}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *KprobeCapability) GetValue() *wrapperspb.Int32Value {
@@ -2080,7 +2206,7 @@ type KprobeUserNamespace struct {
 func (x *KprobeUserNamespace) Reset() {
 	*x = KprobeUserNamespace{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[19]
+		mi := &file_tetragon_tetragon_proto_msgTypes[21]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2093,7 +2219,7 @@ func (x *KprobeUserNamespace) String() string {
 func (*KprobeUserNamespace) ProtoMessage() {}
 
 func (x *KprobeUserNamespace) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[19]
+	mi := &file_tetragon_tetragon_proto_msgTypes[21]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2106,7 +2232,7 @@ func (x *KprobeUserNamespace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeUserNamespace.ProtoReflect.Descriptor instead.
 func (*KprobeUserNamespace) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{19}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *KprobeUserNamespace) GetLevel() *wrapperspb.Int32Value {
@@ -2150,7 +2276,7 @@ type KprobeBpfAttr struct {
 func (x *KprobeBpfAttr) Reset() {
 	*x = KprobeBpfAttr{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[20]
+		mi := &file_tetragon_tetragon_proto_msgTypes[22]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2163,7 +2289,7 @@ func (x *KprobeBpfAttr) String() string {
 func (*KprobeBpfAttr) ProtoMessage() {}
 
 func (x *KprobeBpfAttr) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[20]
+	mi := &file_tetragon_tetragon_proto_msgTypes[22]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2176,7 +2302,7 @@ func (x *KprobeBpfAttr) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeBpfAttr.ProtoReflect.Descriptor instead.
 func (*KprobeBpfAttr) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{20}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *KprobeBpfAttr) GetProgType() string {
@@ -2214,7 +2340,7 @@ type KprobePerfEvent struct {
 func (x *KprobePerfEvent) Reset() {
 	*x = KprobePerfEvent{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[21]
+		mi := &file_tetragon_tetragon_proto_msgTypes[23]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2227,7 +2353,7 @@ func (x *KprobePerfEvent) String() string {
 func (*KprobePerfEvent) ProtoMessage() {}
 
 func (x *KprobePerfEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[21]
+	mi := &file_tetragon_tetragon_proto_msgTypes[23]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2240,7 +2366,7 @@ func (x *KprobePerfEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobePerfEvent.ProtoReflect.Descriptor instead.
 func (*KprobePerfEvent) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{21}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *KprobePerfEvent) GetKprobeFunc() string {
@@ -2286,7 +2412,7 @@ type KprobeBpfMap struct {
 func (x *KprobeBpfMap) Reset() {
 	*x = KprobeBpfMap{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[22]
+		mi := &file_tetragon_tetragon_proto_msgTypes[24]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2299,7 +2425,7 @@ func (x *KprobeBpfMap) String() string {
 func (*KprobeBpfMap) ProtoMessage() {}
 
 func (x *KprobeBpfMap) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[22]
+	mi := &file_tetragon_tetragon_proto_msgTypes[24]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2312,7 +2438,7 @@ func (x *KprobeBpfMap) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeBpfMap.ProtoReflect.Descriptor instead.
 func (*KprobeBpfMap) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{22}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *KprobeBpfMap) GetMapType() string {
@@ -2384,7 +2510,7 @@ type KprobeArgument struct {
 func (x *KprobeArgument) Reset() {
 	*x = KprobeArgument{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[23]
+		mi := &file_tetragon_tetragon_proto_msgTypes[25]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2397,7 +2523,7 @@ func (x *KprobeArgument) String() string {
 func (*KprobeArgument) ProtoMessage() {}
 
 func (x *KprobeArgument) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[23]
+	mi := &file_tetragon_tetragon_proto_msgTypes[25]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2410,7 +2536,7 @@ func (x *KprobeArgument) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KprobeArgument.ProtoReflect.Descriptor instead.
 func (*KprobeArgument) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{23}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{25}
 }
 
 func (m *KprobeArgument) GetArg() isKprobeArgument_Arg {
@@ -2723,7 +2849,7 @@ type ProcessKprobe struct {
 func (x *ProcessKprobe) Reset() {
 	*x = ProcessKprobe{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[24]
+		mi := &file_tetragon_tetragon_proto_msgTypes[26]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2736,7 +2862,7 @@ func (x *ProcessKprobe) String() string {
 func (*ProcessKprobe) ProtoMessage() {}
 
 func (x *ProcessKprobe) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[24]
+	mi := &file_tetragon_tetragon_proto_msgTypes[26]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2749,7 +2875,7 @@ func (x *ProcessKprobe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessKprobe.ProtoReflect.Descriptor instead.
 func (*ProcessKprobe) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{24}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ProcessKprobe) GetProcess() *Process {
@@ -2849,7 +2975,7 @@ type ProcessTracepoint struct {
 func (x *ProcessTracepoint) Reset() {
 	*x = ProcessTracepoint{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[25]
+		mi := &file_tetragon_tetragon_proto_msgTypes[27]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2862,7 +2988,7 @@ func (x *ProcessTracepoint) String() string {
 func (*ProcessTracepoint) ProtoMessage() {}
 
 func (x *ProcessTracepoint) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[25]
+	mi := &file_tetragon_tetragon_proto_msgTypes[27]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2875,7 +3001,7 @@ func (x *ProcessTracepoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessTracepoint.ProtoReflect.Descriptor instead.
 func (*ProcessTracepoint) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{25}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ProcessTracepoint) GetProcess() *Process {
@@ -2954,7 +3080,7 @@ type ProcessUprobe struct {
 func (x *ProcessUprobe) Reset() {
 	*x = ProcessUprobe{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[26]
+		mi := &file_tetragon_tetragon_proto_msgTypes[28]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2967,7 +3093,7 @@ func (x *ProcessUprobe) String() string {
 func (*ProcessUprobe) ProtoMessage() {}
 
 func (x *ProcessUprobe) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[26]
+	mi := &file_tetragon_tetragon_proto_msgTypes[28]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2980,7 +3106,7 @@ func (x *ProcessUprobe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessUprobe.ProtoReflect.Descriptor instead.
 func (*ProcessUprobe) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{26}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ProcessUprobe) GetProcess() *Process {
@@ -3049,7 +3175,7 @@ type KernelModule struct {
 func (x *KernelModule) Reset() {
 	*x = KernelModule{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[27]
+		mi := &file_tetragon_tetragon_proto_msgTypes[29]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3062,7 +3188,7 @@ func (x *KernelModule) String() string {
 func (*KernelModule) ProtoMessage() {}
 
 func (x *KernelModule) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[27]
+	mi := &file_tetragon_tetragon_proto_msgTypes[29]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3075,7 +3201,7 @@ func (x *KernelModule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KernelModule.ProtoReflect.Descriptor instead.
 func (*KernelModule) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{27}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *KernelModule) GetName() string {
@@ -3113,7 +3239,7 @@ type Test struct {
 func (x *Test) Reset() {
 	*x = Test{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[28]
+		mi := &file_tetragon_tetragon_proto_msgTypes[30]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3126,7 +3252,7 @@ func (x *Test) String() string {
 func (*Test) ProtoMessage() {}
 
 func (x *Test) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[28]
+	mi := &file_tetragon_tetragon_proto_msgTypes[30]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3139,7 +3265,7 @@ func (x *Test) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Test.ProtoReflect.Descriptor instead.
 func (*Test) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{28}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *Test) GetArg0() uint64 {
@@ -3181,7 +3307,7 @@ type GetHealthStatusRequest struct {
 func (x *GetHealthStatusRequest) Reset() {
 	*x = GetHealthStatusRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[29]
+		mi := &file_tetragon_tetragon_proto_msgTypes[31]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3194,7 +3320,7 @@ func (x *GetHealthStatusRequest) String() string {
 func (*GetHealthStatusRequest) ProtoMessage() {}
 
 func (x *GetHealthStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[29]
+	mi := &file_tetragon_tetragon_proto_msgTypes[31]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3207,7 +3333,7 @@ func (x *GetHealthStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHealthStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetHealthStatusRequest) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{29}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetHealthStatusRequest) GetEventSet() []HealthStatusType {
@@ -3230,7 +3356,7 @@ type HealthStatus struct {
 func (x *HealthStatus) Reset() {
 	*x = HealthStatus{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[30]
+		mi := &file_tetragon_tetragon_proto_msgTypes[32]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3243,7 +3369,7 @@ func (x *HealthStatus) String() string {
 func (*HealthStatus) ProtoMessage() {}
 
 func (x *HealthStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[30]
+	mi := &file_tetragon_tetragon_proto_msgTypes[32]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3256,7 +3382,7 @@ func (x *HealthStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthStatus.ProtoReflect.Descriptor instead.
 func (*HealthStatus) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{30}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *HealthStatus) GetEvent() HealthStatusType {
@@ -3291,7 +3417,7 @@ type GetHealthStatusResponse struct {
 func (x *GetHealthStatusResponse) Reset() {
 	*x = GetHealthStatusResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[31]
+		mi := &file_tetragon_tetragon_proto_msgTypes[33]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3304,7 +3430,7 @@ func (x *GetHealthStatusResponse) String() string {
 func (*GetHealthStatusResponse) ProtoMessage() {}
 
 func (x *GetHealthStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[31]
+	mi := &file_tetragon_tetragon_proto_msgTypes[33]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3317,7 +3443,7 @@ func (x *GetHealthStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetHealthStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetHealthStatusResponse) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{31}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetHealthStatusResponse) GetHealthStatus() []*HealthStatus {
@@ -3341,7 +3467,7 @@ type ProcessLoader struct {
 func (x *ProcessLoader) Reset() {
 	*x = ProcessLoader{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[32]
+		mi := &file_tetragon_tetragon_proto_msgTypes[34]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3354,7 +3480,7 @@ func (x *ProcessLoader) String() string {
 func (*ProcessLoader) ProtoMessage() {}
 
 func (x *ProcessLoader) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[32]
+	mi := &file_tetragon_tetragon_proto_msgTypes[34]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3367,7 +3493,7 @@ func (x *ProcessLoader) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessLoader.ProtoReflect.Descriptor instead.
 func (*ProcessLoader) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{32}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ProcessLoader) GetProcess() *Process {
@@ -3406,7 +3532,7 @@ type RuntimeHookRequest struct {
 func (x *RuntimeHookRequest) Reset() {
 	*x = RuntimeHookRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[33]
+		mi := &file_tetragon_tetragon_proto_msgTypes[35]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3419,7 +3545,7 @@ func (x *RuntimeHookRequest) String() string {
 func (*RuntimeHookRequest) ProtoMessage() {}
 
 func (x *RuntimeHookRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[33]
+	mi := &file_tetragon_tetragon_proto_msgTypes[35]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3432,7 +3558,7 @@ func (x *RuntimeHookRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeHookRequest.ProtoReflect.Descriptor instead.
 func (*RuntimeHookRequest) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{33}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{35}
 }
 
 func (m *RuntimeHookRequest) GetEvent() isRuntimeHookRequest_Event {
@@ -3468,7 +3594,7 @@ type RuntimeHookResponse struct {
 func (x *RuntimeHookResponse) Reset() {
 	*x = RuntimeHookResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[34]
+		mi := &file_tetragon_tetragon_proto_msgTypes[36]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3481,7 +3607,7 @@ func (x *RuntimeHookResponse) String() string {
 func (*RuntimeHookResponse) ProtoMessage() {}
 
 func (x *RuntimeHookResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[34]
+	mi := &file_tetragon_tetragon_proto_msgTypes[36]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3494,7 +3620,7 @@ func (x *RuntimeHookResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeHookResponse.ProtoReflect.Descriptor instead.
 func (*RuntimeHookResponse) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{34}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{36}
 }
 
 // CreateContainer informs the agent that a container was created
@@ -3520,7 +3646,7 @@ type CreateContainer struct {
 func (x *CreateContainer) Reset() {
 	*x = CreateContainer{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[35]
+		mi := &file_tetragon_tetragon_proto_msgTypes[37]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3533,7 +3659,7 @@ func (x *CreateContainer) String() string {
 func (*CreateContainer) ProtoMessage() {}
 
 func (x *CreateContainer) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[35]
+	mi := &file_tetragon_tetragon_proto_msgTypes[37]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3546,7 +3672,7 @@ func (x *CreateContainer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateContainer.ProtoReflect.Descriptor instead.
 func (*CreateContainer) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{35}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CreateContainer) GetCgroupsPath() string {
@@ -3586,7 +3712,7 @@ type StackTraceEntry struct {
 func (x *StackTraceEntry) Reset() {
 	*x = StackTraceEntry{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tetragon_tetragon_proto_msgTypes[36]
+		mi := &file_tetragon_tetragon_proto_msgTypes[38]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3599,7 +3725,7 @@ func (x *StackTraceEntry) String() string {
 func (*StackTraceEntry) ProtoMessage() {}
 
 func (x *StackTraceEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_tetragon_tetragon_proto_msgTypes[36]
+	mi := &file_tetragon_tetragon_proto_msgTypes[38]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3612,7 +3738,7 @@ func (x *StackTraceEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StackTraceEntry.ProtoReflect.Descriptor instead.
 func (*StackTraceEntry) Descriptor() ([]byte, []int) {
-	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{36}
+	return file_tetragon_tetragon_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *StackTraceEntry) GetAddress() uint64 {
@@ -3776,20 +3902,33 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x74, 0x69, 0x65, 0x73, 0x52, 0x04, 0x63, 0x61, 0x70, 0x73, 0x12, 0x30, 0x0a, 0x07, 0x75, 0x73,
 	0x65, 0x72, 0x5f, 0x6e, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x17, 0x2e, 0x74, 0x65,
 	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x55, 0x73, 0x65, 0x72, 0x4e, 0x61, 0x6d, 0x65, 0x73,
-	0x70, 0x61, 0x63, 0x65, 0x52, 0x06, 0x75, 0x73, 0x65, 0x72, 0x4e, 0x73, 0x22, 0xd1, 0x01, 0x0a,
-	0x10, 0x42, 0x69, 0x6e, 0x61, 0x72, 0x79, 0x50, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x69, 0x65,
-	0x73, 0x12, 0x34, 0x0a, 0x06, 0x73, 0x65, 0x74, 0x75, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
-	0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
-	0x62, 0x75, 0x66, 0x2e, 0x55, 0x49, 0x6e, 0x74, 0x33, 0x32, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52,
-	0x06, 0x73, 0x65, 0x74, 0x75, 0x69, 0x64, 0x12, 0x34, 0x0a, 0x06, 0x73, 0x65, 0x74, 0x67, 0x69,
-	0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
-	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x49, 0x6e, 0x74, 0x33, 0x32,
-	0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x06, 0x73, 0x65, 0x74, 0x67, 0x69, 0x64, 0x12, 0x51, 0x0a,
-	0x12, 0x70, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x5f, 0x63, 0x68, 0x61, 0x6e,
-	0x67, 0x65, 0x64, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x22, 0x2e, 0x74, 0x65, 0x74, 0x72,
-	0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x50, 0x72, 0x69, 0x76,
-	0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x64, 0x52, 0x11, 0x70,
-	0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x64,
+	0x70, 0x61, 0x63, 0x65, 0x52, 0x06, 0x75, 0x73, 0x65, 0x72, 0x4e, 0x73, 0x22, 0x53, 0x0a, 0x05,
+	0x49, 0x6e, 0x6f, 0x64, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x06, 0x6e, 0x75, 0x6d, 0x62, 0x65, 0x72, 0x12, 0x32, 0x0a,
+	0x05, 0x6c, 0x69, 0x6e, 0x6b, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67,
+	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55,
+	0x49, 0x6e, 0x74, 0x33, 0x32, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x05, 0x6c, 0x69, 0x6e, 0x6b,
+	0x73, 0x22, 0x4b, 0x0a, 0x0e, 0x46, 0x69, 0x6c, 0x65, 0x50, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74,
+	0x69, 0x65, 0x73, 0x12, 0x25, 0x0a, 0x05, 0x69, 0x6e, 0x6f, 0x64, 0x65, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x0b, 0x32, 0x0f, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x49, 0x6e,
+	0x6f, 0x64, 0x65, 0x52, 0x05, 0x69, 0x6e, 0x6f, 0x64, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x70, 0x61,
+	0x74, 0x68, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x22, 0xff,
+	0x01, 0x0a, 0x10, 0x42, 0x69, 0x6e, 0x61, 0x72, 0x79, 0x50, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74,
+	0x69, 0x65, 0x73, 0x12, 0x34, 0x0a, 0x06, 0x73, 0x65, 0x74, 0x75, 0x69, 0x64, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x49, 0x6e, 0x74, 0x33, 0x32, 0x56, 0x61, 0x6c, 0x75,
+	0x65, 0x52, 0x06, 0x73, 0x65, 0x74, 0x75, 0x69, 0x64, 0x12, 0x34, 0x0a, 0x06, 0x73, 0x65, 0x74,
+	0x67, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67,
+	0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x55, 0x49, 0x6e, 0x74,
+	0x33, 0x32, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x06, 0x73, 0x65, 0x74, 0x67, 0x69, 0x64, 0x12,
+	0x51, 0x0a, 0x12, 0x70, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x5f, 0x63, 0x68,
+	0x61, 0x6e, 0x67, 0x65, 0x64, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0e, 0x32, 0x22, 0x2e, 0x74, 0x65,
+	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x50, 0x72,
+	0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x64, 0x52,
+	0x11, 0x70, 0x72, 0x69, 0x76, 0x69, 0x6c, 0x65, 0x67, 0x65, 0x73, 0x43, 0x68, 0x61, 0x6e, 0x67,
+	0x65, 0x64, 0x12, 0x2c, 0x0a, 0x04, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x18, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x46, 0x69, 0x6c, 0x65,
+	0x50, 0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x69, 0x65, 0x73, 0x52, 0x04, 0x66, 0x69, 0x6c, 0x65,
 	0x22, 0xdc, 0x05, 0x0a, 0x07, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x12, 0x17, 0x0a, 0x07,
 	0x65, 0x78, 0x65, 0x63, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x65,
 	0x78, 0x65, 0x63, 0x49, 0x64, 0x12, 0x2e, 0x0a, 0x03, 0x70, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01,
@@ -4240,7 +4379,7 @@ func file_tetragon_tetragon_proto_rawDescGZIP() []byte {
 }
 
 var file_tetragon_tetragon_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_tetragon_tetragon_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
+var file_tetragon_tetragon_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_tetragon_tetragon_proto_goTypes = []interface{}{
 	(KprobeAction)(0),               // 0: tetragon.KprobeAction
 	(HealthStatusType)(0),           // 1: tetragon.HealthStatusType
@@ -4254,148 +4393,153 @@ var file_tetragon_tetragon_proto_goTypes = []interface{}{
 	(*Namespaces)(nil),              // 9: tetragon.Namespaces
 	(*UserNamespace)(nil),           // 10: tetragon.UserNamespace
 	(*ProcessCredentials)(nil),      // 11: tetragon.ProcessCredentials
-	(*BinaryProperties)(nil),        // 12: tetragon.BinaryProperties
-	(*Process)(nil),                 // 13: tetragon.Process
-	(*ProcessExec)(nil),             // 14: tetragon.ProcessExec
-	(*ProcessExit)(nil),             // 15: tetragon.ProcessExit
-	(*KprobeSock)(nil),              // 16: tetragon.KprobeSock
-	(*KprobeSkb)(nil),               // 17: tetragon.KprobeSkb
-	(*KprobePath)(nil),              // 18: tetragon.KprobePath
-	(*KprobeFile)(nil),              // 19: tetragon.KprobeFile
-	(*KprobeTruncatedBytes)(nil),    // 20: tetragon.KprobeTruncatedBytes
-	(*KprobeCred)(nil),              // 21: tetragon.KprobeCred
-	(*KprobeCapability)(nil),        // 22: tetragon.KprobeCapability
-	(*KprobeUserNamespace)(nil),     // 23: tetragon.KprobeUserNamespace
-	(*KprobeBpfAttr)(nil),           // 24: tetragon.KprobeBpfAttr
-	(*KprobePerfEvent)(nil),         // 25: tetragon.KprobePerfEvent
-	(*KprobeBpfMap)(nil),            // 26: tetragon.KprobeBpfMap
-	(*KprobeArgument)(nil),          // 27: tetragon.KprobeArgument
-	(*ProcessKprobe)(nil),           // 28: tetragon.ProcessKprobe
-	(*ProcessTracepoint)(nil),       // 29: tetragon.ProcessTracepoint
-	(*ProcessUprobe)(nil),           // 30: tetragon.ProcessUprobe
-	(*KernelModule)(nil),            // 31: tetragon.KernelModule
-	(*Test)(nil),                    // 32: tetragon.Test
-	(*GetHealthStatusRequest)(nil),  // 33: tetragon.GetHealthStatusRequest
-	(*HealthStatus)(nil),            // 34: tetragon.HealthStatus
-	(*GetHealthStatusResponse)(nil), // 35: tetragon.GetHealthStatusResponse
-	(*ProcessLoader)(nil),           // 36: tetragon.ProcessLoader
-	(*RuntimeHookRequest)(nil),      // 37: tetragon.RuntimeHookRequest
-	(*RuntimeHookResponse)(nil),     // 38: tetragon.RuntimeHookResponse
-	(*CreateContainer)(nil),         // 39: tetragon.CreateContainer
-	(*StackTraceEntry)(nil),         // 40: tetragon.StackTraceEntry
-	nil,                             // 41: tetragon.Pod.PodLabelsEntry
-	nil,                             // 42: tetragon.CreateContainer.AnnotationsEntry
-	(*timestamppb.Timestamp)(nil),   // 43: google.protobuf.Timestamp
-	(*wrapperspb.UInt32Value)(nil),  // 44: google.protobuf.UInt32Value
-	(CapabilitiesType)(0),           // 45: tetragon.CapabilitiesType
-	(*wrapperspb.Int32Value)(nil),   // 46: google.protobuf.Int32Value
-	(SecureBitsType)(0),             // 47: tetragon.SecureBitsType
-	(ProcessPrivilegesChanged)(0),   // 48: tetragon.ProcessPrivilegesChanged
-	(*wrapperspb.BoolValue)(nil),    // 49: google.protobuf.BoolValue
+	(*Inode)(nil),                   // 12: tetragon.Inode
+	(*FileProperties)(nil),          // 13: tetragon.FileProperties
+	(*BinaryProperties)(nil),        // 14: tetragon.BinaryProperties
+	(*Process)(nil),                 // 15: tetragon.Process
+	(*ProcessExec)(nil),             // 16: tetragon.ProcessExec
+	(*ProcessExit)(nil),             // 17: tetragon.ProcessExit
+	(*KprobeSock)(nil),              // 18: tetragon.KprobeSock
+	(*KprobeSkb)(nil),               // 19: tetragon.KprobeSkb
+	(*KprobePath)(nil),              // 20: tetragon.KprobePath
+	(*KprobeFile)(nil),              // 21: tetragon.KprobeFile
+	(*KprobeTruncatedBytes)(nil),    // 22: tetragon.KprobeTruncatedBytes
+	(*KprobeCred)(nil),              // 23: tetragon.KprobeCred
+	(*KprobeCapability)(nil),        // 24: tetragon.KprobeCapability
+	(*KprobeUserNamespace)(nil),     // 25: tetragon.KprobeUserNamespace
+	(*KprobeBpfAttr)(nil),           // 26: tetragon.KprobeBpfAttr
+	(*KprobePerfEvent)(nil),         // 27: tetragon.KprobePerfEvent
+	(*KprobeBpfMap)(nil),            // 28: tetragon.KprobeBpfMap
+	(*KprobeArgument)(nil),          // 29: tetragon.KprobeArgument
+	(*ProcessKprobe)(nil),           // 30: tetragon.ProcessKprobe
+	(*ProcessTracepoint)(nil),       // 31: tetragon.ProcessTracepoint
+	(*ProcessUprobe)(nil),           // 32: tetragon.ProcessUprobe
+	(*KernelModule)(nil),            // 33: tetragon.KernelModule
+	(*Test)(nil),                    // 34: tetragon.Test
+	(*GetHealthStatusRequest)(nil),  // 35: tetragon.GetHealthStatusRequest
+	(*HealthStatus)(nil),            // 36: tetragon.HealthStatus
+	(*GetHealthStatusResponse)(nil), // 37: tetragon.GetHealthStatusResponse
+	(*ProcessLoader)(nil),           // 38: tetragon.ProcessLoader
+	(*RuntimeHookRequest)(nil),      // 39: tetragon.RuntimeHookRequest
+	(*RuntimeHookResponse)(nil),     // 40: tetragon.RuntimeHookResponse
+	(*CreateContainer)(nil),         // 41: tetragon.CreateContainer
+	(*StackTraceEntry)(nil),         // 42: tetragon.StackTraceEntry
+	nil,                             // 43: tetragon.Pod.PodLabelsEntry
+	nil,                             // 44: tetragon.CreateContainer.AnnotationsEntry
+	(*timestamppb.Timestamp)(nil),   // 45: google.protobuf.Timestamp
+	(*wrapperspb.UInt32Value)(nil),  // 46: google.protobuf.UInt32Value
+	(CapabilitiesType)(0),           // 47: tetragon.CapabilitiesType
+	(*wrapperspb.Int32Value)(nil),   // 48: google.protobuf.Int32Value
+	(SecureBitsType)(0),             // 49: tetragon.SecureBitsType
+	(ProcessPrivilegesChanged)(0),   // 50: tetragon.ProcessPrivilegesChanged
+	(*wrapperspb.BoolValue)(nil),    // 51: google.protobuf.BoolValue
 }
 var file_tetragon_tetragon_proto_depIdxs = []int32{
-	4,  // 0: tetragon.Container.image:type_name -> tetragon.Image
-	43, // 1: tetragon.Container.start_time:type_name -> google.protobuf.Timestamp
-	44, // 2: tetragon.Container.pid:type_name -> google.protobuf.UInt32Value
-	5,  // 3: tetragon.Pod.container:type_name -> tetragon.Container
-	41, // 4: tetragon.Pod.pod_labels:type_name -> tetragon.Pod.PodLabelsEntry
-	45, // 5: tetragon.Capabilities.permitted:type_name -> tetragon.CapabilitiesType
-	45, // 6: tetragon.Capabilities.effective:type_name -> tetragon.CapabilitiesType
-	45, // 7: tetragon.Capabilities.inheritable:type_name -> tetragon.CapabilitiesType
-	8,  // 8: tetragon.Namespaces.uts:type_name -> tetragon.Namespace
-	8,  // 9: tetragon.Namespaces.ipc:type_name -> tetragon.Namespace
-	8,  // 10: tetragon.Namespaces.mnt:type_name -> tetragon.Namespace
-	8,  // 11: tetragon.Namespaces.pid:type_name -> tetragon.Namespace
-	8,  // 12: tetragon.Namespaces.pid_for_children:type_name -> tetragon.Namespace
-	8,  // 13: tetragon.Namespaces.net:type_name -> tetragon.Namespace
-	8,  // 14: tetragon.Namespaces.time:type_name -> tetragon.Namespace
-	8,  // 15: tetragon.Namespaces.time_for_children:type_name -> tetragon.Namespace
-	8,  // 16: tetragon.Namespaces.cgroup:type_name -> tetragon.Namespace
-	8,  // 17: tetragon.Namespaces.user:type_name -> tetragon.Namespace
-	46, // 18: tetragon.UserNamespace.level:type_name -> google.protobuf.Int32Value
-	44, // 19: tetragon.UserNamespace.uid:type_name -> google.protobuf.UInt32Value
-	44, // 20: tetragon.UserNamespace.gid:type_name -> google.protobuf.UInt32Value
-	8,  // 21: tetragon.UserNamespace.ns:type_name -> tetragon.Namespace
-	44, // 22: tetragon.ProcessCredentials.uid:type_name -> google.protobuf.UInt32Value
-	44, // 23: tetragon.ProcessCredentials.gid:type_name -> google.protobuf.UInt32Value
-	44, // 24: tetragon.ProcessCredentials.euid:type_name -> google.protobuf.UInt32Value
-	44, // 25: tetragon.ProcessCredentials.egid:type_name -> google.protobuf.UInt32Value
-	44, // 26: tetragon.ProcessCredentials.suid:type_name -> google.protobuf.UInt32Value
-	44, // 27: tetragon.ProcessCredentials.sgid:type_name -> google.protobuf.UInt32Value
-	44, // 28: tetragon.ProcessCredentials.fsuid:type_name -> google.protobuf.UInt32Value
-	44, // 29: tetragon.ProcessCredentials.fsgid:type_name -> google.protobuf.UInt32Value
-	47, // 30: tetragon.ProcessCredentials.securebits:type_name -> tetragon.SecureBitsType
-	7,  // 31: tetragon.ProcessCredentials.caps:type_name -> tetragon.Capabilities
-	10, // 32: tetragon.ProcessCredentials.user_ns:type_name -> tetragon.UserNamespace
-	44, // 33: tetragon.BinaryProperties.setuid:type_name -> google.protobuf.UInt32Value
-	44, // 34: tetragon.BinaryProperties.setgid:type_name -> google.protobuf.UInt32Value
-	48, // 35: tetragon.BinaryProperties.privileges_changed:type_name -> tetragon.ProcessPrivilegesChanged
-	44, // 36: tetragon.Process.pid:type_name -> google.protobuf.UInt32Value
-	44, // 37: tetragon.Process.uid:type_name -> google.protobuf.UInt32Value
-	43, // 38: tetragon.Process.start_time:type_name -> google.protobuf.Timestamp
-	44, // 39: tetragon.Process.auid:type_name -> google.protobuf.UInt32Value
-	6,  // 40: tetragon.Process.pod:type_name -> tetragon.Pod
-	7,  // 41: tetragon.Process.cap:type_name -> tetragon.Capabilities
-	9,  // 42: tetragon.Process.ns:type_name -> tetragon.Namespaces
-	44, // 43: tetragon.Process.tid:type_name -> google.protobuf.UInt32Value
-	11, // 44: tetragon.Process.process_credentials:type_name -> tetragon.ProcessCredentials
-	12, // 45: tetragon.Process.binary_properties:type_name -> tetragon.BinaryProperties
-	13, // 46: tetragon.ProcessExec.process:type_name -> tetragon.Process
-	13, // 47: tetragon.ProcessExec.parent:type_name -> tetragon.Process
-	13, // 48: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
-	13, // 49: tetragon.ProcessExit.process:type_name -> tetragon.Process
-	13, // 50: tetragon.ProcessExit.parent:type_name -> tetragon.Process
-	43, // 51: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
-	45, // 52: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
-	45, // 53: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
-	45, // 54: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
-	46, // 55: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
-	46, // 56: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
-	44, // 57: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
-	44, // 58: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
-	8,  // 59: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
-	17, // 60: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
-	18, // 61: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
-	19, // 62: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
-	20, // 63: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
-	16, // 64: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
-	21, // 65: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
-	24, // 66: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
-	25, // 67: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
-	26, // 68: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
-	23, // 69: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
-	22, // 70: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
-	11, // 71: tetragon.KprobeArgument.process_credentials_arg:type_name -> tetragon.ProcessCredentials
-	10, // 72: tetragon.KprobeArgument.user_ns_arg:type_name -> tetragon.UserNamespace
-	31, // 73: tetragon.KprobeArgument.module_arg:type_name -> tetragon.KernelModule
-	13, // 74: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
-	13, // 75: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
-	27, // 76: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
-	27, // 77: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
-	0,  // 78: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
-	40, // 79: tetragon.ProcessKprobe.stack_trace:type_name -> tetragon.StackTraceEntry
-	0,  // 80: tetragon.ProcessKprobe.return_action:type_name -> tetragon.KprobeAction
-	13, // 81: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
-	13, // 82: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
-	27, // 83: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
-	0,  // 84: tetragon.ProcessTracepoint.action:type_name -> tetragon.KprobeAction
-	13, // 85: tetragon.ProcessUprobe.process:type_name -> tetragon.Process
-	13, // 86: tetragon.ProcessUprobe.parent:type_name -> tetragon.Process
-	27, // 87: tetragon.ProcessUprobe.args:type_name -> tetragon.KprobeArgument
-	49, // 88: tetragon.KernelModule.signature_ok:type_name -> google.protobuf.BoolValue
-	3,  // 89: tetragon.KernelModule.tainted:type_name -> tetragon.TaintedBitsType
-	1,  // 90: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
-	1,  // 91: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
-	2,  // 92: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
-	34, // 93: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
-	13, // 94: tetragon.ProcessLoader.process:type_name -> tetragon.Process
-	39, // 95: tetragon.RuntimeHookRequest.createContainer:type_name -> tetragon.CreateContainer
-	42, // 96: tetragon.CreateContainer.annotations:type_name -> tetragon.CreateContainer.AnnotationsEntry
-	97, // [97:97] is the sub-list for method output_type
-	97, // [97:97] is the sub-list for method input_type
-	97, // [97:97] is the sub-list for extension type_name
-	97, // [97:97] is the sub-list for extension extendee
-	0,  // [0:97] is the sub-list for field type_name
+	4,   // 0: tetragon.Container.image:type_name -> tetragon.Image
+	45,  // 1: tetragon.Container.start_time:type_name -> google.protobuf.Timestamp
+	46,  // 2: tetragon.Container.pid:type_name -> google.protobuf.UInt32Value
+	5,   // 3: tetragon.Pod.container:type_name -> tetragon.Container
+	43,  // 4: tetragon.Pod.pod_labels:type_name -> tetragon.Pod.PodLabelsEntry
+	47,  // 5: tetragon.Capabilities.permitted:type_name -> tetragon.CapabilitiesType
+	47,  // 6: tetragon.Capabilities.effective:type_name -> tetragon.CapabilitiesType
+	47,  // 7: tetragon.Capabilities.inheritable:type_name -> tetragon.CapabilitiesType
+	8,   // 8: tetragon.Namespaces.uts:type_name -> tetragon.Namespace
+	8,   // 9: tetragon.Namespaces.ipc:type_name -> tetragon.Namespace
+	8,   // 10: tetragon.Namespaces.mnt:type_name -> tetragon.Namespace
+	8,   // 11: tetragon.Namespaces.pid:type_name -> tetragon.Namespace
+	8,   // 12: tetragon.Namespaces.pid_for_children:type_name -> tetragon.Namespace
+	8,   // 13: tetragon.Namespaces.net:type_name -> tetragon.Namespace
+	8,   // 14: tetragon.Namespaces.time:type_name -> tetragon.Namespace
+	8,   // 15: tetragon.Namespaces.time_for_children:type_name -> tetragon.Namespace
+	8,   // 16: tetragon.Namespaces.cgroup:type_name -> tetragon.Namespace
+	8,   // 17: tetragon.Namespaces.user:type_name -> tetragon.Namespace
+	48,  // 18: tetragon.UserNamespace.level:type_name -> google.protobuf.Int32Value
+	46,  // 19: tetragon.UserNamespace.uid:type_name -> google.protobuf.UInt32Value
+	46,  // 20: tetragon.UserNamespace.gid:type_name -> google.protobuf.UInt32Value
+	8,   // 21: tetragon.UserNamespace.ns:type_name -> tetragon.Namespace
+	46,  // 22: tetragon.ProcessCredentials.uid:type_name -> google.protobuf.UInt32Value
+	46,  // 23: tetragon.ProcessCredentials.gid:type_name -> google.protobuf.UInt32Value
+	46,  // 24: tetragon.ProcessCredentials.euid:type_name -> google.protobuf.UInt32Value
+	46,  // 25: tetragon.ProcessCredentials.egid:type_name -> google.protobuf.UInt32Value
+	46,  // 26: tetragon.ProcessCredentials.suid:type_name -> google.protobuf.UInt32Value
+	46,  // 27: tetragon.ProcessCredentials.sgid:type_name -> google.protobuf.UInt32Value
+	46,  // 28: tetragon.ProcessCredentials.fsuid:type_name -> google.protobuf.UInt32Value
+	46,  // 29: tetragon.ProcessCredentials.fsgid:type_name -> google.protobuf.UInt32Value
+	49,  // 30: tetragon.ProcessCredentials.securebits:type_name -> tetragon.SecureBitsType
+	7,   // 31: tetragon.ProcessCredentials.caps:type_name -> tetragon.Capabilities
+	10,  // 32: tetragon.ProcessCredentials.user_ns:type_name -> tetragon.UserNamespace
+	46,  // 33: tetragon.Inode.links:type_name -> google.protobuf.UInt32Value
+	12,  // 34: tetragon.FileProperties.inode:type_name -> tetragon.Inode
+	46,  // 35: tetragon.BinaryProperties.setuid:type_name -> google.protobuf.UInt32Value
+	46,  // 36: tetragon.BinaryProperties.setgid:type_name -> google.protobuf.UInt32Value
+	50,  // 37: tetragon.BinaryProperties.privileges_changed:type_name -> tetragon.ProcessPrivilegesChanged
+	13,  // 38: tetragon.BinaryProperties.file:type_name -> tetragon.FileProperties
+	46,  // 39: tetragon.Process.pid:type_name -> google.protobuf.UInt32Value
+	46,  // 40: tetragon.Process.uid:type_name -> google.protobuf.UInt32Value
+	45,  // 41: tetragon.Process.start_time:type_name -> google.protobuf.Timestamp
+	46,  // 42: tetragon.Process.auid:type_name -> google.protobuf.UInt32Value
+	6,   // 43: tetragon.Process.pod:type_name -> tetragon.Pod
+	7,   // 44: tetragon.Process.cap:type_name -> tetragon.Capabilities
+	9,   // 45: tetragon.Process.ns:type_name -> tetragon.Namespaces
+	46,  // 46: tetragon.Process.tid:type_name -> google.protobuf.UInt32Value
+	11,  // 47: tetragon.Process.process_credentials:type_name -> tetragon.ProcessCredentials
+	14,  // 48: tetragon.Process.binary_properties:type_name -> tetragon.BinaryProperties
+	15,  // 49: tetragon.ProcessExec.process:type_name -> tetragon.Process
+	15,  // 50: tetragon.ProcessExec.parent:type_name -> tetragon.Process
+	15,  // 51: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
+	15,  // 52: tetragon.ProcessExit.process:type_name -> tetragon.Process
+	15,  // 53: tetragon.ProcessExit.parent:type_name -> tetragon.Process
+	45,  // 54: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
+	47,  // 55: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
+	47,  // 56: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
+	47,  // 57: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
+	48,  // 58: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
+	48,  // 59: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
+	46,  // 60: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
+	46,  // 61: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
+	8,   // 62: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
+	19,  // 63: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
+	20,  // 64: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
+	21,  // 65: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
+	22,  // 66: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
+	18,  // 67: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
+	23,  // 68: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
+	26,  // 69: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
+	27,  // 70: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
+	28,  // 71: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
+	25,  // 72: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
+	24,  // 73: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
+	11,  // 74: tetragon.KprobeArgument.process_credentials_arg:type_name -> tetragon.ProcessCredentials
+	10,  // 75: tetragon.KprobeArgument.user_ns_arg:type_name -> tetragon.UserNamespace
+	33,  // 76: tetragon.KprobeArgument.module_arg:type_name -> tetragon.KernelModule
+	15,  // 77: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
+	15,  // 78: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
+	29,  // 79: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
+	29,  // 80: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
+	0,   // 81: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
+	42,  // 82: tetragon.ProcessKprobe.stack_trace:type_name -> tetragon.StackTraceEntry
+	0,   // 83: tetragon.ProcessKprobe.return_action:type_name -> tetragon.KprobeAction
+	15,  // 84: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
+	15,  // 85: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
+	29,  // 86: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
+	0,   // 87: tetragon.ProcessTracepoint.action:type_name -> tetragon.KprobeAction
+	15,  // 88: tetragon.ProcessUprobe.process:type_name -> tetragon.Process
+	15,  // 89: tetragon.ProcessUprobe.parent:type_name -> tetragon.Process
+	29,  // 90: tetragon.ProcessUprobe.args:type_name -> tetragon.KprobeArgument
+	51,  // 91: tetragon.KernelModule.signature_ok:type_name -> google.protobuf.BoolValue
+	3,   // 92: tetragon.KernelModule.tainted:type_name -> tetragon.TaintedBitsType
+	1,   // 93: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
+	1,   // 94: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
+	2,   // 95: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
+	36,  // 96: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
+	15,  // 97: tetragon.ProcessLoader.process:type_name -> tetragon.Process
+	41,  // 98: tetragon.RuntimeHookRequest.createContainer:type_name -> tetragon.CreateContainer
+	44,  // 99: tetragon.CreateContainer.annotations:type_name -> tetragon.CreateContainer.AnnotationsEntry
+	100, // [100:100] is the sub-list for method output_type
+	100, // [100:100] is the sub-list for method input_type
+	100, // [100:100] is the sub-list for extension type_name
+	100, // [100:100] is the sub-list for extension extendee
+	0,   // [0:100] is the sub-list for field type_name
 }
 
 func init() { file_tetragon_tetragon_proto_init() }
@@ -4502,7 +4646,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*BinaryProperties); i {
+			switch v := v.(*Inode); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4514,7 +4658,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Process); i {
+			switch v := v.(*FileProperties); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4526,7 +4670,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessExec); i {
+			switch v := v.(*BinaryProperties); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4538,7 +4682,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessExit); i {
+			switch v := v.(*Process); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4550,7 +4694,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeSock); i {
+			switch v := v.(*ProcessExec); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4562,7 +4706,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeSkb); i {
+			switch v := v.(*ProcessExit); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4574,7 +4718,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobePath); i {
+			switch v := v.(*KprobeSock); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4586,7 +4730,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeFile); i {
+			switch v := v.(*KprobeSkb); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4598,7 +4742,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeTruncatedBytes); i {
+			switch v := v.(*KprobePath); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4610,7 +4754,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[17].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeCred); i {
+			switch v := v.(*KprobeFile); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4622,7 +4766,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeCapability); i {
+			switch v := v.(*KprobeTruncatedBytes); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4634,7 +4778,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeUserNamespace); i {
+			switch v := v.(*KprobeCred); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4646,7 +4790,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeBpfAttr); i {
+			switch v := v.(*KprobeCapability); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4658,7 +4802,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobePerfEvent); i {
+			switch v := v.(*KprobeUserNamespace); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4670,7 +4814,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeBpfMap); i {
+			switch v := v.(*KprobeBpfAttr); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4682,7 +4826,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KprobeArgument); i {
+			switch v := v.(*KprobePerfEvent); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4694,7 +4838,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessKprobe); i {
+			switch v := v.(*KprobeBpfMap); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4706,7 +4850,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessTracepoint); i {
+			switch v := v.(*KprobeArgument); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4718,7 +4862,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessUprobe); i {
+			switch v := v.(*ProcessKprobe); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4730,7 +4874,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*KernelModule); i {
+			switch v := v.(*ProcessTracepoint); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4742,7 +4886,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Test); i {
+			switch v := v.(*ProcessUprobe); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4754,7 +4898,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetHealthStatusRequest); i {
+			switch v := v.(*KernelModule); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4766,7 +4910,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*HealthStatus); i {
+			switch v := v.(*Test); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4778,7 +4922,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetHealthStatusResponse); i {
+			switch v := v.(*GetHealthStatusRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4790,7 +4934,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[32].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ProcessLoader); i {
+			switch v := v.(*HealthStatus); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4802,7 +4946,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[33].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RuntimeHookRequest); i {
+			switch v := v.(*GetHealthStatusResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4814,7 +4958,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[34].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RuntimeHookResponse); i {
+			switch v := v.(*ProcessLoader); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4826,7 +4970,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[35].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CreateContainer); i {
+			switch v := v.(*RuntimeHookRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -4838,6 +4982,30 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 		file_tetragon_tetragon_proto_msgTypes[36].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*RuntimeHookResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tetragon_tetragon_proto_msgTypes[37].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CreateContainer); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tetragon_tetragon_proto_msgTypes[38].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*StackTraceEntry); i {
 			case 0:
 				return &v.state
@@ -4850,7 +5018,7 @@ func file_tetragon_tetragon_proto_init() {
 			}
 		}
 	}
-	file_tetragon_tetragon_proto_msgTypes[23].OneofWrappers = []interface{}{
+	file_tetragon_tetragon_proto_msgTypes[25].OneofWrappers = []interface{}{
 		(*KprobeArgument_StringArg)(nil),
 		(*KprobeArgument_IntArg)(nil),
 		(*KprobeArgument_SkbArg)(nil),
@@ -4872,7 +5040,7 @@ func file_tetragon_tetragon_proto_init() {
 		(*KprobeArgument_UserNsArg)(nil),
 		(*KprobeArgument_ModuleArg)(nil),
 	}
-	file_tetragon_tetragon_proto_msgTypes[33].OneofWrappers = []interface{}{
+	file_tetragon_tetragon_proto_msgTypes[35].OneofWrappers = []interface{}{
 		(*RuntimeHookRequest_CreateContainer)(nil),
 	}
 	type x struct{}
@@ -4881,7 +5049,7 @@ func file_tetragon_tetragon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_tetragon_tetragon_proto_rawDesc,
 			NumEnums:      4,
-			NumMessages:   39,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.json.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.json.go
@@ -136,6 +136,38 @@ func (msg *ProcessCredentials) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
+func (msg *Inode) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseEnumNumbers:  false,
+		EmitUnpopulated: false,
+		UseProtoNames:   true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *Inode) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{
+		DiscardUnknown: false,
+	}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
+func (msg *FileProperties) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseEnumNumbers:  false,
+		EmitUnpopulated: false,
+		UseProtoNames:   true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *FileProperties) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{
+		DiscardUnknown: false,
+	}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
 func (msg *BinaryProperties) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseEnumNumbers:  false,

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
@@ -136,6 +136,20 @@ message ProcessCredentials {
 	UserNamespace user_ns = 11;
 }
 
+message Inode {
+	// The inode number
+	uint64 number = 1;
+	// The inode links on the file system. If zero means the file is only in memory
+	google.protobuf.UInt32Value links = 2;
+}
+
+message FileProperties {
+	// Inode of the file
+	Inode inode = 1;
+	// Path of the file
+	string path = 2;
+}
+
 message BinaryProperties {
 	// If set then this is the set user ID used for execution
 	google.protobuf.UInt32Value setuid = 1;
@@ -145,6 +159,11 @@ message BinaryProperties {
 	// a binary with the set-user-ID to root or file capability sets.
 	// The final granted privileges can be listed inside the `process_credentials` or capabilities fields part of of the `process` object.
 	repeated ProcessPrivilegesChanged privileges_changed = 3;
+	// File properties in case the executed binary is:
+	// 1. An anonymous shared memory file https://man7.org/linux/man-pages/man7/shm_overview.7.html.
+	// 2. An anonymous file obtained with memfd API https://man7.org/linux/man-pages/man2/memfd_create.2.html.
+	// 3. Or it was deleted from the file system.
+	FileProperties file = 4;
 }
 
 message Process {


### PR DESCRIPTION
Detect execution of anonymous binaries, these are binaries that are not linked on a filesystem, where nlink is zero.

1. An anonymous shared memory file
       https://man7.org/linux/man-pages/man7/shm_overview.7.html.
2. An anonymous file obtained with memfd API
       https://man7.org/linux/man-pages/man2/memfd_create.2.html.
3. Or it was deleted from the file system.

```
"process_exec": {
   "process": {
      "binary_properties": {
        "file": {
           "inode": {
              "number": "182698",
              "links": 0
            }
         }
      }
   }
}
```