### PR TITLE
tetragon: fix initialization deadlock

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,10 +55,10 @@ type getEventsListener struct {
 	events chan *tetragon.GetEventsResponse
 }
 
-func NewServer(ctx context.Context, wg *sync.WaitGroup, notifier notifier, observer observer) *Server {
+func NewServer(ctx context.Context, cleanupWg *sync.WaitGroup, notifier notifier, observer observer) *Server {
 	return &Server{
 		ctx:          ctx,
-		ctxCleanupWG: wg,
+		ctxCleanupWG: cleanupWg,
 		notifier:     notifier,
 		observer:     observer,
 	}


### PR DESCRIPTION
There is a potential for a deadlock in the initialization case. This might happen if, for example, we pass a wrong filename for the config file.

We fix this by generating a new context which we can cancel without causing deadlocks.

The patch also adds comments to explain why this is needed so more details can be found there.

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>
Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>
Reported-by:  Zhiyu Wang <zhiyuwang.newbis@gmail.com>