### PR TITLE
ci: bump golangci-lint to v1.50.1

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -18,14 +18,11 @@ jobs:
         with:
           go-version: '1.18.3'
       - name: Run static checks
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376
         with:
-          version: v1.47.0
+          version: v1.50.1
           args: --config=.golangci.yml --verbose
-          only-new-issues: false
-          skip-go-installation: true
-          skip-pkg-cache: true
-          skip-build-cache: true
+          skip-cache: true
       - name: Check gofmt formatting
         run: |
           go fmt ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - revive
     - staticcheck
     - unused
-    - varcheck
 
 issues:
   exclude-rules:

--- a/Dockerfile.golangci-lint
+++ b/Dockerfile.golangci-lint
@@ -1,4 +1,4 @@
-FROM docker.io/golangci/golangci-lint:v1.49.0
+FROM docker.io/golangci/golangci-lint:v1.50.1
 RUN apt-get -y update
 RUN apt-get -y install libz-dev libelf-dev
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO_IMAGE_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(VERSION)'
 GO_OPERATOR_IMAGE_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(VERSION)' -s -w"
 
 
-GOLANGCILINT_WANT_VERSION = 1.45.2
+GOLANGCILINT_WANT_VERSION = 1.50.1
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
 
@@ -264,7 +264,7 @@ endif
 
 .PHONY: go-format
 go-format:
-	find . -name '*.go' -not -path './vendor/*' -not -path './api/vendor/*' -not -path './pkg/k8s/vendor/*' | xargs gofmt -w
+	find . -name '*.go' -not -path './vendor/*' -not -path './api/vendor/*' -not -path './pkg/k8s/vendor/*' -not -path './api/v1/tetragon/codegen/*' | xargs gofmt -w
 
 .PHONY: format
 format: go-format clang-format

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ install:
 vendor:
 	$(MAKE) -C ./api vendor
 	$(MAKE) -C ./pkg/k8s vendor
-	$(GO) mod tidy -compat=1.17
+	$(GO) mod tidy -compat=1.18
 	$(GO) mod vendor
 	$(GO) mod verify
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -20,6 +20,6 @@ v1:
 
 .PHONY: vendor
 vendor:
-	$(GO) mod tidy -compat=1.17
+	$(GO) mod tidy -compat=1.18
 	$(GO) mod vendor
 	$(GO) mod verify

--- a/cmd/tetragon/addr.go
+++ b/cmd/tetragon/addr.go
@@ -10,8 +10,9 @@ import (
 // with net.Listen.
 //
 // addresses can be:
-//  unix://absolute_path for unix sockets
-//  <host>:<port> for TCP (more specifically, an address that can be passed to net.Listen)
+//
+//	unix://absolute_path for unix sockets
+//	<host>:<port> for TCP (more specifically, an address that can be passed to net.Listen)
 //
 // Note that the client (tetra) uses https://github.com/grpc/grpc-go/blob/v1.51.0/clientconn.go#L135
 // With the syntax is documented in https://github.com/grpc/grpc/blob/master/doc/naming.md. The

--- a/pkg/k8s/Makefile
+++ b/pkg/k8s/Makefile
@@ -5,7 +5,7 @@ GO_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(VERSION)'"
 GO_IMAGE_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(VERSION)' -linkmode external -extldflags -static"
 GO_OPERATOR_IMAGE_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(VERSION)' -s -w"
 
-GOLANGCILINT_WANT_VERSION = 1.45.2
+GOLANGCILINT_WANT_VERSION = 1.50.1
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
 all: generate

--- a/pkg/k8s/Makefile
+++ b/pkg/k8s/Makefile
@@ -32,6 +32,6 @@ generate:
 
 .PHONY: vendor
 vendor:
-	$(GO) mod tidy -compat=1.17
+	$(GO) mod tidy -compat=1.18
 	$(GO) mod vendor
 	$(GO) mod verify

--- a/pkg/unixlisten/unixlisten.go
+++ b/pkg/unixlisten/unixlisten.go
@@ -12,9 +12,9 @@ import (
 // ListenWithRename creates a "unix" listener for the given path and the given mode
 //
 // Go's net.Listen() performs three system calls at once:
-//  - socket, where the file descriptor is created
-//  - bind, where the unix socket file is created
-//  - listen, where the socket can now accept connections
+//   - socket, where the file descriptor is created
+//   - bind, where the unix socket file is created
+//   - listen, where the socket can now accept connections
 //
 // Hence, doing a chmod(2) after Listen is racy because a client can connect
 // between the listen(2) and the chmod(2) calls. One solution would be to use


### PR DESCRIPTION
Also bump the golangci-lint action to v3.3.1. Use the new `skip-cache` directive to disable caching instead of the more specific options. Remove `only-new-issues: false` given that `false` is the default value. Finally, remove `skip-go-installation` as this is an unknown config option to the linter which gives a warning.