### PR TITLE
tests/e2e: handle procRoot correctly in KinD clusters

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   clusterName: tetragon-ci
-  ciliumCliVersion: v0.11.11
+  ciliumCliVersion: v0.12.11
 
 jobs:
   e2e-test:
@@ -89,18 +89,11 @@ jobs:
         rm -rf "$TEMP"
         cilium version
 
-    - name: Create KinD Cluster
-      run: |
-        kind create cluster --name ${{ env.clusterName }}
-        kind load docker-image --name ${{ env.clusterName }} ${{ steps.vars.outputs.agentImage }}
-        kind load docker-image --name ${{ env.clusterName }} ${{ steps.vars.outputs.operatorImage }}
-        cilium install
-
     - name: Run e2e Tests
       run: |
         cd go/src/github.com/cilium/tetragon
 
-        make e2e-test E2E_BUILD_IMAGES=0 E2E_AGENT=${{ steps.vars.outputs.agentImage }} E2E_OPERATOR=${{ steps.vars.outputs.operatorImage }} EXTRA_TESTFLAGS="-tetragon.install-cilium=false -cluster-name=${{ env.clusterName }} -kubeconfig ~/.kube/config -args -v=4"
+        make e2e-test E2E_BUILD_IMAGES=0 E2E_AGENT=${{ steps.vars.outputs.agentImage }} E2E_OPERATOR=${{ steps.vars.outputs.operatorImage }} EXTRA_TESTFLAGS="-cluster-name=${{ env.clusterName }} -args -v=4"
 
     - name: Copy out e2e test logs
       if: ${{ failure() || cancelled() }}

--- a/tests/e2e/flags/flags.go
+++ b/tests/e2e/flags/flags.go
@@ -26,7 +26,7 @@ var Opts = Flags{
 	},
 	KeepExportData: false,
 	InstallCilium:  true,
-	CiliumVersion:  "v1.12.4",
+	CiliumVersion:  "v1.12.6",
 }
 
 func init() {


### PR DESCRIPTION
Because KinD clusters run in nested containers, the Tetragon Helm Chart was not correctly mounting the host procfs into the Tetragon container. This was causing potential flakes in the end-to-end tests by making it impossible to correctly initialize data for already running processes on the host system. Since we're not interested in offering full support for KinD, let's just make the tests work by hacking them to mount the real host procfs into the Tetragon container.

To do this, we create the KinD cluster with an extra volume that mounts host procfs then link it up with Tetragon by adding an extra volume mount via the Helm chart and modifying Tetragon's startup arguments. Finally, we update the end-to-end CI job to make use of this by removing some logic to use a single shared cluster and instead letting e2e framework take care of the cluster creation for us. If optimization is necessary in the future, we can look into adding some logic to use a single shared kind cluster within e2e framework, but I don't see this as necessary at the moment.

Signed-off-by: William Findlay <will@isovalent.com>