### PR TITLE
tetragon: release memory used for loading programs

### DIFF
--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -227,6 +228,12 @@ func (k *Observer) runEvents(stopCtx context.Context, ready func()) error {
 			}
 		}
 		k.log.WithError(stopCtx.Err()).Info("Listening for events completed.")
+	}()
+
+	// Loading default program consumes some memory lets kick GC to give
+	// this back to the OS (K8s).
+	go func() {
+		runtime.GC()
 	}()
 
 	// Wait for context to be cancelled and then stop.


### PR DESCRIPTION
To load programs we use a good chunk of memory 30MB or more just to pull in BTF, lookup attach function and so on. In many cases all the needed programs will be loaded on start. So this patch calls the GC to cleanup any memory and return it to the system.

When running with memory limits this helps Tetragon stay below max mem usage limits in k8s.