### PR TITLE
helm: recreate daemonset pod when configmap changes

### DIFF
--- a/install/kubernetes/templates/daemonset.yaml
+++ b/install/kubernetes/templates/daemonset.yaml
@@ -23,8 +23,9 @@ spec:
     {{- end }}
   template:
     metadata:
-    {{- if .Values.podAnnotations }}
       annotations:
+        checksum/configmap: {{  toJson .Values.tetragon | sha256sum }}
+    {{- if .Values.podAnnotations }}
     {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
After the helm upgrade with new configmap changes. the daemonset pod is not recreated to retrieve the new configmap.

The readconfig function only read on pod start https://github.com/cilium/tetragon/blob/main/cmd/tetragon/main.go#L542

to make Tetragon restart and retrieve the new configuration. Kubernetes annotation helps determine whenever the pod needs to be recreated.