### PR TITLE
tetragon: Allow to use data events for char_buf data

### DIFF
--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -38,6 +38,18 @@ struct {
 	__type(value, __s32);
 } override_tasks SEC(".maps");
 
+#ifdef __LARGE_BPF_PROG
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct msg_data);
+} data_heap SEC(".maps");
+#define data_heap_ptr &data_heap
+#else
+#define data_heap_ptr 0
+#endif
+
 struct filter_map_value {
 	unsigned char buf[FILTER_SIZE];
 };
@@ -145,7 +157,8 @@ generic_kprobe_process_event0(void *ctx)
 	return generic_process_event_and_setup(
 		ctx, (struct bpf_map_def *)&process_call_heap,
 		(struct bpf_map_def *)&kprobe_calls,
-		(struct bpf_map_def *)&config_map);
+		(struct bpf_map_def *)&config_map,
+		(struct bpf_map_def *)data_heap_ptr);
 }
 
 __attribute__((section("kprobe/1"), used)) int
@@ -154,7 +167,8 @@ generic_kprobe_process_event1(void *ctx)
 	return generic_process_event(ctx, 1,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&kprobe_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map,
+				     (struct bpf_map_def *)data_heap_ptr);
 }
 
 __attribute__((section("kprobe/2"), used)) int
@@ -163,7 +177,8 @@ generic_kprobe_process_event2(void *ctx)
 	return generic_process_event(ctx, 2,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&kprobe_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map,
+				     (struct bpf_map_def *)data_heap_ptr);
 }
 
 __attribute__((section("kprobe/3"), used)) int
@@ -172,7 +187,8 @@ generic_kprobe_process_event3(void *ctx)
 	return generic_process_event(ctx, 3,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&kprobe_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map,
+				     (struct bpf_map_def *)data_heap_ptr);
 }
 
 __attribute__((section("kprobe/4"), used)) int
@@ -181,7 +197,8 @@ generic_kprobe_process_event4(void *ctx)
 	return generic_process_event(ctx, 4,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&kprobe_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map,
+				     (struct bpf_map_def *)data_heap_ptr);
 }
 
 __attribute__((section("kprobe/5"), used)) int

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -28,6 +28,18 @@ struct {
 	__type(value, struct event_config);
 } config_map SEC(".maps");
 
+#ifdef __LARGE_BPF_PROG
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct msg_data);
+} data_heap SEC(".maps");
+#define data_heap_ptr &data_heap
+#else
+#define data_heap_ptr 0
+#endif
+
 #ifdef __MULTI_KPROBE
 #define MAIN "kprobe.multi/generic_retkprobe"
 #else
@@ -70,7 +82,7 @@ BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 	ty_arg = config->argreturn;
 	do_copy = config->argreturncopy;
 	if (ty_arg)
-		size += read_call_arg(ctx, e, 0, ty_arg, size, ret, 0);
+		size += read_call_arg(ctx, e, 0, ty_arg, size, ret, 0, (struct bpf_map_def *)data_heap_ptr);
 
 	/*
 	 * 0x1000 should be maximum argument length, so masking
@@ -81,7 +93,7 @@ BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 
 	switch (do_copy) {
 	case char_buf:
-		size += __copy_char_buf(size, info.ptr, ret, e);
+		size += __copy_char_buf(ctx, size, info.ptr, ret, false, e, (struct bpf_map_def *)data_heap_ptr);
 		break;
 	case char_iovec:
 		size += __copy_char_iovec(size, info.ptr, info.cnt, ret, e);

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -199,7 +199,7 @@ generic_tracepoint_event0(void *ctx)
 {
 	return generic_process_event(ctx, 0, (struct bpf_map_def *)&tp_heap,
 				     (struct bpf_map_def *)&tp_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("tracepoint/1"), used)) int
@@ -207,7 +207,7 @@ generic_tracepoint_event1(void *ctx)
 {
 	return generic_process_event(ctx, 1, (struct bpf_map_def *)&tp_heap,
 				     (struct bpf_map_def *)&tp_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("tracepoint/2"), used)) int
@@ -215,7 +215,7 @@ generic_tracepoint_event2(void *ctx)
 {
 	return generic_process_event(ctx, 2, (struct bpf_map_def *)&tp_heap,
 				     (struct bpf_map_def *)&tp_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("tracepoint/3"), used)) int
@@ -223,7 +223,7 @@ generic_tracepoint_event3(void *ctx)
 {
 	return generic_process_event(ctx, 3, (struct bpf_map_def *)&tp_heap,
 				     (struct bpf_map_def *)&tp_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("tracepoint/4"), used)) int
@@ -231,7 +231,7 @@ generic_tracepoint_event4(void *ctx)
 {
 	return generic_process_event(ctx, 4, (struct bpf_map_def *)&tp_heap,
 				     (struct bpf_map_def *)&tp_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("tracepoint/5"), used)) int

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -103,7 +103,7 @@ generic_uprobe_process_event0(void *ctx)
 	return generic_process_event_and_setup(
 		ctx, (struct bpf_map_def *)&process_call_heap,
 		(struct bpf_map_def *)&uprobe_calls,
-		(struct bpf_map_def *)&config_map);
+		(struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("uprobe/1"), used)) int
@@ -112,7 +112,7 @@ generic_uprobe_process_event1(void *ctx)
 	return generic_process_event(ctx, 1,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&uprobe_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("uprobe/2"), used)) int
@@ -121,7 +121,7 @@ generic_uprobe_process_event2(void *ctx)
 	return generic_process_event(ctx, 2,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&uprobe_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("uprobe/3"), used)) int
@@ -130,7 +130,7 @@ generic_uprobe_process_event3(void *ctx)
 	return generic_process_event(ctx, 3,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&uprobe_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("uprobe/4"), used)) int
@@ -139,7 +139,7 @@ generic_uprobe_process_event4(void *ctx)
 	return generic_process_event(ctx, 4,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&uprobe_calls,
-				     (struct bpf_map_def *)&config_map);
+				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("uprobe/5"), used)) int

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -10,7 +10,8 @@
 
 static inline __attribute__((always_inline)) int
 generic_process_event(void *ctx, int index, struct bpf_map_def *heap_map,
-		      struct bpf_map_def *tailcals, struct bpf_map_def *config_map)
+		      struct bpf_map_def *tailcals, struct bpf_map_def *config_map,
+		      struct bpf_map_def *data_heap)
 {
 	struct msg_generic_kprobe *e;
 	struct event_config *config;
@@ -39,7 +40,7 @@ generic_process_event(void *ctx, int index, struct bpf_map_def *heap_map,
 		asm volatile("%[am] &= 0xffff;\n" ::[am] "+r"(am)
 			     :);
 
-		errv = read_call_arg(ctx, e, index, ty, total, a, am);
+		errv = read_call_arg(ctx, e, index, ty, total, a, am, data_heap);
 		if (errv > 0)
 			total += errv;
 		/* Follow filter lookup failed so lets abort the event.
@@ -84,7 +85,8 @@ static inline __attribute__((always_inline)) int
 generic_process_event_and_setup(struct pt_regs *ctx,
 				struct bpf_map_def *heap_map,
 				struct bpf_map_def *tailcals,
-				struct bpf_map_def *config_map)
+				struct bpf_map_def *config_map,
+				struct bpf_map_def *data_heap)
 {
 	struct msg_generic_kprobe *e;
 	struct event_config *config;
@@ -139,7 +141,7 @@ generic_process_event_and_setup(struct pt_regs *ctx,
 	generic_process_init(e, MSG_OP_GENERIC_UPROBE, config);
 #endif
 
-	return generic_process_event(ctx, 0, heap_map, tailcals, config_map);
+	return generic_process_event(ctx, 0, heap_map, tailcals, config_map, data_heap);
 }
 
 #endif /* __GENERIC_CALLS_H__ */

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -697,18 +697,12 @@ filter_file_buf(struct selector_arg_filter *filter, char *args)
 }
 
 static inline __attribute__((always_inline)) long
-__copy_char_iovec(long off, unsigned long arg, unsigned long meta,
+__copy_char_iovec(long off, unsigned long arg, unsigned long cnt,
 		  unsigned long max, struct msg_generic_kprobe *e)
 {
 	long size, off_orig = off;
-	int err, i = 0, cnt;
+	unsigned long i = 0;
 	int *s;
-
-	err = probe_read(&cnt, sizeof(cnt), &meta);
-	if (err < 0) {
-		char *args = args_off(e, off_orig);
-		return return_stack_error(args, 0, char_buf_pagefault);
-	}
 
 	size = 0;
 	off += 8;

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -289,6 +289,30 @@ args:
 ```
 This tells the printer to skip printing the `int` arg because it's not useful.
 
+For `char_buf` type up to the 4096 bytes are stored. Data with bigger size are
+cut and returned as truncated bytes.
+
+You can specify `maxData` flag for `char_buf` type to read maximum possible data
+(currently 327360 bytes), like:
+
+```yaml
+args:
+- index: 1
+  type: "char_buf"
+  maxData: true
+  sizeArgIndex: 3
+- index: 2
+  type: "size_t"
+```
+
+This field is only used for `char_buff` data. When this value is false (default),
+the bpf program will fetch at most 4096 bytes.  In later kernels (>=5.4) tetragon
+supports fetching up to 327360 bytes if this flag is turned on.
+
+The `maxData` flag does not work with `returnCopy` flag at the moment, so it's
+usable only for syscalls/functions that do not require return probe to read the
+data.
+
 ### Selectors
 
 A `TracingPolicy` can contain from 0 to 5 selectors. A selector is composed of

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -49,6 +49,11 @@ spec:
                             format: int32
                             minimum: 0
                             type: integer
+                          maxData:
+                            default: false
+                            description: Read maximum possible data. This field is
+                              used only for char_buf type.
+                            type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
@@ -107,6 +112,11 @@ spec:
                           format: int32
                           minimum: 0
                           type: integer
+                        maxData:
+                          default: false
+                          description: Read maximum possible data. This field is used
+                            only for char_buf type.
+                          type: boolean
                         returnCopy:
                           default: false
                           description: This field is used only for char_buf and char_iovec
@@ -465,6 +475,11 @@ spec:
                             format: int32
                             minimum: 0
                             type: integer
+                          maxData:
+                            default: false
+                            description: Read maximum possible data. This field is
+                              used only for char_buf type.
+                            type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -49,6 +49,11 @@ spec:
                             format: int32
                             minimum: 0
                             type: integer
+                          maxData:
+                            default: false
+                            description: Read maximum possible data. This field is
+                              used only for char_buf type.
+                            type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
@@ -107,6 +112,11 @@ spec:
                           format: int32
                           minimum: 0
                           type: integer
+                        maxData:
+                          default: false
+                          description: Read maximum possible data. This field is used
+                            only for char_buf type.
+                          type: boolean
                         returnCopy:
                           default: false
                           description: This field is used only for char_buf and char_iovec
@@ -465,6 +475,11 @@ spec:
                             format: int32
                             minimum: 0
                             type: integer
+                          maxData:
+                            default: false
+                            description: Read maximum possible data. This field is
+                              used only for char_buf type.
+                            type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -136,6 +136,10 @@ type KProbeArg struct {
 	// +kubebuilder:default=false
 	// This field is used only for char_buf and char_iovec types.
 	ReturnCopy bool `json:"returnCopy"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// Read maximum possible data. This field is used only for char_buf type.
+	MaxData bool `json:"maxData"`
 }
 
 type BinarySelector struct {

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -649,7 +649,7 @@ func handleGenericTracepoint(r *bytes.Reader) ([]observer.Event, error) {
 			unix.Args = append(unix.Args, val)
 
 		case gt.GenericCharBuffer, gt.GenericCharIovec:
-			if arg, err := ReadArgBytes(r, idx); err == nil {
+			if arg, err := ReadArgBytes(r, idx, false); err == nil {
 				unix.Args = append(unix.Args, arg.Value)
 			} else {
 				logger.GetLogger().WithError(err).Warnf("failed to read bytes argument")

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2831,9 +2831,6 @@ func TestLoadKprobeSensor(t *testing.T) {
 		// generic_kprobe_actions
 		tus.SensorMap{Name: "override_tasks", Progs: []uint{12}},
 
-		// generic_kprobe_output,generic_retkprobe_event
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{13, 14}},
-
 		// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
 		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 
@@ -2844,9 +2841,16 @@ func TestLoadKprobeSensor(t *testing.T) {
 	if kernels.EnableLargeProgs() {
 		// shared with base sensor
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10, 11, 13, 14}})
+
+		// generic_kprobe_process_event*,generic_kprobe_output,generic_retkprobe_event
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 3, 4, 5, 13, 14}})
+
 	} else {
 		// shared with base sensor
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10, 11, 14}})
+
+		// generic_kprobe_output,generic_retkprobe_event
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{13, 14}})
 	}
 
 	readHook := `

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -49,6 +49,11 @@ spec:
                             format: int32
                             minimum: 0
                             type: integer
+                          maxData:
+                            default: false
+                            description: Read maximum possible data. This field is
+                              used only for char_buf type.
+                            type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
@@ -107,6 +112,11 @@ spec:
                           format: int32
                           minimum: 0
                           type: integer
+                        maxData:
+                          default: false
+                          description: Read maximum possible data. This field is used
+                            only for char_buf type.
+                          type: boolean
                         returnCopy:
                           default: false
                           description: This field is used only for char_buf and char_iovec
@@ -465,6 +475,11 @@ spec:
                             format: int32
                             minimum: 0
                             type: integer
+                          maxData:
+                            default: false
+                            description: Read maximum possible data. This field is
+                              used only for char_buf type.
+                            type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -49,6 +49,11 @@ spec:
                             format: int32
                             minimum: 0
                             type: integer
+                          maxData:
+                            default: false
+                            description: Read maximum possible data. This field is
+                              used only for char_buf type.
+                            type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
@@ -107,6 +112,11 @@ spec:
                           format: int32
                           minimum: 0
                           type: integer
+                        maxData:
+                          default: false
+                          description: Read maximum possible data. This field is used
+                            only for char_buf type.
+                          type: boolean
                         returnCopy:
                           default: false
                           description: This field is used only for char_buf and char_iovec
@@ -465,6 +475,11 @@ spec:
                             format: int32
                             minimum: 0
                             type: integer
+                          maxData:
+                            default: false
+                            description: Read maximum possible data. This field is
+                              used only for char_buf type.
+                            type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -136,6 +136,10 @@ type KProbeArg struct {
 	// +kubebuilder:default=false
 	// This field is used only for char_buf and char_iovec types.
 	ReturnCopy bool `json:"returnCopy"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// Read maximum possible data. This field is used only for char_buf type.
+	MaxData bool `json:"maxData"`
 }
 
 type BinarySelector struct {


### PR DESCRIPTION
Adding support to specify 'maxData: true' flag for char_buf argument
type to retrieve maximum data.

Using data events (same as for exec sensor) to retrieve and send
data to the user space from bpf program.

It's available for large kernels. Kernels < 5.3 won't load the 
generic kprobe with data events due to verifier size limit.

It's possible to use the maxData flag like:
```
  - call: "__x64_sys_write"
    return: false
    syscall: true
    args:
    - index: 0
      type: "int"
    - index: 1
      type: "char_buf"
      sizeArgIndex: 3
      maxData: true
    - index: 2
      type: "size_t"
```
The data events are used only if the data won't fit into standard
event size.

There's no return kprobe support at the moment. I'm adding this
for terminal sniff, where it's not needed.

The maximum size for char_buf argument with maxData flag is 327360 bytes.
