### PR TITLE
Fix for execve events that come after clone

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -235,7 +235,7 @@ func GetParentProcessInternal(pid uint32, ktime uint64) (*ProcessInternal, *Proc
 // AddExecEvent constructs a new ProcessInternal structure from an Execve event, adds it to the cache, and also returns it
 func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 	var proc *ProcessInternal
-	if event.CleanupProcess.Ktime == 0 {
+	if event.CleanupProcess.Ktime == 0 || event.Process.Flags&api.EventClone != 0 {
 		// there is a case where we cannot find this entry in execve_map
 		// in that case we use as parent what Linux knows
 		proc, _ = GetProcess(event.Process, event.Kube.Docker, event.Parent, event.Capabilities, event.Namespaces)


### PR DESCRIPTION
https://github.com/cilium/tetragon/commit/ef0a4260f4be702ca31d5e1525e20c841647d6eb changes the behaviour of exec events that come after a clone event.

Before that commit we used to have:
```
process_clone with process pid 10 parent pid 9 // we cannot see that event as process_clone are not exported 
process_exec with process pid 10 parent pid 9  // will have as parent pid the clone's event parent pid 
process_exec with process pid 10 parent pid 10 // will have as parent the previous exec's pid
```

Now we have:
```
process_clone with process pid 10 parent pid 9 // we cannot see that event as process_clone are not exported 
process_exec with process pid 10 parent pid 10 // will have as parent pid the one from the clone event 
process_exec with process pid 10 parent pid 10 // will have as parent the previous exec's pid
```

This commit fixes that to behave the same as before. This is done by using the real parent for the first exec event after a clone event.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>