### PR TITLE
fix the URL for the "first good issue" list

### DIFF
--- a/docs/contributing/development/README.md
+++ b/docs/contributing/development/README.md
@@ -32,7 +32,7 @@ Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings
 5. Prepare your [Development Setup](#development-setup), see below.
 
 6. Check the GitHub issues for [good tasks to get
-started](https://github.com/cilium/tetragon/issues?q=is%3Aopen+is%3Aissue+label%3Agood-first-issue)
+started](https://github.com/cilium/tetragon/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 
 7. Follow the steps in [Making Changes](#making-changes) to start contributing :)
 


### PR DESCRIPTION
PR fixes the URL in the "good tasks to get started" list, pointing to the list of issues with the parameters:
`is:issue is:open label:"good first issue" `
https://github.com/cilium/tetragon/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22