### PR TITLE
data: silence annoying debug log messages

### DIFF
--- a/pkg/observer/data.go
+++ b/pkg/observer/data.go
@@ -45,7 +45,7 @@ func add(r *bytes.Reader, m *dataapi.MsgData) error {
 		dataMap.Add(m.Id, data)
 	}
 
-	logger.GetLogger().Debugf("Data message received id %v, size %v, total %v", m.Id, size, len(data))
+	logger.GetLogger().WithFields(nil).Tracef("Data message received id %v, size %v, total %v", m.Id, size, len(data))
 	return nil
 }
 
@@ -56,7 +56,7 @@ func DataGet(id dataapi.DataEventId) ([]byte, error) {
 	}
 
 	dataMap.Remove(id)
-	logger.GetLogger().Debugf("Data message used id %v, data len %v", id, len(data))
+	logger.GetLogger().WithFields(nil).Tracef("Data message used id %v, data len %v", id, len(data))
 	return data, nil
 }
 


### PR DESCRIPTION
The "Data message received" and "Data message used" log messages flood the Tetragon logs when debug logging is enabled, to the point that it obfuscates all other debug messages. Bump these messages up to the trace level so that they are less annoying.

Signed-off-by: William Findlay <will@isovalent.com>