### PR TITLE
tetragon: Add support to run execve sensor as raw tp btf program type

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -8,8 +8,8 @@ PROCESSDIR := process/
 BPFTESTDIR := test/
 
 ALIGNCHECKER = bpf_alignchecker.o
-PROCESS = bpf_execve_event.o bpf_execve_event_v53.o bpf_fork.o bpf_exit.o bpf_generic_kprobe.o \
-	  bpf_generic_kprobe_v53.o bpf_generic_retkprobe.o bpf_generic_retkprobe_v53.o \
+PROCESS = bpf_execve_event.o bpf_execve_event_v53.o bpf_execve_event_btftp.o bpf_fork.o bpf_exit.o \
+	  bpf_generic_kprobe.o bpf_generic_kprobe_v53.o bpf_generic_retkprobe.o bpf_generic_retkprobe_v53.o \
 	  bpf_multi_kprobe_v53.o bpf_multi_retkprobe_v53.o \
 	  bpf_generic_tracepoint.o bpf_generic_tracepoint_v53.o
 BPFTEST = bpf_lseek.o bpf_globals.o
@@ -71,11 +71,15 @@ objs/%.ll: $(PROCESSDIR)%.c
 	$(CLANG) $(CLANG_FLAGS) -c $< -o $@
 
 objs/bpf_execve_event_v53.ll: process/bpf_execve_event.c
+objs/bpf_execve_event_btftp.ll: process/bpf_execve_event.c
 objs/bpf_generic_kprobe_v53.ll: process/bpf_generic_kprobe.c
 objs/bpf_generic_retkprobe_v53.ll: process/bpf_generic_retkprobe.c
 objs/bpf_multi_kprobe_v53.ll: process/bpf_generic_kprobe.c
 objs/bpf_multi_retkprobe_v53.ll: process/bpf_generic_retkprobe.c
 objs/bpf_generic_tracepoint_v53.ll: process/bpf_generic_tracepoint.c
+
+objs/%_btftp.ll:
+	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__BTFTP -c $< -o $@
 
 objs/bpf_multi_kprobe_v53.ll objs/bpf_multi_retkprobe_v53.ll:
 	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__MULTI_KPROBE -c $< -o $@
@@ -87,6 +91,7 @@ $(DEPSDIR)%.d: $(PROCESSDIR)%.c
 	$(CLANG) $(CLANG_FLAGS) -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
 
 deps/bpf_execve_event_v53.d: process/bpf_execve_event.c
+deps/bpf_execve_event_btftp.d: process/bpf_execve_event.c
 deps/bpf_generic_kprobe_v53.d: process/bpf_generic_kprobe.c
 deps/bpf_generic_retkprobe_v53.d: process/bpf_generic_retkprobe.c
 deps/bpf_multi_kprobe_v53.d: process/bpf_generic_kprobe.c

--- a/pkg/bpf/detect.go
+++ b/pkg/bpf/detect.go
@@ -20,6 +20,7 @@ type Feature struct {
 var (
 	overrideHelper = Feature{false, false}
 	kprobeMulti    = Feature{false, false}
+	rawtpbtf       = Feature{false, false}
 )
 
 func HasOverrideHelper() bool {
@@ -78,4 +79,30 @@ func HasKprobeMulti() bool {
 	kprobeMulti.detected = detectKprobeMulti()
 	kprobeMulti.initialized = true
 	return kprobeMulti.detected
+}
+
+func detectRawTpBtf() bool {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "test",
+		Type: ebpf.Tracing,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		},
+		AttachTo:   "kfree_skb",
+		AttachType: ebpf.AttachTraceRawTp,
+		License:    "GPL",
+	})
+	prog.Close()
+	return err == nil
+}
+
+func HasRawTpBtf() bool {
+	if rawtpbtf.initialized {
+		return rawtpbtf.detected
+	}
+
+	rawtpbtf.detected = detectRawTpBtf()
+	rawtpbtf.initialized = true
+	return rawtpbtf.detected
 }

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/dataapi"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/processapi"
+	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/data"
 	exec "github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/logger"
@@ -240,7 +241,14 @@ type execSensor struct {
 }
 
 func (e *execSensor) LoadProbe(args sensors.LoadProbeArgs) error {
-	err := program.LoadTracepointProgram(args.BPFDir, args.MapDir, args.Load, args.Verbose)
+	var err error
+
+	if bpf.HasRawTpBtf() {
+		err = program.LoadTracingProgram(args.BPFDir, args.MapDir, args.Load, args.Verbose)
+	} else {
+		err = program.LoadTracepointProgram(args.BPFDir, args.MapDir, args.Load, args.Verbose)
+	}
+
 	if err == nil {
 		procevents.GetRunningProcs()
 	}

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -308,9 +308,24 @@ func doLoadProgram(
 	// the ones used.
 	var progSpec *ebpf.ProgramSpec
 
+	matchProg := func(prog *ebpf.ProgramSpec, load *Program) bool {
+		// there's no program name, match just the section name
+		if load.ProgName == "" && prog.SectionName == load.Label {
+			return true
+		}
+		// match section name and program name
+		if prog.SectionName == load.Label && load.ProgName == prog.Name {
+			return true
+		}
+		return false
+	}
+
 	refMaps := make(map[string]bool)
 	for _, prog := range spec.Programs {
-		if prog.SectionName == load.Label {
+		if matchProg(prog, load) {
+			progSpec = prog
+		}
+		if matchProg(prog, load) {
 			progSpec = prog
 		}
 		for _, inst := range prog.Instructions {

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -220,7 +220,14 @@ func LoadMultiKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) e
 }
 
 func LoadTracingProgram(bpfDir, mapDir string, load *Program, verbose int) error {
-	return loadProgram(bpfDir, []string{mapDir}, load, TracingAttach(load), nil, verbose)
+	var ci *customInstall
+	for mName, mPath := range load.PinMap {
+		if mName == "execve_calls" {
+			ci = &customInstall{mPath, "", "execve_"}
+			break
+		}
+	}
+	return loadProgram(bpfDir, []string{mapDir}, load, TracingAttach(load), ci, verbose)
 }
 
 func slimVerifierError(errStr string) string {

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -26,6 +26,7 @@ type AttachFunc func(*ebpf.Program, *ebpf.ProgramSpec) (unloader.Unloader, error
 type customInstall struct {
 	mapName   string
 	secPrefix string
+	prgPrefix string
 }
 
 func RawAttach(targetFD int) AttachFunc {
@@ -168,7 +169,7 @@ func LoadTracepointProgram(bpfDir, mapDir string, load *Program, verbose int) er
 	var ci *customInstall
 	for mName, mPath := range load.PinMap {
 		if mName == "tp_calls" || mName == "execve_calls" {
-			ci = &customInstall{mPath, "tracepoint"}
+			ci = &customInstall{mPath, "tracepoint", ""}
 			break
 		}
 	}
@@ -183,7 +184,7 @@ func LoadKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error 
 	var ci *customInstall
 	for mName, mPath := range load.PinMap {
 		if mName == "kprobe_calls" {
-			ci = &customInstall{mPath, "kprobe"}
+			ci = &customInstall{mPath, "kprobe", ""}
 			break
 		}
 	}
@@ -195,7 +196,7 @@ func LoadTailCallProgram(bpfDir, mapDir string, load *Program, verbose int) erro
 }
 
 func LoadMultiKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
-	ci := &customInstall{fmt.Sprintf("%s-kp_calls", load.PinPath), "kprobe"}
+	ci := &customInstall{fmt.Sprintf("%s-kp_calls", load.PinPath), "kprobe", ""}
 	return loadProgram(bpfDir, []string{mapDir}, load, MultiKprobeAttach(load), ci, verbose)
 }
 
@@ -242,7 +243,7 @@ func installTailCalls(mapDir string, spec *ebpf.CollectionSpec, coll *ebpf.Colle
 		secToProgName[prog.SectionName] = name
 	}
 
-	install := func(mapName string, secPrefix string) error {
+	installSection := func(mapName string, secPrefix string) error {
 		tailCallsMap, err := ebpf.LoadPinnedMap(filepath.Join(mapDir, mapName), nil)
 		if err != nil {
 			return nil
@@ -263,18 +264,43 @@ func installTailCalls(mapDir string, spec *ebpf.CollectionSpec, coll *ebpf.Colle
 		return nil
 	}
 
-	if err := install("http1_calls", "sk_msg"); err != nil {
+	installProgram := func(mapName string, prgPrefix string) error {
+		tailCallsMap, err := ebpf.LoadPinnedMap(filepath.Join(mapDir, mapName), nil)
+		if err != nil {
+			return nil
+		}
+		defer tailCallsMap.Close()
+
+		for i := 0; i < 11; i++ {
+			progName := fmt.Sprintf("%s%d", prgPrefix, i)
+			if prog, ok := coll.Programs[progName]; ok {
+				err := tailCallsMap.Update(uint32(i), uint32(prog.FD()), ebpf.UpdateAny)
+				if err != nil {
+					return fmt.Errorf("update of tail-call map '%s' failed: %w", mapName, err)
+				}
+			}
+		}
+		return nil
+	}
+
+	if err := installSection("http1_calls", "sk_msg"); err != nil {
 		return err
 	}
-	if err := install("http1_calls_skb", "sk_skb/stream_verdict"); err != nil {
+	if err := installSection("http1_calls_skb", "sk_skb/stream_verdict"); err != nil {
 		return err
 	}
-	if err := install("tls_calls", "classifier"); err != nil {
+	if err := installSection("tls_calls", "classifier"); err != nil {
 		return err
 	}
 	if ci != nil {
-		if err := install(ci.mapName, ci.secPrefix); err != nil {
-			return err
+		if ci.secPrefix != "" {
+			if err := installSection(ci.mapName, ci.secPrefix); err != nil {
+				return err
+			}
+		} else {
+			if err := installProgram(ci.mapName, ci.prgPrefix); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -17,6 +17,7 @@ func Builder(
 		Name:       objFile,
 		Attach:     attach,
 		Label:      label,
+		ProgName:   "",
 		PinPath:    pinFile,
 		RetProbe:   false,
 		ErrorFatal: true,
@@ -48,6 +49,9 @@ type Program struct {
 	Attach string
 	// Label is the program section name to load from program.
 	Label string
+	// program name
+	ProgName string
+
 	// PinPath is the pinned path to this program. Note this is a relative path
 	// based on the BPF directory FGS is running under.
 	PinPath string
@@ -93,6 +97,11 @@ func (p *Program) SetRetProbe(ret bool) *Program {
 
 func (p *Program) SetLoaderData(d interface{}) *Program {
 	p.LoaderData = d
+	return p
+}
+
+func (p *Program) SetProgName(name string) *Program {
+	p.ProgName = name
 	return p
 }
 


### PR DESCRIPTION
This way we can directly acces its arguments and call BTF based
helpers, which will be needed in future changes like for getting
buildid or cgroup data.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
