### PR TITLE
TracingPolicy examples: use portable symbols for syscalls

### DIFF
--- a/examples/tracingpolicy/fd_memfd_kill.yaml
+++ b/examples/tracingpolicy/fd_memfd_kill.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   kprobes:
 # int close(int fd);
-  - call: "__x64_sys_close"
+  - call: "sys_close"
     syscall: true
     args:
     - index: 0
@@ -23,7 +23,7 @@ spec:
         argFd: 0
         argName: 0
   # int memfd_create(const char *name, unsigned int flags);
-  - call: "__x64_sys_memfd_create"
+  - call: "sys_memfd_create"
     syscall: true
     args:
     - index: 0
@@ -39,7 +39,7 @@ spec:
         - 0
         - 1
 # int execve(const char *pathname, char *const argv[],char *const envp[]);
-  - call: "__x64_sys_execve"
+  - call: "sys_execve"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/hardlink-observe.yaml
+++ b/examples/tracingpolicy/hardlink-observe.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "sys-linkat-passwd"
 spec:
   kprobes:
-  - call: "__x64_sys_linkat"
+  - call: "sys_linkat"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/hardlink-override.yaml
+++ b/examples/tracingpolicy/hardlink-override.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "sys-linkat-passwd"
 spec:
   kprobes:
-  - call: "__x64_sys_linkat"
+  - call: "sys_linkat"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/match_capability_changes.yaml
+++ b/examples/tracingpolicy/match_capability_changes.yaml
@@ -79,7 +79,7 @@ spec:
       - action: FollowFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/match_namespace_changes.yaml
+++ b/examples/tracingpolicy/match_namespace_changes.yaml
@@ -68,7 +68,7 @@ spec:
       - action: FollowFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/names.yaml
+++ b/examples/tracingpolicy/names.yaml
@@ -25,7 +25,7 @@ spec:
       - action: FollowFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_close"
+  - call: "sys_close"
     syscall: true
     args:
     - index: 0
@@ -35,7 +35,7 @@ spec:
       - action: UnfollowFD
         argFd: 0
         argName: 0
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/open_kill.yaml
+++ b/examples/tracingpolicy/open_kill.yaml
@@ -28,7 +28,7 @@ spec:
       - action: FollowFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_close"
+  - call: "sys_close"
     syscall: true
     args:
     - index: 0
@@ -45,7 +45,7 @@ spec:
       - action: UnfollowFD
         argFd: 0
         argName: 0
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/symlink-observe.yaml
+++ b/examples/tracingpolicy/symlink-observe.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "sys-symlink-passwd"
 spec:
   kprobes:
-  - call: "__x64_sys_symlinkat"
+  - call: "sys_symlinkat"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/symlink-override.yaml
+++ b/examples/tracingpolicy/symlink-override.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "sys-symlink-passwd"
 spec:
   kprobes:
-  - call: "__x64_sys_symlinkat"
+  - call: "sys_symlinkat"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/sys_clock_settime.yaml
+++ b/examples/tracingpolicy/sys_clock_settime.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   kprobes:
   # __x64_sys_clock_settime(clockid_t which_clock, const struct kernel_timespec __user *tp)
-  - call: "__x64_sys_clock_settime"
+  - call: "sys_clock_settime"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/sys_mount.yaml
+++ b/examples/tracingpolicy/sys_mount.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   kprobes:
   # int mount(const char *source, const char *target, const char *filesystemtype, unsigned long mountflags, const void *data);
-  - call: "__x64_sys_mount"
+  - call: "sys_mount"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/sys_pivot_root.yaml
+++ b/examples/tracingpolicy/sys_pivot_root.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   kprobes:
   # __x64_sys_pivot_root(const char new root, const char put_old)
-  - call: "__x64_sys_pivot_root"
+  - call: "sys_pivot_root"
     syscall: true
     args:
       - index: 0

--- a/examples/tracingpolicy/sys_ptrace.yaml
+++ b/examples/tracingpolicy/sys_ptrace.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   kprobes:
   # long ptrace(enum __ptrace_request request, pid_t pid, void *addr, void *data);
-  - call: "__x64_sys_ptrace"
+  - call: "sys_ptrace"
     syscall: true
     args:
      - index: 2

--- a/examples/tracingpolicy/sys_setuid.yaml
+++ b/examples/tracingpolicy/sys_setuid.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   kprobes:
   # int setuid(uid_t uid);
-  - call: "__x64_sys_setuid"
+  - call: "sys_setuid"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/sys_write_follow_fd_etc_pwd.yaml
+++ b/examples/tracingpolicy/sys_write_follow_fd_etc_pwd.yaml
@@ -28,7 +28,7 @@ spec:
       - action: FollowFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/sys_write_follow_fd_prefix.yaml
+++ b/examples/tracingpolicy/sys_write_follow_fd_prefix.yaml
@@ -28,7 +28,7 @@ spec:
       - action: FollowFD
         argFd: 0
         argName: 1
-  - call: "__x64_sys_close"
+  - call: "sys_close"
     syscall: true
     args:
     - index: 0
@@ -38,7 +38,7 @@ spec:
       - action: UnfollowFD
         argFd: 0
         argName: 0
-  - call: "__x64_sys_read"
+  - call: "sys_read"
     syscall: true
     args:
     - index: 0
@@ -48,7 +48,7 @@ spec:
       returnCopy: true
     - index: 2
       type: "size_t"
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/sys_write_sigkill.yaml
+++ b/examples/tracingpolicy/sys_write_sigkill.yaml
@@ -40,7 +40,7 @@ spec:
       - action: FollowFD
         argFd: 2
         argName: 1
-  - call: "__x64_sys_close"
+  - call: "sys_close"
     syscall: true
     args:
     - index: 0
@@ -50,7 +50,7 @@ spec:
       - action: UnfollowFD
         argFd: 0
         argName: 0
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0

--- a/examples/tracingpolicy/write.yaml
+++ b/examples/tracingpolicy/write.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "sys-write"
 spec:
   kprobes:
-  - call: "__x64_sys_write"
+  - call: "sys_write"
     syscall: true
     args:
     - index: 0


### PR DESCRIPTION
This patch includes the change done by this command: 
```shell
find . -type f -name '*' -print0 | xargs -0 sed -i 's/call: "__x64_sys_/call: "sys_/g'
```

Apart from that, it highlights the issue that for the user, the symbol declared `sys_write` will be different than the symbol he can see from the logs `__x64_sys_write` or `__arm64_sys_write`. Should we do something about it? We could:
- retranslate `__x64_sys_write` to `sys_write` at the agent level so that all logs contain this symbol name;
- just provide a translation in `tetra`;
- nothing.