### PR TITLE
tetragon: introduce Cgroup ID Tracker

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -105,6 +105,11 @@
 #define ARGSBUFFERMASK	 (ARGSBUFFER - 1)
 #define MAXARGMASK	 (MAXARG - 1)
 
+/* Task flags */
+#ifndef PF_KTHREAD
+#define PF_KTHREAD 0x00200000 /* I am a kernel thread */
+#endif
+
 /* Msg flags */
 #define EVENT_UNKNOWN		      0x00
 #define EVENT_EXECVE		      0x01
@@ -276,6 +281,7 @@ struct execve_map_value {
 	__u32 nspid;
 	__u32 binary;
 	__u32 pad;
+	__u64 cgrpid_tracker; /* Pinned Cgroup ID Tracker */
 	struct msg_ns ns;
 	struct msg_capabilities caps;
 } __attribute__((packed)) __attribute__((aligned(8)));

--- a/bpf/process/bpf_fork.c
+++ b/bpf/process/bpf_fork.c
@@ -6,7 +6,9 @@
 #include "bpf_tracing.h"
 
 #include "hubble_msg.h"
+#include "bpf_cgroup.h"
 #include "bpf_events.h"
+#include "environ_conf.h"
 #include "bpf_process_event.h"
 
 char _license[] __attribute__((section("license"), used)) = "GPL";
@@ -19,7 +21,10 @@ __attribute__((section("kprobe/wake_up_new_task"), used)) int
 BPF_KPROBE(event_wake_up_new_task, struct task_struct *task)
 {
 	struct execve_map_value *curr, *parent;
-	u32 pid = 0;
+	struct task_struct *current_task;
+	struct tetragon_conf *config;
+	u32 pid = 0, ppid = 0, error_flags = 0;
+	int zero = 0;
 
 	if (!task)
 		return 0;
@@ -28,6 +33,24 @@ BPF_KPROBE(event_wake_up_new_task, struct task_struct *task)
 	curr = execve_map_get(pid);
 	if (!curr)
 		return 0;
+
+	/* Cgroup environment */
+	config = map_lookup_elem(&tg_conf_map, &zero);
+	if (config) {
+		/* Set the tracking cgroup ID for the new task if not already set */
+		__set_task_cgrpid_tracker(config, task, curr, &error_flags);
+
+		/* Let's try to catch current or "parent" if it was not tracked */
+		current_task = (struct task_struct *)get_current_task();
+		probe_read(&ppid, sizeof(ppid), _(&current_task->tgid));
+		/* If they share same thread group nothing todo... */
+		if (pid != ppid) {
+			parent = execve_map_get(ppid);
+			if (parent)
+				__set_task_cgrpid_tracker(config, current_task,
+							  parent, &error_flags);
+		}
+	}
 
 	/* generate an EVENT_COMMON_FLAG_CLONE event only once per process */
 	if (curr->key.ktime != 0)
@@ -53,6 +76,9 @@ BPF_KPROBE(event_wake_up_new_task, struct task_struct *task)
 			.nspid = curr->nspid,
 			.flags = curr->flags,
 		};
+
+		/* Last: set any encountered error when setting cgroup info */
+		msg.flags |= error_flags;
 
 		perf_event_output(ctx, &tcpmon_map, BPF_F_CURRENT_CPU, &msg,
 				  size);

--- a/pkg/sensors/exec/execvemap/execve.go
+++ b/pkg/sensors/exec/execvemap/execve.go
@@ -16,14 +16,15 @@ type ExecveKey struct {
 }
 
 type ExecveValue struct {
-	Process      processapi.MsgExecveKey    `align:"key"`
-	Parent       processapi.MsgExecveKey    `align:"pkey"`
-	Flags        uint32                     `align:"flags"`
-	Nspid        uint32                     `align:"nspid"`
-	Binary       uint32                     `align:"binary"`
-	Pad          uint32                     `align:"pad"`
-	Namespaces   processapi.MsgNamespaces   `align:"ns"`
-	Capabilities processapi.MsgCapabilities `align:"caps"`
+	Process       processapi.MsgExecveKey    `align:"key"`
+	Parent        processapi.MsgExecveKey    `align:"pkey"`
+	Flags         uint32                     `align:"flags"`
+	Nspid         uint32                     `align:"nspid"`
+	Binary        uint32                     `align:"binary"`
+	Pad           uint32                     `align:"pad"`
+	CgrpIdTracker uint64                     `align:"cgrpid_tracker"`
+	Namespaces    processapi.MsgNamespaces   `align:"ns"`
+	Capabilities  processapi.MsgCapabilities `align:"caps"`
 }
 
 func (k *ExecveKey) String() string             { return fmt.Sprintf("key=%d", k.Pid) }

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -126,11 +126,11 @@ func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []S
 		SensorMap{Name: "tcpmon_map", Progs: []uint{0, 1, 2, 3}},
 
 		// all but event_execve
-		SensorMap{Name: "execve_map_stats", Progs: []uint{1, 2, 3}},
+		SensorMap{Name: "execve_map_stats", Progs: []uint{0, 1, 2, 3}},
 
 		// event_execve
 		SensorMap{Name: "names_map", Progs: []uint{0}},
-		SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
+		SensorMap{Name: "tg_conf_map", Progs: []uint{0, 2}},
 
 		// event_wake_up_new_task
 		SensorMap{Name: "execve_val", Progs: []uint{2}},


### PR DESCRIPTION
Add cgrpid_tracker inside execve_map_value struct which will be used to track every process by its pinned Cgroup ID.

The cgrpid_tracker will be set to the cgroup ID of the tracking cgroup, could be a pod/container/systemd service, etc. Right now we set it to current cgroup ID. As we advance in next patches we will set it to the tracking cgroup ID.

Signed-off-by: Djalal Harouni <djalal@isovalent.com>