### PR TITLE
backports/v0.8: ci: pin docker buildx version to v0.9.1

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          version: v0.9.1
+
       - name: Login to quay.io
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -29,6 +29,11 @@ jobs:
             dockerfile: ./operator.Dockerfile
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          version: v0.9.1
+
       - name: Login to quay.io for CI
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -26,6 +26,11 @@ jobs:
             dockerfile: ./operator.Dockerfile
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          version: v0.9.1
+
       - name: Login to quay.io
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:


### PR DESCRIPTION
[upstream commit: 7f9ac8a28f2f625184206b59f2cc85b7231f31f6]

Our image builder jobs were breaking due to incompaitibilies with a newer docker buildx version. Pin the version now to avoid breakages.

Original commit message from cilium/cilium:

    GitHub recently rolled out Docker buildx version v0.10.0 on their
    builders, which transparently changed the MediaType of docker images to
    OCI v1 and added provenance attestations.

    Unfortunately, various tools we use in CI like SBOM tooling and docker
    manifest inspect do not properly support some aspect of the new image
    formats. This resulted in breaking CI, with some messages like this:

    level=fatal msg="generating doc: creating SPDX document: generating
    SPDX package from image ref quay.io/cilium/docker-plugin-ci:XXX:
    generating image package"
    This could also lead CI to fail while waiting for image builds to
    complete, because the command we use to test whether the image is
    available did not support the image types.

    This commit attempts to revert buildx back to v0.9.1 to prevent it from
    generating the images in a format that other tooling doesn't expect.
    Over time we can work on migrating to buildx v0.10, testing various
    parts of our CI as we do so.

    This is a quick-and-dirty hack to stabilize CI for the short term, then
    we can figure out over time how to properly resolve the conflict between
    these systems.

Signed-off-by: William Findlay <will@isovalent.com>