### PR TITLE
pks/metrics: add syscall metrics

### DIFF
--- a/examples/tracingpolicy/raw_syscalls.yaml
+++ b/examples/tracingpolicy/raw_syscalls.yaml
@@ -1,3 +1,4 @@
+apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
   name: "raw-syscalls"
@@ -8,7 +9,8 @@ spec:
       # args: add both the syscall id, and the array with the arguments
       args:
         - index: 4
-        - index: 5
+          type: "int64"
+      #  - index: 5
       #selectors:
       #- matchPIDs:
       #  - operator: In

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/syscallmetrics"
 	v1 "github.com/cilium/tetragon/pkg/oldhubble/api/v1"
 	"github.com/cilium/tetragon/pkg/reader/exec"
 	"github.com/prometheus/client_golang/prometheus"
@@ -79,4 +80,5 @@ func handleProcessedEvent(processedEvent interface{}) {
 func ProcessEvent(originalEvent interface{}, processedEvent interface{}) {
 	handleOriginalEvent(originalEvent)
 	handleProcessedEvent(processedEvent)
+	syscallmetrics.Handle(processedEvent)
 }

--- a/pkg/metrics/syscallmetrics/syscallmetrics.go
+++ b/pkg/metrics/syscallmetrics/syscallmetrics.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package syscallmetrics
+
+import (
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+	"github.com/cilium/tetragon/pkg/syscallinfo"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	syscallStats = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        consts.MetricNamePrefix + "syscall_stats",
+		Help:        "System calls observed.",
+		ConstLabels: nil,
+	}, []string{"syscall", "namespace", "pod", "binary"})
+)
+
+func Handle(event interface{}) {
+	ev, ok := event.(*tetragon.GetEventsResponse)
+	if !ok {
+		return
+	}
+
+	var syscall, namespace, pod, binary string
+	if tpEvent := ev.GetProcessTracepoint(); tpEvent != nil {
+		if tpEvent.Subsys == "raw_syscalls" && tpEvent.Event == "sys_enter" {
+			syscall = rawSyscallName(tpEvent)
+			if tpEvent.Process != nil {
+				if tpEvent.Process.Pod != nil {
+					namespace = tpEvent.Process.Pod.Namespace
+					pod = tpEvent.Process.Pod.Name
+				}
+				binary = tpEvent.Process.Binary
+			}
+		}
+	}
+
+	if syscall != "" {
+		syscallStats.WithLabelValues(syscall, namespace, pod, binary).Inc()
+	}
+}
+
+func rawSyscallName(tp *tetragon.ProcessTracepoint) string {
+	sysID := int64(-1)
+	if len(tp.Args) > 0 && tp.Args[0] != nil {
+		if x, ok := tp.Args[0].GetArg().(*tetragon.KprobeArgument_LongArg); ok {
+			sysID = x.LongArg
+		}
+	}
+	if sysID == -1 {
+		return ""
+	}
+	return syscallinfo.GetSyscallName(int(sysID))
+}


### PR DESCRIPTION
This patch adds system call metrics. It looks for raw_syscall/sys_enter events and updates metrics.

It is expected to work with the examples/tracingpolicy/raw_syscalls.yaml custom resource. We can also update the code to work with kprobes, but this is left as future work.

The patch also updates the above yaml, so that it can be applied via kubectl.
