### PR TITLE
tetragon: Add support for and filter operation

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -799,12 +799,24 @@ filter_64ty_selector_val(struct selector_arg_filter *filter, char *args)
 #pragma unroll
 	for (i = 0; i < MAX_MATCH_VALUES; i++) {
 		__u64 w = v[i];
-		bool res = (*(u64 *)args == w);
+		bool res;
 
-		if (filter->op == op_filter_eq && res)
-			return 1;
-		if (filter->op == op_filter_neq && !res)
-			return 1;
+		switch (filter->op) {
+		case op_filter_eq:
+		case op_filter_neq:
+			res = (*(u64 *)args == w);
+
+			if (filter->op == op_filter_eq && res)
+				return 1;
+			if (filter->op == op_filter_neq && !res)
+				return 1;
+			break;
+		case op_filter_mask:
+			if (*(u64 *)args & w)
+				return 1;
+		default:
+			break;
+		}
 		j += 8;
 		if (j + 8 >= filter->vallen)
 			break;
@@ -857,6 +869,7 @@ filter_64ty(struct selector_arg_filter *filter, char *args)
 	switch (filter->op) {
 	case op_filter_eq:
 	case op_filter_neq:
+	case op_filter_mask:
 		return filter_64ty_selector_val(filter, args);
 	case op_filter_inmap:
 	case op_filter_notinmap:
@@ -875,12 +888,24 @@ filter_32ty_selector_val(struct selector_arg_filter *filter, char *args)
 #pragma unroll
 	for (i = 0; i < MAX_MATCH_VALUES; i++) {
 		__u32 w = v[i];
-		bool res = (*(u32 *)args == w);
+		bool res;
 
-		if (filter->op == op_filter_eq && res)
-			return 1;
-		if (filter->op == op_filter_neq && !res)
-			return 1;
+		switch (filter->op) {
+		case op_filter_eq:
+		case op_filter_neq:
+			res = (*(u32 *)args == w);
+
+			if (filter->op == op_filter_eq && res)
+				return 1;
+			if (filter->op == op_filter_neq && !res)
+				return 1;
+			break;
+		case op_filter_mask:
+			if (*(u32 *)args & w)
+				return 1;
+		default:
+			break;
+		}
 		// placed here to allow llvm unroll this loop
 		j += 4;
 		if (j + 8 >= filter->vallen)
@@ -919,6 +944,7 @@ filter_32ty(struct selector_arg_filter *filter, char *args)
 	switch (filter->op) {
 	case op_filter_eq:
 	case op_filter_neq:
+	case op_filter_mask:
 		return filter_32ty_selector_val(filter, args);
 	case op_filter_inmap:
 	case op_filter_notinmap:

--- a/bpf/process/types/operations.h
+++ b/bpf/process/types/operations.h
@@ -20,6 +20,7 @@ enum {
 	// map membership ops
 	op_filter_inmap = 10,
 	op_filter_notinmap = 11,
+	op_filter_mask = 12,
 };
 
 #endif // __OPERATIONS_H__

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -356,6 +356,7 @@ The available operators for `matchArgs` are:
 - `NotEqual`
 - `Prefix`
 - `Postfix`
+- `Mask`
 
 **Further examples**
 
@@ -1258,6 +1259,7 @@ There are different types supported for each operator. In case of `matchArgs`:
 * NotEqual
 * Prefix
 * Postfix
+* Mask
 
 The operator types `Equal` and `NotEqual` are used to test whether the certain
 argument of a system call is equal to the defined value in the CR.
@@ -1307,6 +1309,29 @@ The above would be executed in the kernel as
 ```yaml
 arg != arg0 AND arg != arg1
 ```
+
+The operator type `Mask` performs and bitwise operation on the argument value
+and defined values. The argument type needs to be one of the value types.
+
+For example in following YAML snippet we match second argument for bits
+1 and 9 (0x200 value). We could use single value 0x201 as well.
+
+```yaml
+matchArgs:
+- index: 2
+  operator: "Mask"
+  values:
+  - 1
+  - 0x200
+```
+
+The above would be executed in the kernel as
+```yaml
+arg & 1 OR arg & 0x200
+```
+
+The value can be specified as hexadecimal (with 0x prefix) octal (with 0 prefix)
+or decimal value (no prefix).
 
 The type `Prefix` checks if the certain argument starts with the defined value,
 while the type `Postfix` compares if the argument matches to the defined value

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -336,8 +336,19 @@ func writeMatchValuesInMap(k *KernelSelectorState, values []string, ty uint32) e
 	return nil
 }
 
+func getBase(v string) int {
+	if strings.HasPrefix(v, "0x") {
+		return 16
+	}
+	if strings.HasPrefix(v, "0") {
+		return 8
+	}
+	return 10
+}
+
 func writeMatchValues(k *KernelSelectorState, values []string, ty uint32) error {
 	for _, v := range values {
+		base := getBase(v)
 		switch ty {
 		case argTypeFd, argTypeFile, argTypePath:
 			value, size := ArgSelectorValue(v)
@@ -348,25 +359,25 @@ func writeMatchValues(k *KernelSelectorState, values []string, ty uint32) error 
 			WriteSelectorUint32(k, size)
 			WriteSelectorByteArray(k, value, size)
 		case argTypeS32, argTypeInt, argTypeSizet:
-			i, err := strconv.ParseInt(v, 10, 32)
+			i, err := strconv.ParseInt(v, base, 32)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
 			}
 			WriteSelectorInt32(k, int32(i))
 		case argTypeU32:
-			i, err := strconv.ParseUint(v, 10, 32)
+			i, err := strconv.ParseUint(v, base, 32)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
 			}
 			WriteSelectorUint32(k, uint32(i))
 		case argTypeS64:
-			i, err := strconv.ParseInt(v, 10, 64)
+			i, err := strconv.ParseInt(v, base, 64)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
 			}
 			WriteSelectorInt64(k, int64(i))
 		case argTypeU64:
-			i, err := strconv.ParseUint(v, 10, 64)
+			i, err := strconv.ParseUint(v, base, 64)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
 			}

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -202,6 +202,8 @@ const (
 	// Map ops
 	SelectorInMap    = 10
 	SelectorNotInMap = 11
+
+	SelectorOpMASK = 12
 )
 
 func SelectorOp(op string) (uint32, error) {
@@ -226,6 +228,8 @@ func SelectorOp(op string) (uint32, error) {
 		return SelectorInMap, nil
 	case "NotInMap":
 		return SelectorNotInMap, nil
+	case "mask", "Mask":
+		return SelectorOpMASK, nil
 	}
 
 	return 0, fmt.Errorf("Unknown op '%s'", op)

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -111,6 +111,9 @@ func TestSelectorOp(t *testing.T) {
 	if op, err := SelectorOp("neq"); op != SelectorOpNEQ || err != nil {
 		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpNEQ, op, err)
 	}
+	if op, err := SelectorOp("Mask"); op != SelectorOpMASK || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpMASK, op, err)
+	}
 	if op, err := SelectorOp("In"); op != SelectorOpIn || err != nil {
 		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpIn, op, err)
 	}

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -576,7 +576,9 @@ func testKprobeObjectFiltered(t *testing.T,
 	checker ec.MultiEventChecker,
 	useMount bool,
 	mntPath string,
-	expectFailure bool) {
+	expectFailure bool,
+	mode int,
+	perm uint32) {
 
 	if useMount == true {
 		if err := syscall.Mount("tmpfs", mntPath, "tmpfs", 0, ""); err != nil {
@@ -618,7 +620,7 @@ func testKprobeObjectFiltered(t *testing.T,
 	}
 	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()
-	fd2, errno := syscall.Open(filePath, syscall.O_RDWR, 0x770)
+	fd2, errno := syscall.Open(filePath, mode, perm)
 	if fd2 < 0 {
 		t.Logf("File open from read failed: %s\n", errno)
 		t.Fatal()
@@ -667,14 +669,14 @@ func TestKprobeObjectOpen(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectOpenMount(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func testKprobeObjectMultiValueOpenHook(pidStr string, path string) string {
@@ -713,14 +715,14 @@ func TestKprobeObjectMultiValueOpen(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectMultiValueOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectMultiValueOpenMount(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectMultiValueOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectFilterOpen(t *testing.T) {
@@ -754,7 +756,7 @@ spec:
         values:
         - "` + dir + `/foofile\0"
 `
-	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true)
+	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectMultiValueFilterOpen(t *testing.T) {
@@ -789,7 +791,7 @@ spec:
         - "` + dir + `/foo\0"
         - "` + dir + `/bar\0"
 `
-	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true)
+	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770)
 }
 
 func testKprobeObjectFilterPrefixOpenHook(pidStr string, path string) string {
@@ -827,14 +829,14 @@ func TestKprobeObjectFilterPrefixOpen(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectFilterPrefixOpenMount(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func testKprobeObjectFilterPrefixExactOpenHook(pidStr string, path string) string {
@@ -872,14 +874,14 @@ func TestKprobeObjectFilterPrefixExactOpen(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixExactOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectFilterPrefixExactOpenMount(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixExactOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func testKprobeObjectFilterPrefixSubdirOpenHook(pidStr string, path string) string {
@@ -917,14 +919,14 @@ func TestKprobeObjectFilterPrefixSubdirOpen(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixSubdirOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectFilterPrefixSubdirOpenMount(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixSubdirOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectFilterPrefixMissOpen(t *testing.T) {
@@ -958,7 +960,7 @@ spec:
         values:
         - "/foo/"
 `
-	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true)
+	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectPostfixOpen(t *testing.T) {
@@ -992,7 +994,7 @@ spec:
         values:
         - "testfile\0"
 `
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func helloIovecWorldWritev() (err error) {
@@ -1112,7 +1114,7 @@ spec:
         values:
         - ` + pidStr + `
      `
-	testKprobeObjectFiltered(t, readHook, getFilpOpenChecker(dir), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getFilpOpenChecker(dir), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectReturnFilenameOpen(t *testing.T) {
@@ -1141,7 +1143,7 @@ spec:
         values:
         - ` + pidStr + `
      `
-	testKprobeObjectFiltered(t, readHook, getFilpOpenChecker(dir), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getFilpOpenChecker(dir), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func testKprobeObjectFileWriteHook(pidStr string) string {
@@ -1263,28 +1265,28 @@ func TestKprobeObjectFileWrite(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFileWriteHook(pidStr)
-	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectFileWriteFiltered(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFileWriteFilteredHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), false, dir, false)
+	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), false, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectFileWriteMount(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFileWriteHook(pidStr)
-	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), true, dir, false)
+	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), true, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func TestKprobeObjectFileWriteMountFiltered(t *testing.T) {
 	pidStr := strconv.Itoa(int(observer.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFileWriteFilteredHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), true, dir, false)
+	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), true, dir, false, syscall.O_RDWR, 0x770)
 }
 
 func corePathTest(t *testing.T, filePath string, readHook string, writeChecker ec.MultiEventChecker) {


### PR DESCRIPTION
Adding support and operator for kernel selector operation.

It's now possible to use it in matchArgs selector like:

```
  selectors:
    - index: 2
      operator: "And"
      values:
        - 1  # O_WRONLY
        - 2  # O_RDWR
```

Rebased on top of  https://github.com/cilium/tetragon/pull/885
Fixes: #933

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
