### PR TITLE
matchBinaries improvements

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -70,7 +70,7 @@ struct names_map_key {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 64);
+	__uint(max_entries, 256); /* maximum number of binary names for all matchBinary selectors */
 	__type(key, struct names_map_key);
 	__type(value, __u32);
 } names_map SEC(".maps");

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -104,6 +104,7 @@
 #define __ASM_ARGSBUFFER 976
 #define ARGSBUFFERMASK	 (ARGSBUFFER - 1)
 #define MAXARGMASK	 (MAXARG - 1)
+#define PATHNAME_SIZE	 256
 
 /* Task flags */
 #ifndef PF_KTHREAD
@@ -316,7 +317,7 @@ struct {
 
 struct execve_heap {
 	union {
-		char pathname[256];
+		char pathname[PATHNAME_SIZE];
 		char maxpath[4096];
 	};
 };

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -135,7 +135,8 @@ event_filename_builder(void *ctx, struct msg_process *curr, __u32 curr_pid,
 	if (!heap)
 		return bin;
 
-	probe_read_str(heap->pathname, 255, filename);
+	memset(heap->pathname, 0, 256);
+	probe_read_str(heap->pathname, size, filename);
 	value = map_lookup_elem(&names_map, heap->pathname);
 	if (value)
 		return *value;

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -130,6 +130,10 @@ event_filename_builder(void *ctx, struct msg_process *curr, __u32 curr_pid, __u3
 	curr->ktime = ktime_get_ns();
 	curr->size = size + offsetof(struct msg_process, args);
 
+	// skip binaries check for long (> 255) filenames for now
+	if (flags & EVENT_DATA_FILENAME)
+		return 0;
+
 	heap = map_lookup_elem(&execve_heap, &zero);
 	if (!heap)
 		return 0;

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -138,7 +138,7 @@ event_filename_builder(void *ctx, struct msg_process *curr, __u32 curr_pid, __u3
 	if (!heap)
 		return 0;
 
-	memset(heap->pathname, 0, 256);
+	memset(heap->pathname, 0, PATHNAME_SIZE);
 	probe_read_str(heap->pathname, size, filename);
 	value = map_lookup_elem(&names_map, heap->pathname);
 	if (value)

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -637,8 +637,8 @@ func parseMatchBinary(k *KernelSelectorState, b *v1alpha1.BinarySelector) error 
 	if err != nil {
 		return fmt.Errorf("matchBinary error: %w", err)
 	}
-	if op != selectorOpIn {
-		return fmt.Errorf("matchBinary error: Only In operator is supported")
+	if op != selectorOpIn && op != selectorOpNotIn {
+		return fmt.Errorf("matchBinary error: Only In and NotIn operators are supported")
 	}
 	k.SetBinaryOp(op)
 	for _, s := range b.Values {

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -397,11 +397,11 @@ func TestMultipleSelectorsExample(t *testing.T) {
 		expectedLen += 4
 	}
 
-	// vaue               absolute offset    explanation
+	// value               absolute offset    explanation
 	expU32Push(2)               // off: 0       number of selectors
 	expU32Push(8)               // off: 4       relative ofset of 1st selector (4 + 8 = 12)
-	expU32Push(104)             // off: 8       relative ofset of 2nd selector (8 + 104 = 112)
-	expU32Push(100)             // off: 12      selector1: length (100 + 12 = 112)
+	expU32Push(80)              // off: 8       relative ofset of 2nd selector (8 + 80 = 88)
+	expU32Push(76)              // off: 12      selector1: length (76 + 12 = 112)
 	expU32Push(24)              // off: 16      selector1: MatchPIDs: len
 	expU32Push(selectorOpNotIn) // off: 20      selector1: MatchPIDs[0]: op
 	expU32Push(0)               // off: 24      selector1: MatchPIDs[0]: flags
@@ -412,12 +412,6 @@ func TestMultipleSelectorsExample(t *testing.T) {
 	expU32Push(4)               // off: 44      selector1: MatchCapabilities: len
 	expU32Push(4)               // off: 48      selector1: MatchNamespaceChanges: len
 	expU32Push(4)               // off: 52      selector1: MatchCapabilityChanges: len
-	expU32Push(4 + 5*4)         // off: 56      selector1: matchBinaries: len
-	expU32Push(0)               // off: 60      selector1: matchBinaries: 0
-	expU32Push(0)               // off: 64      selector1: matchBinaries: 1
-	expU32Push(0)               // off: 68      selector1: matchBinaries: 2
-	expU32Push(0)               // off: 72      selector1: matchBinaries: 3
-	expU32Push(0)               // off: 76      selector1: matchBinaries: 4
 	expU32Push(28)              // off: 80      selector1: matchArgs: len
 	expU32Push(1)               // off: 84      selector1: matchArgs: arg0: index
 	expU32Push(selectorOpEQ)    // off: 88      selector1: matchArgs: arg0: operator
@@ -426,7 +420,7 @@ func TestMultipleSelectorsExample(t *testing.T) {
 	expU32Push(10)              // off: 100     selector1: matchArgs: arg0: val0: 10
 	expU32Push(20)              // off: 104     selector1: matchArgs: arg0: val1: 20
 	expU32Push(4)               // off: 108     selector1: matchActions: length
-	expU32Push(100)             // off: 112     selector2: length
+	expU32Push(76)              // off: 112     selector2: length
 	// ... everything else should be the same as selector1 ...
 
 	if bytes.Equal(expected[:expectedLen], b[:expectedLen]) == false {
@@ -443,11 +437,11 @@ func TestInitKernelSelectors(t *testing.T) {
 	}
 
 	expected_selsize_small := []byte{
-		0xfe, 0x00, 0x00, 0x00, // size = pids + binarys + args + actions + namespaces + capabilities  + 4
+		0xe6, 0x00, 0x00, 0x00, // size = pids + args + actions + namespaces + capabilities  + 4
 	}
 
 	expected_selsize_large := []byte{
-		0x1a, 0x01, 0x00, 0x00, // size = pids + binarys + args + actions + namespaces + namespacesChanges + capabilities + capabilityChanges + 4
+		0x02, 0x01, 0x00, 0x00, // size = pids + args + actions + namespaces + namespacesChanges + capabilities + capabilityChanges + 4
 	}
 
 	expected_filters := []byte{
@@ -531,17 +525,6 @@ func TestInitKernelSelectors(t *testing.T) {
 	}
 
 	expected_last := []byte{
-		// binaryNames header
-		24, 0x00, 0x00, 0x00, // size = sizeof(uint32) * 4
-
-		// binaryNames Ids, always has 4 to ease verify complexity and
-		// zeroes unused entries.
-		0x00, 0x00, 0x00, 0x00, // op
-		0x00, 0x00, 0x00, 0x00, // index0
-		0x00, 0x00, 0x00, 0x00, // index1
-		0x00, 0x00, 0x00, 0x00, // index2
-		0x00, 0x00, 0x00, 0x00, // index3
-
 		// arg header
 		54, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 4
 

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -57,7 +57,7 @@ func (k *KernelSelectorState) AddBinaryName(binary string) {
 	binIdx++
 	binVals[binary] = idx      // global map of all names_map entries
 	k.newBinVals[idx] = binary // new names_map entries that we should add
-	k.selNamesMap[idx] = 1     // value in the per-selector names_map
+	k.selNamesMap[idx] = 1     // value in the per-selector names_map (we ignore the value)
 }
 
 func (k *KernelSelectorState) GetNewBinaryMappings() map[uint32]string {

--- a/pkg/sensors/tracing/binaryentry.go
+++ b/pkg/sensors/tracing/binaryentry.go
@@ -3,31 +3,18 @@
 package tracing
 
 import (
-	"fmt"
-	"unsafe"
-
-	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/ebpf"
 )
 
 type BinaryMapKey struct {
 	PathName [256]byte
 }
 
-func (k *BinaryMapKey) String() string             { return fmt.Sprintf("pathname: %s", string(k.PathName[:])) }
-func (k *BinaryMapKey) NewValue() bpf.MapValue     { return &BinaryMapValue{} }
-func (k *BinaryMapKey) GetKeyPtr() unsafe.Pointer  { return unsafe.Pointer(k) }
-func (k *BinaryMapKey) DeepCopyMapKey() bpf.MapKey { return &BinaryMapKey{} }
-
 type BinaryMapValue struct {
 	Id uint32
 }
 
-func (v *BinaryMapValue) String() string                 { return fmt.Sprintf("ID: %d", v.Id) }
-func (v *BinaryMapValue) NewValue() bpf.MapValue         { return &BinaryMapValue{} }
-func (v *BinaryMapValue) GetValuePtr() unsafe.Pointer    { return unsafe.Pointer(v) }
-func (v *BinaryMapValue) DeepCopyMapValue() bpf.MapValue { return &BinaryMapValue{} }
-
-func writeBinaryMap(id int, path string, m *bpf.Map) error {
+func writeBinaryMap(m *ebpf.Map, id uint32, path string) error {
 	p := [256]byte{0}
 	copy(p[:], path)
 
@@ -37,6 +24,5 @@ func writeBinaryMap(id int, path string, m *bpf.Map) error {
 	v := &BinaryMapValue{
 		Id: uint32(id),
 	}
-	err := m.Update(k, v)
-	return err
+	return m.Update(k, v, ebpf.UpdateAny)
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -186,17 +186,6 @@ func getMetaValue(arg *v1alpha1.KProbeArg) (int, error) {
 	return meta, nil
 }
 
-var binaryNames []v1alpha1.BinarySelector
-
-func initBinaryNames(spec *v1alpha1.KProbeSpec) error {
-	for _, s := range spec.Selectors {
-		for _, b := range s.MatchBinaries {
-			binaryNames = append(binaryNames, b)
-		}
-	}
-	return nil
-}
-
 func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.EntryID) ([]*program.Program, []*program.Map) {
 	var progs []*program.Program
 	var maps []*program.Map
@@ -390,11 +379,6 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 					config.ArgM[j] = 0
 				}
 			}
-		}
-
-		// Parse Binary Name into kernel data structures
-		if err := initBinaryNames(f); err != nil {
-			return nil, err
 		}
 
 		hasOverride := selectors.HasOverride(f)
@@ -614,14 +598,14 @@ func loadSingleKprobeSensor(id idtable.EntryID, bpfDir, mapDir string, load *pro
 		return err
 	}
 
-	m, err := bpf.OpenMap(filepath.Join(mapDir, base.NamesMap.Name))
+	m, err := ebpf.LoadPinnedMap(filepath.Join(mapDir, base.NamesMap.Name), nil)
 	if err != nil {
 		return err
 	}
-	for i, b := range binaryNames {
-		for _, path := range b.Values {
-			writeBinaryMap(i+1, path, m)
-		}
+	defer m.Close()
+
+	for i, path := range gk.loadArgs.selectors.GetBinaryMappings() {
+		writeBinaryMap(m, i, path)
 	}
 
 	return err
@@ -662,13 +646,17 @@ func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir, mapDir string, load *p
 		return err
 	}
 
-	m, err := bpf.OpenMap(filepath.Join(mapDir, base.NamesMap.Name))
+	m, err := ebpf.LoadPinnedMap(filepath.Join(mapDir, base.NamesMap.Name), nil)
 	if err != nil {
 		return err
 	}
-	for i, b := range binaryNames {
-		for _, path := range b.Values {
-			writeBinaryMap(i+1, path, m)
+	defer m.Close()
+
+	for _, id := range ids {
+		if gk, err := genericKprobeTableGet(id); err == nil {
+			for i, path := range gk.loadArgs.selectors.GetBinaryMappings() {
+				writeBinaryMap(m, i, path)
+			}
 		}
 	}
 

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -230,6 +230,9 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 	callHeap := program.MapBuilderPin("process_call_heap", sensors.PathJoin(pinPath, "process_call_heap"), load)
 	maps = append(maps, callHeap)
 
+	selNamesMap := program.MapBuilderPin("sel_names_map", sensors.PathJoin(pinPath, "sel_names_map"), load)
+	maps = append(maps, selNamesMap)
+
 	if len(multiRetIDs) != 0 {
 		loadret := program.Builder(
 			path.Join(option.Config.HubbleLib, loadProgRetName),
@@ -491,6 +494,9 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 		callHeap := program.MapBuilderPin("process_call_heap", sensors.PathJoin(pinPath, "process_call_heap"), load)
 		maps = append(maps, callHeap)
 
+		selNamesMap := program.MapBuilderPin("sel_names_map", sensors.PathJoin(pinPath, "sel_names_map"), load)
+		maps = append(maps, selNamesMap)
+
 		if setRetprobe {
 			pinRetProg := sensors.PathJoin(pinPath, fmt.Sprintf("%s_ret_prog", kprobeEntry.funcName))
 			loadret := program.Builder(
@@ -604,7 +610,7 @@ func loadSingleKprobeSensor(id idtable.EntryID, bpfDir, mapDir string, load *pro
 	}
 	defer m.Close()
 
-	for i, path := range gk.loadArgs.selectors.GetBinaryMappings() {
+	for i, path := range gk.loadArgs.selectors.GetNewBinaryMappings() {
 		writeBinaryMap(m, i, path)
 	}
 
@@ -654,7 +660,7 @@ func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir, mapDir string, load *p
 
 	for _, id := range ids {
 		if gk, err := genericKprobeTableGet(id); err == nil {
-			for i, path := range gk.loadArgs.selectors.GetBinaryMappings() {
+			for i, path := range gk.loadArgs.selectors.GetNewBinaryMappings() {
 				writeBinaryMap(m, i, path)
 			}
 		}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -365,6 +365,9 @@ func createGenericTracepointSensor(name string, confs []GenericTracepointConf) (
 
 		argFilterMaps := program.MapBuilderPin("argfilter_maps", sensors.PathJoin(pinPath, "argfilter_maps"), prog0)
 		maps = append(maps, argFilterMaps)
+
+		selNamesMap := program.MapBuilderPin("sel_names_map", sensors.PathJoin(pinPath, "sel_names_map"), prog0)
+		maps = append(maps, selNamesMap)
 	}
 
 	return &sensors.Sensor{


### PR DESCRIPTION
This PR fixes several issues regarding `matchBinaries` selector.

The first patch fixes some issues related to `matchBinaries` selector, but keeps the limit of 4 values. The second patch removes the limit of 4 values per `matchBinaries` selector. More details on the patches. 

Additionally, this PR adds support for NotIn operator in `matchBinaries` selector.

Signed-off-by: Anastasios Papagiannis <tasos.papagiannnis@gmail.com>