### PR TITLE
tetragon: Loader fixes

### DIFF
--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -279,10 +279,6 @@ func LoadUprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error 
 	return loadProgram(bpfDir, []string{mapDir}, load, UprobeAttach(load), ci, verbose)
 }
 
-func LoadTailCallProgram(bpfDir, mapDir string, load *Program, verbose int) error {
-	return loadProgram(bpfDir, []string{mapDir}, load, NoAttach(), nil, verbose)
-}
-
 func LoadMultiKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
 	ci := &customInstall{fmt.Sprintf("%s-kp_calls", load.PinPath), "kprobe"}
 	return loadProgram(bpfDir, []string{mapDir}, load, MultiKprobeAttach(load), ci, verbose)

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -29,6 +29,11 @@ type customInstall struct {
 	secPrefix string
 }
 
+type loadOpts struct {
+	attach AttachFunc
+	ci     *customInstall
+}
+
 func RawAttach(targetFD int) AttachFunc {
 	return RawAttachWithFlags(targetFD, 0)
 }
@@ -250,11 +255,18 @@ func LoadTracepointProgram(bpfDir, mapDir string, load *Program, verbose int) er
 			break
 		}
 	}
-	return loadProgram(bpfDir, []string{mapDir}, load, TracepointAttach(load), ci, verbose)
+	opts := &loadOpts{
+		attach: TracepointAttach(load),
+		ci:     ci,
+	}
+	return loadProgram(bpfDir, []string{mapDir}, load, opts, verbose)
 }
 
 func LoadRawTracepointProgram(bpfDir, mapDir string, load *Program, verbose int) error {
-	return loadProgram(bpfDir, []string{mapDir}, load, RawTracepointAttach(load), nil, verbose)
+	opts := &loadOpts{
+		attach: RawTracepointAttach(load),
+	}
+	return loadProgram(bpfDir, []string{mapDir}, load, opts, verbose)
 }
 
 func LoadKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
@@ -265,7 +277,11 @@ func LoadKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error 
 			break
 		}
 	}
-	return loadProgram(bpfDir, []string{mapDir}, load, KprobeAttach(load), ci, verbose)
+	opts := &loadOpts{
+		attach: KprobeAttach(load),
+		ci:     ci,
+	}
+	return loadProgram(bpfDir, []string{mapDir}, load, opts, verbose)
 }
 
 func LoadUprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
@@ -276,20 +292,33 @@ func LoadUprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error 
 			break
 		}
 	}
-	return loadProgram(bpfDir, []string{mapDir}, load, UprobeAttach(load), ci, verbose)
+	opts := &loadOpts{
+		attach: UprobeAttach(load),
+		ci:     ci,
+	}
+	return loadProgram(bpfDir, []string{mapDir}, load, opts, verbose)
 }
 
 func LoadMultiKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
-	ci := &customInstall{fmt.Sprintf("%s-kp_calls", load.PinPath), "kprobe"}
-	return loadProgram(bpfDir, []string{mapDir}, load, MultiKprobeAttach(load), ci, verbose)
+	opts := &loadOpts{
+		attach: MultiKprobeAttach(load),
+		ci:     &customInstall{fmt.Sprintf("%s-kp_calls", load.PinPath), "kprobe"},
+	}
+	return loadProgram(bpfDir, []string{mapDir}, load, opts, verbose)
 }
 
 func LoadTracingProgram(bpfDir, mapDir string, load *Program, verbose int) error {
-	return loadProgram(bpfDir, []string{mapDir}, load, TracingAttach(), nil, verbose)
+	opts := &loadOpts{
+		attach: TracingAttach(),
+	}
+	return loadProgram(bpfDir, []string{mapDir}, load, opts, verbose)
 }
 
 func LoadLSMProgram(bpfDir, mapDir string, load *Program, verbose int) error {
-	return loadProgram(bpfDir, []string{mapDir}, load, LSMAttach(), nil, verbose)
+	opts := &loadOpts{
+		attach: LSMAttach(),
+	}
+	return loadProgram(bpfDir, []string{mapDir}, load, opts, verbose)
 }
 
 func slimVerifierError(errStr string) string {
@@ -378,8 +407,7 @@ func doLoadProgram(
 	bpfDir string,
 	mapDirs []string,
 	load *Program,
-	withProgram AttachFunc,
-	ci *customInstall,
+	loadOpts *loadOpts,
 	verbose int,
 ) (*LoadedCollection, error) {
 	var btfSpec *btf.Spec
@@ -501,7 +529,7 @@ func doLoadProgram(
 	}
 	defer coll.Close()
 
-	err = installTailCalls(mapDirs[0], spec, coll, ci)
+	err = installTailCalls(mapDirs[0], spec, coll, loadOpts.ci)
 	if err != nil {
 		return nil, fmt.Errorf("installing tail calls failed: %s", err)
 	}
@@ -538,7 +566,7 @@ func doLoadProgram(
 			return nil, fmt.Errorf("pinning '%s' to '%s' failed: %w", load.Label, pinPath, err)
 		}
 
-		load.unloaderOverride, err = withProgram(progOverride, progOverrideSpec)
+		load.unloaderOverride, err = loadOpts.attach(progOverride, progOverrideSpec)
 		if err != nil {
 			logger.GetLogger().Warnf("Failed to attach override program: %w", err)
 		}
@@ -569,7 +597,7 @@ func doLoadProgram(
 		return nil, fmt.Errorf("pinning '%s' to '%s' failed: %w", load.Label, pinPath, err)
 	}
 
-	load.unloader, err = withProgram(prog, progSpec)
+	load.unloader, err = loadOpts.attach(prog, progSpec)
 	if err != nil {
 		if err := prog.Unpin(); err != nil {
 			logger.GetLogger().Warnf("Unpinning '%s' failed: %w", pinPath, err)
@@ -588,11 +616,10 @@ func loadProgram(
 	bpfDir string,
 	mapDirs []string,
 	load *Program,
-	withProgram AttachFunc,
-	ci *customInstall,
+	opts *loadOpts,
 	verbose int,
 ) error {
-	lc, err := doLoadProgram(bpfDir, mapDirs, load, withProgram, ci, verbose)
+	lc, err := doLoadProgram(bpfDir, mapDirs, load, opts, verbose)
 	if err != nil {
 		return err
 	}
@@ -607,8 +634,9 @@ func LoadProgram(
 	bpfDir string,
 	mapDirs []string,
 	load *Program,
-	withProgram AttachFunc,
+	attach AttachFunc,
 	verbose int,
 ) error {
-	return loadProgram(bpfDir, mapDirs, load, withProgram, nil, verbose)
+	opts := &loadOpts{attach: attach}
+	return loadProgram(bpfDir, mapDirs, load, opts, verbose)
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -58,8 +58,6 @@ const (
 	CharBufErrorPageFault   = -2
 	CharBufErrorTooLarge    = -3
 	CharBufSavedForRetprobe = -4
-
-	MaxKprobesMulti = 100 // MAX_ENTRIES_CONFIG in bpf code
 )
 
 func kprobeCharBufErrorToString(e int32) string {


### PR DESCRIPTION
Making the loader more configurable through opts and moving override
code loading out of the loader core into kprobe opts callbacks,
plus other small fixes.