### PR TITLE
Backports/v0.8: tetragon: main agent and logging fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ RUN strip bpftool
 
 FROM docker.io/library/alpine:3.16.2@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
 RUN apk add iproute2
-RUN addgroup hubble	     && \
-    mkdir /var/lib/tetragon/ && \
+RUN mkdir /var/lib/tetragon/ && \
     apk add --no-cache --update bash
 COPY --from=bpftool-builder /src/linux/tools/bpf/bpftool/bpftool /usr/bin/bpftool
 COPY --from=hubble-builder /go/src/github.com/cilium/tetragon/tetragon /usr/bin/

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -336,6 +336,13 @@ func startExporter(ctx context.Context, server *server.Server) error {
 		MaxBackups: exportFileMaxBackups,
 		Compress:   exportFileCompress,
 	}
+
+	// For non k8s deployments we explicitly want log files
+	// with permission 0600
+	if !option.Config.EnableK8s {
+		writer.FileMode = os.FileMode(0600)
+	}
+
 	if exportFileRotationInterval != 0 {
 		log.WithField("duration", exportFileRotationInterval).Info("Periodically rotating JSON export files")
 		go func() {

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -407,8 +407,8 @@ func getWatcher() (watcher.K8sResourceWatcher, error) {
 
 func execute() error {
 	rootCmd := &cobra.Command{
-		Use:   "tetragon SOURCE_DIR BUCKET",
-		Short: "Tetragon",
+		Use:   "tetragon",
+		Short: "Run the tetragon agent",
 		Run: func(cmd *cobra.Command, args []string) {
 			readAndSetFlags()
 

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -204,6 +204,8 @@ func tetragonExecute() error {
 	}()
 
 	go func() {
+		// if we receive a signal, call cancel so that contexts are finalized, which will
+		// leads to normally return from tetragonExecute().
 		s := <-sigs
 		log.Infof("Received signal %s, shutting down...", s)
 		cancel()
@@ -245,12 +247,24 @@ func tetragonExecute() error {
 		return err
 	}
 
-	var cancelWg sync.WaitGroup
-	defer cancelWg.Wait()
+	// cleanupWg is needed to ensure that gRPC code cleanly finishes before we exit (e.g,
+	// due to a signal). This is needed, for example, so that the exported writes full
+	// (uncorrupted) to the file. See: 4b7c8d1c427a46b864763e910e8f3511e1c4eb00.
+	var cleanupWg sync.WaitGroup
+	defer cleanupWg.Wait()
+
+	// The "defer cleanupWg.Wait()" above, might introduce deadlocks if an error happens.
+	// This is because cancel() will not be called until cleanupWg.Wait() returns.
+	// But, the code in server/server.go:GetEventsWG() will only call cleanupWg.Done() if ctx.Done()
+	// Which causes a deadlock. To fix this, we add a new ctx and we pass that to the rest of the
+	// initialization functions. This means that we can cancel them without causing a deadlock
+	// using cancel2.
+	ctx, cancel2 := context.WithCancel(ctx)
+	defer cancel2()
 
 	pm, err := tetragonGrpc.NewProcessManager(
 		ctx,
-		&cancelWg,
+		&cleanupWg,
 		ciliumState,
 		observer.SensorManager)
 	if err != nil {

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -312,7 +312,43 @@ func tetragonExecute() error {
 		}
 	}
 
+	// Periodically log status
+	go logStatus(ctx, obs)
+
 	return obs.Start(ctx)
+}
+
+// Periodically log current status every 1 hour. For lost or error
+// events we ratelimit statistics to 1 message per every 5mins to
+// continuously infor users that events are being lost without
+// polluting logs.
+func logStatus(ctx context.Context, obs *observer.Observer) {
+	prevLost := uint64(0)
+	prevErrors := uint64(0)
+	lostTicker := time.NewTicker(5 * time.Minute)
+	defer lostTicker.Stop()
+	logTicker := time.NewTicker(1 * time.Hour)
+	defer logTicker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-logTicker.C:
+			// We always print stats
+			obs.PrintStats()
+			// Update lost and errors, to not print two consecutive lines at same time
+			prevLost = obs.ReadLostEvents()
+			prevErrors = obs.ReadErrorEvents()
+		case <-lostTicker.C:
+			lost := obs.ReadLostEvents()
+			errors := obs.ReadErrorEvents()
+			if lost > prevLost || errors > prevErrors {
+				obs.PrintStats()
+				prevLost = lost
+				prevErrors = errors
+			}
+		}
+	}
 }
 
 // getObserverDir returns the path to the observer directory based on the BPF

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cilium/ebpf v0.9.3
 	github.com/cilium/hubble v0.5.3-0.20220311154618-3e44df066567
 	github.com/cilium/little-vm-helper v0.0.0-20220812055014-101c3e342e13
-	github.com/cilium/lumberjack/v2 v2.2.2
+	github.com/cilium/lumberjack/v2 v2.3.0
 	github.com/cilium/tetragon/api v0.0.0-00010101000000-000000000000
 	github.com/cilium/tetragon/pkg/k8s v0.0.0-00010101000000-000000000000
 	github.com/fatih/color v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/cilium/ipam v0.0.0-20201020084809-76717fcdb3a2/go.mod h1:Ascfar4FtgB+
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
 github.com/cilium/little-vm-helper v0.0.0-20220812055014-101c3e342e13 h1:R1X8fZxqDnOZqDEWIcWR3t5utglPk2cWzS8VPBf1PFE=
 github.com/cilium/little-vm-helper v0.0.0-20220812055014-101c3e342e13/go.mod h1:Ya+Z4TOpZlsTtFZg3teKp9lzNd/BTgC4MlRN4drM328=
-github.com/cilium/lumberjack/v2 v2.2.2 h1:RKTdhb63DY0Xu7pE1pipMj7Zq28LyvBGSrCneHiKm4A=
-github.com/cilium/lumberjack/v2 v2.2.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
+github.com/cilium/lumberjack/v2 v2.3.0 h1:IhVJMvPpqDYmQzC0KDhAoy7KlaRsyOsZnT97Nsa3u0o=
+github.com/cilium/lumberjack/v2 v2.3.0/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20191113190709-4c7b379792e6/go.mod h1:lbRnBzpxwMP5KsTu99cM654ShwTWamyhrF6cCLuYqhE=
 github.com/cilium/proxy v0.0.0-20200309181938-3cf80fe45d03/go.mod h1:MsrtgITWuZatZCS715qDH+dp2iaVjOuxnIr8uwja5cM=
 github.com/cilium/proxy v0.0.0-20210511221533-82a70d56bf32/go.mod h1:mvauc94lqkyJunRsU9Ef5FIsixi8vBeDoxuMYoGBemk=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,10 +55,10 @@ type getEventsListener struct {
 	events chan *tetragon.GetEventsResponse
 }
 
-func NewServer(ctx context.Context, wg *sync.WaitGroup, notifier notifier, observer observer) *Server {
+func NewServer(ctx context.Context, cleanupWg *sync.WaitGroup, notifier notifier, observer observer) *Server {
 	return &Server{
 		ctx:          ctx,
-		ctxCleanupWG: wg,
+		ctxCleanupWG: cleanupWg,
 		notifier:     notifier,
 		observer:     observer,
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -93,7 +93,7 @@ github.com/cilium/hubble/pkg/servicecache
 ## explicit; go 1.18
 github.com/cilium/little-vm-helper/pkg/images
 github.com/cilium/little-vm-helper/pkg/logcmd
-# github.com/cilium/lumberjack/v2 v2.2.2
+# github.com/cilium/lumberjack/v2 v2.3.0
 ## explicit; go 1.13
 github.com/cilium/lumberjack/v2
 # github.com/cilium/tetragon/api v0.0.0-00010101000000-000000000000 => ./api


### PR DESCRIPTION
This backport contains:

- https://github.com/cilium/tetragon/pull/565
- https://github.com/cilium/tetragon/pull/574
- https://github.com/cilium/tetragon/pull/582
- https://github.com/cilium/tetragon/pull/588
- https://github.com/cilium/tetragon/pull/590

Goes on top of https://github.com/cilium/tetragon/pull/629