### PR TITLE
Remove ifdefs from msg_selector_data

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -21,12 +21,8 @@ struct msg_selector_data {
 	__u64 curr;
 	__u64 pass;
 	bool active[MAX_CONFIGURED_SELECTORS];
-#ifdef __NS_CHANGES_FILTER
 	__u64 match_ns;
-#endif
-#ifdef __CAP_CHANGES_FILTER
 	__u64 match_cap;
-#endif
 };
 
 struct msg_generic_kprobe {


### PR DESCRIPTION
This will simplify having programs for different kernel versions.