### PR TITLE
clang image: add support for arm64 and detect arch for BPF compilation

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -23,6 +23,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
+        with:
+          platforms: amd64,arm64
+
+      # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
 
@@ -56,7 +63,7 @@ jobs:
           context: .
           file: ./Dockerfile.clang
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,13 +12,18 @@ fgs-bench-rootfs*
 ksrc
 kbuild
 latest.json
+strange.txt
+compile_commands.json
+contrib/tester-progs/sigkill-unprivileged-user-ns-tester
+/release
+
+# project tool artifacts
+.vagrant/
+.vscode
 cscope.files
 cscope.po.out
 cscope.out
 cscope.in.out
-strange.txt
-.vagrant/
-.vscode
-compile_commands.json
-contrib/tester-progs/sigkill-unprivileged-user-ns-tester
-/release
+
+# macOS artifacts
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LOCAL_CLANG ?= 0
 LOCAL_CLANG_FORMAT ?= 0
 FORMAT_FIND_FLAGS ?= -name '*.c' -o -name '*.h' -not -path 'bpf/include/vmlinux.h' -not -path 'bpf/include/api.h' -not -path 'bpf/libbpf/*'
 NOOPT ?= 0
-CLANG_IMAGE  = quay.io/cilium/clang:ca424d14eb4326ffc65fccd8049d8a7bfdd06607@sha256:be37c932add0b5f22edd72da3af4ccc4df6dbd54e6e99424fa5190bafc10e55f
+CLANG_IMAGE = quay.io/cilium/clang@sha256:b440ae7b3591a80ffef8120b2ac99e802bbd31dee10f5f15a48566832ae0866f
 TESTER_PROGS_DIR = "contrib/tester-progs"
 # Extra flags to pass to test binary
 EXTRA_TESTFLAGS ?=

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -6,9 +6,15 @@ SHELL=/bin/bash # needed for the *.{o,ll,i,s} pattern in the clean target
 CLANG  ?= clang
 LLC    ?= llc
 
-# By default we build for amd64 that is in libbpf x86
-# To build for other architectures check $TARGET_ARCH
-# var exported from parent Makefile.
+# Build the BPF programs for the detected architecture, default to x86, and
+# allow easy overriding by using ?= for cross-compilation
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
+	BPF_TARGET_ARCH ?= x86
+endif
+ifeq ($(UNAME_M),aarch64)
+	BPF_TARGET_ARCH ?= arm64
+endif
 BPF_TARGET_ARCH ?= x86
 
 ALIGNCHECKERDIR = alignchecker/


### PR DESCRIPTION
Add multi-arch build for clang image to support both amd64 and arm64,
see https://docs.docker.com/build/ci/github-actions/multi-platform/.

To test, you can try on a platform that has the QEMU emulation thing: `docker buildx build --platform linux/arm64,linux/amd64 --tag mytag/clang . --file=Dockerfile.clang`, it works.

Occasionally adds `.DS_Store` files to .gitignore.