### PR TITLE
tests: automatically clean up test sensors

### DIFF
--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -410,6 +410,13 @@ func loadObserver(t *testing.T, ctx context.Context, base *sensors.Sensor, sens 
 		}
 		t.Fatalf("LoadConfig error: %s\n", err)
 	}
+
+	t.Cleanup(func() {
+		if err := sens.Unload(); err != nil {
+			t.Errorf("failed to unload sensor: %s", err)
+		}
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
We should be cleaning up our sensors between tests to avoid polluting state between test runs. This PR does exactly this by registering a test cleanup func that calls sens.Unload().