### PR TITLE
Make size of event queue configurable

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -20,9 +20,6 @@ jobs:
       with:
         go-version: '1.18.3'
 
-    - name: Install docker
-      uses: docker-practice/actions-setup-docker@master
-
     - name: Checkout code
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       with:
@@ -46,7 +43,7 @@ jobs:
       run: |
         #  see testfile below
         cd go/src/github.com/cilium/tetragon/
-        go run ./tools/split-tetragon-gotests -ci-run 5
+        go run ./tools/split-tetragon-gotests -ci-run 1
 
     - name: tar build
       run: |
@@ -64,30 +61,25 @@ jobs:
         fail-fast: false
         matrix:
            kernel:
+              - '5.15'
               - '5.10'
               - '5.4'
               - '4.19'
            group:
               - 0
-              - 1
-              - 2
-              - 3
-              - 4
     concurrency:
       group: ${{ github.ref }}-vmtest-${{ matrix.kernel }}-${{ matrix.group }}
       cancel-in-progress: true
     needs: build
     name: Test kernel ${{ matrix.kernel }} / test group ${{ matrix.group }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4cores-16gb
     timeout-minutes: 60
     steps:
-    - name: Install docker
-      uses: docker-practice/actions-setup-docker@master
     - name: Install VM test dependencies
       run: |
         sudo apt-get -qy update
         sudo apt-cache search qemu
-        sudo apt-get -qy install mmdebstrap libguestfs-tools qemu-utils qemu-system-x86 docker
+        sudo apt-get -qy install mmdebstrap libguestfs-tools qemu-utils qemu-system-x86 cpu-checker qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager
 
     - name: Make kernel accessible
       run: |
@@ -109,7 +101,7 @@ jobs:
       run: |
         cd go/src/github.com/cilium/tetragon
         ./tests/vmtests/fetch-data.sh ${{ matrix.kernel }}
-        ./tests/vmtests/tetragon-vmtests-run \
+        sudo ./tests/vmtests/tetragon-vmtests-run \
                 --kernel tests/vmtests/test-data/kernels/${{ matrix.kernel }}/boot/vmlinuz* \
                 --base tests/vmtests/test-data/images/base.qcow2 \
                 --testsfile ./tests/vmtests/test-group-${{ matrix.group }}
@@ -119,7 +111,7 @@ jobs:
       run: |
         cd go/src/github.com/cilium/tetragon
         ./tests/vmtests/fetch-data.sh ${{ matrix.kernel }}
-        ./tests/vmtests/tetragon-vmtests-run \
+        sudo ./tests/vmtests/tetragon-vmtests-run \
                 --kernel tests/vmtests/test-data/kernels/${{ matrix.kernel }}/boot/vmlinuz* \
                 --btf-file tests/vmtests/test-data/kernels/${{ matrix.kernel }}/boot/btf-* \
                 --base tests/vmtests/test-data/images/base.qcow2 \

--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -65,6 +65,8 @@ const (
 	keyRBSizeTotal = "rb-size-total"
 
 	keyReleasePinnedBPF = "release-pinned-bpf"
+
+	keyEventQueueSize = "event-queue-size"
 )
 
 var (
@@ -137,4 +139,6 @@ func readAndSetFlags() {
 	memProfile = viper.GetString(keyMemProfile)
 
 	option.Config.ReleasePinned = viper.GetBool(keyReleasePinnedBPF)
+
+	option.Config.EventQueueSize = viper.GetUint(keyEventQueueSize)
 }

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -479,6 +479,7 @@ func execute() error {
 	flags.String(keyCiliumBPF, "", "Cilium BPF directory")
 	flags.Bool(keyEnableProcessCred, false, "Enable process_cred events")
 	flags.Bool(keyEnableProcessNs, false, "Enable namespace information in process_exec and process_kprobe events")
+	flags.Uint(keyEventQueueSize, 10000, "Set the size of the internal event queue.")
 
 	// Config files
 	flags.String(keyConfigFile, "", "Configuration file to load from")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -40,6 +40,8 @@ type config struct {
 	RBSizeTotal int
 
 	ReleasePinned bool
+
+	EventQueueSize uint
 }
 
 var (

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/tetragon/pkg/health"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/version"
 )
@@ -64,8 +65,12 @@ func NewServer(ctx context.Context, wg *sync.WaitGroup, notifier notifier, obser
 }
 
 func newListener() *getEventsListener {
+	var chanSize uint = 10000
+	if option.Config.EventQueueSize > 0 {
+		chanSize = option.Config.EventQueueSize
+	}
 	return &getEventsListener{
-		events: make(chan *tetragon.GetEventsResponse, 100),
+		events: make(chan *tetragon.GetEventsResponse, chanSize),
 	}
 }
 


### PR DESCRIPTION
The internal event queue had a fixed size of 100 events. If the event queue became full, additional events would be dropped. This commit raises the default size to 10000 events and makes the size configurable through a --event-queue-size command line flag.

Signed-off-by: Kevin Sheldrake <kevin.sheldrake@isovalent.com>