### PR TITLE
tetragon: handle process threads in kprobes and tracepoints

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -34,8 +34,8 @@ struct msg_generic_kprobe {
 	struct msg_execve_key current;
 	struct msg_ns ns;
 	struct msg_capabilities caps;
-	__u64 id;
-	__u64 thread_id;
+	__u64 func_id;
+	__u64 retprobe_id;
 	__u64 action;
 	__u32 action_arg_id; // only one URL or FQDN action can be fired per match
 	__u32 pad;

--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -38,7 +38,7 @@ struct msg_generic_kprobe {
 	__u64 retprobe_id;
 	__u64 action;
 	__u32 action_arg_id; // only one URL or FQDN action can be fired per match
-	__u32 pad;
+	__u32 tid; // Thread ID that triggered the event
 	/* anything above is shared with the userspace so it should match structs MsgGenericKprobe and MsgGenericTracepoint in Go */
 	char args[24000];
 	unsigned long a0, a1, a2, a3, a4;

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -90,7 +90,7 @@ generic_kprobe_start_process_filter(void *ctx)
 		return 0;
 	if (!policy_filter_check(config->policy_id))
 		return 0;
-	msg->id = config->func_id;
+	msg->func_id = config->func_id;
 
 	/* Initialize selector index to 0 */
 	msg->sel.curr = 0;

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -70,10 +70,10 @@ BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 	if (!config)
 		return 0;
 
-	e->id = config->func_id;
-	e->thread_id = retprobe_map_get_key(ctx);
+	e->func_id = config->func_id;
+	e->retprobe_id = retprobe_map_get_key(ctx);
 
-	if (!retprobe_map_get(e->id, e->thread_id, &info))
+	if (!retprobe_map_get(e->func_id, e->retprobe_id, &info))
 		return 0;
 
 	*(unsigned long *)e->args = info.ktime_enter;
@@ -120,7 +120,7 @@ BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 	e->current.pad[2] = 0;
 	e->current.pad[3] = 0;
 
-	e->id = config->func_id;
+	e->func_id = config->func_id;
 
 	total = size;
 	total += generic_kprobe_common_size();

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -72,6 +72,7 @@ BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 
 	e->func_id = config->func_id;
 	e->retprobe_id = retprobe_map_get_key(ctx);
+	e->tid = (__u32)get_current_pid_tgid();
 
 	if (!retprobe_map_get(e->func_id, e->retprobe_id, &info))
 		return 0;

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -129,7 +129,8 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 
 	/* Tail call into filters. */
 	msg->idx = 0;
-	msg->id = config->func_id;
+	msg->func_id = config->func_id;
+	msg->retprobe_id = 0;
 
 	msg->a0 = ({
 		unsigned long ctx_off = config->t_arg0_ctx_off;

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -83,7 +83,8 @@ generic_uprobe_start_process_filter(void *ctx)
 	if (!config)
 		return 0;
 	msg->idx = 0;
-	msg->id = config->func_id;
+	msg->func_id = config->func_id;
+	msg->retprobe_id = 0;
 	if (!generic_process_filter_binary(config))
 		return 0;
 	/* Tail call into filters. */

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -49,7 +49,7 @@ generic_process_event(void *ctx, int index, struct bpf_map_def *heap_map,
 		 * do it where it makes most sense.
 		 */
 		if (errv < 0)
-			return filter_args_reject(e->id);
+			return filter_args_reject(e->func_id);
 	}
 	e->common.size = total;
 	/* Continue to process other arguments. */
@@ -123,12 +123,12 @@ generic_process_event_and_setup(struct pt_regs *ctx,
 
 	generic_process_init(e, MSG_OP_GENERIC_KPROBE, config);
 
-	e->thread_id = retprobe_map_get_key(ctx);
+	e->retprobe_id = retprobe_map_get_key(ctx);
 
 	/* If return arg is needed mark retprobe */
 	ty = config->argreturn;
 	if (ty > 0)
-		retprobe_map_set(e->id, e->thread_id, e->common.ktime, 1);
+		retprobe_map_set(e->func_id, e->retprobe_id, e->common.ktime, 1);
 #endif
 
 #ifdef GENERIC_UPROBE

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -79,6 +79,9 @@ generic_process_init(struct msg_generic_kprobe *e, u8 op, struct event_config *c
 	e->current.pad[3] = 0;
 
 	e->action = 0;
+
+	/* Initialize with the calling TID */
+	e->tid = (__u32)get_current_pid_tgid();
 }
 
 static inline __attribute__((always_inline)) int

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -578,8 +578,9 @@ copy_char_buf(void *ctx, long off, unsigned long arg, int argm,
 	size_t bytes = 0;
 
 	if (hasReturnCopy(argm)) {
-		u64 tid = retprobe_map_get_key(ctx);
-		retprobe_map_set(e->id, tid, e->common.ktime, arg);
+		u64 retid = retprobe_map_get_key(ctx);
+
+		retprobe_map_set(e->func_id, retid, e->common.ktime, arg);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
 	meta = get_arg_meta(argm, e);
@@ -726,8 +727,9 @@ copy_char_iovec(void *ctx, long off, unsigned long arg, int argm,
 	meta = get_arg_meta(argm, e);
 
 	if (hasReturnCopy(argm)) {
-		u64 tid = retprobe_map_get_key(ctx);
-		retprobe_map_set_iovec(e->id, tid, e->common.ktime, arg, meta);
+		u64 retid = retprobe_map_get_key(ctx);
+
+		retprobe_map_set_iovec(e->func_id, retid, e->common.ktime, arg, meta);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
 	return __copy_char_iovec(off, arg, meta, 0, e);
@@ -1207,7 +1209,7 @@ filter_args(struct msg_generic_kprobe *e, int index, void *filter_map,
 	 * have their arg filters run.
 	 */
 	if (index > SELECTORS_ACTIVE)
-		return filter_args_reject(e->id);
+		return filter_args_reject(e->func_id);
 
 	if (e->sel.active[index]) {
 		int pass = selector_arg_offset(f, e, index, early_binary_filter);
@@ -1453,7 +1455,7 @@ filter_read_arg(void *ctx, int index, struct bpf_map_def *heap,
 		if (index <= MAX_SELECTORS && e->sel.active[index])
 			tail_call(ctx, tailcalls, MIN_FILTER_TAILCALL + index);
 		// reject if we did not attempt to tailcall, or if tailcall failed.
-		return filter_args_reject(e->id);
+		return filter_args_reject(e->func_id);
 	}
 
 	// If pass >1 then we need to consult the selector actions

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -23,7 +23,7 @@ all: $(PROGS)
 	$(GCC) -Wall $< -o $@
 
 threads-tester: threads-tester.c
-	$(GCC) -Wall $< -o $@ -lcap -lpthread
+	$(GCC) -Wall -fno-inline $< -o $@ -lcap -lpthread
 
 capabilities-tester: capabilities-tester.c
 	$(GCC) -Wall $< -o $@ -lcap

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -48,7 +48,7 @@ type MsgGenericKprobe struct {
 	RetProbeId   uint64
 	ActionId     uint64
 	ActionArgId  uint32
-	Pad          uint32
+	Tid          uint32 // The recorded TID that triggered the event
 }
 
 type MsgGenericKprobeArgPath struct {

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -44,8 +44,8 @@ type MsgGenericKprobe struct {
 	ProcessKey   processapi.MsgExecveKey
 	Namespaces   processapi.MsgNamespaces
 	Capabilities processapi.MsgCapabilities
-	Id           uint64
-	ThreadId     uint64
+	FuncId       uint64
+	RetProbeId   uint64
 	ActionId     uint64
 	ActionArgId  uint32
 	Pad          uint32

--- a/pkg/api/tracingapi/client_tracepoint.go
+++ b/pkg/api/tracingapi/client_tracepoint.go
@@ -16,5 +16,5 @@ type MsgGenericTracepoint struct {
 	RetProbeId   uint64
 	ActionId     uint64
 	ActionArgId  uint32
-	Pad          uint32
+	Tid          uint32 // The recorded TID that triggered the event
 }

--- a/pkg/api/tracingapi/client_tracepoint.go
+++ b/pkg/api/tracingapi/client_tracepoint.go
@@ -12,8 +12,8 @@ type MsgGenericTracepoint struct {
 	ProcessKey   processapi.MsgExecveKey
 	Namespaces   processapi.MsgNamespaces
 	Capabilities processapi.MsgCapabilities
-	Id           int64
-	ThreadId     uint64
+	FuncId       int64
+	RetProbeId   uint64
 	ActionId     uint64
 	ActionArgId  uint32
 	Pad          uint32

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -311,7 +311,7 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 		proc.RefDec()
 		tetragonEvent.Process = proc.GetProcessCopy()
 		// Use the bpf recorded TID to update the event
-		process.UpdateEventProcessTid(tetragonEvent.Process, event.Info.Tid)
+		process.UpdateEventProcessTid(tetragonEvent.Process, &event.Info.Tid)
 	}
 	return tetragonEvent
 }
@@ -347,7 +347,7 @@ func (msg *MsgExitEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*
 		}
 		proc := internal.GetProcessCopy()
 		// Update the Process TID with the recorded one from BPF side
-		process.UpdateEventProcessTid(proc, msg.Info.Tid)
+		process.UpdateEventProcessTid(proc, &msg.Info.Tid)
 	} else {
 		errormetrics.ErrorTotalInc(errormetrics.EventCacheProcessInfoFailed)
 		err = eventcache.ErrFailedToGetProcessInfo

--- a/pkg/grpc/test/test.go
+++ b/pkg/grpc/test/test.go
@@ -27,7 +27,7 @@ func (msg *MsgTestEventUnix) Notify() bool {
 }
 
 func (msg *MsgTestEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, 0, timestamp)
+	return eventcache.HandleGenericInternal(ev, 0, nil, timestamp)
 }
 
 func (msg *MsgTestEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -467,6 +467,7 @@ func (msg *MsgProcessLoaderUnix) Cast(o interface{}) notify.Message {
 type MsgGenericUprobeUnix struct {
 	Common     processapi.MsgCommon
 	ProcessKey processapi.MsgExecveKey
+	Tid        uint32
 	Path       string
 	Symbol     string
 	PolicyName string
@@ -494,15 +495,15 @@ func (msg *MsgGenericUprobeUnix) Retry(internal *process.ProcessInternal, ev not
 func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {
 	var tetragonParent, tetragonProcess *tetragon.Process
 
-	process, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
-	if process == nil {
+	proc, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
+	if proc == nil {
 		tetragonProcess = &tetragon.Process{
 			Pid:       &wrapperspb.UInt32Value{Value: event.ProcessKey.Pid},
 			StartTime: ktime.ToProto(event.ProcessKey.Ktime),
 		}
 	} else {
-		tetragonProcess = process.UnsafeGetProcess()
-		if err := process.AnnotateProcess(option.Config.EnableProcessCred, option.Config.EnableProcessNs); err != nil {
+		tetragonProcess = proc.UnsafeGetProcess()
+		if err := proc.AnnotateProcess(option.Config.EnableProcessCred, option.Config.EnableProcessNs); err != nil {
 			logger.GetLogger().WithError(err).WithField("processId", tetragonProcess.Pid).
 				Debugf("Failed to annotate process with capabilities and namespaces info")
 		}
@@ -526,8 +527,10 @@ func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {
 		return nil
 	}
 
-	if process != nil {
-		tetragonEvent.Process = process.GetProcessCopy()
+	if proc != nil {
+		tetragonEvent.Process = proc.GetProcessCopy()
+		// Use the bpf recorded TID to update the event
+		process.UpdateEventProcessTid(tetragonEvent.Process, event.Tid)
 	}
 	if parent != nil {
 		tetragonEvent.Parent = parent.GetProcessCopy()

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -60,15 +60,15 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 	var tetragonArgs []*tetragon.KprobeArgument
 	var tetragonReturnArg *tetragon.KprobeArgument
 
-	process, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
-	if process == nil {
+	proc, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
+	if proc == nil {
 		tetragonProcess = &tetragon.Process{
 			Pid:       &wrapperspb.UInt32Value{Value: event.ProcessKey.Pid},
 			StartTime: ktime.ToProto(event.ProcessKey.Ktime),
 		}
 	} else {
-		tetragonProcess = process.UnsafeGetProcess()
-		if err := process.AnnotateProcess(option.Config.EnableProcessCred, option.Config.EnableProcessNs); err != nil {
+		tetragonProcess = proc.UnsafeGetProcess()
+		if err := proc.AnnotateProcess(option.Config.EnableProcessCred, option.Config.EnableProcessNs); err != nil {
 			logger.GetLogger().WithError(err).WithField("processId", tetragonProcess.Pid).Debugf("Failed to annotate process with capabilities and namespaces info")
 		}
 	}
@@ -214,8 +214,10 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 		return nil
 	}
 
-	if process != nil {
-		tetragonEvent.Process = process.GetProcessCopy()
+	if proc != nil {
+		tetragonEvent.Process = proc.GetProcessCopy()
+		// Use the bpf recorded TID to update the event
+		process.UpdateEventProcessTid(tetragonEvent.Process, event.Tid)
 	}
 	if parent != nil {
 		tetragonEvent.Parent = parent.GetProcessCopy()
@@ -228,6 +230,7 @@ type MsgGenericTracepointUnix struct {
 	Common     processapi.MsgCommon
 	ProcessKey processapi.MsgExecveKey
 	Id         int64
+	Tid        uint32
 	Subsys     string
 	Event      string
 	Args       []tracingapi.MsgGenericTracepointArg
@@ -249,14 +252,14 @@ func (msg *MsgGenericTracepointUnix) Retry(internal *process.ProcessInternal, ev
 func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse {
 	var tetragonParent, tetragonProcess *tetragon.Process
 
-	process, parent := process.GetParentProcessInternal(msg.ProcessKey.Pid, msg.ProcessKey.Ktime)
-	if process == nil {
+	proc, parent := process.GetParentProcessInternal(msg.ProcessKey.Pid, msg.ProcessKey.Ktime)
+	if proc == nil {
 		tetragonProcess = &tetragon.Process{
 			Pid:       &wrapperspb.UInt32Value{Value: msg.ProcessKey.Pid},
 			StartTime: ktime.ToProto(msg.ProcessKey.Ktime),
 		}
 	} else {
-		tetragonProcess = process.UnsafeGetProcess()
+		tetragonProcess = proc.UnsafeGetProcess()
 	}
 	if parent != nil {
 		tetragonParent = parent.UnsafeGetProcess()
@@ -303,8 +306,10 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 		return nil
 	}
 
-	if process != nil {
-		tetragonEvent.Process = process.GetProcessCopy()
+	if proc != nil {
+		tetragonEvent.Process = proc.GetProcessCopy()
+		// Use the bpf recorded TID to update the event
+		process.UpdateEventProcessTid(tetragonEvent.Process, msg.Tid)
 	}
 	if parent != nil {
 		tetragonEvent.Parent = parent.GetProcessCopy()
@@ -336,6 +341,7 @@ type MsgGenericKprobeUnix struct {
 	Capabilities processapi.MsgCapabilities
 	Id           uint64
 	Action       uint64
+	Tid          uint32
 	FuncName     string
 	Args         []tracingapi.MsgGenericKprobeArg
 	PolicyName   string

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -217,7 +217,7 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 	if proc != nil {
 		tetragonEvent.Process = proc.GetProcessCopy()
 		// Use the bpf recorded TID to update the event
-		process.UpdateEventProcessTid(tetragonEvent.Process, event.Tid)
+		process.UpdateEventProcessTid(tetragonEvent.Process, &event.Tid)
 	}
 	if parent != nil {
 		tetragonEvent.Parent = parent.GetProcessCopy()
@@ -242,7 +242,7 @@ func (msg *MsgGenericTracepointUnix) Notify() bool {
 }
 
 func (msg *MsgGenericTracepointUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, timestamp)
+	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, &msg.Tid, timestamp)
 }
 
 func (msg *MsgGenericTracepointUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
@@ -309,7 +309,7 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 	if proc != nil {
 		tetragonEvent.Process = proc.GetProcessCopy()
 		// Use the bpf recorded TID to update the event
-		process.UpdateEventProcessTid(tetragonEvent.Process, msg.Tid)
+		process.UpdateEventProcessTid(tetragonEvent.Process, &msg.Tid)
 	}
 	if parent != nil {
 		tetragonEvent.Parent = parent.GetProcessCopy()
@@ -352,7 +352,7 @@ func (msg *MsgGenericKprobeUnix) Notify() bool {
 }
 
 func (msg *MsgGenericKprobeUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, timestamp)
+	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, &msg.Tid, timestamp)
 }
 
 func (msg *MsgGenericKprobeUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
@@ -438,7 +438,7 @@ func (msg *MsgProcessLoaderUnix) Notify() bool {
 }
 
 func (msg *MsgProcessLoaderUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, timestamp)
+	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, nil, timestamp)
 }
 
 func (msg *MsgProcessLoaderUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
@@ -485,7 +485,7 @@ func (msg *MsgGenericUprobeUnix) PolicyInfo() tracingpolicy.PolicyInfo {
 }
 
 func (msg *MsgGenericUprobeUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, timestamp)
+	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, &msg.Tid, timestamp)
 }
 
 func (msg *MsgGenericUprobeUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
@@ -530,7 +530,7 @@ func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {
 	if proc != nil {
 		tetragonEvent.Process = proc.GetProcessCopy()
 		// Use the bpf recorded TID to update the event
-		process.UpdateEventProcessTid(tetragonEvent.Process, event.Tid)
+		process.UpdateEventProcessTid(tetragonEvent.Process, &event.Tid)
 	}
 	if parent != nil {
 		tetragonEvent.Parent = parent.GetProcessCopy()

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -168,8 +168,10 @@ func (pi *ProcessInternal) RefGet() uint32 {
 //
 // There is no point on calling this helper on clone or execve events,
 // however on all other events it is perfectly fine.
-func UpdateEventProcessTid(process *tetragon.Process, tid uint32) {
-	process.Tid = &wrapperspb.UInt32Value{Value: tid}
+func UpdateEventProcessTid(process *tetragon.Process, tid *uint32) {
+	if process != nil && tid != nil {
+		process.Tid = &wrapperspb.UInt32Value{Value: *tid}
+	}
 }
 
 func GetProcessID(pid uint32, ktime uint64) string {

--- a/pkg/sensors/exec/threads_test.go
+++ b/pkg/sensors/exec/threads_test.go
@@ -47,23 +47,6 @@ func TestThreadTesterParser(t *testing.T) {
 	assert.Equal(t, cti.ParentPid, cti.ParentThread1Pid)
 }
 
-func assertPidsTids(t *testing.T, tti *testutils.ThreadTesterInfo) {
-	require.NotZero(t, tti.ParentPid)
-	require.Equal(t, tti.ParentPid, tti.ParentTid)
-
-	require.NotZero(t, tti.Child1Pid)
-	require.NotZero(t, tti.Child1Tid)
-	require.Equal(t, tti.Child1Pid, tti.Child1Tid)
-
-	require.NotZero(t, tti.Thread1Pid)
-	require.NotZero(t, tti.Thread1Tid)
-	require.NotEqual(t, tti.Thread1Pid, tti.Thread1Tid)
-
-	require.Equal(t, tti.Child1Pid, tti.Thread1Pid)
-	require.Equal(t, tti.ParentChild1Pid, tti.ParentPid)
-	require.Equal(t, tti.ParentThread1Pid, tti.ParentPid)
-}
-
 func TestCloneThreadsTester(t *testing.T) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
@@ -98,7 +81,7 @@ func TestCloneThreadsTester(t *testing.T) {
 		t.Fatalf("command failed with %s. Context error: %v", err, ctx.Err())
 	}
 
-	assertPidsTids(t, tti)
+	tti.AssertPidsTids(t)
 }
 
 func TestMatchCloneThreadsIDs(t *testing.T) {
@@ -158,7 +141,7 @@ func TestMatchCloneThreadsIDs(t *testing.T) {
 		}
 	}
 
-	assertPidsTids(t, tti)
+	tti.AssertPidsTids(t)
 
 	require.NotZero(t, execPID)
 	require.Equal(t, execPID, execTID)
@@ -209,7 +192,7 @@ func TestExecThreads(t *testing.T) {
 		t.Fatalf("command failed with %s. Context error: %v", err, ctx.Err())
 	}
 
-	assertPidsTids(t, cti)
+	cti.AssertPidsTids(t)
 
 	binCheck := ec.NewProcessChecker().
 		WithBinary(sm.Suffix("threads-tester")).

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -912,6 +912,7 @@ func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
 	unix.ProcessKey = m.ProcessKey
 	unix.Id = m.FuncId
 	unix.Action = m.ActionId
+	unix.Tid = m.Tid
 	unix.FuncName = gk.funcName
 	unix.Namespaces = m.Namespaces
 	unix.Capabilities = m.Capabilities

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -584,6 +584,7 @@ func handleGenericTracepoint(r *bytes.Reader) ([]observer.Event, error) {
 		Common:     m.Common,
 		ProcessKey: m.ProcessKey,
 		Id:         m.FuncId,
+		Tid:        m.Tid,
 		Subsys:     "UNKNOWN",
 		Event:      "UNKNOWN",
 	}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -583,14 +583,14 @@ func handleGenericTracepoint(r *bytes.Reader) ([]observer.Event, error) {
 	unix := &tracing.MsgGenericTracepointUnix{
 		Common:     m.Common,
 		ProcessKey: m.ProcessKey,
-		Id:         m.Id,
+		Id:         m.FuncId,
 		Subsys:     "UNKNOWN",
 		Event:      "UNKNOWN",
 	}
 
-	tp, err := genericTracepointTable.getTracepoint(int(m.Id))
+	tp, err := genericTracepointTable.getTracepoint(int(m.FuncId))
 	if err != nil {
-		logger.GetLogger().WithField("id", m.Id).WithError(err).Warnf("genericTracepoint info not found")
+		logger.GetLogger().WithField("id", m.FuncId).WithError(err).Warnf("genericTracepoint info not found")
 		return []observer.Event{unix}, nil
 	}
 

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -88,6 +88,7 @@ func handleGenericUprobe(r *bytes.Reader) ([]observer.Event, error) {
 	unix := &tracing.MsgGenericUprobeUnix{}
 	unix.Common = m.Common
 	unix.ProcessKey = m.ProcessKey
+	unix.Tid = m.Tid
 	unix.Path = uprobeEntry.path
 	unix.Symbol = uprobeEntry.symbol
 

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -79,9 +79,9 @@ func handleGenericUprobe(r *bytes.Reader) ([]observer.Event, error) {
 		return nil, fmt.Errorf("Failed to read process call msg")
 	}
 
-	uprobeEntry, err := genericUprobeTableGet(idtable.EntryID{ID: int(m.Id)})
+	uprobeEntry, err := genericUprobeTableGet(idtable.EntryID{ID: int(m.FuncId)})
 	if err != nil {
-		logger.GetLogger().WithError(err).Warnf("Failed to match id:%d", m.Id)
+		logger.GetLogger().WithError(err).Warnf("Failed to match id:%d", m.FuncId)
 		return nil, fmt.Errorf("Failed to match id")
 	}
 

--- a/pkg/sensors/tracing/kprobe_threads_test.go
+++ b/pkg/sensors/tracing/kprobe_threads_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
+	"github.com/cilium/tetragon/pkg/logger"
+	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/testutils"
+	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKprobeCloneThreads(t *testing.T) {
+	testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	testConfigFile := fmt.Sprintf("%s/tetragon-kprobe-threads.yaml", t.TempDir())
+
+	configHook_ := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "kprobe-threads-tests"
+spec:
+  kprobes:
+  - call: "fd_install"
+    syscall: false
+    args:
+    - index: 0
+      type: int
+    - index: 1
+      type: "file"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "/etc/issue"
+`
+	configHook := []byte(configHook_)
+	err := os.WriteFile(testConfigFile, configHook, 0644)
+	if err != nil {
+		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
+	}
+
+	testBinPath := "contrib/tester-progs/threads-tester"
+	testBin := testutils.RepoRootPath(testBinPath)
+	testCmd := exec.CommandContext(ctx, testBin, "--sensor", "kprobe")
+	testPipes, err := testutils.NewCmdBufferedPipes(testCmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testPipes.Close()
+
+	t.Logf("starting observer")
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	cti := &testutils.ThreadTesterInfo{}
+	if err := testCmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	logWG := testPipes.ParseAndLogCmdOutput(t, cti.ParseLine, nil)
+	logWG.Wait()
+	if err := testCmd.Wait(); err != nil {
+		t.Fatalf("command failed with %s. Context error: %v", err, ctx.Err())
+	}
+
+	cti.AssertPidsTids(t)
+
+	parentCheck := ec.NewProcessChecker().
+		WithBinary(sm.Suffix("threads-tester")).
+		WithPid(cti.ParentPid).
+		WithTid(cti.ParentTid)
+
+	execCheck := ec.NewProcessExecChecker("").
+		WithProcess(parentCheck)
+
+	exitCheck := ec.NewProcessExitChecker("").
+		WithProcess(parentCheck)
+
+	child1Checker := ec.NewProcessChecker().
+		WithBinary(sm.Suffix("threads-tester")).
+		WithPid(cti.Child1Pid).
+		WithTid(cti.Child1Tid)
+
+	child1KpChecker := ec.NewProcessKprobeChecker("").
+		WithProcess(child1Checker).WithParent(parentCheck)
+
+	thread1Checker := ec.NewProcessChecker().
+		WithBinary(sm.Suffix("threads-tester")).
+		WithPid(cti.Thread1Pid).
+		WithTid(cti.Thread1Tid)
+
+	thread1KpChecker := ec.NewProcessKprobeChecker("").
+		WithProcess(thread1Checker).WithParent(parentCheck)
+
+	checker := ec.NewUnorderedEventChecker(execCheck, child1KpChecker, thread1KpChecker, exitCheck)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}

--- a/pkg/testutils/threadevents.go
+++ b/pkg/testutils/threadevents.go
@@ -6,6 +6,9 @@ package testutils
 import (
 	"regexp"
 	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type ThreadTesterInfo struct {
@@ -60,4 +63,21 @@ func (tti *ThreadTesterInfo) ParseLine(l string) error {
 		}
 	}
 	return err
+}
+
+func (tti *ThreadTesterInfo) AssertPidsTids(t *testing.T) {
+	require.NotZero(t, tti.ParentPid)
+	require.Equal(t, tti.ParentPid, tti.ParentTid)
+
+	require.NotZero(t, tti.Child1Pid)
+	require.NotZero(t, tti.Child1Tid)
+	require.Equal(t, tti.Child1Pid, tti.Child1Tid)
+
+	require.NotZero(t, tti.Thread1Pid)
+	require.NotZero(t, tti.Thread1Tid)
+	require.NotEqual(t, tti.Thread1Pid, tti.Thread1Tid)
+
+	require.Equal(t, tti.Child1Pid, tti.Thread1Pid)
+	require.Equal(t, tti.ParentChild1Pid, tti.ParentPid)
+	require.Equal(t, tti.ParentThread1Pid, tti.ParentPid)
 }


### PR DESCRIPTION
This PR adds the TID the thread ID to kprobe and tracepoint events