### PR TITLE
tetragon: handle process threads in clone and process_{exec|exit} events

### DIFF
--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -637,6 +637,7 @@ https://github.com/opencontainers/runtime-spec/blob/main/config.md#createcontain
 | refcnt | [uint32](#uint32) |  |  |
 | cap | [Capabilities](#tetragon-Capabilities) |  |  |
 | ns | [Namespaces](#tetragon-Namespaces) |  |  |
+| tid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | tid is the thread id. (For the thread group leader, tid is equal to pid.) |
 
 
 

--- a/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -2255,6 +2255,7 @@ type ProcessChecker struct {
 	Refcnt       *uint32                            `json:"refcnt,omitempty"`
 	Cap          *CapabilitiesChecker               `json:"cap,omitempty"`
 	Ns           *NamespacesChecker                 `json:"ns,omitempty"`
+	Tid          *uint32                            `json:"tid,omitempty"`
 }
 
 // NewProcessChecker creates a new ProcessChecker
@@ -2358,6 +2359,14 @@ func (checker *ProcessChecker) Check(event *tetragon.Process) error {
 				return fmt.Errorf("Ns check failed: %w", err)
 			}
 		}
+		if checker.Tid != nil {
+			if event.Tid == nil {
+				return fmt.Errorf("Tid is nil and does not match expected value %v", *checker.Tid)
+			}
+			if *checker.Tid != event.Tid.Value {
+				return fmt.Errorf("Tid has value %v which does not match expected value %v", event.Tid.Value, *checker.Tid)
+			}
+		}
 		return nil
 	}
 	if err := fieldChecks(); err != nil {
@@ -2456,6 +2465,12 @@ func (checker *ProcessChecker) WithNs(check *NamespacesChecker) *ProcessChecker 
 	return checker
 }
 
+// WithTid adds a Tid check to the ProcessChecker
+func (checker *ProcessChecker) WithTid(check uint32) *ProcessChecker {
+	checker.Tid = &check
+	return checker
+}
+
 //FromProcess populates the ProcessChecker using data from a Process field
 func (checker *ProcessChecker) FromProcess(event *tetragon.Process) *ProcessChecker {
 	if event == nil {
@@ -2494,6 +2509,10 @@ func (checker *ProcessChecker) FromProcess(event *tetragon.Process) *ProcessChec
 	}
 	if event.Ns != nil {
 		checker.Ns = NewNamespacesChecker().FromNamespaces(event.Ns)
+	}
+	if event.Tid != nil {
+		val := event.Tid.Value
+		checker.Tid = &val
 	}
 	return checker
 }

--- a/api/v1/tetragon/tetragon.pb.go
+++ b/api/v1/tetragon/tetragon.pb.go
@@ -696,6 +696,7 @@ type Process struct {
 	Refcnt       uint32                  `protobuf:"varint,13,opt,name=refcnt,proto3" json:"refcnt,omitempty"`
 	Cap          *Capabilities           `protobuf:"bytes,14,opt,name=cap,proto3" json:"cap,omitempty"`
 	Ns           *Namespaces             `protobuf:"bytes,15,opt,name=ns,proto3" json:"ns,omitempty"`
+	Tid          *wrapperspb.UInt32Value `protobuf:"bytes,16,opt,name=tid,proto3" json:"tid,omitempty"` // tid is the thread id. (For the thread group leader, tid is equal to pid.)
 }
 
 func (x *Process) Reset() {
@@ -831,6 +832,13 @@ func (x *Process) GetCap() *Capabilities {
 func (x *Process) GetNs() *Namespaces {
 	if x != nil {
 		return x.Ns
+	}
+	return nil
+}
+
+func (x *Process) GetTid() *wrapperspb.UInt32Value {
+	if x != nil {
+		return x.Tid
 	}
 	return nil
 }
@@ -2888,7 +2896,7 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x52, 0x06, 0x63, 0x67, 0x72, 0x6f, 0x75,
 	0x70, 0x12, 0x27, 0x0a, 0x04, 0x75, 0x73, 0x65, 0x72, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x0b, 0x32,
 	0x13, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x73,
-	0x70, 0x61, 0x63, 0x65, 0x52, 0x04, 0x75, 0x73, 0x65, 0x72, 0x22, 0x94, 0x04, 0x0a, 0x07, 0x50,
+	0x70, 0x61, 0x63, 0x65, 0x52, 0x04, 0x75, 0x73, 0x65, 0x72, 0x22, 0xc4, 0x04, 0x0a, 0x07, 0x50,
 	0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x12, 0x17, 0x0a, 0x07, 0x65, 0x78, 0x65, 0x63, 0x5f, 0x69,
 	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x65, 0x78, 0x65, 0x63, 0x49, 0x64, 0x12,
 	0x2e, 0x0a, 0x03, 0x70, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67,
@@ -2922,7 +2930,10 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x6c, 0x69, 0x74, 0x69, 0x65, 0x73, 0x52, 0x03, 0x63, 0x61, 0x70, 0x12, 0x24, 0x0a, 0x02, 0x6e,
 	0x73, 0x18, 0x0f, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67,
 	0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x73, 0x52, 0x02, 0x6e,
-	0x73, 0x22, 0x96, 0x01, 0x0a, 0x0b, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x45, 0x78, 0x65,
+	0x73, 0x12, 0x2e, 0x0a, 0x03, 0x74, 0x69, 0x64, 0x18, 0x10, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c,
+	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+	0x2e, 0x55, 0x49, 0x6e, 0x74, 0x33, 0x32, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x03, 0x74, 0x69,
+	0x64, 0x22, 0x96, 0x01, 0x0a, 0x0b, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x45, 0x78, 0x65,
 	0x63, 0x12, 0x2b, 0x0a, 0x07, 0x70, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x18, 0x01, 0x20, 0x01,
 	0x28, 0x0b, 0x32, 0x11, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72,
 	0x6f, 0x63, 0x65, 0x73, 0x73, 0x52, 0x07, 0x70, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x12, 0x29,
@@ -3313,53 +3324,54 @@ var file_tetragon_tetragon_proto_depIdxs = []int32{
 	5,  // 22: tetragon.Process.pod:type_name -> tetragon.Pod
 	6,  // 23: tetragon.Process.cap:type_name -> tetragon.Capabilities
 	8,  // 24: tetragon.Process.ns:type_name -> tetragon.Namespaces
-	9,  // 25: tetragon.ProcessExec.process:type_name -> tetragon.Process
-	9,  // 26: tetragon.ProcessExec.parent:type_name -> tetragon.Process
-	9,  // 27: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
-	9,  // 28: tetragon.ProcessExit.process:type_name -> tetragon.Process
-	9,  // 29: tetragon.ProcessExit.parent:type_name -> tetragon.Process
-	37, // 30: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
-	39, // 31: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
-	39, // 32: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
-	39, // 33: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
-	40, // 34: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
-	40, // 35: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
-	38, // 36: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
-	38, // 37: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
-	7,  // 38: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
-	13, // 39: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
-	14, // 40: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
-	15, // 41: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
-	16, // 42: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
-	12, // 43: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
-	17, // 44: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
-	20, // 45: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
-	21, // 46: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
-	22, // 47: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
-	19, // 48: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
-	18, // 49: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
-	9,  // 50: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
-	9,  // 51: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
-	23, // 52: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
-	23, // 53: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
-	0,  // 54: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
-	9,  // 55: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
-	9,  // 56: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
-	23, // 57: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
-	9,  // 58: tetragon.ProcessUprobe.process:type_name -> tetragon.Process
-	9,  // 59: tetragon.ProcessUprobe.parent:type_name -> tetragon.Process
-	1,  // 60: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
-	1,  // 61: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
-	2,  // 62: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
-	29, // 63: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
-	9,  // 64: tetragon.ProcessLoader.process:type_name -> tetragon.Process
-	34, // 65: tetragon.RuntimeHookRequest.createContainer:type_name -> tetragon.CreateContainer
-	36, // 66: tetragon.CreateContainer.annotations:type_name -> tetragon.CreateContainer.AnnotationsEntry
-	67, // [67:67] is the sub-list for method output_type
-	67, // [67:67] is the sub-list for method input_type
-	67, // [67:67] is the sub-list for extension type_name
-	67, // [67:67] is the sub-list for extension extendee
-	0,  // [0:67] is the sub-list for field type_name
+	38, // 25: tetragon.Process.tid:type_name -> google.protobuf.UInt32Value
+	9,  // 26: tetragon.ProcessExec.process:type_name -> tetragon.Process
+	9,  // 27: tetragon.ProcessExec.parent:type_name -> tetragon.Process
+	9,  // 28: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
+	9,  // 29: tetragon.ProcessExit.process:type_name -> tetragon.Process
+	9,  // 30: tetragon.ProcessExit.parent:type_name -> tetragon.Process
+	37, // 31: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
+	39, // 32: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
+	39, // 33: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
+	39, // 34: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
+	40, // 35: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
+	40, // 36: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
+	38, // 37: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
+	38, // 38: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
+	7,  // 39: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
+	13, // 40: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
+	14, // 41: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
+	15, // 42: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
+	16, // 43: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
+	12, // 44: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
+	17, // 45: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
+	20, // 46: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
+	21, // 47: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
+	22, // 48: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
+	19, // 49: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
+	18, // 50: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
+	9,  // 51: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
+	9,  // 52: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
+	23, // 53: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
+	23, // 54: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
+	0,  // 55: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
+	9,  // 56: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
+	9,  // 57: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
+	23, // 58: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
+	9,  // 59: tetragon.ProcessUprobe.process:type_name -> tetragon.Process
+	9,  // 60: tetragon.ProcessUprobe.parent:type_name -> tetragon.Process
+	1,  // 61: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
+	1,  // 62: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
+	2,  // 63: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
+	29, // 64: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
+	9,  // 65: tetragon.ProcessLoader.process:type_name -> tetragon.Process
+	34, // 66: tetragon.RuntimeHookRequest.createContainer:type_name -> tetragon.CreateContainer
+	36, // 67: tetragon.CreateContainer.annotations:type_name -> tetragon.CreateContainer.AnnotationsEntry
+	68, // [68:68] is the sub-list for method output_type
+	68, // [68:68] is the sub-list for method input_type
+	68, // [68:68] is the sub-list for extension type_name
+	68, // [68:68] is the sub-list for extension extendee
+	0,  // [0:68] is the sub-list for field type_name
 }
 
 func init() { file_tetragon_tetragon_proto_init() }

--- a/api/v1/tetragon/tetragon.proto
+++ b/api/v1/tetragon/tetragon.proto
@@ -95,6 +95,7 @@ message Process {
     uint32 refcnt = 13;
     Capabilities cap = 14;
     Namespaces ns = 15;
+    google.protobuf.UInt32Value tid = 16; // tid is the thread id. (For the thread group leader, tid is equal to pid.)
 }
 
 message ProcessExec {

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -149,7 +149,7 @@
 #define DOCKER_ID_LENGTH 128
 
 struct msg_execve_key {
-	__u32 pid;
+	__u32 pid; // Process TGID
 	__u8 pad[4];
 	__u64 ktime;
 }; // All fields aligned so no 'packed' attribute.
@@ -176,7 +176,8 @@ struct msg_process {
 struct msg_clone_event {
 	struct msg_common common;
 	struct msg_execve_key parent;
-	__u32 pid;
+	__u32 tgid;
+	__u32 tid;
 	__u32 nspid;
 	__u32 flags;
 	__u64 ktime;

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -93,7 +93,7 @@
  */
 #define CWD_MAX	     256
 #define BUFFER	     1024
-#define SIZEOF_EVENT 32
+#define SIZEOF_EVENT 40
 #define PADDED_BUFFER \
 	(BUFFER + MAXARGLENGTH + SIZEOF_EVENT + SIZEOF_EVENT + CWD_MAX)
 /* This is the usable buffer size for args and filenames. It is calculated
@@ -161,8 +161,10 @@ struct msg_execve_key {
  */
 struct msg_process {
 	__u32 size;
-	__u32 pid;
+	__u32 pid; // Process TGID
+	__u32 tid; // Process thread
 	__u32 nspid;
+	__u32 pad;
 	__u32 uid;
 	__u32 auid;
 	__u32 flags;
@@ -276,6 +278,9 @@ struct msg_execve_event {
 	__u32 binary;
 }; // All fields aligned so no 'packed' attribute.
 
+// The execve_map_value is tracked by the TGID of the thread group
+// the msg_execve_key.pid. The thread IDs are recorded on the
+// fly and sent with every corresponding event.
 struct execve_map_value {
 	struct msg_execve_key key;
 	struct msg_execve_key pkey;

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -206,7 +206,7 @@ enum {
 
 struct exit_info {
 	__u32 code;
-	__u32 pad;
+	__u32 tid; // Thread ID
 };
 
 struct msg_exit {

--- a/bpf/process/bpf_exit.h
+++ b/bpf/process/bpf_exit.h
@@ -56,6 +56,8 @@ static inline __attribute__((always_inline)) void event_exit_send(void *ctx,
 		exit->current.pad[3] = 0;
 		exit->current.ktime = enter->key.ktime;
 
+		/* We track and report only thread leader so here tgid == tid */
+		exit->info.tid = tgid;
 		probe_read(&exit->info.code, sizeof(exit->info.code),
 			   _(&task->exit_code));
 

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -14,12 +14,16 @@ PROGS = sigkill-tester \
 	exit-code \
 	uprobe-test-1 \
 	uprobe-test-2 \
-	lseek-pipe
+	lseek-pipe \
+	threads-tester
 
 all: $(PROGS)
 
 %: %.c
 	$(GCC) -Wall $< -o $@
+
+threads-tester: threads-tester.c
+	$(GCC) -Wall $< -o $@ -lcap -lpthread
 
 capabilities-tester: capabilities-tester.c
 	$(GCC) -Wall $< -o $@ -lcap

--- a/contrib/tester-progs/threads-tester.c
+++ b/contrib/tester-progs/threads-tester.c
@@ -1,0 +1,88 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/sched.h>
+#include <linux/types.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/capability.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <dirent.h>
+
+#define FILENAME "/etc/issue"
+
+#define errExit(msg) \
+	do { \
+		perror(msg); \
+		exit(EXIT_FAILURE); \
+	} while (0)
+
+/* Use direct syscalls and avoid NPTL POSIX standard */
+static inline pid_t sys_gettid(void)
+{
+	return (pid_t)syscall(__NR_gettid);
+}
+
+void do_open(const char *process, const char *pathname)
+{
+	FILE *fptr = fopen(pathname, "r");
+	if(fptr == NULL)
+		errExit("fopen");
+
+	printf("%s\t(pid:%d, tid:%d, ppid:%d)\topen(\"%s\") succeeded\n", process, getpid(), sys_gettid(), getppid(), pathname);
+	fclose(fptr);
+}
+
+void *thread(void *arg)
+{
+	do_open("Thread 1:", FILENAME);
+
+	fflush(stdout);
+	return 0;
+}
+
+void child1()
+{
+	pthread_t ttid;
+
+	pthread_create(&ttid, NULL, thread, NULL);
+	fflush(stdout);
+	pthread_join(ttid, NULL);
+
+	do_open("Child 1:", FILENAME);
+
+	fflush(stdout);
+}
+
+int main(int argc, char **argv)
+{
+	pid_t pid;
+
+	printf("parent:\t\t(pid:%d, tid:%d, ppid:%d)\tstarts\n", getpid(), sys_gettid(), getppid());
+
+	if  ((pid = fork()) == -1) {
+		perror("fork");
+		exit(1);
+	} else if (pid == 0) {
+		child1();
+		/* child */
+		return 0;
+	}
+
+	/* wait for child1 to exit */
+	int status;
+	pid = wait(&status);
+	printf("parent:\t\t(pid:%d, tid:%d, ppid:%d)\tchild1 (%d) exited with: %d\n", getpid(), sys_gettid(), getppid(), pid, status);
+
+	return 0;
+}

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -140,7 +140,7 @@ type MsgProcess struct {
 
 type MsgExitInfo struct {
 	Code uint32 `align:"code"`
-	Pad1 uint32 `align:"pad"`
+	Tid  uint32 `align:"tid"`
 }
 
 type MsgExitEvent struct {

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -97,6 +97,7 @@ type MsgCloneEvent struct {
 	Common MsgCommon
 	Parent MsgExecveKey
 	PID    uint32
+	TID    uint32
 	NSPID  uint32
 	Flags  uint32
 	Ktime  uint64

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -19,7 +19,7 @@ const (
 	CGROUP_PATH_LENGTH = 4096
 
 	MSG_SIZEOF_MAXARG = 100
-	MSG_SIZEOF_EXECVE = 32
+	MSG_SIZEOF_EXECVE = 40
 	MSG_SIZEOF_CWD    = 256
 	MSG_SIZEOF_ARGS   = 1024
 	MSG_SIZEOF_BUFFER = MSG_SIZEOF_ARGS +
@@ -34,7 +34,9 @@ const (
 type MsgExec struct {
 	Size  uint32
 	PID   uint32
+	TID   uint32
 	NSPID uint32
+	PAD   uint32
 	UID   uint32
 	AUID  uint32
 	Flags uint32
@@ -126,6 +128,7 @@ type MsgNamespaces struct {
 type MsgProcess struct {
 	Size     uint32
 	PID      uint32
+	TID      uint32
 	NSPID    uint32
 	UID      uint32
 	AUID     uint32

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -273,9 +273,9 @@ func (msg *MsgCloneEventUnix) Cast(o interface{}) notify.Message {
 func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 	var tetragonProcess, tetragonParent *tetragon.Process
 
-	process, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
-	if process != nil {
-		tetragonProcess = process.UnsafeGetProcess()
+	proc, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
+	if proc != nil {
+		tetragonProcess = proc.UnsafeGetProcess()
 	} else {
 		tetragonProcess = &tetragon.Process{
 			Pid:       &wrapperspb.UInt32Value{Value: event.ProcessKey.Pid},
@@ -307,9 +307,11 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 		parent.RefDec()
 		tetragonEvent.Parent = parent.GetProcessCopy()
 	}
-	if process != nil {
-		process.RefDec()
-		tetragonEvent.Process = process.GetProcessCopy()
+	if proc != nil {
+		proc.RefDec()
+		tetragonEvent.Process = proc.GetProcessCopy()
+		// Use the bpf recorded TID to update the event
+		process.UpdateEventProcessTid(tetragonEvent.Process, event.Info.Tid)
 	}
 	return tetragonEvent
 }
@@ -343,7 +345,9 @@ func (msg *MsgExitEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*
 			internal.RefDec()
 			msg.RefCntDone[ProcessRefCnt] = true
 		}
-		ev.SetProcess(internal.GetProcessCopy())
+		proc := internal.GetProcessCopy()
+		// Update the Process TID with the recorded one from BPF side
+		process.UpdateEventProcessTid(proc, msg.Info.Tid)
 	} else {
 		errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		err = eventcache.ErrFailedToGetProcessInfo

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -206,7 +206,7 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 		},
 		Info: tetragonAPI.MsgExitInfo{
 			Code: 0,
-			Pad1: 0,
+			Tid:  Pid,
 		},
 	}
 
@@ -254,7 +254,7 @@ func CreateCloneEvents[CLONE notify.Message, EXIT notify.Message](Pid uint32, Kt
 		},
 		Info: tetragonAPI.MsgExitInfo{
 			Code: 0,
-			Pad1: 0,
+			Tid:  Pid,
 		},
 	}
 

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -165,7 +165,9 @@ func (pc *Cache) get(processID string) (*ProcessInternal, error) {
 	return process, nil
 }
 
-func (pc *Cache) Add(process *ProcessInternal) bool {
+// Add a ProcessInternal structure to the cache. Must be called only from
+// clone or execve events
+func (pc *Cache) add(process *ProcessInternal) bool {
 	evicted := pc.cache.Add(process.process.ExecId, process)
 	if evicted {
 		errormetrics.ErrorTotalInc(errormetrics.ProcessCacheEvicted)

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -30,7 +30,7 @@ func TestProcessCache(t *testing.T) {
 			},
 		},
 	}
-	cache.Add(&proc)
+	cache.add(&proc)
 	assert.Equal(t, cache.len(), 1)
 
 	result, err := cache.get(proc.process.ExecId)

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -240,7 +240,7 @@ func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 	} else {
 		proc, _ = GetProcess(event.Process, event.Kube.Docker, event.CleanupProcess, event.Capabilities, event.Namespaces)
 	}
-	procCache.Add(proc)
+	procCache.add(proc)
 	return proc
 }
 
@@ -289,7 +289,7 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 				pi.AddPodInfo(podInfo)
 			}
 		}
-		procCache.Add(pi)
+		procCache.add(pi)
 	}
 	return nil
 }

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -97,6 +97,7 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, bool, error) {
 
 	proc.Size = exec.Size
 	proc.PID = exec.PID
+	proc.TID = exec.TID
 	proc.NSPID = exec.NSPID
 	proc.UID = exec.UID
 	proc.Flags = exec.Flags

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -244,7 +244,7 @@ type execProbe struct{}
 func (e *execProbe) LoadProbe(args sensors.LoadProbeArgs) error {
 	err := program.LoadTracepointProgram(args.BPFDir, args.MapDir, args.Load, args.Verbose)
 	if err == nil {
-		procevents.GetRunningProcs()
+		err = procevents.GetRunningProcs()
 	}
 	return err
 }

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -59,6 +59,7 @@ type procs struct {
 	size                 uint32
 	uid                  uint32
 	pid                  uint32
+	tid                  uint32
 	nspid                uint32
 	auid                 uint32
 	flags                uint32
@@ -91,6 +92,7 @@ func procKernel() procs {
 		size:        uint32(processapi.MSG_SIZEOF_EXECVE + len(kernelArgs) + processapi.MSG_SIZEOF_CWD),
 		uid:         0,
 		pid:         kernelPid,
+		tid:         kernelPid,
 		nspid:       0,
 		auid:        0,
 		flags:       api.EventProcFS,
@@ -164,6 +166,7 @@ func pushExecveEvents(p procs) {
 
 	m.Process.Size = p.size
 	m.Process.PID = p.pid
+	m.Process.TID = p.tid
 	m.Process.NSPID = p.nspid
 	m.Process.UID = p.uid
 	m.Process.AUID = p.auid
@@ -417,11 +420,14 @@ func GetRunningProcs() error {
 
 		p := procs{
 			ppid: uint32(_ppid), pnspid: pnspid, pargs: pcmdsUTF,
-			pflags: api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
-			pktime: pktime,
-			uid:    euid, // use euid to be compatible with ps
-			auid:   auid,
-			pid:    uint32(pid), nspid: nspid, args: cmdsUTF,
+			pflags:               api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
+			pktime:               pktime,
+			uid:                  euid, // use euid to be compatible with ps
+			auid:                 auid,
+			pid:                  uint32(pid),
+			tid:                  uint32(pid), // Read dir does not return threads and we only track tgid
+			nspid:                nspid,
+			args:                 cmdsUTF,
 			flags:                api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
 			ktime:                ktime,
 			permitted:            permitted,

--- a/pkg/sensors/exec/procevents/proc_reader_test.go
+++ b/pkg/sensors/exec/procevents/proc_reader_test.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package procevents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListRunningProcs(t *testing.T) {
+	procs, err := listRunningProcs("/proc")
+	require.NoError(t, err)
+	require.NotNil(t, procs)
+	require.NotEqual(t, 0, len(procs))
+
+	for _, p := range procs {
+		require.NotZero(t, p.pid)
+		require.Equal(t, p.pid, p.tid)
+	}
+}

--- a/pkg/sensors/exec/threads_test.go
+++ b/pkg/sensors/exec/threads_test.go
@@ -7,8 +7,11 @@ import (
 	"sync"
 	"testing"
 
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	grpcexec "github.com/cilium/tetragon/pkg/grpc/exec"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/logger"
+	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors/base"
@@ -42,6 +45,23 @@ func TestThreadTesterParser(t *testing.T) {
 	assert.Equal(t, uint32(143564), cti.Thread1Pid)
 	assert.Equal(t, uint32(143565), cti.Thread1Tid)
 	assert.Equal(t, cti.ParentPid, cti.ParentThread1Pid)
+}
+
+func assertPidsTids(t *testing.T, tti *testutils.ThreadTesterInfo) {
+	require.NotZero(t, tti.ParentPid)
+	require.Equal(t, tti.ParentPid, tti.ParentTid)
+
+	require.NotZero(t, tti.Child1Pid)
+	require.NotZero(t, tti.Child1Tid)
+	require.Equal(t, tti.Child1Pid, tti.Child1Tid)
+
+	require.NotZero(t, tti.Thread1Pid)
+	require.NotZero(t, tti.Thread1Tid)
+	require.NotEqual(t, tti.Thread1Pid, tti.Thread1Tid)
+
+	require.Equal(t, tti.Child1Pid, tti.Thread1Pid)
+	require.Equal(t, tti.ParentChild1Pid, tti.ParentPid)
+	require.Equal(t, tti.ParentThread1Pid, tti.ParentPid)
 }
 
 func TestCloneThreadsTester(t *testing.T) {
@@ -78,17 +98,7 @@ func TestCloneThreadsTester(t *testing.T) {
 		t.Fatalf("command failed with %s. Context error: %v", err, ctx.Err())
 	}
 
-	require.NotZero(t, tti.Child1Pid)
-	require.NotZero(t, tti.Child1Tid)
-	require.Equal(t, tti.Child1Pid, tti.Child1Tid)
-
-	require.NotZero(t, tti.Thread1Pid)
-	require.NotZero(t, tti.Thread1Tid)
-	require.NotEqual(t, tti.Thread1Pid, tti.Thread1Tid)
-
-	require.Equal(t, tti.Child1Pid, tti.Thread1Pid)
-	require.Equal(t, tti.ParentChild1Pid, tti.ParentPid)
-	require.Equal(t, tti.ParentThread1Pid, tti.ParentPid)
+	assertPidsTids(t, tti)
 }
 
 func TestMatchCloneThreadsIDs(t *testing.T) {
@@ -148,6 +158,8 @@ func TestMatchCloneThreadsIDs(t *testing.T) {
 		}
 	}
 
+	assertPidsTids(t, tti)
+
 	require.NotZero(t, execPID)
 	require.Equal(t, execPID, execTID)
 
@@ -162,4 +174,56 @@ func TestMatchCloneThreadsIDs(t *testing.T) {
 
 	// ensure that threads match on the thread group leader
 	require.Equal(t, tti.Child1Pid, tti.Thread1Pid)
+}
+
+func TestExecThreads(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	testBin := testutils.RepoRootPath("contrib/tester-progs/threads-tester")
+	testCmd := exec.CommandContext(ctx, testBin)
+	testPipes, err := testutils.NewCmdBufferedPipes(testCmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testPipes.Close()
+
+	t.Logf("starting observer")
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	cti := &testutils.ThreadTesterInfo{}
+	if err := testCmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	logWG := testPipes.ParseAndLogCmdOutput(t, cti.ParseLine, nil)
+	logWG.Wait()
+	if err := testCmd.Wait(); err != nil {
+		t.Fatalf("command failed with %s. Context error: %v", err, ctx.Err())
+	}
+
+	assertPidsTids(t, cti)
+
+	binCheck := ec.NewProcessChecker().
+		WithBinary(sm.Suffix("threads-tester")).
+		WithPid(cti.ParentPid).
+		WithTid(cti.ParentTid)
+
+	execCheck := ec.NewProcessExecChecker("").
+		WithProcess(binCheck)
+
+	exitCheck := ec.NewProcessExitChecker("").
+		WithProcess(binCheck)
+
+	checker := ec.NewUnorderedEventChecker(execCheck, exitCheck)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
 }

--- a/pkg/sensors/exec/threads_test.go
+++ b/pkg/sensors/exec/threads_test.go
@@ -1,0 +1,165 @@
+package exec
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	grpcexec "github.com/cilium/tetragon/pkg/grpc/exec"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/sensors/base"
+	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
+	"github.com/cilium/tetragon/pkg/testutils"
+	"github.com/cilium/tetragon/pkg/testutils/perfring"
+	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleThreadTesterOutput = `
+parent:		(pid:143563, tid:143563, ppid:7860)	starts
+Thread 1:	(pid:143564, tid:143565, ppid:143563)	open("/etc/issue") succeeded
+Child 1:	(pid:143564, tid:143564, ppid:143563)	open("/etc/issue") succeeded
+parent:		(pid:143563, tid:143563, ppid:7860)	child1 (143564) exited with: 0
+`
+
+func TestThreadTesterParser(t *testing.T) {
+	cti := &testutils.ThreadTesterInfo{}
+	for _, l := range strings.Split(sampleThreadTesterOutput, "\n") {
+		cti.ParseLine(l)
+	}
+
+	assert.Equal(t, uint32(143563), cti.ParentPid)
+	assert.Equal(t, cti.ParentPid, cti.ParentTid)
+	assert.Equal(t, uint32(143564), cti.Child1Pid)
+	assert.Equal(t, cti.Child1Pid, cti.Child1Tid)
+	assert.Equal(t, cti.ParentPid, cti.ParentChild1Pid)
+	assert.Equal(t, uint32(143564), cti.Thread1Pid)
+	assert.Equal(t, uint32(143565), cti.Thread1Tid)
+	assert.Equal(t, cti.ParentPid, cti.ParentThread1Pid)
+}
+
+func TestCloneThreadsTester(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	testBinPath := "contrib/tester-progs/threads-tester"
+	testBin := testutils.RepoRootPath(testBinPath)
+	testCmd := exec.CommandContext(ctx, testBin)
+	testPipes, err := testutils.NewCmdBufferedPipes(testCmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testPipes.Close()
+
+	t.Logf("starting observer")
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	tti := &testutils.ThreadTesterInfo{}
+	if err := testCmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	logWG := testPipes.ParseAndLogCmdOutput(t, tti.ParseLine, nil)
+	logWG.Wait()
+	if err := testCmd.Wait(); err != nil {
+		t.Fatalf("command failed with %s. Context error: %v", err, ctx.Err())
+	}
+
+	require.NotZero(t, tti.Child1Pid)
+	require.NotZero(t, tti.Child1Tid)
+	require.Equal(t, tti.Child1Pid, tti.Child1Tid)
+
+	require.NotZero(t, tti.Thread1Pid)
+	require.NotZero(t, tti.Thread1Tid)
+	require.NotEqual(t, tti.Thread1Pid, tti.Thread1Tid)
+
+	require.Equal(t, tti.Child1Pid, tti.Thread1Pid)
+	require.Equal(t, tti.ParentChild1Pid, tti.ParentPid)
+	require.Equal(t, tti.ParentThread1Pid, tti.ParentPid)
+}
+
+func TestMatchCloneThreadsIDs(t *testing.T) {
+	testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	if err := observer.InitDataCache(1024); err != nil {
+		t.Fatalf("observer.InitDataCache: %s", err)
+	}
+
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	tus.LoadSensor(ctx, t, base.GetInitialSensor())
+	tus.LoadSensor(ctx, t, testsensor.GetTestSensor())
+
+	testBinPath := "contrib/tester-progs/threads-tester"
+	testBin := testutils.RepoRootPath(testBinPath)
+
+	tti := &testutils.ThreadTesterInfo{}
+	ops := func() {
+		testCmd := exec.CommandContext(ctx, testBin)
+		testPipes, err := testutils.NewCmdBufferedPipes(testCmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer testPipes.Close()
+
+		if err := testCmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		logWG := testPipes.ParseAndLogCmdOutput(t, tti.ParseLine, nil)
+		logWG.Wait()
+		if err := testCmd.Wait(); err != nil {
+			t.Fatalf("command failed with %s. Context error: %v", err, ctx.Err())
+		}
+	}
+
+	execPID, execTID := uint32(0), uint32(0)
+	clonePID, cloneTID := uint32(0), uint32(0)
+	events := perfring.RunTestEvents(t, ctx, ops)
+	for _, ev := range events {
+		switch ev.(type) {
+		case *grpcexec.MsgExecveEventUnix:
+			exec := ev.(*grpcexec.MsgExecveEventUnix)
+			if exec.Process.Filename == testBin {
+				execPID = exec.Process.PID
+				execTID = exec.Process.TID
+			}
+		case *grpcexec.MsgCloneEventUnix:
+			msg := ev.(*grpcexec.MsgCloneEventUnix)
+			// We found the exec parent then catch the single per thread
+			// clone event
+			if execPID != 0 && clonePID == 0 {
+				clonePID = msg.PID
+				cloneTID = msg.TID
+			}
+		}
+	}
+
+	require.NotZero(t, execPID)
+	require.Equal(t, execPID, execTID)
+
+	// ensure exec and all follow clone with all threads match back to parent exec
+	require.Equal(t, execPID, tti.ParentPid)
+	require.Equal(t, execPID, tti.ParentChild1Pid)
+	require.Equal(t, execPID, tti.ParentThread1Pid)
+
+	// ensure clone event matches
+	require.Equal(t, clonePID, cloneTID)
+	require.Equal(t, clonePID, tti.Child1Pid) // First clone
+
+	// ensure that threads match on the thread group leader
+	require.Equal(t, tti.Child1Pid, tti.Thread1Pid)
+}

--- a/pkg/testutils/threadevents.go
+++ b/pkg/testutils/threadevents.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package testutils
+
+import (
+	"regexp"
+	"strconv"
+)
+
+type ThreadTesterInfo struct {
+	ParentPid, ParentTid                     uint32
+	Child1Pid, Child1Tid, ParentChild1Pid    uint32
+	Thread1Pid, Thread1Tid, ParentThread1Pid uint32
+}
+
+var (
+	ParentStartsRe = regexp.MustCompile(`parent:\t\t\(pid:(\d+), tid:(\d+), ppid:(\d+)\)\tstarts`)
+	Child1Re       = regexp.MustCompile(`Child 1:\t\(pid:(\d+), tid:(\d+), ppid:(\d+)\)\t`)
+	Thread1Re      = regexp.MustCompile(`Thread 1:\t\(pid:(\d+), tid:(\d+), ppid:(\d+)\)\t`)
+)
+
+func (tti *ThreadTesterInfo) ParseLine(l string) error {
+	var err error
+	var v uint64
+	if match := ParentStartsRe.FindStringSubmatch(l); len(match) > 0 {
+		v, err = strconv.ParseUint(match[1], 10, 32)
+		if err == nil {
+			tti.ParentPid = uint32(v)
+		}
+		v, err = strconv.ParseUint(match[2], 10, 32)
+		if err == nil {
+			tti.ParentTid = uint32(v)
+		}
+	} else if match := Child1Re.FindStringSubmatch(l); len(match) > 0 {
+		v, err = strconv.ParseUint(match[1], 10, 32)
+		if err == nil {
+			tti.Child1Pid = uint32(v)
+		}
+		v, err = strconv.ParseUint(match[2], 10, 32)
+		if err == nil {
+			tti.Child1Tid = uint32(v)
+		}
+		v, err = strconv.ParseUint(match[3], 10, 32)
+		if err == nil {
+			tti.ParentChild1Pid = uint32(v)
+		}
+	} else if match := Thread1Re.FindStringSubmatch(l); len(match) > 0 {
+		v, err = strconv.ParseUint(match[1], 10, 32)
+		if err == nil {
+			tti.Thread1Pid = uint32(v)
+		}
+		v, err = strconv.ParseUint(match[2], 10, 32)
+		if err == nil {
+			tti.Thread1Tid = uint32(v)
+		}
+		v, err = strconv.ParseUint(match[3], 10, 32)
+		if err == nil {
+			tti.ParentThread1Pid = uint32(v)
+		}
+	}
+	return err
+}

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -2255,6 +2255,7 @@ type ProcessChecker struct {
 	Refcnt       *uint32                            `json:"refcnt,omitempty"`
 	Cap          *CapabilitiesChecker               `json:"cap,omitempty"`
 	Ns           *NamespacesChecker                 `json:"ns,omitempty"`
+	Tid          *uint32                            `json:"tid,omitempty"`
 }
 
 // NewProcessChecker creates a new ProcessChecker
@@ -2358,6 +2359,14 @@ func (checker *ProcessChecker) Check(event *tetragon.Process) error {
 				return fmt.Errorf("Ns check failed: %w", err)
 			}
 		}
+		if checker.Tid != nil {
+			if event.Tid == nil {
+				return fmt.Errorf("Tid is nil and does not match expected value %v", *checker.Tid)
+			}
+			if *checker.Tid != event.Tid.Value {
+				return fmt.Errorf("Tid has value %v which does not match expected value %v", event.Tid.Value, *checker.Tid)
+			}
+		}
 		return nil
 	}
 	if err := fieldChecks(); err != nil {
@@ -2456,6 +2465,12 @@ func (checker *ProcessChecker) WithNs(check *NamespacesChecker) *ProcessChecker 
 	return checker
 }
 
+// WithTid adds a Tid check to the ProcessChecker
+func (checker *ProcessChecker) WithTid(check uint32) *ProcessChecker {
+	checker.Tid = &check
+	return checker
+}
+
 //FromProcess populates the ProcessChecker using data from a Process field
 func (checker *ProcessChecker) FromProcess(event *tetragon.Process) *ProcessChecker {
 	if event == nil {
@@ -2494,6 +2509,10 @@ func (checker *ProcessChecker) FromProcess(event *tetragon.Process) *ProcessChec
 	}
 	if event.Ns != nil {
 		checker.Ns = NewNamespacesChecker().FromNamespaces(event.Ns)
+	}
+	if event.Tid != nil {
+		val := event.Tid.Value
+		checker.Tid = &val
 	}
 	return checker
 }

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
@@ -696,6 +696,7 @@ type Process struct {
 	Refcnt       uint32                  `protobuf:"varint,13,opt,name=refcnt,proto3" json:"refcnt,omitempty"`
 	Cap          *Capabilities           `protobuf:"bytes,14,opt,name=cap,proto3" json:"cap,omitempty"`
 	Ns           *Namespaces             `protobuf:"bytes,15,opt,name=ns,proto3" json:"ns,omitempty"`
+	Tid          *wrapperspb.UInt32Value `protobuf:"bytes,16,opt,name=tid,proto3" json:"tid,omitempty"` // tid is the thread id. (For the thread group leader, tid is equal to pid.)
 }
 
 func (x *Process) Reset() {
@@ -831,6 +832,13 @@ func (x *Process) GetCap() *Capabilities {
 func (x *Process) GetNs() *Namespaces {
 	if x != nil {
 		return x.Ns
+	}
+	return nil
+}
+
+func (x *Process) GetTid() *wrapperspb.UInt32Value {
+	if x != nil {
+		return x.Tid
 	}
 	return nil
 }
@@ -2888,7 +2896,7 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x52, 0x06, 0x63, 0x67, 0x72, 0x6f, 0x75,
 	0x70, 0x12, 0x27, 0x0a, 0x04, 0x75, 0x73, 0x65, 0x72, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x0b, 0x32,
 	0x13, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x73,
-	0x70, 0x61, 0x63, 0x65, 0x52, 0x04, 0x75, 0x73, 0x65, 0x72, 0x22, 0x94, 0x04, 0x0a, 0x07, 0x50,
+	0x70, 0x61, 0x63, 0x65, 0x52, 0x04, 0x75, 0x73, 0x65, 0x72, 0x22, 0xc4, 0x04, 0x0a, 0x07, 0x50,
 	0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x12, 0x17, 0x0a, 0x07, 0x65, 0x78, 0x65, 0x63, 0x5f, 0x69,
 	0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x65, 0x78, 0x65, 0x63, 0x49, 0x64, 0x12,
 	0x2e, 0x0a, 0x03, 0x70, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67,
@@ -2922,7 +2930,10 @@ var file_tetragon_tetragon_proto_rawDesc = []byte{
 	0x6c, 0x69, 0x74, 0x69, 0x65, 0x73, 0x52, 0x03, 0x63, 0x61, 0x70, 0x12, 0x24, 0x0a, 0x02, 0x6e,
 	0x73, 0x18, 0x0f, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x14, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67,
 	0x6f, 0x6e, 0x2e, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x73, 0x52, 0x02, 0x6e,
-	0x73, 0x22, 0x96, 0x01, 0x0a, 0x0b, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x45, 0x78, 0x65,
+	0x73, 0x12, 0x2e, 0x0a, 0x03, 0x74, 0x69, 0x64, 0x18, 0x10, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c,
+	0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66,
+	0x2e, 0x55, 0x49, 0x6e, 0x74, 0x33, 0x32, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x03, 0x74, 0x69,
+	0x64, 0x22, 0x96, 0x01, 0x0a, 0x0b, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x45, 0x78, 0x65,
 	0x63, 0x12, 0x2b, 0x0a, 0x07, 0x70, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x18, 0x01, 0x20, 0x01,
 	0x28, 0x0b, 0x32, 0x11, 0x2e, 0x74, 0x65, 0x74, 0x72, 0x61, 0x67, 0x6f, 0x6e, 0x2e, 0x50, 0x72,
 	0x6f, 0x63, 0x65, 0x73, 0x73, 0x52, 0x07, 0x70, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x12, 0x29,
@@ -3313,53 +3324,54 @@ var file_tetragon_tetragon_proto_depIdxs = []int32{
 	5,  // 22: tetragon.Process.pod:type_name -> tetragon.Pod
 	6,  // 23: tetragon.Process.cap:type_name -> tetragon.Capabilities
 	8,  // 24: tetragon.Process.ns:type_name -> tetragon.Namespaces
-	9,  // 25: tetragon.ProcessExec.process:type_name -> tetragon.Process
-	9,  // 26: tetragon.ProcessExec.parent:type_name -> tetragon.Process
-	9,  // 27: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
-	9,  // 28: tetragon.ProcessExit.process:type_name -> tetragon.Process
-	9,  // 29: tetragon.ProcessExit.parent:type_name -> tetragon.Process
-	37, // 30: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
-	39, // 31: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
-	39, // 32: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
-	39, // 33: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
-	40, // 34: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
-	40, // 35: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
-	38, // 36: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
-	38, // 37: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
-	7,  // 38: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
-	13, // 39: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
-	14, // 40: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
-	15, // 41: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
-	16, // 42: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
-	12, // 43: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
-	17, // 44: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
-	20, // 45: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
-	21, // 46: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
-	22, // 47: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
-	19, // 48: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
-	18, // 49: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
-	9,  // 50: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
-	9,  // 51: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
-	23, // 52: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
-	23, // 53: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
-	0,  // 54: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
-	9,  // 55: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
-	9,  // 56: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
-	23, // 57: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
-	9,  // 58: tetragon.ProcessUprobe.process:type_name -> tetragon.Process
-	9,  // 59: tetragon.ProcessUprobe.parent:type_name -> tetragon.Process
-	1,  // 60: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
-	1,  // 61: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
-	2,  // 62: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
-	29, // 63: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
-	9,  // 64: tetragon.ProcessLoader.process:type_name -> tetragon.Process
-	34, // 65: tetragon.RuntimeHookRequest.createContainer:type_name -> tetragon.CreateContainer
-	36, // 66: tetragon.CreateContainer.annotations:type_name -> tetragon.CreateContainer.AnnotationsEntry
-	67, // [67:67] is the sub-list for method output_type
-	67, // [67:67] is the sub-list for method input_type
-	67, // [67:67] is the sub-list for extension type_name
-	67, // [67:67] is the sub-list for extension extendee
-	0,  // [0:67] is the sub-list for field type_name
+	38, // 25: tetragon.Process.tid:type_name -> google.protobuf.UInt32Value
+	9,  // 26: tetragon.ProcessExec.process:type_name -> tetragon.Process
+	9,  // 27: tetragon.ProcessExec.parent:type_name -> tetragon.Process
+	9,  // 28: tetragon.ProcessExec.ancestors:type_name -> tetragon.Process
+	9,  // 29: tetragon.ProcessExit.process:type_name -> tetragon.Process
+	9,  // 30: tetragon.ProcessExit.parent:type_name -> tetragon.Process
+	37, // 31: tetragon.ProcessExit.time:type_name -> google.protobuf.Timestamp
+	39, // 32: tetragon.KprobeCred.permitted:type_name -> tetragon.CapabilitiesType
+	39, // 33: tetragon.KprobeCred.effective:type_name -> tetragon.CapabilitiesType
+	39, // 34: tetragon.KprobeCred.inheritable:type_name -> tetragon.CapabilitiesType
+	40, // 35: tetragon.KprobeCapability.value:type_name -> google.protobuf.Int32Value
+	40, // 36: tetragon.KprobeUserNamespace.level:type_name -> google.protobuf.Int32Value
+	38, // 37: tetragon.KprobeUserNamespace.owner:type_name -> google.protobuf.UInt32Value
+	38, // 38: tetragon.KprobeUserNamespace.group:type_name -> google.protobuf.UInt32Value
+	7,  // 39: tetragon.KprobeUserNamespace.ns:type_name -> tetragon.Namespace
+	13, // 40: tetragon.KprobeArgument.skb_arg:type_name -> tetragon.KprobeSkb
+	14, // 41: tetragon.KprobeArgument.path_arg:type_name -> tetragon.KprobePath
+	15, // 42: tetragon.KprobeArgument.file_arg:type_name -> tetragon.KprobeFile
+	16, // 43: tetragon.KprobeArgument.truncated_bytes_arg:type_name -> tetragon.KprobeTruncatedBytes
+	12, // 44: tetragon.KprobeArgument.sock_arg:type_name -> tetragon.KprobeSock
+	17, // 45: tetragon.KprobeArgument.cred_arg:type_name -> tetragon.KprobeCred
+	20, // 46: tetragon.KprobeArgument.bpf_attr_arg:type_name -> tetragon.KprobeBpfAttr
+	21, // 47: tetragon.KprobeArgument.perf_event_arg:type_name -> tetragon.KprobePerfEvent
+	22, // 48: tetragon.KprobeArgument.bpf_map_arg:type_name -> tetragon.KprobeBpfMap
+	19, // 49: tetragon.KprobeArgument.user_namespace_arg:type_name -> tetragon.KprobeUserNamespace
+	18, // 50: tetragon.KprobeArgument.capability_arg:type_name -> tetragon.KprobeCapability
+	9,  // 51: tetragon.ProcessKprobe.process:type_name -> tetragon.Process
+	9,  // 52: tetragon.ProcessKprobe.parent:type_name -> tetragon.Process
+	23, // 53: tetragon.ProcessKprobe.args:type_name -> tetragon.KprobeArgument
+	23, // 54: tetragon.ProcessKprobe.return:type_name -> tetragon.KprobeArgument
+	0,  // 55: tetragon.ProcessKprobe.action:type_name -> tetragon.KprobeAction
+	9,  // 56: tetragon.ProcessTracepoint.process:type_name -> tetragon.Process
+	9,  // 57: tetragon.ProcessTracepoint.parent:type_name -> tetragon.Process
+	23, // 58: tetragon.ProcessTracepoint.args:type_name -> tetragon.KprobeArgument
+	9,  // 59: tetragon.ProcessUprobe.process:type_name -> tetragon.Process
+	9,  // 60: tetragon.ProcessUprobe.parent:type_name -> tetragon.Process
+	1,  // 61: tetragon.GetHealthStatusRequest.event_set:type_name -> tetragon.HealthStatusType
+	1,  // 62: tetragon.HealthStatus.event:type_name -> tetragon.HealthStatusType
+	2,  // 63: tetragon.HealthStatus.status:type_name -> tetragon.HealthStatusResult
+	29, // 64: tetragon.GetHealthStatusResponse.health_status:type_name -> tetragon.HealthStatus
+	9,  // 65: tetragon.ProcessLoader.process:type_name -> tetragon.Process
+	34, // 66: tetragon.RuntimeHookRequest.createContainer:type_name -> tetragon.CreateContainer
+	36, // 67: tetragon.CreateContainer.annotations:type_name -> tetragon.CreateContainer.AnnotationsEntry
+	68, // [68:68] is the sub-list for method output_type
+	68, // [68:68] is the sub-list for method input_type
+	68, // [68:68] is the sub-list for extension type_name
+	68, // [68:68] is the sub-list for extension extendee
+	0,  // [0:68] is the sub-list for field type_name
 }
 
 func init() { file_tetragon_tetragon_proto_init() }

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
@@ -95,6 +95,7 @@ message Process {
     uint32 refcnt = 13;
     Capabilities cap = 14;
     Namespaces ns = 15;
+    google.protobuf.UInt32Value tid = 16; // tid is the thread id. (For the thread group leader, tid is equal to pid.)
 }
 
 message ProcessExec {


### PR DESCRIPTION
This PR adds the TID the thread ID to Process object and then it adds support to clone and process_exec|exit events.

The TID makes more sense in kprobe and tracepoints, however since we share the Process object with process_exec, let's reuse it here and ensure that the TID is not zero during process_{exec|exit}

For more details, see commits.