### PR TITLE
Add documentation in the CRD for `maxData` and `returnCopy` flags and update doc

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -51,13 +51,22 @@ spec:
                             type: integer
                           maxData:
                             default: false
-                            description: Read maximum possible data. This field is
-                              used only for char_buf type.
+                            description: Read maximum possible data (currently 327360).
+                              This field is only used for char_buff data. When this
+                              value is false (default), the bpf program will fetch
+                              at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is
+                              turned on
                             type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
-                              char_iovec types.
+                              char_iovec types. It indicates that this argument should
+                              be read later (when the kretprobe for the symbol is
+                              triggered) because it might not be populated when the
+                              kprobe is triggered at the entrance of the function.
+                              For example, a buffer supplied to read(2) won't have
+                              content until kretprobe is triggered.
                             type: boolean
                           sizeArgIndex:
                             description: Specifies the position of the corresponding
@@ -114,13 +123,21 @@ spec:
                           type: integer
                         maxData:
                           default: false
-                          description: Read maximum possible data. This field is used
-                            only for char_buf type.
+                          description: Read maximum possible data (currently 327360).
+                            This field is only used for char_buff data. When this
+                            value is false (default), the bpf program will fetch at
+                            most 4096 bytes. In later kernels (>=5.4) tetragon supports
+                            fetching up to 327360 bytes if this flag is turned on
                           type: boolean
                         returnCopy:
                           default: false
                           description: This field is used only for char_buf and char_iovec
-                            types.
+                            types. It indicates that this argument should be read
+                            later (when the kretprobe for the symbol is triggered)
+                            because it might not be populated when the kprobe is triggered
+                            at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe
+                            is triggered.
                           type: boolean
                         sizeArgIndex:
                           description: Specifies the position of the corresponding
@@ -530,13 +547,22 @@ spec:
                             type: integer
                           maxData:
                             default: false
-                            description: Read maximum possible data. This field is
-                              used only for char_buf type.
+                            description: Read maximum possible data (currently 327360).
+                              This field is only used for char_buff data. When this
+                              value is false (default), the bpf program will fetch
+                              at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is
+                              turned on
                             type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
-                              char_iovec types.
+                              char_iovec types. It indicates that this argument should
+                              be read later (when the kretprobe for the symbol is
+                              triggered) because it might not be populated when the
+                              kprobe is triggered at the entrance of the function.
+                              For example, a buffer supplied to read(2) won't have
+                              content until kretprobe is triggered.
                             type: boolean
                           sizeArgIndex:
                             description: Specifies the position of the corresponding

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -51,13 +51,22 @@ spec:
                             type: integer
                           maxData:
                             default: false
-                            description: Read maximum possible data. This field is
-                              used only for char_buf type.
+                            description: Read maximum possible data (currently 327360).
+                              This field is only used for char_buff data. When this
+                              value is false (default), the bpf program will fetch
+                              at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is
+                              turned on
                             type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
-                              char_iovec types.
+                              char_iovec types. It indicates that this argument should
+                              be read later (when the kretprobe for the symbol is
+                              triggered) because it might not be populated when the
+                              kprobe is triggered at the entrance of the function.
+                              For example, a buffer supplied to read(2) won't have
+                              content until kretprobe is triggered.
                             type: boolean
                           sizeArgIndex:
                             description: Specifies the position of the corresponding
@@ -114,13 +123,21 @@ spec:
                           type: integer
                         maxData:
                           default: false
-                          description: Read maximum possible data. This field is used
-                            only for char_buf type.
+                          description: Read maximum possible data (currently 327360).
+                            This field is only used for char_buff data. When this
+                            value is false (default), the bpf program will fetch at
+                            most 4096 bytes. In later kernels (>=5.4) tetragon supports
+                            fetching up to 327360 bytes if this flag is turned on
                           type: boolean
                         returnCopy:
                           default: false
                           description: This field is used only for char_buf and char_iovec
-                            types.
+                            types. It indicates that this argument should be read
+                            later (when the kretprobe for the symbol is triggered)
+                            because it might not be populated when the kprobe is triggered
+                            at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe
+                            is triggered.
                           type: boolean
                         sizeArgIndex:
                           description: Specifies the position of the corresponding
@@ -530,13 +547,22 @@ spec:
                             type: integer
                           maxData:
                             default: false
-                            description: Read maximum possible data. This field is
-                              used only for char_buf type.
+                            description: Read maximum possible data (currently 327360).
+                              This field is only used for char_buff data. When this
+                              value is false (default), the bpf program will fetch
+                              at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is
+                              turned on
                             type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
-                              char_iovec types.
+                              char_iovec types. It indicates that this argument should
+                              be read later (when the kretprobe for the symbol is
+                              triggered) because it might not be populated when the
+                              kprobe is triggered at the entrance of the function.
+                              For example, a buffer supplied to read(2) won't have
+                              content until kretprobe is triggered.
                             type: boolean
                           sizeArgIndex:
                             description: Specifies the position of the corresponding

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -139,11 +139,18 @@ type KProbeArg struct {
 	SizeArgIndex uint32 `json:"sizeArgIndex"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// This field is used only for char_buf and char_iovec types.
+    // This field is used only for char_buf and char_iovec types. It indicates
+    // that this argument should be read later (when the kretprobe for the
+    // symbol is triggered) because it might not be populated when the kprobe
+    // is triggered at the entrance of the function. For example, a buffer
+    // supplied to read(2) won't have content until kretprobe is triggered.
 	ReturnCopy bool `json:"returnCopy"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// Read maximum possible data. This field is used only for char_buf type.
+    // Read maximum possible data (currently 327360). This field is only used
+    // for char_buff data. When this value is false (default), the bpf program
+    // will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+    // supports fetching up to 327360 bytes if this flag is turned on
 	MaxData bool `json:"maxData"`
 }
 

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -51,13 +51,22 @@ spec:
                             type: integer
                           maxData:
                             default: false
-                            description: Read maximum possible data. This field is
-                              used only for char_buf type.
+                            description: Read maximum possible data (currently 327360).
+                              This field is only used for char_buff data. When this
+                              value is false (default), the bpf program will fetch
+                              at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is
+                              turned on
                             type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
-                              char_iovec types.
+                              char_iovec types. It indicates that this argument should
+                              be read later (when the kretprobe for the symbol is
+                              triggered) because it might not be populated when the
+                              kprobe is triggered at the entrance of the function.
+                              For example, a buffer supplied to read(2) won't have
+                              content until kretprobe is triggered.
                             type: boolean
                           sizeArgIndex:
                             description: Specifies the position of the corresponding
@@ -114,13 +123,21 @@ spec:
                           type: integer
                         maxData:
                           default: false
-                          description: Read maximum possible data. This field is used
-                            only for char_buf type.
+                          description: Read maximum possible data (currently 327360).
+                            This field is only used for char_buff data. When this
+                            value is false (default), the bpf program will fetch at
+                            most 4096 bytes. In later kernels (>=5.4) tetragon supports
+                            fetching up to 327360 bytes if this flag is turned on
                           type: boolean
                         returnCopy:
                           default: false
                           description: This field is used only for char_buf and char_iovec
-                            types.
+                            types. It indicates that this argument should be read
+                            later (when the kretprobe for the symbol is triggered)
+                            because it might not be populated when the kprobe is triggered
+                            at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe
+                            is triggered.
                           type: boolean
                         sizeArgIndex:
                           description: Specifies the position of the corresponding
@@ -530,13 +547,22 @@ spec:
                             type: integer
                           maxData:
                             default: false
-                            description: Read maximum possible data. This field is
-                              used only for char_buf type.
+                            description: Read maximum possible data (currently 327360).
+                              This field is only used for char_buff data. When this
+                              value is false (default), the bpf program will fetch
+                              at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is
+                              turned on
                             type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
-                              char_iovec types.
+                              char_iovec types. It indicates that this argument should
+                              be read later (when the kretprobe for the symbol is
+                              triggered) because it might not be populated when the
+                              kprobe is triggered at the entrance of the function.
+                              For example, a buffer supplied to read(2) won't have
+                              content until kretprobe is triggered.
                             type: boolean
                           sizeArgIndex:
                             description: Specifies the position of the corresponding

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -51,13 +51,22 @@ spec:
                             type: integer
                           maxData:
                             default: false
-                            description: Read maximum possible data. This field is
-                              used only for char_buf type.
+                            description: Read maximum possible data (currently 327360).
+                              This field is only used for char_buff data. When this
+                              value is false (default), the bpf program will fetch
+                              at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is
+                              turned on
                             type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
-                              char_iovec types.
+                              char_iovec types. It indicates that this argument should
+                              be read later (when the kretprobe for the symbol is
+                              triggered) because it might not be populated when the
+                              kprobe is triggered at the entrance of the function.
+                              For example, a buffer supplied to read(2) won't have
+                              content until kretprobe is triggered.
                             type: boolean
                           sizeArgIndex:
                             description: Specifies the position of the corresponding
@@ -114,13 +123,21 @@ spec:
                           type: integer
                         maxData:
                           default: false
-                          description: Read maximum possible data. This field is used
-                            only for char_buf type.
+                          description: Read maximum possible data (currently 327360).
+                            This field is only used for char_buff data. When this
+                            value is false (default), the bpf program will fetch at
+                            most 4096 bytes. In later kernels (>=5.4) tetragon supports
+                            fetching up to 327360 bytes if this flag is turned on
                           type: boolean
                         returnCopy:
                           default: false
                           description: This field is used only for char_buf and char_iovec
-                            types.
+                            types. It indicates that this argument should be read
+                            later (when the kretprobe for the symbol is triggered)
+                            because it might not be populated when the kprobe is triggered
+                            at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe
+                            is triggered.
                           type: boolean
                         sizeArgIndex:
                           description: Specifies the position of the corresponding
@@ -530,13 +547,22 @@ spec:
                             type: integer
                           maxData:
                             default: false
-                            description: Read maximum possible data. This field is
-                              used only for char_buf type.
+                            description: Read maximum possible data (currently 327360).
+                              This field is only used for char_buff data. When this
+                              value is false (default), the bpf program will fetch
+                              at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is
+                              turned on
                             type: boolean
                           returnCopy:
                             default: false
                             description: This field is used only for char_buf and
-                              char_iovec types.
+                              char_iovec types. It indicates that this argument should
+                              be read later (when the kretprobe for the symbol is
+                              triggered) because it might not be populated when the
+                              kprobe is triggered at the entrance of the function.
+                              For example, a buffer supplied to read(2) won't have
+                              content until kretprobe is triggered.
                             type: boolean
                           sizeArgIndex:
                             description: Specifies the position of the corresponding

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -139,11 +139,18 @@ type KProbeArg struct {
 	SizeArgIndex uint32 `json:"sizeArgIndex"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// This field is used only for char_buf and char_iovec types.
+    // This field is used only for char_buf and char_iovec types. It indicates
+    // that this argument should be read later (when the kretprobe for the
+    // symbol is triggered) because it might not be populated when the kprobe
+    // is triggered at the entrance of the function. For example, a buffer
+    // supplied to read(2) won't have content until kretprobe is triggered.
 	ReturnCopy bool `json:"returnCopy"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// Read maximum possible data. This field is used only for char_buf type.
+    // Read maximum possible data (currently 327360). This field is only used
+    // for char_buff data. When this value is false (default), the bpf program
+    // will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+    // supports fetching up to 327360 bytes if this flag is turned on
 	MaxData bool `json:"maxData"`
 }
 


### PR DESCRIPTION
Fixes #958.