### PR TITLE
policyfilter: only deal with running containers

### DIFF
--- a/pkg/policyfilter/k8s_test.go
+++ b/pkg/policyfilter/k8s_test.go
@@ -144,6 +144,9 @@ func (tp *testPod) Pod() *v1.Pod {
 		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, v1.ContainerStatus{
 			Name:        cont.name,
 			ContainerID: cont.id,
+			State: v1.ContainerState{
+				Running: &v1.ContainerStateRunning{},
+			},
 		})
 	}
 

--- a/pkg/policyfilter/podhelpers.go
+++ b/pkg/policyfilter/podhelpers.go
@@ -13,7 +13,9 @@ import (
 func podForAllContainers(pod *v1.Pod, fn func(c *v1.ContainerStatus)) {
 	run := func(s []v1.ContainerStatus) {
 		for i := range s {
-			fn(&s[i])
+			if s[i].State.Running != nil {
+				fn(&s[i])
+			}
 		}
 	}
 

--- a/pkg/policyfilter/state.go
+++ b/pkg/policyfilter/state.go
@@ -745,8 +745,8 @@ func (pod *podInfo) containerDiff(newContainerIDs []string) ([]string, []string)
 }
 
 // UpdatePod updates the pod state for a pod
-// containerIDs contains all the container ids for the given pod.
-// so this function will:
+// containerIDs contains all the running container ids for the given pod.
+// This function will:
 //   - remove the containers that are not part of the containerIDs list
 //   - add the ones that do not exist in the current state
 //


### PR DESCRIPTION
As things stand now, we pass all containers to the policyfilter code. As a result, we get log warnings for containers that are not running because we are unable to find their cgroup ids.

This patch fixes this issue by only dealing with containers that have a running status.