### PR TITLE
fixup server address when port is not present

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -457,10 +457,10 @@ func startExporter(ctx context.Context, server *server.Server) error {
 	return nil
 }
 
-func Serve(ctx context.Context, listenAddr string, server *server.Server) error {
+func Serve(ctx context.Context, listenAddr string, srv *server.Server) error {
 	grpcServer := grpc.NewServer()
-	tetragon.RegisterFineGuidanceSensorsServer(grpcServer, server)
-	proto, addr, err := splitListenAddr(listenAddr)
+	tetragon.RegisterFineGuidanceSensorsServer(grpcServer, srv)
+	proto, addr, err := server.SplitListenAddr(listenAddr)
 	if err != nil {
 		return fmt.Errorf("failed to parse listen address: %w", err)
 	}

--- a/pkg/server/addr.go
+++ b/pkg/server/addr.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import (
 	"fmt"
@@ -20,7 +20,7 @@ import (
 // "ipv6" for tcp connections.
 // Hence, because we want the same string to work the same way both on the client and the server, we
 // only support the two addresses above.
-func splitListenAddr(arg string) (string, string, error) {
+func SplitListenAddr(arg string) (string, string, error) {
 
 	if strings.HasPrefix(arg, "unix://") {
 		path := strings.TrimPrefix(arg, "unix://")

--- a/pkg/server/addr.go
+++ b/pkg/server/addr.go
@@ -30,6 +30,14 @@ func SplitListenAddr(arg string) (string, string, error) {
 		return "unix", path, nil
 	}
 
+	// Some recent changes to the way we input the address string in Helm have introduced
+	// an unfortunate compatibility breakage with the old default values which did not
+	// include a port number in the address string. To provide backward compatibility
+	// here, let's just assume a default of `:54321` when the port is not present.
+	if !strings.Contains(arg, ":") {
+		arg += ":54321"
+	}
+
 	// assume everything else is TCP to support strings such as "localhost:51234" and let
 	// net.Listen figure things out.
 	return "tcp", arg, nil

--- a/pkg/server/addr_test.go
+++ b/pkg/server/addr_test.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import "testing"
 
@@ -26,7 +26,7 @@ func TestSplitListenAddr(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		proto, addr, err := splitListenAddr(c.arg)
+		proto, addr, err := SplitListenAddr(c.arg)
 		if c.expectedErr {
 			if err == nil {
 				t.Fatalf("expected error for %s", c.arg)

--- a/pkg/server/addr_test.go
+++ b/pkg/server/addr_test.go
@@ -15,9 +15,13 @@ func TestSplitListenAddr(t *testing.T) {
 			proto: "unix",
 			addr:  "/var/run/tetragon/tetragon.sock",
 		}, {
-			arg:   "localhost:51234",
+			arg:   "localhost:54321",
 			proto: "tcp",
-			addr:  "localhost:51234",
+			addr:  "localhost:54321",
+		}, {
+			arg:   "localhost",
+			proto: "tcp",
+			addr:  "localhost:54321",
 		}, {
 			// NB: expect error on relative paths
 			arg:         "unix://var/run/tetragon/tetragon.sock",


### PR DESCRIPTION
Some recent changes to the way we input the address string in Helm have introduced an
unfortunately compatibility breakage with the old default values which did not include
a port number in the address string. To provide backward compatibility here, let's just
assume a default of `:54321` when the port is not present.