### PR TITLE
tetragon: Add v6.0 bpf objects and related fixes

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -12,7 +12,12 @@ ALIGNCHECKER = bpf_alignchecker.o
 PROCESS = bpf_execve_event.o bpf_execve_event_v53.o bpf_fork.o bpf_exit.o bpf_generic_kprobe.o \
 	  bpf_generic_kprobe_v53.o bpf_generic_retkprobe.o bpf_generic_retkprobe_v53.o \
 	  bpf_multi_kprobe_v53.o bpf_multi_retkprobe_v53.o \
-	  bpf_generic_tracepoint.o bpf_generic_tracepoint_v53.o
+	  bpf_generic_tracepoint.o bpf_generic_tracepoint_v53.o \
+	  bpf_execve_event_v60.o \
+	  bpf_generic_kprobe_v60.o bpf_generic_retkprobe_v60.o \
+	  bpf_generic_tracepoint_v60.o \
+	  bpf_multi_kprobe_v60.o bpf_multi_retkprobe_v60.o
+
 CGROUP = bpf_cgroup_mkdir.o bpf_cgroup_rmdir.o bpf_cgroup_release.o
 BPFTEST = bpf_lseek.o bpf_globals.o
 
@@ -98,6 +103,29 @@ deps/bpf_generic_tracepoint_v53.d: process/bpf_generic_tracepoint.c
 
 $(DEPSDIR)%_v53.d:
 	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
+
+objs/bpf_execve_event_v60.ll: process/bpf_execve_event.c
+objs/bpf_generic_kprobe_v60.ll: process/bpf_generic_kprobe.c
+objs/bpf_generic_retkprobe_v60.ll: process/bpf_generic_retkprobe.c
+objs/bpf_multi_kprobe_v60.ll: process/bpf_generic_kprobe.c
+objs/bpf_multi_retkprobe_v60.ll: process/bpf_generic_retkprobe.c
+objs/bpf_generic_tracepoint_v60.ll: process/bpf_generic_tracepoint.c
+
+objs/bpf_multi_kprobe_v60.ll objs/bpf_multi_retkprobe_v60.ll:
+	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__V60_BPF_PROG -D__MULTI_KPROBE -c $< -o $@
+
+objs/%_v60.ll:
+	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__V60_BPF_PROG -c $< -o $@
+
+deps/bpf_execve_event_v60.d: process/bpf_execve_event.c
+deps/bpf_generic_kprobe_v60.d: process/bpf_generic_kprobe.c
+deps/bpf_generic_retkprobe_v60.d: process/bpf_generic_retkprobe.c
+deps/bpf_multi_kprobe_v60.d: process/bpf_generic_kprobe.c
+deps/bpf_multi_retkprobe_v60.d: process/bpf_generic_retkprobe.c
+deps/bpf_generic_tracepoint_v60.d: process/bpf_generic_tracepoint.c
+
+$(DEPSDIR)%_v60.d:
+	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG  -D__V60_BPF_PROG -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
 
 # BPFTESTDIR
 objs/%.ll: $(BPFTESTDIR)%.c

--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -227,6 +227,8 @@ static int BPF_FUNC(override_return, void *regs, uint64_t rc);
 
 static __u64 BPF_FUNC(get_attach_cookie, void *ctx);
 
+static long BPF_FUNC(loop, __u32 nr_loops, void *callback_fn, void *callback_ctx, __u64 flags);
+
 /** LLVM built-ins, mem*() routines work for constant size */
 
 #ifndef lock_xadd

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -164,6 +164,7 @@ struct cwd_read_data {
 	const struct path *root;
 	char *bf;
 	struct dentry *dentry;
+	struct vfsmount *vfsmnt;
 };
 
 static inline __attribute__((always_inline)) int
@@ -174,7 +175,6 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		.root = root,
 		.bf = bf,
 	};
-	struct vfsmount *vfsmnt;
 	struct mount *mnt;
 	struct qstr d_name;
 	int error = 0;
@@ -185,8 +185,8 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 	bptr = *buffer;
 	blen = *buflen;
 	probe_read(&data.dentry, sizeof(data.dentry), _(&path->dentry));
-	probe_read(&vfsmnt, sizeof(vfsmnt), _(&path->mnt));
-	mnt = real_mount(vfsmnt);
+	probe_read(&data.vfsmnt, sizeof(data.vfsmnt), _(&path->mnt));
+	mnt = real_mount(data.vfsmnt);
 
 #ifndef __LARGE_BPF_PROG
 #pragma unroll
@@ -201,6 +201,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		struct dentry *root_dentry;
 		const struct path *root = data.root;
 		struct dentry *dentry = data.dentry;
+		struct vfsmount *vfsmnt = data.vfsmnt;
 
 		probe_read(&root_dentry, sizeof(root_dentry), _(&root->dentry));
 		probe_read(&root_mnt, sizeof(root_mnt), _(&root->mnt));
@@ -223,7 +224,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 				probe_read(&data.dentry, sizeof(data.dentry),
 					   _(&mnt->mnt_mountpoint));
 				mnt = parent;
-				probe_read(&vfsmnt, sizeof(vfsmnt),
+				probe_read(&data.vfsmnt, sizeof(data.vfsmnt),
 					   _(&mnt->mnt));
 				continue;
 			}

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -160,10 +160,19 @@ prepend(char **buffer, int *buflen, const char *str, int namelen)
 	return 0;
 }
 
+struct cwd_read_data {
+	const struct path *root;
+	char *bf;
+};
+
 static inline __attribute__((always_inline)) int
 prepend_path(const struct path *path, const struct path *root, char *bf,
 	     char **buffer, int *buflen)
 {
+	struct cwd_read_data data = {
+		.root = root,
+		.bf = bf,
+	};
 	struct dentry *dentry;
 	struct vfsmount *vfsmnt;
 	struct mount *mnt;
@@ -190,6 +199,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		struct dentry *vfsmnt_mnt_root;
 		struct vfsmount *root_mnt;
 		struct dentry *root_dentry;
+		const struct path *root = data.root;
 
 		probe_read(&root_dentry, sizeof(root_dentry), _(&root->dentry));
 		probe_read(&root_mnt, sizeof(root_mnt), _(&root->mnt));
@@ -223,7 +233,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		}
 		probe_read(&parent, sizeof(parent), _(&dentry->d_parent));
 		probe_read(&d_name, sizeof(d_name), _(&dentry->d_name));
-		error = prepend_name(bf, &bptr, &blen,
+		error = prepend_name(data.bf, &bptr, &blen,
 				     (const char *)d_name.name, d_name.len);
 		// This will happen where the dentry name does not fit in the buffer.
 		// We will stop the loop with resolved == false and later we will

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -171,6 +171,69 @@ struct cwd_read_data {
 	bool resolved;
 };
 
+static inline __attribute__((always_inline)) long
+cwd_read(struct cwd_read_data *data)
+{
+	struct qstr d_name;
+	struct dentry *parent;
+	struct dentry *vfsmnt_mnt_root;
+	struct vfsmount *root_mnt;
+	struct dentry *root_dentry;
+	const struct path *root = data->root;
+	struct dentry *dentry = data->dentry;
+	struct vfsmount *vfsmnt = data->vfsmnt;
+	struct mount *mnt = data->mnt;
+	int error;
+
+	probe_read(&root_dentry, sizeof(root_dentry), _(&root->dentry));
+	probe_read(&root_mnt, sizeof(root_mnt), _(&root->mnt));
+	if (!(dentry != root_dentry || vfsmnt != root_mnt)) {
+		data->resolved =
+			true; // resolved all path components successfully
+		return 1;
+	}
+
+	probe_read(&vfsmnt_mnt_root, sizeof(vfsmnt_mnt_root),
+		   _(&vfsmnt->mnt_root));
+	if (dentry == vfsmnt_mnt_root || IS_ROOT(dentry)) {
+		struct mount *parent;
+
+		probe_read(&parent, sizeof(parent), _(&mnt->mnt_parent));
+
+		/* Global root? */
+		if (data->mnt != parent) {
+			probe_read(&data->dentry, sizeof(data->dentry),
+				   _(&mnt->mnt_mountpoint));
+			data->mnt = parent;
+			probe_read(&data->vfsmnt, sizeof(data->vfsmnt),
+				   _(&mnt->mnt));
+			return 0;
+		}
+		// resolved all path components successfully
+		data->resolved = true;
+		return 1;
+	}
+	probe_read(&parent, sizeof(parent), _(&dentry->d_parent));
+	probe_read(&d_name, sizeof(d_name), _(&dentry->d_name));
+	error = prepend_name(data->bf, &data->bptr, &data->blen,
+			     (const char *)d_name.name, d_name.len);
+	// This will happen where the dentry name does not fit in the buffer.
+	// We will stop the loop with resolved == false and later we will
+	// set the proper value in error before function return.
+	if (error)
+		return 1;
+
+	data->dentry = parent;
+	return 0;
+}
+
+#ifdef __V60_BPF_PROG
+static long cwd_read_v60(__u32 index, void *data)
+{
+	return cwd_read(data);
+}
+#endif
+
 static inline __attribute__((always_inline)) int
 prepend_path(const struct path *path, const struct path *root, char *bf,
 	     char **buffer, int *buflen)
@@ -181,72 +244,22 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		.bptr = *buffer,
 		.blen = *buflen,
 	};
-	struct qstr d_name;
 	int error = 0;
-	int i;
 
 	probe_read(&data.dentry, sizeof(data.dentry), _(&path->dentry));
 	probe_read(&data.vfsmnt, sizeof(data.vfsmnt), _(&path->mnt));
 	data.mnt = real_mount(data.vfsmnt);
 
-#ifndef __LARGE_BPF_PROG
+#ifndef __V60_BPF_PROG
 #pragma unroll
-#else
-#pragma nounroll
-#endif
-	for (i = 0; i < PROBE_CWD_READ_ITERATIONS;
-	     ++i) { // maximum number of path compoments
-		struct dentry *parent;
-		struct dentry *vfsmnt_mnt_root;
-		struct vfsmount *root_mnt;
-		struct dentry *root_dentry;
-		const struct path *root = data.root;
-		struct dentry *dentry = data.dentry;
-		struct vfsmount *vfsmnt = data.vfsmnt;
-		struct mount *mnt = data.mnt;
-
-		probe_read(&root_dentry, sizeof(root_dentry), _(&root->dentry));
-		probe_read(&root_mnt, sizeof(root_mnt), _(&root->mnt));
-		if (!(dentry != root_dentry || vfsmnt != root_mnt)) {
-			data.resolved =
-				true; // resolved all path components successfully
+	for (int i = 0; i < PROBE_CWD_READ_ITERATIONS; ++i) {
+		if (cwd_read(&data))
 			break;
-		}
-
-		probe_read(&vfsmnt_mnt_root, sizeof(vfsmnt_mnt_root),
-			   _(&vfsmnt->mnt_root));
-		if (dentry == vfsmnt_mnt_root || IS_ROOT(dentry)) {
-			struct mount *parent;
-
-			probe_read(&parent, sizeof(parent),
-				   _(&mnt->mnt_parent));
-
-			/* Global root? */
-			if (data.mnt != parent) {
-				probe_read(&data.dentry, sizeof(data.dentry),
-					   _(&mnt->mnt_mountpoint));
-				data.mnt = parent;
-				probe_read(&data.vfsmnt, sizeof(data.vfsmnt),
-					   _(&mnt->mnt));
-				continue;
-			}
-
-			data.resolved =
-				true; // resolved all path components successfully
-			break;
-		}
-		probe_read(&parent, sizeof(parent), _(&dentry->d_parent));
-		probe_read(&d_name, sizeof(d_name), _(&dentry->d_name));
-		error = prepend_name(data.bf, &data.bptr, &data.blen,
-				     (const char *)d_name.name, d_name.len);
-		// This will happen where the dentry name does not fit in the buffer.
-		// We will stop the loop with resolved == false and later we will
-		// set the proper value in error before function return.
-		if (error)
-			break;
-
-		data.dentry = parent;
 	}
+#else
+	loop(PROBE_CWD_READ_ITERATIONS, cwd_read_v60, (void *)&data, 0);
+#endif /* __V60_BPF_PROG */
+
 	if (data.bptr == *buffer) {
 		*buflen = 0;
 		return 0;

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -163,6 +163,7 @@ prepend(char **buffer, int *buflen, const char *str, int namelen)
 struct cwd_read_data {
 	const struct path *root;
 	char *bf;
+	struct dentry *dentry;
 };
 
 static inline __attribute__((always_inline)) int
@@ -173,7 +174,6 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		.root = root,
 		.bf = bf,
 	};
-	struct dentry *dentry;
 	struct vfsmount *vfsmnt;
 	struct mount *mnt;
 	struct qstr d_name;
@@ -184,7 +184,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 
 	bptr = *buffer;
 	blen = *buflen;
-	probe_read(&dentry, sizeof(dentry), _(&path->dentry));
+	probe_read(&data.dentry, sizeof(data.dentry), _(&path->dentry));
 	probe_read(&vfsmnt, sizeof(vfsmnt), _(&path->mnt));
 	mnt = real_mount(vfsmnt);
 
@@ -200,6 +200,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		struct vfsmount *root_mnt;
 		struct dentry *root_dentry;
 		const struct path *root = data.root;
+		struct dentry *dentry = data.dentry;
 
 		probe_read(&root_dentry, sizeof(root_dentry), _(&root->dentry));
 		probe_read(&root_mnt, sizeof(root_mnt), _(&root->mnt));
@@ -219,7 +220,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 
 			/* Global root? */
 			if (mnt != parent) {
-				probe_read(&dentry, sizeof(dentry),
+				probe_read(&data.dentry, sizeof(data.dentry),
 					   _(&mnt->mnt_mountpoint));
 				mnt = parent;
 				probe_read(&vfsmnt, sizeof(vfsmnt),
@@ -241,7 +242,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		if (error)
 			break;
 
-		dentry = parent;
+		data.dentry = parent;
 	}
 	if (bptr == *buffer) {
 		*buflen = 0;

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -168,6 +168,7 @@ struct cwd_read_data {
 	struct mount *mnt;
 	char *bptr;
 	int blen;
+	bool resolved;
 };
 
 static inline __attribute__((always_inline)) int
@@ -183,7 +184,6 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 	struct qstr d_name;
 	int error = 0;
 	int i;
-	bool resolved = false;
 
 	probe_read(&data.dentry, sizeof(data.dentry), _(&path->dentry));
 	probe_read(&data.vfsmnt, sizeof(data.vfsmnt), _(&path->mnt));
@@ -208,7 +208,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		probe_read(&root_dentry, sizeof(root_dentry), _(&root->dentry));
 		probe_read(&root_mnt, sizeof(root_mnt), _(&root->mnt));
 		if (!(dentry != root_dentry || vfsmnt != root_mnt)) {
-			resolved =
+			data.resolved =
 				true; // resolved all path components successfully
 			break;
 		}
@@ -231,7 +231,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 				continue;
 			}
 
-			resolved =
+			data.resolved =
 				true; // resolved all path components successfully
 			break;
 		}
@@ -251,7 +251,7 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 		*buflen = 0;
 		return 0;
 	}
-	if (!resolved)
+	if (!data.resolved)
 		error = UNRESOLVED_PATH_COMPONENTS;
 	*buffer = data.bptr;
 	*buflen = data.blen;

--- a/contrib/verify/verify.sh
+++ b/contrib/verify/verify.sh
@@ -62,6 +62,11 @@ for obj in "$TETRAGONDIR"/*.o; do
 		continue
 	fi
 
+    # skip v6.0 objects check, because it is still not widely around
+	if [[ "$B" == *60.o ]]; then
+		continue
+	fi
+
 	echo -e -n "Verifying $BLUEUNDER$obj$NOCOLOR... "
 	OUT="/tmp/tetragon-verify-$B"
 

--- a/pkg/kernels/kernels.go
+++ b/pkg/kernels/kernels.go
@@ -120,6 +120,14 @@ func MinKernelVersion(kernel string) bool {
 	return false
 }
 
+func EnableV60Progs() bool {
+	if option.Config.ForceSmallProgs {
+		return false
+	}
+	kernelVer, _, _ := GetKernelVersion(option.Config.KernelVersion, option.Config.ProcFS)
+	return (int64(kernelVer) >= KernelStringToNumeric("6.0.0"))
+}
+
 func EnableLargeProgs() bool {
 	if option.Config.ForceSmallProgs {
 		return false

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -26,6 +26,14 @@ var (
 		"execve",
 	)
 
+	ExecveV60 = program.Builder(
+		"bpf_execve_event_v60.o",
+		"sched/sched_process_exec",
+		"tracepoint/sys_execve",
+		"event_execve",
+		"execve",
+	)
+
 	Exit = program.Builder(
 		"bpf_exit.o",
 		"sched/sched_process_exit",
@@ -45,28 +53,37 @@ var (
 	/* Event Ring map */
 	TCPMonMap    = program.MapBuilder("tcpmon_map", Execve)
 	TCPMonMapV53 = program.MapBuilder("tcpmon_map", ExecveV53)
+	TCPMonMapV60 = program.MapBuilder("tcpmon_map", ExecveV60)
 
 	/* Networking and Process Monitoring maps */
 	ExecveMap    = program.MapBuilder("execve_map", Execve)
 	ExecveMapV53 = program.MapBuilder("execve_map", ExecveV53)
+	ExecveMapV60 = program.MapBuilder("execve_map", ExecveV60)
 
 	ExecveTailCallsMap    = program.MapBuilderPin("execve_calls", "execve_calls", Execve)
 	ExecveTailCallsMapV53 = program.MapBuilderPin("execve_calls", "execve_calls", ExecveV53)
+	ExecveTailCallsMapV60 = program.MapBuilderPin("execve_calls", "execve_calls", ExecveV60)
 
 	/* Policy maps populated from base programs */
 	NamesMap    = program.MapBuilder("names_map", Execve)
 	NamesMapV53 = program.MapBuilder("names_map", ExecveV53)
+	NamesMapV60 = program.MapBuilder("names_map", ExecveV60)
 
 	/* Tetragon runtime configuration */
 	TetragonConfMap    = program.MapBuilder("tg_conf_map", Execve)
 	TetragonConfMapV53 = program.MapBuilder("tg_conf_map", ExecveV53)
+	TetragonConfMapV60 = program.MapBuilder("tg_conf_map", ExecveV60)
 
 	/* Internal statistics for debugging */
 	ExecveStats    = program.MapBuilder("execve_map_stats", Execve)
 	ExecveStatsV53 = program.MapBuilder("execve_map_stats", ExecveV53)
+	ExecveStatsV60 = program.MapBuilder("execve_map_stats", ExecveV60)
 )
 
 func GetExecveMap() *program.Map {
+	if kernels.EnableV60Progs() {
+		return ExecveMapV60
+	}
 	if kernels.EnableLargeProgs() {
 		return ExecveMapV53
 	}
@@ -74,6 +91,9 @@ func GetExecveMap() *program.Map {
 }
 
 func GetExecveMapStats() *program.Map {
+	if kernels.EnableV60Progs() {
+		return ExecveStatsV60
+	}
 	if kernels.EnableLargeProgs() {
 		return ExecveStatsV53
 	}
@@ -81,6 +101,9 @@ func GetExecveMapStats() *program.Map {
 }
 
 func GetTetragonConfMap() *program.Map {
+	if kernels.EnableV60Progs() {
+		return TetragonConfMapV60
+	}
 	if kernels.EnableLargeProgs() {
 		return TetragonConfMapV53
 	}
@@ -92,7 +115,9 @@ func GetDefaultPrograms() []*program.Program {
 		Exit,
 		Fork,
 	}
-	if kernels.EnableLargeProgs() {
+	if kernels.EnableV60Progs() {
+		progs = append(progs, ExecveV60)
+	} else if kernels.EnableLargeProgs() {
 		progs = append(progs, ExecveV53)
 	} else {
 		progs = append(progs, Execve)
@@ -103,7 +128,16 @@ func GetDefaultPrograms() []*program.Program {
 func GetDefaultMaps() []*program.Map {
 	maps := []*program.Map{}
 
-	if kernels.EnableLargeProgs() {
+	if kernels.EnableV60Progs() {
+		maps = append(maps,
+			ExecveMapV60,
+			ExecveStatsV60,
+			ExecveTailCallsMapV60,
+			NamesMapV60,
+			TCPMonMapV60,
+			TetragonConfMapV60,
+		)
+	} else if kernels.EnableLargeProgs() {
 		maps = append(maps,
 			ExecveMapV53,
 			ExecveStatsV53,

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -205,10 +205,17 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 	var progs []*program.Program
 	var maps []*program.Map
 
+	loadProgName := "bpf_multi_kprobe_v53.o"
+	loadProgRetName := "bpf_multi_retkprobe_v53.o"
+	if kernels.EnableV60Progs() {
+		loadProgName = "bpf_multi_kprobe_v60.o"
+		loadProgRetName = "bpf_multi_retkprobe_v60.o"
+	}
+
 	pinPath := sensors.PathJoin(sensorPath, "multi_kprobe")
 
 	load := program.Builder(
-		path.Join(option.Config.HubbleLib, "bpf_multi_kprobe_v53.o"),
+		path.Join(option.Config.HubbleLib, loadProgName),
 		"",
 		"kprobe.multi/generic_kprobe",
 		pinPath,
@@ -240,7 +247,7 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 
 	if len(multiRetIDs) != 0 {
 		loadret := program.Builder(
-			path.Join(option.Config.HubbleLib, "bpf_multi_retkprobe_v53.o"),
+			path.Join(option.Config.HubbleLib, loadProgRetName),
 			"",
 			"kprobe.multi/generic_retkprobe",
 			"multi_retkprobe",
@@ -270,7 +277,10 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 
 	loadProgName := "bpf_generic_kprobe.o"
 	loadProgRetName := "bpf_generic_retkprobe.o"
-	if kernels.EnableLargeProgs() {
+	if kernels.EnableV60Progs() {
+		loadProgName = "bpf_generic_kprobe_v60.o"
+		loadProgRetName = "bpf_generic_retkprobe_v60.o"
+	} else if kernels.EnableLargeProgs() {
 		loadProgName = "bpf_generic_kprobe_v53.o"
 		loadProgRetName = "bpf_generic_retkprobe_v53.o"
 	}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -327,7 +327,9 @@ func createGenericTracepointSensor(name string, confs []GenericTracepointConf) (
 	}
 
 	progName := "bpf_generic_tracepoint.o"
-	if kernels.EnableLargeProgs() {
+	if kernels.EnableV60Progs() {
+		progName = "bpf_generic_tracepoint_v60.o"
+	} else if kernels.EnableLargeProgs() {
 		progName = "bpf_generic_tracepoint_v53.o"
 	}
 


### PR DESCRIPTION
With clang 14 the prepend_path loop code does not pass verifier
on v6.x kernels, which can be fixed by using bpf_loop helper.

In order to use bpf_loop helper easily, I'm adding v6.0 version of
bpf objects, so we don't need to detect features and have specific
binary for each.

The v6.0 seems to be the latest stable, I'm not sure it will be longterm,
but with 5.19 EOL the other possibility is 5.15 which does not have
bpf_loop helper.. but I'm open to suggestions in here ;-)

Note I plan to move kprobe_multi objects into v60 in following changes.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
