### PR TITLE
tetragon: Add support for LT/GT operators for matchReturnArgs

### DIFF
--- a/examples/tracingpolicy/openat_write.yaml
+++ b/examples/tracingpolicy/openat_write.yaml
@@ -1,0 +1,34 @@
+apiVersion: cilium.io/v1alpha1
+metadata:
+  name: "sys-openat"
+spec:
+  kprobes:
+  - call: "sys_openat"
+    return: true
+    syscall: true
+    args:
+    - index: 0
+      type: int
+    - index: 1
+      type: "string"
+    - index: 2
+      type: "int"
+    returnArg:
+      type: int
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "/etc/passwd\0"
+      - index: 2
+        operator: "Mask"
+        values:
+        - 0x40 # CREATE
+        - 0x1  # WRONLY
+        - 0x2  # RDWR
+      matchReturnArgs:
+      - index: 0
+        operator: "GT"
+        values:
+        - 0

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -231,6 +231,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -436,6 +440,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -651,6 +659,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -856,6 +868,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -958,6 +974,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1163,6 +1183,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -231,6 +231,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -436,6 +440,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -651,6 +659,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -856,6 +868,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -958,6 +974,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1163,6 +1183,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -243,7 +243,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -231,6 +231,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -436,6 +440,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -651,6 +659,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -856,6 +868,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -958,6 +974,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1163,6 +1183,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -231,6 +231,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -436,6 +440,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -651,6 +659,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -856,6 +868,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -958,6 +974,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1163,6 +1183,10 @@ spec:
                                   - NotEqual
                                   - Prefix
                                   - Postfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -243,7 +243,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.


### PR DESCRIPTION
Adding support for LessThan/GreaterThan (LT/GT) operators for matchReturnArgs,
so we can use following selector:

```
      matchReturnArgs:
      - index: 0
        operator: "GT"
        values:
        - 0
```

that checks return value is > 0

The filter is done in user space at the moment, still it's useful to ensure syscalls like openat returned valid fd.
