### PR TITLE
Make functions in pkg/selectors/kernel.go public

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -249,7 +249,7 @@ func pidSelectorValue(pid *v1alpha1.PIDSelector) ([]byte, uint32) {
 	return b, uint32(len(b))
 }
 
-func parseMatchPid(k *KernelSelectorState, pid *v1alpha1.PIDSelector) error {
+func ParseMatchPid(k *KernelSelectorState, pid *v1alpha1.PIDSelector) error {
 	op, err := selectorOp(pid.Operator)
 	if err != nil {
 		return fmt.Errorf("matchpid error: %w", err)
@@ -265,10 +265,10 @@ func parseMatchPid(k *KernelSelectorState, pid *v1alpha1.PIDSelector) error {
 	return nil
 }
 
-func parseMatchPids(k *KernelSelectorState, matchPids []v1alpha1.PIDSelector) error {
+func ParseMatchPids(k *KernelSelectorState, matchPids []v1alpha1.PIDSelector) error {
 	loff := AdvanceSelectorLength(k)
 	for _, p := range matchPids {
-		if err := parseMatchPid(k, &p); err != nil {
+		if err := ParseMatchPid(k, &p); err != nil {
 			return err
 		}
 	}
@@ -365,7 +365,7 @@ func writeMatchValues(k *KernelSelectorState, values []string, ty uint32) error 
 	return nil
 }
 
-func parseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1alpha1.KProbeArg) error {
+func ParseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1alpha1.KProbeArg) error {
 	WriteSelectorUint32(k, arg.Index)
 
 	op, err := selectorOp(arg.Operator)
@@ -395,10 +395,10 @@ func parseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 	WriteSelectorLength(k, moff)
 	return nil
 }
-func parseMatchArgs(k *KernelSelectorState, args []v1alpha1.ArgSelector, sig []v1alpha1.KProbeArg) error {
+func ParseMatchArgs(k *KernelSelectorState, args []v1alpha1.ArgSelector, sig []v1alpha1.KProbeArg) error {
 	loff := AdvanceSelectorLength(k)
 	for _, a := range args {
-		if err := parseMatchArg(k, &a, sig); err != nil {
+		if err := ParseMatchArg(k, &a, sig); err != nil {
 			return err
 		}
 	}
@@ -406,7 +406,7 @@ func parseMatchArgs(k *KernelSelectorState, args []v1alpha1.ArgSelector, sig []v
 	return nil
 }
 
-func parseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, actionArgTable *idtable.Table) error {
+func ParseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, actionArgTable *idtable.Table) error {
 	act, ok := actionTypeTable[strings.ToLower(action.Action)]
 	if !ok {
 		return fmt.Errorf("parseMatchAction: ActionType %s unknown", action.Action)
@@ -434,10 +434,10 @@ func parseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, a
 	return nil
 }
 
-func parseMatchActions(k *KernelSelectorState, actions []v1alpha1.ActionSelector, actionArgTable *idtable.Table) error {
+func ParseMatchActions(k *KernelSelectorState, actions []v1alpha1.ActionSelector, actionArgTable *idtable.Table) error {
 	loff := AdvanceSelectorLength(k)
 	for _, a := range actions {
-		if err := parseMatchAction(k, &a, actionArgTable); err != nil {
+		if err := ParseMatchAction(k, &a, actionArgTable); err != nil {
 			return err
 		}
 	}
@@ -472,7 +472,7 @@ func namespaceSelectorValue(ns *v1alpha1.NamespaceSelector, nstype string) ([]by
 	return b, uint32(len(b)), nil
 }
 
-func parseMatchNamespace(k *KernelSelectorState, action *v1alpha1.NamespaceSelector) error {
+func ParseMatchNamespace(k *KernelSelectorState, action *v1alpha1.NamespaceSelector) error {
 	nsstr := strings.ToLower(action.Namespace)
 	// write namespace type
 	ns, ok := namespaceTypeTable[nsstr]
@@ -501,7 +501,7 @@ func parseMatchNamespace(k *KernelSelectorState, action *v1alpha1.NamespaceSelec
 	return nil
 }
 
-func parseMatchNamespaces(k *KernelSelectorState, actions []v1alpha1.NamespaceSelector) error {
+func ParseMatchNamespaces(k *KernelSelectorState, actions []v1alpha1.NamespaceSelector) error {
 	max_nactions := 4 // 4 should match the value of the NUM_NS_FILTERS_SMALL in pfilter.h
 	if kernels.EnableLargeProgs() {
 		max_nactions = 10 // 10 should match the value of ns_max_types in hubble_msg.h
@@ -512,7 +512,7 @@ func parseMatchNamespaces(k *KernelSelectorState, actions []v1alpha1.NamespaceSe
 	loff := AdvanceSelectorLength(k)
 	// maybe write the number of namespace matches
 	for _, a := range actions {
-		if err := parseMatchNamespace(k, &a); err != nil {
+		if err := ParseMatchNamespace(k, &a); err != nil {
 			return err
 		}
 	}
@@ -520,7 +520,7 @@ func parseMatchNamespaces(k *KernelSelectorState, actions []v1alpha1.NamespaceSe
 	return nil
 }
 
-func parseMatchNamespaceChange(k *KernelSelectorState, action *v1alpha1.NamespaceChangesSelector) error {
+func ParseMatchNamespaceChange(k *KernelSelectorState, action *v1alpha1.NamespaceChangesSelector) error {
 	// write operator
 	op, err := selectorOp(action.Operator)
 	if err != nil {
@@ -545,7 +545,7 @@ func parseMatchNamespaceChange(k *KernelSelectorState, action *v1alpha1.Namespac
 	return nil
 }
 
-func parseMatchNamespaceChanges(k *KernelSelectorState, actions []v1alpha1.NamespaceChangesSelector) error {
+func ParseMatchNamespaceChanges(k *KernelSelectorState, actions []v1alpha1.NamespaceChangesSelector) error {
 	if len(actions) > 1 {
 		return fmt.Errorf("matchNamespaceChanges supports only a single filter (current number of filters is %d)", len(actions))
 	}
@@ -555,7 +555,7 @@ func parseMatchNamespaceChanges(k *KernelSelectorState, actions []v1alpha1.Names
 	loff := AdvanceSelectorLength(k)
 	// maybe write the number of namespace matches
 	for _, a := range actions {
-		if err := parseMatchNamespaceChange(k, &a); err != nil {
+		if err := ParseMatchNamespaceChange(k, &a); err != nil {
 			return err
 		}
 	}
@@ -563,7 +563,7 @@ func parseMatchNamespaceChanges(k *KernelSelectorState, actions []v1alpha1.Names
 	return nil
 }
 
-func parseMatchCaps(k *KernelSelectorState, action *v1alpha1.CapabilitiesSelector) error {
+func ParseMatchCaps(k *KernelSelectorState, action *v1alpha1.CapabilitiesSelector) error {
 	// type
 	tystr := strings.ToLower(action.Type)
 	ty, ok := capabilitiesTypeTable[tystr]
@@ -610,10 +610,10 @@ func parseMatchCaps(k *KernelSelectorState, action *v1alpha1.CapabilitiesSelecto
 	return nil
 }
 
-func parseMatchCapabilities(k *KernelSelectorState, actions []v1alpha1.CapabilitiesSelector) error {
+func ParseMatchCapabilities(k *KernelSelectorState, actions []v1alpha1.CapabilitiesSelector) error {
 	loff := AdvanceSelectorLength(k)
 	for _, a := range actions {
-		if err := parseMatchCaps(k, &a); err != nil {
+		if err := ParseMatchCaps(k, &a); err != nil {
 			return err
 		}
 	}
@@ -621,10 +621,10 @@ func parseMatchCapabilities(k *KernelSelectorState, actions []v1alpha1.Capabilit
 	return nil
 }
 
-func parseMatchCapabilityChanges(k *KernelSelectorState, actions []v1alpha1.CapabilitiesSelector) error {
+func ParseMatchCapabilityChanges(k *KernelSelectorState, actions []v1alpha1.CapabilitiesSelector) error {
 	loff := AdvanceSelectorLength(k)
 	for _, a := range actions {
-		if err := parseMatchCaps(k, &a); err != nil {
+		if err := ParseMatchCaps(k, &a); err != nil {
 			return err
 		}
 	}
@@ -632,7 +632,7 @@ func parseMatchCapabilityChanges(k *KernelSelectorState, actions []v1alpha1.Capa
 	return nil
 }
 
-func parseMatchBinary(k *KernelSelectorState, b *v1alpha1.BinarySelector) error {
+func ParseMatchBinary(k *KernelSelectorState, b *v1alpha1.BinarySelector) error {
 	op, err := selectorOp(b.Operator)
 	if err != nil {
 		return fmt.Errorf("matchBinary error: %w", err)
@@ -650,12 +650,12 @@ func parseMatchBinary(k *KernelSelectorState, b *v1alpha1.BinarySelector) error 
 	return nil
 }
 
-func parseMatchBinaries(k *KernelSelectorState, binarys []v1alpha1.BinarySelector) error {
+func ParseMatchBinaries(k *KernelSelectorState, binarys []v1alpha1.BinarySelector) error {
 	if len(binarys) > 1 {
 		return fmt.Errorf("Only support single binary selector")
 	}
 	for _, s := range binarys {
-		if err := parseMatchBinary(k, &s); err != nil {
+		if err := ParseMatchBinary(k, &s); err != nil {
 			return err
 		}
 	}
@@ -667,28 +667,28 @@ func parseSelector(
 	selectors *v1alpha1.KProbeSelector,
 	args []v1alpha1.KProbeArg,
 	actionArgTable *idtable.Table) error {
-	if err := parseMatchPids(k, selectors.MatchPIDs); err != nil {
+	if err := ParseMatchPids(k, selectors.MatchPIDs); err != nil {
 		return fmt.Errorf("parseMatchPids error: %w", err)
 	}
-	if err := parseMatchNamespaces(k, selectors.MatchNamespaces); err != nil {
+	if err := ParseMatchNamespaces(k, selectors.MatchNamespaces); err != nil {
 		return fmt.Errorf("parseMatchNamespaces error: %w", err)
 	}
-	if err := parseMatchCapabilities(k, selectors.MatchCapabilities); err != nil {
+	if err := ParseMatchCapabilities(k, selectors.MatchCapabilities); err != nil {
 		return fmt.Errorf("parseMatchCapabilities error: %w", err)
 	}
-	if err := parseMatchNamespaceChanges(k, selectors.MatchNamespaceChanges); err != nil {
+	if err := ParseMatchNamespaceChanges(k, selectors.MatchNamespaceChanges); err != nil {
 		return fmt.Errorf("parseMatchNamespaceChanges error: %w", err)
 	}
-	if err := parseMatchCapabilityChanges(k, selectors.MatchCapabilityChanges); err != nil {
+	if err := ParseMatchCapabilityChanges(k, selectors.MatchCapabilityChanges); err != nil {
 		return fmt.Errorf("parseMatchCapabilityChanges error: %w", err)
 	}
-	if err := parseMatchBinaries(k, selectors.MatchBinaries); err != nil {
+	if err := ParseMatchBinaries(k, selectors.MatchBinaries); err != nil {
 		return fmt.Errorf("parseMatchBinaries error: %w", err)
 	}
-	if err := parseMatchArgs(k, selectors.MatchArgs, args); err != nil {
+	if err := ParseMatchArgs(k, selectors.MatchArgs, args); err != nil {
 		return fmt.Errorf("parseMatchArgs  error: %w", err)
 	}
-	if err := parseMatchActions(k, selectors.MatchActions, actionArgTable); err != nil {
+	if err := ParseMatchActions(k, selectors.MatchActions, actionArgTable); err != nil {
 		return fmt.Errorf("parseMatchActions error: %w", err)
 	}
 	return nil

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -184,7 +184,7 @@ func TestParseMatchArg(t *testing.T) {
 		0x06, 0x00, 0x00, 0x00, // value length == 6
 		102, 111, 111, 98, 97, 114, // value ascii "foobar"
 	}
-	if err := parseMatchArg(k, arg1, sig); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
+	if err := ParseMatchArg(k, arg1, sig); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
 		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected1, k.e[0:k.off], arg1)
 	}
 
@@ -198,7 +198,7 @@ func TestParseMatchArg(t *testing.T) {
 		0x01, 0x00, 0x00, 0x00, // value 1
 		0x02, 0x00, 0x00, 0x00, // value 2
 	}
-	if err := parseMatchArg(k, arg2, sig); err != nil || bytes.Equal(expected2, k.e[nextArg:k.off]) == false {
+	if err := ParseMatchArg(k, arg2, sig); err != nil || bytes.Equal(expected2, k.e[nextArg:k.off]) == false {
 		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected2, k.e[nextArg:k.off], arg2)
 	}
 
@@ -207,7 +207,7 @@ func TestParseMatchArg(t *testing.T) {
 	expected3 = append(expected3, expected2[:]...)
 	arg3 := []v1alpha1.ArgSelector{*arg1, *arg2}
 	ks := &KernelSelectorState{off: 0}
-	if err := parseMatchArgs(ks, arg3, sig); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
+	if err := ParseMatchArgs(ks, arg3, sig); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
 		t.Errorf("parseMatchArgs: error %v expected %v bytes %v parsing %v\n", err, expected3, ks.e[0:k.off], arg3)
 	}
 }
@@ -223,7 +223,7 @@ func TestParseMatchPid(t *testing.T) {
 		0x02, 0x00, 0x00, 0x00, // Values[1] == 2
 		0x03, 0x00, 0x00, 0x00, // Values[2] == 3
 	}
-	if err := parseMatchPid(k, pid1); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
+	if err := ParseMatchPid(k, pid1); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
 		t.Errorf("parseMatchPid: error %v expected %v bytes %v parsing %v\n", err, expected1, k.e[0:k.off], pid1)
 	}
 
@@ -238,7 +238,7 @@ func TestParseMatchPid(t *testing.T) {
 		0x03, 0x00, 0x00, 0x00, // Values[2] == 3
 		0x04, 0x00, 0x00, 0x00, // Values[2] == 3
 	}
-	if err := parseMatchPid(k, pid2); err != nil || bytes.Equal(expected2, k.e[nextPid:k.off]) == false {
+	if err := ParseMatchPid(k, pid2); err != nil || bytes.Equal(expected2, k.e[nextPid:k.off]) == false {
 		t.Errorf("parseMatchPid: error %v expected %v bytes %v parsing %v\n", err, expected2, k.e[nextPid:k.off], pid2)
 	}
 
@@ -247,7 +247,7 @@ func TestParseMatchPid(t *testing.T) {
 	expected3 = append(expected3, expected2[:]...)
 	pid3 := []v1alpha1.PIDSelector{*pid1, *pid2}
 	ks := &KernelSelectorState{off: 0}
-	if err := parseMatchPids(ks, pid3); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
+	if err := ParseMatchPids(ks, pid3); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
 		t.Errorf("parseMatchPid: error %v expected %v bytes %v parsing %v\n", err, expected3, ks.e[0:ks.off], pid3)
 	}
 }
@@ -263,7 +263,7 @@ func TestParseMatchNamespaces(t *testing.T) {
 		0x02, 0x00, 0x00, 0x00, // Values[1] == 2
 		0x03, 0x00, 0x00, 0x00, // Values[2] == 3
 	}
-	if err := parseMatchNamespace(k, ns1); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
+	if err := ParseMatchNamespace(k, ns1); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
 		t.Errorf("parseMatchNamespace: error %v expected %v bytes %v parsing %v\n", err, expected1, k.e[0:k.off], ns1)
 	}
 
@@ -278,7 +278,7 @@ func TestParseMatchNamespaces(t *testing.T) {
 		0x03, 0x00, 0x00, 0x00, // Values[2] == 3
 		0x04, 0x00, 0x00, 0x00, // Values[2] == 3
 	}
-	if err := parseMatchNamespace(k, ns2); err != nil || bytes.Equal(expected2, k.e[nextPid:k.off]) == false {
+	if err := ParseMatchNamespace(k, ns2); err != nil || bytes.Equal(expected2, k.e[nextPid:k.off]) == false {
 		t.Errorf("parseMatchNamespace: error %v expected %v bytes %v parsing %v\n", err, expected2, k.e[nextPid:k.off], ns2)
 	}
 
@@ -287,7 +287,7 @@ func TestParseMatchNamespaces(t *testing.T) {
 	expected3 = append(expected3, expected2[:]...)
 	ns3 := []v1alpha1.NamespaceSelector{*ns1, *ns2}
 	ks := &KernelSelectorState{off: 0}
-	if err := parseMatchNamespaces(ks, ns3); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
+	if err := ParseMatchNamespaces(ks, ns3); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
 		t.Errorf("parseMatchNamespaces: error %v expected %v bytes %v parsing %v\n", err, expected3, ks.e[0:ks.off], ns3)
 	}
 }
@@ -299,7 +299,7 @@ func TestParseMatchNamespaceChanges(t *testing.T) {
 		0x05, 0x00, 0x00, 0x00, // op == In
 		0x05, 0x00, 0x00, 0x00, // values
 	}
-	if err := parseMatchNamespaceChange(k, ns1); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
+	if err := ParseMatchNamespaceChange(k, ns1); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
 		t.Errorf("parseMatchNamespaceChange: error %v expected %v bytes %v parsing %v\n", err, expected1, k.e[0:k.off], ns1)
 	}
 }
@@ -313,7 +313,7 @@ func TestParseMatchCapabilities(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // IsNamespaceCapability = false
 		0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Values (uint64)
 	}
-	if err := parseMatchCaps(k, cap1); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
+	if err := ParseMatchCaps(k, cap1); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
 		t.Errorf("parseMatchCaps: error %v expected %v bytes %v parsing %v\n", err, expected1, k.e[0:k.off], cap1)
 	}
 
@@ -325,7 +325,7 @@ func TestParseMatchCapabilities(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // IsNamespaceCapability = false
 		0x00, 0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, // Values (uint64)
 	}
-	if err := parseMatchCaps(k, cap2); err != nil || bytes.Equal(expected2, k.e[nextPid:k.off]) == false {
+	if err := ParseMatchCaps(k, cap2); err != nil || bytes.Equal(expected2, k.e[nextPid:k.off]) == false {
 		t.Errorf("parseMatchCaps: error %v expected %v bytes %v parsing %v\n", err, expected2, k.e[nextPid:k.off], cap2)
 	}
 
@@ -334,7 +334,7 @@ func TestParseMatchCapabilities(t *testing.T) {
 	expected3 = append(expected3, expected2[:]...)
 	cap3 := []v1alpha1.CapabilitiesSelector{*cap1, *cap2}
 	ks := &KernelSelectorState{off: 0}
-	if err := parseMatchCapabilities(ks, cap3); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
+	if err := ParseMatchCapabilities(ks, cap3); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
 		t.Errorf("parseMatchCapabilities: error %v expected %v bytes %v parsing %v\n", err, expected3, ks.e[0:ks.off], cap3)
 	}
 }
@@ -349,7 +349,7 @@ func TestParseMatchAction(t *testing.T) {
 	expected1 := []byte{
 		0x00, 0x00, 0x00, 0x00, // Action = "post"
 	}
-	if err := parseMatchAction(k, act1, &actionArgTable); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
+	if err := ParseMatchAction(k, act1, &actionArgTable); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
 		t.Errorf("parseMatchAction: error %v expected %v bytes %v parsing %v\n", err, expected1, k.e[0:k.off], act1)
 	}
 	// This is a bit contrived because we only have single action so far
@@ -364,7 +364,7 @@ func TestParseMatchAction(t *testing.T) {
 
 	act := []v1alpha1.ActionSelector{*act1, *act2}
 	ks := &KernelSelectorState{off: 0}
-	if err := parseMatchActions(ks, act, &actionArgTable); err != nil || bytes.Equal(expected, ks.e[0:ks.off]) == false {
+	if err := ParseMatchActions(ks, act, &actionArgTable); err != nil || bytes.Equal(expected, ks.e[0:ks.off]) == false {
 		t.Errorf("parseMatchActions: error %v expected %v bytes %v parsing %v\n", err, expected, ks.e[0:ks.off], act)
 	}
 }


### PR DESCRIPTION
This patch makes selector functions public in order to be used in other (than kprobes and tracepoints) places.

This will allow use to define a different selector with different actions.