### PR TITLE
bugfix: matchBinaries in multiple selectors

### DIFF
--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -8,3 +8,6 @@ nop
 sigkill-unprivileged-user-ns-tester
 exit-leader
 exit-tester
+libuprobe.so
+uprobe-test-1
+uprobe-test-2

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -17,6 +17,15 @@ var (
 	binVals = make(map[string]uint32)
 )
 
+type MatchBinariesMappings struct {
+	op          uint32
+	selNamesMap map[uint32]uint32 // these will be used for the sel_names_map
+}
+
+func (k *MatchBinariesMappings) GetBinSelNamesMap() map[uint32]uint32 {
+	return k.selNamesMap
+}
+
 type KernelSelectorState struct {
 	off uint32     // offset into encoding
 	e   [4096]byte // kernel encoding of selectors
@@ -24,48 +33,53 @@ type KernelSelectorState struct {
 	// valueMaps are used to populate value maps for InMap and NotInMap operators
 	valueMaps []map[[8]byte]struct{}
 
-	// matchBinaries mappings
-	op          uint32
-	newBinVals  map[uint32]string // these should be added in the names_map
-	selNamesMap map[uint32]uint32 // these will be used for the sel_names_map
-	initOnce    sync.Once
+	matchBinaries map[int]*MatchBinariesMappings // matchBinaries mappings (one per selector)
+	newBinVals    map[uint32]string              // these should be added in the names_map
 }
 
-func (k *KernelSelectorState) SetBinaryOp(op uint32) {
-	k.op = op
+func newKernelSelectorState() *KernelSelectorState {
+	return &KernelSelectorState{
+		matchBinaries: make(map[int]*MatchBinariesMappings),
+		newBinVals:    make(map[uint32]string),
+	}
 }
 
-func (k *KernelSelectorState) GetBinaryOp() uint32 {
-	return k.op
+func (k *KernelSelectorState) SetBinaryOp(selIdx int, op uint32) {
+	// init a new entry (if needed)
+	if _, ok := k.matchBinaries[selIdx]; !ok {
+		k.matchBinaries[selIdx] = &MatchBinariesMappings{
+			selNamesMap: make(map[uint32]uint32),
+		}
+	}
+	k.matchBinaries[selIdx].op = op
 }
 
-func (k *KernelSelectorState) AddBinaryName(binary string) {
-	k.initOnce.Do(func() {
-		k.newBinVals = make(map[uint32]string)
-		k.selNamesMap = make(map[uint32]uint32)
-	})
+func (k *KernelSelectorState) GetBinaryOp(selIdx int) uint32 {
+	return k.matchBinaries[selIdx].op
+}
 
+func (k *KernelSelectorState) AddBinaryName(selIdx int, binary string) {
 	binMu.Lock()
 	defer binMu.Unlock()
 	idx, ok := binVals[binary]
 	if ok {
-		k.selNamesMap[idx] = 1
+		k.matchBinaries[selIdx].selNamesMap[idx] = 1
 		return
 	}
 
 	idx = binIdx
 	binIdx++
-	binVals[binary] = idx      // global map of all names_map entries
-	k.newBinVals[idx] = binary // new names_map entries that we should add
-	k.selNamesMap[idx] = 1     // value in the per-selector names_map (we ignore the value)
+	binVals[binary] = idx                        // global map of all names_map entries
+	k.newBinVals[idx] = binary                   // new names_map entries that we should add
+	k.matchBinaries[selIdx].selNamesMap[idx] = 1 // value in the per-selector names_map (we ignore the value)
 }
 
 func (k *KernelSelectorState) GetNewBinaryMappings() map[uint32]string {
 	return k.newBinVals
 }
 
-func (k *KernelSelectorState) GetBinSelNamesMap() map[uint32]uint32 {
-	return k.selNamesMap
+func (k *KernelSelectorState) GetBinSelNamesMap() map[int]*MatchBinariesMappings {
+	return k.matchBinaries
 }
 
 func (k *KernelSelectorState) Buffer() [4096]byte {

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -124,18 +124,8 @@ func (k *observerUprobeSensor) LoadProbe(args sensors.LoadProbeArgs) error {
 		{
 			Index: 0,
 			Name:  "sel_names_map",
-			Load: func(m *ebpf.Map, index uint32) error {
-				// add a special entry (key == UINT32_MAX) that has as a value the number of matchBinaries entry
-				// if this is zero we don't have any matchBinaries selectors
-				if err := m.Update(uint32(0xffffffff), uprobeEntry.selectors.GetBinaryOp(), ebpf.UpdateAny); err != nil {
-					return err
-				}
-				for idx, val := range uprobeEntry.selectors.GetBinSelNamesMap() {
-					if err := m.Update(idx, val, ebpf.UpdateAny); err != nil {
-						return err
-					}
-				}
-				return nil
+			Load: func(outerMap *ebpf.Map, index uint32) error {
+				return populateBinariesMaps(uprobeEntry.selectors, uprobeEntry.pinPathPrefix, outerMap)
 			},
 		},
 	}


### PR DESCRIPTION
Using the following tracing policy:
```
kprobes:
- call: "fd_install"
  syscall: false
  args:
  - index: 0
    type: int
  - index: 1
    type: "file"
  selectors:
  - matchBinaries:
    - operator: "In"
      values:
      - "/usr/bin/cat"
    matchArgs:
    - index: 1
      operator: "Equal"
      values:
      - "/etc/passwd"
  - matchBinaries:
    - operator: "In"
      values:
      - "/usr/bin/tail"
    matchArgs:
    - index: 1
      operator: "Equal"
      values:
      - "/etc/shadow"
```
we expect to get events if:
`[ binary == /usr/bin/cat AND arg1 == /etc/passwd ] OR [ binary == /usr/bin/tail AND arg1 == /etc/shadow ]`

By running:
`/usr/bin/cat /etc/passwd && /usr/bin/cat /etc/shadow && /usr/bin/tail /etc/passwd && /usr/bin/tail /etc/shadow`

We get events for all of these. Which is not the expected behavior.

The issue is that in https://github.com/cilium/tetragon/pull/686 we use a single map for all `matchBinaries` selectors. That makes the previous tracing policy to behave as:
`[ (binary == /usr/bin/cat OR binary == /usr/bin/tail) AND arg1 == /etc/passwd ] OR [ (binary == /usr/bin/cat OR binary == /usr/bin/tail) AND arg1 == /etc/shadow ]`

This patch fixes that issues. We move from a `BPF_MAP_TYPE_HASH` to a `BPF_MAP_TYPE_HASH_OF_MAPS`. We index the outter map based on the selector ID and the inner map is exactly the same as the one we used in https://github.com/cilium/tetragon/pull/686.

Based on the previous tracing policy, the user side will generate the `names_map` and `sel_names_map`. `names_map` is shared among all selectors that have `matchBinaries`. Each distinct binary name will appear in the names_map with a unique value per entry (> 0). The contents of the `names_map` for the previous tracing policy will be:

```
names_map["/usr/bin/cat"] = 1
names_map["/usr/bin/tail"] = 2
```

Whenever we have an execve event, we check the execve binary name and if is that inside `names_map`, we set `execve_map_value->binary` to the value of that entry. If we cannot find that entry inside `names_map`, we set `execve_map_value->binary` equals to 0 which means that this binary name is nowhere in all `matchBinaries`.

Based in that we also generate the `sel_names_map`. These are one per-sensor. This is a `BPF_MAP_TYPE_HASH_OF_MAPS` map where we index in the outter map using the selector ID and we index in the inner map using the `execve_map_value->binary`. If that exists, then `matchBinary` will be matched.

The contents of the `sel_names_map` based on the previous tracing policy will be:
```
sel_names_map[0 /* sel_index */ ] = {
  hash_map[1 /* value of cat in names_map */] = 1 /* always 1 for now */
}
sel_names_map[1 /* sel_index */ ] = {
  hash_map[2 /* value of tail in names_map */] = 1 /* always 1 for now */
}
```

Finally, if `sel_names_map[sel_idx]` is NULL this means that the specific selector does not container a `matchBinaries` action. If `sel_names_map[sel_idx].hash_map[idx]` is NULL this means that we don't care about the specific binary.