### PR TITLE
tetragon: Switch exit tracepoint to __put_task_struct kprobe

### DIFF
--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -627,6 +627,7 @@
 | parent | [Process](#tetragon-Process) |  |  |
 | signal | [string](#string) |  |  |
 | status | [uint32](#uint32) |  |  |
+| time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
 
 
 

--- a/api/v1/tetragon/tetragon.pb.go
+++ b/api/v1/tetragon/tetragon.pb.go
@@ -898,10 +898,11 @@ type ProcessExit struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Process *Process `protobuf:"bytes,1,opt,name=process,proto3" json:"process,omitempty"`
-	Parent  *Process `protobuf:"bytes,2,opt,name=parent,proto3" json:"parent,omitempty"`
-	Signal  string   `protobuf:"bytes,3,opt,name=signal,proto3" json:"signal,omitempty"`
-	Status  uint32   `protobuf:"varint,4,opt,name=status,proto3" json:"status,omitempty"`
+	Process *Process               `protobuf:"bytes,1,opt,name=process,proto3" json:"process,omitempty"`
+	Parent  *Process               `protobuf:"bytes,2,opt,name=parent,proto3" json:"parent,omitempty"`
+	Signal  string                 `protobuf:"bytes,3,opt,name=signal,proto3" json:"signal,omitempty"`
+	Status  uint32                 `protobuf:"varint,4,opt,name=status,proto3" json:"status,omitempty"`
+	Time    *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=time,proto3" json:"time,omitempty"`
 }
 
 func (x *ProcessExit) Reset() {
@@ -962,6 +963,13 @@ func (x *ProcessExit) GetStatus() uint32 {
 		return x.Status
 	}
 	return 0
+}
+
+func (x *ProcessExit) GetTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Time
+	}
+	return nil
 }
 
 type KprobeSock struct {
@@ -2602,7 +2610,7 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x73, 0x52, 0x06, 0x70, 0x61, 0x72, 0x65, 0x6e, 0x74, 0x12, 0x2f, 0x0a, 0x09, 0x61, 0x6e, 0x63,
 	0x65, 0x73, 0x74, 0x6f, 0x72, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x11, 0x2e, 0x74,
 	0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x52,
-	0x09, 0x61, 0x6e, 0x63, 0x65, 0x73, 0x74, 0x6f, 0x72, 0x73, 0x22, 0x95, 0x01, 0x0a, 0x0b, 0x50,
+	0x09, 0x61, 0x6e, 0x63, 0x65, 0x73, 0x74, 0x6f, 0x72, 0x73, 0x22, 0xc5, 0x01, 0x0a, 0x0b, 0x50,
 	0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x45, 0x78, 0x69, 0x74, 0x12, 0x2b, 0x0a, 0x07, 0x70, 0x72,
 	0x6f, 0x63, 0x65, 0x73, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x11, 0x2e, 0x74, 0x65,
 	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x52, 0x07,
@@ -2612,7 +2620,10 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x6e, 0x74, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x61, 0x6c, 0x18, 0x03, 0x20, 0x01,
 	0x28, 0x09, 0x52, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x61, 0x6c, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x74,
 	0x61, 0x74, 0x75, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x06, 0x73, 0x74, 0x61, 0x74,
-	0x75, 0x73, 0x22, 0xdc, 0x01, 0x0a, 0x0a, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53, 0x6f, 0x63,
+	0x75, 0x73, 0x12, 0x2e, 0x0a, 0x04, 0x74, 0x69, 0x6d, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
+	0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x04, 0x74, 0x69,
+	0x6d, 0x65, 0x22, 0xdc, 0x01, 0x0a, 0x0a, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53, 0x6f, 0x63,
 	0x6b, 0x12, 0x16, 0x0a, 0x06, 0x66, 0x61, 0x6d, 0x69, 0x6c, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28,
 	0x09, 0x52, 0x06, 0x66, 0x61, 0x6d, 0x69, 0x6c, 0x79, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70,
 	0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1a, 0x0a,
@@ -2938,42 +2949,43 @@ var file_tetragon_tetragon_proto_depIdxs = []int32{
 	9,  // 27: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
 	9,  // 28: tetragon.ProcessExit.process:type_name -> tetragon.Process
 	9,  // 29: tetragon.ProcessExit.parent:type_name -> tetragon.Process
-	33, // 30: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
-	33, // 31: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
-	33, // 32: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
-	34, // 33: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
-	34, // 34: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
-	32, // 35: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
-	32, // 36: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
-	7,  // 37: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
-	13, // 38: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
-	14, // 39: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
-	15, // 40: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
-	16, // 41: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
-	12, // 42: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
-	17, // 43: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
-	20, // 44: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
-	21, // 45: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
-	22, // 46: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
-	19, // 47: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
-	18, // 48: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
-	9,  // 49: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
-	9,  // 50: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
-	23, // 51: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
-	23, // 52: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
-	0,  // 53: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
-	9,  // 54: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
-	9,  // 55: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
-	23, // 56: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
-	1,  // 57: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
-	1,  // 58: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
-	2,  // 59: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
-	28, // 60: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
-	61, // [61:61] is the sub-list for method output_type
-	61, // [61:61] is the sub-list for method input_type
-	61, // [61:61] is the sub-list for extension type_name
-	61, // [61:61] is the sub-list for extension extendee
-	0,  // [0:61] is the sub-list for field type_name
+	31, // 30: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
+	33, // 31: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
+	33, // 32: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
+	33, // 33: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
+	34, // 34: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
+	34, // 35: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
+	32, // 36: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
+	32, // 37: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
+	7,  // 38: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
+	13, // 39: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
+	14, // 40: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
+	15, // 41: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
+	16, // 42: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
+	12, // 43: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
+	17, // 44: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
+	20, // 45: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
+	21, // 46: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
+	22, // 47: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
+	19, // 48: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
+	18, // 49: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
+	9,  // 50: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
+	9,  // 51: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
+	23, // 52: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
+	23, // 53: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
+	0,  // 54: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
+	9,  // 55: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
+	9,  // 56: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
+	23, // 57: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
+	1,  // 58: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
+	1,  // 59: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
+	2,  // 60: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
+	28, // 61: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
+	62, // [62:62] is the sub-list for method output_type
+	62, // [62:62] is the sub-list for method input_type
+	62, // [62:62] is the sub-list for extension type_name
+	62, // [62:62] is the sub-list for extension extendee
+	0,  // [0:62] is the sub-list for field type_name
 }
 
 func init() { file_tetragon_tetragon_proto_init() }

--- a/api/v1/tetragon/tetragon.proto
+++ b/api/v1/tetragon/tetragon.proto
@@ -109,6 +109,7 @@ message ProcessExit {
     Process parent  = 2;
     string  signal  = 3;
     uint32  status  = 4;
+    google.protobuf.Timestamp time = 5;
 }
 
 message KprobeSock {

--- a/bpf/process/bpf_exit.c
+++ b/bpf/process/bpf_exit.c
@@ -23,6 +23,6 @@ event_exit(struct pt_regs *ctx)
 	 * would otherwise occur.
 	 */
 	if (pid == tgid)
-		event_exit_send(ctx, tgid);
+		event_exit_send(ctx, tgid, task);
 	return 0;
 }

--- a/bpf/process/bpf_exit.c
+++ b/bpf/process/bpf_exit.c
@@ -1,17 +1,28 @@
 // SPDX-License-Identifier: GPL-2.0
 /* Copyright Authors of Cilium */
 
+#include "vmlinux.h"
 #include "bpf_exit.h"
+#include "bpf_tracing.h"
 
 char _license[] __attribute__((section("license"), used)) = "GPL";
 
-__attribute__((section("tracepoint/sys_exit"), used)) int
-event_exit(struct sched_execve_args *ctx)
+__attribute__((section("kprobe/__put_task_struct"), used)) int
+event_exit(struct pt_regs *ctx)
 {
-	__u64 pid_tgid;
+	struct task_struct *task =
+		(struct task_struct *)PT_REGS_PARM1_CORE(ctx);
+	__u32 pid, tgid;
 
-	pid_tgid = get_current_pid_tgid();
+	pid = BPF_CORE_READ(task, pid);
+	tgid = BPF_CORE_READ(task, tgid);
 
-	event_exit_send(ctx, pid_tgid);
+	/* We are only tracking group leaders so if tgid is not
+	 * the same as the pid then this is an untracked child
+	 * and we can skip the lookup/insert/delete cycle that
+	 * would otherwise occur.
+	 */
+	if (pid == tgid)
+		event_exit_send(ctx, tgid);
 	return 0;
 }

--- a/bpf/process/bpf_exit.h
+++ b/bpf/process/bpf_exit.h
@@ -14,22 +14,10 @@ struct {
 	__type(value, struct msg_exit);
 } exit_heap_map SEC(".maps");
 
-static inline __attribute__((always_inline)) void
-event_exit_send(struct sched_execve_args *ctx, __u64 current)
+static inline __attribute__((always_inline)) void event_exit_send(void *ctx,
+								  __u32 tgid)
 {
 	struct execve_map_value *enter;
-	__u32 pid, tgid;
-
-	pid = current & 0xFFFFffff;
-	tgid = current >> 32;
-
-	/* We are only tracking group leaders so if tgid is not
-	 * the same as the pid then this is an untracked child
-	 * and we can skip the lookup/insert/delete cycle that
-	 * would otherwise occur.
-	 */
-	if (pid != tgid)
-		return;
 
 	/* It is safe to do a map_lookup_event() here because
 	 * we must have captured the execve case in order for an

--- a/bpf/process/bpf_exit.h
+++ b/bpf/process/bpf_exit.h
@@ -14,8 +14,8 @@ struct {
 	__type(value, struct msg_exit);
 } exit_heap_map SEC(".maps");
 
-static inline __attribute__((always_inline)) void event_exit_send(void *ctx,
-								  __u32 tgid)
+static inline __attribute__((always_inline)) void
+event_exit_send(void *ctx, __u32 tgid, struct task_struct *task)
 {
 	struct execve_map_value *enter;
 
@@ -31,8 +31,6 @@ static inline __attribute__((always_inline)) void event_exit_send(void *ctx,
 	if (!enter)
 		return;
 	if (enter->key.ktime) {
-		struct task_struct *task =
-			(struct task_struct *)get_current_task();
 		size_t size = sizeof(struct msg_exit);
 		struct msg_exit *exit;
 		int zero = 0;

--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -6,3 +6,4 @@ dup-tester
 trigger-test-events
 nop
 sigkill-unprivileged-user-ns-tester
+exit-leader

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -8,7 +8,8 @@ PROGS = sigkill-tester \
 	dup-tester \
 	trigger-test-events \
 	sigkill-unprivileged-user-ns-tester \
-	nop
+	nop \
+	exit-leader
 
 all: $(PROGS)
 
@@ -20,6 +21,9 @@ capabilities-tester: capabilities-tester.c
 
 sigkill-unprivileged-user-ns-tester: sigkill-unprivileged-user-ns-tester.c
 	$(GCC) -Wall $< -o $@ -lcap
+
+exit-leader: exit-leader.c
+	$(GCC) -Wall $< -o $@ -lpthread
 
 .PHONY: clean
 clean:

--- a/contrib/tester-progs/exit-leader.c
+++ b/contrib/tester-progs/exit-leader.c
@@ -1,0 +1,29 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+
+static void *worker(void *ctx)
+{
+	int cnt = 3;
+
+	while (cnt--) {
+		sleep(1);
+	}
+	return NULL;
+}
+
+int main(void)
+{
+	pthread_t th;
+	int err;
+
+	err = pthread_create(&th, NULL, worker, NULL);
+	if (err) {
+		perror("pthread_create");
+		return -1;
+	}
+	syscall(SYS_exit, 0);
+}

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -294,6 +294,7 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 		Parent:  tetragonParent,
 		Signal:  signal,
 		Status:  code,
+		Time:    ktime.ToProto(event.Common.Ktime),
 	}
 	ec := eventcache.Get()
 	if ec != nil &&

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -28,10 +28,10 @@ var (
 
 	Exit = program.Builder(
 		"bpf_exit.o",
-		"sched/sched_process_exit",
-		"tracepoint/sys_exit",
+		"__put_task_struct",
+		"kprobe/__put_task_struct",
 		"event_exit",
-		"tracepoint",
+		"kprobe",
 	)
 
 	Fork = program.Builder(

--- a/pkg/sensors/exec/exit_test.go
+++ b/pkg/sensors/exec/exit_test.go
@@ -1,0 +1,121 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
+	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/testutils"
+	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExit(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("Failed to run observer: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	testNop := testutils.ContribPath("tester-progs/nop")
+
+	procChecker := ec.NewProcessChecker().
+		WithBinary(sm.Full(testNop))
+
+	execChecker := ec.NewProcessExecChecker().WithProcess(procChecker)
+	exitChecker := ec.NewProcessExitChecker().WithProcess(procChecker)
+
+	var checker *ec.UnorderedEventChecker
+
+	checker = ec.NewUnorderedEventChecker(execChecker, exitChecker)
+
+	if err := exec.Command(testNop).Run(); err != nil {
+		t.Fatalf("Failed to execute test binary: %s\n", err)
+	}
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestExitLeader(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("Failed to run observer: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	testExitLeader := testutils.ContribPath("tester-progs/exit-leader")
+
+	var startTime, exitTime time.Time
+
+	// The test executes 'exit-leader' benary which spawns a thread and
+	// exits the leader immediately while the new thread continues to
+	// run for 3 seconds and exits. We verify that we get exit event 3
+	// seconds after the start.
+
+	nextCheck := func(event ec.Event, l *logrus.Logger) (bool, error) {
+		switch ev := event.(type) {
+		case *tetragon.ProcessExec:
+			if ev.Process.Binary == testExitLeader {
+				startTime = ev.Process.StartTime.AsTime()
+			}
+			return false, nil
+		case *tetragon.ProcessExit:
+			if ev.Process.Binary == testExitLeader {
+				exitTime = ev.Time.AsTime()
+			}
+			return false, nil
+		}
+		return false, nil
+	}
+
+	finalCheck := func(l *logrus.Logger) error {
+		delta := exitTime.Sub(startTime)
+
+		fmt.Printf("execTime %v\n", startTime)
+		fmt.Printf("exitTime %v\n", exitTime)
+		fmt.Printf("delta %v\n", delta)
+
+		if delta < 3*time.Second {
+			return fmt.Errorf("unexpected delta < 3 seconds")
+		}
+		return nil
+	}
+
+	checker := &ec.FnEventChecker{
+		NextCheckFn:  nextCheck,
+		FinalCheckFn: finalCheck,
+	}
+
+	if err := exec.Command(testExitLeader).Run(); err != nil {
+		t.Fatalf("Failed to execute test binary: %s\n", err)
+	}
+
+	if err := jsonchecker.JsonTestCheck(t, checker); err != nil {
+		t.Logf("error: %s", err)
+		t.Fail()
+	}
+}

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -115,7 +115,7 @@ func mergeSensorMaps(t *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []Se
 func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []SensorProg) ([]SensorMap, []SensorProg) {
 	var baseProgs = []SensorProg{
 		0: SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
-		1: SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
+		1: SensorProg{Name: "event_exit", Type: ebpf.Kprobe},
 		2: SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
 		3: SensorProg{Name: "execve_send", Type: ebpf.TracePoint},
 	}

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
@@ -898,10 +898,11 @@ type ProcessExit struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Process *Process `protobuf:"bytes,1,opt,name=process,proto3" json:"process,omitempty"`
-	Parent  *Process `protobuf:"bytes,2,opt,name=parent,proto3" json:"parent,omitempty"`
-	Signal  string   `protobuf:"bytes,3,opt,name=signal,proto3" json:"signal,omitempty"`
-	Status  uint32   `protobuf:"varint,4,opt,name=status,proto3" json:"status,omitempty"`
+	Process *Process               `protobuf:"bytes,1,opt,name=process,proto3" json:"process,omitempty"`
+	Parent  *Process               `protobuf:"bytes,2,opt,name=parent,proto3" json:"parent,omitempty"`
+	Signal  string                 `protobuf:"bytes,3,opt,name=signal,proto3" json:"signal,omitempty"`
+	Status  uint32                 `protobuf:"varint,4,opt,name=status,proto3" json:"status,omitempty"`
+	Time    *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=time,proto3" json:"time,omitempty"`
 }
 
 func (x *ProcessExit) Reset() {
@@ -962,6 +963,13 @@ func (x *ProcessExit) GetStatus() uint32 {
 		return x.Status
 	}
 	return 0
+}
+
+func (x *ProcessExit) GetTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Time
+	}
+	return nil
 }
 
 type KprobeSock struct {
@@ -2602,7 +2610,7 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x73, 0x52, 0x06, 0x70, 0x61, 0x72, 0x65, 0x6e, 0x74, 0x12, 0x2f, 0x0a, 0x09, 0x61, 0x6e, 0x63,
 	0x65, 0x73, 0x74, 0x6f, 0x72, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x11, 0x2e, 0x74,
 	0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x52,
-	0x09, 0x61, 0x6e, 0x63, 0x65, 0x73, 0x74, 0x6f, 0x72, 0x73, 0x22, 0x95, 0x01, 0x0a, 0x0b, 0x50,
+	0x09, 0x61, 0x6e, 0x63, 0x65, 0x73, 0x74, 0x6f, 0x72, 0x73, 0x22, 0xc5, 0x01, 0x0a, 0x0b, 0x50,
 	0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x45, 0x78, 0x69, 0x74, 0x12, 0x2b, 0x0a, 0x07, 0x70, 0x72,
 	0x6f, 0x63, 0x65, 0x73, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x11, 0x2e, 0x74, 0x65,
 	0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x52, 0x07,
@@ -2612,7 +2620,10 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x6e, 0x74, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x61, 0x6c, 0x18, 0x03, 0x20, 0x01,
 	0x28, 0x09, 0x52, 0x06, 0x73, 0x69, 0x67, 0x6e, 0x61, 0x6c, 0x12, 0x16, 0x0a, 0x06, 0x73, 0x74,
 	0x61, 0x74, 0x75, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x06, 0x73, 0x74, 0x61, 0x74,
-	0x75, 0x73, 0x22, 0xdc, 0x01, 0x0a, 0x0a, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53, 0x6f, 0x63,
+	0x75, 0x73, 0x12, 0x2e, 0x0a, 0x04, 0x74, 0x69, 0x6d, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62,
+	0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x04, 0x74, 0x69,
+	0x6d, 0x65, 0x22, 0xdc, 0x01, 0x0a, 0x0a, 0x4b, 0x70, 0x72, 0x6f, 0x62, 0x65, 0x53, 0x6f, 0x63,
 	0x6b, 0x12, 0x16, 0x0a, 0x06, 0x66, 0x61, 0x6d, 0x69, 0x6c, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28,
 	0x09, 0x52, 0x06, 0x66, 0x61, 0x6d, 0x69, 0x6c, 0x79, 0x12, 0x12, 0x0a, 0x04, 0x74, 0x79, 0x70,
 	0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x74, 0x79, 0x70, 0x65, 0x12, 0x1a, 0x0a,
@@ -2938,42 +2949,43 @@ var file_tetragon_tetragon_proto_depIdxs = []int32{
 	9,  // 27: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
 	9,  // 28: tetragon.ProcessExit.process:type_name -> tetragon.Process
 	9,  // 29: tetragon.ProcessExit.parent:type_name -> tetragon.Process
-	33, // 30: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
-	33, // 31: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
-	33, // 32: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
-	34, // 33: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
-	34, // 34: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
-	32, // 35: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
-	32, // 36: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
-	7,  // 37: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
-	13, // 38: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
-	14, // 39: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
-	15, // 40: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
-	16, // 41: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
-	12, // 42: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
-	17, // 43: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
-	20, // 44: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
-	21, // 45: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
-	22, // 46: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
-	19, // 47: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
-	18, // 48: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
-	9,  // 49: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
-	9,  // 50: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
-	23, // 51: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
-	23, // 52: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
-	0,  // 53: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
-	9,  // 54: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
-	9,  // 55: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
-	23, // 56: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
-	1,  // 57: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
-	1,  // 58: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
-	2,  // 59: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
-	28, // 60: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
-	61, // [61:61] is the sub-list for method output_type
-	61, // [61:61] is the sub-list for method input_type
-	61, // [61:61] is the sub-list for extension type_name
-	61, // [61:61] is the sub-list for extension extendee
-	0,  // [0:61] is the sub-list for field type_name
+	31, // 30: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
+	33, // 31: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
+	33, // 32: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
+	33, // 33: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
+	34, // 34: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
+	34, // 35: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
+	32, // 36: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
+	32, // 37: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
+	7,  // 38: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
+	13, // 39: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
+	14, // 40: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
+	15, // 41: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
+	16, // 42: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
+	12, // 43: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
+	17, // 44: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
+	20, // 45: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
+	21, // 46: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
+	22, // 47: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
+	19, // 48: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
+	18, // 49: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
+	9,  // 50: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
+	9,  // 51: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
+	23, // 52: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
+	23, // 53: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
+	0,  // 54: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
+	9,  // 55: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
+	9,  // 56: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
+	23, // 57: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
+	1,  // 58: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
+	1,  // 59: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
+	2,  // 60: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
+	28, // 61: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
+	62, // [62:62] is the sub-list for method output_type
+	62, // [62:62] is the sub-list for method input_type
+	62, // [62:62] is the sub-list for extension type_name
+	62, // [62:62] is the sub-list for extension extendee
+	0,  // [0:62] is the sub-list for field type_name
 }
 
 func init() { file_tetragon_tetragon_proto_init() }

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
@@ -109,6 +109,7 @@ message ProcessExit {
     Process parent  = 2;
     string  signal  = 3;
     uint32  status  = 4;
+    google.protobuf.Timestamp time = 5;
 }
 
 message KprobeSock {


### PR DESCRIPTION
backport exit tracepoint switch to __put_task_struct kprobe

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
