### PR TITLE
Logger is not displaying wrapped errors correctly

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -343,6 +343,17 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec, polic
 		config.PolicyID = uint32(policyID)
 
 		argRetprobe = nil // holds pointer to arg for return handler
+
+		// modifying f.Call directly instead of writing to funcName
+		// because of BTF validation later using the whole v1alpha1.KProbeSpec object
+		if f.Syscall {
+			prefixedName, err := arch.AddSyscallPrefix(f.Call)
+			if err != nil {
+				logger.GetLogger().Warnf("kprobe syscall prefix: %v", err)
+			} else {
+				f.Call = prefixedName
+			}
+		}
 		funcName := f.Call
 
 		// Parse Arguments


### PR DESCRIPTION
fix: Logger is not displaying wrapped errors correctly
Fixes: #761 
Signed-off-by: Haiyu Zuo <958474674@qq.com>