### PR TITLE
CRD examples: Replace invalid TracingPolicy names

### DIFF
--- a/crds/examples/fd_install_cap_changes.yaml
+++ b/crds/examples/fd_install_cap_changes.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "fd_install"
+  name: "fd-install"
 spec:
   kprobes:
   - call: "fd_install"

--- a/crds/examples/fd_install_caps.yaml
+++ b/crds/examples/fd_install_caps.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "fd_install"
+  name: "fd-install"
 spec:
   kprobes:
   - call: "fd_install"

--- a/crds/examples/fd_install_ns.yaml
+++ b/crds/examples/fd_install_ns.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "fd_install"
+  name: "fd-install"
 spec:
   kprobes:
   - call: "fd_install"

--- a/crds/examples/fd_install_ns_host.yaml
+++ b/crds/examples/fd_install_ns_host.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "fd_install"
+  name: "fd-install"
 spec:
   kprobes:
   - call: "fd_install"

--- a/crds/examples/hardlink-observe.yaml
+++ b/crds/examples/hardlink-observe.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "sys_linkat_passwd"
+  name: "sys-linkat-passwd"
 spec:
   kprobes:
   - call: "__x64_sys_linkat"

--- a/crds/examples/hardlink-override.yaml
+++ b/crds/examples/hardlink-override.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "sys_linkat_passwd"
+  name: "sys-linkat-passwd"
 spec:
   kprobes:
   - call: "__x64_sys_linkat"

--- a/crds/examples/match_capability_changes.yaml
+++ b/crds/examples/match_capability_changes.yaml
@@ -52,7 +52,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "fd_install"
+  name: "fd-install"
 spec:
   kprobes:
   - call: "fd_install"

--- a/crds/examples/match_namespace_changes.yaml
+++ b/crds/examples/match_namespace_changes.yaml
@@ -41,7 +41,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "fd_install"
+  name: "fd-install"
 spec:
   kprobes:
   - call: "fd_install"

--- a/crds/examples/symlink-observe.yaml
+++ b/crds/examples/symlink-observe.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "sys_symlink_passwd"
+  name: "sys-symlink-passwd"
 spec:
   kprobes:
   - call: "__x64_sys_symlinkat"

--- a/crds/examples/symlink-override.yaml
+++ b/crds/examples/symlink-override.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "sys_symlink_passwd"
+  name: "sys-symlink-passwd"
 spec:
   kprobes:
   - call: "__x64_sys_symlinkat"

--- a/crds/sandbox/linux-namespaces/kill_unprivileged_user_namespace.yaml
+++ b/crds/sandbox/linux-namespaces/kill_unprivileged_user_namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "kill_unprivileged_user_namespace"
+  name: "kill-unprivileged-user-namespace"
 
 #
 # Adds ability to sandbox access to unprivileged user namespaces.

--- a/crds/sandbox/linux-namespaces/kill_unprivileged_user_namespace_in_pid_namespace.yaml
+++ b/crds/sandbox/linux-namespaces/kill_unprivileged_user_namespace_in_pid_namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "kill_unprivileged_user_namespace_in_pid_namespace"
+  name: "kill-unprivileged-user-namespace-in-pid-namespace"
 
 #
 # Adds ability to sandbox access to unprivileged user namespaces.


### PR DESCRIPTION
Many `metadata.name` of the `TracingPolicy` examples contained underscores in their name, and unfortunately, that makes it impossible to deploy them on Kubernetes. I assumed they were passed to Tetragon via flags using `--config-file` or similar. 

Maybe it would be interesting to implement the regex check in Tetragon to avoid this pitfall? 

Kubernetes objects names comply with lowercase RFC 1123 subdomain convention: they must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is `[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`)