### PR TITLE
tetragon: Make sure to read meaningful size data from char_buf args

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -520,8 +520,8 @@ __copy_char_buf(long off, unsigned long arg, unsigned long bytes,
 	int err;
 
 	/* Bound bytes <4095 to ensure bytes does not read past end of buffer */
-	rd_bytes = bytes;
-	rd_bytes &= 0xfff;
+	rd_bytes = bytes < 0x1000 ? bytes : 0xfff;
+	asm volatile("%[rd_bytes] &= 0xfff;\n" ::[rd_bytes] "+r"(rd_bytes) :);
 	err = probe_read(&s[2], rd_bytes, (char *)arg);
 	if (err < 0)
 		return return_error(s, char_buf_pagefault);


### PR DESCRIPTION
The ```char_buf``` args obtained from ```kprobes``` or ```tracepoints``` events is sometimes not a useful value that can be used for analysis.
the ```size``` of ```bpf_probe_read(void *dst, u32 size, const void *unsafe_ptr)``` in ```__copy_char_buf``` used ```rd_bytes &= 0xfff```. when ```bytes``` , the meta size of char_buf args  is 4096, ```rd_bytes``` will be 0, then nothing can be read from arg.
[source code](https://github.com/cilium/tetragon/blob/c338a633b4818dba9ba327188531da4a1f76c9f7/bpf/process/types/basic.h#L524)
![image](https://user-images.githubusercontent.com/39187264/204304541-f356f2f4-3f3e-45e8-b8ea-93f689e5162d.png)

In this pr, when ```rd_bytes > 0xfff```, the right-shift operation is performed to reduce ```rd_bytes``` until it becomes a value in the range of 4096, so that a part of the data at the beginning of char_buf can always be read by ```bpf_probe_read```.

**Example**
if you want get http response message by tracepoints ```sys_enter_write```,  then you will not lose any request response.
（ In this example I limit ```rb_bytes```< 0x3ff )
TracingPolicy:
```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "http"
spec:
  tracepoints:
    - subsystem: syscalls
      event: sys_enter_write
      args:
        - index: 5
          type: "fd"
        - index: 6
          type: "char_buf"
          sizeArgIndex: 8
        - index: 7
          type: "size_t"
    - subsystem: syscalls
      event: sys_enter_read
      args:
        - index: 5
          type: "fd"
        - index: 6
          type: "char_buf"
          sizeArgIndex: 8
        - index: 7
          type: "size_t"
```
got event:
```json
 {
        "process_tracepoint":{
            "process":{
                "exec_id":"ZWtsZXQtc3VibmV0LWJ4Z2tmbjFxOjk3NDM1Nzg3ODkwOjY2Ng==",
                "pid":666,
                "uid":0,
                "cwd":"/data/code",
                "binary":"/data/code/main",
                "flags":"execve clone",
                "start_time":"2022-11-28T14:59:39.370992262Z",
                "auid":4294967295,
                "pod":{
                    "namespace":"dctestpro",
                    "name":"tetragon-dev-v1-6bbd4d675c-r25b6",
                    "container":{ },
                    "pod_labels":{}
                },
                "docker":"",
                "parent_exec_id":"==",
                "refcnt":1
            },
            "parent":{ },
            "subsys":"syscalls",
            "event":"sys_enter_write",
            "args":[
                {
                    "size_arg":"7"
                },
                {
                    "bytes_arg":"SFRUUC8xLjEgMjAwIE9LDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb247IGNoYXJzZXQ9dXRmLTgNCkRhdGU6IE1vbiwgMjggTm92IDIwMjIgMTU6MjY6MTUgR01UDQpUcmFuc2Zlci1FbmNvZGluZzogY2h1bmtlZA0KDQoxNTdlDQp7ImNvZGUiOiIwIiwiY29zdCI6NzEyMjIsImRhdGEiOiJcbiNpbmNsdWRlIFx1MDAzY2xpbnV4L3NjaGVkLmhcdTAwM2VcbiNpbmNsdWRlIFx1MDAzY3VhcGkvbGludXgvcHRyYWNlLmhcdTAwM2VcbiNpbmNsdWRlIFx1MDAzY3VhcGkvbGludXgvc3RhdC5oXHUwMDNlXG4jaW5jbHVkZSBcdTAwM2NsaW51eC9maWxlLmhcdTAwM2VcbiNpbmNsdWRlIFx1MDAzY2xpbnV4L2ZzLmhcdTAwM2VcbiNpbmNsdWRlIFx1MDAzY2xpbnV4L3N0YXQuaFx1MDAzZVxuI2luY2x1ZGUgXHUwMDNjbGludXgvc29ja2V0LmhcdTAwM2VcblxuLyoqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG4gKiBCUEYgUHJvZ3JhbSB0aGF0IHRyYWNlcyBhIHJlcXVlc3QgbGlmZWN5Y2xlOlxuICogICBTdGFydHMgYXQgYWNjZXB0NCAoZXN0YWJsaXNoIGNvbm5lY3Rpb24pXG4gKiAgIFdyaXRlIChleHRyYWN0IGRhdGEpXG4gKiAgIENsb3NlIChjb21wbGV0ZSByZXF1ZXN0KVxuICoqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKiovXG5zdHJ1Y3QgYWRkcl9pbmZvX3Qge1xuICBzdHJ1Y3Qgc29ja2FkZHIgKmFkZHI7XG4gIHNpemVfdCAqYWRkcmxlbjtcbn07XG5cbiNkZWZpbmUgTUFYX01TR19TSVpFIDEwMjRcblxuQlBGX1BFUkZfT1VUUFVUKHN5c2NhbGxfd3JpdGVfZXZlbnRzKTtcblxuLy8gVGhpcyBuZWVkcyB0byBtYXRjaCBleGFjdGx5IHdpdGggdGhlIEdvIHZlcnNpb24gb2YgdGhlIHN0cnVjdC5cbnN0cnVjdCBzeXNjYWxsX3dyaXRlX2V2ZW50X3Qge1xuICAvLyBXZSBzcGxpdCBhdHRyaWJ1dGVzIGludG8gYSBzZXBhcmF0ZSBzdHJ1Y3QsIGJlY2F1c2UgQlBGIGdldHMgdXBz"
                },
                {
                    "size_arg":"154"
                }
            ]
        },
        "node_name":"",
        "time":"2022-11-28T15:00:47.888337488Z"
    }
```
-------------------------------- base64 decrypt bytes_arg----------------------------------
```
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Date: Mon, 28 Nov 2022 15:26:15 GMT
Transfer-Encoding: chunked

157e
{"code":"0","cost":71222,"data":"\n#include \u003clinux/sched.h\u003e\n#include \u003cuapi/linux/ptrace.h\u003e\n#include \u003cuapi/linux/stat.h\u003e\n#include \u003clinux/file.h\u003e\n#include \u003clinux/fs.h\u003e\n#include \u003clinux/stat.h\u003e\n#include \u003clinux/socket.h\u003e\n\n/***********************************************************\n * BPF Program that traces a request lifecycle:\n *   Starts at accept4 (establish connection)\n *   Write (extract data)\n *   Close (complete request)\n **********************************************************/\nstruct addr_info_t {\n  struct sockaddr *addr;\n  size_t *addrlen;\n};\n\n#define MAX_MSG_SIZE 1024\n\nBPF_PERF_OUTPUT(syscall_write_events);\n\n// This needs to match exactly with the Go version of the struct.\nstruct syscall_write_event_t {\n  // We split attributes into a separate struct, because BPF gets ups
```
use go ```net/http``` ```http.ReadResponse``` can parse it to a http response.

**Notice**
The char_buf data obtained by this way may still be truncated. but not empty or too short.

fix #562 
Signed-off-by: dechengyuan <dechengyuan@tencent.com>