### PR TITLE
Revert "build(deps): bump sigstore/cosign-installer from 2.8.1 to 3.0.1"

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install Cosign
         if: github.event_name == 'push'
-        uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
 
       - name: Sign Container Image
         if: github.event_name == 'push' && steps.tag-in-repositories.outputs.exists == 'false'

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -71,7 +71,7 @@ jobs:
           echo "TETRAGON_VERSION=$(make version)" >> $GITHUB_ENV
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
 
       - name: Install Bom
         shell: bash

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -76,7 +76,7 @@ jobs:
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
 
       - name: Sign Container Image
         env:


### PR DESCRIPTION
This reverts commit eceacc854304748cc19f115277b0342381788626 (https://github.com/cilium/tetragon/pull/771).

Reverting this dependabot change because it breaks the build.

> Run cosign sign quay.io/cilium/tetragon-operator-ci@sha256:32851e6980638f3cd364fd52174b041de3e4bf433b3b49c57f58c0f2dc341970 | Generating ephemeral keys...
>  Retrieving signed certificate...
>  Successfully verified SCT...
> 
> 	Note that there may be personally identifiable information associated with this signed artifact. | 	This may include the email address associated with the account with which you authenticate. | 	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later. |
> By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs. | Are you sure you would like to continue? [y/N] Error: signing [quay.io/cilium/tetragon-operator-ci@sha256:32851e6980638f3cd364fd52174b041de3e4bf433b3b49c57f58c0f2dc341970]: signing digest: should upload to tlog: user declined the prompt | main.go:74: error during command execution: signing [quay.io/cilium/tetragon-operator-ci@sha256:32851e6980638f3cd364fd52174b041de3e4bf433b3b49c57f58c0f2dc341970]: signing digest: should upload to tlog: user declined the prompt | Error: Process completed with exit code 1.