### PR TITLE
Workflow: fix syntax of build image CI

### DIFF
--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -174,7 +174,6 @@ jobs:
 
       - name: Sign SBOM Image
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
-        run: |
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |


### PR DESCRIPTION
I accidentally added a run line here:

https://github.com/cilium/tetragon/blob/540a7bd4d5bd2d3df306a1b0244406efbaf249d5/.github/workflows/build-images-ci.yml#L175-L184

And it broke the workflow (which not triggered an alert in the checks since it was a `pull_request_target`) https://github.com/cilium/tetragon/pull/816#issuecomment-1472545789 it was in plain sight here. Anyway, here's a patch.