### PR TITLE
fix: injecting Git version into tetragon-operator binary fails

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -17,10 +17,11 @@ ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETARCH
 ARG NOSTRIP
+ARG TETRAGON_VERSION
 
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/tetragon --mount=target=/root/.cache,type=cache --mount=target=/go/pkg/mod,type=cache \
-    make GOARCH=${TARGETARCH} tetragon-operator-image \
+    make GOARCH=${TARGETARCH} VERSION=${TETRAGON_VERSION} tetragon-operator-image \
     && mkdir -p /out/${TARGETOS}/${TARGETARCH}/usr/bin && mv tetragon-operator /out/${TARGETOS}/${TARGETARCH}/usr/bin
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Fixes #881 