### PR TITLE
jsonchecker: retry on EOF/UnexpectedEOF in unmarshaller

### DIFF
--- a/pkg/jsonchecker/jsonchecker.go
+++ b/pkg/jsonchecker/jsonchecker.go
@@ -80,6 +80,12 @@ func JsonCheck(jsonFile *os.File, checker ec.MultiEventChecker, log *logrus.Logg
 		var dbgErr *DebugError
 		var ev tetragon.GetEventsResponse
 		if err := dec.Decode(&ev); err != nil {
+			if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+				return &JsonEOF{
+					count: count,
+					err:   fmt.Errorf("unmarshal failed: %w", err),
+				}
+			}
 			return fmt.Errorf("unmarshal failed: %w", err)
 		}
 		count++


### PR DESCRIPTION
I ran into a corner case in CI a few times where it seems that the exporter is in the middle of writing an event when the jsonchecker decides to open the file and check it. In this case, the unmarshaller will bubble up either an EOF or UnexpectedEOF error which will fail the test. To handle this, let's just treat these errors the same way we treat regular JSON EOF: by retrying after a few seconds.

Signed-off-by: William Findlay <will@isovalent.com>