### PR TITLE
tetragon: Minor include headers changes in loader

### DIFF
--- a/bpf/process/bpf_loader.c
+++ b/bpf/process/bpf_loader.c
@@ -5,9 +5,8 @@
 #include "api.h"
 #include "bpf_tracing.h"
 #include "bpf_helpers.h"
-#include "lib/common.h"
-#include "lib/hubble_msg.h"
-#include "lib/bpf_events.h"
+#include "hubble_msg.h"
+#include "bpf_events.h"
 
 struct msg_loader {
 	struct msg_common common;


### PR DESCRIPTION
Follow the standard way of including bpf/lib headers, so it won't mess the hubble sync.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>