### PR TITLE
tetragon: fixup generic tracepoint sensor create

### DIFF
--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -318,8 +318,8 @@ func createGenericTracepoint(sensorName string, conf *GenericTracepointConf) (*g
 func createGenericTracepointSensor(name string, confs []GenericTracepointConf) (*sensors.Sensor, error) {
 
 	tracepoints := make([]*genericTracepoint, 0, len(confs))
-	for _, conf := range confs {
-		tp, err := createGenericTracepoint(name, &conf)
+	for i := range confs {
+		tp, err := createGenericTracepoint(name, &confs[i])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
tracepoint sensor creation not as expected.
[source code](https://github.com/cilium/tetragon/blob/3a3f8990503153b2ea63e15b3a62cbed6f8d1949/pkg/sensors/tracing/generictracepoint.go#L322)
use ```&conf``` cause all ```genericTracepoint.Spec``` as same as the last element in ```genericTracepointTable```, should use ```&confs[i]``` instead.
<img width="960" alt="image" src="https://user-images.githubusercontent.com/39187264/204755088-b2258b92-fa39-448e-9133-b93dd2646388.png">
fix #569 
Signed-off-by: dechengyuan <dechengyuan@tencent.com>