### PR TITLE
tetragon: Export podInformer

### DIFF
--- a/pkg/podhooks/podhooks.go
+++ b/pkg/podhooks/podhooks.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package podhooks
+
+import (
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	allCallbacks  = []Callbacks{}
+	allowRegister = true
+)
+
+type Callbacks struct {
+	PodCallbacks func(podInformer cache.SharedIndexInformer)
+}
+
+// RegisterCallbacksAtInit registers callbacks (should be called at init())
+func RegisterCallbacksAtInit(cbs Callbacks) {
+	if !allowRegister {
+		panic("podhooks.RegisterCallbacksAtInit must be called only in init()")
+	}
+	allCallbacks = append(allCallbacks, cbs)
+}
+
+// runHooks executes all registered callbacks
+func InstallHooks(podInformer cache.SharedIndexInformer) {
+	allowRegister = false
+	for _, cbs := range allCallbacks {
+		if fn := cbs.PodCallbacks; fn != nil {
+			fn(podInformer)
+		}
+	}
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/policyfilter"
+	"github.com/cilium/tetragon/pkg/podhooks"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -123,11 +123,7 @@ func NewK8sWatcher(k8sClient kubernetes.Interface, stateSyncIntervalSec time.Dur
 		panic(err)
 	}
 
-	// register pod handlers for policyfilters
-	if pfState, err := policyfilter.GetState(); err == nil {
-		logger.GetLogger().Info("registering policyfilter pod handlers")
-		pfState.RegisterPodHandlers(podInformer)
-	}
+	podhooks.InstallHooks(podInformer)
 
 	k8sInformerFactory.Start(wait.NeverStop)
 	k8sInformerFactory.WaitForCacheSync(wait.NeverStop)


### PR DESCRIPTION
This patch allows different modules to register custom functions to watch the creation/deletion/update of pods.