### PR TITLE
dependabot: remove ignore on tag name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,12 +32,6 @@ updates:
       interval: daily
     open-pull-requests-limit: 1
     rebase-strategy: disabled
-    ignore:
-      # latest was outdated and it caused an update to an older version
-      # https://github.com/cilium/tetragon/pull/909#pullrequestreview-1378642231
-      - dependency-name: "cilium/alpine-curl"
-        versions:
-          - "latest"
     labels:
     - kind/enhancement
     - release-blocker


### PR DESCRIPTION
This kinda revert 22c9d55afb899aa5fbdfdbebbd0a154b428f749a.

Dependabot cannot ignore tags on Docker images, it only works on semantic version numbers. It is not documented but the GitHub support provided us the information. We could not patch dependabot behavior via configuration so we bumped the image tag itself.