### PR TITLE
tetragon: tty monitoring

### DIFF
--- a/bpf/include/vmlinux.h
+++ b/bpf/include/vmlinux.h
@@ -11800,21 +11800,30 @@ struct iovec;
 struct kvec;
 
 struct iov_iter {
-	unsigned int type;
-	size_t iov_offset;
+	u8 iter_type;
+	bool nofault;
+	bool data_source;
+	bool user_backed;
+	union {
+		size_t iov_offset;
+		int last_offset;
+	};
 	size_t count;
 	union {
 		const struct iovec *iov;
 		const struct kvec *kvec;
 		const struct bio_vec *bvec;
+		struct xarray *xarray;
 		struct pipe_inode_info *pipe;
+		void *ubuf;
 	};
 	union {
-		long unsigned int nr_segs;
+		unsigned long nr_segs;
 		struct {
 			unsigned int head;
 			unsigned int start_head;
 		};
+		loff_t xarray_start;
 	};
 };
 
@@ -36839,11 +36848,14 @@ enum mapping_flags {
 };
 
 enum iter_type {
-	ITER_IOVEC = 4,
-	ITER_KVEC = 8,
-	ITER_BVEC = 16,
-	ITER_PIPE = 32,
-	ITER_DISCARD = 64,
+	/* iter types */
+	ITER_IOVEC,
+	ITER_KVEC,
+	ITER_BVEC,
+	ITER_PIPE,
+	ITER_XARRAY,
+	ITER_DISCARD,
+	ITER_UBUF,
 };
 
 struct pagevec {

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -51,6 +51,8 @@ enum {
 	user_namespace_type = 22,
 	capability_type = 23,
 
+	kiocb_type = 24,
+
 	nop_s64_ty = -10,
 	nop_u64_ty = -11,
 	nop_u32_ty = -12,
@@ -1794,6 +1796,15 @@ read_call_arg(void *ctx, struct msg_generic_kprobe *e, int index, int type,
 	e->argsoff[index] = orig_off;
 
 	switch (type) {
+	case kiocb_type: {
+		struct kiocb *kiocb = (struct kiocb *)arg;
+		struct file *file;
+
+		arg = (unsigned long)_(&kiocb->ki_filp);
+		probe_read(&file, sizeof(file), (const void *)arg);
+		arg = (unsigned long)file;
+	}
+		// fallthrough to file_ty
 	case file_ty: {
 		struct file *file;
 		probe_read(&file, sizeof(file), &arg);

--- a/cmd/tetra/common/flags.go
+++ b/cmd/tetra/common/flags.go
@@ -7,5 +7,6 @@ const (
 	KeyColor         = "color"          // string
 	KeyDebug         = "debug"          // bool
 	KeyOutput        = "output"         // string
+	KeyTty           = "tty-encode"     // string
 	KeyServerAddress = "server-address" // string
 )

--- a/examples/tracingpolicy/tty.yaml
+++ b/examples/tracingpolicy/tty.yaml
@@ -1,0 +1,14 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tty"
+spec:
+  kprobes:
+  - call: "tty_write"
+    syscall: false
+    args:
+    - index: 0
+      type: "kiocb"
+    - index: 1
+      type: "iov_iter"
+      maxData: true

--- a/examples/tracingpolicy/tty_419.yaml
+++ b/examples/tracingpolicy/tty_419.yaml
@@ -1,0 +1,16 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tty"
+spec:
+  kprobes:
+  - call: "tty_write"
+    syscall: false
+    args:
+    - index: 0
+      type: "file"
+    - index: 1
+      type: "char_buf"
+      sizeArgIndex: 3
+    - index: 2
+      type: "size_t"

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -31,6 +31,8 @@ const (
 	GenericUserNamespace = 22
 	GenericCapability    = 23
 
+	GenericKiocb = 24
+
 	GenericNopType     = -1
 	GenericInvalidType = -2
 )
@@ -83,6 +85,8 @@ func GenericTypeFromString(arg string) int {
 		return GenericUserNamespace
 	case "capability":
 		return GenericCapability
+	case "kiocb":
+		return GenericKiocb
 	default:
 		return GenericInvalidType
 	}

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -31,7 +31,8 @@ const (
 	GenericUserNamespace = 22
 	GenericCapability    = 23
 
-	GenericKiocb = 24
+	GenericKiocb   = 24
+	GenericIovIter = 25
 
 	GenericNopType     = -1
 	GenericInvalidType = -2
@@ -87,6 +88,8 @@ func GenericTypeFromString(arg string) int {
 		return GenericCapability
 	case "kiocb":
 		return GenericKiocb
+	case "iov_iter":
+		return GenericIovIter
 	default:
 		return GenericInvalidType
 	}

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -102,6 +102,7 @@ spec:
                             - bpf_map
                             - user_namespace
                             - capability
+                            - kiocb
                             type: string
                         required:
                         - index
@@ -176,6 +177,7 @@ spec:
                           - bpf_map
                           - user_namespace
                           - capability
+                          - kiocb
                           type: string
                       required:
                       - index
@@ -628,6 +630,7 @@ spec:
                             - bpf_map
                             - user_namespace
                             - capability
+                            - kiocb
                             type: string
                         required:
                         - index

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -103,6 +103,7 @@ spec:
                             - user_namespace
                             - capability
                             - kiocb
+                            - iov_iter
                             type: string
                         required:
                         - index
@@ -178,6 +179,7 @@ spec:
                           - user_namespace
                           - capability
                           - kiocb
+                          - iov_iter
                           type: string
                       required:
                       - index
@@ -631,6 +633,7 @@ spec:
                             - user_namespace
                             - capability
                             - kiocb
+                            - iov_iter
                             type: string
                         required:
                         - index

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -102,6 +102,7 @@ spec:
                             - bpf_map
                             - user_namespace
                             - capability
+                            - kiocb
                             type: string
                         required:
                         - index
@@ -176,6 +177,7 @@ spec:
                           - bpf_map
                           - user_namespace
                           - capability
+                          - kiocb
                           type: string
                       required:
                       - index
@@ -628,6 +630,7 @@ spec:
                             - bpf_map
                             - user_namespace
                             - capability
+                            - kiocb
                             type: string
                         required:
                         - index

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -103,6 +103,7 @@ spec:
                             - user_namespace
                             - capability
                             - kiocb
+                            - iov_iter
                             type: string
                         required:
                         - index
@@ -178,6 +179,7 @@ spec:
                           - user_namespace
                           - capability
                           - kiocb
+                          - iov_iter
                           type: string
                       required:
                       - index
@@ -631,6 +633,7 @@ spec:
                             - user_namespace
                             - capability
                             - kiocb
+                            - iov_iter
                             type: string
                         required:
                         - index

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -129,7 +129,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;
+	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;
 	// Argument type.
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -129,7 +129,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;
+	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;
 	// Argument type.
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -950,7 +950,7 @@ func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
 			arg.Value = output
 			arg.Label = a.label
 			unix.Args = append(unix.Args, arg)
-		case gt.GenericFileType, gt.GenericFdType:
+		case gt.GenericFileType, gt.GenericFdType, gt.GenericKiocb:
 			var arg api.MsgGenericKprobeArgFile
 			var flags uint32
 			var b int32

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -1026,7 +1026,7 @@ func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
 			arg.Inheritable = cred.Inheritable
 			arg.Label = a.label
 			unix.Args = append(unix.Args, arg)
-		case gt.GenericCharBuffer, gt.GenericCharIovec:
+		case gt.GenericCharBuffer, gt.GenericCharIovec, gt.GenericIovIter:
 			if arg, err := ReadArgBytes(r, a.index, a.maxData); err == nil {
 				arg.Label = a.label
 				unix.Args = append(unix.Args, *arg)

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -102,6 +102,7 @@ spec:
                             - bpf_map
                             - user_namespace
                             - capability
+                            - kiocb
                             type: string
                         required:
                         - index
@@ -176,6 +177,7 @@ spec:
                           - bpf_map
                           - user_namespace
                           - capability
+                          - kiocb
                           type: string
                       required:
                       - index
@@ -628,6 +630,7 @@ spec:
                             - bpf_map
                             - user_namespace
                             - capability
+                            - kiocb
                             type: string
                         required:
                         - index

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -103,6 +103,7 @@ spec:
                             - user_namespace
                             - capability
                             - kiocb
+                            - iov_iter
                             type: string
                         required:
                         - index
@@ -178,6 +179,7 @@ spec:
                           - user_namespace
                           - capability
                           - kiocb
+                          - iov_iter
                           type: string
                       required:
                       - index
@@ -631,6 +633,7 @@ spec:
                             - user_namespace
                             - capability
                             - kiocb
+                            - iov_iter
                             type: string
                         required:
                         - index

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -102,6 +102,7 @@ spec:
                             - bpf_map
                             - user_namespace
                             - capability
+                            - kiocb
                             type: string
                         required:
                         - index
@@ -176,6 +177,7 @@ spec:
                           - bpf_map
                           - user_namespace
                           - capability
+                          - kiocb
                           type: string
                       required:
                       - index
@@ -628,6 +630,7 @@ spec:
                             - bpf_map
                             - user_namespace
                             - capability
+                            - kiocb
                             type: string
                         required:
                         - index

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -103,6 +103,7 @@ spec:
                             - user_namespace
                             - capability
                             - kiocb
+                            - iov_iter
                             type: string
                         required:
                         - index
@@ -178,6 +179,7 @@ spec:
                           - user_namespace
                           - capability
                           - kiocb
+                          - iov_iter
                           type: string
                       required:
                       - index
@@ -631,6 +633,7 @@ spec:
                             - user_namespace
                             - capability
                             - kiocb
+                            - iov_iter
                             type: string
                         required:
                         - index

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -129,7 +129,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;
+	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;
 	// Argument type.
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -129,7 +129,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;
+	// +kubebuilder:validation:Enum=int;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;
 	// Argument type.
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
Adding way to monitor terminals, with following crd:

```
# ./tetragon --bpf-lib ./bpf/objs/ --config-file ./examples/tracingpolicy/tty.yaml
```
run on monitored terminal:
```
# tty
/dev/pts/1
...
```
on another terminal:
```
# tetra getevents --tty-encode=/dev/pts/1
...
```
you should see data from monitored terminal.

Works on 6.x kernels so far.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>