### PR TITLE
Handle multiple URL and DNS selectors correctly

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -37,6 +37,8 @@ struct msg_generic_kprobe {
 	__u64 id;
 	__u64 thread_id;
 	__u64 action;
+	__u32 action_arg_id; // only one URL or FQDN action can be fired per match
+	__u32 pad;
 	/* anything above is shared with the userspace so it should match structs MsgGenericKprobe and MsgGenericTracepoint in Go */
 	char args[24000];
 	unsigned long a0, a1, a2, a3, a4;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1248,6 +1248,11 @@ __do_action(long i, struct msg_generic_kprobe *e,
 		else
 			map_update_elem(override_tasks, &id, &error, BPF_ANY);
 		break;
+	case ACTION_GETURL:
+	case ACTION_DNSLOOKUP:
+		/* Set the URL or DNS action */
+		e->action_arg_id = actions->act[++i];
+		break;
 	default:
 		break;
 	}

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -18,6 +18,8 @@ const (
 	ActionUnfollowFd = 3
 	ActionOverride   = 4
 	ActionCopyFd     = 5
+	ActionGetUrl     = 6
+	ActionLookupDns  = 7
 )
 
 const (
@@ -43,6 +45,8 @@ type MsgGenericKprobe struct {
 	Id           uint64
 	ThreadId     uint64
 	ActionId     uint64
+	ActionArgId  uint32
+	Pad          uint32
 }
 
 type MsgGenericKprobeArgPath struct {

--- a/pkg/api/tracingapi/client_tracepoint.go
+++ b/pkg/api/tracingapi/client_tracepoint.go
@@ -15,4 +15,6 @@ type MsgGenericTracepoint struct {
 	Id           int64
 	ThreadId     uint64
 	ActionId     uint64
+	ActionArgId  uint32
+	Pad          uint32
 }

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -39,6 +39,10 @@ func kprobeAction(act uint64) tetragon.KprobeAction {
 		return tetragon.KprobeAction_KPROBE_ACTION_OVERRIDE
 	case tracingapi.ActionCopyFd:
 		return tetragon.KprobeAction_KPROBE_ACTION_COPYFD
+	case tracingapi.ActionGetUrl:
+		return tetragon.KprobeAction_KPROBE_ACTION_GETURL
+	case tracingapi.ActionLookupDns:
+		return tetragon.KprobeAction_KPROBE_ACTION_DNSLOOKUP
 	default:
 		return tetragon.KprobeAction_KPROBE_ACTION_UNKNOWN
 	}

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/idtable"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/reader/namespace"
@@ -48,6 +49,20 @@ var actionTypeStringTable = map[uint32]string{
 	ActionTypeDnsLookup:  "dnslookup",
 }
 
+// Action argument table entry (for URL and FQDN arguments)
+type ActionArgEntry struct {
+	arg     string
+	tableId idtable.EntryID
+}
+
+func (g *ActionArgEntry) SetID(id idtable.EntryID) {
+	g.tableId = id
+}
+
+func (g *ActionArgEntry) GetArg() string {
+	return g.arg
+}
+
 func MatchActionSigKill(spec interface{}) bool {
 	var sels []v1alpha1.KProbeSelector
 	switch s := spec.(type) {
@@ -67,36 +82,6 @@ func MatchActionSigKill(spec interface{}) bool {
 		}
 	}
 	return false
-}
-
-func GetUrls(spec *v1alpha1.KProbeSpec) []string {
-	var urls []string
-	sels := spec.Selectors
-	for _, s := range sels {
-		for _, act := range s.MatchActions {
-			if strings.ToLower(act.Action) == actionTypeStringTable[ActionTypeGetUrl] {
-				if len(act.ArgUrl) > 0 {
-					urls = append(urls, act.ArgUrl)
-				}
-			}
-		}
-	}
-	return urls
-}
-
-func GetDnsFQDNs(spec *v1alpha1.KProbeSpec) []string {
-	var fqdns []string
-	sels := spec.Selectors
-	for _, s := range sels {
-		for _, act := range s.MatchActions {
-			if strings.ToLower(act.Action) == actionTypeStringTable[ActionTypeDnsLookup] {
-				if len(act.ArgFqdn) > 0 {
-					fqdns = append(fqdns, act.ArgFqdn)
-				}
-			}
-		}
-	}
-	return fqdns
 }
 
 const (
@@ -421,7 +406,7 @@ func parseMatchArgs(k *KernelSelectorState, args []v1alpha1.ArgSelector, sig []v
 	return nil
 }
 
-func parseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector) error {
+func parseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, actionArgTable *idtable.Table) error {
 	act, ok := actionTypeTable[strings.ToLower(action.Action)]
 	if !ok {
 		return fmt.Errorf("parseMatchAction: ActionType %s unknown", action.Action)
@@ -433,18 +418,26 @@ func parseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector) e
 		WriteSelectorUint32(k, action.ArgName)
 	case ActionTypeOverride:
 		WriteSelectorInt32(k, action.ArgError)
-	case ActionTypeGetUrl:
-		WriteSelectorByteArray(k, []byte(action.ArgUrl), uint32(len(action.ArgUrl)))
-	case ActionTypeDnsLookup:
-		WriteSelectorByteArray(k, []byte(action.ArgFqdn), uint32(len(action.ArgFqdn)))
+	case ActionTypeGetUrl, ActionTypeDnsLookup:
+		actionArg := ActionArgEntry{
+			tableId: idtable.UninitializedEntryID,
+		}
+		switch act {
+		case ActionTypeGetUrl:
+			actionArg.arg = action.ArgUrl
+		case ActionTypeDnsLookup:
+			actionArg.arg = action.ArgFqdn
+		}
+		actionArgTable.AddEntry(&actionArg)
+		WriteSelectorUint32(k, uint32(actionArg.tableId.ID))
 	}
 	return nil
 }
 
-func parseMatchActions(k *KernelSelectorState, actions []v1alpha1.ActionSelector) error {
+func parseMatchActions(k *KernelSelectorState, actions []v1alpha1.ActionSelector, actionArgTable *idtable.Table) error {
 	loff := AdvanceSelectorLength(k)
 	for _, a := range actions {
-		if err := parseMatchAction(k, &a); err != nil {
+		if err := parseMatchAction(k, &a, actionArgTable); err != nil {
 			return err
 		}
 	}
@@ -676,7 +669,8 @@ func parseMatchBinaries(k *KernelSelectorState, binarys []v1alpha1.BinarySelecto
 func parseSelector(
 	k *KernelSelectorState,
 	selectors *v1alpha1.KProbeSelector,
-	args []v1alpha1.KProbeArg) error {
+	args []v1alpha1.KProbeArg,
+	actionArgTable *idtable.Table) error {
 	if err := parseMatchPids(k, selectors.MatchPIDs); err != nil {
 		return fmt.Errorf("parseMatchPids error: %w", err)
 	}
@@ -698,7 +692,7 @@ func parseSelector(
 	if err := parseMatchArgs(k, selectors.MatchArgs, args); err != nil {
 		return fmt.Errorf("parseMatchArgs  error: %w", err)
 	}
-	if err := parseMatchActions(k, selectors.MatchActions); err != nil {
+	if err := parseMatchActions(k, selectors.MatchActions, actionArgTable); err != nil {
 		return fmt.Errorf("parseMatchActions error: %w", err)
 	}
 	return nil
@@ -741,15 +735,16 @@ func parseSelector(
 // valueInt := [len][v]
 //
 // For some examples, see kernel_test.go
-func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg) ([4096]byte, error) {
-	kernelSelectors, err := InitKernelSelectorState(selectors, args)
+func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg, actionArgTable *idtable.Table) ([4096]byte, error) {
+	kernelSelectors, err := InitKernelSelectorState(selectors, args, actionArgTable)
 	if err != nil {
 		return [4096]byte{}, err
 	}
 	return kernelSelectors.e, nil
 }
 
-func InitKernelSelectorState(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg) (*KernelSelectorState, error) {
+func InitKernelSelectorState(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg,
+	actionArgTable *idtable.Table) (*KernelSelectorState, error) {
 	kernelSelectors := &KernelSelectorState{}
 
 	WriteSelectorUint32(kernelSelectors, uint32(len(selectors)))
@@ -760,7 +755,7 @@ func InitKernelSelectorState(selectors []v1alpha1.KProbeSelector, args []v1alpha
 	for i, s := range selectors {
 		WriteSelectorLength(kernelSelectors, soff[i])
 		loff := AdvanceSelectorLength(kernelSelectors)
-		if err := parseSelector(kernelSelectors, &s, args); err != nil {
+		if err := parseSelector(kernelSelectors, &s, args, actionArgTable); err != nil {
 			return nil, err
 		}
 		WriteSelectorLength(kernelSelectors, loff)

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
+	"github.com/cilium/tetragon/pkg/idtable"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/logger"
@@ -71,6 +72,9 @@ type genericTracepoint struct {
 
 	// index to access this on genericTracepointTable
 	tableIdx int
+
+	// for tracepoints that have a GetUrl or DnsLookup action, we store the table of arguments.
+	actionArgs idtable.Table
 
 	pinPathPrefix string
 }
@@ -405,7 +409,7 @@ func (tp *genericTracepoint) KernelSelectors() (*selectors.KernelSelectorState, 
 		}
 	}
 
-	return selectors.InitKernelSelectorState(selSelectors, selArgs)
+	return selectors.InitKernelSelectorState(selSelectors, selArgs, &tp.actionArgs)
 }
 
 func (tp *genericTracepoint) EventConfig() (api.EventConfig, error) {
@@ -551,6 +555,24 @@ func handleGenericTracepoint(r *bytes.Reader) ([]observer.Event, error) {
 	if err != nil {
 		logger.GetLogger().WithField("id", m.Id).WithError(err).Warnf("genericTracepoint info not found")
 		return []observer.Event{unix}, nil
+	}
+
+	switch m.ActionId {
+	case selectors.ActionTypeGetUrl, selectors.ActionTypeDnsLookup:
+		actionArgEntry, err := tp.actionArgs.GetEntry(idtable.EntryID{ID: int(m.ActionArgId)})
+		if err != nil {
+			logger.GetLogger().WithError(err).Warnf("Failed to find argument for id:%d", m.ActionArgId)
+			return nil, fmt.Errorf("Failed to find argument for id")
+		}
+		actionArg := actionArgEntry.(*selectors.ActionArgEntry).GetArg()
+		switch m.ActionId {
+		case selectors.ActionTypeGetUrl:
+			logger.GetLogger().WithField("URL", actionArg).Trace("Get URL Action")
+			getUrl(actionArg)
+		case selectors.ActionTypeDnsLookup:
+			logger.GetLogger().WithField("FQDN", actionArg).Trace("DNS lookup")
+			dnsLookup(actionArg)
+		}
 	}
 
 	unix.Subsys = tp.Info.Subsys

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
+	"github.com/cilium/tetragon/pkg/idtable"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/observer"
@@ -364,7 +365,10 @@ func TestKprobeSelectors(t *testing.T) {
 			spec := makeSpec(t, tcs.specFilterVals, tcs.specOperator)
 			if i == 0 {
 			} else {
-				if err := ReloadGenericKprobeSelectors(kpSensor, &spec.KProbes[0]); err != nil {
+				// Create URL and FQDN tables to store URLs and FQDNs for this kprobe
+				var argActionTable idtable.Table
+
+				if err := ReloadGenericKprobeSelectors(kpSensor, &spec.KProbes[0], &argActionTable); err != nil {
 					t.Fatalf("failed to reload kprobe prog: %s", err)
 				}
 			}


### PR DESCRIPTION
Currently we have experimental support for URL and DNS actions, which could be used to trigger Thinkst canaries. This experimental support incorrectly handles multiple selectors – it simply collects all the URLs in the kprobe and all the FQDNs in the kprobe into lists, and when a URL or FQDN action fires on it, it triggers everything in the corresponding list. This is obviously wrong.

This commit fixes this as follows. Each kprobe stores a table of URLs and FQDNs that it references, each entry with its own index. These indices are provided in the config to the match actions in the selectors, and the BPF program reports the matching index. In user space, the URL or FQDN is retrieved from the table using this index.

Note that only one URL and/or FQDN action is permitted per selector. It will be possible to enable multiple if necessary, but it is deemed that a single trigger should be sufficient to trigger any further triggers.