### PR TITLE
e2e-framework: minor refactors to improve image dumps

### DIFF
--- a/tests/e2e/helpers/dumpinfo.go
+++ b/tests/e2e/helpers/dumpinfo.go
@@ -291,28 +291,6 @@ func StartMetricsDumper(ctx context.Context, exportDir string, interval time.Dur
 	}()
 }
 
-// DumpBin dumps the Tetragon binary from gops. We keep this separate from dumpGops
-// because it is a more expensive operation and dumps something that is not expected to
-// change. Therefore we only want to call this once per test.
-func DumpBin(port int, podName string, exportDir string) {
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", port))
-	if err != nil {
-		klog.ErrorS(err, "failed to resolve gops address")
-		return
-	}
-	klog.V(2).Info("contacting gops agent", "addr", addr)
-
-	out, err := gops.DumpBinary(*addr)
-	if err != nil {
-		klog.ErrorS(err, "failed to dump binary", "addr", addr)
-		return
-	}
-	fname := filepath.Join(exportDir, fmt.Sprintf("tetragon.%s.bin", podName))
-	if err := os.WriteFile(fname, out, os.FileMode(0o644)); err != nil {
-		klog.ErrorS(err, "failed to write Tetragon binary to file", "file", fname, "addr", addr)
-	}
-}
-
 // dumpGops dumps the gops heap and and memstats
 func dumpGops(port int, podName string, exportDir string) {
 	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", port))
@@ -321,8 +299,6 @@ func dumpGops(port int, podName string, exportDir string) {
 		return
 	}
 	klog.V(2).Info("contacting gops agent", "addr", addr)
-
-	// NOTE: We explicitly do not dump binary info here. See DumpBin() for details.
 
 	out, err := gops.DumpHeapProfile(*addr)
 	if err != nil {

--- a/tests/e2e/helpers/gops/gops.go
+++ b/tests/e2e/helpers/gops/gops.go
@@ -21,14 +21,6 @@ func DumpHeapProfile(addr net.TCPAddr) ([]byte, error) {
 	return out, nil
 }
 
-func DumpBinary(addr net.TCPAddr) ([]byte, error) {
-	out, err := cmd(addr, signal.BinaryDump)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dump binary: %w", err)
-	}
-	return out, nil
-}
-
 func DumpMemStats(addr net.TCPAddr) ([]byte, error) {
 	out, err := cmd(addr, signal.MemStats)
 	if err != nil {

--- a/tests/e2e/runners/runners.go
+++ b/tests/e2e/runners/runners.go
@@ -179,15 +179,6 @@ func (r *Runner) Init() *Runner {
 		helpers.StartMetricsDumper(ctx, exportDir, 30*time.Second)
 		helpers.StartGopsDumper(ctx, exportDir, 30*time.Second)
 
-		// The binary won't change, so dump it now at the beginning
-		if ports, ok := ctx.Value(state.GopsForwardedPorts).(map[string]int); ok {
-			for podName, port := range ports {
-				helpers.DumpBin(port, podName, exportDir)
-			}
-		} else {
-			klog.V(4).Info("failed to retrieve gops portforward, refusing to dump binary")
-		}
-
 		return ctx, nil
 	})
 

--- a/tests/e2e/state/state.go
+++ b/tests/e2e/state/state.go
@@ -21,10 +21,10 @@ var (
 	MinKernelVersion = Key{slug: "MinKernelVersion"}
 	// Stores a list of event checkers that were used in the test
 	EventCheckers = Key{slug: "EventCheckers"}
-	// Stores the most recent *testing.T
-	Test = Key{slug: "Test"}
 	// Key for storing the export directory for this test
 	ExportDir = Key{slug: "ExportDir"}
 	// Key for storing the cluster name
 	ClusterName = Key{slug: "ClusterName"}
+	// Key for storing test failure
+	TestFailure = Key{slug: "TestFailure"}
 )

--- a/tests/e2e/tests/labels/labels_test.go
+++ b/tests/e2e/tests/labels/labels_test.go
@@ -93,6 +93,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestLabelsDemoApp(t *testing.T) {
+	// Must be called at the beginning of every test
+	runner.SetupExport(t)
+
 	// Grab the minimum kernel version in all cluster nodes and define an RPC checker with it
 	kversion := helpers.GetMinKernelVersion(t, runner.Environment)
 	labelsChecker := labelsEventChecker(kversion).WithEventLimit(5000).WithTimeLimit(5 * time.Minute)

--- a/tests/e2e/tests/skeleton/skeleton_test.go
+++ b/tests/e2e/tests/skeleton/skeleton_test.go
@@ -84,6 +84,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestSkeletonBasic(t *testing.T) {
+	// Must be called at the beginning of every test
+	runner.SetupExport(t)
+
 	// Grab the minimum kernel version in all cluster nodes and define an RPC checker with it
 	kversion := helpers.GetMinKernelVersion(t, runner.Environment)
 	// Create an curl event checker with a limit or 10 events or 30 seconds, whichever comes first


### PR DESCRIPTION
This PR introduces some refactors to tests/e2e to improve image dumps, reduce their size, and avoid duplicated information. Best reviewed by commit.