### PR TITLE
tetragon: log pinned bpf and maps status

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -203,7 +203,12 @@ func tetragonExecute() error {
 
 	// Check if option to remove old BPF and maps is enabled.
 	if option.Config.ReleasePinned {
-		os.RemoveAll(observerDir)
+		err := os.RemoveAll(observerDir)
+		if err != nil {
+			log.WithField("bpf-dir", observerDir).WithError(err).Warn("BPF: failed to release pinned BPF programs and maps, Consider removing it manually")
+		} else {
+			log.WithField("bpf-dir", observerDir).Info("BPF: successfully released pinned BPF programs and maps")
+		}
 	}
 
 	// Get observer from configFile
@@ -294,6 +299,8 @@ func tetragonExecute() error {
 	if option.Config.EnableK8s {
 		go crd.WatchTracePolicy(ctx, observer.SensorManager)
 	}
+
+	obs.LogPinnedBpf(observerDir)
 
 	// load base sensor
 	if err := base.GetInitialSensor().Load(ctx, observerDir, observerDir, option.Config.CiliumDir); err != nil {


### PR DESCRIPTION
This logs the release bpf resources operation in case, and also before starting the bpf loading logic logs the current pinned ones if any.

For bpf developers some errors are easy to spot, for others let's add more logging.

Example:
time="2023-01-27T14:29:41+01:00" level=info msg="BPF: resources are empty" bpf-dir=/sys/fs/bpf/tetragon

Or:
time="2023-01-27T14:28:34+01:00" level=info msg="BPF: found active BPF resources" bpf-dir=/sys/fs/bpf/tetragon pinned-bpf="[event_execve event_exit execve_calls execve_map execve_map_stats kprobe_pid_clear names_map tcpmon_map tg_conf_map]"

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>