### PR TITLE
Documentation: add a links checker to the CI

### DIFF
--- a/.github/workflows/check-links-cron.yaml
+++ b/.github/workflows/check-links-cron.yaml
@@ -1,0 +1,53 @@
+name: Periodically check docs links
+
+on:
+  schedule:
+    - cron: '0 10 * * 1-5'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/check-links-cron.yaml'
+
+jobs:
+  links-checker:
+    env:
+      ISSUE_NAME: 'Documentation: broken links automatic report'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Links Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@9ace499fe66cee282a29eaa628fdac2c72fa087f
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          args: --base https://tetragon.cilium.io docs/content README.md
+
+      # to avoid automated spam, try to find an existing open issue before opening a new one
+      - name: Search for existing issue number
+        id: search-issue
+        run: |
+          encoded_issue_name=$(echo "$ISSUE_NAME" | sed 's/ /%20/g')
+          response=$(curl -s -X GET "https://api.github.com/search/issues?q=$encoded_issue_name+repo:cilium/tetragon+state:open+label:automated-issue&type=Issues")
+          issue_number=$(echo "$response" | jq -r '.items[0].number // empty')
+          echo "issue_number=$issue_number" >> $GITHUB_OUTPUT
+
+      - name: Create or update issue with report
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f
+        with:
+          title: ${{ env.ISSUE_NAME }}
+          content-filepath: ./lychee/out.md
+          issue-number: ${{ steps.search-issue.outputs.issue_number }}
+          labels: automated-issue
+
+      - name: Close automated issue
+        if: env.lychee_exit_code == 0 && steps.search-issue.outputs.issue_number != ''
+        uses: peter-evans/close-issue@1373cadf1f0c96c1420bc000cfba2273ea307fd1
+        with:
+          issue-number: ${{ steps.search-issue.outputs.issue_number }}
+          comment: '[Periodic links check](https://github.com/cilium/tetragon/actions/workflows/check-links-cron.yaml) no longer finds broken links, closing issue.'

--- a/.github/workflows/check-links-pr.yaml
+++ b/.github/workflows/check-links-pr.yaml
@@ -1,0 +1,47 @@
+name: Check docs links
+
+on:
+  pull_request:
+    paths:
+      - 'docs/content/**.md'
+      - '.github/workflows/check-links-pr.yaml'
+
+jobs:
+  links-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d
+        with:
+          hugo-version: '0.111.2'
+          extended: true
+
+      - name: Serve the Hugo website
+        working-directory: docs
+        run: hugo server &
+
+      - name: Wait for server to be ready
+        uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        with:
+          timeout_seconds: 2
+          max_attempts: 10
+          retry_wait_seconds: 3
+          command: |
+            set -e
+            curl -s http://localhost:1313 > /dev/null
+
+      - name: Links Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@9ace499fe66cee282a29eaa628fdac2c72fa087f
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          args: --base http://localhost:1313 --exclude cilium.herokuapp.com docs/content
+          fail: true
+          format: json
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ When used in a Kubernetes environment, Tetragon is Kubernetes-aware - that is, i
 Kubernetes identities such as namespaces, pods and so-on - so that security event detection
 can be configured in relation to individual workloads.
 
-![Tetragon Overview Diagram](docs/static/images/smart_observability.png)
+![Tetragon Overview Diagram](https://github.com/cilium/tetragon/blob/main/docs/static/images/smart_observability.png)
 
 ## Functionality Overview
 
@@ -706,9 +706,9 @@ To check if BTF is enabled on your Linux system, the standard location is:
 $ ls /sys/kernel/btf/
 ```
 
-Otherwise Tetragon repository provides a [Vagrantfile](Vagrantfile) that can
-be used to install a vagrant box for running Tetragon with BTF requirement. Other VM solutions
-work as well.
+Otherwise Tetragon repository provides a [Vagrantfile](https://github.com/cilium/tetragon/blob/main/Vagrantfile)
+that can be used to install a vagrant box for running Tetragon with BTF
+requirement. Other VM solutions work as well.
 
 To run with [vagrant](https://learn.hashicorp.com/tutorials/vagrant/getting-started-index?in=vagrant/getting-started)
 we provide a standard VagrantFile with the required components enabled. Simply run,

--- a/docs/content/en/docs/contribution-guide/development-setup.md
+++ b/docs/content/en/docs/contribution-guide/development-setup.md
@@ -78,8 +78,8 @@ in` .pb.go`), do not modify them directly. Instead, you can edit the files in
 
 ### Building and running a Docker image
 
-The base kernel should support [BTF](../../../README.md#btf-requirement) or a
-BTF file should be bind mounted on top of `/var/lib/tetragon/btf` inside
+The base kernel should support [BTF](https://github.com/cilium/tetragon#btf-requirement)
+or a BTF file should be bind mounted on top of `/var/lib/tetragon/btf` inside
 container.
 
 To build Tetragon image:
@@ -111,10 +111,8 @@ make tarball
 ```
 
 The produced tarball will be inside directory `./build/`, then follow the
-[Package deployment guide][package-deployment] to install it as a systemd
-service.
-
-[package-deployment]: ../../deployment/package/README.md
+[Package deployment guide](/docs/getting-started/deployment/package/) to
+install it as a systemd service.
 
 ### Running Tetragon in kind
 
@@ -168,5 +166,5 @@ minikube ssh sudo "sh -c 'NODE_NAME=minikube /home/kkourt/src/tetragon/tetragon 
 
 ### What's next
 
-See how to [make your first changes](/docs/contribution-guide/making-changes/).
+See how to [make your first changes](/docs/contribution-guide/making-changes).
 

--- a/docs/content/en/docs/faq/_index.md
+++ b/docs/content/en/docs/faq/_index.md
@@ -7,7 +7,7 @@ description: "List of frequently asked questions"
 **Q:** Can I install and use Tetragon in standalone mode (outside of k8s)?
 
 **A:** Yes! You can run `make` to generate standalone binaries and run them directly.
-Make sure to take a look at the [Development Setup](docs/contributing/development/README.md#development-setup)
+Make sure to take a look at the [Development Setup](/docs/contribution-guide/development-setup/)
 guide for the build requirements. Then use `sudo ./tetragon --bpf-lib bpf/objs`
 to run Tetragon.
 

--- a/docs/content/en/docs/getting-started/deployment/package.md
+++ b/docs/content/en/docs/getting-started/deployment/package.md
@@ -26,7 +26,7 @@ Default configurations are shipped with Tetragon packages that local administrat
 can override by using their own configurations inside `/etc/tetragon/` directory.
 
 To read more about how configurations are handled please check the
-[Configuration](/docs/getting-started/documentation) documentation.
+[Configuration](/docs/getting-started/configuration) documentation.
 
 ## Linux Binary Tarball
 
@@ -111,7 +111,7 @@ By default Tetragon configuration will be installed in
 If you want to change the configuration, then add your drop-ins inside
 `/etc/tetragon/tetragon.conf.d/` to override the default settings. For further
 details and examples, please check the
-[Configuration](/docs/getting-started/documentation) documentation.
+[Configuration](/docs/getting-started/configuration) documentation.
 
 To restore default settings, remove any added configuration inside
 `/etc/tetragon/`.

--- a/docs/content/en/docs/getting-started/explore-security-observability-events.md
+++ b/docs/content/en/docs/getting-started/explore-security-observability-events.md
@@ -5,7 +5,7 @@ description: "Learn how to start exploring the Tetragon events"
 ---
 
 After Tetragon and the [demo application is up and
-running](http://localhost:1313/docs/getting-started/kubernetes-quickstart-guide/#deploy-demo-application)
+running](/docs/getting-started/kubernetes-quickstart-guide/#deploy-the-demo-application)
 you can examine the security and observability events produced by Tetragon in
 different ways.
 

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -638,7 +638,7 @@ matchNamespaceChanges:
 
 The `unshare` command, or executing in the host namespace using `nsenter` can
 be used to test this feature. See a
-[demonstration example](https://github.com/cilium/tetragon/main/examples/tracingpolicy/match_namespace_changes.yaml)
+[demonstration example](https://github.com/cilium/tetragon/blob/main/examples/tracingpolicy/match_namespace_changes.yaml)
 of this feature.
 
 #### Capability changes filter
@@ -659,7 +659,7 @@ matchCapabilityChanges:
   - "CAP_SETUID"
 ```
 
-See a [demonstration example](https://github.com/cilium/tetragon/main/examples/tracingpolicy/match_capability_changes.yaml)
+See a [demonstration example](https://github.com/cilium/tetragon/blob/main/examples/tracingpolicy/match_capability_changes.yaml)
 of this feature.
 
 #### Actions filter


### PR DESCRIPTION
Please appreciate how painful it was to make that work like a charm:
```yaml
      # to avoid automated spam, try to find an existing open issue before opening a new one
      - name: Search for existing issue number
        id: search-issue
        run: |
          encoded_issue_name=$(echo "$ISSUE_NAME" | sed 's/ /%20/g')
          response=$(curl -s -X GET "https://api.github.com/search/issues?q=$encoded_issue_name+repo:cilium/tetragon+state:open+label:automated-issue&type=Issues")
          issue_number=$(echo "$response" | jq -r '.items[0].number // empty')
          echo "issue_number=$issue_number" >> $GITHUB_OUTPUT
          
      - name: Create or update issue with report
        if: env.lychee_exit_code != 0
        uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f
        with:
          title: ${{ env.ISSUE_NAME }}
          content-filepath: ./lychee/out.md
          issue-number: ${{ steps.search-issue.outputs.issue_number }}
          labels: automated-issue
```