### PR TITLE
gettid wrapper

### DIFF
--- a/contrib/tester-progs/exit-tester.c
+++ b/contrib/tester-progs/exit-tester.c
@@ -10,6 +10,14 @@
 #include <errno.h>
 #include <stdbool.h>
 
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#include <sys/syscall.h>
+static inline pid_t gettid(void)
+{
+	return (pid_t)syscall(__NR_gettid);
+}
+#endif
+
 // is_zombie reads /proc/<pid>/stat, and returns true if status is Z (zombie)
 bool is_zombie(int pid) {
 	const int buff_size = 128;


### PR DESCRIPTION
when trying to build on RHEL8 (with `CONTAINER_ENGINE='sudo podman' LOCAL_CLANG=1 LOCAL_CLANG_FORMAT=1 make`), I'm getting a build failure due to missing `gettid` function.  This seems to be a problem with glibc...  The suggested workaround gets the codebase to compile - would like you r(and CI builds' 😄 ) opinion whether this would generally work and be the right way to fix this.  NB: this is cumulative with #637, I'll rebase once that one is merged.

```
make -C "contrib/tester-progs"
make[1]: Entering directory '/home/dmitris/gh/cilium/tetragon/contrib/tester-progs'
gcc -Wall exit-tester.c -o exit-tester -lpthread
exit-tester.c: In function ‘thread’:
exit-tester.c:34:41: warning: implicit declaration of function ‘gettid’; did you mean ‘getgid’? [-Wimplicit-function-declaration]
  printf("thread: pid:%d tid:%d\n", pid, gettid());
                                         ^~~~~~
                                         getgid
/tmp/ccEikzeG.o: In function `thread':
exit-tester.c:(.text+0x168): undefined reference to `gettid'
/tmp/ccEikzeG.o: In function `main':
exit-tester.c:(.text+0x284): undefined reference to `gettid'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:24: exit-tester] Error 1
make[1]: Leaving directory '/home/dmitris/gh/cilium/tetragon/contrib/tester-progs'
make: *** [Makefile:279: tester-progs] Error 2
```