### PR TITLE
ci: replace deprecated set-output directives

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -34,9 +34,9 @@ jobs:
         id: tag
         run: |
           if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
-            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+            echo "tag=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=tag::${{ github.sha }}
+            echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout Source Code

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -40,9 +40,9 @@ jobs:
         id: tag
         run: |
           if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
-            echo ::set-output name=tag::${{ github.event.pull_request.head.sha }}
+            echo "tag=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=tag::${{ github.sha }}
+            echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout Source Code

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Getting image tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF##*/}
+          echo "tag=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
       - name: Checkout Source Code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -43,9 +43,9 @@ jobs:
         else
           SHA=${{ github.sha }}
         fi
-        echo ::set-output name=sha::${SHA}
-        echo ::set-output name=agentImage::quay.io/cilium/tetragon-ci:${SHA}
-        echo ::set-output name=operatorImage::quay.io/cilium/tetragon-operator-ci:${SHA}
+        echo "sha=${SHA}" >> $GITHUB_OUTPUT
+        echo "agentImage=quay.io/cilium/tetragon-ci:${SHA}" >> $GITHUB_OUTPUT
+        echo "operatorImage=quay.io/cilium/tetragon-operator-ci:${SHA}" >> $GITHUB_OUTPUT
 
     - name: Pull Tetragon Images
       uses: nick-invision/retry@v2


### PR DESCRIPTION
GitHub has deprecated `set-output` in favour of the newer "environment files". Let's update our actions accordingly so they don't break.

Signed-off-by: William Findlay <will@isovalent.com>