### PR TITLE
Makefile.cli: deal with {g,u}id collision

### DIFF
--- a/Makefile.cli
+++ b/Makefile.cli
@@ -13,8 +13,8 @@ cli-release:
 		--workdir /tetragon \
 		--volume `pwd`:/tetragon docker.io/library/golang:1.19.0-alpine3.16 \
 		sh -c "apk add --no-cache make git && \
-			addgroup -g $(RELEASE_GID) release && \
-			adduser -u $(RELEASE_UID) -D -G release release && \
+			(addgroup -g $(RELEASE_GID) release || addgroup release )&& \
+			(adduser -u $(RELEASE_UID) -D -G release release || adduser -D -G release release )&& \
 			su release -c 'make cli-local-release VERSION=${VERSION}'"
 
 cli-local-release: cli-clean


### PR DESCRIPTION
CLI builds have been failing with:
> addgroup: gid '123' in use

Fix this by redoing the addgroup, adduser command without a specific gid/uid.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>