### PR TITLE
build(deps): bump library/golang from 1.18.3 to 1.20.1

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -11,7 +11,7 @@ RUN apt-get install -y linux-libc-dev
 COPY . ./
 RUN make tetragon-bpf && pwd
 
-FROM docker.io/library/golang:1.18.3@sha256:af65c2761458722a028131c06edbdff97d6efcd2d66630fbfe0572b18185c7a4
+FROM docker.io/library/golang:1.20.1@sha256:b03e75040e516c6e349e27a0f64a99883728958b38e744ea0293389e3643ecbb
 RUN apt-get update
 RUN apt-get install -y linux-libc-dev rpm2cpio cpio git flex bison autoconf libelf-dev bc netcat-traditional
 WORKDIR /go/src/github.com/cilium/tetragon


### PR DESCRIPTION
build(deps): bump library/golang from 1.18.3 to 1.20.1
Fixes: #766 #791  