### PR TITLE
build: Generate SBOM during image release

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -66,6 +66,35 @@ jobs:
         run: |
           cosign sign quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
 
+      - name: Install Bom
+        shell: bash
+        run: |
+          curl -L https://github.com/kubernetes-sigs/bom/releases/download/v0.4.1/bom-linux-amd64 -o bom
+          sudo mv ./bom /usr/local/bin/bom
+          sudo chmod +x /usr/local/bin/bom
+
+      - name: Generate SBOM
+        shell: bash
+        # To-Do: Format SBOM output to JSON after a new version of cosign is released after v1.13.1. Ref: https://github.com/sigstore/cosign/pull/2479
+        run: |
+          bom generate -o sbom_clang_${{ steps.tag.outputs.tag }}.spdx \
+          --dirs= . \
+          --image=quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}
+
+      - name: Attach SBOM to container image
+        run: |
+          cosign attach sbom --sbom sbom_clang_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
+
+      - name: Sign SBOM Image
+        if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          docker_build_release_digest="${{ steps.docker_build_release.outputs.digest }}"
+          image_name="quay.io/${{ github.repository_owner }}/clang:${docker_build_release_digest/:/-}.sbom"
+          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
+          cosign sign "quay.io/${{ github.repository_owner }}/clang@${docker_build_release_sbom_digest}"
+
       - name: Image Release Digest
         shell: bash
         run: |

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
 
+      - name: Install Bom
+        shell: bash
+        run: |
+          curl -L https://github.com/kubernetes-sigs/bom/releases/download/v0.4.1/bom-linux-amd64 -o bom
+          sudo mv ./bom /usr/local/bin/bom
+          sudo chmod +x /usr/local/bin/bom
+
       # main branch pushes
       - name: CI Build (main)
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -81,6 +88,30 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main.outputs.digest }}
+
+      - name: Generate SBOM
+        if: ${{ github.event_name != 'pull_request_target' }}
+        shell: bash
+        # To-Do: Format SBOM output to JSON after a new version of cosign is released after v1.13.1. Ref: https://github.com/sigstore/cosign/pull/2479
+        run: |
+          bom generate -o sbom_ci_main_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx \
+          --dirs=. \
+          --image=quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+
+      - name: Attach SBOM to container images
+        if: ${{ github.event_name != 'pull_request_target' }}
+        run: |
+          cosign attach sbom --sbom sbom_ci_main_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main.outputs.digest }}
+
+      - name: Sign SBOM Image
+        if: ${{ github.event_name != 'pull_request_target' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          docker_build_ci_main_digest="${{ steps.docker_build_ci_main.outputs.digest }}"
+          image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_ci_main_digest/:/-}.sbom"
+          docker_build_ci_main_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
+          cosign sign "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_ci_main_sbom_digest}"
 
       - name: CI Image Releases digests (main)
         if: ${{ github.event_name != 'pull_request_target' }}
@@ -110,6 +141,30 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr.outputs.digest }}
+
+      - name: Generate SBOM
+        if: ${{ github.event_name == 'pull_request_target' }}
+        shell: bash
+        # To-Do: Format SBOM output to JSON after a new version of cosign is released after v1.13.1. Ref: https://github.com/sigstore/cosign/pull/2479
+        run: |
+          bom generate --format json -o sbom_ci_pr_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx \
+          --dirs=. \
+          --image=quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+
+      - name: Attach SBOM to container images
+        if: ${{ github.event_name == 'pull_request_target' }}
+        run: |
+          cosign attach sbom --sbom sbom_ci_pr_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr.outputs.digest }}
+
+      - name: Sign SBOM Image
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          docker_build_ci_pr_digest="${{ steps.docker_build_ci_main.outputs.digest }}"
+          image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_ci_pr_digest/:/-}.sbom"
+          docker_build_ci_pr_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
+          cosign sign "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_ci_pr_sbom_digest}"
 
       - name: CI Image Releases digests (PR)
         if: ${{ github.event_name == 'pull_request_target' }}

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -72,6 +72,39 @@ jobs:
           cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
           cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
 
+      - name: Install Bom
+        shell: bash
+        run: |
+          curl -L https://github.com/kubernetes-sigs/bom/releases/download/v0.4.1/bom-linux-amd64 -o bom
+          sudo mv ./bom /usr/local/bin/bom
+          sudo chmod +x /usr/local/bin/bom
+
+      - name: Generate SBOM
+        shell: bash
+        # To-Do: Format SBOM output to JSON after a new version of cosign is released after v1.13.1. Ref: https://github.com/sigstore/cosign/pull/2479
+        run: |
+          bom generate -o sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx \
+          --dirs= . \
+          --image=quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+
+      - name: Attach SBOM to container image
+        run: |
+          cosign attach sbom --sbom sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
+          cosign attach sbom --sbom sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
+
+      - name: Sign SBOM Image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          docker_build_release_digest="${{ steps.docker_build_release.outputs.digest }}"
+          image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${docker_build_release_digest/:/-}.sbom"
+          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
+          cosign sign "quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${docker_build_release_sbom_digest}"
+
+          image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_release_digest/:/-}.sbom"
+          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
+          cosign sign "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_release_sbom_digest}"
+
       - name: Image Release Digest
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -649,6 +649,35 @@ $ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository c
 
 `--certificate-github-workflow-ref string` contains the ref claim from the GitHub OIDC Identity token that contains the git ref that the workflow run was based upon.
 
+## Software Bill of Materials
+
+A Software Bill of Materials (SBOM) is a complete, formally structured list of
+components that are required to build a given piece of software. SBOM provides
+insight into the software supply chain and any potential concerns related to
+license compliance and security that might exist.
+
+Starting with version 0.8.4, all Tetragon images include an SBOM. The SBOM is
+generated in [SPDX](https://spdx.dev/) format using the [bom](https://github.com/kubernetes-sigs/bom) tool.
+If you are new to the concept of SBOM, see [what an SBOM can do for you](https://www.chainguard.dev/unchained/what-an-sbom-can-do-for-you).
+
+### Download SBOM
+
+  The SBOM can be downloaded from the supplied Tetragon image using the `cosign download sbom` command.
+
+  ```bash
+  $ cosign download sbom --output-file sbom.spdx <Image URL>
+  ```
+### Verify SBOM Image Signature
+
+To ensure the SBOM is tamper-proof, its signature can be verified using the
+`cosign verify` command.
+
+```bash
+$ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository cilium/cilium --certificate-oidc-issuer https://token.actions.githubusercontent.com --attachment sbom <Image URL> | jq
+```
+It can be validated that the SBOM image was signed using Github Actions in the Cilium
+repository from the `Issuer` and `Subject` fields of the output.
+
 # FAQ
 
 **Q:** Can I install and use Tetragon in standalone mode (outside of k8s)?


### PR DESCRIPTION
Add a Software Bill of Materials (SBOM) generated from source code and the image using the Kubernetes bom tool to the Tetragon image during image build.

Signed-off-by: Sandipan Panda <samparksandipan@gmail.com>