### PR TITLE
Update Makefile test target dependencies and run test as root

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -42,16 +42,15 @@ jobs:
     - name: Run go tests
       env:
         GOPATH: /home/runner/work/tetragon/tetragon/go
+        SUDO: sudo -E
       run: |
         cd go/src/github.com/cilium/tetragon/
         make check-copyright
-        sudo make tetragon-bpf
         sudo -E echo "run go tests: " `uname -a`
         sudo -E go mod verify
         sudo -E GO111MODULE=off go get -u golang.org/x/lint/golint
         export TETRAGON_LIB=$(realpath "bpf/objs/")
-        sudo -E make tester-progs
-        sudo -E make test
+        make test
 
     - name: Upload Tetragon logs
       if: failure()

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CLANG_IMAGE  = quay.io/cilium/clang:ca424d14eb4326ffc65fccd8049d8a7bfdd06607@sha
 TESTER_PROGS_DIR = "contrib/tester-progs"
 # Extra flags to pass to test binary
 EXTRA_TESTFLAGS ?=
+SUDO ?= sudo
 
 VERSION ?= $(shell git describe --tags --always)
 GO_GCFLAGS ?= ""
@@ -133,8 +134,8 @@ clean: cli-clean
 	$(MAKE) -C $(TESTER_PROGS_DIR) clean
 
 .PHONY: test
-test:
-	$(GO) test -p 1 -parallel 1 $(GOFLAGS) -gcflags=$(GO_GCFLAGS) -timeout 20m -failfast -cover ./pkg/... ${EXTRA_TESTFLAGS}
+test: tester-progs tetragon-bpf
+	$(SUDO) $(GO) test -p 1 -parallel 1 $(GOFLAGS) -gcflags=$(GO_GCFLAGS) -timeout 20m -failfast -cover ./pkg/... ${EXTRA_TESTFLAGS}
 
 # Agent image to use for end-to-end tests
 E2E_AGENT ?= "cilium/tetragon:$(DOCKER_IMAGE_TAG)"


### PR DESCRIPTION
- Make explicit the implicit dependencies there were between `tetragon-bpf` and `tester-progs` for the target `test`. Also, run the tests as root with sudo using the `SUDO` variable.
- Simplify the associated GitHub action