### PR TITLE
server: drop events if listener channel is full

### DIFF
--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -28,6 +28,11 @@ var (
 		Help:        "The total number of Tetragon flags. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
+	NotifyOverflowedEvents = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        consts.MetricNamePrefix + "notify_overflowed_events",
+		Help:        "The total number of events dropped because listener buffer was full",
+		ConstLabels: nil,
+	}, nil)
 )
 
 func GetProcessInfo(process *tetragon.Process) (binary, pod, namespace string) {


### PR DESCRIPTION
There was report about a deadlock when executing `tetra getevents` (issue #492 ).

After investigation, the issue seems to be that the notifier channel is full and the consumer is stuck trying to send a gRPC response. Since listeners use libraries for handling events that i) may block and ii) we do not control, the best option seems to be to drop events whenever the listener buffer is full. This is what this patch does. It also adds a metric to count these drops.

More details: looking at the stack trace, One goroutine seems to be stuck in Notify():

```
func (l *getEventsListener) Notify(res *tetragon.GetEventsResponse) {
	l.events <- res
}
```

The events are consumed by function GetEventsWG which seems to be stuck in grpc land.

```
goroutine 82988 [select, 47 minutes]:
google.golang.org/grpc/internal/transport.(*writeQuota).get(0xc008692980, 0x583)
	/go/src/github.com/cilium/tetragon/vendor/google.golang.org/grpc/internal/transport/flowcontrol.go:59 +0x6e
google.golang.org/grpc/internal/transport.(*http2Server).Write(0xc005d02340, 0xc005861560, {0xc001f1af00, 0x5, 0x5}, {0xc008eae100, 0x57e, 0x57e}, 0x0?)
	/go/src/github.com/cilium/tetragon/vendor/google.golang.org/grpc/internal/transport/http2_server.go:1096 +0x16a
google.golang.org/grpc.(*serverStream).SendMsg(0xc00553bd40, {0x1d82b00?, 0xc005a96ea0})
	/go/src/github.com/cilium/tetragon/vendor/google.golang.org/grpc/stream.go:1543 +0x1c2
github.com/cilium/tetragon/api/v1/tetragon.(*fineGuidanceSensorsGetEventsServer).Send(0xc00062b3a8?, 0x1?)
	/go/src/github.com/cilium/tetragon/vendor/github.com/cilium/tetragon/api/v1/tetragon/sensors_grpc.pb.go:252 +0x2b
github.com/cilium/tetragon/pkg/server.(*Server).GetEventsWG(0xc0016b7480, 0xc008c71c00, {0x2162030, 0xc00795bbd0}, {0x0, 0x0}, 0x0)
	/go/src/github.com/cilium/tetragon/pkg/server/server.go:151 +0x623
github.com/cilium/tetragon/pkg/server.(*Server).GetEvents(0xc00553bd40?, 0x1d4e420?, {0x2162030?, 0xc00795bbd0?})
	/go/src/github.com/cilium/tetragon/pkg/server/server.go:98 +0x2b
github.com/cilium/tetragon/api/v1/tetragon._FineGuidanceSensors_GetEvents_Handler({0x1d7a0e0?, 0xc0016b7480}, {0x2160e20, 0xc00553bd40})
	/go/src/github.com/cilium/tetragon/vendor/github.com/cilium/tetragon/api/v1/tetragon/sensors_grpc.pb.go:239 +0xd0
google.golang.org/grpc.(*Server).processStreamingRPC(0xc001185680, {0x2164740, 0xc005d02340}, 0xc005861560, 0xc001d1a930, 0x2fb3880, 0x0)
	/go/src/github.com/cilium/tetragon/vendor/google.golang.org/grpc/server.go:1558 +0xf46
google.golang.org/grpc.(*Server).handleStream(0xc001185680, {0x2164740, 0xc005d02340}, 0xc005861560, 0x0)
	/go/src/github.com/cilium/tetragon/vendor/google.golang.org/grpc/server.go:1640 +0x9d6
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/go/src/github.com/cilium/tetragon/vendor/google.golang.org/grpc/server.go:932 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/go/src/github.com/cilium/tetragon/vendor/google.golang.org/grpc/server.go:930 +0x28a
```

In the meantime, the caller of .Notify() holds a mutex that does not allow other goroutines to progress.

Fixes: #492 

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>