### PR TITLE
eventcache: update PodInfoError on pod error

### DIFF
--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -119,7 +119,7 @@ func (ec *Cache) handleEvents() {
 			if errors.Is(err, ErrFailedToGetProcessInfo) {
 				eventcachemetrics.ProcessInfoError(notify.EventTypeString(event.event)).Inc()
 			} else if errors.Is(err, ErrFailedToGetPodInfo) {
-				eventcachemetrics.ProcessInfoError(notify.EventTypeString(event.event)).Inc()
+				eventcachemetrics.PodInfoError(notify.EventTypeString(event.event)).Inc()
 			}
 		}
 


### PR DESCRIPTION
There seems to be a typo where we update the ProcessInfoError metric even when the error ErrFailedToGetPodInfo.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>