### PR TITLE
add kubebuilder validation GetUrl;DnsLookup , it can't get "The Traci…

### DIFF
--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -189,7 +189,7 @@ type ArgSelector struct {
 }
 
 type ActionSelector struct {
-	// +kubebuilder:validation:Enum=Post;FollowFD;UnfollowFD;Sigkill;CopyFD;Override
+	// +kubebuilder:validation:Enum=Post;FollowFD;UnfollowFD;Sigkill;CopyFD;Override;GetUrl;DnsLookup
 	// Action to execute.
 	Action string `json:"action"`
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
…ngPolicy "url" is invalid: spec.kprobes[0].selectors[0].matchActions[0].action: Unsupported value: "GetUrl": supported values: "Post", "FollowFD", "UnfollowFD", "Sigkill", "CopyFD", "Override""