### PR TITLE
tetragon: fix graceful shutdown and exit code

### DIFF
--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -209,7 +209,7 @@ func (k *Observer) runEvents(stopCtx context.Context, ready func()) error {
 		for stopCtx.Err() == nil {
 			record, err := perfReader.Read()
 			if err != nil {
-				// NOTE(JM): Keeping the old behaviour for now and just counting the errors without stopping
+				// NOTE(JM and Djalal): count and log errors while excluding the stopping context
 				if stopCtx.Err() == nil {
 					k.errorCntr++
 					ringbufmetrics.ErrorsSet(float64(k.errorCntr))


### PR DESCRIPTION
Right now tetragon always exit with 1, let's fix this and improve graceful shutdown, so service monitors and container managers... won't treat Tetragon as it failed.

Some start up logic was re-ordered to improve how we cleanup things.

Also this change will make tetragonExecute() return up to callers, and allow Tetragon main to exit with 0.

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>