### PR TITLE
tetragon: Cleanup func_id/id mess in struct msg_generic_kprobe

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -42,8 +42,7 @@ struct msg_generic_kprobe {
 	unsigned long a0, a1, a2, a3, a4;
 	long argsoff[MAX_POSSIBLE_ARGS];
 	struct msg_selector_data sel;
-	int idx;
-	int func_id;
+	__u32 idx;
 };
 
 static inline __attribute__((always_inline)) size_t generic_kprobe_common_size()

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -24,7 +24,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, MAX_ENTRIES_CONFIG);
-	__type(key, int);
+	__type(key, __u32);
 	__type(value, struct event_config);
 } config_map SEC(".maps");
 
@@ -52,15 +52,16 @@ BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 	if (!e)
 		return 0;
 
-	setup_index(ctx, e, (struct bpf_map_def *)&config_map);
+	e->idx = get_index(ctx);
 
 	config = map_lookup_elem(&config_map, &e->idx);
 	if (!config)
 		return 0;
 
+	e->id = config->func_id;
 	e->thread_id = retprobe_map_get_key(ctx);
 
-	if (!retprobe_map_get(e->func_id, e->thread_id, &info))
+	if (!retprobe_map_get(e->id, e->thread_id, &info))
 		return 0;
 
 	*(unsigned long *)e->args = info.ktime_enter;

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -41,7 +41,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 1);
-	__type(key, int);
+	__type(key, __u32);
 	__type(value, struct event_config);
 } config_map SEC(".maps");
 
@@ -178,6 +178,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 #endif
 	/* Tail call into filters. */
 	msg->idx = 0;
+	msg->id = config->func_id;
 	tail_call(ctx, &tp_calls, 5);
 	return 0;
 }

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -40,14 +40,13 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 	e->current.pad[2] = 0;
 	e->current.pad[3] = 0;
 
-	e->id = config->func_id;
 	e->thread_id = retprobe_map_get_key(ctx);
 
 	/* If return arg is needed mark retprobe */
 #ifdef GENERIC_KPROBE
 	ty = config->argreturn;
 	if (ty > 0)
-		retprobe_map_set(e->func_id, e->thread_id, e->common.ktime, 1);
+		retprobe_map_set(e->id, e->thread_id, e->common.ktime, 1);
 #endif
 
 	/* Read out args1-5 */
@@ -68,7 +67,7 @@ generic_process_event0(struct pt_regs *ctx, struct bpf_map_def *heap_map,
 		 * do it where it makes most sense.
 		 */
 		if (errv < 0)
-			return filter_args_reject(e->func_id);
+			return filter_args_reject(e->id);
 	}
 	e->common.flags = 0;
 	e->common.size = total;
@@ -153,7 +152,7 @@ generic_process_event1(void *ctx, struct bpf_map_def *heap_map,
 		if (errv > 0)
 			total += errv;
 		if (errv < 0)
-			return filter_args_reject(e->func_id);
+			return filter_args_reject(e->id);
 	}
 	e->common.size = total;
 	tail_call(ctx, tailcals, 2);
@@ -195,7 +194,7 @@ generic_process_event2(void *ctx, struct bpf_map_def *heap_map,
 		if (errv > 0)
 			total += errv;
 		if (errv < 0)
-			return filter_args_reject(e->func_id);
+			return filter_args_reject(e->id);
 	}
 	e->common.size = total;
 	tail_call(ctx, tailcals, 3);
@@ -238,7 +237,7 @@ generic_process_event3(void *ctx, struct bpf_map_def *heap_map,
 		if (errv > 0)
 			total += errv;
 		if (errv < 0)
-			return filter_args_reject(e->func_id);
+			return filter_args_reject(e->id);
 	}
 	e->common.size = total;
 	tail_call(ctx, tailcals, 4);
@@ -280,7 +279,7 @@ generic_process_event4(void *ctx, struct bpf_map_def *heap_map,
 		if (errv > 0)
 			total += errv;
 		if (errv < 0)
-			return filter_args_reject(e->func_id);
+			return filter_args_reject(e->id);
 	}
 	e->common.size = total;
 	/* Post event */

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -142,30 +142,14 @@ struct event_config {
 #define MAX_STRING 1024
 
 #ifdef __MULTI_KPROBE
-static inline __attribute__((always_inline)) void
-setup_index(void *ctx, struct msg_generic_kprobe *msg,
-	    struct bpf_map_def *config_map)
+static inline __attribute__((always_inline)) __u32 get_index(void *ctx)
 {
-	int idx = (int)get_attach_cookie(ctx);
-	struct event_config *config;
-
-	config = map_lookup_elem(config_map, &idx);
-	if (!config)
-		return;
-	msg->idx = idx;
-	msg->func_id = config->func_id;
+	return (__u32)get_attach_cookie(ctx);
 }
 
 #define MAX_ENTRIES_CONFIG 100 /* MaxKprobesMulti in go code */
 #else
-static inline __attribute__((always_inline)) void
-setup_index(void *ctx, struct msg_generic_kprobe *msg,
-	    struct bpf_map_def *config_map)
-{
-	msg->idx = 0;
-	msg->func_id = 0;
-}
-
+#define get_index(ctx)	   0
 #define MAX_ENTRIES_CONFIG 1
 #endif
 
@@ -540,7 +524,7 @@ copy_char_buf(void *ctx, long off, unsigned long arg, int argm,
 
 	if (hasReturnCopy(argm)) {
 		u64 tid = retprobe_map_get_key(ctx);
-		retprobe_map_set(e->func_id, tid, e->common.ktime, arg);
+		retprobe_map_set(e->id, tid, e->common.ktime, arg);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
 	meta = get_arg_meta(argm, e);
@@ -688,8 +672,7 @@ copy_char_iovec(void *ctx, long off, unsigned long arg, int argm,
 
 	if (hasReturnCopy(argm)) {
 		u64 tid = retprobe_map_get_key(ctx);
-		retprobe_map_set_iovec(e->func_id, tid, e->common.ktime, arg,
-				       meta);
+		retprobe_map_set_iovec(e->id, tid, e->common.ktime, arg, meta);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
 	return __copy_char_iovec(off, arg, meta, 0, e);
@@ -1041,10 +1024,10 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx)
 	return pass ? seloff : 0;
 }
 
-static inline __attribute__((always_inline)) int filter_args_reject(int idx)
+static inline __attribute__((always_inline)) int filter_args_reject(u64 id)
 {
 	u64 tid = get_current_pid_tgid();
-	retprobe_map_clear(idx, tid);
+	retprobe_map_clear(id, tid);
 	return 0;
 }
 
@@ -1068,7 +1051,7 @@ filter_args(struct msg_generic_kprobe *e, int index, void *filter_map)
 	 * have their arg filters run.
 	 */
 	if (index > SELECTORS_ACTIVE)
-		return filter_args_reject(e->func_id);
+		return filter_args_reject(e->id);
 
 	if (e->sel.active[index]) {
 		int pass = selector_arg_offset(f, e, index);
@@ -1285,7 +1268,7 @@ filter_read_arg(void *ctx, int index, struct bpf_map_def *heap,
 		if (index <= MAX_SELECTORS && e->sel.active[index])
 			tail_call(ctx, tailcalls, MIN_FILTER_TAILCALL + index);
 		// reject if we did not attempt to tailcall, or if tailcall failed.
-		return filter_args_reject(e->func_id);
+		return filter_args_reject(e->id);
 	}
 
 	// If pass >1 then we need to consult the selector actions

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2427,11 +2427,11 @@ func TestLoadKprobeSensor(t *testing.T) {
 	}
 
 	if kernels.EnableLargeProgs() {
-		// all kprobe but generic_kprobe_process_filter,generic_kprobe_event
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}})
+		// all kprobe but generic_kprobe_process_filter
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}})
 	} else {
-		// all kprobe but generic_kprobe_process_filter,generic_kprobe_event
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{1, 2, 3, 4, 5}})
+		// all kprobe but generic_kprobe_process_filter
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5}})
 	}
 
 	readHook := `


### PR DESCRIPTION
Currently we have 'id' and 'func_id' in struct msg_generic_kprobe keeping the same value. There's no need, we can use just the 'id' value for everything.

Also use __u32 as config_map key type.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>