### PR TITLE
Add Flags To Raw Attach

### DIFF
--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -30,11 +30,16 @@ type customInstall struct {
 }
 
 func RawAttach(targetFD int) AttachFunc {
+	return RawAttachWithFlags(targetFD, 0)
+}
+
+func RawAttachWithFlags(targetFD int, flags uint32) AttachFunc {
 	return func(prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
 		err := link.RawAttachProgram(link.RawAttachProgramOptions{
 			Target:  targetFD,
 			Program: prog,
 			Attach:  spec.AttachType,
+			Flags:   flags,
 		})
 		if err != nil {
 			prog.Close()


### PR DESCRIPTION
Cgroup SKB programs can be attached using the program.RawAttach method. This method sets the attach flags to 0. If multiple Cgroup SKB programs are to be attached to the same attachment point, then the BPF_F_ALLOW_MULTI flag needs to be passed. This patch adds a program.RawAttachWithFlags method that can be used to pass this. The program.RawAttach method has been rewritten to reuse this new method, but passing 0 as the flags.