### PR TITLE
kprobe: detect and add missing syscall arch prefix

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -14,7 +14,9 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"github.com/cilium/ebpf"
@@ -62,6 +64,8 @@ const (
 
 	MaxKprobesMulti = 100 // MAX_ENTRIES_CONFIG in bpf code
 )
+
+var supportedArchPrefix = map[string]string{"amd64": "__x64_", "arm64": "__arm64_"}
 
 func kprobeCharBufErrorToString(e int32) string {
 	switch e {
@@ -255,6 +259,35 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 	return progs, maps
 }
 
+// addSyscallPrefix detects if the symbol is already prefixed with arch specific
+// prefix in the form of "__x64_" or "__arm64_", and if not, adds it based on
+// provided arch.
+//
+// Note that cilium/ebpf, retries to attach to an arch specific version of the
+// symbol after a failure thus making possible to attach to "sys_listen" which
+// will fail and retry with the corrected "__arm64_sys_listen" if you are
+// running on arm64. See https://github.com/cilium/ebpf/pull/304.  However, this
+// causes Tetragon users to believe that two symbols exist (following the same
+// example) "__arm64_sys_listen" and "sys_listen", which results in differents
+// events.  Because we actually know if a call is a syscall, we can pre-format
+// the symbol directly here to allow the user to specify the "sys_listen"
+// version while only registering the real symbol "__arm64_sys_listen".
+func addSyscallPrefix(symbol string, arch string) (string, error) {
+	for prefix_arch, prefix := range supportedArchPrefix {
+		if strings.HasPrefix(symbol, prefix) {
+			// check that the prefix found is the correct one
+			if prefix_arch != arch {
+				return "", fmt.Errorf("expecting %s and got %s", supportedArchPrefix[arch], prefix)
+			}
+			return symbol, nil
+		}
+	}
+	if prefix, found := supportedArchPrefix[arch]; found {
+		return prefix + symbol, nil
+	}
+	return "", fmt.Errorf("unsupported architecture %s", arch)
+}
+
 func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sensors.Sensor, error) {
 	var progs []*program.Program
 	var maps []*program.Map
@@ -283,6 +316,17 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec) (*sen
 		config := &api.EventConfig{}
 
 		argRetprobe = nil // holds pointer to arg for return handler
+
+		// modifying f.Call directly instead of writing to funcName
+		// because of BTF validation later using the whole v1alpha1.KProbeSpec object
+		if f.Syscall {
+			prefixedName, err := addSyscallPrefix(f.Call, runtime.GOARCH)
+			if err != nil {
+				logger.GetLogger().Warnf("kprobe syscall prefix: %w", err)
+			} else {
+				f.Call = prefixedName
+			}
+		}
 		funcName := f.Call
 
 		var err error

--- a/pkg/sensors/tracing/generickprobe_test.go
+++ b/pkg/sensors/tracing/generickprobe_test.go
@@ -1,0 +1,34 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_addSyscallPrefix(t *testing.T) {
+	symbol := "sys_test"
+	arch := "test64"
+	supportedArchPrefix[arch] = "__test64_"
+	prefixedSymbol := supportedArchPrefix[arch] + symbol
+
+	// adding prefix
+	res, err := addSyscallPrefix(symbol, arch)
+	assert.NoError(t, err)
+	assert.Equal(t, prefixedSymbol, res)
+
+	// doing nothing
+	res, err = addSyscallPrefix(prefixedSymbol, arch)
+	assert.NoError(t, err)
+	assert.Equal(t, prefixedSymbol, res)
+
+	// wrong prefix for current arch
+	res, err = addSyscallPrefix("__x64_"+symbol, arch)
+	assert.Error(t, err)
+	assert.Empty(t, res)
+
+	// not supported arch
+	res, err = addSyscallPrefix(symbol, "unsupported64")
+	assert.Error(t, err)
+	assert.Empty(t, res)
+}


### PR DESCRIPTION
This fixes https://github.com/cilium/tetragon/issues/751.

If kprobe call is a syscall, we try to detect if the user specified a prefix in the form of "__x64" or "__arm64", and if not, transparently add it based on runtime.GOARCH.

```
// Note that cilium/ebpf, retries to attach to an arch specific version of the
// symbol after a failure thus making possible to attach to "sys_listen" which
// will fail and retry with the corrected "__arm64_sys_listen" if you are
// running on arm64. See https://github.com/cilium/ebpf/pull/304.  However, this
// causes Tetragon users to believe that two symbols exist (following the same
// example) "__arm64_sys_listen" and "sys_listen", which results in differents
// events.  Because we actually know if a call is a syscall, we can pre-format
// the symbol directly here to allow the user to specify the "sys_listen"
// version while having only registering the real symbol "__arm64_sys_listen".
```

~~I would like to add some tests and docs but it's already reviewable.~~