### PR TITLE
helm: use a specific conf.d directory for --config-dir

### DIFF
--- a/install/kubernetes/templates/_container_tetragon.tpl
+++ b/install/kubernetes/templates/_container_tetragon.tpl
@@ -11,7 +11,7 @@
     - /usr/bin/tetragon
 {{- end }}
   args:
-    - --config-dir=/etc/tetragon
+    - --config-dir=/etc/tetragon/tetragon.conf.d/
 {{- with .Values.tetragon.argsOverride }}
   {{- toYaml . | nindent 2 }}
 {{- else }}
@@ -31,7 +31,7 @@
     - mountPath: /var/lib/tetragon/metadata
       name: metadata-files
     {{- end }}
-    - mountPath: /etc/tetragon
+    - mountPath: /etc/tetragon/tetragon.conf.d/
       name: tetragon-config
       readOnly: true
     - mountPath: /sys/fs/bpf


### PR DESCRIPTION
Use a specific directory for tetragon configmap.

Right now we are using /etc/tetragon/ as the base for configmap, however in future we want to put CRD rules under that same path /etc/tetragon/tetragon.rules.d/ .

So change the mountPath where tetragon-config points from:
  /etc/tetragon/ => /etc/tetragon/tetragon.conf.d/

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>