### PR TITLE
.github: set the right step ID for pull request builds

### DIFF
--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -161,9 +161,14 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
+          echo "${{ steps.docker_build_ci_pr.outputs }}"
+          echo "${{ steps.docker_build_ci_pr.outputs.digest }}"
           docker_build_ci_pr_digest="${{ steps.docker_build_ci_pr.outputs.digest }}"
+          echo ${docker_build_ci_pr_digest}
           image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_ci_pr_digest/:/-}.sbom"
+          echo ${image_name}
           docker_build_ci_pr_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
+          echo ${docker_build_ci_pr_sbom_digest}
           cosign sign "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_ci_pr_sbom_digest}"
 
       - name: CI Image Releases digests (PR)

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -161,7 +161,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          docker_build_ci_pr_digest="${{ steps.docker_build_ci_main.outputs.digest }}"
+          docker_build_ci_pr_digest="${{ steps.docker_build_ci_pr.outputs.digest }}"
           image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_ci_pr_digest/:/-}.sbom"
           docker_build_ci_pr_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
           cosign sign "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_ci_pr_sbom_digest}"


### PR DESCRIPTION
The step ID used to derive the image digest was not correctly set which made the SBOM signature to fail. This commit sets the right step ID so the SBOM is signed for PRs.

Fixes: 343e9f94c6ec ("build: Generate SBOM during image release")
Signed-off-by: André Martins <andre@cilium.io>