### PR TITLE
Fix SBOM image signing and update image siganture verification docs

### DIFF
--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -161,7 +161,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          docker_build_ci_pr_digest="${{ steps.docker_build_ci_main.outputs.digest }}"
+          docker_build_ci_pr_digest="${{ steps.docker_build_ci_pr.outputs.digest }}"
           image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_ci_pr_digest/:/-}.sbom"
           docker_build_ci_pr_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
           cosign sign "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_ci_pr_sbom_digest}"

--- a/README.md
+++ b/README.md
@@ -638,16 +638,12 @@ Since version 0.8.4, all Tetragon container images are signed using cosign.
 Let's verify a Tetragon image's signature using the `cosign verify` command:
 
 ```bash
-$ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository cilium/tetragon --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-github-workflow-name "Image CI Releases" --certificate-github-workflow-ref refs/tags/[RELEASE TAG] quay.io/cilium/tetragon:v0.8.4 | jq
+$ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository cilium/tetragon --certificate-oidc-issuer https://token.actions.githubusercontent.com <Image URL> | jq
 ```
 
 **Note**
 
 `COSIGN_EXPERIMENTAL=1` is used to allow verification of images signed in KEYLESS mode. To learn more about keyless signing, please refer to [Keyless Signatures](https://github.com/sigstore/cosign/blob/main/KEYLESS.md#keyless-signatures).
-
-`--certificate-github-workflow-name string` contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow. For the names of workflows used to build Tetragon images, see the build image workflows under [Tetragon workflows](https://github.com/cilium/tetragon/tree/main/.github/workflows).
-
-`--certificate-github-workflow-ref string` contains the ref claim from the GitHub OIDC Identity token that contains the git ref that the workflow run was based upon.
 
 ## Software Bill of Materials
 
@@ -673,7 +669,7 @@ To ensure the SBOM is tamper-proof, its signature can be verified using the
 `cosign verify` command.
 
 ```bash
-$ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository cilium/cilium --certificate-oidc-issuer https://token.actions.githubusercontent.com --attachment sbom <Image URL> | jq
+$ COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository cilium/tetragon --certificate-oidc-issuer https://token.actions.githubusercontent.com --attachment sbom <Image URL> | jq
 ```
 It can be validated that the SBOM image was signed using Github Actions in the Cilium
 repository from the `Issuer` and `Subject` fields of the output.


### PR DESCRIPTION
Fix CI build PR updates image digest output which was causing the `Sign SBOM Image` step introduced in 343e9f94c6eca025307cc5219638102c57c184c2 to fail.

Update cosign verify command flags used to verify cosign claims
and signing certificates on the Tetragon images