### PR TITLE
clang image: rework workflow to dry run on PR

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -1,15 +1,20 @@
 name: Build Clang Image
 
+# we want this action to dry run in case it's triggered from a PR
+# - docker/login-action only logs in to quay on GA 'push' event
+# - docker/build-push-action only pushes to quay on GA 'push' event
 on:
   push:
     branches:
       - main
       - v*
     paths:
-    - 'Dockerfile.clang'
-  pull_request:
+      - 'Dockerfile.clang'
+      - '.github/workflows/build-clang-image.yaml'
+  pull_request_target:
     paths:
-    - 'Dockerfile.clang'
+      - 'Dockerfile.clang'
+      - '.github/workflows/build-clang-image.yaml'
 
 permissions:
   # To be able to access the repository with `actions/checkout`
@@ -19,9 +24,11 @@ permissions:
 
 jobs:
   build-and-push:
-    environment: release-clang
     runs-on: ubuntu-20.04
-
+    environment: release-clang
+    permissions:
+      # To be able to access the repository with `actions/checkout`
+      contents: read
     steps:
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
@@ -34,6 +41,7 @@ jobs:
         uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7
 
       - name: Login to quay.io
+        if: github.event_name == 'push'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io
@@ -62,16 +70,25 @@ jobs:
           provenance: false
           context: .
           file: ./Dockerfile.clang
-          push: true
           platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
           tags: |
             quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}
 
+  sign-and-sbom:
+    permissions:
+      # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+      id-token: write
+    name: Sign image and generate SBOM
+    if: github.event_name == 'push'
+    needs: build-and-push
+    runs-on: ubuntu-20.04
+    steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
 
       - name: Sign Container Image
-        if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
+        if: steps.tag-in-repositories.outputs.exists == 'false'
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
@@ -97,7 +114,7 @@ jobs:
           cosign attach sbom --sbom sbom_clang_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
 
       - name: Sign SBOM Image
-        if: ${{ steps.tag-in-repositories.outputs.exists == 'false' }}
+        if: steps.tag-in-repositories.outputs.exists == 'false'
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
@@ -129,10 +146,10 @@ jobs:
           retention-days: 1
 
   image-digests:
-    if: ${{ github.repository == 'cilium/tetragon' }}
+    if: github.event_name == 'push' && github.repository == 'cilium/tetragon'
     name: Display Digests
     runs-on: ubuntu-20.04
-    needs: build-and-push
+    needs: sign-and-sbom
     steps:
       - name: Downloading Image Digests
         shell: bash


### PR DESCRIPTION
Fixes https://github.com/cilium/tetragon/issues/750 since other workflows `build-image-ci.yml` and `build-images-releases.yml` are already acting differently in the case of push on main and PRs.

- Add a path addition to allow for the workflow to be tested when we modify it in a PR.
- Add a boolean condition in quay login step and at pushing step to only push on commit on main.
- Remove the environment since the workflow can run without approval now. We will still need the credential from the environment to login to quay thought.

**Warning**: I need external action on the repo for this PR to work when merged:
```yaml
          username: ${{ secrets.QUAY_CLANG_RELEASE_USERNAME }}
          password: ${{ secrets.QUAY_CLANG_RELEASE_PASSWORD }}
```
These secrets must be moved from the `environment: release-clang` to the global env if it makes sense.