### PR TITLE
tetragon: Add buffer between perf reader and events processing code

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -67,6 +67,7 @@ const (
 
 	keyRBSize      = "rb-size"
 	keyRBSizeTotal = "rb-size-total"
+	keyRBQueueSize = "rb-queue-size"
 
 	keyEventQueueSize = "event-queue-size"
 
@@ -102,6 +103,7 @@ func readAndSetFlags() {
 
 	option.Config.RBSize = viper.GetInt(keyRBSize)
 	option.Config.RBSizeTotal = viper.GetInt(keyRBSizeTotal)
+	option.Config.RBQueueSize = viper.GetInt(keyRBQueueSize)
 
 	option.Config.GopsAddr = viper.GetString(keyGopsAddr)
 

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -768,6 +768,8 @@ func execute() error {
 
 	flags.StringSlice(keyKmods, []string{}, "List of kernel modules to load symbols from")
 
+	flags.Int(keyRBQueueSize, 65535, "Set size of channel between ring buffer and sensor go routines (default 65k)")
+
 	viper.BindPFlags(flags)
 	return rootCmd.Execute()
 }

--- a/pkg/metrics/config/initmetrics.go
+++ b/pkg/metrics/config/initmetrics.go
@@ -14,6 +14,7 @@ import (
 	pfmetrics "github.com/cilium/tetragon/pkg/metrics/policyfilter"
 	"github.com/cilium/tetragon/pkg/metrics/processexecmetrics"
 	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/ringbufqueuemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/syscallmetrics"
 	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
 	"github.com/cilium/tetragon/pkg/observer"
@@ -30,6 +31,7 @@ func InitAllMetrics(registry *prometheus.Registry) {
 	pfmetrics.InitMetrics(registry)
 	processexecmetrics.InitMetrics(registry)
 	ringbufmetrics.InitMetrics(registry)
+	ringbufqueuemetrics.InitMetrics(registry)
 	syscallmetrics.InitMetrics(registry)
 	watchermetrics.InitMetrics(registry)
 	observer.InitMetrics(registry)

--- a/pkg/metrics/ringbufqueuemetrics/ringbufqueuemetrics.go
+++ b/pkg/metrics/ringbufqueuemetrics/ringbufqueuemetrics.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package ringbufqueuemetrics
+
+import (
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	Received = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   consts.MetricsNamespace,
+		Name:        "ringbuf_queue_received_total",
+		Help:        "The total number of Tetragon events ring buffer queue received.",
+		ConstLabels: nil,
+	})
+	Lost = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   consts.MetricsNamespace,
+		Name:        "ringbuf_queue_lost_total",
+		Help:        "The total number of Tetragon events ring buffer queue lost.",
+		ConstLabels: nil,
+	})
+)
+
+func InitMetrics(registry *prometheus.Registry) {
+	registry.MustRegister(Received)
+	registry.MustRegister(Lost)
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -42,6 +42,7 @@ type config struct {
 
 	RBSize      int
 	RBSizeTotal int
+	RBQueueSize int
 
 	ProcessCacheSize int
 	DataCacheSize    int


### PR DESCRIPTION
Adding extra layer between perf ring buffer reader and event
processing by sensor code.

This way we keep the perf reader fast and we won't get lost events
if sensor processing code have a hiccup and takes longer.