### PR TITLE
e2e-framework: force update when adding helm repo

### DIFF
--- a/tests/e2e/install/tetragon/tetragon.go
+++ b/tests/e2e/install/tetragon/tetragon.go
@@ -94,7 +94,7 @@ func Install(opts ...Option) env.Func {
 		// Only add and upate repo if helm url is specified
 		if o.HelmRepoUrl != "" {
 			repoName := strings.Split(o.HelmChart, "/")[0]
-			if err := manager.RunRepo(helm.WithArgs("add", repoName, o.HelmRepoUrl)); err != nil {
+			if err := manager.RunRepo(helm.WithArgs("add", "--force-update", repoName, o.HelmRepoUrl)); err != nil {
 				return ctx, fmt.Errorf("failed to add helm repo %s (%s): %w", repoName, o.HelmRepoUrl, err)
 			}
 


### PR DESCRIPTION
In some versions of helm, it complains when we try to add a repo that already exists. To prevent this, pass the `--force-update` flag.

Signed-off-by: William Findlay <will@isovalent.com>