### PR TITLE
matchBinaries: Add NotIn in tracing policy

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -236,6 +236,7 @@ spec:
                                   description: Filter operation.
                                   enum:
                                   - In
+                                  - NotIn
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -592,6 +593,7 @@ spec:
                                   description: Filter operation.
                                   enum:
                                   - In
+                                  - NotIn
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -103,7 +103,7 @@ type KProbeArg struct {
 }
 
 type BinarySelector struct {
-	// +kubebuilder:validation:Enum=In
+	// +kubebuilder:validation:Enum=In;NotIn
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -236,6 +236,7 @@ spec:
                                   description: Filter operation.
                                   enum:
                                   - In
+                                  - NotIn
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -592,6 +593,7 @@ spec:
                                   description: Filter operation.
                                   enum:
                                   - In
+                                  - NotIn
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -103,7 +103,7 @@ type KProbeArg struct {
 }
 
 type BinarySelector struct {
-	// +kubebuilder:validation:Enum=In
+	// +kubebuilder:validation:Enum=In;NotIn
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.


### PR DESCRIPTION
In https://github.com/cilium/tetragon/pull/686/commits/84e71d2777f43b53fcb8b53caa01431d4640ffa6 we introduced the implementation of NotIn operator in matchBinaries selector. We missed to add this in the tracing policy definition.

This patch fixes that.