### PR TITLE
use  go 1.19.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y linux-libc-dev
 COPY . ./
 RUN make tetragon-bpf LOCAL_CLANG=1
 
-FROM quay.io/cilium/cilium-builder:a2dc3278c48e1593b1f6c8fd9e5c6a982d56a875@sha256:98c4e694805e9a9d410ed73d555e97e91d77e2ab4529b6b51f5243b33ab411b1 as hubble-builder
+FROM quay.io/cilium/cilium-builder:6615810f9d5595ea9639e91255bdbe83acb4b5fb@sha256:595c6a8c06db1dd2a71a4a2891b270af674705b7d1f7a2cfec5bfac64bd2af74 as hubble-builder
 ARG TETRAGON_VERSION
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN apt-get update && apt-get install -y libelf-dev zlib1g-dev

--- a/Dockerfile.codegen
+++ b/Dockerfile.codegen
@@ -1,4 +1,4 @@
-FROM quay.io/cilium/cilium-builder:a2dc3278c48e1593b1f6c8fd9e5c6a982d56a875@sha256:98c4e694805e9a9d410ed73d555e97e91d77e2ab4529b6b51f5243b33ab411b1
+FROM quay.io/cilium/cilium-builder:6615810f9d5595ea9639e91255bdbe83acb4b5fb@sha256:595c6a8c06db1dd2a71a4a2891b270af674705b7d1f7a2cfec5bfac64bd2af74
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/tetragon cd /go/src/github.com/cilium/tetragon && go install ./cmd/protoc-gen-go-tetragon
 
 #- vi:ft=dockerfile -#

--- a/api/v1/tetragon/capabilities.pb.go
+++ b/api/v1/tetragon/capabilities.pb.go
@@ -38,44 +38,47 @@ type CapabilitiesType int32
 
 const (
 	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
-	//overrides the restriction of changing file ownership and group
-	//ownership.
+	// overrides the restriction of changing file ownership and group
+	// ownership.
 	CapabilitiesType_CAP_CHOWN CapabilitiesType = 0
 	// Override all DAC access, including ACL execute access if
-	//[_POSIX_ACL] is defined. Excluding DAC access covered by
-	//CAP_LINUX_IMMUTABLE.
+	// [_POSIX_ACL] is defined. Excluding DAC access covered by
+	// CAP_LINUX_IMMUTABLE.
 	CapabilitiesType_DAC_OVERRIDE CapabilitiesType = 1
 	// Overrides all DAC restrictions regarding read and search on files
-	//and directories, including ACL restrictions if [_POSIX_ACL] is
-	//defined. Excluding DAC access covered by "$1"_LINUX_IMMUTABLE.
+	// and directories, including ACL restrictions if [_POSIX_ACL] is
+	// defined. Excluding DAC access covered by "$1"_LINUX_IMMUTABLE.
 	CapabilitiesType_CAP_DAC_READ_SEARCH CapabilitiesType = 2
 	// Overrides all restrictions about allowed operations on files, where
-	//file owner ID must be equal to the user ID, except where CAP_FSETID
-	//is applicable. It doesn't override MAC and DAC restrictions.
+	// file owner ID must be equal to the user ID, except where CAP_FSETID
+	// is applicable. It doesn't override MAC and DAC restrictions.
 	CapabilitiesType_CAP_FOWNER CapabilitiesType = 3
 	// Overrides the following restrictions that the effective user ID
-	//shall match the file owner ID when setting the S_ISUID and S_ISGID
-	//bits on that file; that the effective group ID (or one of the
-	//supplementary group IDs) shall match the file owner ID when setting
-	//the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
-	//cleared on successful return from chown(2) (not implemented).
+	// shall match the file owner ID when setting the S_ISUID and S_ISGID
+	// bits on that file; that the effective group ID (or one of the
+	// supplementary group IDs) shall match the file owner ID when setting
+	// the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+	// cleared on successful return from chown(2) (not implemented).
 	CapabilitiesType_CAP_FSETID CapabilitiesType = 4
 	// Overrides the restriction that the real or effective user ID of a
-	//process sending a signal must match the real or effective user ID
-	//of the process receiving the signal.
+	// process sending a signal must match the real or effective user ID
+	// of the process receiving the signal.
 	CapabilitiesType_CAP_KILL CapabilitiesType = 5
 	// Allows forged gids on socket credentials passing.
 	CapabilitiesType_CAP_SETGID CapabilitiesType = 6
 	// Allows forged pids on socket credentials passing.
 	CapabilitiesType_CAP_SETUID CapabilitiesType = 7
 	// Without VFS support for capabilities:
-	//   Transfer any capability in your permitted set to any pid,
-	//   remove any capability in your permitted set from any pid
+	//
+	//	Transfer any capability in your permitted set to any pid,
+	//	remove any capability in your permitted set from any pid
+	//
 	// With VFS support for capabilities (neither of above, but)
-	//   Add any capability from current's capability bounding set
-	//       to the current process' inheritable set
-	//   Allow taking bits out of capability bounding set
-	//   Allow modification of the securebits for a process
+	//
+	//	Add any capability from current's capability bounding set
+	//	    to the current process' inheritable set
+	//	Allow taking bits out of capability bounding set
+	//	Allow modification of the securebits for a process
 	CapabilitiesType_CAP_SETPCAP CapabilitiesType = 8
 	// Allow modification of S_IMMUTABLE and S_APPEND file attributes
 	CapabilitiesType_CAP_LINUX_IMMUTABLE CapabilitiesType = 9
@@ -88,7 +91,7 @@ const (
 	// Allow binding to any address for transparent proxying (also via NET_ADMIN)
 	CapabilitiesType_CAP_NET_RAW CapabilitiesType = 13
 	// Allow mlock and mlockall (which doesn't really have anything to do
-	//with IPC)
+	// with IPC)
 	CapabilitiesType_CAP_IPC_LOCK CapabilitiesType = 14
 	// Override IPC ownership checks
 	CapabilitiesType_CAP_IPC_OWNER CapabilitiesType = 15
@@ -125,17 +128,17 @@ const (
 	// Set or remove capabilities on files
 	CapabilitiesType_CAP_SETFCAP CapabilitiesType = 31
 	// Override MAC access.
-	//The base kernel enforces no MAC policy.
-	//An LSM may enforce a MAC policy, and if it does and it chooses
-	//to implement capability based overrides of that policy, this is
-	//the capability it should use to do so.
+	// The base kernel enforces no MAC policy.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based overrides of that policy, this is
+	// the capability it should use to do so.
 	CapabilitiesType_CAP_MAC_OVERRIDE CapabilitiesType = 32
 	// Allow MAC configuration or state changes.
-	//The base kernel requires no MAC configuration.
-	//An LSM may enforce a MAC policy, and if it does and it chooses
-	//to implement capability based checks on modifications to that
-	//policy or the data required to maintain it, this is the
-	//capability it should use to do so.
+	// The base kernel requires no MAC configuration.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based checks on modifications to that
+	// policy or the data required to maintain it, this is the
+	// capability it should use to do so.
 	CapabilitiesType_CAP_MAC_ADMIN CapabilitiesType = 33
 	// Allow configuring the kernel's syslog (printk behaviour)
 	CapabilitiesType_CAP_SYSLOG CapabilitiesType = 34
@@ -145,11 +148,9 @@ const (
 	CapabilitiesType_CAP_BLOCK_SUSPEND CapabilitiesType = 36
 	// Allow reading the audit log via multicast netlink socket
 	CapabilitiesType_CAP_AUDIT_READ CapabilitiesType = 37
-	//
 	// Allow system performance and observability privileged operations
 	// using perf_events, i915_perf and other kernel subsystems
 	CapabilitiesType_CAP_PERFMON CapabilitiesType = 38
-	//
 	// CAP_BPF allows the following BPF operations:
 	// - Creating all types of BPF maps
 	// - Advanced verifier features
@@ -160,6 +161,7 @@ const (
 	//   - Larger complexity limits
 	//   - Dead code elimination
 	//   - And potentially other features
+	//
 	// - Loading BPF Type Format (BTF) data
 	// - Retrieve xlated and JITed code of BPF programs
 	// - Use bpf_spin_lock() helper

--- a/api/v1/tetragon/events.pb.go
+++ b/api/v1/tetragon/events.pb.go
@@ -551,6 +551,7 @@ type GetEventsResponse struct {
 	// NOTE: Numbers must stay in sync with enum EventType.
 	//
 	// Types that are assignable to Event:
+	//
 	//	*GetEventsResponse_ProcessExec
 	//	*GetEventsResponse_ProcessExit
 	//	*GetEventsResponse_ProcessKprobe

--- a/api/v1/tetragon/tetragon.pb.go
+++ b/api/v1/tetragon/tetragon.pb.go
@@ -270,10 +270,10 @@ type Container struct {
 	Pid *wrapperspb.UInt32Value `protobuf:"bytes,5,opt,name=pid,proto3" json:"pid,omitempty"`
 	// If this is set true, it means that the process might have been originated from
 	// a Kubernetes exec probe. For this field to be true, the following must be true:
-	// 1. The binary field matches the first element of the exec command list for either
-	//    liveness or readiness probe excluding the basename. For example, "/bin/ls"
-	//    and "ls" are considered a match.
-	// 2. The arguments field exactly matches the rest of the exec command list.
+	//  1. The binary field matches the first element of the exec command list for either
+	//     liveness or readiness probe excluding the basename. For example, "/bin/ls"
+	//     and "ls" are considered a match.
+	//  2. The arguments field exactly matches the rest of the exec command list.
 	MaybeExecProbe bool `protobuf:"varint,13,opt,name=maybe_exec_probe,json=maybeExecProbe,proto3" json:"maybe_exec_probe,omitempty"`
 }
 
@@ -1799,6 +1799,7 @@ type KprobeArgument struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Arg:
+	//
 	//	*KprobeArgument_StringArg
 	//	*KprobeArgument_IntArg
 	//	*KprobeArgument_SkbArg
@@ -2549,6 +2550,7 @@ type RuntimeHookRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Event:
+	//
 	//	*RuntimeHookRequest_CreateContainer
 	Event isRuntimeHookRequest_Event `protobuf_oneof:"event"`
 }

--- a/contrib/update-cilium-builder.sh
+++ b/contrib/update-cilium-builder.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# script to update cilium builder images, and effectively the go version with which we build our
+# images.
+
+# get latest image from cilium repo
+new_image=$(wget https://raw.githubusercontent.com/cilium/cilium/master/images/cilium/Dockerfile -q -O - | sed -ne 's/^ARG CILIUM_BUILDER_IMAGE=//p')
+
+# find files that we need to update, and update them.
+myname=$(basename $0)
+for file in $(git grep -l quay.io/cilium/cilium-builder ":(exclude)*$myname"); do
+        sed -i -e "s%quay.io/cilium/cilium-builder[^ ]\+%${new_image}%" $file
+done
+
+make vendor
+echo "New go version: $(docker run $new_image go version)"

--- a/operator.Dockerfile
+++ b/operator.Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BASE_IMAGE=scratch
-ARG GOLANG_IMAGE=quay.io/cilium/cilium-builder:a2dc3278c48e1593b1f6c8fd9e5c6a982d56a875@sha256:98c4e694805e9a9d410ed73d555e97e91d77e2ab4529b6b51f5243b33ab411b1
+ARG GOLANG_IMAGE=quay.io/cilium/cilium-builder:6615810f9d5595ea9639e91255bdbe83acb4b5fb@sha256:595c6a8c06db1dd2a71a4a2891b270af674705b7d1f7a2cfec5bfac64bd2af74
 ARG ALPINE_IMAGE=docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/capabilities.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/capabilities.pb.go
@@ -38,44 +38,47 @@ type CapabilitiesType int32
 
 const (
 	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
-	//overrides the restriction of changing file ownership and group
-	//ownership.
+	// overrides the restriction of changing file ownership and group
+	// ownership.
 	CapabilitiesType_CAP_CHOWN CapabilitiesType = 0
 	// Override all DAC access, including ACL execute access if
-	//[_POSIX_ACL] is defined. Excluding DAC access covered by
-	//CAP_LINUX_IMMUTABLE.
+	// [_POSIX_ACL] is defined. Excluding DAC access covered by
+	// CAP_LINUX_IMMUTABLE.
 	CapabilitiesType_DAC_OVERRIDE CapabilitiesType = 1
 	// Overrides all DAC restrictions regarding read and search on files
-	//and directories, including ACL restrictions if [_POSIX_ACL] is
-	//defined. Excluding DAC access covered by "$1"_LINUX_IMMUTABLE.
+	// and directories, including ACL restrictions if [_POSIX_ACL] is
+	// defined. Excluding DAC access covered by "$1"_LINUX_IMMUTABLE.
 	CapabilitiesType_CAP_DAC_READ_SEARCH CapabilitiesType = 2
 	// Overrides all restrictions about allowed operations on files, where
-	//file owner ID must be equal to the user ID, except where CAP_FSETID
-	//is applicable. It doesn't override MAC and DAC restrictions.
+	// file owner ID must be equal to the user ID, except where CAP_FSETID
+	// is applicable. It doesn't override MAC and DAC restrictions.
 	CapabilitiesType_CAP_FOWNER CapabilitiesType = 3
 	// Overrides the following restrictions that the effective user ID
-	//shall match the file owner ID when setting the S_ISUID and S_ISGID
-	//bits on that file; that the effective group ID (or one of the
-	//supplementary group IDs) shall match the file owner ID when setting
-	//the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
-	//cleared on successful return from chown(2) (not implemented).
+	// shall match the file owner ID when setting the S_ISUID and S_ISGID
+	// bits on that file; that the effective group ID (or one of the
+	// supplementary group IDs) shall match the file owner ID when setting
+	// the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+	// cleared on successful return from chown(2) (not implemented).
 	CapabilitiesType_CAP_FSETID CapabilitiesType = 4
 	// Overrides the restriction that the real or effective user ID of a
-	//process sending a signal must match the real or effective user ID
-	//of the process receiving the signal.
+	// process sending a signal must match the real or effective user ID
+	// of the process receiving the signal.
 	CapabilitiesType_CAP_KILL CapabilitiesType = 5
 	// Allows forged gids on socket credentials passing.
 	CapabilitiesType_CAP_SETGID CapabilitiesType = 6
 	// Allows forged pids on socket credentials passing.
 	CapabilitiesType_CAP_SETUID CapabilitiesType = 7
 	// Without VFS support for capabilities:
-	//   Transfer any capability in your permitted set to any pid,
-	//   remove any capability in your permitted set from any pid
+	//
+	//	Transfer any capability in your permitted set to any pid,
+	//	remove any capability in your permitted set from any pid
+	//
 	// With VFS support for capabilities (neither of above, but)
-	//   Add any capability from current's capability bounding set
-	//       to the current process' inheritable set
-	//   Allow taking bits out of capability bounding set
-	//   Allow modification of the securebits for a process
+	//
+	//	Add any capability from current's capability bounding set
+	//	    to the current process' inheritable set
+	//	Allow taking bits out of capability bounding set
+	//	Allow modification of the securebits for a process
 	CapabilitiesType_CAP_SETPCAP CapabilitiesType = 8
 	// Allow modification of S_IMMUTABLE and S_APPEND file attributes
 	CapabilitiesType_CAP_LINUX_IMMUTABLE CapabilitiesType = 9
@@ -88,7 +91,7 @@ const (
 	// Allow binding to any address for transparent proxying (also via NET_ADMIN)
 	CapabilitiesType_CAP_NET_RAW CapabilitiesType = 13
 	// Allow mlock and mlockall (which doesn't really have anything to do
-	//with IPC)
+	// with IPC)
 	CapabilitiesType_CAP_IPC_LOCK CapabilitiesType = 14
 	// Override IPC ownership checks
 	CapabilitiesType_CAP_IPC_OWNER CapabilitiesType = 15
@@ -125,17 +128,17 @@ const (
 	// Set or remove capabilities on files
 	CapabilitiesType_CAP_SETFCAP CapabilitiesType = 31
 	// Override MAC access.
-	//The base kernel enforces no MAC policy.
-	//An LSM may enforce a MAC policy, and if it does and it chooses
-	//to implement capability based overrides of that policy, this is
-	//the capability it should use to do so.
+	// The base kernel enforces no MAC policy.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based overrides of that policy, this is
+	// the capability it should use to do so.
 	CapabilitiesType_CAP_MAC_OVERRIDE CapabilitiesType = 32
 	// Allow MAC configuration or state changes.
-	//The base kernel requires no MAC configuration.
-	//An LSM may enforce a MAC policy, and if it does and it chooses
-	//to implement capability based checks on modifications to that
-	//policy or the data required to maintain it, this is the
-	//capability it should use to do so.
+	// The base kernel requires no MAC configuration.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based checks on modifications to that
+	// policy or the data required to maintain it, this is the
+	// capability it should use to do so.
 	CapabilitiesType_CAP_MAC_ADMIN CapabilitiesType = 33
 	// Allow configuring the kernel's syslog (printk behaviour)
 	CapabilitiesType_CAP_SYSLOG CapabilitiesType = 34
@@ -145,11 +148,9 @@ const (
 	CapabilitiesType_CAP_BLOCK_SUSPEND CapabilitiesType = 36
 	// Allow reading the audit log via multicast netlink socket
 	CapabilitiesType_CAP_AUDIT_READ CapabilitiesType = 37
-	//
 	// Allow system performance and observability privileged operations
 	// using perf_events, i915_perf and other kernel subsystems
 	CapabilitiesType_CAP_PERFMON CapabilitiesType = 38
-	//
 	// CAP_BPF allows the following BPF operations:
 	// - Creating all types of BPF maps
 	// - Advanced verifier features
@@ -160,6 +161,7 @@ const (
 	//   - Larger complexity limits
 	//   - Dead code elimination
 	//   - And potentially other features
+	//
 	// - Loading BPF Type Format (BTF) data
 	// - Retrieve xlated and JITed code of BPF programs
 	// - Use bpf_spin_lock() helper

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/events.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/events.pb.go
@@ -551,6 +551,7 @@ type GetEventsResponse struct {
 	// NOTE: Numbers must stay in sync with enum EventType.
 	//
 	// Types that are assignable to Event:
+	//
 	//	*GetEventsResponse_ProcessExec
 	//	*GetEventsResponse_ProcessExit
 	//	*GetEventsResponse_ProcessKprobe

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
@@ -270,10 +270,10 @@ type Container struct {
 	Pid *wrapperspb.UInt32Value `protobuf:"bytes,5,opt,name=pid,proto3" json:"pid,omitempty"`
 	// If this is set true, it means that the process might have been originated from
 	// a Kubernetes exec probe. For this field to be true, the following must be true:
-	// 1. The binary field matches the first element of the exec command list for either
-	//    liveness or readiness probe excluding the basename. For example, "/bin/ls"
-	//    and "ls" are considered a match.
-	// 2. The arguments field exactly matches the rest of the exec command list.
+	//  1. The binary field matches the first element of the exec command list for either
+	//     liveness or readiness probe excluding the basename. For example, "/bin/ls"
+	//     and "ls" are considered a match.
+	//  2. The arguments field exactly matches the rest of the exec command list.
 	MaybeExecProbe bool `protobuf:"varint,13,opt,name=maybe_exec_probe,json=maybeExecProbe,proto3" json:"maybe_exec_probe,omitempty"`
 }
 
@@ -1799,6 +1799,7 @@ type KprobeArgument struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Arg:
+	//
 	//	*KprobeArgument_StringArg
 	//	*KprobeArgument_IntArg
 	//	*KprobeArgument_SkbArg
@@ -2549,6 +2550,7 @@ type RuntimeHookRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Event:
+	//
 	//	*RuntimeHookRequest_CreateContainer
 	Event isRuntimeHookRequest_Event `protobuf_oneof:"event"`
 }


### PR DESCRIPTION
add a script to update cilium builder, and perform an update so that we can build with a new version of go.