### PR TITLE
Add support for arm64 for building, running and testing

### DIFF
--- a/bpf/include/vmlinux.h
+++ b/bpf/include/vmlinux.h
@@ -1411,6 +1411,8 @@ struct range {
 	u64 end;
 };
 
+#if defined(__TARGET_ARCH_x86)
+
 struct pt_regs {
 	long unsigned int r15;
 	long unsigned int r14;
@@ -1434,6 +1436,40 @@ struct pt_regs {
 	long unsigned int sp;
 	long unsigned int ss;
 };
+
+#elif defined(__TARGET_ARCH_arm64)
+/* definitions for arm64 in this vmlinux.h file might be incomplete or wrong
+ * for more information, see: https://github.com/cilium/tetragon/issues/786
+ */
+
+struct user_pt_regs {
+	__u64 regs[31];
+	__u64 sp;
+	__u64 pc;
+	__u64 pstate;
+};
+
+struct pt_regs {
+	union {
+		struct user_pt_regs user_regs;
+		struct {
+			u64 regs[31];
+			u64 sp;
+			u64 pc;
+			u64 pstate;
+		};
+	};
+	u64 orig_x0;
+	s32 syscallno;
+	u32 unused2;
+	u64 sdei_ttbr1;
+	u64 pmr_save;
+	u64 stackframe[2];
+	u64 lockdep_hardirqs;
+	u64 exit_rcu;
+};
+
+#endif
 
 struct desc_ptr {
 	short unsigned int size;

--- a/bpf/libbpf/bpf_tracing.h
+++ b/bpf/libbpf/bpf_tracing.h
@@ -142,7 +142,7 @@ struct pt_regs___arm64 {
 #define __PT_SP_REG sp
 #define __PT_IP_REG pc
 #define PT_REGS_PARM1_SYSCALL(x) PT_REGS_PARM1_CORE_SYSCALL(x)
-#define PT_REGS_PARM1_CORE_SYSCALL(x) BPF_CORE_READ((const struct pt_regs___arm64 *)(x), orig_x0)
+#define PT_REGS_PARM1_CORE_SYSCALL(x) (unsigned long)BPF_CORE_READ((const struct pt_regs___arm64 *)(x), orig_x0)
 
 #elif defined(bpf_target_mips)
 

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"testing"
 )
 
 var supportedArchPrefix = map[string]string{"amd64": "__x64_", "arm64": "__arm64_"}
@@ -41,9 +42,15 @@ func AddSyscallPrefix(symbol string) (string, error) {
 	return addSyscallPrefix(symbol, runtime.GOARCH)
 }
 
-// MustAddSyscallPrefix is like AddSyscallPrefix but panics if the arch is
-// unsupported or if the symbol has already a prefix that doesn't correspond to
-// the running arch.
+// AddSyscallPrefixTestHelper is like AddSyscallPrefix but calls t.Fatal if the
+// arch is unsupported or if the symbol has already a prefix that doesn't
+// correspond to the running arch.
 //
 // It's a helper supposed to be used only in testing code.
-func MustAddSyscallPrefix(symbol string) string
+func AddSyscallPrefixTestHelper(t *testing.T, symbol string) string {
+	syscallName, err := AddSyscallPrefix(symbol)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return syscallName
+}

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -1,0 +1,49 @@
+package arch
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+var supportedArchPrefix = map[string]string{"amd64": "__x64_", "arm64": "__arm64_"}
+
+func addSyscallPrefix(symbol string, arch string) (string, error) {
+	for prefix_arch, prefix := range supportedArchPrefix {
+		if strings.HasPrefix(symbol, prefix) {
+			// check that the prefix found is the correct one
+			if prefix_arch != arch {
+				return "", fmt.Errorf("expecting %s and got %s", supportedArchPrefix[arch], prefix)
+			}
+			return symbol, nil
+		}
+	}
+	if prefix, found := supportedArchPrefix[arch]; found {
+		return prefix + symbol, nil
+	}
+	return "", fmt.Errorf("unsupported architecture %s", arch)
+}
+
+// AddSyscallPrefix detects if the symbol is already prefixed with arch specific
+// prefix in the form of "__x64_" or "__arm64_", and if not, adds it based on
+// provided arch.
+//
+// Note that cilium/ebpf, retries to attach to an arch specific version of the
+// symbol after a failure thus making possible to attach to "sys_listen" which
+// will fail and retry with the corrected "__arm64_sys_listen" if you are
+// running on arm64. See https://github.com/cilium/ebpf/pull/304.  However, this
+// causes Tetragon users to believe that two symbols exist (following the same
+// example) "__arm64_sys_listen" and "sys_listen", which results in differents
+// events.  Because we actually know if a call is a syscall, we can pre-format
+// the symbol directly here to allow the user to specify the "sys_listen"
+// version while only registering the real symbol "__arm64_sys_listen".
+func AddSyscallPrefix(symbol string) (string, error) {
+	return addSyscallPrefix(symbol, runtime.GOARCH)
+}
+
+// MustAddSyscallPrefix is like AddSyscallPrefix but panics if the arch is
+// unsupported or if the symbol has already a prefix that doesn't correspond to
+// the running arch.
+//
+// It's a helper supposed to be used only in testing code.
+func MustAddSyscallPrefix(symbol string) string

--- a/pkg/arch/arch_test.go
+++ b/pkg/arch/arch_test.go
@@ -1,4 +1,4 @@
-package tracing
+package arch
 
 import (
 	"testing"

--- a/pkg/bench/trace_bench_open.go
+++ b/pkg/bench/trace_bench_open.go
@@ -81,7 +81,7 @@ metadata:
   name: "sys-write-writev"
 spec:
   kprobes:
-  - call: "__x64_sys_openat"
+  - call: "sys_openat"
     syscall: true
     args:
     - index: 0

--- a/pkg/bench/trace_bench_rw.go
+++ b/pkg/bench/trace_bench_rw.go
@@ -127,7 +127,7 @@ metadata:
   name: "sys-write-writev"
 spec:
   kprobes:
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0
@@ -137,7 +137,7 @@ spec:
       sizeArgIndex: 3
     - index: 2
       type: "int"
-  - call: "__x64_sys_read"
+  - call: "sys_read"
     syscall: true
     return: true
     args:

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -26,7 +26,7 @@ metadata:
   name: "sys-write"
 spec:
   kprobes:
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     return: false
     syscall: true
     args:
@@ -93,7 +93,7 @@ var expectedWrite = GenericTracingConf{
 	Spec: v1alpha1.TracingPolicySpec{
 		KProbes: []v1alpha1.KProbeSpec{
 			{
-				Call:    "__x64_sys_write",
+				Call:    "sys_write",
 				Return:  false,
 				Syscall: true,
 				Args: []v1alpha1.KProbeArg{

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -452,7 +452,7 @@ func TestDocker(t *testing.T) {
 	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 
 	readyWG.Wait()
-	serverDockerID := observer.DockerRun(t, "--name", "fgs-test-server", "--entrypoint", "nc", "quay.io/cilium/alpine-curl:1.0", "-nvlp", "8081", "-s", "0.0.0.0")
+	serverDockerID := observer.DockerRun(t, "--name", "fgs-test-server", "--entrypoint", "nc", "quay.io/cilium/alpine-curl:v1.6.0", "-nvlp", "8081", "-s", "0.0.0.0")
 	time.Sleep(1 * time.Second)
 
 	// Tetragon sends 31 bytes + \0 to user-space. Since it might have an arbitrary prefix,

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -14,14 +14,13 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strconv"
-	"strings"
 	"sync/atomic"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
+	"github.com/cilium/tetragon/pkg/arch"
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
@@ -64,8 +63,6 @@ const (
 
 	MaxKprobesMulti = 100 // MAX_ENTRIES_CONFIG in bpf code
 )
-
-var supportedArchPrefix = map[string]string{"amd64": "__x64_", "arm64": "__arm64_"}
 
 func kprobeCharBufErrorToString(e int32) string {
 	switch e {
@@ -259,35 +256,6 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 	return progs, maps
 }
 
-// addSyscallPrefix detects if the symbol is already prefixed with arch specific
-// prefix in the form of "__x64_" or "__arm64_", and if not, adds it based on
-// provided arch.
-//
-// Note that cilium/ebpf, retries to attach to an arch specific version of the
-// symbol after a failure thus making possible to attach to "sys_listen" which
-// will fail and retry with the corrected "__arm64_sys_listen" if you are
-// running on arm64. See https://github.com/cilium/ebpf/pull/304.  However, this
-// causes Tetragon users to believe that two symbols exist (following the same
-// example) "__arm64_sys_listen" and "sys_listen", which results in differents
-// events.  Because we actually know if a call is a syscall, we can pre-format
-// the symbol directly here to allow the user to specify the "sys_listen"
-// version while only registering the real symbol "__arm64_sys_listen".
-func addSyscallPrefix(symbol string, arch string) (string, error) {
-	for prefix_arch, prefix := range supportedArchPrefix {
-		if strings.HasPrefix(symbol, prefix) {
-			// check that the prefix found is the correct one
-			if prefix_arch != arch {
-				return "", fmt.Errorf("expecting %s and got %s", supportedArchPrefix[arch], prefix)
-			}
-			return symbol, nil
-		}
-	}
-	if prefix, found := supportedArchPrefix[arch]; found {
-		return prefix + symbol, nil
-	}
-	return "", fmt.Errorf("unsupported architecture %s", arch)
-}
-
 func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sensors.Sensor, error) {
 	var progs []*program.Program
 	var maps []*program.Map
@@ -320,7 +288,7 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 		// modifying f.Call directly instead of writing to funcName
 		// because of BTF validation later using the whole v1alpha1.KProbeSpec object
 		if f.Syscall {
-			prefixedName, err := addSyscallPrefix(f.Call, runtime.GOARCH)
+			prefixedName, err := arch.AddSyscallPrefix(f.Call)
 			if err != nil {
 				logger.GetLogger().Warnf("kprobe syscall prefix: %w", err)
 			} else {

--- a/pkg/sensors/tracing/kprobe_copyfd_test.go
+++ b/pkg/sensors/tracing/kprobe_copyfd_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/arch"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/kernels"
 	bc "github.com/cilium/tetragon/pkg/matchers/bytesmatcher"
@@ -87,7 +88,7 @@ func TestCopyFd(t *testing.T) {
 	}
 
 	kpChecker := ec.NewProcessKprobeChecker("").
-		WithFunctionName(sm.Full("__x64_sys_read")).
+		WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_read"))).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(

--- a/pkg/sensors/tracing/kprobe_filterchange_test.go
+++ b/pkg/sensors/tracing/kprobe_filterchange_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/arch"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/kernels"
 	bc "github.com/cilium/tetragon/pkg/matchers/bytesmatcher"
@@ -89,7 +90,7 @@ func TestKprobeNSChanges(t *testing.T) {
 	writeArg2 := ec.NewKprobeArgumentChecker().WithSizeArg(9)
 
 	kprobeChecker := ec.NewProcessKprobeChecker("").
-		WithFunctionName(sm.Full("__x64_sys_write")).
+		WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_write"))).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(
@@ -170,7 +171,7 @@ func testKprobeCapChanges(t *testing.T, spec string, op string, value string) {
 	writeArg2 := ec.NewKprobeArgumentChecker().WithSizeArg(9)
 
 	kprobeChecker := ec.NewProcessKprobeChecker("").
-		WithFunctionName(sm.Full("__x64_sys_write")).
+		WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_write"))).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(

--- a/pkg/sensors/tracing/kprobe_sigkill_test.go
+++ b/pkg/sensors/tracing/kprobe_sigkill_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/arch"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/kernels"
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
@@ -94,7 +95,7 @@ func TestKprobeSigkill(t *testing.T) {
 	}
 
 	kpChecker := ec.NewProcessKprobeChecker("").
-		WithFunctionName(sm.Full("__x64_sys_lseek")).
+		WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_lseek"))).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
+	"github.com/cilium/tetragon/pkg/arch"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/idtable"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
@@ -293,7 +294,7 @@ func TestKprobeSelectors(t *testing.T) {
 		sels := selectorsFromWhenceVals(t, filterWhenceVals, 2 /* whenceIdx */, filterOperator)
 		spec := v1alpha1.TracingPolicySpec{
 			KProbes: []v1alpha1.KProbeSpec{{
-				Call:    "__x64_sys_lseek",
+				Call:    "sys_lseek",
 				Return:  true,
 				Syscall: true,
 				ReturnArg: v1alpha1.KProbeArg{
@@ -317,7 +318,7 @@ func TestKprobeSelectors(t *testing.T) {
 		ret := make(map[uint64]int)
 		perfring.RunSubTest(t, ctx, name, op, func(ev notify.Message) error {
 			if kpEvent, ok := ev.(*tracing.MsgGenericKprobeUnix); ok {
-				if kpEvent.FuncName != "__x64_sys_lseek" {
+				if kpEvent.FuncName != arch.AddSyscallPrefixTestHelper(t, "sys_lseek") {
 					return fmt.Errorf("unexpected kprobe event, func:%s", kpEvent.FuncName)
 				}
 				if len(kpEvent.Args) != 2 {

--- a/pkg/tracepoint/tracepoint_test.go
+++ b/pkg/tracepoint/tracepoint_test.go
@@ -5,6 +5,7 @@ package tracepoint
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/cilium/tetragon/pkg/kernels"
@@ -22,20 +23,27 @@ func TestTracepointLoadFormat(t *testing.T) {
 		t.FailNow()
 	}
 
+	// the standard does not specify if char is signed or not
+	// historically, it's signed on amd64 and unsigned on arm64
+	isCharSigned := true
+	if runtime.GOARCH == "arm64" {
+		isCharSigned = false
+	}
+
 	var commField FieldFormat
 	if kernels.MinKernelVersion("5.17.0") {
 		commField = FieldFormat{
 			FieldStr: "char comm[TASK_COMM_LEN]",
 			Offset:   12,
 			Size:     16,
-			IsSigned: true,
+			IsSigned: isCharSigned,
 		}
 	} else {
 		commField = FieldFormat{
 			FieldStr: "char comm[16]",
 			Offset:   12,
 			Size:     16,
-			IsSigned: true,
+			IsSigned: isCharSigned,
 		}
 	}
 

--- a/testdata/specs/capchanges.yaml.tmpl
+++ b/testdata/specs/capchanges.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
       - action: FollowFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0

--- a/testdata/specs/copyfd-__fd_install.yaml.tmpl
+++ b/testdata/specs/copyfd-__fd_install.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
       - action: FollowFD
         argFd: 1
         argName: 2
-  - call: "__x64_sys_dup2"
+  - call: "sys_dup2"
     syscall: true
     args:
     - index: 0
@@ -50,7 +50,7 @@ spec:
       - action: CopyFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_dup3"
+  - call: "sys_dup3"
     syscall: true
     args:
     - index: 0
@@ -74,7 +74,7 @@ spec:
       - action: CopyFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_close"
+  - call: "sys_close"
     syscall: true
     args:
     - index: 0
@@ -89,7 +89,7 @@ spec:
       - action: UnfollowFD
         argFd: 0
         argName: 0
-  - call: "__x64_sys_read"
+  - call: "sys_read"
     syscall: true
     args:
     - index: 0

--- a/testdata/specs/copyfd-fd_install.yaml.tmpl
+++ b/testdata/specs/copyfd-fd_install.yaml.tmpl
@@ -26,7 +26,7 @@ spec:
       - action: FollowFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_dup2"
+  - call: "sys_dup2"
     syscall: true
     args:
     - index: 0
@@ -48,7 +48,7 @@ spec:
       - action: CopyFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_dup3"
+  - call: "sys_dup3"
     syscall: true
     args:
     - index: 0
@@ -72,7 +72,7 @@ spec:
       - action: CopyFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_close"
+  - call: "sys_close"
     syscall: true
     args:
     - index: 0
@@ -87,7 +87,7 @@ spec:
       - action: UnfollowFD
         argFd: 0
         argName: 0
-  - call: "__x64_sys_read"
+  - call: "sys_read"
     syscall: true
     args:
     - index: 0

--- a/testdata/specs/nschanges.yaml.tmpl
+++ b/testdata/specs/nschanges.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
       - action: FollowFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0

--- a/testdata/specs/sigkill.yaml.tmpl
+++ b/testdata/specs/sigkill.yaml.tmpl
@@ -5,7 +5,7 @@ metadata:
   name: "sigkilltest"
 spec:
   kprobes:
-  - call: "__x64_sys_lseek"
+  - call: "sys_lseek"
     syscall: true
     args:
     - index: 2

--- a/testdata/specs/syslseek.yaml
+++ b/testdata/specs/syslseek.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "sys-lseek"
 spec:
   kprobes:
-  - call: "__x64_sys_lseek"
+  - call: "sys_lseek"
     syscall: true
     args:
     - index: 0

--- a/testdata/specs/syswrongargindex.yaml
+++ b/testdata/specs/syswrongargindex.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "sys-lseek"
 spec:
   kprobes:
-  - call: "__x64_sys_lseek"
+  - call: "sys_lseek"
     syscall: true
     args:
     - index: 100

--- a/testdata/specs/syswrongargtype.yaml
+++ b/testdata/specs/syswrongargtype.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "sys-lseek"
 spec:
   kprobes:
-  - call: "__x64_sys_lseek"
+  - call: "sys_lseek"
     syscall: true
     args:
     - index: 0


### PR DESCRIPTION
Thanks to the work done previously (see https://github.com/cilium/tetragon/issues/487), it is pretty straightforward to build Tetragon on arm64 and it seems to mostly work out of the box. The exec probes seem to be working, and I tried to load some TracingPolicy with kprobe hooks that just worked.

### Building

~~The makefile assumes that we are building using the clang docker image by default, and this one is built only for amd64 at the moment. I saw there was previously a PR attempt https://github.com/cilium/tetragon/pull/50 that was unfortunately reverted https://github.com/cilium/tetragon/pull/55 because it might have been really too early to build every images for arm64 (including the Tetragon one). It would simplify the workflow to build a multi-arch image and use it in the Makefile.~~

- [x] Build the clang image for arm64 via emulation, push a multi-arch image and update the Makefile with the new multi-arch image
   https://github.com/cilium/tetragon/pull/743

This part is done, and we can now easily build on arm64 just by using `make tetragon-bpf`.

### Tests

~~I tried running the tests on arm64 and some stuff broke with obvious issues displaying messages like:~~
```text
failed: creating perf_kprobe PMU: token __arm64___x64_sys_dup2: not found: no such file or directory
```
~~So we might have some quick wins on the tests and maybe some other more difficult things to fix.~~

- [x] Some docker image used in the test could not run on arm64, bumping tag was enough: https://github.com/cilium/tetragon/pull/734/commits/0be8dae2e45bd037432b341afa75927bc318167c
- [x] Issue: https://github.com/cilium/tetragon/pull/751
   PR: https://github.com/cilium/tetragon/pull/752
   Adapt the templates and the check to the new prefix-less syscalls symbols, see https://github.com/cilium/tetragon/pull/734/commits/d8fda5cd17a7b6d28d9533b2c0ee6a2c3cefb5bc.
- [x] Adapt a test on Tracepoint format because `char` is unsigned on arm64, contrary to amd64, see [Tracepoint: adapt a format test on task_newtask to arm64](https://github.com/cilium/tetragon/pull/734/commits/4ce7bdf4c359f198c7bb93b2669d57fb7bdf0387).

This part is done! Now tests can run on amd64 and arm64! 🥳 

### Trying Tetragon on arm64

```shell
# synchronize your git repo to my branch
git fetch && git checkout pr/mtardy/arm64
# compile Tetragon and the BPF programs
make tetragon tetragon-bpf
# run with
sudo ./tetragon --bpf-lib bpf/objs
```

