### PR TITLE
Docs: add netlify config file to ignore non-docs related PRs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  base = "docs/"
+  publish = "docs/public"
+  command = "npm ci && hugo"
+  environment = { HUGO_VERSION = "0.111.3" }
+  ignore = "! git diff main --name-only | grep ^docs/"


### PR DESCRIPTION
In order to avoid notification spam on our PRs preview on non-docs related PRs, we need to add a ignore command.