### PR TITLE
tetragon: set default value of release-pinned-bpf to true

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -613,9 +613,10 @@ func execute() error {
 	flags.Int(keyRBSizeTotal, 0, "Set perf ring buffer size in total for all cpus (default 65k per cpu)")
 	flags.Int(keyRBSize, 0, "Set perf ring buffer size for single cpu (default 65k)")
 
-	// Provide option to remove existing pinned BPF programs and maps in
-	// Tetragon's observer dir. Useful for doing upgrades/downgrades.
-	flags.Bool(keyReleasePinnedBPF, false, "Release all pinned BPF programs and maps in Tetragon BPF directory")
+	// Provide option to remove existing pinned BPF programs and maps in Tetragon's
+	// observer dir on startup. Useful for doing upgrades/downgrades. Set to false to
+	// disable.
+	flags.Bool(keyReleasePinnedBPF, true, "Release all pinned BPF programs and maps in Tetragon BPF directory. Enabled by default. Set to false to disable")
 
 	viper.BindPFlags(flags)
 	return rootCmd.Execute()


### PR DESCRIPTION
When upgrading between minor versions of Tetragon, sometimes programs and maps can change enough that leaving the old ones kicking around can introduce bugs on the BPF side. We added the --release-pinned-bpf flag to help solve this issue by giving users a way to tell Tetragon that it should clear existing BPF programs and maps when it starts up.

While this flag was initially set to default false, there are currently no downsides to making it default to true since we typically clear remaining BPF programs and maps on termination anyway and any remaining ones would currently be considered bugs. Therefore, let's just set this flag to true by default and gives users the option to turn it off if they like. In the future, when Tetragon supports persisting policy between restarts, we can re-evaluate these defaults.

Signed-off-by: William Findlay <will@isovalent.com>