### PR TITLE
Unpin buildx version in CI

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -54,6 +52,7 @@ jobs:
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
         id: docker_build_release
         with:
+          provenance: false
           context: .
           file: ./Dockerfile.clang
           push: true

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to quay.io for CI
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -77,6 +75,7 @@ jobs:
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
         id: docker_build_ci_main
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
@@ -131,6 +130,7 @@ jobs:
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
         id: docker_build_ci_pr
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: true

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-        with:
-          version: v0.9.1
 
       - name: Login to quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -57,6 +55,7 @@ jobs:
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
         id: docker_build_release
         with:
+          provenance: false
           context: .
           file: ${{ matrix.dockerfile }}
           push: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
@@ -165,8 +164,6 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
-        with:
-          go-version: 1.19.1
 
       - name: Generate tetra CLI artifacts
         run: make cli-release


### PR DESCRIPTION
Related to commit [`f1cbb5f`](https://github.com/cilium/cilium/commit/f1cbb5f8a908659817e5c0e6a3692424fa647ab9) on cilium/cilium.

GitHub recently rolled out Docker buildx version v0.10.0 on their builders, which transparently changed the MediaType of docker images to OCI v1 and added provenance attestations.

Unfortunately, various tools we use in CI like SBOM tooling and docker manifest inspect do not properly support some aspect of the new image formats. This resulted in breaking CI, with some messages like this:

    level=fatal msg="generating doc: creating SPDX document: generating
    SPDX package from image ref quay.io/cilium/docker-plugin-ci:XXX:
    generating image package"

This could also lead CI to fail while waiting for image builds to complete, because the command we use to test whether the image is available did not support the image types.

The commit 7f9ac8a attempted to fix this problem by pinning the buildx version to v0.9.1 but unfortunately that didn't work since that version became unavailable. This commit reverts those changes and adds the "provenance: false", which is a flag available in docker buildx >= v0.10.0, to disable the provenance attestation.