### PR TITLE
tetragon: Check and remove not compatible map pin paths on loading

### DIFF
--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -61,6 +61,33 @@ func (m *Map) LoadPinnedMap(path string) error {
 	return err
 }
 
+// MapSpec.Compatible will be exported in ebpf v0.9.3,
+// meanwhile steal that and make it our own ;-)
+func compatible(ms *ebpf.MapSpec, m *ebpf.Map) error {
+	switch {
+	case m.Type() != ms.Type:
+		return fmt.Errorf("expected type %v, got %v: %w", ms.Type, m.Type(), ebpf.ErrMapIncompatible)
+
+	case m.KeySize() != ms.KeySize:
+		return fmt.Errorf("expected key size %v, got %v: %w", ms.KeySize, m.KeySize(), ebpf.ErrMapIncompatible)
+
+	case m.ValueSize() != ms.ValueSize:
+		return fmt.Errorf("expected value size %v, got %v: %w", ms.ValueSize, m.ValueSize(), ebpf.ErrMapIncompatible)
+
+	case !(ms.Type == ebpf.PerfEventArray && ms.MaxEntries == 0) &&
+		m.MaxEntries() != ms.MaxEntries:
+		return fmt.Errorf("expected max entries %v, got %v: %w", ms.MaxEntries, m.MaxEntries(), ebpf.ErrMapIncompatible)
+
+	case m.Flags() != ms.Flags:
+		return fmt.Errorf("expected flags %v, got %v: %w", ms.Flags, m.Flags(), ebpf.ErrMapIncompatible)
+	}
+	return nil
+}
+
+func (m *Map) IsCompatibleWith(spec *ebpf.MapSpec) error {
+	return compatible(spec, m.MapHandle)
+}
+
 func (m *Map) Close() error {
 	return m.MapHandle.Close()
 }


### PR DESCRIPTION
Following cilium/ebpf interface creates map from pin path
and checks if the pin is compatible with the map spec:

  ebpf.NewMapWithOptions(spec, ebpf.MapOptions{PinPath: path, FullPath: true})

use that in the sensors map loading code

TODO split the cilium/ebpf change and push it separately 

Signed-off-by: Jiri Olsa <jolsa@kernel.org>