### PR TITLE
trivial:doc: add code documentation for nspid when getting Pod info

### DIFF
--- a/pkg/process/podinfo.go
+++ b/pkg/process/podinfo.go
@@ -64,7 +64,7 @@ func getPodInfo(
 		labels = endpoint.Labels
 	}
 
-	// Don't set container PIDs if it's zero.
+	// This is the PID inside the container. Don't set it if zero.
 	var containerPID *wrapperspb.UInt32Value
 	if nspid > 0 {
 		containerPID = &wrapperspb.UInt32Value{

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -205,6 +205,8 @@ func GetProcess(
 	}, endpoint
 }
 
+// GetPodInfo() constructs and returns the Kubernetes Pod information associated with
+// the Container ID and the PID inside this container.
 func GetPodInfo(cid, bin, args string, nspid uint32) (*tetragon.Pod, *hubblev1.Endpoint) {
 	return getPodInfo(k8s, cid, bin, args, nspid)
 }
@@ -259,6 +261,7 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 		pi.process.StartTime = ktime.ToProto(event.Ktime)
 		pi.process.Refcnt = 1
 		if pi.process.Pod != nil && pi.process.Pod.Container != nil {
+			// Set the pid inside the container
 			pi.process.Pod.Container.Pid = &wrapperspb.UInt32Value{Value: event.NSPID}
 		}
 		if option.Config.EnableK8s && pi.process.Docker != "" && pi.process.Pod == nil {

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -360,6 +360,9 @@ func GetRunningProcs() []Procs {
 		// On error procsDockerId zeros dockerId so we can ignore any errors.
 		dockerId, _ := procsDockerId(uint32(pid))
 		if dockerId == "" {
+			// If we do not have a container ID, then set nspid to zero.
+			// This field is used to construct the pod information to
+			// identify pids inside the container.
 			nspid = 0
 		}
 
@@ -385,6 +388,7 @@ func GetRunningProcs() []Procs {
 			}
 
 			if dockerId != "" {
+				// We have a container ID so let's get the nspid inside.
 				pnspid, _, _, _ = caps.GetPIDCaps(filepath.Join(option.Config.ProcFS, ppid, "status"))
 			}
 		} else {


### PR DESCRIPTION
When constructing Pod information we want to have the PID inside the related container that triggered events. To achieve this we read the nspid from the container view then pass it back to GetPodInfo().

This does not introduce any code change.

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>