### PR TITLE
Make size of event queue configurable

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -63,6 +63,8 @@ const (
 
 	keyRBSize      = "rb-size"
 	keyRBSizeTotal = "rb-size-total"
+
+	keyEventQueueSize = "event-queue-size"
 )
 
 var (
@@ -133,4 +135,6 @@ func readAndSetFlags() {
 
 	cpuProfile = viper.GetString(keyCpuProfile)
 	memProfile = viper.GetString(keyMemProfile)
+
+	option.Config.EventQueueSize = viper.GetUint(keyEventQueueSize)
 }

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -463,6 +463,7 @@ func execute() error {
 	flags.String(keyCiliumBPF, "", "Cilium BPF directory")
 	flags.Bool(keyEnableProcessCred, false, "Enable process_cred events")
 	flags.Bool(keyEnableProcessNs, false, "Enable namespace information in process_exec and process_kprobe events")
+	flags.Uint(keyEventQueueSize, 10000, "Set the size of the internal event queue.")
 
 	// Config files
 	flags.String(keyConfigFile, "", "Configuration file to load from")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -38,6 +38,8 @@ type config struct {
 
 	RBSize      int
 	RBSizeTotal int
+
+	EventQueueSize uint
 }
 
 var (

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/tetragon/pkg/health"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/version"
 )
@@ -64,8 +65,12 @@ func NewServer(ctx context.Context, wg *sync.WaitGroup, notifier notifier, obser
 }
 
 func newListener() *getEventsListener {
+	var chanSize uint = 10000
+	if option.Config.EventQueueSize > 0 {
+		chanSize = option.Config.EventQueueSize
+	}
 	return &getEventsListener{
-		events: make(chan *tetragon.GetEventsResponse, 100),
+		events: make(chan *tetragon.GetEventsResponse, chanSize),
 	}
 }
 


### PR DESCRIPTION
The internal event queue had a fixed size of 100 events. If the event queue became full, additional events would be dropped. This commit raises the default size to 10000 events and makes the size configurable through a --event-queue-size command line flag.

Signed-off-by: Kevin Sheldrake <kevin.sheldrake@isovalent.com>