### PR TITLE
tetragon: Add pprof http support

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -40,6 +40,7 @@ const (
 
 	keyCpuProfile = "cpuprofile"
 	keyMemProfile = "memprofile"
+	keyPprofAddr  = "pprof-addr"
 
 	keyExportFilename             = "export-filename"
 	keyExportFileMaxSizeMB        = "export-file-max-size-mb"
@@ -90,6 +91,7 @@ var (
 
 	cpuProfile string
 	memProfile string
+	pprofAddr  string
 )
 
 func readAndSetFlags() {
@@ -137,6 +139,7 @@ func readAndSetFlags() {
 
 	cpuProfile = viper.GetString(keyCpuProfile)
 	memProfile = viper.GetString(keyMemProfile)
+	pprofAddr = viper.GetString(keyPprofAddr)
 
 	option.Config.EventQueueSize = viper.GetUint(keyEventQueueSize)
 


### PR DESCRIPTION
This PR adds support for pprof http endpoints.

Fixes: https://github.com/cilium/tetragon/issues/550

Signed-off-by: Andzej Maciusovic [andzej.maciusovic@gmail.com](mailto:andzej.maciusovic@gmail.com)