### PR TITLE
Add start time to event cache object

### DIFF
--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -35,6 +35,7 @@ type CacheObj struct {
 	internal  *process.ProcessInternal
 	event     notify.Event
 	timestamp uint64
+	startTime uint64
 	color     int
 	msg       notify.Message
 }
@@ -105,7 +106,7 @@ func (ec *Cache) handleEvents() {
 		// now because it should be available. Otherwise we have a valid
 		// process and lets copy it across.
 		if event.internal == nil {
-			event.internal, err = event.msg.RetryInternal(event.event, event.timestamp)
+			event.internal, err = event.msg.RetryInternal(event.event, event.startTime)
 		}
 		if err == nil {
 			err = event.msg.Retry(event.internal, event.event)
@@ -193,8 +194,9 @@ func (ec *Cache) Needed(proc *tetragon.Process) bool {
 func (ec *Cache) Add(internal *process.ProcessInternal,
 	e notify.Event,
 	t uint64,
+	s uint64,
 	msg notify.Message) {
-	ec.objsChan <- CacheObj{internal: internal, event: e, timestamp: t, msg: msg}
+	ec.objsChan <- CacheObj{internal: internal, event: e, timestamp: t, startTime: s, msg: msg}
 }
 
 func NewWithTimer(s *server.Server, dur time.Duration) *Cache {

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -70,7 +70,7 @@ func GetProcessExec(event *MsgExecveEventUnix, useCache bool) *tetragon.ProcessE
 	if useCache {
 		if ec := eventcache.Get(); ec != nil &&
 			(ec.Needed(tetragonEvent.Process) || (tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonEvent.Parent))) {
-			ec.Add(proc, tetragonEvent, event.Common.Ktime, event)
+			ec.Add(proc, tetragonEvent, event.Common.Ktime, event.Process.Ktime, event)
 			return nil
 		}
 	}
@@ -255,7 +255,7 @@ func (msg *MsgCloneEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 		if err := process.AddCloneEvent(&msg.MsgCloneEvent); err != nil {
 			ec := eventcache.Get()
 			if ec != nil {
-				ec.Add(nil, nil, msg.MsgCloneEvent.Ktime, msg)
+				ec.Add(nil, nil, msg.MsgCloneEvent.Common.Ktime, msg.MsgCloneEvent.Ktime, msg)
 			}
 		}
 	default:
@@ -300,7 +300,7 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 	if ec != nil &&
 		(ec.Needed(tetragonProcess) ||
 			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
-		ec.Add(nil, tetragonEvent, event.ProcessKey.Ktime, event)
+		ec.Add(nil, tetragonEvent, event.Common.Ktime, event.ProcessKey.Ktime, event)
 		return nil
 	}
 	if parent != nil {
@@ -433,7 +433,7 @@ func (msg *MsgProcessCleanupEventUnix) HandleMessage() *tetragon.GetEventsRespon
 		process.RefDec()
 	} else {
 		if ec := eventcache.Get(); ec != nil {
-			ec.Add(nil, nil, msg.Ktime, msg)
+			ec.Add(nil, nil, msg.Ktime, msg.Ktime, msg)
 		}
 	}
 	return nil

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -199,7 +199,7 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 	if ec := eventcache.Get(); ec != nil &&
 		(ec.Needed(tetragonProcess) ||
 			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
-		ec.Add(nil, tetragonEvent, event.ProcessKey.Ktime, event)
+		ec.Add(nil, tetragonEvent, event.Common.Ktime, event.ProcessKey.Ktime, event)
 		return nil
 	}
 
@@ -287,7 +287,7 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 	if ec := eventcache.Get(); ec != nil &&
 		(ec.Needed(tetragonProcess) ||
 			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
-		ec.Add(nil, tetragonEvent, msg.ProcessKey.Ktime, msg)
+		ec.Add(nil, tetragonEvent, msg.Common.Ktime, msg.ProcessKey.Ktime, msg)
 		return nil
 	}
 
@@ -387,7 +387,7 @@ func GetProcessLoader(msg *MsgProcessLoaderUnix) *tetragon.ProcessLoader {
 		tetragonEvent.Process = tetragonProcess
 		tetragonEvent.Path = msg.Path
 		tetragonEvent.Buildid = msg.Buildid
-		ec.Add(nil, tetragonEvent, msg.ProcessKey.Ktime, msg)
+		ec.Add(nil, tetragonEvent, msg.Ktime, msg.ProcessKey.Ktime, msg)
 		return nil
 	}
 


### PR DESCRIPTION
The event cache takes a timestamp via its Add method. This is used in two places: once in the RetryInternal method and again as the timestamp of the event. The RetryInternal method actually wants a process start time, and that is typically what functions give it. Using this as the event timestamp is therefore incorrect.

This commit adds a further parameter to the Add method and the event cache object: process start time. Functions will have to provide the event timestamp and the process start time in order to use the event cache, but this will solve the issue of the event being given the wrong timestamp.