### PR TITLE
Dockerfiles: use ENTRYPOINT instead of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ COPY --from=tetragon-builder /go/src/github.com/cilium/tetragon/tetragon /usr/bi
 COPY --from=tetragon-builder /go/src/github.com/cilium/tetragon/tetra /usr/bin/
 COPY --from=gops /go/src/github.com/google/gops/gops /usr/bin/
 COPY --from=bpf-builder /go/src/github.com/cilium/tetragon/bpf/objs/*.o /var/lib/tetragon/
-CMD ["sh", "-c", "/usr/bin/tetragon"]
+ENTRYPOINT ["/usr/bin/tetragon"]
 
 # This target only builds with the `--target release` option and reduces the
 # size of the final image with a static build of bpftool without the LLVM

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -40,6 +40,6 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/tetragon-operator /usr/bin/tetragon-operator
 WORKDIR /
 ENV GOPS_CONFIG_DIR=/
-CMD ["/usr/bin/tetragon-operator"]
+ENTRYPOINT ["/usr/bin/tetragon-operator"]
 
 FROM release

--- a/docs/content/en/docs/getting-started/deployment/container.md
+++ b/docs/content/en/docs/getting-started/deployment/container.md
@@ -48,8 +48,7 @@ docker run --name tetragon \
    --rm -it -d --pid=host \
    --cgroupns=host --privileged \
    -v /sys/kernel/btf/vmlinux:/var/lib/tetragon/btf \
-   quay.io/cilium/tetragon-ci:latest \
-   bash -c "/usr/bin/tetragon"
+   quay.io/cilium/tetragon-ci:latest
 ```
 
 ## What's next

--- a/install/kubernetes/templates/_container_tetragon.tpl
+++ b/install/kubernetes/templates/_container_tetragon.tpl
@@ -4,11 +4,9 @@
     {{- toYaml .Values.tetragon.securityContext | nindent 4 }}
   image: "{{ if .Values.tetragon.image.override }}{{ .Values.tetragon.image.override }}{{ else }}{{ .Values.tetragon.image.repository }}:{{ .Values.tetragon.image.tag | default .Chart.AppVersion }}{{ end }}"
   imagePullPolicy: {{ .Values.imagePullPolicy }}
-  command:
 {{- with .Values.tetragon.commandOverride }}
+  command:
   {{- toYaml . | nindent 2 }}
-{{- else }}
-    - /usr/bin/tetragon
 {{- end }}
   args:
     - --config-dir=/etc/tetragon/tetragon.conf.d/
@@ -82,8 +80,6 @@
 {{- define "container.tetragon.init-operator" -}}
 {{- if .Values.tetragonOperator.enabled -}}
 - name: {{ include "container.tetragon.name" . }}-operator
-  command:
-  - tetragon-operator
   image: "{{ if .Values.tetragonOperator.image.override }}{{ .Values.tetragonOperator.image.override }}{{ else }}{{ .Values.tetragonOperator.image.repository }}{{ .Values.tetragonOperator.image.suffix }}:{{ .Values.tetragonOperator.image.tag }}{{ end }}"
   imagePullPolicy: {{ .Values.imagePullPolicy }}
 {{- end }}


### PR DESCRIPTION
ENTRYPOINT should be used instead of CMD to declare the main program of the Dockerfile. CMD should be used for default parameters to the entrypoint binary if any.

It's still possible to modify the entrypoint with the `--entrypoint` flag, to execute a bash in the container for example and it makes the image "ready to consume", i.e. you can directly pass args and flags to the image.

See this example where we simulate the ENTRYPOINT this patch would add with the `--entrypoint` flag, to understand the convenience: 
```
docker run --rm --entrypoint /usr/bin/tetragon quay.io/cilium/tetragon:v0.9.0 --help
```
This will become:
```
docker run --rm quay.io/cilium/tetragon:vTDB --help
```