### PR TITLE
tetragon: Fix multi kprobe attach data

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -649,7 +649,7 @@ func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir, mapDir string, load *p
 		data.Cookies = append(data.Cookies, uint64(index))
 	}
 
-	load.SetAttachData(&data)
+	load.SetAttachData(data)
 
 	if err := program.LoadMultiKprobeProgram(bpfDir, mapDir, load, verbose); err == nil {
 		logger.GetLogger().Infof("Loaded generic kprobe sensor: %s -> %s", load.Name, load.Attach)


### PR DESCRIPTION
The MultiKprobeAttach expects pointer to attach, but we are passing poitner to pointer.