### PR TITLE
sensor cleanups

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,6 @@ cmd/protoc-gen-go-tetragon/ @willfindlay
 
 # Request a review from William when CI is edited
 .github/workflows/ @willfindlay
+
+# Request a review from kkourt when core sensor files are modified
+pkg/src/sensors/ @kkourt

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -221,11 +221,10 @@ func tetragonExecute() error {
 		cancel()
 	}()
 
-	sensors.LogRegisteredSensorsAndProbes()
-
 	if err := obs.InitSensorManager(); err != nil {
 		return err
 	}
+	observer.SensorManager.LogSensorsAndProbes(ctx)
 
 	/* Remove any stale programs, otherwise feature set change can cause
 	 * old programs to linger resulting in undefined behavior. And because

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -26,6 +26,14 @@ func (cnf *GenericTracingConf) Name() string {
 	return fmt.Sprintf("%s", cnf.Metadata.Name)
 }
 
+func (cnf *GenericTracingConf) TpSpec() *v1alpha1.TracingPolicySpec {
+	return &cnf.Spec
+}
+
+func (cnf *GenericTracingConf) TpInfo() string {
+	return fmt.Sprintf("%s", cnf.Metadata.Name)
+}
+
 func ReadConfigYaml(data string) (*GenericTracingConf, error) {
 	var k GenericTracingConf
 

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/ratelimit"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/server"
@@ -104,7 +105,7 @@ func (f *fakeObserver) GetTreeProto(ctx context.Context, tname string) (*tetrago
 	return nil, nil
 }
 
-func (f *fakeObserver) AddTracingPolicy(ctx context.Context, sensorName string, spec interface{}) error {
+func (f *fakeObserver) AddTracingPolicy(ctx context.Context, sensorName string, spec *v1alpha1.TracingPolicySpec) error {
 	return nil
 }
 

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -14,9 +14,7 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/ratelimit"
-	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/server"
 	"github.com/stretchr/testify/assert"
 )
@@ -79,50 +77,12 @@ func (f *fakeNotifier) NotifyListener(original interface{}, processed *tetragon.
 	}
 }
 
-type fakeObserver struct{}
-
-func (f *fakeObserver) ListSensors(ctx context.Context) (*[]sensors.SensorStatus, error) {
-	return nil, nil
-}
-
-func (f *fakeObserver) EnableSensor(ctx context.Context, name string) error {
-	return nil
-}
-
-func (f *fakeObserver) DisableSensor(ctx context.Context, name string) error {
-	return nil
-}
-
-func (f *fakeObserver) GetSensorConfig(ctx context.Context, k string, v string) (string, error) {
-	return "", nil
-}
-
-func (f *fakeObserver) SetSensorConfig(ctx context.Context, name string, cfgkey string, cfgval string) error {
-	return nil
-}
-
-func (f *fakeObserver) GetTreeProto(ctx context.Context, tname string) (*tetragon.StackTraceNode, error) {
-	return nil, nil
-}
-
-func (f *fakeObserver) AddTracingPolicy(ctx context.Context, sensorName string, spec *v1alpha1.TracingPolicySpec) error {
-	return nil
-}
-
-func (f *fakeObserver) DelTracingPolicy(ctx context.Context, sensorName string) error {
-	return nil
-}
-
-func (f *fakeObserver) RemoveSensor(ctx context.Context, sensorName string) error {
-	return nil
-}
-
 func TestExporter_Send(t *testing.T) {
 	var wg sync.WaitGroup
 
 	eventNotifier := newFakeNotifier()
 	ctx, cancel := context.WithCancel(context.Background())
-	grpcServer := server.NewServer(ctx, &wg, eventNotifier, &fakeObserver{})
+	grpcServer := server.NewServer(ctx, &wg, eventNotifier, &server.FakeObserver{})
 	numRecords := 2
 	results := newArrayWriter(numRecords)
 	encoder := json.NewEncoder(results)
@@ -226,7 +186,7 @@ func Test_rateLimitExport(t *testing.T) {
 		t.Run(fmt.Sprintf("%s (%d events, %d rate limit)", tt.name, tt.totalEvents, tt.rateLimit), func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			eventNotifier := newFakeNotifier()
-			grpcServer := server.NewServer(ctx, &wg, eventNotifier, &fakeObserver{})
+			grpcServer := server.NewServer(ctx, &wg, eventNotifier, &server.FakeObserver{})
 			results := newArrayWriter(tt.totalEvents)
 			encoder := json.NewEncoder(results)
 			request := &tetragon.GetEventsRequest{}

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -14,6 +14,7 @@ import (
 	tetragonAPI "github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/cilium"
 	"github.com/cilium/tetragon/pkg/eventcache"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/notify"
@@ -84,7 +85,7 @@ type DummyObserver struct {
 	t *testing.T
 }
 
-func (o DummyObserver) AddTracingPolicy(ctx context.Context, sensorName string, spec interface{}) error {
+func (o DummyObserver) AddTracingPolicy(ctx context.Context, sensorName string, spec *v1alpha1.TracingPolicySpec) error {
 	return nil
 }
 

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -4,6 +4,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	ciliumio "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -43,6 +45,14 @@ type TracingPolicySpec struct {
 	// +kubebuilder:validation:Optional
 	// A list of tracepoint specs.
 	Tracepoints []TracepointSpec `json:"tracepoints"`
+}
+
+func (tp *TracingPolicy) TpSpec() *TracingPolicySpec {
+	return &tp.Spec
+}
+
+func (tp *TracingPolicy) TpInfo() string {
+	return fmt.Sprintf("%s (object:%d/%s) (type:%s/%s)", tp.ObjectMeta.Name, tp.ObjectMeta.Generation, tp.ObjectMeta.UID, tp.TypeMeta.Kind, tp.TypeMeta.APIVersion)
 }
 
 type KProbeSpec struct {

--- a/pkg/sensors/collection.go
+++ b/pkg/sensors/collection.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package sensors
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/multierr"
+)
+
+// collection is a collection of sensors
+// This can either be creating from a tracing policy, or by loading sensors indepenently for sensors
+// that are not loaded via a tracing policy (e.g., base sensor) and testing.
+type collection struct {
+	sensors []*Sensor
+	name    string
+}
+
+// load will attempt to load a collection of sensors. If loading one of the sensors fails, it
+// will attempt to unload the already loaded sensors.
+func (c *collection) load(ctx context.Context, bpfDir, mapDir, ciliumDir string, cbArg *LoadArg) error {
+
+	var err error
+	for _, sensor := range c.sensors {
+		if sensor.Loaded {
+			// NB: For now, we don't treat a sensor already loaded as an error
+			// because that would complicate things.
+			continue
+		}
+		if err = sensor.FindPrograms(ctx); err != nil {
+			err = fmt.Errorf("sensor %s programs from collection %s could not be found: %s", sensor.Name, c.name, err)
+			break
+		}
+
+		if err = sensor.Load(ctx, bpfDir, mapDir, ciliumDir); err != nil {
+			err = fmt.Errorf("sensor %s from collection %s could failed to load: %s", sensor.Name, c.name, err)
+			break
+		}
+	}
+
+	// if there was an error, try to unload all the sensors
+	if err != nil {
+		// NB: we could try to unload sensors going back from the one that failed, but since
+		// unload() checks s.Loaded, is easier to just do use unload().
+		if unloadErr := c.unload(nil); unloadErr != nil {
+			err = multierr.Append(err, fmt.Errorf("unloading after loading failure failed: %w", unloadErr))
+		}
+	} else {
+		// otherwise, call the loaded callbalcks for all the sensors
+		if cbArg != nil {
+			for _, sensor := range c.sensors {
+				if sensor.Ops != nil {
+					sensor.Ops.Loaded(*cbArg)
+				}
+			}
+		}
+	}
+
+	return err
+}
+
+// unload will attempt to unload all the sensors in a collection
+func (c *collection) unload(cbArg *UnloadArg) error {
+	var err error
+	for _, s := range c.sensors {
+		if !s.Loaded {
+			continue
+		}
+		if unloadErr := s.Unload(); unloadErr == nil && cbArg != nil && s.Ops != nil {
+			s.Ops.Unloaded(*cbArg)
+		}
+		err = multierr.Append(err, s.Unload())
+	}
+
+	if err != nil {
+		err = fmt.Errorf("failed to unload all sensors from collection %s: %w", c.name, err)
+	}
+	return err
+}

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -84,10 +84,6 @@ var (
 	}
 )
 
-func init() {
-	tus.RegisterSensorsAtInit(loadedSensors)
-}
-
 func logDefaultCgroupConfig(t *testing.T) {
 	path := cgroups.GetCgroupFSPath()
 	magic := cgroups.GetCgroupFSMagic()
@@ -451,10 +447,7 @@ func TestCgroupNoEvents(t *testing.T) {
 	testManager := tus.StartTestSensorManager(ctx, t)
 	observer.SensorManager = testManager.Manager
 
-	testManager.EnableSensors(ctx, t, loadedSensors)
-	t.Cleanup(func() {
-		testManager.DisableSensors(ctx, t, loadedSensors)
-	})
+	testManager.AddAndEnableSensors(ctx, t, loadedSensors)
 
 	// Set Cgroup Tracking level to Zero means no tracking and no
 	// cgroup events, all bpf cgroups related programs have no effect
@@ -510,7 +503,7 @@ func TestCgroupEventMkdirRmdir(t *testing.T) {
 	testManager := tus.StartTestSensorManager(ctx, t)
 	observer.SensorManager = testManager.Manager
 
-	testManager.EnableSensors(ctx, t, loadedSensors)
+	testManager.AddAndEnableSensors(ctx, t, loadedSensors)
 	t.Cleanup(func() {
 		testManager.DisableSensors(ctx, t, loadedSensors)
 	})
@@ -690,7 +683,7 @@ func testCgroupv2K8sHierarchy(ctx context.Context, t *testing.T, mode cgroups.Cg
 	testManager := tus.StartTestSensorManager(ctx, t)
 	observer.SensorManager = testManager.Manager
 
-	testManager.EnableSensors(ctx, t, loadedSensors)
+	testManager.AddAndEnableSensors(ctx, t, loadedSensors)
 	t.Cleanup(func() {
 		testManager.DisableSensors(ctx, t, loadedSensors)
 	})
@@ -860,10 +853,7 @@ func testCgroupv1K8sHierarchyInHybrid(t *testing.T, selectedController string) {
 	testManager := tus.StartTestSensorManager(ctx, t)
 	observer.SensorManager = testManager.Manager
 
-	testManager.EnableSensors(ctx, t, loadedSensors)
-	t.Cleanup(func() {
-		testManager.DisableSensors(ctx, t, loadedSensors)
-	})
+	testManager.AddAndEnableSensors(ctx, t, loadedSensors)
 
 	// Probe full environment detection
 	setupTgRuntimeConf(t, invalidValue, invalidValue, invalidValue, invalidValue)

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -237,11 +237,9 @@ func handleCgroupEvent(r *bytes.Reader) ([]observer.Event, error) {
 	return []observer.Event{msgUnix}, nil
 }
 
-type execSensor struct {
-	name string
-}
+type execProbe struct{}
 
-func (e *execSensor) LoadProbe(args sensors.LoadProbeArgs) error {
+func (e *execProbe) LoadProbe(args sensors.LoadProbeArgs) error {
 	err := program.LoadTracepointProgram(args.BPFDir, args.MapDir, args.Load, args.Verbose)
 	if err == nil {
 		procevents.GetRunningProcs()
@@ -249,19 +247,12 @@ func (e *execSensor) LoadProbe(args sensors.LoadProbeArgs) error {
 	return err
 }
 
-func (e *execSensor) SpecHandler(spec interface{}) (*sensors.Sensor, error) {
-	return nil, nil
-}
-
 func init() {
 	AddExec()
 }
 
 func AddExec() {
-	execveProbe := &execSensor{
-		name: "exec base sensor",
-	}
-	sensors.RegisterProbeType("execve", execveProbe)
+	sensors.RegisterProbeType("execve", &execProbe{})
 
 	observer.RegisterEventHandlerAtInit(ops.MSG_OP_EXECVE, handleExecve)
 	observer.RegisterEventHandlerAtInit(ops.MSG_OP_EXIT, handleExit)

--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -95,7 +95,7 @@ func (s *Sensor) Load(stopCtx context.Context, bpfDir, mapDir, ciliumDir string)
 		return fmt.Errorf("tetragon, aborting could not find BPF programs: %w", err)
 	}
 
-	if err := s.LoadMaps(stopCtx, mapDir); err != nil {
+	if err := s.loadMaps(stopCtx, mapDir); err != nil {
 		return fmt.Errorf("tetragon, aborting could not load sensor BPF maps: %w", err)
 	}
 
@@ -157,8 +157,8 @@ func isValidSubdir(dir string) bool {
 	return dir != "." && dir != ".."
 }
 
-// LoadMaps loads all the BPF maps in the sensor.
-func (s *Sensor) LoadMaps(stopCtx context.Context, mapDir string) error {
+// loadMaps loads all the BPF maps in the sensor.
+func (s *Sensor) loadMaps(stopCtx context.Context, mapDir string) error {
 	l := logger.GetLogger()
 	for _, m := range s.Maps {
 		if m.PinState.IsLoaded() {

--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -340,7 +340,7 @@ func createDir(bpfDir, mapDir string) {
 
 func UnloadAll(bpfDir string) {
 	for _, l := range AllPrograms {
-		RemoveProgram(bpfDir, l)
+		unloadProgram(l)
 	}
 
 	for _, m := range AllMaps {

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -28,6 +28,10 @@ func StartSensorManager(bpfDir, mapDir, ciliumDir string) (*Manager, error) {
 
 	c := make(chan sensorOp)
 	go func() {
+
+		// list of availableSensors
+		availableSensors := map[string][]*Sensor{}
+
 		done := false
 		for !done {
 			op_ := <-c

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger"
 	sttManager "github.com/cilium/tetragon/pkg/stt"
 )
@@ -311,7 +312,7 @@ func (h *Manager) SetSensorConfig(ctx context.Context, name string, cfgkey strin
 }
 
 // AddTracingPolicy adds a new sensor based on a tracing policy
-func (h *Manager) AddTracingPolicy(ctx context.Context, sensorName string, spec interface{}) error {
+func (h *Manager) AddTracingPolicy(ctx context.Context, sensorName string, spec *v1alpha1.TracingPolicySpec) error {
 	retc := make(chan error)
 	op := &tracingPolicyAdd{
 		ctx:        ctx,

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package sensors
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type dummyHandler struct {
+	s *Sensor
+	e error
+}
+
+func (d *dummyHandler) SpecHandler(raw interface{}) (*Sensor, error) {
+	return d.s, d.e
+}
+
+// TestAddPolicy tests the addition of a policy with a dummy sensor
+func TestAddPolicy(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	RegisterSpecHandlerAtInit("dummy", &dummyHandler{s: &Sensor{Name: "dummy-sensor"}})
+	t.Cleanup(func() {
+		delete(registeredSpecHandlers, "dummy")
+	})
+
+	policy := v1alpha1.TracingPolicy{}
+	mgr, err := StartSensorManager("", "", "")
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		if err := mgr.StopSensorManager(ctx); err != nil {
+			panic("failed to stop sensor manager")
+		}
+	})
+	err = mgr.AddTracingPolicy(ctx, "test-policy", &policy)
+	assert.NoError(t, err)
+	l, err := mgr.ListSensors(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, []SensorStatus{{Name: "dummy-sensor", Enabled: true}}, *l)
+}
+
+// TestAddPolicies tests the addition of a policy with two dummy sensors
+func TestAddPolicies(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	RegisterSpecHandlerAtInit("dummy1", &dummyHandler{s: &Sensor{Name: "dummy-sensor1"}})
+	RegisterSpecHandlerAtInit("dummy2", &dummyHandler{s: &Sensor{Name: "dummy-sensor2"}})
+	t.Cleanup(func() {
+		delete(registeredSpecHandlers, "dummy1")
+		delete(registeredSpecHandlers, "dummy2")
+	})
+
+	policy := v1alpha1.TracingPolicy{}
+	mgr, err := StartSensorManager("", "", "")
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		if err := mgr.StopSensorManager(ctx); err != nil {
+			panic("failed to stop sensor manager")
+		}
+	})
+	err = mgr.AddTracingPolicy(ctx, "test-policy", &policy)
+	assert.NoError(t, err)
+	l, err := mgr.ListSensors(ctx)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []SensorStatus{
+		{Name: "dummy-sensor1", Enabled: true},
+		{Name: "dummy-sensor2", Enabled: true},
+	}, *l)
+}
+
+// TestAddPolicySpecError tests the addition of a policy where a spec fails to load
+func TestAddPolicySpecError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	RegisterSpecHandlerAtInit("dummy", &dummyHandler{s: &Sensor{Name: "dummy-sensor"}})
+	RegisterSpecHandlerAtInit("spec-fail", &dummyHandler{e: errors.New("spec load is expected to fail: failed")})
+	t.Cleanup(func() {
+		delete(registeredSpecHandlers, "dummy")
+		delete(registeredSpecHandlers, "spec-fail")
+	})
+
+	policy := v1alpha1.TracingPolicy{}
+	mgr, err := StartSensorManager("", "", "")
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		if err := mgr.StopSensorManager(ctx); err != nil {
+			panic("failed to stop sensor manager")
+		}
+	})
+	err = mgr.AddTracingPolicy(ctx, "test-policy", &policy)
+	assert.NotNil(t, err)
+	t.Logf("got error (as expected): %s", err)
+	l, err := mgr.ListSensors(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, []SensorStatus{}, *l)
+}
+
+// TestAddPolicyLoadError tests the addition of a policy where the sensor is expected to fail
+func TestAddPolicyLoadError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	RegisterSpecHandlerAtInit("dummy", &dummyHandler{s: &Sensor{Name: "dummy-sensor"}})
+	RegisterSpecHandlerAtInit("load-fail", &dummyHandler{s: &Sensor{
+		Name:  "dummy-sensor",
+		Progs: []*program.Program{{Name: "bpf-program-that-does-not-exist"}},
+	}})
+	t.Cleanup(func() {
+		delete(registeredSpecHandlers, "dummy")
+		delete(registeredSpecHandlers, "load-fail")
+	})
+
+	policy := v1alpha1.TracingPolicy{}
+	mgr, err := StartSensorManager("", "", "")
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		if err := mgr.StopSensorManager(ctx); err != nil {
+			panic("failed to stop sensor manager")
+		}
+	})
+	err = mgr.AddTracingPolicy(ctx, "test-policy", &policy)
+	assert.NotNil(t, err)
+	t.Logf("got error (as expected): %s", err)
+	l, err := mgr.ListSensors(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, []SensorStatus{}, *l)
+}

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -5,7 +5,6 @@ package sensors
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/sensors/program"
@@ -111,28 +110,6 @@ func RegisterProbeType(probeType string, s tracingSensor) {
 		panic(fmt.Sprintf("RegisterProbeType called, but %s is already registered", probeType))
 	}
 	registeredProbeLoad[probeType] = s
-}
-
-func LogRegisteredSensorsAndProbes() {
-	log := logger.GetLogger()
-
-	names := []string{}
-	for n := range availableSensors {
-		names = append(names, n)
-	}
-	log.WithField("sensors", strings.Join(names, ", ")).Info("Available sensors")
-
-	names = []string{}
-	for n := range registeredTracingSensors {
-		names = append(names, n)
-	}
-	log.WithField("sensors", strings.Join(names, ", ")).Info("Registered tracing sensors")
-
-	names = []string{}
-	for n := range registeredProbeLoad {
-		names = append(names, n)
-	}
-	log.WithField("types", strings.Join(names, ", ")).Info("Registered probe types")
 }
 
 type tracingSensor interface {

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -97,7 +97,7 @@ var (
 // This will register a CRD or config file handler so that the config file
 // or CRDs will be passed to the handler to be parsed.
 func RegisterTracingSensorsAtInit(name string, s tracingSensor) {
-	if _, exists := availableSensors[name]; exists {
+	if _, exists := registeredTracingSensors[name]; exists {
 		panic(fmt.Sprintf("RegisterTracingSensor called, but %s is already registered", name))
 	}
 	registeredTracingSensors[name] = s

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -87,8 +87,6 @@ var (
 	registeredTracingSensors = map[string]tracingSensor{}
 	// list of registers loaders, see registerProbeType()
 	registeredProbeLoad = map[string]tracingSensor{}
-
-	manager *Manager
 )
 
 // RegisterTracingSensorsAtInit registers a handler for Tracing policy.

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -147,20 +147,6 @@ type LoadProbeArgs struct {
 	Version, Verbose          int
 }
 
-// registerSensor registers a sensor so that it is available to users.
-//
-// This function is meant to be called in an init().
-// This ensures that the function is called before controller goroutine starts,
-// and that the availableSensors is setup without having to worry about
-// synchronization.
-func RegisterSensorAtInit(s *Sensor) {
-	if _, exists := availableSensors[s.Name]; exists {
-		panic(fmt.Sprintf("registerSensor called, but %s is already registered", s.Name))
-	}
-
-	availableSensors[s.Name] = []*Sensor{s}
-}
-
 func GetSensorsFromParserPolicy(spec interface{}) ([]*Sensor, error) {
 	var sensors []*Sensor
 	for _, s := range registeredTracingSensors {

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -28,9 +28,10 @@ var (
 
 // Sensor is a set of BPF programs and maps that are managed as a unit.
 //
-// NB: For now we assume that sensors use disjoint sets of progs and maps.  If
-// that assumption breaks, we need to be smarter about loading/deleting programs
-// and maps (e.g., keep reference counts).
+// NB: We need to rethink the Ops field. See manager main loop for some
+// discussion on this. If we decide to keep them, we should merge them with the
+// UnloadHook since the two are similar: ops.Unloaded is called when a sensor
+// is successfully unloaded, while UnloadHook is called during unloading.
 type Sensor struct {
 	// Name is a human-readbale description.
 	Name string

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -88,8 +88,6 @@ type probeLoader interface {
 }
 
 var (
-	// list of availableSensors, see registerSensor()
-	availableSensors = map[string][]*Sensor{}
 	// list of registered Tracing handlers, see registerTracingHandler()
 	registeredSpecHandlers = map[string]specHandler{}
 	// list of registers loaders, see registerProbeType()

--- a/pkg/sensors/sync.go
+++ b/pkg/sensors/sync.go
@@ -41,7 +41,7 @@ func StartSensorManager(bpfDir, mapDir, ciliumDir string) (*Manager, error) {
 					break
 				}
 				sensors := []*Sensor{}
-				for _, s := range registeredTracingSensors {
+				for _, s := range registeredSpecHandlers {
 					sensor, err = s.SpecHandler(op.spec)
 					if err != nil {
 						break
@@ -376,10 +376,10 @@ func (h *Manager) LogSensorsAndProbes(ctx context.Context) {
 	log.WithField("sensors", strings.Join(names, ", ")).Info("Available sensors")
 
 	names = []string{}
-	for n := range registeredTracingSensors {
+	for n := range registeredSpecHandlers {
 		names = append(names, n)
 	}
-	log.WithField("sensors", strings.Join(names, ", ")).Info("Registered tracing sensors")
+	log.WithField("spec-handlers", strings.Join(names, ", ")).Info("Registered tracing sensors")
 
 	names = []string{}
 	for n := range registeredProbeLoad {

--- a/pkg/sensors/sync.go
+++ b/pkg/sensors/sync.go
@@ -27,10 +27,6 @@ type SensorStatus struct {
 func StartSensorManager(bpfDir, mapDir, ciliumDir string) (*Manager, error) {
 	var m Manager
 
-	if manager != nil {
-		return nil, fmt.Errorf("failed to start sensor controller: channel already exists")
-	}
-
 	c := make(chan sensorOp)
 	go func() {
 		done := false

--- a/pkg/sensors/sync.go
+++ b/pkg/sensors/sync.go
@@ -211,7 +211,7 @@ func StartSensorManager(bpfDir, mapDir, ciliumDir string) (*Manager, error) {
 	return &m, nil
 }
 
-func RemoveProgram(bpfDir string, prog *program.Program) {
+func unloadProgram(prog *program.Program) {
 	log := logger.GetLogger().WithField("label", prog.Label).WithField("pin", prog.PinPath)
 
 	if !prog.LoadState.IsLoaded() {
@@ -243,7 +243,7 @@ func UnloadSensor(ctx context.Context, bpfDir, mapDir string, sensor *Sensor) er
 	}
 
 	for _, p := range sensor.Progs {
-		RemoveProgram(bpfDir, p)
+		unloadProgram(p)
 	}
 
 	for _, m := range sensor.Maps {

--- a/pkg/sensors/sync.go
+++ b/pkg/sensors/sync.go
@@ -362,6 +362,32 @@ func (h *Manager) StopSensorManager(ctx context.Context) error {
 	return <-retc
 }
 
+func (h *Manager) LogSensorsAndProbes(ctx context.Context) {
+	log := logger.GetLogger()
+	sensors, err := h.ListSensors(ctx)
+	if err != nil {
+		log.WithError(err).Warn("failed to list sensors")
+	}
+
+	names := []string{}
+	for _, s := range *sensors {
+		names = append(names, s.Name)
+	}
+	log.WithField("sensors", strings.Join(names, ", ")).Info("Available sensors")
+
+	names = []string{}
+	for n := range registeredTracingSensors {
+		names = append(names, n)
+	}
+	log.WithField("sensors", strings.Join(names, ", ")).Info("Registered tracing sensors")
+
+	names = []string{}
+	for n := range registeredProbeLoad {
+		names = append(names, n)
+	}
+	log.WithField("types", strings.Join(names, ", ")).Info("Registered probe types")
+}
+
 // Manager handles dynamic sensor management, such as adding / removing sensors
 // at runtime.
 type Manager struct {

--- a/pkg/sensors/sync.go
+++ b/pkg/sensors/sync.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/sensors/program"
 	sttManager "github.com/cilium/tetragon/pkg/stt"
 )
 
@@ -209,25 +208,6 @@ func StartSensorManager(bpfDir, mapDir, ciliumDir string) (*Manager, error) {
 	m.STTManager = sttManager.StartSttManager()
 	m.sensorCtl = c
 	return &m, nil
-}
-
-func unloadProgram(prog *program.Program) {
-	log := logger.GetLogger().WithField("label", prog.Label).WithField("pin", prog.PinPath)
-
-	if !prog.LoadState.IsLoaded() {
-		log.Debugf("Refusing to remove %s, program not loaded", prog.Label)
-		return
-	}
-	if count := prog.LoadState.RefDec(); count > 0 {
-		log.Debugf("Program reference count %d, not unloading yet", count)
-		return
-	}
-
-	if err := prog.Unload(); err != nil {
-		logger.GetLogger().WithField("name", prog.Name).WithError(err).Warn("Failed to unload program")
-	}
-
-	log.Info("BPF prog was unloaded")
 }
 
 /*

--- a/pkg/sensors/test/lseek_test.go
+++ b/pkg/sensors/test/lseek_test.go
@@ -5,16 +5,13 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"sync"
 	"testing"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
-	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/observer"
-	"github.com/cilium/tetragon/pkg/sensors"
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
@@ -78,31 +75,10 @@ func TestSensorLseekEnable(t *testing.T) {
 	}
 
 	sensor := GetTestSensor()
-	sensors.RegisterSensorAtInit(sensor)
 
-	mapDir := bpf.MapPrefixPath()
-	smanager, err := sensors.StartSensorManager(mapDir, mapDir, "")
-	if err != nil {
-		t.Fatalf("startSensorController failed: %s", err)
-	}
-	observer.SensorManager = smanager
-	defer func() {
-		err := smanager.StopSensorManager(ctx)
-		if err != nil {
-			fmt.Printf("stopSensorController failed: %s\n", err)
-		}
-	}()
-
-	if err := smanager.EnableSensor(ctx, sensor.Name); err != nil {
-		t.Fatalf("EnableSensor error: %s", err)
-	}
-
-	defer func() {
-		err := smanager.DisableSensor(ctx, sensor.Name)
-		if err != nil {
-			fmt.Printf("DisableSensor failed: %s\n", err)
-		}
-	}()
+	smanager := tus.StartTestSensorManager(ctx, t)
+	observer.SensorManager = smanager.Manager
+	smanager.AddAndEnableSensor(ctx, t, sensor, sensor.Name)
 
 	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -49,7 +49,7 @@ func init() {
 		name: "kprobe sensor",
 	}
 	sensors.RegisterProbeType("generic_kprobe", kprobe)
-	sensors.RegisterTracingSensorsAtInit(kprobe.name, kprobe)
+	sensors.RegisterSpecHandlerAtInit(kprobe.name, kprobe)
 	observer.RegisterEventHandlerAtInit(ops.MSG_OP_GENERIC_KPROBE, handleGenericKprobe)
 }
 

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -58,7 +58,7 @@ func init() {
 		name: "tracepoint sensor",
 	}
 	sensors.RegisterProbeType("generic_tracepoint", tp)
-	sensors.RegisterTracingSensorsAtInit(tp.name, tp)
+	sensors.RegisterSpecHandlerAtInit(tp.name, tp)
 	observer.RegisterEventHandlerAtInit(ops.MSG_OP_GENERIC_TRACEPOINT, handleGenericTracepoint)
 }
 

--- a/pkg/server/fake_observer.go
+++ b/pkg/server/fake_observer.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package server
+
+import (
+	"context"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/sensors"
+)
+
+type FakeObserver struct{}
+
+func (f *FakeObserver) ListSensors(ctx context.Context) (*[]sensors.SensorStatus, error) {
+	return nil, nil
+}
+
+func (f *FakeObserver) EnableSensor(ctx context.Context, name string) error {
+	return nil
+}
+
+func (f *FakeObserver) DisableSensor(ctx context.Context, name string) error {
+	return nil
+}
+
+func (f *FakeObserver) GetSensorConfig(ctx context.Context, k string, v string) (string, error) {
+	return "", nil
+}
+
+func (f *FakeObserver) SetSensorConfig(ctx context.Context, name string, cfgkey string, cfgval string) error {
+	return nil
+}
+
+func (f *FakeObserver) GetTreeProto(ctx context.Context, tname string) (*tetragon.StackTraceNode, error) {
+	return nil, nil
+}
+
+func (f *FakeObserver) AddTracingPolicy(ctx context.Context, sensorName string, spec *v1alpha1.TracingPolicySpec) error {
+	return nil
+}
+
+func (f *FakeObserver) DelTracingPolicy(ctx context.Context, sensorName string) error {
+	return nil
+}
+
+func (f *FakeObserver) RemoveSensor(ctx context.Context, sensorName string) error {
+	return nil
+}

--- a/pkg/server/fake_observer.go
+++ b/pkg/server/fake_observer.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/sensors"
 )
 
@@ -37,7 +36,7 @@ func (f *FakeObserver) GetTreeProto(ctx context.Context, tname string) (*tetrago
 	return nil, nil
 }
 
-func (f *FakeObserver) AddTracingPolicy(ctx context.Context, sensorName string, spec *v1alpha1.TracingPolicySpec) error {
+func (f *FakeObserver) AddTracingPolicy(ctx context.Context, sensorName string, tp sensors.TracingPolicy) error {
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/tetragon/pkg/config"
 	"github.com/cilium/tetragon/pkg/filters"
 	"github.com/cilium/tetragon/pkg/health"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/option"
@@ -34,7 +35,7 @@ type notifier interface {
 }
 
 type observer interface {
-	AddTracingPolicy(ctx context.Context, sensorName string, spec interface{}) error
+	AddTracingPolicy(ctx context.Context, sensorName string, spec *v1alpha1.TracingPolicySpec) error
 	DelTracingPolicy(ctx context.Context, sensorName string) error
 	EnableSensor(ctx context.Context, name string) error
 	DisableSensor(ctx context.Context, name string) error

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/tetragon/pkg/config"
 	"github.com/cilium/tetragon/pkg/filters"
 	"github.com/cilium/tetragon/pkg/health"
-	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/option"
@@ -35,7 +34,7 @@ type notifier interface {
 }
 
 type observer interface {
-	AddTracingPolicy(ctx context.Context, sensorName string, spec *v1alpha1.TracingPolicySpec) error
+	AddTracingPolicy(ctx context.Context, sensorName string, policy sensors.TracingPolicy) error
 	DelTracingPolicy(ctx context.Context, sensorName string) error
 	EnableSensor(ctx context.Context, name string) error
 	DisableSensor(ctx context.Context, name string) error
@@ -207,7 +206,7 @@ func (s *Server) AddTracingPolicy(ctx context.Context, req *tetragon.AddTracingP
 	if err != nil {
 		return nil, err
 	}
-	if err := s.observer.AddTracingPolicy(ctx, conf.Metadata.Name, &conf.Spec); err != nil {
+	if err := s.observer.AddTracingPolicy(ctx, conf.Metadata.Name, conf); err != nil {
 		return nil, err
 	}
 	return &tetragon.AddTracingPolicyResponse{}, nil

--- a/pkg/testutils/sensors/sensors.go
+++ b/pkg/testutils/sensors/sensors.go
@@ -26,7 +26,7 @@ func LoadSensor(ctx context.Context, t *testing.T, sensor *sensors.Sensor) {
 	}
 
 	t.Cleanup(func() {
-		sensors.UnloadSensor(ctx, mapDir, mapDir, sensor)
+		sensor.Unload()
 	})
 }
 

--- a/pkg/testutils/sensors/sensors.go
+++ b/pkg/testutils/sensors/sensors.go
@@ -8,12 +8,6 @@ import (
 	"github.com/cilium/tetragon/pkg/sensors"
 )
 
-func RegisterSensorsAtInit(loaded []*sensors.Sensor) {
-	for _, s := range loaded {
-		sensors.RegisterSensorAtInit(s)
-	}
-}
-
 // LoadSensor is a helper for loading a sensor in tests
 func LoadSensor(ctx context.Context, t *testing.T, sensor *sensors.Sensor) {
 
@@ -87,6 +81,18 @@ func (tsm *TestSensorManager) EnableSensors(
 		if err := tsm.Manager.EnableSensor(ctx, s.Name); err != nil {
 			t.Fatalf("EnableSensor error: %s", err)
 		}
+	}
+}
+
+// AddAndEnableSensor is a helper function that adds and enables a new sensor
+func (tsm *TestSensorManager) AddAndEnableSensors(
+	ctx context.Context,
+	t *testing.T,
+	targets []*sensors.Sensor,
+) {
+	for i := range targets {
+		sensor := targets[i]
+		tsm.AddAndEnableSensor(ctx, t, sensor, sensor.Name)
 	}
 }
 

--- a/pkg/watcher/crd/watcher.go
+++ b/pkg/watcher/crd/watcher.go
@@ -61,7 +61,7 @@ func WatchTracePolicy(ctx context.Context, s *sensors.Manager) {
 				return
 			}
 			log.WithField("policy", policy.Spec).Info("tracing policy added")
-			err := s.AddTracingPolicy(ctx, policy.ObjectMeta.Name, &policy.Spec)
+			err := s.AddTracingPolicy(ctx, policy.ObjectMeta.Name, policy)
 			if err != nil {
 				log.WithError(err).Warn("adding tracing policy failed")
 			}
@@ -93,7 +93,7 @@ func WatchTracePolicy(ctx context.Context, s *sensors.Manager) {
 				log.WithError(err).Warnf("Failed to remove sensor %s to perform update", oldPolicy.ObjectMeta.Name)
 				return
 			}
-			err = s.AddTracingPolicy(ctx, newPolicy.ObjectMeta.Name, &newPolicy.Spec)
+			err = s.AddTracingPolicy(ctx, newPolicy.ObjectMeta.Name, newPolicy)
 			if err != nil {
 				log.WithError(err).Warn("adding new tracing policy failed")
 			}

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -4,6 +4,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	ciliumio "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -43,6 +45,14 @@ type TracingPolicySpec struct {
 	// +kubebuilder:validation:Optional
 	// A list of tracepoint specs.
 	Tracepoints []TracepointSpec `json:"tracepoints"`
+}
+
+func (tp *TracingPolicy) TpSpec() *TracingPolicySpec {
+	return &tp.Spec
+}
+
+func (tp *TracingPolicy) TpInfo() string {
+	return fmt.Sprintf("%s (object:%d/%s) (type:%s/%s)", tp.ObjectMeta.Name, tp.ObjectMeta.Generation, tp.ObjectMeta.UID, tp.TypeMeta.Kind, tp.TypeMeta.APIVersion)
 }
 
 type KProbeSpec struct {


### PR DESCRIPTION
This PR cleanups the sensor code as a preparation for subsequent patches.

It is split in small patches to ease reviewing.

The only user-visible change is that when a sensor in a tracing policy fails to load, we will unload all the sensors of said tracing policy.

Please review commit by commit. 