### PR TITLE
bpf: kprobe: use defines for tail call numbers

### DIFF
--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -14,7 +14,7 @@
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(max_entries, 11);
+	__uint(max_entries, 12);
 	__uint(key_size, sizeof(__u32));
 	__uint(value_size, sizeof(__u32));
 } tp_calls SEC(".maps");

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -367,4 +367,5 @@ type EventConfig struct {
 	Syscall       uint32                     `align:"syscall"`
 	ArgReturnCopy int32                      `align:"argreturncopy"`
 	ArgReturn     int32                      `align:"argreturn"`
+	PolicyID      uint32                     `align:"policy_id"`
 }

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -250,7 +250,7 @@ func installTailCalls(mapDir string, spec *ebpf.CollectionSpec, coll *ebpf.Colle
 		}
 		defer tailCallsMap.Close()
 
-		for i := 0; i < 11; i++ {
+		for i := 0; i < 12; i++ {
 			secName := fmt.Sprintf("%s/%d", secPrefix, i)
 			if progName, ok := secToProgName[secName]; ok {
 				if prog, ok := coll.Programs[progName]; ok {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2397,12 +2397,13 @@ func TestLoadKprobeSensor(t *testing.T) {
 		11: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
 		// retkprobe
 		12: tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
+		13: tus.SensorProg{Name: "generic_kprobe_policy_filter", Type: ebpf.Kprobe},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all kprobe programs
 		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
-		tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+		tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13}},
 
 		// only retkprobe
 		tus.SensorMap{Name: "process_call_heap", Progs: []uint{12}},
@@ -2427,11 +2428,11 @@ func TestLoadKprobeSensor(t *testing.T) {
 	}
 
 	if kernels.EnableLargeProgs() {
-		// all kprobe but generic_kprobe_process_filter,generic_kprobe_event
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}})
+		// all kprobe but generic_kprobe_process_filter
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}})
 	} else {
-		// all kprobe but generic_kprobe_process_filter,generic_kprobe_event
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{1, 2, 3, 4, 5}})
+		// all kprobe but generic_kprobe_process_filter
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5}})
 	}
 
 	readHook := `


### PR DESCRIPTION
Using raw numbers for tail calls makes the code difficult to understand. Instead, use proper defines.

Signed-off-by: Kornilios Kourtis <kornilios@isovalent.com>