### PR TITLE
tetragon: Fix action offset masking

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1310,13 +1310,13 @@ filter_read_arg(void *ctx, int index, struct bpf_map_def *heap,
 		if (f) {
 			bool postit;
 
-			asm volatile("%[pass] &= 0xeff;\n"
+			asm volatile("%[pass] &= 0x7ff;\n"
 				     : [pass] "+r"(pass)
 				     :);
 			arg = (struct selector_arg_filter *)&f[pass];
 
 			actoff = pass + arg->arglen;
-			asm volatile("%[actoff] &= 0xeff;\n"
+			asm volatile("%[actoff] &= 0x7ff;\n"
 				     : [actoff] "+r"(actoff)
 				     :);
 			actions = (struct selector_action *)&f[actoff];

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1004,7 +1004,7 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx)
 	asm volatile("%[index] &= 0x7;\n" ::[index] "+r"(index)
 		     :);
 	argoff = e->argsoff[index];
-	asm volatile("%[argoff] &= 0xeff;\n" ::[argoff] "+r"(argoff)
+	asm volatile("%[argoff] &= 0x7ff;\n" ::[argoff] "+r"(argoff)
 		     :);
 	args = &e->args[argoff];
 
@@ -1109,7 +1109,7 @@ installfd(struct msg_generic_kprobe *e, int fd, int name, bool follow)
 		return 0;
 	}
 	fdoff = e->argsoff[fd];
-	asm volatile("%[fdoff] &= 0xeff;\n"
+	asm volatile("%[fdoff] &= 0x7ff;\n"
 		     : [fdoff] "+r"(fdoff)
 		     :);
 	key.pad = 0;
@@ -1125,7 +1125,7 @@ installfd(struct msg_generic_kprobe *e, int fd, int name, bool follow)
 		if (name > 5)
 			return 0;
 		nameoff = e->argsoff[name];
-		asm volatile("%[nameoff] &= 0xeff;\n"
+		asm volatile("%[nameoff] &= 0x7ff;\n"
 			     : [nameoff] "+r"(nameoff)
 			     :);
 
@@ -1157,7 +1157,7 @@ copyfd(struct msg_generic_kprobe *e, int oldfd, int newfd)
 	if (oldfd > 5)
 		return 0;
 	oldfdoff = e->argsoff[oldfd];
-	asm volatile("%[oldfdoff] &= 0xeff;\n"
+	asm volatile("%[oldfdoff] &= 0x7ff;\n"
 		     : [oldfdoff] "+r"(oldfdoff)
 		     :);
 	key.pad = 0;
@@ -1172,7 +1172,7 @@ copyfd(struct msg_generic_kprobe *e, int oldfd, int newfd)
 		if (newfd > 5)
 			return 0;
 		newfdoff = e->argsoff[newfd];
-		asm volatile("%[newfdoff] &= 0xeff;\n"
+		asm volatile("%[newfdoff] &= 0x7ff;\n"
 			     : [newfdoff] "+r"(newfdoff)
 			     :);
 		key.pad = 0;

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -448,6 +448,9 @@ func parseMatchActions(k *KernelSelectorState, actions []v1alpha1.ActionSelector
 			return err
 		}
 	}
+
+	// Zero length value is also default ActionTypePost action
+	// that bpf program reads when no other action is specified.
 	WriteSelectorLength(k, loff)
 	return nil
 }


### PR DESCRIPTION
Kevin reported issue with longer selectors sending kprobes with
override action.

The problem is that we are masking action offset with wrong mask
bin(0xeff) == 0b111011111111, which was mangling offsets bigger
than 255, so the action code worked on top of wrong data.

Selector total length is 0x1000, so next longest mask to use here
is 0x7ff.

Note we should test longer selectors and make sure verifier is
happy with them.

Reported-by: Kevin Sheldrake <kevin.sheldrake@isovalent.com>
Signed-off-by: Jiri Olsa <jolsa@kernel.org>

Fixes: https://github.com/cilium/tetragon/issues/462
