### PR TITLE
Unpin TC progs on Unload

### DIFF
--- a/pkg/sensors/unloader/unloader.go
+++ b/pkg/sensors/unloader/unloader.go
@@ -91,6 +91,7 @@ func (rdu *RawDetachUnloader) Unload() error {
 
 // TcUnloader unloads programs attached to TC filters
 type TcUnloader struct {
+	Prog        *ebpf.Program
 	Attachments []TcAttachment
 }
 


### PR DESCRIPTION
Currently, we detach TC programs from their qdisc, but we fail to properly unpin them, leaving them lying around, albeit unattached (and therefore not operational).

This commit adds the ebpf.Program to the TcUnloader struct, and on Unload(), if the program has been set, it is Close()ed and Unpin()ed.

Signed-off-by: Kevin Sheldrake <kevin.sheldrake@isovalent.com>