### PR TITLE
tetragon: deal with duplicated tcpmon_map issue

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -222,10 +222,22 @@ func tetragonExecute() error {
 		cancel()
 	}()
 
-	if err := obs.InitSensorManager(); err != nil {
+	// start sensor manager, and have it wait on sensorMgWait until we load
+	// the base sensor. note that this means that calling methods on the
+	// manager will block so they will have to either be executed in a
+	// goroutine or after we close the sensorMgWait channel to avoid
+	// deadlock.
+	sensorMgWait := make(chan struct{})
+	defer func() {
+		// if we fail before closing the channel, close it so that
+		// the sensor manager routine is unblocked.
+		if sensorMgWait != nil {
+			close(sensorMgWait)
+		}
+	}()
+	if err := obs.InitSensorManager(sensorMgWait); err != nil {
 		return err
 	}
-	observer.SensorManager.LogSensorsAndProbes(ctx)
 
 	/* Remove any stale programs, otherwise feature set change can cause
 	 * old programs to linger resulting in undefined behavior. And because
@@ -312,6 +324,11 @@ func tetragonExecute() error {
 	if err := base.GetInitialSensor().Load(ctx, observerDir, observerDir, option.Config.CiliumDir); err != nil {
 		return err
 	}
+
+	// now that the base sensor was loaded, we can start the sensor manager
+	close(sensorMgWait)
+	sensorMgWait = nil
+	observer.SensorManager.LogSensorsAndProbes(ctx)
 
 	// load sensor from configuration file
 	if len(option.Config.ConfigFile) > 0 {

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -89,7 +89,7 @@ func runTetragon(ctx context.Context, configFile string, args *Arguments, summar
 	option.Config.MapDir = bpf.MapPrefixPath()
 	obs := observer.NewObserver(configFile)
 
-	if err := obs.InitSensorManager(); err != nil {
+	if err := obs.InitSensorManager(nil); err != nil {
 		logger.GetLogger().Fatalf("InitSensorManager failed: %v", err)
 	}
 

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -291,10 +291,10 @@ func (k *Observer) Start(ctx context.Context) error {
 	return nil
 }
 
-// InitSensorManager starts the sensor controller and stt manager.
-func (k *Observer) InitSensorManager() error {
+// InitSensorManager starts the sensor controller
+func (k *Observer) InitSensorManager(waitChan chan struct{}) error {
 	var err error
-	SensorManager, err = sensors.StartSensorManager(option.Config.BpfDir, option.Config.MapDir, option.Config.CiliumDir)
+	SensorManager, err = sensors.StartSensorManager(option.Config.BpfDir, option.Config.MapDir, option.Config.CiliumDir, waitChan)
 	return err
 }
 

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -316,7 +316,7 @@ func loadExporter(t *testing.T, ctx context.Context, obs *Observer, opts *testEx
 	processCacheSize := 32768
 	dataCacheSize := 1024
 
-	if err := obs.InitSensorManager(); err != nil {
+	if err := obs.InitSensorManager(nil); err != nil {
 		return err
 	}
 

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -27,7 +27,14 @@ type SensorStatus struct {
 // The purpose of this goroutine is to serialize loading and unloading of
 // sensors as requested from different goroutines (e.g., different GRPC
 // clients).
-func StartSensorManager(bpfDir, mapDir, ciliumDir string) (*Manager, error) {
+//
+// if waitChan is not nil, the serving of sensor requests will block until
+// something is received. The intention of this is to allow the main function
+// to first load the base sensor before the sensor manager starts loading other sensors.
+func StartSensorManager(
+	bpfDir, mapDir, ciliumDir string,
+	waitChan chan struct{},
+) (*Manager, error) {
 	c := make(chan sensorOp)
 	m := Manager{
 		STTManager: sttManager.StartSttManager(),
@@ -39,6 +46,14 @@ func StartSensorManager(bpfDir, mapDir, ciliumDir string) (*Manager, error) {
 	}
 
 	go func() {
+
+		// wait until start serving requests
+		if waitChan != nil {
+			logger.GetLogger().Infof("sensor controller waiting on channel")
+			<-waitChan
+			logger.GetLogger().Infof("sensor controller starts")
+		}
+
 		done := false
 		for !done {
 			op_ := <-c

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -37,7 +37,7 @@ func TestAddPolicy(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("", "", "")
+	mgr, err := StartSensorManager("", "", "", nil)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
@@ -65,7 +65,7 @@ func TestAddPolicies(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("", "", "")
+	mgr, err := StartSensorManager("", "", "", nil)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
@@ -96,7 +96,7 @@ func TestAddPolicySpecError(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("", "", "")
+	mgr, err := StartSensorManager("", "", "", nil)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
@@ -128,7 +128,7 @@ func TestAddPolicyLoadError(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("", "", "")
+	mgr, err := StartSensorManager("", "", "", nil)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {

--- a/pkg/testutils/sensors/sensors.go
+++ b/pkg/testutils/sensors/sensors.go
@@ -34,7 +34,7 @@ type TestSensorManager struct {
 // will also register the necessary cleanup functions using t.Cleanup()
 func StartTestSensorManager(ctx context.Context, t *testing.T) *TestSensorManager {
 	path := bpf.MapPrefixPath()
-	mgr, err := sensors.StartSensorManager(path, path, "")
+	mgr, err := sensors.StartSensorManager(path, path, "", nil)
 	if err != nil {
 		t.Fatalf("startSensorController failed: %s", err)
 	}


### PR DESCRIPTION
Backport of: https://github.com/cilium/tetragon/pull/938

[ upstream commit ab79e3998917de942b764aa6da3d7a4fff59e039 ]

We have some reports of sensors using the wrong tcpmon_map. Specifically, we observe sensor programs using a different tcpmon_map than the execve program.

Below is an analysis of what may cause this, and a description of the solution implemented in this patch.

The initialization order in cmd/tetragon/main.go:
 1. initialize sensor manager (InitSensorManager)
 2. create k8s watcher (getWatcher)
 3. start gRPC server (Serve)
 4. load base sensor (directly)

The intention behind the sensor manager is to serialize all concurrent requests for loading programs/creating maps/etc. Hence, all sensors are loaded via the sensor manager except the base sensor (this is partly for historic reasons, but there are also some assumptions in the code that the base sensor is loaded first).

There are two ways that the code tries to avoid duplicated maps:

First, the code in loadMaps (pkg/sensors/load.go) checks whether the map is already loaded.

	if m.PinState.IsLoaded() {
		l.WithFields(logrus.Fields{
			"sensor": s.Name,
			"map":    m.Name,
		}).Info("map is already loaded, incrementing reference count")
		m.PinState.RefInc()
		continue
	}

For above to work, the senors need to use the same pkg.sensors.program.Map instance. This not the case for tcpmon_map.

Second, the loader code checks whether the pinned path exists for the map, and if it does it just loads the map from the filesystem.

  if err := m.LoadOrCreatePinnedMap(pinPath, mapSpec); err != nil {
	return fmt.Errorf("failed to load map '%s' for sensor '%s': %w", m.Name, s.Name, err)
  }

Both of these approaches, however, cannot handle concurrent operations. For example, the IsLoaded() check does not happen atomically. Hence, the best solution without reorganizing a lot of code to deal with above issue is to ensure that loading the base sensor is also serialized with respect to the sensor manager.

To this end, we add a wait channel as an argument to the function that starts the sensor manager. if the channel is not nil, the sensor manager goroutine will wait on this channel before it starts serving requests. We use this channel in the main function to start the sensor manager after the base sensor is loaded.