### PR TITLE
Fix: avoid hang when err occure

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -131,7 +131,6 @@ func stopProfile() {
 
 func tetragonExecute() error {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
@@ -246,6 +245,7 @@ func tetragonExecute() error {
 
 	var cancelWg sync.WaitGroup
 	defer cancelWg.Wait()
+	defer cancel()
 
 	pm, err := tetragonGrpc.NewProcessManager(
 		ctx,


### PR DESCRIPTION
Premature WaitGroup waiting may cause deadlock.
If a code error occurs after ProcessManager is started (for example, an error occurs in loading a configuration file),
ProcessManager cannot exit and a deadlock occurs.

Signed-off-by: Zhiyu Wang <zhiyuwang.newbis@gmail.com>