### PR TITLE
tetragon: Add --force-large-progs option to force large bpf programs

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -23,6 +23,7 @@ const (
 	keyProcessCacheSize = "process-cache-size"
 	keyDataCacheSize    = "data-cache-size"
 	keyForceSmallProgs  = "force-small-progs"
+	keyForceLargeProgs  = "force-large-progs"
 
 	keyLogLevel  = "log-level"
 	keyLogFormat = "log-format"
@@ -106,6 +107,7 @@ func readAndSetFlags() {
 	option.Config.KernelVersion = viper.GetString(keyKernelVersion)
 	option.Config.Verbosity = viper.GetInt(keyVerbosity)
 	option.Config.ForceSmallProgs = viper.GetBool(keyForceSmallProgs)
+	option.Config.ForceLargeProgs = viper.GetBool(keyForceLargeProgs)
 	option.Config.Debug = viper.GetBool(keyDebug)
 
 	option.Config.EnableProcessCred = viper.GetBool(keyEnableProcessCred)

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -140,6 +140,18 @@ func tetragonExecute() error {
 	log.WithField("version", version.Version).Info("Starting tetragon")
 	log.WithField("config", viper.AllSettings()).Info("config settings")
 
+	if option.Config.ForceLargeProgs && option.Config.ForceSmallProgs {
+		log.Fatalf("Can't specify --force-small-progs and --force-large-progs together")
+	}
+
+	if option.Config.ForceLargeProgs {
+		log.Info("Force loading large programs")
+	}
+
+	if option.Config.ForceSmallProgs {
+		log.Info("Force loading smallprograms")
+	}
+
 	if viper.IsSet(keyNetnsDir) {
 		defaults.NetnsDir = viper.GetString(keyNetnsDir)
 	}
@@ -555,6 +567,7 @@ func execute() error {
 	flags.Int(keyProcessCacheSize, 65536, "Size of the process cache")
 	flags.Int(keyDataCacheSize, 1024, "Size of the data events cache")
 	flags.Bool(keyForceSmallProgs, false, "Force loading small programs, even in kernels with >= 5.3 versions")
+	flags.Bool(keyForceLargeProgs, false, "Force loading large programs, even in kernels with < 5.3 versions")
 	flags.String(keyExportFilename, "", "Filename for JSON export. Disabled by default")
 	flags.Int(keyExportFileMaxSizeMB, 10, "Size in MB for rotating JSON export files")
 	flags.Duration(keyExportFileRotationInterval, 0, "Interval at which to rotate JSON export files in addition to rotating them by size")

--- a/examples/tracingpolicy/sys_write_sigkill.yaml
+++ b/examples/tracingpolicy/sys_write_sigkill.yaml
@@ -1,0 +1,75 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "syswritefollowfdpsswd"
+spec:
+  kprobes:
+  - call: "fd_install"
+    syscall: false
+    args:
+    - index: 0
+      type: int
+    - index: 1
+      type: "file"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "/tmp/passwd"
+      matchActions:
+      - action: FollowFD
+        argFd: 0
+        argName: 1
+  - call: "do_dup2"
+    syscall: false
+    args:
+    - index: 0
+      type: int
+    - index: 1
+      type: "file"
+    - index: 2
+      type: int
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "/tmp/passwd"
+      matchActions:
+      - action: FollowFD
+        argFd: 2
+        argName: 1
+  - call: "__x64_sys_close"
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchActions:
+      - action: UnfollowFD
+        argFd: 0
+        argName: 0
+  - call: "__x64_sys_write"
+    syscall: true
+    args:
+    - index: 0
+      type: "fd"
+    - index: 1
+      type: "char_buf"
+      sizeArgIndex: 3
+    - index: 2
+      type: "size_t"
+    selectors:
+    - matchPIDs:
+      - operator: NotIn
+        values:
+        - 0
+        - 1
+      matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "/tmp/passwd"
+      matchActions:
+      - action: SigKill

--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -70,7 +70,7 @@ func hasSigkillAction(kspec *v1alpha1.KProbeSpec) bool {
 // syscalls). We still keep this code in the btf package for now, and we can
 // move it once we found a better home for it.
 func ValidateKprobeSpec(bspec *btf.Spec, kspec *v1alpha1.KProbeSpec) error {
-	if hasSigkillAction(kspec) && !kernels.MinKernelVersion("5.3.0") {
+	if hasSigkillAction(kspec) && !kernels.EnableLargeProgs() {
 		return &ValidationFailed{s: "sigkill action requires kernel >= 5.3.0"}
 	}
 

--- a/pkg/kernels/kernels.go
+++ b/pkg/kernels/kernels.go
@@ -132,6 +132,9 @@ func EnableLargeProgs() bool {
 	if option.Config.ForceSmallProgs {
 		return false
 	}
+	if option.Config.ForceLargeProgs {
+		return true
+	}
 	kernelVer, _, _ := GetKernelVersion(option.Config.KernelVersion, option.Config.ProcFS)
 	return (int64(kernelVer) >= KernelStringToNumeric("5.3.0"))
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -20,6 +20,7 @@ type config struct {
 	BTF             string
 	Verbosity       int
 	ForceSmallProgs bool
+	ForceLargeProgs bool
 
 	EnableCilium      bool
 	EnableProcessNs   bool


### PR DESCRIPTION
Adding --force-large-progs option to force loading of large bpf
programs.

It's usefull in situations where kernel contains backports and
its version does not reflect actual features.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>