### PR TITLE
ci: use large github runner

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -20,9 +20,6 @@ jobs:
       with:
         go-version: '1.18.3'
 
-    - name: Install docker
-      uses: docker-practice/actions-setup-docker@master
-
     - name: Checkout code
       uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       with:
@@ -46,7 +43,7 @@ jobs:
       run: |
         #  see testfile below
         cd go/src/github.com/cilium/tetragon/
-        go run ./tools/split-tetragon-gotests -ci-run 5
+        go run ./tools/split-tetragon-gotests -ci-run 1
 
     - name: tar build
       run: |
@@ -64,30 +61,25 @@ jobs:
         fail-fast: false
         matrix:
            kernel:
+              - '5.15'
               - '5.10'
               - '5.4'
               - '4.19'
            group:
               - 0
-              - 1
-              - 2
-              - 3
-              - 4
     concurrency:
       group: ${{ github.ref }}-vmtest-${{ matrix.kernel }}-${{ matrix.group }}
       cancel-in-progress: true
     needs: build
     name: Test kernel ${{ matrix.kernel }} / test group ${{ matrix.group }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4cores-16gb
     timeout-minutes: 60
     steps:
-    - name: Install docker
-      uses: docker-practice/actions-setup-docker@master
     - name: Install VM test dependencies
       run: |
         sudo apt-get -qy update
         sudo apt-cache search qemu
-        sudo apt-get -qy install mmdebstrap libguestfs-tools qemu-utils qemu-system-x86 docker
+        sudo apt-get -qy install mmdebstrap libguestfs-tools qemu-utils qemu-system-x86 cpu-checker qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager
 
     - name: Make kernel accessible
       run: |
@@ -109,7 +101,7 @@ jobs:
       run: |
         cd go/src/github.com/cilium/tetragon
         ./tests/vmtests/fetch-data.sh ${{ matrix.kernel }}
-        ./tests/vmtests/tetragon-vmtests-run \
+        sudo ./tests/vmtests/tetragon-vmtests-run \
                 --kernel tests/vmtests/test-data/kernels/${{ matrix.kernel }}/boot/vmlinuz* \
                 --base tests/vmtests/test-data/images/base.qcow2 \
                 --testsfile ./tests/vmtests/test-group-${{ matrix.group }}
@@ -119,7 +111,7 @@ jobs:
       run: |
         cd go/src/github.com/cilium/tetragon
         ./tests/vmtests/fetch-data.sh ${{ matrix.kernel }}
-        ./tests/vmtests/tetragon-vmtests-run \
+        sudo ./tests/vmtests/tetragon-vmtests-run \
                 --kernel tests/vmtests/test-data/kernels/${{ matrix.kernel }}/boot/vmlinuz* \
                 --btf-file tests/vmtests/test-data/kernels/${{ matrix.kernel }}/boot/btf-* \
                 --base tests/vmtests/test-data/images/base.qcow2 \


### PR DESCRIPTION
Move away from the regular GitHub runner to a large one, which supports KVM acceleration.
This should significantly speed up test performance, so let's drop down to one group per
test and add a 5.15 test while we're at it.

Signed-off-by: William Findlay <will@isovalent.com>