### PR TITLE
tetragon: Add bpf_printk helper from libbpf

### DIFF
--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -121,12 +121,8 @@ static uint64_t BPF_FUNC(get_socket_cookie, void *ctx);
 __attribute__((__format__(__printf__, 1, 3)))
 static void BPF_FUNC(trace_printk, const char *fmt, int fmt_size, ...);
 
-#ifndef printt
-# define printt(fmt, ...)						\
-	({								\
-		trace_printk(____fmt, ##__VA_ARGS__);			\
-	})
-#endif
+static long BPF_FUNC(trace_vprintk, const char *fmt, __u32 fmt_size, const void *data, __u32 data_len);
+
 
 /* Random numbers */
 static uint32_t BPF_FUNC(get_prandom_u32);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -23,12 +23,6 @@ struct msg_test {
 #define BPF_F_INDEX_MASK  0xffffffffULL
 #define BPF_F_CURRENT_CPU BPF_F_INDEX_MASK
 
-#define bpf_printk(fmt, ...)                                                   \
-	({                                                                     \
-		char ____fmt[] = fmt;                                          \
-		trace_printk(____fmt, sizeof(____fmt), ##__VA_ARGS__);         \
-	})
-
 #ifndef bpf_ntohs
 #define bpf_ntohs(x) __builtin_bswap16(x)
 #endif


### PR DESCRIPTION
Adding bpf_printk helper from bpf selftests that allows to use bpf_trace_vprintk helper and display more than 3 format arguments. This helper did not make it to 5.15 so it's available later on.

Up to 5.15 we can use bpf_printk with 3 format arguments, later versions can use up to 12 format arguments.

We need to use global data variable for format string for kernel versions < 5.2 (needs to be on stack), so I'm using __LARGE_BPF_PROG for that.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>