### PR TITLE
tetragon: Move matchBinaries filter to be executed earlier

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -49,4 +49,7 @@ struct bpf_map_def {
 };
 #endif
 
+#define BIT(nr)	    (1 << (nr))
+#define BIT_ULL(nr) (1ULL << (nr))
+
 #endif // _MSG_COMMON__

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -74,6 +74,8 @@ generic_kprobe_start_process_filter(void *ctx)
 	config = map_lookup_elem(&config_map, &msg->idx);
 	if (!config)
 		return 0;
+	if (!generic_process_filter_binary(config))
+		return 0;
 	if (!policy_filter_check(config->policy_id))
 		return 0;
 	msg->id = config->func_id;

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -120,6 +120,9 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	if (!config)
 		return 0;
 
+	if (!generic_process_filter_binary(config))
+		return 0;
+
 	/* check policy filter */
 	if (!policy_filter_check(config->policy_id))
 		return 0;

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -84,6 +84,8 @@ generic_uprobe_start_process_filter(void *ctx)
 		return 0;
 	msg->idx = 0;
 	msg->id = config->func_id;
+	if (!generic_process_filter_binary(config))
+		return 0;
 	/* Tail call into filters. */
 	tail_call(ctx, &uprobe_calls, 5);
 	return 0;

--- a/bpf/process/bpf_loader.c
+++ b/bpf/process/bpf_loader.c
@@ -58,9 +58,9 @@ struct {
 #define VM_EXEC	      0x00000004
 #define MSG_OP_LOADER 26
 
-#define ATTR_BIT_MMAP	 (1ULL << 8)
-#define ATTR_BIT_MMAP2	 (1ULL << 23)
-#define ATTR_BIT_BUILDID (1ULL << 34)
+#define ATTR_BIT_MMAP	 BIT_ULL(8)
+#define ATTR_BIT_MMAP2	 BIT_ULL(23)
+#define ATTR_BIT_BUILDID BIT_ULL(34)
 
 __attribute__((section(("kprobe/perf_event_mmap_output")), used)) int
 loader_kprobe(struct pt_regs *ctx)

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -15,6 +15,7 @@
 #include "user_namespace.h"
 #include "capabilities.h"
 #include "../argfilter_maps.h"
+#include "common.h"
 
 /* Type IDs form API with user space generickprobe.go */
 enum {
@@ -481,8 +482,8 @@ copy_capability(char *args, unsigned long arg)
 	return sizeof(struct capability_info_type);
 }
 
-#define ARGM_INDEX_MASK	 ((1 << 4) - 1)
-#define ARGM_RETURN_COPY (1 << 4)
+#define ARGM_RETURN_COPY BIT(4)
+#define ARGM_INDEX_MASK	 ARGM_RETURN_COPY - 1
 
 static inline __attribute__((always_inline)) bool
 hasReturnCopy(unsigned long argm)

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -382,4 +382,5 @@ type EventConfig struct {
 	ArgReturnCopy int32                      `align:"argreturncopy"`
 	ArgReturn     int32                      `align:"argreturn"`
 	PolicyID      uint32                     `align:"policy_id"`
+	Flags         uint32                     `align:"flags"`
 }

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -769,3 +769,23 @@ func HasOverride(spec *v1alpha1.KProbeSpec) bool {
 	}
 	return false
 }
+
+func HasEarlyBinaryFilter(selectors []v1alpha1.KProbeSelector) bool {
+	if len(selectors) == 0 {
+		return false
+	}
+	for _, s := range selectors {
+		if len(s.MatchPIDs) > 0 ||
+			len(s.MatchNamespaces) > 0 ||
+			len(s.MatchCapabilities) > 0 ||
+			len(s.MatchNamespaceChanges) > 0 ||
+			len(s.MatchCapabilityChanges) > 0 ||
+			len(s.MatchArgs) > 0 {
+			return false
+		}
+	}
+	if len(selectors) == 1 && len(selectors[0].MatchBinaries) > 0 {
+		return true
+	}
+	return false
+}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -452,6 +452,10 @@ func (tp *genericTracepoint) EventConfig() (api.EventConfig, error) {
 		config.Sigkill = 1
 	}
 
+	if selectors.HasEarlyBinaryFilter(tp.Spec.Selectors) {
+		config.Flags |= flagsEarlyFilter
+	}
+
 	return config, nil
 }
 
@@ -540,7 +544,8 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 	load.MapLoad = append(load.MapLoad, cfg)
 
 	if err := program.LoadTracepointProgram(bpfDir, mapDir, load, verbose); err == nil {
-		logger.GetLogger().Infof("Loaded generic tracepoint program: %s -> %s", load.Name, load.Attach)
+		logger.GetLogger().WithField("flags", flagsString(config.Flags)).
+			Infof("Loaded generic tracepoint program: %s -> %s", load.Name, load.Attach)
 	} else {
 		return err
 	}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -149,7 +149,8 @@ func (k *observerUprobeSensor) LoadProbe(args sensors.LoadProbeArgs) error {
 		writeBinaryMap(m, i, path)
 	}
 
-	logger.GetLogger().Infof("Loaded generic uprobe program: %s -> %s [%s]", args.Load.Name, uprobeEntry.path, uprobeEntry.symbol)
+	logger.GetLogger().WithField("flags", flagsString(uprobeEntry.config.Flags)).
+		Infof("Loaded generic uprobe program: %s -> %s [%s]", args.Load.Name, uprobeEntry.path, uprobeEntry.symbol)
 	return nil
 }
 
@@ -210,6 +211,10 @@ func createGenericUprobeSensor(name string, uprobes []v1alpha1.UProbeSpec) (*sen
 
 		uprobeEntry.pinPathPrefix = sensors.PathJoin(sensorPath, fmt.Sprintf("%d", id))
 		config.FuncId = uint32(id)
+
+		if selectors.HasEarlyBinaryFilter(spec.Selectors) {
+			config.Flags |= flagsEarlyFilter
+		}
 
 		pinPath := uprobeEntry.pinPathPrefix
 		pinProg := sensors.PathJoin(pinPath, "prog")

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2515,22 +2515,14 @@ func TestLoadKprobeSensor(t *testing.T) {
 		// generic_kprobe_filter_arg*,generic_retkprobe_event,base
 		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{6, 7, 8, 9, 10, 12}},
 
-		// only retkprobe
-		tus.SensorMap{Name: "config_map", Progs: []uint{12}},
+		// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
+		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 
 		// shared with base sensor
 		tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10, 11, 12}},
 
 		// generic_kprobe_process_event*,generic_kprobe_filter_arg*,retkprobe
 		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12}},
-	}
-
-	if kernels.EnableLargeProgs() {
-		// all kprobe but generic_kprobe_process_filter
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}})
-	} else {
-		// all kprobe but generic_kprobe_process_filter
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5}})
 	}
 
 	readHook := `

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -17,7 +17,6 @@ import (
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
-	"github.com/cilium/tetragon/pkg/kernels"
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	smatcher "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/observer"
@@ -433,16 +432,11 @@ func TestLoadTracepointSensor(t *testing.T) {
 		// generic_tracepoint_arg**,base
 		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 3, 4, 5}},
 
+		// all kprobe but generic_tracepoint_filter
+		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+
 		// shared with base sensor
 		tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 2, 3, 4, 5, 11}},
-	}
-
-	if kernels.EnableLargeProgs() {
-		// all kprobe but generic_kprobe_process_filter,generic_kprobe_event
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}})
-	} else {
-		// all kprobe but generic_kprobe_process_filter,generic_kprobe_event
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 6, 7, 8, 9, 10}})
 	}
 
 	readHook := `

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -48,7 +48,7 @@ func TestUprobeLoad(t *testing.T) {
 		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{6, 7, 8, 9, 10, 12}},
 
 		// shared with base sensor
-		tus.SensorMap{Name: "execve_map", Progs: []uint{6, 7, 8, 9, 10, 11, 12}},
+		tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10, 11, 12}},
 	}
 
 	nopHook := `


### PR DESCRIPTION
The matchBinary filter des not have any selector record, so we can do that as a first thing in probe.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
