### PR TITLE
bpf_alignchecker.c: avoid unused var error

### DIFF
--- a/bpf/alignchecker/bpf_alignchecker.c
+++ b/bpf/alignchecker/bpf_alignchecker.c
@@ -44,5 +44,6 @@ int main(void)
 	DECLARE(struct, tetragon_conf, iter);
 	DECLARE(struct, cgroup_tracking_value, iter);
 
-	return 0;
+	// avoid unused variable warning/error
+	return iter * 0;
 }


### PR DESCRIPTION
Currently when compiling on Fedora37 with clang 15.0.4, the build fails because of the unused variable `iter` in bpf/alignchecker/bpf_alignchecker.c https://github.com/cilium/tetragon/blob/main/bpf/alignchecker/bpf_alignchecker.c#L30 (error below).  PR suggest to change the return statement of the (unused) main function to `return iter * 0` to avoid that error.  If there are better ways to make code compile on Fedora, please let me know! 

```
$ CONTAINER_ENGINE='sudo podman' LOCAL_CLANG=1 LOCAL_CLANG_FORMAT=1 make

/bin/sh: line 1: docker: command not found
make -C ./bpf
make[1]: Entering directory '/gh/cilium/tetragon/bpf'
clang -I. -Wall -Werror -Wno-address-of-packed-member -Wno-compare-distinct-pointer-types -Wno-unknown-warning-option -O2 -I ./libbpf/ -I ./include/ -I ./lib -target bpf -emit-llvm -g -D__TARGET_ARCH_x86 -fdebug-default-version=4 -MM -MP -MT  objs/bpf_alignchecker.ll   alignchecker/bpf_alignchecker.c > deps/bpf_alignchecker.d
clang -I. -Wall -Werror -Wno-address-of-packed-member -Wno-compare-distinct-pointer-types -Wno-unknown-warning-option -O2 -I ./libbpf/ -I ./include/ -I ./lib -target bpf -emit-llvm -g -D__TARGET_ARCH_x86 -fdebug-default-version=4 -c alignchecker/bpf_alignchecker.c -o objs/bpf_alignchecker.ll
alignchecker/bpf_alignchecker.c:30:6: error: variable 'iter' set but not used [-Werror,-Wunused-but-set-variable]
        int iter = 0;
            ^
1 error generated.
make[1]: *** [Makefile:72: objs/bpf_alignchecker.ll] Error 1
make[1]: Leaving directory '/gh/cilium/tetragon/bpf'
make: *** [Makefile:75: tetragon-bpf-local] Error 2
```