### PR TITLE
tetragon: Get rid of generic_process_event* functions

### DIFF
--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -143,37 +143,37 @@ generic_kprobe_process_event0(void *ctx)
 __attribute__((section("kprobe/1"), used)) int
 generic_kprobe_process_event1(void *ctx)
 {
-	return generic_process_event1(ctx,
-				      (struct bpf_map_def *)&process_call_heap,
-				      (struct bpf_map_def *)&kprobe_calls,
-				      (struct bpf_map_def *)&config_map);
+	return generic_process_event(ctx, 1,
+				     (struct bpf_map_def *)&process_call_heap,
+				     (struct bpf_map_def *)&kprobe_calls,
+				     (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("kprobe/2"), used)) int
 generic_kprobe_process_event2(void *ctx)
 {
-	return generic_process_event2(ctx,
-				      (struct bpf_map_def *)&process_call_heap,
-				      (struct bpf_map_def *)&kprobe_calls,
-				      (struct bpf_map_def *)&config_map);
+	return generic_process_event(ctx, 2,
+				     (struct bpf_map_def *)&process_call_heap,
+				     (struct bpf_map_def *)&kprobe_calls,
+				     (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("kprobe/3"), used)) int
 generic_kprobe_process_event3(void *ctx)
 {
-	return generic_process_event3(ctx,
-				      (struct bpf_map_def *)&process_call_heap,
-				      (struct bpf_map_def *)&kprobe_calls,
-				      (struct bpf_map_def *)&config_map);
+	return generic_process_event(ctx, 3,
+				     (struct bpf_map_def *)&process_call_heap,
+				     (struct bpf_map_def *)&kprobe_calls,
+				     (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("kprobe/4"), used)) int
 generic_kprobe_process_event4(void *ctx)
 {
-	return generic_process_event4(ctx,
-				      (struct bpf_map_def *)&process_call_heap,
-				      (struct bpf_map_def *)&kprobe_calls,
-				      (struct bpf_map_def *)&config_map);
+	return generic_process_event(ctx, 4,
+				     (struct bpf_map_def *)&process_call_heap,
+				     (struct bpf_map_def *)&kprobe_calls,
+				     (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("kprobe/5"), used)) int

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -188,41 +188,41 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 __attribute__((section("tracepoint/0"), used)) int
 generic_tracepoint_event0(void *ctx)
 {
-	return generic_process_event0(ctx, (struct bpf_map_def *)&tp_heap,
-				      (struct bpf_map_def *)&tp_calls,
-				      (struct bpf_map_def *)&config_map);
+	return generic_process_event(ctx, 0, (struct bpf_map_def *)&tp_heap,
+				     (struct bpf_map_def *)&tp_calls,
+				     (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/1"), used)) int
 generic_tracepoint_event1(void *ctx)
 {
-	return generic_process_event1(ctx, (struct bpf_map_def *)&tp_heap,
-				      (struct bpf_map_def *)&tp_calls,
-				      (struct bpf_map_def *)&config_map);
+	return generic_process_event(ctx, 1, (struct bpf_map_def *)&tp_heap,
+				     (struct bpf_map_def *)&tp_calls,
+				     (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/2"), used)) int
 generic_tracepoint_event2(void *ctx)
 {
-	return generic_process_event2(ctx, (struct bpf_map_def *)&tp_heap,
-				      (struct bpf_map_def *)&tp_calls,
-				      (struct bpf_map_def *)&config_map);
+	return generic_process_event(ctx, 2, (struct bpf_map_def *)&tp_heap,
+				     (struct bpf_map_def *)&tp_calls,
+				     (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/3"), used)) int
 generic_tracepoint_event3(void *ctx)
 {
-	return generic_process_event3(ctx, (struct bpf_map_def *)&tp_heap,
-				      (struct bpf_map_def *)&tp_calls,
-				      (struct bpf_map_def *)&config_map);
+	return generic_process_event(ctx, 3, (struct bpf_map_def *)&tp_heap,
+				     (struct bpf_map_def *)&tp_calls,
+				     (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/4"), used)) int
 generic_tracepoint_event4(void *ctx)
 {
-	return generic_process_event4(ctx, (struct bpf_map_def *)&tp_heap,
-				      (struct bpf_map_def *)&tp_calls,
-				      (struct bpf_map_def *)&config_map);
+	return generic_process_event(ctx, 4, (struct bpf_map_def *)&tp_heap,
+				     (struct bpf_map_def *)&tp_calls,
+				     (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/5"), used)) int

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -159,6 +159,8 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
+	generic_process_init(msg, MSG_OP_GENERIC_TRACEPOINT, config);
+
 	msg->common.op = MSG_OP_GENERIC_TRACEPOINT;
 	msg->sel.curr = 0;
 #pragma unroll


### PR DESCRIPTION
Getting rid of generic_process_event* functions, one is enough.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
