### PR TITLE
dependabot: fix a tag issue with alpine-curl image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,14 +33,11 @@ updates:
     open-pull-requests-limit: 1
     rebase-strategy: disabled
     ignore:
-      # this dependency has tags beginning with `v` and some without, which
-      # means that for dependabot, 1.1 < v1.6.0. Let's ignore the first tags
-      # without the `v` letter. See more information here:
+      # latest was outdated and it caused an update to an older version
       # https://github.com/cilium/tetragon/pull/909#pullrequestreview-1378642231
       - dependency-name: "cilium/alpine-curl"
         versions:
-          - "1.1"
-          - "1.0"
+          - "latest"
     labels:
     - kind/enhancement
     - release-blocker


### PR DESCRIPTION
Partially reverts commit a05a988523c68eacd4ea3bad4f541560b0441f4c and fix by ignoring the latest tag.