### PR TITLE
tetragon: Fix bpf_printk for single string argument

### DIFF
--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -118,7 +118,7 @@ static uint64_t BPF_FUNC(get_socket_cookie, void *ctx);
 
 /* Debugging */
 
-__attribute__((__format__(__printf__, 1, 3)))
+__attribute__((__format__(__printf__, 1, 0)))
 static void BPF_FUNC(trace_printk, const char *fmt, int fmt_size, ...);
 
 static long BPF_FUNC(trace_vprintk, const char *fmt, __u32 fmt_size, const void *data, __u32 data_len);


### PR DESCRIPTION
Currently we can't use bpf_printk macro with just single argument, like:

```
   generic_kprobe_event(struct pt_regs *ctx)
   {
  +       bpf_printk("DEBUG\n");
          return generic_kprobe_start_process_filter(ctx);
   }
```
The reason is that for single string argument the __bpf_printk macro calls trace_printk helper without the 3rd argument, just the format string  and in this case the current __format__ attribute check will cause error:

  __attribute__((__format__(__printf__, 1, 3)))

because there's no 3rd argument passed, but the format check expects it with '3' as in first-to-check index value.

Disabling the format arguments check by passing 0 instead. In this case the compiler only checks the format string for consistency.

As we use trace_printk just for debugging purpose I think it's safe to disable format checking and allow above use of bpf_printk.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>