### PR TITLE
pkg/encoder: make customized syscalls printers portable and add open/openat

### DIFF
--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -54,3 +54,13 @@ func AddSyscallPrefixTestHelper(t *testing.T, symbol string) string {
 	}
 	return syscallName
 }
+
+// CutSyscallPrefix removes a potential arch specific prefix from the symbol
+func CutSyscallPrefix(symbol string) string {
+	for _, prefix := range supportedArchPrefix {
+		if strings.HasPrefix(symbol, prefix) {
+			return symbol[len(prefix):]
+		}
+	}
+	return symbol
+}

--- a/pkg/encoder/encoder.go
+++ b/pkg/encoder/encoder.go
@@ -190,7 +190,21 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 				file = p.Colorer.Cyan.Sprint(kprobe.Args[1].GetFileArg().Path)
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, file), caps), nil
-		case "__x64_sys_close":
+		case "sys_openat":
+			event := p.Colorer.Blue.Sprintf("📬️ %-7s", "openat")
+			file := ""
+			if len(kprobe.Args) > 1 && kprobe.Args[1] != nil {
+				file = p.Colorer.Cyan.Sprint(kprobe.Args[1].GetStringArg())
+			}
+			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, file), caps), nil
+		case "sys_open":
+			event := p.Colorer.Blue.Sprintf("📬️ %-7s", "open")
+			file := ""
+			if len(kprobe.Args) > 1 && kprobe.Args[1] != nil {
+				file = p.Colorer.Cyan.Sprint(kprobe.Args[1].GetStringArg())
+			}
+			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, file), caps), nil
+		case "sys_close":
 			event := p.Colorer.Blue.Sprintf("📪 %-7s", "close")
 			file := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil && kprobe.Args[0].GetFileArg() != nil {
@@ -294,7 +308,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, attr), caps), nil
 		default:
-			event := p.Colorer.Blue.Sprintf("⁉️ %-7s", "syscall")
+			event := p.Colorer.Blue.Sprintf("❓ %-7s", "syscall")
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, kprobe.FunctionName), caps), nil
 		}
 	case *tetragon.GetEventsResponse_ProcessTracepoint:

--- a/pkg/encoder/encoder_test.go
+++ b/pkg/encoder/encoder_test.go
@@ -146,7 +146,8 @@ func TestCompactEncoder_KprobeEventToString(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, "⁉️ syscall kube-system/tetragon /usr/bin/curl unhandled_function", result)
+	assert.Equal(t, "❓ syscall kube-system/tetragon /usr/bin/curl unhandled_function", result)
+
 }
 
 func TestCompactEncoder_KprobeOpenEventToString(t *testing.T) {


### PR DESCRIPTION
Also rename the output for fd_install to fd_install instead of open and change the default emoji for unrecognized symbols since previous emoji was shifting alignment.