### PR TITLE
v0.9: tetragon backports to reduce memory limits

### DIFF
--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -17,7 +17,6 @@ import (
 )
 
 var (
-	btfObj  *btf.Spec
 	btfFile string
 )
 
@@ -89,14 +88,9 @@ func InitCachedBTF(ctx context.Context, lib, btf string) error {
 	if err != nil {
 		return fmt.Errorf("tetragon, aborting kernel autodiscovery failed: %w", err)
 	}
-	btfObj, err = NewBTF()
 	return err
 }
 
 func GetCachedBTFFile() string {
 	return btfFile
-}
-
-func GetCachedBTF() *btf.Spec {
-	return btfObj
 }

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -227,6 +228,12 @@ func (k *Observer) runEvents(stopCtx context.Context, ready func()) error {
 			}
 		}
 		k.log.WithError(stopCtx.Err()).Info("Listening for events completed.")
+	}()
+
+	// Loading default program consumes some memory lets kick GC to give
+	// this back to the OS (K8s).
+	go func() {
+		runtime.GC()
 	}()
 
 	// Wait for context to be cancelled and then stop.


### PR DESCRIPTION
Couple fixes to reduce memory consumption on startup as a few folks have complained we use too much memory.