### PR TITLE
pkg/metrics: add event for tracing policy metrics

### DIFF
--- a/pkg/metrics/eventmetrics/eventmetrics_test.go
+++ b/pkg/metrics/eventmetrics/eventmetrics_test.go
@@ -16,47 +16,47 @@ import (
 
 func TestHandleProcessedEvent(t *testing.T) {
 	assert.NoError(t, testutil.CollectAndCompare(EventsProcessed, strings.NewReader("")))
-	handleProcessedEvent(nil)
+	handleProcessedEvent(nil, nil)
 	// empty process
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: &tetragon.ProcessKprobe{}}})
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExec{ProcessExec: &tetragon.ProcessExec{}}})
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessTracepoint{ProcessTracepoint: &tetragon.ProcessTracepoint{}}})
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExit{ProcessExit: &tetragon.ProcessExit{}}})
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: &tetragon.ProcessKprobe{}}})
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExec{ProcessExec: &tetragon.ProcessExec{}}})
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessTracepoint{ProcessTracepoint: &tetragon.ProcessTracepoint{}}})
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExit{ProcessExit: &tetragon.ProcessExit{}}})
 
 	// empty pod
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: &tetragon.ProcessKprobe{
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: &tetragon.ProcessKprobe{
 		Process: &tetragon.Process{Binary: "binary_a"},
 	}}})
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExec{ProcessExec: &tetragon.ProcessExec{
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExec{ProcessExec: &tetragon.ProcessExec{
 		Process: &tetragon.Process{Binary: "binary_b"},
 	}}})
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessTracepoint{ProcessTracepoint: &tetragon.ProcessTracepoint{
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessTracepoint{ProcessTracepoint: &tetragon.ProcessTracepoint{
 		Process: &tetragon.Process{Binary: "binary_c"},
 	}}})
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExit{ProcessExit: &tetragon.ProcessExit{
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExit{ProcessExit: &tetragon.ProcessExit{
 		Process: &tetragon.Process{Binary: "binary_e"},
 	}}})
 
 	// with pod
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: &tetragon.ProcessKprobe{
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: &tetragon.ProcessKprobe{
 		Process: &tetragon.Process{
 			Binary: "binary_a",
 			Pod:    &tetragon.Pod{Namespace: "namespace_a", Name: "pod_a"},
 		},
 	}}})
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExec{ProcessExec: &tetragon.ProcessExec{
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExec{ProcessExec: &tetragon.ProcessExec{
 		Process: &tetragon.Process{
 			Binary: "binary_b",
 			Pod:    &tetragon.Pod{Namespace: "namespace_b", Name: "pod_b"},
 		},
 	}}})
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessTracepoint{ProcessTracepoint: &tetragon.ProcessTracepoint{
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessTracepoint{ProcessTracepoint: &tetragon.ProcessTracepoint{
 		Process: &tetragon.Process{
 			Binary: "binary_c",
 			Pod:    &tetragon.Pod{Namespace: "namespace_c", Name: "pod_c"},
 		},
 	}}})
-	handleProcessedEvent(&tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExit{ProcessExit: &tetragon.ProcessExit{
+	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessExit{ProcessExit: &tetragon.ProcessExit{
 		Process: &tetragon.Process{
 			Binary: "binary_e",
 			Pod:    &tetragon.Pod{Namespace: "namespace_e", Name: "pod_e"},

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -114,6 +114,9 @@ type genericKprobe struct {
 	actionArgs idtable.Table
 
 	pinPathPrefix string
+
+	// policyName is the name of the policy that this tracepoint belongs to
+	policyName string
 }
 
 // pendingEvent is an event waiting to be merged with another event.
@@ -326,7 +329,12 @@ func flagsString(flags uint32) string {
 	return s
 }
 
-func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec, policyID policyfilter.PolicyID) (*sensors.Sensor, error) {
+func createGenericKprobeSensor(
+	name string,
+	kprobes []v1alpha1.KProbeSpec,
+	policyID policyfilter.PolicyID,
+	policyName string,
+) (*sensors.Sensor, error) {
 	var progs []*program.Program
 	var maps []*program.Map
 	var multiIDs, multiRetIDs []idtable.EntryID
@@ -479,6 +487,7 @@ func createGenericKprobeSensor(name string, kprobes []v1alpha1.KProbeSpec, polic
 			funcName:          funcName,
 			pendingEvents:     nil,
 			tableId:           idtable.UninitializedEntryID,
+			policyName:        policyName,
 		}
 
 		// Parse Filters into kernel filter logic
@@ -855,6 +864,7 @@ func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
 	unix.FuncName = gk.funcName
 	unix.Namespaces = m.Namespaces
 	unix.Capabilities = m.Capabilities
+	unix.PolicyName = gk.policyName
 
 	returnEvent := m.Common.Flags > 0
 

--- a/pkg/sensors/tracing/policyhandler.go
+++ b/pkg/sensors/tracing/policyhandler.go
@@ -21,6 +21,7 @@ func (h policyHandler) PolicyHandler(
 	policyID policyfilter.PolicyID,
 ) (*sensors.Sensor, error) {
 
+	policyName := policy.TpName()
 	spec := policy.TpSpec()
 	if len(spec.KProbes) > 0 && len(spec.Tracepoints) > 0 {
 		return nil, errors.New("tracing policies with both kprobes and tracepoints are not currently supported")
@@ -31,11 +32,11 @@ func (h policyHandler) PolicyHandler(
 		if err != nil {
 			return nil, err
 		}
-		return createGenericKprobeSensor(name, spec.KProbes, policyID)
+		return createGenericKprobeSensor(name, spec.KProbes, policyID, policyName)
 	}
 	if len(spec.Tracepoints) > 0 {
 		name := fmt.Sprintf("gtp-sensor-%d", atomic.AddUint64(&sensorCounter, 1))
-		return createGenericTracepointSensor(name, spec.Tracepoints, policyID)
+		return createGenericTracepointSensor(name, spec.Tracepoints, policyID, policyName)
 	}
 	return nil, nil
 }

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -20,6 +20,7 @@ import (
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	smatcher "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/sensors"
 	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
@@ -65,7 +66,7 @@ func TestGenericTracepointSimple(t *testing.T) {
 
 	sm := tus.StartTestSensorManager(ctx, t)
 	// create and add sensor
-	sensor, err := createGenericTracepointSensor("GtpLseekTest", []GenericTracepointConf{lseekConf}, 0)
+	sensor, err := createGenericTracepointSensor("GtpLseekTest", []GenericTracepointConf{lseekConf}, policyfilter.NoFilterID, "policyName")
 	if err != nil {
 		t.Fatalf("failed to create generic tracepoint sensor: %s", err)
 	}
@@ -124,7 +125,7 @@ func doTestGenericTracepointPidFilter(t *testing.T, conf GenericTracepointConf, 
 
 	sm := tus.StartTestSensorManager(ctx, t)
 	// create and add sensor
-	sensor, err := createGenericTracepointSensor("GtpLseekTest", []GenericTracepointConf{conf}, 0)
+	sensor, err := createGenericTracepointSensor("GtpLseekTest", []GenericTracepointConf{conf}, policyfilter.NoFilterID, "policyName")
 	if err != nil {
 		t.Fatalf("failed to create generic tracepoint sensor: %s", err)
 	}

--- a/pkg/tracingpolicy/tracingpolicy.go
+++ b/pkg/tracingpolicy/tracingpolicy.go
@@ -30,3 +30,12 @@ type TracingPolicyNamespaced interface {
 }
 
 // revive:enable:exported
+
+type PolicyInfo struct {
+	Name string
+	Hook string
+}
+
+type PolicyEvent interface {
+	PolicyInfo() PolicyInfo
+}


### PR DESCRIPTION
This patch adds metrics for tracing policy events. It uses the policy name and a hook name as labels.

As an example, with this policy:
```
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "kubectlexec-net"
spec:
  kprobes:
  - call: "tcp_connect"
    syscall: false
    args:
     - index: 0
       type: "sock"
    selectors:
    - matchPIDs:
      - operator: NotIn
        followForks: true
        isNamespacePID: true
        values:
        - 1
  - call: "tcp_close"
    syscall: false
    args:
     - index: 0
       type: "sock"
    selectors:
    - matchPIDs:
      - operator: NotIn
        followForks: true
        isNamespacePID: true
        values:
        - 1
  - call: "tcp_sendmsg"
    syscall: false
    args:
     - index: 0
       type: "sock"
     - index: 2
       type: int
    # follow any non-init pids (e.g., exec into container)
    selectors:
    - matchPIDs:
      - operator: NotIn
        followForks: true
        isNamespacePID: true
        values:
        - 1
```

We will see the following events:
```
tetragon_policy_stats{binary="/usr/bin/curl",hook="kprobe:tcp_close",namespace="default",pod="pizza",policy="kubectlexec-net"} 1                              │
tetragon_policy_stats{binary="/usr/bin/curl",hook="kprobe:tcp_connect",namespace="default",pod="pizza",policy="kubectlexec-net"} 1                            │
tetragon_policy_stats{binary="/usr/bin/curl",hook="kprobe:tcp_sendmsg",namespace="default",pod="pizza",policy="kubectlexec-net"} 1
```