### PR TITLE
tests/e2e: make cilium version configurable

### DIFF
--- a/tests/e2e/flags/flags.go
+++ b/tests/e2e/flags/flags.go
@@ -26,6 +26,7 @@ var Opts = Flags{
 	},
 	KeepExportData: false,
 	InstallCilium:  true,
+	CiliumVersion:  "v1.12.4",
 }
 
 func init() {
@@ -82,6 +83,11 @@ func init() {
 		"tetragon.btf",
 		Opts.Helm.BTF,
 		"A BTF file on the host that should be loaded into the KinD cluster. Will override helm BTF settings. Only makes sense when testing on a KinD cluster.")
+
+	flag.StringVar(&Opts.CiliumVersion,
+		"tetragon.cilium-version",
+		Opts.CiliumVersion,
+		"Version of Cilium to install. Only makes sense if tetragon.install-cilium is true.")
 }
 
 type Flags struct {
@@ -90,6 +96,8 @@ type Flags struct {
 	KeepExportData bool
 	// Should we install Cilium in the test?
 	InstallCilium bool
+	// Version of Cilium to use
+	CiliumVersion string
 }
 
 type HelmOptions struct {

--- a/tests/e2e/install/cilium/cilium.go
+++ b/tests/e2e/install/cilium/cilium.go
@@ -19,6 +19,7 @@ import (
 type Opts struct {
 	Wait           bool
 	Namespace      string
+	Version        string
 	ChartDirectory string
 	HelmOptions    map[string]string
 }
@@ -31,6 +32,10 @@ func WithWait(wait bool) Option {
 
 func WithNamespace(namespace string) Option {
 	return func(o *Opts) { o.Namespace = namespace }
+}
+
+func WithVersion(version string) Option {
+	return func(o *Opts) { o.Version = version }
 }
 
 func WithChartDirectory(chartDirectory string) Option {
@@ -103,6 +108,9 @@ func (c *ciliumCLI) install(ctx context.Context) error {
 	}
 	if c.opts.ChartDirectory != "" {
 		opts.WriteString(fmt.Sprintf(" --chart-directory=%s", c.opts.ChartDirectory))
+	}
+	if c.opts.Version != "" {
+		opts.WriteString(fmt.Sprintf(" --version=%s", c.opts.Version))
 	}
 	for k, v := range c.opts.HelmOptions {
 		opts.WriteString(fmt.Sprintf(" --helm-set=%s=%s", k, v))

--- a/tests/e2e/runners/runners.go
+++ b/tests/e2e/runners/runners.go
@@ -55,7 +55,7 @@ var DefaultRunner = Runner{
 		// Only install Cilium if it does not already exist
 		ciliumDs := &appsv1.DaemonSet{}
 		if err := client.Resources("kube-system").Get(ctx, "cilium", "kube-system", ciliumDs); err != nil && apierrors.IsNotFound(err) {
-			return cilium.Setup(cilium.WithNamespace("kube-system"))(ctx, c)
+			return cilium.Setup(cilium.WithNamespace("kube-system"), cilium.WithVersion(flags.Opts.CiliumVersion))(ctx, c)
 		}
 		return ctx, nil
 	},


### PR DESCRIPTION
Make the installed version of Cilium configurable with a new command line flag: `-tetragon.cilium-version`.

Signed-off-by: William Findlay <will@isovalent.com>