### PR TITLE
pkg:observer: during stats printing check if total events is not zero

### DIFF
--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -333,7 +333,10 @@ func (k *Observer) PrintStats() {
 	recvCntr := k.ReadReceivedEvents()
 	lostCntr := k.ReadLostEvents()
 	total := float64(recvCntr + lostCntr)
-	loss := (float64(lostCntr) * 100.0) / total
+	loss := float64(0)
+	if total > 0 {
+		loss = (float64(lostCntr) * 100.0) / total
+	}
 	k.log.Infof("BPF events statistics: %d received, %.2g%% events loss", recvCntr, loss)
 
 	k.log.WithFields(logrus.Fields{


### PR DESCRIPTION
Check if the total events is not zero before printing stats, right now we fail to do so, which will produce an NaN on division by zero.

This happens only if tetragon starts and finish before capturing any event, which rarely happens in practice. Plus today's systems seems to not trap on floating point division by zero.

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>