### PR TITLE
build: sign Tetragon container images

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -11,6 +11,12 @@ on:
     paths:
     - 'Dockerfile.clang'
 
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+
 jobs:
   build-and-push:
     environment: release-clang
@@ -49,6 +55,16 @@ jobs:
           platforms: linux/amd64
           tags: |
             quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+
+      - name: Sign Container Image
+        if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
 
       - name: Image Release Digest
         shell: bash

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - main
 
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+
 jobs:
   build-and-push-prs:
     runs-on: ubuntu-20.04
@@ -50,6 +56,9 @@ jobs:
         run: |
           echo "TETRAGON_VERSION=$(make version)" >> $GITHUB_ENV
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+
       # main branch pushes
       - name: CI Build (main)
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -65,6 +74,13 @@ jobs:
           tags: |
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest
+
+      - name: Sign Container Image
+        if: ${{ github.event_name != 'pull_request_target' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main.outputs.digest }}
 
       - name: CI Image Releases digests (main)
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -87,6 +103,13 @@ jobs:
             TETRAGON_VERSION=${{ env.TETRAGON_VERSION }}
           tags: |
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+
+      - name: Sign Container Image
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr.outputs.digest }}
 
       - name: CI Image Releases digests (PR)
         if: ${{ github.event_name == 'pull_request_target' }}

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -6,6 +6,12 @@ on:
       - v*
       - test*
 
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+
 jobs:
   build-and-push:
     environment: release
@@ -55,6 +61,16 @@ jobs:
           tags: |
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+
+      - name: Sign Container Image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
+          cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
 
       - name: Image Release Digest
         shell: bash

--- a/README.md
+++ b/README.md
@@ -625,6 +625,30 @@ we provide a standard VagrantFile with the required components enabled. Simply r
 
 This should be sufficient to create a Kind cluster and run Tetragon. For more information on the vagrant builds, see the [Development Guide](docs/contributing/development/README.md#local-development-in-vagrant-box).
 
+## Verify Tetragon Image Signatures
+
+### Prerequisites
+
+You will need to [install cosign](https://docs.sigstore.dev/cosign/installation/).
+
+### Verify Signed Container Images
+
+Since version 0.8.4, all Tetragon container images are signed using cosign.
+
+Let's verify a Tetragon image's signature using the `cosign verify` command:
+
+```bash
+$ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository cilium/tetragon --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-github-workflow-name "Image CI Releases" --certificate-github-workflow-ref refs/tags/[RELEASE TAG] quay.io/cilium/tetragon:v0.8.4 | jq
+```
+
+**Note**
+
+`COSIGN_EXPERIMENTAL=1` is used to allow verification of images signed in KEYLESS mode. To learn more about keyless signing, please refer to [Keyless Signatures](https://github.com/sigstore/cosign/blob/main/KEYLESS.md#keyless-signatures).
+
+`--certificate-github-workflow-name string` contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow. For the names of workflows used to build Tetragon images, see the build image workflows under [Tetragon workflows](https://github.com/cilium/tetragon/tree/main/.github/workflows).
+
+`--certificate-github-workflow-ref string` contains the ref claim from the GitHub OIDC Identity token that contains the git ref that the workflow run was based upon.
+
 # FAQ
 
 **Q:** Can I install and use Tetragon in standalone mode (outside of k8s)?


### PR DESCRIPTION
Implement container image signing using cosign in build images workflows. Leveraging image signing gives users confidence that the container images they got from the container registry were the trusted code that the maintainer built and published. This is part of efforts to improve the security posture of the Cilium family’s open source projects.

Signed-off-by: Sandipan Panda <samparksandipan@gmail.com>