### PR TITLE
Backport:v0.8 Handle multiple URL and DNS selectors correctly

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -37,6 +37,8 @@ struct msg_generic_kprobe {
 	__u64 id;
 	__u64 thread_id;
 	__u64 action;
+	__u32 action_arg_id; // only one URL or FQDN action can be fired per match
+	__u32 pad;
 	/* anything above is shared with the userspace so it should match structs MsgGenericKprobe and MsgGenericTracepoint in Go */
 	char args[24000];
 	unsigned long a0, a1, a2, a3, a4;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1236,6 +1236,11 @@ __do_action(long i, struct msg_generic_kprobe *e,
 		else
 			map_update_elem(override_tasks, &id, &error, BPF_ANY);
 		break;
+	case ACTION_GETURL:
+	case ACTION_DNSLOOKUP:
+		/* Set the URL or DNS action */
+		e->action_arg_id = actions->act[++i];
+		break;
 	default:
 		break;
 	}

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -18,6 +18,8 @@ const (
 	ActionUnfollowFd = 3
 	ActionOverride   = 4
 	ActionCopyFd     = 5
+	ActionGetUrl     = 6
+	ActionLookupDns  = 7
 )
 
 const (
@@ -33,6 +35,8 @@ type MsgGenericKprobe struct {
 	Id           uint64
 	ThreadId     uint64
 	ActionId     uint64
+	ActionArgId  uint32
+	Pad          uint32
 }
 
 type MsgGenericKprobeArgPath struct {

--- a/pkg/api/tracingapi/client_tracepoint.go
+++ b/pkg/api/tracingapi/client_tracepoint.go
@@ -15,4 +15,6 @@ type MsgGenericTracepoint struct {
 	Id           int64
 	ThreadId     uint64
 	ActionId     uint64
+	ActionArgId  uint32
+	Pad          uint32
 }

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -39,6 +39,10 @@ func kprobeAction(act uint64) tetragon.KprobeAction {
 		return tetragon.KprobeAction_KPROBE_ACTION_OVERRIDE
 	case tracingapi.ActionCopyFd:
 		return tetragon.KprobeAction_KPROBE_ACTION_COPYFD
+	case tracingapi.ActionGetUrl:
+		return tetragon.KprobeAction_KPROBE_ACTION_GETURL
+	case tracingapi.ActionLookupDns:
+		return tetragon.KprobeAction_KPROBE_ACTION_DNSLOOKUP
 	default:
 		return tetragon.KprobeAction_KPROBE_ACTION_UNKNOWN
 	}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -5,6 +5,7 @@ package tracing
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -111,13 +112,8 @@ type genericKprobe struct {
 
 	tableId idtable.EntryID
 
-	// for kprobes that have a GetUrl action, we store the list of URLs
-	// to get.
-	urls []string
-
-	// for kprobes that have a DnsRequest action, we store the list of
-	// FQDNs to request.
-	fqdns []string
+	// for kprobes that have a GetUrl or DnsLookup action, we store the table of arguments.
+	actionArgs idtable.Table
 
 	pinPathPrefix string
 }
@@ -386,12 +382,6 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 			}
 		}
 
-		// Parse Filters into kernel filter logic
-		kernelSelectorState, err := selectors.InitKernelSelectorState(f.Selectors, f.Args)
-		if err != nil {
-			return nil, err
-		}
-
 		// Parse Binary Name into kernel data structures
 		if err := initBinaryNames(f); err != nil {
 			return nil, err
@@ -433,17 +423,13 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 			config.Sigkill = 0
 		}
 
-		urls := selectors.GetUrls(f)
-		fqdns := selectors.GetDnsFQDNs(f)
-
 		// create a new entry on the table, and pass its id to BPF-side
 		// so that we can do the matching at event-generation time
 		kprobeEntry := genericKprobe{
 			loadArgs: kprobeLoadArgs{
-				selectors: kernelSelectorState,
-				retprobe:  setRetprobe,
-				syscall:   is_syscall,
-				config:    config,
+				retprobe: setRetprobe,
+				syscall:  is_syscall,
+				config:   config,
 			},
 			argSigPrinters:    argSigPrinters,
 			argReturnPrinters: argReturnPrinters,
@@ -451,8 +437,12 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 			funcName:          funcName,
 			pendingEvents:     nil,
 			tableId:           idtable.UninitializedEntryID,
-			urls:              urls,
-			fqdns:             fqdns,
+		}
+
+		// Parse Filters into kernel filter logic
+		kprobeEntry.loadArgs.selectors, err = selectors.InitKernelSelectorState(f.Selectors, f.Args, &kprobeEntry.actionArgs)
+		if err != nil {
+			return nil, err
 		}
 
 		kprobeEntry.pendingEvents, err = lru.New(4096)
@@ -550,7 +540,7 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 // This is intended for speeding up testing, so DO NOT USE elsewhere without
 // checking its implementation first because limitations may exist (e.g,. the
 // config map is not updated, the retprobe is not reloaded, userspace return filters are not updated, etc.).
-func ReloadGenericKprobeSelectors(kpSensor *sensors.Sensor, conf *v1alpha1.KProbeSpec) error {
+func ReloadGenericKprobeSelectors(kpSensor *sensors.Sensor, conf *v1alpha1.KProbeSpec, actionArgTable *idtable.Table) error {
 	// The first program should be the (entry) kprobe, and that's the only
 	// one we will reload. We could reload the retprobe, but the assumption
 	// is that we don't need to, because it will never be executed if the
@@ -569,7 +559,7 @@ func ReloadGenericKprobeSelectors(kpSensor *sensors.Sensor, conf *v1alpha1.KProb
 		return fmt.Errorf("unlinking %v failed: %s", kprobeProg, err)
 	}
 
-	kState, err := selectors.InitKernelSelectorState(conf.Selectors, conf.Args)
+	kState, err := selectors.InitKernelSelectorState(conf.Selectors, conf.Args, actionArgTable)
 	if err != nil {
 		return err
 	}
@@ -757,7 +747,14 @@ func getUrl(url string) {
 
 func dnsLookup(fqdn string) {
 	// We fire and forget DNS lookups, and we don't care if they hit or not.
-	net.LookupIP(fqdn)
+	res := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			dial := net.Dialer{}
+			return dial.Dial("udp", "1.1.1.1:53")
+		},
+	}
+	res.LookupIP(context.Background(), "ip4", fqdn)
 }
 
 func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
@@ -775,15 +772,20 @@ func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
 	}
 
 	switch m.ActionId {
-	case selectors.ActionTypeGetUrl:
-		for _, url := range gk.urls {
-			logger.GetLogger().WithField("URL", url).Trace("Get URL Action")
-			getUrl(url)
+	case selectors.ActionTypeGetUrl, selectors.ActionTypeDnsLookup:
+		actionArgEntry, err := gk.actionArgs.GetEntry(idtable.EntryID{ID: int(m.ActionArgId)})
+		if err != nil {
+			logger.GetLogger().WithError(err).Warnf("Failed to find argument for id:%d", m.ActionArgId)
+			return nil, fmt.Errorf("Failed to find argument for id")
 		}
-	case selectors.ActionTypeDnsLookup:
-		for _, fqdn := range gk.fqdns {
-			logger.GetLogger().WithField("FQDN", fqdn).Trace("DNS lookup")
-			dnsLookup(fqdn)
+		actionArg := actionArgEntry.(*selectors.ActionArgEntry).GetArg()
+		switch m.ActionId {
+		case selectors.ActionTypeGetUrl:
+			logger.GetLogger().WithField("URL", actionArg).Trace("Get URL Action")
+			getUrl(actionArg)
+		case selectors.ActionTypeDnsLookup:
+			logger.GetLogger().WithField("FQDN", actionArg).Trace("DNS lookup")
+			dnsLookup(actionArg)
 		}
 	}
 

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
+	"github.com/cilium/tetragon/pkg/idtable"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/observer"
@@ -361,7 +362,10 @@ func TestKprobeSelectors(t *testing.T) {
 			spec := makeSpec(t, tcs.specFilterVals, tcs.specOperator)
 			if i == 0 {
 			} else {
-				if err := ReloadGenericKprobeSelectors(kpSensor, &spec.KProbes[0]); err != nil {
+				// Create URL and FQDN tables to store URLs and FQDNs for this kprobe
+				var argActionTable idtable.Table
+
+				if err := ReloadGenericKprobeSelectors(kpSensor, &spec.KProbes[0], &argActionTable); err != nil {
 					t.Fatalf("failed to reload kprobe prog: %s", err)
 				}
 			}


### PR DESCRIPTION
Currently we have experimental support for URL and DNS actions, which could be used to trigger Thinkst canaries. This experimental support incorrectly handles multiple selectors – it simply collects all the URLs in the kprobe and all the FQDNs in the kprobe into lists, and when a URL or FQDN action fires on it, it triggers everything in the corresponding list. This is obviously wrong.

This commit fixes this as follows. Each kprobe stores a table of URLs and FQDNs that it references, each entry with its own index. These indices are provided in the config to the match actions in the selectors, and the BPF program reports the matching index. In user space, the URL or FQDN is retrieved from the table using this index.

Note that only one URL and/or FQDN action is permitted per selector. It will be possible to enable multiple if necessary, but it is deemed that a single trigger should be sufficient to trigger any further triggers.

[Upstream commit: 15d2eaa]