### PR TITLE
Add skb_adjust_room helper

### DIFF
--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -166,6 +166,8 @@ static int BPF_FUNC(skb_change_proto, struct __sk_buff *skb, uint32_t proto,
 		    uint32_t flags);
 static int BPF_FUNC(skb_change_tail, struct __sk_buff *skb, uint32_t nlen,
 		    uint32_t flags);
+static int BPF_FUNC(skb_adjust_room, struct __sk_buff *skb, int32_t len_diff,
+		    uint32_t mode, uint64_t flags);
 static int BPF_FUNC(skb_pull_data, struct __sk_buff *skb, uint32_t len);
 
 /* Packet vlan encap/decap */


### PR DESCRIPTION
skb_adjust_room() allows skbs to be modified to different sizes.

Signed-off-by: Kevin Sheldrake <kevin.sheldrake@isovalent.com>