### PR TITLE
tetra: use field filters when reading via `io_reader_client`

### DIFF
--- a/cmd/tetra/getevents/getevents.go
+++ b/cmd/tetra/getevents/getevents.go
@@ -149,7 +149,7 @@ func New() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringP("output", "o", "json", "Output format. json or compact")
 	flags.String("color", "auto", "Colorize compact output. auto, always, or never")
-	flags.StringSliceP("include-fields", "f", nil, "Include fields in events")
+	flags.StringSliceP("include-fields", "f", nil, "Include only fields in events")
 	flags.StringSliceP("exclude-fields", "F", nil, "Exclude fields from events")
 	flags.StringSliceP("namespace", "n", nil, "Get events by Kubernetes namespaces")
 	flags.StringSlice("process", nil, "Get events by process name regex")

--- a/cmd/tetra/getevents/getevents_test.go
+++ b/cmd/tetra/getevents/getevents_test.go
@@ -5,8 +5,10 @@ package getevents
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
+	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -62,5 +64,45 @@ func Test_GetEvents_Process(t *testing.T) {
 		cmd.SetArgs([]string{"--process", "docker"})
 		output := testutils.RedirectStdoutExecuteCmd(t, cmd)
 		assert.Equal(t, 2, bytes.Count(output, []byte("\n")))
+	})
+}
+
+func Test_GetEvents_FilterFields(t *testing.T) {
+	t.Run("ExcludeParent", func(t *testing.T) {
+		testutils.MockPipedFile(t, testutils.RepoRootPath("testdata/events.json"))
+		cmd := New()
+		cmd.SetArgs([]string{"-F", "parent"})
+		output := testutils.RedirectStdoutExecuteCmd(t, cmd)
+		// remove last trailing newline for splitting
+		output = bytes.TrimSpace(output)
+		lines := bytes.Split(output, []byte("\n"))
+		for _, line := range lines {
+			var res tetragon.GetEventsResponse
+			err := json.Unmarshal(line, &res)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.NotEmpty(t, res.GetProcessExec().Process)
+			assert.Empty(t, res.GetProcessExec().Parent)
+		}
+	})
+
+	t.Run("IncludeParent", func(t *testing.T) {
+		testutils.MockPipedFile(t, testutils.RepoRootPath("testdata/events.json"))
+		cmd := New()
+		cmd.SetArgs([]string{"-f", "parent"})
+		output := testutils.RedirectStdoutExecuteCmd(t, cmd)
+		// remove last trailing newline for splitting
+		output = bytes.TrimSpace(output)
+		lines := bytes.Split(output, []byte("\n"))
+		for _, line := range lines {
+			var res tetragon.GetEventsResponse
+			err := json.Unmarshal(line, &res)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Empty(t, res.GetProcessExec().Process)
+			assert.NotEmpty(t, res.GetProcessExec().Parent)
+		}
 	})
 }


### PR DESCRIPTION
Previously the field filters were used only in the server-side code:
https://github.com/cilium/tetragon/blob/cd96d7ca3d7556f0d44da7da0ab4cdf943d29957/pkg/server/server.go#L145-L149