### PR TITLE
kprobes: add a prevalidate kprobe semantics phase

### DIFF
--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -78,7 +78,7 @@ func ValidateKprobeSpec(bspec *btf.Spec, kspec *v1alpha1.KProbeSpec) error {
 
 	err := bspec.TypeByName(kspec.Call, &fn)
 	if err != nil {
-		return fmt.Errorf("kprobe spec validation failed: call %s not found", kspec.Call)
+		return &ValidationFailed{s: fmt.Sprintf("call %q not found", kspec.Call)}
 	}
 
 	proto, ok := fn.Type.(*btf.FuncProto)

--- a/pkg/sensors/tracing/policyhandler.go
+++ b/pkg/sensors/tracing/policyhandler.go
@@ -27,6 +27,10 @@ func (h policyHandler) PolicyHandler(
 	}
 	if len(spec.KProbes) > 0 {
 		name := fmt.Sprintf("gkp-sensor-%d", atomic.AddUint64(&sensorCounter, 1))
+		err := preValidateKprobes(name, spec.KProbes)
+		if err != nil {
+			return nil, err
+		}
 		return createGenericKprobeSensor(name, spec.KProbes, policyID)
 	}
 	if len(spec.Tracepoints) > 0 {


### PR DESCRIPTION
kprobes: pre-validate kprobe semantics
    
This adds a pre-validate kprobe semantics phase in order to:
1. Separate kprobe semantics errors from BPF related ones.
2. Fail early without probing BPF on some errors and avoid loading BPF resources
3. Reduce user confusion if a policy was loaded or not

Before:
```
time="2023-03-22T12:48:47+01:00" level=debug msg="Received an AddTracingPolicy request" request="yaml:\"apiVersion: cilium.io/v1alpha1\\nkind: TracingPolicy\\nmetadata:\\n name: \\\"fake\\\"\\nspec:\\n kprobes:\\n - call: \\\"sys_fake\\\"\\n   syscall: true\\n\""
time="2023-03-22T12:48:47+01:00" level=warning msg="invalid or old kprobe spec: kprobe spec validation failed: call __x64_sys_fake not found"
time="2023-03-22T12:48:47+01:00" level=debug msg="Kprobe spec pre-validation succeeded" name=gkp-sensor-1
time="2023-03-22T12:48:47+01:00" level=info msg="Added generic kprobe sensor: bpf/objs/bpf_generic_kprobe_v53.o -> __x64_sys_fake"
time="2023-03-22T12:48:47+01:00" level=debug msg="Checking for bpf file" file=bpf/objs/bpf_generic_kprobe_v53.o
time="2023-03-22T12:48:47+01:00" level=debug msg="Found bpf file" file=bpf/objs/bpf_generic_kprobe_v53.o
...
time="2023-03-22T12:48:47+01:00" level=debug msg="Found bpf file" file=bpf/objs/bpf_generic_kprobe_v53.o
time="2023-03-22T12:48:47+01:00" level=info msg="tetragon, map loaded." map=fdinstall_map path=/sys/fs/bpf/tetragon/gkp-sensor-1-fdinstall_map sensor=gkp-sensor-1
time="2023-03-22T12:48:47+01:00" level=info msg="tetragon, map loaded." map=config_map path=/sys/fs/bpf/tetragon/gkp-sensor-1-gkp-0-config_map sensor=gkp-sensor-1
time="2023-03-22T12:48:47+01:00" level=info msg="tetragon, map loaded." map=kprobe_calls path=/sys/fs/bpf/tetragon/gkp-sensor-1-gkp-0-kp_calls sensor=gkp-sensor-1
time="2023-03-22T12:48:47+01:00" level=info msg="tetragon, map loaded." map=filter_map path=/sys/fs/bpf/tetragon/gkp-sensor-1-gkp-0-filter_map sensor=gkp-sensor-1
time="2023-03-22T12:48:47+01:00" level=info msg="tetragon, map loaded." map=argfilter_maps path=/sys/fs/bpf/tetragon/gkp-sensor-1-gkp-0-argfilter_maps sensor=gkp-sensor-1
time="2023-03-22T12:48:47+01:00" level=info msg="tetragon, map loaded." map=retprobe_map path=/sys/fs/bpf/tetragon/gkp-sensor-1-gkp-0-retprobe_map sensor=gkp-sensor-1
time="2023-03-22T12:48:47+01:00" level=info msg="tetragon, map loaded." map=process_call_heap path=/sys/fs/bpf/tetragon/gkp-sensor-1-gkp-0-process_call_heap sensor=gkp-sensor-1
time="2023-03-22T12:48:47+01:00" level=info msg="tetragon, map loaded." map=sel_names_map path=/sys/fs/bpf/tetragon/gkp-sensor-1-gkp-0-sel_names_map sensor=gkp-sensor-1
time="2023-03-22T12:48:47+01:00" level=debug msg=observerLoadInstancebpf/objs/bpf_generic_kprobe_v53.o330240 kern_version=330240 prog=bpf/objs/bpf_generic_kprobe_v53.o
time="2023-03-22T12:48:47+01:00" level=info msg="Loading registered BPF probe" Program=bpf/objs/bpf_generic_kprobe_v53.o Type=generic_kprobe
time="2023-03-22T12:48:47+01:00" level=debug msg="pin file for map 'policy_filter_maps' not found, map is not shared!\n" prog=kprobe/generic_kprobe
time="2023-03-22T12:48:47+01:00" level=debug msg="pin file for map 'override_tasks' not found, map is not shared!\n" prog=kprobe/generic_kprobe
time="2023-03-22T12:48:47+01:00" level=debug msg="pin file for map 'buffer_heap_map' not found, map is not shared!\n" prog=kprobe/generic_kprobe
```

After this patch:
```
time="2023-03-27T11:30:45+02:00" level=debug msg="Received an AddTracingPolicy request" request="yaml:\"apiVersion: cilium.io/v1alpha1\\nkind: TracingPolicy\\nmetadata:\\n  name: \\\"sys-fake\\\"\\nspec:\\n  kprobes:\\n  - call: \\\"sys_fake\\\"\\n    syscall: true\\n\""
time="2023-03-27T11:30:45+02:00" level=warning msg="Server AddTracingPolicy request failed" error="policy handler tracing failed: kprobe spec pre-validation failed: call \"__x64_sys_fake\" not found" metadata.name=sys-fake metadata.namespace=
```
    
Signed-off-by: Djalal Harouni <tixxdz@gmail.com>