### PR TITLE
eventchecker: implement checker names

### DIFF
--- a/cmd/protoc-gen-go-tetragon/common/common.go
+++ b/cmd/protoc-gen-go-tetragon/common/common.go
@@ -126,6 +126,12 @@ func FmtErrorf(g *protogen.GeneratedFile, fmt_ string, args ...string) string {
 	return fmt.Sprintf("%s(%s)", GoIdent(g, "fmt", "Errorf"), strings.Join(args, ", "))
 }
 
+// FmtSprintf is a convenience helper that generates a call to fmt.Sprintf
+func FmtSprintf(g *protogen.GeneratedFile, fmt_ string, args ...string) string {
+	args = append([]string{fmt.Sprintf("\"%s\"", fmt_)}, args...)
+	return fmt.Sprintf("%s(%s)", GoIdent(g, "fmt", "Sprintf"), strings.Join(args, ", "))
+}
+
 // EventFieldCheck returns true if the event has the field
 func EventFieldCheck(msg *protogen.Message, field string) bool {
 	if msg.Desc.Fields().ByName(protoreflect.Name(field)) != nil {

--- a/cmd/protoc-gen-go-tetragon/eventchecker/field.go
+++ b/cmd/protoc-gen-go-tetragon/eventchecker/field.go
@@ -280,7 +280,7 @@ func (field *Field) getFieldCheck(g *protogen.GeneratedFile, checkerName, checke
 
 	if field.isList() {
 		return `if err := ` + checkerVar + `.Check(` + eventVar + `); err != nil {
-		return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" check failed: %w", "err") + `
+		return ` + common.FmtErrorf(g, field.GoName+" check failed: %w", "err") + `
 		}`, nil
 	}
 
@@ -306,7 +306,7 @@ func checkForMap(g *protogen.GeneratedFile, field *Field, checkerName, checkerVa
                     // Attempt to grab the matcher for this key
                     if matcher, ok := ` + checkerVar + `[key]; ok {
                         if err := matcher.Match(value); err != nil {
-                            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+"[%s] (%s=%s) check failed: %w", "key", "key", "value", "err") + `
+                            return ` + common.FmtErrorf(g, field.GoName+"[%s] (%s=%s) check failed: %w", "key", "key", "value", "err") + `
                         }
                         matched[key] = struct{}{}
                     }
@@ -320,7 +320,7 @@ func checkForMap(g *protogen.GeneratedFile, field *Field, checkerName, checkerVa
                         unmatched = append(unmatched, k)
                     }
                 }
-                return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" unmatched: %v", "unmatched") + `
+                return ` + common.FmtErrorf(g, field.GoName+" unmatched: %v", "unmatched") + `
             }`, nil
 	}
 
@@ -376,11 +376,11 @@ func checkForKind(g *protogen.GeneratedFile, field *Field, checkerName, checkerV
 		ff := kindToFormat(kind)
 		if field.IsInnerField {
 			return `if ` + checkerVar + ` != ` + eventVar + ` {
-                return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" has value "+ff+" which does not match expected value "+ff, eventVar, checkerVar) + `
+                return ` + common.FmtErrorf(g, field.GoName+" has value "+ff+" which does not match expected value "+ff, eventVar, checkerVar) + `
             }`
 		}
 		return `if *` + checkerVar + ` != ` + eventVar + ` {
-            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" has value "+ff+" which does not match expected value "+ff, eventVar, "*"+checkerVar) + `
+            return ` + common.FmtErrorf(g, field.GoName+" has value "+ff+" which does not match expected value "+ff, eventVar, "*"+checkerVar) + `
         }`
 	}
 
@@ -389,46 +389,46 @@ func checkForKind(g *protogen.GeneratedFile, field *Field, checkerName, checkerV
 		ff := kindToFormat(kind)
 		wrapperVal := fmt.Sprintf("%s.Value", eventVar)
 		return `if ` + eventVar + ` == nil {
-            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" is nil and does not match expected value "+ff, "*"+checkerVar) + `
+            return ` + common.FmtErrorf(g, field.GoName+" is nil and does not match expected value "+ff, "*"+checkerVar) + `
         }
         if *` + checkerVar + ` != ` + wrapperVal + ` {
-            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" has value "+ff+" which does not match expected value "+ff, wrapperVal, "*"+checkerVar) + `
+            return ` + common.FmtErrorf(g, field.GoName+" has value "+ff+" which does not match expected value "+ff, wrapperVal, "*"+checkerVar) + `
         }`
 	}
 
 	doCheckerCheck := func() string {
 		return `if err := ` + checkerVar + `.Check(` + eventVar + `); err != nil {
-            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" check failed: %w", "err") + `
+            return ` + common.FmtErrorf(g, field.GoName+" check failed: %w", "err") + `
         }`
 	}
 
 	doEnumCheck := func() string {
 		return `if err := ` + checkerVar + `.Check(&` + eventVar + `); err != nil {
-            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" check failed: %w", "err") + `
+            return ` + common.FmtErrorf(g, field.GoName+" check failed: %w", "err") + `
         }`
 	}
 
 	doStringCheck := func() string {
 		return `if err := ` + checkerVar + `.Match(` + eventVar + `); err != nil {
-            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" check failed: %w", "err") + `
+            return ` + common.FmtErrorf(g, field.GoName+" check failed: %w", "err") + `
         }`
 	}
 
 	doBytesCheck := func() string {
 		return `if err := ` + checkerVar + `.Match(` + eventVar + `); err != nil {
-            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" check failed: %w", "err") + `
+            return ` + common.FmtErrorf(g, field.GoName+" check failed: %w", "err") + `
         }`
 	}
 
 	doTimestampCheck := func() string {
 		return `if err := ` + checkerVar + `.Match(` + eventVar + `); err != nil {
-            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" check failed: %w", "err") + `
+            return ` + common.FmtErrorf(g, field.GoName+" check failed: %w", "err") + `
         }`
 	}
 
 	doDurationCheck := func() string {
 		return `if err := ` + checkerVar + `.Match(` + eventVar + `); err != nil {
-            return ` + common.FmtErrorf(g, checkerName+": "+field.GoName+" check failed: %w", "err") + `
+            return ` + common.FmtErrorf(g, field.GoName+" check failed: %w", "err") + `
         }`
 	}
 

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -131,7 +131,7 @@ func TestNamespaces(t *testing.T) {
 		WithNs(nsChecker)
 
 	checker := ec.NewUnorderedEventChecker(
-		ec.NewProcessExecChecker().
+		ec.NewProcessExecChecker("").
 			WithProcess(selfChecker).
 			WithParent(ec.NewProcessChecker()),
 	)
@@ -167,7 +167,7 @@ func TestEventExecve(t *testing.T) {
 		WithBinary(sm.Full(testNop)).
 		WithArguments(sm.Full("arg1 arg2 arg3"))
 
-	execChecker := ec.NewProcessExecChecker().WithProcess(procChecker)
+	execChecker := ec.NewProcessExecChecker("").WithProcess(procChecker)
 	checker := ec.NewUnorderedEventChecker(execChecker)
 
 	if err := exec.Command(testNop, "arg1", "arg2", "arg3").Run(); err != nil {
@@ -239,7 +239,7 @@ func TestEventExecveLongPath(t *testing.T) {
 		WithBinary(sm.Full(testBin)).
 		WithArguments(sm.Full("arg1 arg2 arg3"))
 
-	execChecker := ec.NewProcessExecChecker().WithProcess(procChecker)
+	execChecker := ec.NewProcessExecChecker("").WithProcess(procChecker)
 	checker := ec.NewUnorderedEventChecker(execChecker)
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
@@ -298,7 +298,7 @@ func TestEventExecveLongArgs(t *testing.T) {
 		WithBinary(sm.Full(testNop)).
 		WithArguments(sm.Full(testArg1 + " " + testArg2 + " " + testArg3))
 
-	execChecker := ec.NewProcessExecChecker().WithProcess(procChecker)
+	execChecker := ec.NewProcessExecChecker("").WithProcess(procChecker)
 	checker := ec.NewUnorderedEventChecker(execChecker)
 
 	if err := exec.Command(testNop, testArg1, testArg2, testArg3).Run(); err != nil {
@@ -386,7 +386,7 @@ func TestEventExecveLongPathLongArgs(t *testing.T) {
 		WithBinary(sm.Full(testBin)).
 		WithArguments(sm.Full(testArg1 + " " + testArg2 + " " + testArg3))
 
-	execChecker := ec.NewProcessExecChecker().WithProcess(procChecker)
+	execChecker := ec.NewProcessExecChecker("").WithProcess(procChecker)
 	checker := ec.NewUnorderedEventChecker(execChecker)
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
@@ -465,10 +465,10 @@ func TestDocker(t *testing.T) {
 		WithDocker(fgsServerID)
 
 	checker := ec.NewUnorderedEventChecker(
-		ec.NewProcessExecChecker().
+		ec.NewProcessExecChecker("client").
 			WithProcess(selfChecker).
 			WithParent(ec.NewProcessChecker()),
-		ec.NewProcessExecChecker().
+		ec.NewProcessExecChecker("server").
 			WithProcess(ncSrvChecker),
 	)
 

--- a/pkg/sensors/exec/exit_test.go
+++ b/pkg/sensors/exec/exit_test.go
@@ -38,8 +38,8 @@ func TestExit(t *testing.T) {
 	procChecker := ec.NewProcessChecker().
 		WithBinary(sm.Full(testNop))
 
-	execChecker := ec.NewProcessExecChecker().WithProcess(procChecker)
-	exitChecker := ec.NewProcessExitChecker().WithProcess(procChecker)
+	execChecker := ec.NewProcessExecChecker("exec").WithProcess(procChecker)
+	exitChecker := ec.NewProcessExitChecker("exit").WithProcess(procChecker)
 
 	var checker *ec.UnorderedEventChecker
 
@@ -166,8 +166,8 @@ func TestExitZombie(t *testing.T) {
 	exitTesterCheck := ec.NewProcessChecker().WithBinary(sm.Suffix("tester-progs/exit-tester"))
 	echoCheck := ec.NewProcessChecker().WithBinary(sm.Full("/bin/sh")).WithArguments(sm.Contains("pizza is the best!"))
 	checker := ec.NewUnorderedEventChecker(
-		ec.NewProcessExecChecker().WithProcess(exitTesterCheck),
-		ec.NewProcessExecChecker().WithProcess(echoCheck).WithParent(exitTesterCheck),
+		ec.NewProcessExecChecker("exitTester").WithProcess(exitTesterCheck),
+		ec.NewProcessExecChecker("echo").WithProcess(echoCheck).WithParent(exitTesterCheck),
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)

--- a/pkg/sensors/exec/fork_test.go
+++ b/pkg/sensors/exec/fork_test.go
@@ -62,7 +62,7 @@ func TestFork(t *testing.T) {
 	binCheck := ec.NewProcessChecker().
 		WithBinary(sm.Suffix("fork-tester")).
 		WithPid(fti.child2Pid)
-	exitCheck := ec.NewProcessExitChecker().
+	exitCheck := ec.NewProcessExitChecker("").
 		WithProcess(binCheck).
 		WithParent(ec.NewProcessChecker().WithPid(fti.child1Pid))
 	checker := ec.NewUnorderedEventChecker(exitCheck)

--- a/pkg/sensors/test/lseek_test.go
+++ b/pkg/sensors/test/lseek_test.go
@@ -37,7 +37,7 @@ func TestSensorLseekLoad(t *testing.T) {
 	defer cancel()
 
 	checker := ec.NewUnorderedEventChecker(
-		ec.NewTestChecker(),
+		ec.NewTestChecker(""),
 	)
 
 	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
@@ -66,7 +66,7 @@ func TestSensorLseekEnable(t *testing.T) {
 	defer cancel()
 
 	checker := ec.NewUnorderedEventChecker(
-		ec.NewTestChecker(),
+		ec.NewTestChecker(""),
 	)
 
 	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)

--- a/pkg/sensors/tracing/kprobe_amd64_test.go
+++ b/pkg/sensors/tracing/kprobe_amd64_test.go
@@ -77,7 +77,7 @@ spec:
 	}
 
 	// Match only owner and group of userns as we are supposed to be real root
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("cap_capable")).
 		WithAction(tetragon.KprobeAction_KPROBE_ACTION_POST).
 		WithArgs(ec.NewKprobeArgumentListMatcher().

--- a/pkg/sensors/tracing/kprobe_copyfd_test.go
+++ b/pkg/sensors/tracing/kprobe_copyfd_test.go
@@ -86,7 +86,7 @@ func TestCopyFd(t *testing.T) {
 		t.Fatalf("command failed with %s. Context error: %s", err, ctx.Err())
 	}
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_read")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).

--- a/pkg/sensors/tracing/kprobe_filterchange_test.go
+++ b/pkg/sensors/tracing/kprobe_filterchange_test.go
@@ -88,7 +88,7 @@ func TestKprobeNSChanges(t *testing.T) {
 	writeArg1 := ec.NewKprobeArgumentChecker().WithBytesArg(bc.Full([]byte("testdata\x00")))
 	writeArg2 := ec.NewKprobeArgumentChecker().WithSizeArg(9)
 
-	kprobeChecker := ec.NewProcessKprobeChecker().
+	kprobeChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_write")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -169,7 +169,7 @@ func testKprobeCapChanges(t *testing.T, spec string, op string, value string) {
 	writeArg1 := ec.NewKprobeArgumentChecker().WithBytesArg(bc.Full([]byte("testdata\x00")))
 	writeArg2 := ec.NewKprobeArgumentChecker().WithSizeArg(9)
 
-	kprobeChecker := ec.NewProcessKprobeChecker().
+	kprobeChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_write")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).

--- a/pkg/sensors/tracing/kprobe_sigkill_test.go
+++ b/pkg/sensors/tracing/kprobe_sigkill_test.go
@@ -93,7 +93,7 @@ func TestKprobeSigkill(t *testing.T) {
 		t.Fatalf("command failed with %s. Context error: %s", err, ctx.Err())
 	}
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_lseek")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -181,7 +181,7 @@ func testUnprivilegedUsernsKill(t *testing.T, pidns bool) {
 		t.Fatalf("command failed with %s. Context error: %s", err, ctx.Err())
 	}
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("create_user_ns")).
 		WithAction(tetragon.KprobeAction_KPROBE_ACTION_SIGKILL)
 

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -148,7 +148,7 @@ func getTestKprobeObjectWRChecker() ec.MultiEventChecker {
 	myNs := ec.NewNamespacesChecker().FromNamespaces(namespace.GetCurrentNamespace())
 	myCaps := ec.NewCapabilitiesChecker().FromCapabilities(caps.GetCurrentCapabilities())
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_write")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -484,7 +484,7 @@ spec:
         values:
         - ` + fdString
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_read")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -532,7 +532,7 @@ spec:
         values:
         - ` + fdString
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_read")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -549,7 +549,7 @@ spec:
 
 // __x64_sys_openat trace
 func getOpenatChecker(dir string) ec.MultiEventChecker {
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_openat")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -564,7 +564,7 @@ func getOpenatChecker(dir string) ec.MultiEventChecker {
 
 // matches any kprobe event, used to test filters
 func getAnyChecker() ec.MultiEventChecker {
-	return ec.NewUnorderedEventChecker(ec.NewProcessKprobeChecker())
+	return ec.NewUnorderedEventChecker(ec.NewProcessKprobeChecker("anyKprobe"))
 }
 
 func testKprobeObjectFiltered(t *testing.T,
@@ -1046,7 +1046,7 @@ spec:
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithProcess(ec.NewProcessChecker().
 			WithBinary(sm.Suffix(tus.Conf().SelfBinary))).
 		WithFunctionName(sm.Full("__x64_sys_writev")).
@@ -1072,7 +1072,7 @@ spec:
 }
 
 func getFilpOpenChecker(dir string) ec.MultiEventChecker {
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("do_filp_open")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -1237,7 +1237,7 @@ func testKprobeObjectFileWriteFilteredHook(pidStr string, dir string) string {
 }
 
 func getWriteChecker(path, flags string) ec.MultiEventChecker {
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_write")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -1525,7 +1525,7 @@ spec:
 	var newFd int32 = -321
 	var flags int32 = 12345
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_linkat")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -1670,7 +1670,7 @@ spec:
         argError: -2
 `
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_openat")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -1806,7 +1806,7 @@ spec:
 		buffer[i] = 'A' + byte(i%26)
 	}
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_writev")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -1859,7 +1859,7 @@ spec:
 		buffer[i] = 'A' + byte(i%26)
 	}
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_writev")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -1913,7 +1913,7 @@ spec:
 		buffer[i] = 'A' + byte(i%26)
 	}
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_readv")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -2036,7 +2036,7 @@ func readFile(t *testing.T, file string) int {
 }
 
 func createFdInstallChecker(fd int, filename string) *ec.ProcessKprobeChecker {
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("fd_install")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -2048,7 +2048,7 @@ func createFdInstallChecker(fd int, filename string) *ec.ProcessKprobeChecker {
 }
 
 func createReadChecker(filename string) *ec.ProcessKprobeChecker {
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("__x64_sys_read")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
@@ -2364,7 +2364,7 @@ spec:
 		t.Fatalf("Loading test CRD failed: %s", err)
 	}
 
-	kpChecker := ec.NewProcessKprobeChecker().
+	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full("bpf_check")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithValues(

--- a/pkg/sensors/tracing/loader_test.go
+++ b/pkg/sensors/tracing/loader_test.go
@@ -115,7 +115,7 @@ spec:
 		t.Fatalf("Failed to ParseBuildId: %v\n", err)
 	}
 
-	loaderChecker := ec.NewProcessLoaderChecker().
+	loaderChecker := ec.NewProcessLoaderChecker("").
 		WithBuildid(bytesmatcher.Full(id)).
 		WithPath(sm.Full(testNop))
 

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -72,7 +72,7 @@ func TestGenericTracepointSimple(t *testing.T) {
 	}
 	sm.AddAndEnableSensor(ctx, t, sensor, "GtpLseekTest")
 
-	tpChecker := ec.NewProcessTracepointChecker().
+	tpChecker := ec.NewProcessTracepointChecker("").
 		WithSubsys(smatcher.Full("syscalls")).
 		WithEvent(smatcher.Full("sys_enter_lseek")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().

--- a/tests/e2e/tests/labels/labels_test.go
+++ b/tests/e2e/tests/labels/labels_test.go
@@ -110,26 +110,26 @@ func TestLabelsDemoApp(t *testing.T) {
 
 func labelsEventChecker(kernelVersion string) *checker.RPCChecker {
 	labelsEventChecker := ec.NewUnorderedEventChecker(
-		ec.NewProcessExecChecker().WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+		ec.NewProcessExecChecker("coreapi").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
 			"app":               *sm.Full("coreapi"),
 			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker().WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+		ec.NewProcessExecChecker("crawler").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
 			"app":               *sm.Full("crawler"),
 			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker().WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+		ec.NewProcessExecChecker("elasticsearch").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
 			"app":                                *sm.Full("elasticsearch-master"),
 			"chart":                              *sm.Full("elasticsearch"),
 			"controller-revision-hash":           *sm.Regex("elasticsearch-master-[a-f0-9]+"),
 			"release":                            *sm.Full("jobs-app"),
 			"statefulset.kubernetes.io/pod-name": *sm.Prefix("elasticsearch-master"),
 		}))),
-		ec.NewProcessExecChecker().WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+		ec.NewProcessExecChecker("jobposting").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
 			"app":               *sm.Full("jobposting"),
 			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker().WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+		ec.NewProcessExecChecker("kafka").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
 			"app.kubernetes.io/instance":         *sm.Full("jobs-app"),
 			"app.kubernetes.io/managed-by":       *sm.Full("strimzi-cluster-operator"),
 			"app.kubernetes.io/name":             *sm.Full("kafka"),
@@ -140,7 +140,7 @@ func labelsEventChecker(kernelVersion string) *checker.RPCChecker {
 			"strimzi.io/kind":                    *sm.Full("Kafka"),
 			"strimzi.io/name":                    *sm.Full("jobs-app-kafka"),
 		}))),
-		ec.NewProcessExecChecker().WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+		ec.NewProcessExecChecker("zookeeper").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
 			"app.kubernetes.io/instance":         *sm.Full("jobs-app"),
 			"app.kubernetes.io/managed-by":       *sm.Full("strimzi-cluster-operator"),
 			"app.kubernetes.io/name":             *sm.Full("zookeeper"),
@@ -151,15 +151,15 @@ func labelsEventChecker(kernelVersion string) *checker.RPCChecker {
 			"strimzi.io/kind":                    *sm.Full("Kafka"),
 			"strimzi.io/name":                    *sm.Full("jobs-app-zookeeper"),
 		}))),
-		ec.NewProcessExecChecker().WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+		ec.NewProcessExecChecker("loader").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
 			"app":               *sm.Full("loader"),
 			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker().WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+		ec.NewProcessExecChecker("recruiter").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
 			"app":               *sm.Full("recruiter"),
 			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker().WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+		ec.NewProcessExecChecker("cluster-operator").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
 			"name":              *sm.Full("strimzi-cluster-operator"),
 			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
 			"strimzi.io/kind":   *sm.Full("cluster-operator"),

--- a/tests/e2e/tests/skeleton/skeleton_test.go
+++ b/tests/e2e/tests/skeleton/skeleton_test.go
@@ -126,7 +126,9 @@ func TestSkeletonBasic(t *testing.T) {
 
 func curlEventChecker(kernelVersion string) *checker.RPCChecker {
 	curlEventChecker := ec.NewUnorderedEventChecker(
-		ec.NewProcessExecChecker().
+		// Checkers should be given a unique name. This shows up in the logs and can be
+		// helpful when debugging failures and flakes.
+		ec.NewProcessExecChecker("checkerNameHere").
 			WithProcess(
 				ec.NewProcessChecker().
 					WithPod(ec.NewPodChecker().


### PR DESCRIPTION
This commit implments eventchecker names for top-level checkers (i.e. checkers that check a process event). These names will show up in the error logs when a check fails. That should hopefully improve the readability of test logs (especially e2e tests) and help us diagnose why tests are failing.

Note that for most of the tests that have only one checker, I have opted to give them an empty name. This is because these are cases where disambiguation is (obviously) unhelpful. For some practical examples of why this construct is actually useful, please refer to the end-to-end tests.

Signed-off-by: William Findlay <will@isovalent.com>