### PR TITLE
tetragon: Use probe task instead of current in event_exit_send

### DIFF
--- a/bpf/process/bpf_exit.c
+++ b/bpf/process/bpf_exit.c
@@ -23,6 +23,6 @@ event_exit(struct pt_regs *ctx)
 	 * would otherwise occur.
 	 */
 	if (pid == tgid)
-		event_exit_send(ctx, tgid);
+		event_exit_send(ctx, tgid, task);
 	return 0;
 }

--- a/bpf/process/bpf_exit.h
+++ b/bpf/process/bpf_exit.h
@@ -15,7 +15,7 @@ struct {
 } exit_heap_map SEC(".maps");
 
 static inline __attribute__((always_inline)) void event_exit_send(void *ctx,
-								  __u32 tgid)
+								  __u32 tgid, struct task_struct *task)
 {
 	struct execve_map_value *enter;
 
@@ -31,8 +31,6 @@ static inline __attribute__((always_inline)) void event_exit_send(void *ctx,
 	if (!enter)
 		return;
 	if (enter->key.ktime) {
-		struct task_struct *task =
-			(struct task_struct *)get_current_task();
 		size_t size = sizeof(struct msg_exit);
 		struct msg_exit *exit;
 		int zero = 0;


### PR DESCRIPTION
We can't use get_current_task in __put_task_struct, we need to use 
__put_task_struct task argument instead, otherwise we read wrong
task's exit_code.

Fixes: 1a37adf4bd40 ("tetragon: Switch exit tracepoint to __put_task_struct kprobe")
Signed-off-by: Jiri Olsa <jolsa@kernel.org>
