### PR TITLE
tetra: transparently handle unix or tcp gRPC socket

### DIFF
--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -5,16 +5,40 @@ package common
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+type daemonInfo struct {
+	ServerAddr string `json:"server_address"`
+}
+
+func getActiveServAddr(fname string) (string, error) {
+	f, err := os.Open(fname)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var info daemonInfo
+	if err := json.NewDecoder(f).Decode(&info); err != nil {
+		return "", err
+	}
+
+	return info.ServerAddr, nil
+}
 
 func CliRunErr(fn func(ctx context.Context, cli tetragon.FineGuidanceSensorsClient), fnErr func(err error)) {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -22,10 +46,42 @@ func CliRunErr(fn func(ctx context.Context, cli tetragon.FineGuidanceSensorsClie
 
 	connCtx, connCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer connCancel()
-	conn, err := grpc.DialContext(connCtx, viper.GetString(KeyServerAddress), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+
+	var conn *grpc.ClientConn
+	var serverAddr string
+	var err error
+
+	// The client cli can run remotely so to support most cases transparently
+	// Check if the server address was set
+	//   - If yes: use it directly, users know better
+	//   - If no: then try the default tetragon-info.json file to find the best
+	//       address if possible (could be unix socket). This also covers the
+	//       case that default address is localhost so we are operating in localhost
+	//       context anyway.
+	//       If that address is set try it, if it fails for any reason then retry
+	//       last time with the server address.
+	if viper.IsSet(KeyServerAddress) == false {
+		// server-address was not set by user, try the tetragon-info.json file
+		serverAddr, err = getActiveServAddr(defaults.InitInfoFile)
+		if err == nil && serverAddr != "" {
+			conn, err = grpc.DialContext(connCtx, serverAddr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+		}
+		// Handle both errors
+		if err != nil {
+			logger.GetLogger().WithFields(logrus.Fields{
+				"InitInfoFile":   defaults.InitInfoFile,
+				"server-address": serverAddr,
+			}).WithError(err).Debugf("Failed to connect to server")
+		}
+	}
+	if conn == nil {
+		// Try the server-address prameter
+		serverAddr = viper.GetString(KeyServerAddress)
+		conn, err = grpc.DialContext(connCtx, serverAddr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	}
 	if err != nil {
 		fnErr(err)
-		logger.GetLogger().WithError(err).Fatal("Failed to connect")
+		logger.GetLogger().WithField("server-address", serverAddr).WithError(err).Fatal("Failed to connect to server")
 	}
 	defer conn.Close()
 	client := tetragon.NewFineGuidanceSensorsClient(conn)

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -84,6 +84,8 @@ func getFieldFilters() ([]*tetragon.FieldFilter, error) {
 	return filters, nil
 }
 
+// Save daemon information so it is used by client cli but
+// also by bugtool
 func saveInitInfo() error {
 	info := bugtool.InitInfo{
 		ExportFname: option.Config.ExportFilename,

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -593,7 +593,7 @@ func execute() error {
 	flags.Bool(keyEnableCiliumAPI, false, "Access Cilium API to associate Tetragon events with Cilium endpoints and DNS cache")
 	flags.Bool(keyEnableProcessAncestors, true, "Include ancestors in process exec events")
 	flags.String(keyMetricsServer, "", "Metrics server address (e.g. ':2112'). Disabled by default")
-	flags.String(keyServerAddress, "localhost:54321", "gRPC server address")
+	flags.String(keyServerAddress, "localhost:54321", "gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock'")
 	flags.String(keyGopsAddr, "", "gops server address (e.g. 'localhost:8118'). Disabled by default")
 	flags.String(keyCiliumBPF, "", "Cilium BPF directory")
 	flags.Bool(keyEnableProcessCred, false, "Enable process_cred events")

--- a/docs/content/en/docs/getting-started/configuration.md
+++ b/docs/content/en/docs/getting-started/configuration.md
@@ -75,3 +75,39 @@ directory into the `/etc/tetragon/tetragon.conf.d/` subdirectory. The latter is
 generally recommended. Defaults can be restored by simply deleting this file
 and all drop-ins.
 
+
+### Restrict gRPC API access
+
+The gRPC API supports unix sockets, it can be set using one of the following methods:
+
+- Use the `--server-address` flag:
+
+   ```
+   --server-address unix:///var/run/tetragon/tetragon.sock
+   ```
+
+- Or use the drop-in configuration file `/etc/tetragon/tetragon.conf.d/server-address` containing:
+
+   ```
+   unix:///var/run/tetragon/tetragon.sock
+   ```
+
+{{< note >}}
+Tetragon tarball by default listens to  `unix:///var/run/tetragon/tetragon.sock`
+{{< /note >}}
+
+Then to access the gRPC API with `tetra` client, set `--server-address` to point to the corresponding address:
+
+   ```
+   sudo tetra --server-address unix:///var/run/tetragon/tetragon.sock getevents
+   ```
+
+{{< note >}}
+When reading events with the `tetra` client, if `--server-address` is not specified,
+it will try to detect if Tetragon daemon is running on the same host and use its
+`server-address` configuration.
+{{< /note >}}
+
+{{< caution >}}
+Ensure that you have enough privileges to open the gRPC unix socket since it is restricted to privileged users only.
+{{< /caution >}}

--- a/pkg/bugtool/bugtool.go
+++ b/pkg/bugtool/bugtool.go
@@ -29,12 +29,6 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-const (
-	// initInfoFile is the file location for the info file.
-	// After initialization, initInfoFname will contain a json representation of InitInfo
-	initInfoFname = defaults.DefaultRunDir + "tetragon-info.json"
-)
-
 // InitInfo contains information about how Tetragon was initialized.
 type InitInfo struct {
 	ExportFname string `json:"export_fname"`
@@ -47,12 +41,12 @@ type InitInfo struct {
 
 // LoadInitInfo returns the InitInfo by reading the info file from its default location
 func LoadInitInfo() (*InitInfo, error) {
-	return doLoadInitInfo(initInfoFname)
+	return doLoadInitInfo(defaults.InitInfoFile)
 }
 
 // SaveInitInfo saves InitInfo to the info file
 func SaveInitInfo(info *InitInfo) error {
-	return doSaveInitInfo(initInfoFname, info)
+	return doSaveInitInfo(defaults.InitInfoFile, info)
 }
 
 func doLoadInitInfo(fname string) (*InitInfo, error) {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -42,6 +42,11 @@ const (
 
 	// Default location for BPF programs and BTF files
 	DefaultTetragonLib = "/var/lib/tetragon/"
+
+	// InitInfoFile is the file location for the info file.
+	// After initialization, InitInfoFile will contain a json representation of InitInfo
+	// Used by both client cli to guess unix socket address and by bugtool
+	InitInfoFile = DefaultRunDir + "tetragon-info.json"
 )
 
 var (


### PR DESCRIPTION
Make tetra cli guess the best configuration to use when connecting to daemon. This saves users from explicitly specifying the server address in case it is a unix socket, as it works in localhost context anyway.
    
Since the client cli is run remotely, check if the server address was set

* If yes: use it directly, users know better.
    
* If no: then try the daemon tetragon-info.json file to find the best address
      if possible (could be unix socket). This also covers the case that default
      address is localhost so we are operating in localhost context anyway.
      If that address is set try it, if it fails for any reason then retry last
      time with the server address.

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>