### PR TITLE
tetragon: we only need to find the BTF file skip creating it

### DIFF
--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -17,7 +17,6 @@ import (
 )
 
 var (
-	btfObj  *btf.Spec
 	btfFile string
 )
 
@@ -89,14 +88,9 @@ func InitCachedBTF(ctx context.Context, lib, btf string) error {
 	if err != nil {
 		return fmt.Errorf("tetragon, aborting kernel autodiscovery failed: %w", err)
 	}
-	btfObj, err = NewBTF()
 	return err
 }
 
 func GetCachedBTFFile() string {
 	return btfFile
-}
-
-func GetCachedBTF() *btf.Spec {
-	return btfObj
 }


### PR DESCRIPTION
Creating BTF obj consumes 30MB of data we really only need to find the file to feed to cilium/ebpf.