### PR TITLE
tetragon: Add ReleasedPinnedBPF option to remove any old progs/maps

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -63,6 +63,8 @@ const (
 
 	keyRBSize      = "rb-size"
 	keyRBSizeTotal = "rb-size-total"
+
+	keyReleasePinnedBPF = "release-pinned-bpf"
 )
 
 var (
@@ -133,4 +135,6 @@ func readAndSetFlags() {
 
 	cpuProfile = viper.GetString(keyCpuProfile)
 	memProfile = viper.GetString(keyMemProfile)
+
+	option.Config.ReleasePinned = viper.GetBool(keyReleasePinnedBPF)
 }

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -190,6 +190,11 @@ func tetragonExecute() error {
 	option.Config.BpfDir = observerDir
 	option.Config.MapDir = observerDir
 
+	// Check if option to remove old BPF and maps is enabled.
+	if option.Config.ReleasePinned {
+		os.RemoveAll(observerDir)
+	}
+
 	// Get observer from configFile
 	obs := observer.NewObserver(configFile)
 	defer func() {
@@ -495,6 +500,10 @@ func execute() error {
 	// Allow to specify perf ring buffer size
 	flags.Int(keyRBSizeTotal, 0, "Set perf ring buffer size in total for all cpus (default 65k per cpu)")
 	flags.Int(keyRBSize, 0, "Set perf ring buffer size for single cpu (default 65k)")
+
+	// Provide option to remove existing pinned BPF programs and maps in
+	// Tetragon's observer dir. Useful for doing upgrades/downgrades.
+	flags.Bool(keyReleasePinnedBPF, false, "Release all pinned BPF programs and maps in Tetragon BPF directory")
 
 	viper.BindPFlags(flags)
 	return rootCmd.Execute()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -38,6 +38,8 @@ type config struct {
 
 	RBSize      int
 	RBSizeTotal int
+
+	ReleasePinned bool
 }
 
 var (


### PR DESCRIPTION
[6e52a3ce tetragon: Add ReleasedPinnedBPF option to remove any old progs/maps]

This adds a ReleasePinnedBPF option that will remove any and all pinned programs and maps in the tetragon directory. In normal use cases we should not require this Tetragon should clean up and reinit its state correctly.

However, some cases we hit recently require a bigger hammer. Specifically, when upgrading between versions and maps or programs are no longer in the new version. We would have to keep code to tear them down on the upgrade. We do this in some cases where we expect users will commonly upgrade through these paths. But, then there are always questions, such as how many versions do we need to maintain this code? For ever? What about downgrades with new maps that no longer exist? And so on.

To handle these cases the ReleasePinnedBPF option gives users that have no need to keep maps across restart a way to do hard resetes of the BPF state of Tetragon. Further, gives us an escape hatch if needed.

Resolved Conflicts:
	cmd/tetragon/flags.go
	pkg/option/config.go

Signed-off-by: John Fastabend <john.fastabend@gmail.com>