### PR TITLE
cleanup: add new linters and fix bugs and alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ kbuild
 latest.json
 strange.txt
 compile_commands.json
-contrib/tester-progs/sigkill-unprivileged-user-ns-tester
 /release
 
 # project tool artifacts

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - asciicheck
     - bidichk
     - makezero
+    - loggercheck
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - misspell
     - asciicheck
     - bidichk
+    - makezero
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - exportloopref
     - dupword
     - gofmt
+    - errname
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - revive
     - staticcheck
     - unused
+    - gosimple
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - bidichk
     - makezero
     - loggercheck
+    - exportloopref
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - loggercheck
     - exportloopref
     - dupword
+    - gofmt
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,18 +6,24 @@ run:
 output:
   format: tab
 
+# See https://golangci-lint.run/usage/linters/ for description of linters
 linters:
   disable-all: true
   enable:
-    - goerr113
-    - goimports
+    # default linters
+    - gosimple
     - govet
     - ineffassign
-    - misspell
-    - revive
     - staticcheck
+    - typecheck
     - unused
-    - gosimple
+    # non default linters
+    - revive
+    - goerr113
+    - goimports
+    - misspell
+    - asciicheck
+    - bidichk
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - gofmt
     - errname
     - gocritic
+    - unparam
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - makezero
     - loggercheck
     - exportloopref
+    - dupword
 
 issues:
   exclude-rules:
@@ -38,3 +39,13 @@ issues:
       text: "exported const"
     - linters: [revive]
       text: "var-naming"
+
+linters-settings:
+  dupword:
+    keywords:
+      - "the"
+      - "and"
+      - "a"
+      - "for"
+      - "to"
+      - "as"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - dupword
     - gofmt
     - errname
+    - gocritic
 
 issues:
   exclude-rules:
@@ -51,3 +52,11 @@ linters-settings:
       - "for"
       - "to"
       - "as"
+  gocritic:
+    disabled-checks:
+      - deprecatedComment
+      - commentFormatting
+      - singleCaseSwitch
+      - ifElseChain
+      - appendAssign
+      - dupSubExpr # seems confused with CGO

--- a/cmd/protoc-gen-go-tetragon/common/common.go
+++ b/cmd/protoc-gen-go-tetragon/common/common.go
@@ -134,11 +134,7 @@ func FmtSprintf(g *protogen.GeneratedFile, fmt_ string, args ...string) string {
 
 // EventFieldCheck returns true if the event has the field
 func EventFieldCheck(msg *protogen.Message, field string) bool {
-	if msg.Desc.Fields().ByName(protoreflect.Name(field)) != nil {
-		return true
-	}
-
-	return false
+	return msg.Desc.Fields().ByName(protoreflect.Name(field)) != nil
 }
 
 // IsProcessEvent returns true if the message is an Tetragon event that has a process field

--- a/cmd/protoc-gen-go-tetragon/common/common.go
+++ b/cmd/protoc-gen-go-tetragon/common/common.go
@@ -86,38 +86,31 @@ func Logger(g *protogen.GeneratedFile) string {
 }
 
 func ProcessIdent(g *protogen.GeneratedFile) string {
-	importPath := filepath.Join("github.com/cilium/tetragon/api/v1/tetragon")
-	return GoIdent(g, importPath, "Process")
+	return GoIdent(g, "github.com/cilium/tetragon/api/v1/tetragon", "Process")
 }
 
 func ListMatcherIdent(g *protogen.GeneratedFile, name string) string {
-	importPath := filepath.Join("github.com/cilium/tetragon/pkg/matchers/listmatcher")
-	return GoIdent(g, importPath, name)
+	return GoIdent(g, "github.com/cilium/tetragon/pkg/matchers/listmatcher", name)
 }
 
 func StringMatcherIdent(g *protogen.GeneratedFile, name string) string {
-	importPath := filepath.Join("github.com/cilium/tetragon/pkg/matchers/stringmatcher")
-	return GoIdent(g, importPath, name)
+	return GoIdent(g, "github.com/cilium/tetragon/pkg/matchers/stringmatcher", name)
 }
 
 func BytesMatcherIdent(g *protogen.GeneratedFile, name string) string {
-	importPath := filepath.Join("github.com/cilium/tetragon/pkg/matchers/bytesmatcher")
-	return GoIdent(g, importPath, name)
+	return GoIdent(g, "github.com/cilium/tetragon/pkg/matchers/bytesmatcher", name)
 }
 
 func DurationMatcherIdent(g *protogen.GeneratedFile, name string) string {
-	importPath := filepath.Join("github.com/cilium/tetragon/pkg/matchers/durationmatcher")
-	return GoIdent(g, importPath, name)
+	return GoIdent(g, "github.com/cilium/tetragon/pkg/matchers/durationmatcher", name)
 }
 
 func TimestampMatcherIdent(g *protogen.GeneratedFile, name string) string {
-	importPath := filepath.Join("github.com/cilium/tetragon/pkg/matchers/timestampmatcher")
-	return GoIdent(g, importPath, name)
+	return GoIdent(g, "github.com/cilium/tetragon/pkg/matchers/timestampmatcher", name)
 }
 
 func PkgProcessIdent(g *protogen.GeneratedFile, name string) string {
-	importPath := filepath.Join("github.com/cilium/tetragon/pkg/process")
-	return GoIdent(g, importPath, name)
+	return GoIdent(g, "github.com/cilium/tetragon/pkg/process", name)
 }
 
 // FmtErrorf is a convenience helper that generates a call to fmt.Errorf

--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -60,7 +60,7 @@ func CliRunErr(fn func(ctx context.Context, cli tetragon.FineGuidanceSensorsClie
 	//       context anyway.
 	//       If that address is set try it, if it fails for any reason then retry
 	//       last time with the server address.
-	if viper.IsSet(KeyServerAddress) == false {
+	if !viper.IsSet(KeyServerAddress) {
 		// server-address was not set by user, try the tetragon-info.json file
 		serverAddr, err = getActiveServAddr(defaults.InitInfoFile)
 		if err == nil && serverAddr != "" {

--- a/cmd/tetragon-vmtests-run/image.go
+++ b/cmd/tetragon-vmtests-run/image.go
@@ -246,7 +246,7 @@ func buildTestImage(log *logrus.Logger, rcnf *RunConf) error {
 
 	forest, err := images.NewImageForest(&cnf, false)
 	if err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	res := forest.BuildAllImages(&images.BuildConf{

--- a/cmd/tetragon-vmtests-run/main.go
+++ b/cmd/tetragon-vmtests-run/main.go
@@ -76,10 +76,7 @@ func main() {
 			}
 
 			qemuBin := "qemu-system-x86_64"
-			qemuArgs, err := buildQemuArgs(log, &rcnf)
-			if err != nil {
-				return err
-			}
+			qemuArgs := buildQemuArgs(log, &rcnf)
 
 			if rcnf.qemuPrint {
 				var sb strings.Builder

--- a/cmd/tetragon-vmtests-run/qemu.go
+++ b/cmd/tetragon-vmtests-run/qemu.go
@@ -52,7 +52,7 @@ func buildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 		}
 		qemuArgs = append(qemuArgs,
 			"-kernel", rcnf.kernelFname,
-			"-append", fmt.Sprintf("%s", strings.Join(appendArgs, " ")),
+			"-append", strings.Join(appendArgs, " "),
 		)
 	}
 

--- a/cmd/tetragon-vmtests-run/qemu.go
+++ b/cmd/tetragon-vmtests-run/qemu.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func buildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
+func buildQemuArgs(log *logrus.Logger, rcnf *RunConf) []string {
 	qemuArgs := []string{
 		// no need for all the default devices
 		"-nodefaults",
@@ -70,5 +70,5 @@ func buildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 		qemuArgs = append(qemuArgs, rcnf.portForwards.QemuArgs()...)
 	}
 
-	return qemuArgs, nil
+	return qemuArgs
 }

--- a/cmd/tetragon/conf.go
+++ b/cmd/tetragon/conf.go
@@ -28,7 +28,7 @@ func readConfigFile(path string, file string) error {
 	if err != nil {
 		return err
 	}
-	if st.Mode().IsRegular() == false {
+	if !st.Mode().IsRegular() {
 		return fmt.Errorf("failed to read config file '%s' not a regular file", file)
 	}
 
@@ -46,7 +46,7 @@ func readConfigDir(path string) error {
 	if err != nil {
 		return err
 	}
-	if st.IsDir() == false {
+	if !st.IsDir() {
 		return fmt.Errorf("'%s' is not a directory", path)
 	}
 

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -109,6 +109,7 @@ func stopProfile() {
 		// get up-to-date statistics
 		runtime.GC()
 		if err := pprof.WriteHeapProfile(f); err != nil {
+			// nolint:gocritic // log.Fatal will exit without running defer but it's okay because fd will be gc
 			log.Fatal("could not write memory profile: ", err)
 		}
 	}
@@ -127,6 +128,7 @@ func tetragonExecute() error {
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	if err := logger.SetupLogging(option.Config.LogOpts, option.Config.Debug); err != nil {
+		// nolint:gocritic // log.Fatal will exit without running defer but it's okay for ctx cancel
 		log.Fatal(err)
 	}
 

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -346,7 +346,7 @@ func tetragonExecute() error {
 	}
 
 	// k8s should have metrics, so periodically log only in a non k8s
-	if option.Config.EnableK8s == false {
+	if !option.Config.EnableK8s {
 		go logStatus(ctx, obs)
 	}
 

--- a/contrib/rthooks/tetragon-oci-hook/main.go
+++ b/contrib/rthooks/tetragon-oci-hook/main.go
@@ -144,6 +144,4 @@ func main() {
 	default:
 		log.WithField("hook", hookName).Warn("hook called with unknown hook")
 	}
-
-	return
 }

--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -13,3 +13,4 @@ libuprobe.so
 uprobe-test-1
 uprobe-test-2
 lseek-pipe
+threads-tester

--- a/pkg/api/ops/ops.go
+++ b/pkg/api/ops/ops.go
@@ -34,8 +34,8 @@ type CgroupOpCode int
 
 // Cgroup Operations that are sent from BPF side. Right now
 // they are used only for logging and debugging, except for
-// for CGROUP_ATTACH_TASK which will be used to detect
-// cgroup configuration.
+// CGROUP_ATTACH_TASK which will be used to detect cgroup
+// configuration.
 const (
 	MSG_OP_CGROUP_UNDEF       CgroupOpCode = iota
 	MSG_OP_CGROUP_MKDIR       CgroupOpCode = 1

--- a/pkg/bench/trace_bench_rw.go
+++ b/pkg/bench/trace_bench_rw.go
@@ -64,7 +64,7 @@ func (src traceBenchRw) benchRwWorker(ctx context.Context) {
 		for {
 			n, errno := f.Write(buffer[:size()])
 			if n < 0 {
-				log.Fatalf("syscall.Write failed: %s\n", errno)
+				log.Panicf("syscall.Write failed: %s\n", errno)
 			}
 
 			// give us a chance to catch up
@@ -82,7 +82,7 @@ func (src traceBenchRw) benchRwWorker(ctx context.Context) {
 		for {
 			n, errno := f.Read(buffer[:size()])
 			if n < 0 {
-				log.Fatalf("syscall.Read failed: %s\n", errno)
+				log.Panicf("syscall.Read failed: %s\n", errno)
 			}
 
 			// give us a chance to catch up
@@ -173,6 +173,7 @@ spec:
 
 	err = template.Must(template.New("crd").Parse(tmpl)).Execute(f, templateArgs)
 	if err != nil {
+		// nolint:gocritic // log.Fatal will exit without running defer but it's okay because fd will be gc
 		log.Fatal(err)
 	}
 	return f.Name()

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -352,10 +352,7 @@ func (m *Map) DumpWithCallback(cb DumpCallback) error {
 // DumpWithCallbackIfExists is similar to DumpWithCallback, but returns earlier
 // if the given map does not exist.
 func (m *Map) DumpWithCallbackIfExists(cb DumpCallback) error {
-	found, err := m.exist()
-	if err != nil {
-		return err
-	}
+	found := m.exist()
 
 	if found {
 		return m.DumpWithCallback(cb)
@@ -383,10 +380,7 @@ func (m *Map) Dump(hash map[string][]string) error {
 // DumpIfExists dumps the contents of the map into hash via Dump() if the map
 // file exists
 func (m *Map) DumpIfExists(hash map[string][]string) error {
-	found, err := m.exist()
-	if err != nil {
-		return err
-	}
+	found := m.exist()
 
 	if found {
 		return m.Dump(hash)
@@ -503,13 +497,10 @@ func LookupElement(fd int, key, value unsafe.Pointer) error {
 	return LookupElementFromPointers(fd, uintptr(unsafe.Pointer(&uba)), unsafe.Sizeof(uba))
 }
 
-func (m *Map) exist() (bool, error) {
+func (m *Map) exist() bool {
 	path := m.Path()
-	if _, err := os.Stat(path); err == nil {
-		return true, nil
-	}
-
-	return false, nil
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func deleteElement(fd int, key unsafe.Pointer) (uintptr, unix.Errno) {

--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -295,10 +295,6 @@ spec:
 	for _, key := range syscallinfo.SyscallsNames() {
 		var fn *btf.Func
 
-		if key == "" {
-			continue
-		}
-
 		sym, err := arch.AddSyscallPrefix(key)
 		if err != nil {
 			return "", err

--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -316,7 +316,7 @@ spec:
         values:
         - "` + binary + `"`
 
-			crd = crd + filter
+			crd += filter
 		}
 	}
 

--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -310,7 +310,7 @@ spec:
 		}
 
 		crd = crd + "\n" + fmt.Sprintf("  - call: \"%s\"", key)
-		crd = crd + "\n" + fmt.Sprintf("    syscall: true")
+		crd = crd + "\n" + "    syscall: true"
 
 		if binary != "" {
 			filter := `

--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -46,7 +46,7 @@ func validate(btf bpf.BTF, spec *v1alpha1.KProbeSpec) (bpf.BtfID, error) {
 
 	llCallTy, err := btf.TypeByID(llCallID)
 	if err != nil {
-		fmt.Errorf("failed to to find syscall type by id: %w", err)
+		fmt.Errorf("failed to find syscall type by id: %w", err)
 	}
 
 	return btf.UnderlyingType(llCallTy)

--- a/pkg/btf/validation_test.go
+++ b/pkg/btf/validation_test.go
@@ -5,7 +5,6 @@ package btf
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -55,7 +54,7 @@ func TestSpecs(t *testing.T) {
 	// NB: for now we check against a single BTF file.
 	btfFname := filepath.Join(testdataPath, "btf", "vmlinux-5.4.104+")
 	if _, err := os.Stat(btfFname); err != nil {
-		t.Skip(fmt.Sprintf("%s not found", btfFname))
+		t.Skipf("%s not found", btfFname)
 	}
 	btf, err := btf.LoadSpec(btfFname)
 	if err != nil {

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -238,7 +238,7 @@ func parseCgroupSubSysIds(filePath string) error {
 	}).Debugf("Cgroup available controllers")
 
 	// Could not find 'memory', 'pids' nor 'cpuset' controllers, are they compiled in?
-	if fixed == false {
+	if !fixed {
 		err = fmt.Errorf("detect cgroup controllers IDs from '%s' failed", filePath)
 		logger.GetLogger().WithFields(logrus.Fields{
 			"cgroup.fs": cgroupFSPath,
@@ -278,7 +278,7 @@ func setDeploymentMode(cgroupPath string) error {
 		return nil
 	}
 
-	if option.Config.EnableK8s == true {
+	if option.Config.EnableK8s {
 		deploymentMode = DEPLOY_K8S
 		return nil
 	}
@@ -354,7 +354,7 @@ func GetCgrpControllerName() string {
 func getValidCgroupv1Path(cgroupPaths []string) (string, error) {
 	for _, controller := range CgroupControllers {
 		// First lets go again over list of active controllers
-		if controller.Active == false {
+		if !controller.Active {
 			logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).Debugf("Cgroup controller '%s' is not active", controller.Name)
 			continue
 		}

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -756,8 +756,8 @@ func HostCgroupRoot() (string, error) {
 	}
 
 	err := multierr.Append(
-		fmt.Errorf("failed to set path %s as as cgroup root %w", path1, err1),
-		fmt.Errorf("failed to set path %s as as cgroup root %w", path2, err2),
+		fmt.Errorf("failed to set path %s as cgroup root %w", path1, err1),
+		fmt.Errorf("failed to set path %s as cgroup root %w", path2, err2),
 	)
 	return "", fmt.Errorf("failed to set cgroup root: %w", err)
 }

--- a/pkg/encoder/encoder.go
+++ b/pkg/encoder/encoder.go
@@ -78,7 +78,7 @@ const (
 
 func CapTrailorPrinter(str string, caps string) string {
 	if len(caps) == 0 {
-		return fmt.Sprintf("%s", str)
+		return str
 	}
 	padding := 0
 	if len(str) < capsPad {

--- a/pkg/eventcheckertests/yamlhelpers/yamlhelpers.go
+++ b/pkg/eventcheckertests/yamlhelpers/yamlhelpers.go
@@ -42,17 +42,11 @@ func AssertUnmarshalRoundTrip(t *testing.T, b []byte, o interface{}) bool {
 // AssertUnmarshal unmarshals an object and makes sure that it unmarshals
 func AssertUnmarshal(t *testing.T, b []byte, o interface{}) bool {
 	err := yaml.Unmarshal(b, o)
-	if !assert.NoError(t, err, "`%v` should unmarshal", o) {
-		return false
-	}
-	return true
+	return assert.NoError(t, err, "`%v` should unmarshal", o)
 }
 
 // AssertMarshal unmarshals an object and makes sure that it unmarshals
 func AssertMarshal(t *testing.T, b []byte, o interface{}) bool {
 	_, err := yaml.Marshal(o)
-	if !assert.NoError(t, err, "`%s` should marshal", string(b)) {
-		return false
-	}
-	return true
+	return assert.NoError(t, err, "`%s` should marshal", string(b))
 }

--- a/pkg/filters/pidSet.go
+++ b/pkg/filters/pidSet.go
@@ -44,7 +44,7 @@ func filterByPidSet(pids []uint32) hubbleFilters.FilterFunc {
 		if parent == nil {
 			return false
 		}
-		if pidSet[parent.Pid.GetValue()] == true {
+		if pidSet[parent.Pid.GetValue()] {
 			return true
 		}
 		for _, pid := range pids {

--- a/pkg/idtable/idtable.go
+++ b/pkg/idtable/idtable.go
@@ -72,7 +72,6 @@ func (t *Table) AddEntry(entry Entry) {
 	idx := t.findEmpty()
 	t.arr[idx] = entry
 	entry.SetID(EntryID{idx})
-	return
 }
 
 func (t *Table) getValidEntryIndex(id EntryID) (int, error) {

--- a/pkg/jsonchecker/jsonchecker.go
+++ b/pkg/jsonchecker/jsonchecker.go
@@ -50,12 +50,12 @@ func (e *DebugError) Unwrap() error {
 	return e.err
 }
 
-// JsonEOF is a type of error where we went over all the events and there was no match.
+// JsonEOFError is a type of error where we went over all the events and there was no match.
 //
 // The reason to have a special error is that there are cases where the events
 // we are looking for might not have been processed yet. In these cases, we
 // need to retry.
-type JsonEOF struct {
+type JsonEOFError struct {
 	// err is what FinalCheck() returned
 	err error
 	// count is the number of events we checked
@@ -63,12 +63,12 @@ type JsonEOF struct {
 }
 
 // Error returns the error message
-func (e *JsonEOF) Error() string {
+func (e *JsonEOFError) Error() string {
 	return fmt.Sprintf("JsonEOF: failed to match after %d events: err:%v", e.count, e.err)
 }
 
 // Unwrap returns the original error
-func (e *JsonEOF) Unwrap() error {
+func (e *JsonEOFError) Unwrap() error {
 	return e.err
 }
 
@@ -81,7 +81,7 @@ func JsonCheck(jsonFile *os.File, checker ec.MultiEventChecker, log *logrus.Logg
 		var ev tetragon.GetEventsResponse
 		if err := dec.Decode(&ev); err != nil {
 			if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
-				return &JsonEOF{
+				return &JsonEOFError{
 					count: count,
 					err:   fmt.Errorf("unmarshal failed: %w", err),
 				}
@@ -113,7 +113,7 @@ func JsonCheck(jsonFile *os.File, checker ec.MultiEventChecker, log *logrus.Logg
 	}
 
 	if err := checker.FinalCheck(log); err != nil {
-		return &JsonEOF{
+		return &JsonEOFError{
 			count: count,
 			err:   err,
 		}
@@ -142,7 +142,7 @@ func doJsonTestCheck(t *testing.T, jsonFile *os.File, checker ec.MultiEventCheck
 
 		// if this is not a JsonEOF error, it means that the checker
 		// concluded that there was a falure. Dont retry.
-		var errEOF *JsonEOF
+		var errEOF *JsonEOFError
 		if !errors.As(err, &errEOF) {
 			break
 		}

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/output.md
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/output.md
@@ -1,0 +1,2153 @@
+# API Reference
+
+Packages:
+
+- [cilium.io/v1alpha1](#ciliumiov1alpha1)
+
+# cilium.io/v1alpha1
+
+Resource Types:
+
+- [TracingPolicy](#tracingpolicy)
+
+
+
+
+## TracingPolicy
+<sup><sup>[↩ Parent](#ciliumiov1alpha1 )</sup></sup>
+
+
+
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+      <td><b>apiVersion</b></td>
+      <td>string</td>
+      <td>cilium.io/v1alpha1</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b>kind</b></td>
+      <td>string</td>
+      <td>TracingPolicy</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td>object</td>
+      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
+      <td>true</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspec">spec</a></b></td>
+        <td>object</td>
+        <td>
+          Tracing policy specification.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec
+<sup><sup>[↩ Parent](#tracingpolicy)</sup></sup>
+
+
+
+Tracing policy specification.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindex">kprobes</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of kprobe specs.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>loader</b></td>
+        <td>boolean</td>
+        <td>
+          Enable loader events<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecpodselector">podSelector</a></b></td>
+        <td>object</td>
+        <td>
+          PodSelector selects pods that this policy applies to<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindex">tracepoints</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of tracepoint specs.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindex">uprobes</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of uprobe specs.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index]
+<sup><sup>[↩ Parent](#tracingpolicyspec)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>call</b></td>
+        <td>string</td>
+        <td>
+          Name of the function to apply the kprobe spec to.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexargsindex">args</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of function arguments to include in the trace output.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>return</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether to collect return value of the traced function.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexreturnarg">returnArg</a></b></td>
+        <td>object</td>
+        <td>
+          A return argument to include in the trace output.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindex">selectors</a></b></td>
+        <td>[]object</td>
+        <td>
+          Selectors to apply before producing trace output. Selectors are ORed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>syscall</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether the traced function is a syscall.<br/>
+          <br/>
+            <i>Default</i>: true<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].args[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Argument type.<br/>
+          <br/>
+            <i>Enum</i>: int, uint32, int32, uint64, int64, char_buf, char_iovec, size_t, skb, sock, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>maxData</b></td>
+        <td>boolean</td>
+        <td>
+          Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnCopy</b></td>
+        <td>boolean</td>
+        <td>
+          This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>sizeArgIndex</b></td>
+        <td>integer</td>
+        <td>
+          Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].returnArg
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindex)</sup></sup>
+
+
+
+A return argument to include in the trace output.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Argument type.<br/>
+          <br/>
+            <i>Enum</i>: int, uint32, int32, uint64, int64, char_buf, char_iovec, size_t, skb, sock, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>maxData</b></td>
+        <td>boolean</td>
+        <td>
+          Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnCopy</b></td>
+        <td>boolean</td>
+        <td>
+          This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>sizeArgIndex</b></td>
+        <td>integer</td>
+        <td>
+          Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindex)</sup></sup>
+
+
+
+KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindexmatchactionsindex">matchActions</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of actions to execute when this selector matches<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindexmatchargsindex">matchArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindexmatchbinariesindex">matchBinaries</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of binary exec name filters.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindexmatchcapabilitiesindex">matchCapabilities</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of capabilities and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindexmatchcapabilitychangesindex">matchCapabilityChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for capabilities changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindexmatchnamespacechangesindex">matchNamespaceChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for namespace changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindexmatchnamespacesindex">matchNamespaces</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of namespaces and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindexmatchpidsindex">matchPIDs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of process ID filters. MatchPIDs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspeckprobesindexselectorsindexmatchreturnargsindex">matchReturnArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index].matchActions[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>action</b></td>
+        <td>enum</td>
+        <td>
+          Action to execute.<br/>
+          <br/>
+            <i>Enum</i>: Post, FollowFD, UnfollowFD, Sigkill, CopyFD, Override, GetUrl, DnsLookup, NoPost<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>argError</b></td>
+        <td>integer</td>
+        <td>
+          error value for override action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFd</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the fd for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFqdn</b></td>
+        <td>string</td>
+        <td>
+          A FQDN to lookup for the dnsLookup action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argName</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the filename for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSig</b></td>
+        <td>integer</td>
+        <td>
+          A signal number for signal action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argUrl</b></td>
+        <td>string</td>
+        <td>
+          A URL for the getUrl action<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index].matchArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, Postfix, GreaterThan, LessThan, GT, LT<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index].matchBinaries[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index].matchCapabilities[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index].matchCapabilityChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index].matchNamespaceChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace types (e.g., Mnt, Pid) to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index].matchNamespaces[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>namespace</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector name.<br/>
+          <br/>
+            <i>Enum</i>: Uts, Ipc, Mnt, Pid, PidForChildren, Net, Time, TimeForChildren, Cgroup, User<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace IDs (or host_ns for host namespace) of namespaces to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index].matchPIDs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          PID selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]integer</td>
+        <td>
+          Process IDs to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>followForks</b></td>
+        <td>boolean</td>
+        <td>
+          Matches any descendant processes of the matching PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>isNamespacePID</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether PIDs are namespace PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.kprobes[index].selectors[index].matchReturnArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspeckprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, Postfix, GreaterThan, LessThan, GT, LT<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.podSelector
+<sup><sup>[↩ Parent](#tracingpolicyspec)</sup></sup>
+
+
+
+PodSelector selects pods that this policy applies to
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#tracingpolicyspecpodselectormatchexpressionsindex">matchExpressions</a></b></td>
+        <td>[]object</td>
+        <td>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchLabels</b></td>
+        <td>map[string]string</td>
+        <td>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.podSelector.matchExpressions[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecpodselector)</sup></sup>
+
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          key is the label key that the selector applies to.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn, Exists, DoesNotExist<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index]
+<sup><sup>[↩ Parent](#tracingpolicyspec)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>event</b></td>
+        <td>string</td>
+        <td>
+          Tracepoint event<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>subsystem</b></td>
+        <td>string</td>
+        <td>
+          Tracepoint subsystem<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexargsindex">args</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of function arguments to include in the trace output.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindex">selectors</a></b></td>
+        <td>[]object</td>
+        <td>
+          Selectors to apply before producing trace output. Selectors are ORed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].args[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Argument type.<br/>
+          <br/>
+            <i>Enum</i>: int, uint32, int32, uint64, int64, char_buf, char_iovec, size_t, skb, sock, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>maxData</b></td>
+        <td>boolean</td>
+        <td>
+          Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnCopy</b></td>
+        <td>boolean</td>
+        <td>
+          This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>sizeArgIndex</b></td>
+        <td>integer</td>
+        <td>
+          Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindex)</sup></sup>
+
+
+
+KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindexmatchactionsindex">matchActions</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of actions to execute when this selector matches<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindexmatchargsindex">matchArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindexmatchbinariesindex">matchBinaries</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of binary exec name filters.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindexmatchcapabilitiesindex">matchCapabilities</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of capabilities and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindexmatchcapabilitychangesindex">matchCapabilityChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for capabilities changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindexmatchnamespacechangesindex">matchNamespaceChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for namespace changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindexmatchnamespacesindex">matchNamespaces</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of namespaces and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindexmatchpidsindex">matchPIDs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of process ID filters. MatchPIDs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspectracepointsindexselectorsindexmatchreturnargsindex">matchReturnArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index].matchActions[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>action</b></td>
+        <td>enum</td>
+        <td>
+          Action to execute.<br/>
+          <br/>
+            <i>Enum</i>: Post, FollowFD, UnfollowFD, Sigkill, CopyFD, Override, GetUrl, DnsLookup, NoPost<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>argError</b></td>
+        <td>integer</td>
+        <td>
+          error value for override action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFd</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the fd for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFqdn</b></td>
+        <td>string</td>
+        <td>
+          A FQDN to lookup for the dnsLookup action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argName</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the filename for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSig</b></td>
+        <td>integer</td>
+        <td>
+          A signal number for signal action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argUrl</b></td>
+        <td>string</td>
+        <td>
+          A URL for the getUrl action<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index].matchArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, Postfix, GreaterThan, LessThan, GT, LT<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index].matchBinaries[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index].matchCapabilities[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index].matchCapabilityChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index].matchNamespaceChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace types (e.g., Mnt, Pid) to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index].matchNamespaces[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>namespace</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector name.<br/>
+          <br/>
+            <i>Enum</i>: Uts, Ipc, Mnt, Pid, PidForChildren, Net, Time, TimeForChildren, Cgroup, User<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace IDs (or host_ns for host namespace) of namespaces to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index].matchPIDs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          PID selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]integer</td>
+        <td>
+          Process IDs to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>followForks</b></td>
+        <td>boolean</td>
+        <td>
+          Matches any descendant processes of the matching PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>isNamespacePID</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether PIDs are namespace PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.tracepoints[index].selectors[index].matchReturnArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspectracepointsindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, Postfix, GreaterThan, LessThan, GT, LT<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index]
+<sup><sup>[↩ Parent](#tracingpolicyspec)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>path</b></td>
+        <td>string</td>
+        <td>
+          Name of the traced binary<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>symbol</b></td>
+        <td>string</td>
+        <td>
+          Name of the traced symbol<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindex">selectors</a></b></td>
+        <td>[]object</td>
+        <td>
+          Selectors to apply before producing trace output. Selectors are ORed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindex)</sup></sup>
+
+
+
+KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindexmatchactionsindex">matchActions</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of actions to execute when this selector matches<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindexmatchargsindex">matchArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindexmatchbinariesindex">matchBinaries</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of binary exec name filters.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindexmatchcapabilitiesindex">matchCapabilities</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of capabilities and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindexmatchcapabilitychangesindex">matchCapabilityChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for capabilities changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindexmatchnamespacechangesindex">matchNamespaceChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for namespace changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindexmatchnamespacesindex">matchNamespaces</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of namespaces and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindexmatchpidsindex">matchPIDs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of process ID filters. MatchPIDs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecuprobesindexselectorsindexmatchreturnargsindex">matchReturnArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index].matchActions[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>action</b></td>
+        <td>enum</td>
+        <td>
+          Action to execute.<br/>
+          <br/>
+            <i>Enum</i>: Post, FollowFD, UnfollowFD, Sigkill, CopyFD, Override, GetUrl, DnsLookup, NoPost<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>argError</b></td>
+        <td>integer</td>
+        <td>
+          error value for override action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFd</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the fd for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFqdn</b></td>
+        <td>string</td>
+        <td>
+          A FQDN to lookup for the dnsLookup action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argName</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the filename for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSig</b></td>
+        <td>integer</td>
+        <td>
+          A signal number for signal action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argUrl</b></td>
+        <td>string</td>
+        <td>
+          A URL for the getUrl action<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index].matchArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, Postfix, GreaterThan, LessThan, GT, LT<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index].matchBinaries[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index].matchCapabilities[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index].matchCapabilityChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index].matchNamespaceChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace types (e.g., Mnt, Pid) to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index].matchNamespaces[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>namespace</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector name.<br/>
+          <br/>
+            <i>Enum</i>: Uts, Ipc, Mnt, Pid, PidForChildren, Net, Time, TimeForChildren, Cgroup, User<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace IDs (or host_ns for host namespace) of namespaces to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index].matchPIDs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          PID selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]integer</td>
+        <td>
+          Process IDs to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>followForks</b></td>
+        <td>boolean</td>
+        <td>
+          Matches any descendant processes of the matching PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>isNamespacePID</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether PIDs are namespace PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.uprobes[index].selectors[index].matchReturnArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecuprobesindexselectorsindex)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, Postfix, GreaterThan, LessThan, GT, LT<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>

--- a/pkg/kernels/kernels.go
+++ b/pkg/kernels/kernels.go
@@ -114,10 +114,7 @@ func MinKernelVersion(kernel string) bool {
 	runningVersion := int(KernelStringToNumeric(release))
 	minVersion := int(KernelStringToNumeric(kernel))
 
-	if minVersion <= runningVersion {
-		return true
-	}
-	return false
+	return minVersion <= runningVersion
 }
 
 func EnableV60Progs() bool {

--- a/pkg/kernels/kernels.go
+++ b/pkg/kernels/kernels.go
@@ -141,7 +141,7 @@ func IsKernelVersionLessThan(version string) bool {
 	return (int64(kernelVer) < KernelStringToNumeric(version))
 }
 
-// GenericKprobeObjs returns the generic kprobe and and generic retprobe objects
+// GenericKprobeObjs returns the generic kprobe and generic retprobe objects
 func GenericKprobeObjs() (string, string) {
 	if EnableV60Progs() {
 		return "bpf_generic_kprobe_v60.o", "bpf_generic_retkprobe_v60.o"

--- a/pkg/ksyms/ksyms.go
+++ b/pkg/ksyms/ksyms.go
@@ -111,7 +111,7 @@ func NewKsyms(procfs string) (*Ksyms, error) {
 	}
 
 	if needsSort {
-		sort.Slice(ksyms.table[:], func(i1, i2 int) bool { return ksyms.table[i1].addr < ksyms.table[i2].addr })
+		sort.Slice(ksyms.table, func(i1, i2 int) bool { return ksyms.table[i1].addr < ksyms.table[i2].addr })
 	}
 
 	fc, err := lru.New[uint64, fnOffsetVal](1024)

--- a/pkg/matchers/durationmatcher/durationmatcher.go
+++ b/pkg/matchers/durationmatcher/durationmatcher.go
@@ -81,7 +81,7 @@ func (m *DurationMatcher) checkGreater(duration *time.Duration) error {
 	}
 
 	if !(*duration >= value.Duration) {
-		return fmt.Errorf("%s is not greater than than %s", *duration, value.Duration)
+		return fmt.Errorf("%s is not greater than %s", *duration, value.Duration)
 	}
 
 	return nil

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -375,7 +375,7 @@ func (k *Observer) LogPinnedBpf(observerDir string) {
 		return
 	}
 
-	if finfo.IsDir() == false {
+	if !finfo.IsDir() {
 		err := fmt.Errorf("is not a directory")
 		k.log.WithField("bpf-dir", observerDir).WithError(err).Warn("BPF: checking BPF resources failed")
 		// Do not fail, let bpf part handle it

--- a/pkg/observer/observer_stats.go
+++ b/pkg/observer/observer_stats.go
@@ -85,10 +85,8 @@ func (k *Observer) startUpdateMapMetrics() {
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {
 		for {
-			select {
-			case <-ticker.C:
-				update()
-			}
+			<-ticker.C
+			update()
 		}
 	}()
 }

--- a/pkg/oldhubble/cilium/endpoint.go
+++ b/pkg/oldhubble/cilium/endpoint.go
@@ -41,7 +41,7 @@ func (s *State) syncEndpoints() {
 		if err != nil {
 			s.log.WithError(err).Error("Unable to get cilium endpoint list")
 			time.Sleep(t)
-			t = t * 2
+			t *= 2
 			continue
 		}
 

--- a/pkg/oldhubble/filters/fqdn.go
+++ b/pkg/oldhubble/filters/fqdn.go
@@ -48,10 +48,10 @@ func parseFQDNFilter(pattern string) (*regexp.Regexp, error) {
 	}
 
 	// "." becomes a literal .
-	pattern = strings.Replace(pattern, ".", "[.]", -1)
+	pattern = strings.ReplaceAll(pattern, ".", "[.]")
 
 	// "*" becomes a zero or more of the allowed characters
-	pattern = strings.Replace(pattern, "*", fqdnFilterAllowedChars, -1)
+	pattern = strings.ReplaceAll(pattern, "*", fqdnFilterAllowedChars)
 
 	return regexp.Compile("^" + pattern + "$")
 }

--- a/pkg/policyfilter/k8s_test.go
+++ b/pkg/policyfilter/k8s_test.go
@@ -238,6 +238,7 @@ func (ts *testState) deletePod(t *testing.T, name string) {
 	var p *testPod
 	for idx, pod := range ts.pods {
 		if pod.name == name {
+			// nolint:exportloopref // directly followed by break
 			p = &pod
 			ts.pods = append(ts.pods[:idx], ts.pods[idx+1:]...)
 			break
@@ -258,6 +259,7 @@ func (ts *testState) findCgroupID(podID PodID, containerID string) (CgroupID, er
 	var p *testPod
 	for _, pod := range ts.pods {
 		if PodID(pod.id) == podID {
+			// nolint:exportloopref // directly followed by break
 			p = &pod
 			break
 		}
@@ -282,6 +284,7 @@ func (ts *testState) podsCgroupIDs(t *testing.T, podNames ...string) []uint64 {
 		var p *testPod
 		for _, pod := range ts.pods {
 			if pod.name == podName {
+				// nolint:exportloopref // directly followed by break
 				p = &pod
 				break
 			}

--- a/pkg/policyfilter/k8s_test.go
+++ b/pkg/policyfilter/k8s_test.go
@@ -562,7 +562,7 @@ func TestK8s(t *testing.T) {
 	ts := newTestState(client)
 	st, err := newState(log, ts)
 	if err != nil {
-		t.Skip(fmt.Sprintf("failed to initialize policy filter state: %s", err))
+		t.Skipf("failed to initialize policy filter state: %s", err)
 	}
 	defer st.Close()
 

--- a/pkg/policyfilter/policyfilter.go
+++ b/pkg/policyfilter/policyfilter.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	glblState   State
-	glblError   error
+	errGlbl     error
 	setGlobalPf sync.Once
 )
 
@@ -23,13 +23,13 @@ func GetState() (State, error) {
 	setGlobalPf.Do(func() {
 		if option.Config.EnablePolicyFilter {
 			logger.GetLogger().Info("Enabling policy filtering")
-			glblState, glblError = New()
+			glblState, errGlbl = New()
 		} else {
 			glblState = &dummy{}
-			glblError = nil
+			errGlbl = nil
 		}
 	})
-	return glblState, glblError
+	return glblState, errGlbl
 }
 
 // ResetStateOnlyForTesting resets the global policyfilter state.
@@ -43,10 +43,10 @@ func ResetStateOnlyForTesting() {
 	}
 	if option.Config.EnablePolicyFilter {
 		logger.GetLogger().Info("Enabling policy filtering")
-		glblState, glblError = New()
+		glblState, errGlbl = New()
 	} else {
 		glblState = &dummy{}
-		glblError = nil
+		errGlbl = nil
 	}
 }
 

--- a/pkg/policyfilter/state_test.go
+++ b/pkg/policyfilter/state_test.go
@@ -4,7 +4,6 @@
 package policyfilter
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -14,7 +13,7 @@ import (
 func TestState(t *testing.T) {
 	s, err := New()
 	if err != nil {
-		t.Skip(fmt.Sprintf("failed to inialize policy filter state: %s", err))
+		t.Skipf("failed to inialize policy filter state: %s", err)
 	}
 	defer s.Close()
 

--- a/pkg/process/args.go
+++ b/pkg/process/args.go
@@ -10,10 +10,7 @@ import (
 )
 
 func argsDecoderTrim(r rune) bool {
-	if r == 0x00 {
-		return true
-	}
-	return false
+	return r == 0x00
 }
 
 func ArgsDecoder(s string, flags uint32) (string, string) {

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -145,10 +145,8 @@ func NewCache(
 	ticker := time.NewTicker(60 * time.Second)
 	go func() {
 		for {
-			select {
-			case <-ticker.C:
-				update()
-			}
+			<-ticker.C
+			update()
 		}
 	}()
 	pm.cacheGarbageCollector()

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -165,6 +165,7 @@ func (pc *Cache) get(processID string) (*ProcessInternal, error) {
 
 // Add a ProcessInternal structure to the cache. Must be called only from
 // clone or execve events
+// nolint:unparam // result is never used but it's okay
 func (pc *Cache) add(process *ProcessInternal) bool {
 	evicted := pc.cache.Add(process.process.ExecId, process)
 	if evicted {

--- a/pkg/reader/namespace/namespace.go
+++ b/pkg/reader/namespace/namespace.go
@@ -42,7 +42,7 @@ func GetMyPidG() uint32 {
 	if procfs := os.Getenv("TETRAGON_PROCFS"); procfs != "" {
 		procFS, _ := os.ReadDir(procfs)
 		for _, d := range procFS {
-			if d.IsDir() == false {
+			if !d.IsDir() {
 				continue
 			}
 			cmdline, err := os.ReadFile(filepath.Join(procfs, d.Name(), "/cmdline"))

--- a/pkg/reader/proc/proc.go
+++ b/pkg/reader/proc/proc.go
@@ -35,7 +35,7 @@ const (
 	// If Tetragon is not run in this initial mapping due to user namespaces or runtime
 	// modifications then reading uids of pids from /proc may return the overflow UID 65534
 	// if the mapping config where Tetragon is running does not have a mapping of the
-	// the uid of the target pid.
+	// uid of the target pid.
 	// The overflow UID is runtime config at /proc/sys/kernel/{overflowuid,overflowgid}.
 	//
 	// The overflow UID historically is also the "nobody" UID, so there is some confusion
@@ -43,7 +43,7 @@ const (
 	// the "nobody" user that some distributions use.
 	//
 	// The UID 4294967295 (-1 as an unsigned integer) is an invalid UID, the kernel
-	// ignores and return it in some cases where there is no mapping or to indicate an
+	// ignores and return it in some cases where there is no mapping or to indicate
 	// an invalid UID. So we use it to initialize our UIDs and return it on errors.
 	InvalidUid = ^uint32(0) // 4294967295 (2^32 - 1)
 )

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -657,7 +657,7 @@ func ParseMatchNamespaceChanges(k *KernelSelectorState, actions []v1alpha1.Names
 	if len(actions) > 1 {
 		return fmt.Errorf("matchNamespaceChanges supports only a single filter (current number of filters is %d)", len(actions))
 	}
-	if (len(actions) == 1) && (kernels.EnableLargeProgs() == false) {
+	if (len(actions) == 1) && !kernels.EnableLargeProgs() {
 		return fmt.Errorf("matchNamespaceChanges is only supported in kernels >= 5.3")
 	}
 	loff := AdvanceSelectorLength(k)
@@ -869,7 +869,7 @@ func InitKernelSelectorState(selectors []v1alpha1.KProbeSelector, args []v1alpha
 func HasOverride(spec *v1alpha1.KProbeSpec) bool {
 	for _, s := range spec.Selectors {
 		for _, action := range s.MatchActions {
-			act, _ := actionTypeTable[strings.ToLower(action.Action)]
+			act := actionTypeTable[strings.ToLower(action.Action)]
 			if act == ActionTypeOverride {
 				return true
 			}

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -174,13 +174,13 @@ func TestNamespaceValueStr(t *testing.T) {
 
 func TestParseMatchArg(t *testing.T) {
 	sig := []v1alpha1.KProbeArg{
-		v1alpha1.KProbeArg{Index: 1, Type: "string", SizeArgIndex: 0, ReturnCopy: false},
-		v1alpha1.KProbeArg{Index: 2, Type: "int", SizeArgIndex: 0, ReturnCopy: false},
-		v1alpha1.KProbeArg{Index: 3, Type: "char_buf", SizeArgIndex: 0, ReturnCopy: false},
-		v1alpha1.KProbeArg{Index: 4, Type: "char_iovec", SizeArgIndex: 0, ReturnCopy: false},
-		v1alpha1.KProbeArg{Index: 5, Type: "sock", SizeArgIndex: 0, ReturnCopy: false},
-		v1alpha1.KProbeArg{Index: 6, Type: "skb", SizeArgIndex: 0, ReturnCopy: false},
-		v1alpha1.KProbeArg{Index: 7, Type: "skb", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 1, Type: "string", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 2, Type: "int", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 3, Type: "char_buf", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 4, Type: "char_iovec", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 5, Type: "sock", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 6, Type: "skb", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 7, Type: "skb", SizeArgIndex: 0, ReturnCopy: false},
 	}
 
 	arg1 := &v1alpha1.ArgSelector{Index: 1, Operator: "Equal", Values: []string{"foobar"}}
@@ -439,10 +439,10 @@ func TestParseMatchActionMax(t *testing.T) {
 	var actionArgTable idtable.Table
 
 	actions := []v1alpha1.ActionSelector{
-		v1alpha1.ActionSelector{Action: "post"},
-		v1alpha1.ActionSelector{Action: "post"},
-		v1alpha1.ActionSelector{Action: "post"},
-		v1alpha1.ActionSelector{Action: "post"},
+		{Action: "post"},
+		{Action: "post"},
+		{Action: "post"},
+		{Action: "post"},
 	}
 
 	k := &KernelSelectorState{off: 0}
@@ -730,10 +730,10 @@ func TestInitKernelSelectors(t *testing.T) {
 		},
 	}
 	args := []v1alpha1.KProbeArg{
-		v1alpha1.KProbeArg{Index: 1, Type: "string", SizeArgIndex: 0, ReturnCopy: false},
-		v1alpha1.KProbeArg{Index: 2, Type: "int", SizeArgIndex: 0, ReturnCopy: false},
-		v1alpha1.KProbeArg{Index: 3, Type: "char_buf", SizeArgIndex: 0, ReturnCopy: false},
-		v1alpha1.KProbeArg{Index: 4, Type: "char_iovec", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 1, Type: "string", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 2, Type: "int", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 3, Type: "char_buf", SizeArgIndex: 0, ReturnCopy: false},
+		{Index: 4, Type: "char_iovec", SizeArgIndex: 0, ReturnCopy: false},
 	}
 
 	// Create URL and FQDN tables to store URLs and FQDNs for this kprobe

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -740,7 +740,7 @@ func TestInitKernelSelectors(t *testing.T) {
 	var actionArgTable idtable.Table
 
 	b, _ := InitKernelSelectors(selectors, args, &actionArgTable)
-	if bytes.Equal(expected[0:len(expected)], b[0:len(expected)]) == false {
+	if bytes.Equal(expected[0:], b[0:len(expected)]) == false {
 		t.Errorf("InitKernelSelectors: expected %v bytes %v\n", expected, b[0:len(expected)])
 	}
 }

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -268,8 +268,8 @@ func TestParseMatchArg(t *testing.T) {
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
 		}
-		expected3 := append(length, expected1[:]...)
-		expected3 = append(expected3, expected2[:]...)
+		expected3 := append(length, expected1...)
+		expected3 = append(expected3, expected2...)
 		arg12 := []v1alpha1.ArgSelector{*arg1, *arg2}
 		ks := &KernelSelectorState{off: 0}
 		if err := ParseMatchArgs(ks, arg12, sig); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
@@ -309,8 +309,8 @@ func TestParseMatchPid(t *testing.T) {
 	}
 
 	length := []byte{56, 0x00, 0x00, 0x00}
-	expected3 := append(length, expected1[:]...)
-	expected3 = append(expected3, expected2[:]...)
+	expected3 := append(length, expected1...)
+	expected3 = append(expected3, expected2...)
 	pid3 := []v1alpha1.PIDSelector{*pid1, *pid2}
 	ks := &KernelSelectorState{off: 0}
 	if err := ParseMatchPids(ks, pid3); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
@@ -349,8 +349,8 @@ func TestParseMatchNamespaces(t *testing.T) {
 	}
 
 	length := []byte{56, 0x00, 0x00, 0x00}
-	expected3 := append(length, expected1[:]...)
-	expected3 = append(expected3, expected2[:]...)
+	expected3 := append(length, expected1...)
+	expected3 = append(expected3, expected2...)
 	ns3 := []v1alpha1.NamespaceSelector{*ns1, *ns2}
 	ks := &KernelSelectorState{off: 0}
 	if err := ParseMatchNamespaces(ks, ns3); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
@@ -396,8 +396,8 @@ func TestParseMatchCapabilities(t *testing.T) {
 	}
 
 	length := []byte{44, 0x00, 0x00, 0x00}
-	expected3 := append(length, expected1[:]...)
-	expected3 = append(expected3, expected2[:]...)
+	expected3 := append(length, expected1...)
+	expected3 = append(expected3, expected2...)
 	cap3 := []v1alpha1.CapabilitiesSelector{*cap1, *cap2}
 	ks := &KernelSelectorState{off: 0}
 	if err := ParseMatchCapabilities(ks, cap3); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
@@ -425,8 +425,8 @@ func TestParseMatchAction(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // Action = "post"
 	}
 	length := []byte{12, 0x00, 0x00, 0x00}
-	expected := append(length, expected1[:]...)
-	expected = append(expected, expected2[:]...)
+	expected := append(length, expected1...)
+	expected = append(expected, expected2...)
 
 	act := []v1alpha1.ActionSelector{*act1, *act2}
 	ks := &KernelSelectorState{off: 0}

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -241,7 +241,7 @@ func unmountCgroupv1Controllers(t *testing.T, cgroupRoot string, controllers []c
 	}
 }
 
-func prepareCgroupv1Hierarchies(controllers []cgroupController, usedController string, trackingCgrpLevel uint32) (map[string][]cgroupHierarchy, error) {
+func prepareCgroupv1Hierarchies(controllers []cgroupController, usedController string, trackingCgrpLevel uint32) map[string][]cgroupHierarchy {
 	kubeCgroupHierarchiesMap := make(map[string][]cgroupHierarchy, len(controllers))
 
 	for _, controller := range controllers {
@@ -276,7 +276,7 @@ func prepareCgroupv1Hierarchies(controllers []cgroupController, usedController s
 		}
 	}
 
-	return kubeCgroupHierarchiesMap, nil
+	return kubeCgroupHierarchiesMap
 }
 
 func cleanupCgroupv1Hierarchies(t *testing.T, cgroupRoot string, controllers []cgroupController, cgroupHierarchiesMap map[string][]cgroupHierarchy) {
@@ -1148,8 +1148,7 @@ func testCgroupv1K8sHierarchyInHybrid(t *testing.T, withExec bool, selectedContr
 		unmountCgroupv1Controllers(t, cgroupRoot, controllers)
 	})
 
-	kubeCgroupHierarchiesMap, err := prepareCgroupv1Hierarchies(controllers, usedController, trackingCgrpLevel)
-	require.NoError(t, err)
+	kubeCgroupHierarchiesMap := prepareCgroupv1Hierarchies(controllers, usedController, trackingCgrpLevel)
 	// Ensure we remove all hierarchies
 	t.Cleanup(func() {
 		cleanupCgroupv1Hierarchies(t, cgroupRoot, controllers, kubeCgroupHierarchiesMap)

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -136,7 +136,7 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, bool, error) {
 		if err != nil {
 			return proc, false, err
 		}
-		proc.Filename = string(data[:])
+		proc.Filename = string(data)
 		args = args[unsafe.Sizeof(desc):]
 	} else if exec.Flags&api.EventErrorFilename == 0 {
 		n := bytes.Index(args, []byte{0x00})

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -205,7 +205,7 @@ func TestEventExecveLongPath(t *testing.T) {
 		for i := 0; i < 254; i++ {
 			testDir = fmt.Sprintf("%s%c", testDir, 'a'+d)
 		}
-		testDir = testDir + "/"
+		testDir += "/"
 	}
 
 	// and add the file
@@ -336,7 +336,7 @@ func TestEventExecveLongPathLongArgs(t *testing.T) {
 		for i := 0; i < 254; i++ {
 			testDir = fmt.Sprintf("%s%c", testDir, 'a'+d)
 		}
-		testDir = testDir + "/"
+		testDir += "/"
 	}
 
 	// and add the file

--- a/pkg/sensors/exec/exit_test.go
+++ b/pkg/sensors/exec/exit_test.go
@@ -41,9 +41,7 @@ func TestExit(t *testing.T) {
 	execChecker := ec.NewProcessExecChecker("exec").WithProcess(procChecker)
 	exitChecker := ec.NewProcessExitChecker("exit").WithProcess(procChecker)
 
-	var checker *ec.UnorderedEventChecker
-
-	checker = ec.NewUnorderedEventChecker(execChecker, exitChecker)
+	checker := ec.NewUnorderedEventChecker(execChecker, exitChecker)
 
 	if err := exec.Command(testNop).Run(); err != nil {
 		t.Fatalf("Failed to execute test binary: %s\n", err)

--- a/pkg/sensors/exec/procevents/proc.go
+++ b/pkg/sensors/exec/procevents/proc.go
@@ -72,7 +72,7 @@ func LookupContainerId(cgroup string, bpfSource bool, walkParent bool) (string, 
 	// We trust BPF part that it will always return null terminated
 	// DOCKER_ID_LENGTH. For other cases where we read through /proc/
 	// strings are not truncated.
-	if bpfSource == true && len(subdir) >= processapi.DOCKER_ID_LENGTH-1 {
+	if bpfSource && len(subdir) >= processapi.DOCKER_ID_LENGTH-1 {
 		idTruncated = true
 	}
 
@@ -86,7 +86,7 @@ func LookupContainerId(cgroup string, bpfSource bool, walkParent bool) (string, 
 	// walkParent argument set and get its parent cgroup
 	if !strings.HasSuffix(container, "service") &&
 		((len(container) >= ContainerIdLength) ||
-			(idTruncated == true && len(container) >= BpfContainerIdLength)) {
+			(idTruncated && len(container) >= BpfContainerIdLength)) {
 		// Return first 31 chars. If the string is less than 31 chars
 		// it's not a docker ID so skip it. For example docker.server
 		// will get here.

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -458,15 +458,15 @@ func listRunningProcs(procPath string) ([]procs, error) {
 			// next try to consume CWD space from child and finally start truncating args
 			// if necessary.
 			deduct = processapi.MSG_SIZEOF_CWD
-			p.pflags = p.pflags & ^uint32(api.EventNeedsCWD)
-			p.pflags = p.pflags | api.EventNoCWDSupport
+			p.pflags &= ^uint32(api.EventNeedsCWD)
+			p.pflags |= api.EventNoCWDSupport
 			p.psize -= deduct
 			need -= int32(deduct)
 			if need > 0 {
 				deduct = processapi.MSG_SIZEOF_CWD
 				p.size -= deduct
-				p.flags = p.flags & ^uint32(api.EventNeedsCWD)
-				p.flags = p.flags | api.EventNoCWDSupport
+				p.flags &= ^uint32(api.EventNeedsCWD)
+				p.flags |= api.EventNoCWDSupport
 				need -= int32(deduct)
 			}
 

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -286,7 +286,7 @@ func listRunningProcs(procPath string) ([]procs, error) {
 		var pexecPath string
 		var pnspid uint32
 
-		if d.IsDir() == false {
+		if !d.IsDir() {
 			continue
 		}
 

--- a/pkg/sensors/exec/threads_test.go
+++ b/pkg/sensors/exec/threads_test.go
@@ -123,20 +123,18 @@ func TestMatchCloneThreadsIDs(t *testing.T) {
 	clonePID, cloneTID := uint32(0), uint32(0)
 	events := perfring.RunTestEvents(t, ctx, ops)
 	for _, ev := range events {
-		switch ev.(type) {
+		switch ev := ev.(type) {
 		case *grpcexec.MsgExecveEventUnix:
-			exec := ev.(*grpcexec.MsgExecveEventUnix)
-			if exec.Process.Filename == testBin {
-				execPID = exec.Process.PID
-				execTID = exec.Process.TID
+			if ev.Process.Filename == testBin {
+				execPID = ev.Process.PID
+				execTID = ev.Process.TID
 			}
 		case *grpcexec.MsgCloneEventUnix:
-			msg := ev.(*grpcexec.MsgCloneEventUnix)
 			// We found the exec parent then catch the single per thread
 			// clone event
 			if execPID != 0 && clonePID == 0 {
-				clonePID = msg.PID
-				cloneTID = msg.TID
+				clonePID = ev.PID
+				cloneTID = ev.TID
 			}
 		}
 	}

--- a/pkg/sensors/handler.go
+++ b/pkg/sensors/handler.go
@@ -142,6 +142,7 @@ func (h *handler) delTracingPolicy(op *tracingPolicyDel) error {
 	return err
 }
 
+// nolint:unparam // error is always nil, needed because of StartSensorManager
 func (h *handler) listTracingPolicies(op *tracingPolicyList) error {
 	ret := tetragon.ListTracingPoliciesResponse{}
 	for name, col := range h.collections {
@@ -215,6 +216,7 @@ func (h *handler) disableSensor(op *sensorDisable) error {
 	return col.unload(&UnloadArg{STTManagerHandle: op.sttManagerHandle})
 }
 
+// nolint:unparam // error is always nil, needed because of StartSensorManager
 func (h *handler) listSensors(op *sensorList) error {
 	ret := make([]SensorStatus, 0)
 	for _, col := range h.collections {

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -495,7 +495,7 @@ func doLoadProgram(
 					if verbose < 2 {
 						fmt.Println(slimVerifierError(fmt.Sprintf("%+v", ve)))
 					} else {
-						fmt.Println(fmt.Sprintf("%+v", ve))
+						fmt.Printf("%+v\n", ve)
 					}
 				}
 			}

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -478,7 +478,7 @@ func doLoadProgram(
 		for {
 			coll, err = ebpf.NewCollectionWithOptions(spec, opts)
 			if errors.Is(err, unix.ENOSPC) {
-				opts.Programs.LogSize = opts.Programs.LogSize * 2
+				opts.Programs.LogSize *= 2
 				continue
 			}
 			break

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -1331,6 +1331,9 @@ func retprobeMerge(prev pendingEvent, curr pendingEvent) (*tracing.MsgGenericKpr
 		if uint64(len(enterEv.Args)) > index {
 			enterEv.Args[index] = retArg
 		} else {
+			// retArg is reused and we are exporting pointers for loop variables
+			// shadowing with a local variable to make pointer export valid
+			retArg := retArg
 			enterEv.Args = append(enterEv.Args, retArg)
 			ret = &retArg
 		}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -301,11 +301,11 @@ func preValidateKprobes(name string, kprobes []v1alpha1.KProbeSpec) error {
 		}
 
 		if err := btf.ValidateKprobeSpec(btfobj, f); err != nil {
-			if warn, ok := err.(*btf.ValidationWarn); ok {
+			if warn, ok := err.(*btf.ValidationWarnError); ok {
 				logger.GetLogger().WithFields(logrus.Fields{
 					"sensor": name,
 				}).WithError(warn).Warn("Kprobe spec pre-validation failed, but will continue with loading")
-			} else if e, ok := err.(*btf.ValidationFailed); ok {
+			} else if e, ok := err.(*btf.ValidationFailedError); ok {
 				return fmt.Errorf("kprobe spec pre-validation failed: %w", e)
 			} else {
 				err = fmt.Errorf("invalid or old kprobe spec: %s", err)

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -456,7 +456,7 @@ func createGenericKprobeSensor(
 		// Mark remaining arguments as 'nops' the kernel side will skip
 		// copying 'nop' args.
 		for j, a := range argsBTFSet {
-			if a == false {
+			if !a {
 				if j != api.ReturnArgIndex {
 					config.Arg[j] = gt.GenericNopType
 					config.ArgM[j] = 0

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -186,10 +186,10 @@ func getMetaValue(arg *v1alpha1.KProbeArg) (int, error) {
 		meta = int(arg.SizeArgIndex)
 	}
 	if arg.ReturnCopy {
-		meta = meta | argReturnCopyBit
+		meta |= argReturnCopyBit
 	}
 	if arg.MaxData {
-		meta = meta | argMaxDataBit
+		meta |= argMaxDataBit
 	}
 	return meta, nil
 }
@@ -679,7 +679,7 @@ func loadSingleKprobeSensor(id idtable.EntryID, bpfDir, mapDir string, load *pro
 		Index: 0,
 		Name:  "config_map",
 		Load: func(m *ebpf.Map, index uint32) error {
-			return m.Update(index, configData.Bytes()[:], ebpf.UpdateAny)
+			return m.Update(index, configData.Bytes(), ebpf.UpdateAny)
 		},
 	}
 	load.MapLoad = append(load.MapLoad, config)
@@ -727,7 +727,7 @@ func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir, mapDir string, load *p
 			Index: uint32(index),
 			Name:  "config_map",
 			Load: func(m *ebpf.Map, index uint32) error {
-				return m.Update(index, bin_buf[index].Bytes()[:], ebpf.UpdateAny)
+				return m.Update(index, bin_buf[index].Bytes(), ebpf.UpdateAny)
 			},
 		}
 		load.MapLoad = append(load.MapLoad, config)
@@ -791,7 +791,7 @@ func handleGenericKprobeString(r *bytes.Reader) string {
 		logger.GetLogger().WithError(err).Warnf("String with size %d type err", b)
 	}
 
-	strVal := string(outputStr[:])
+	strVal := string(outputStr)
 	lenStrVal := len(strVal)
 	if lenStrVal > 0 && strVal[lenStrVal-1] == '\x00' {
 		strVal = strVal[0 : lenStrVal-1]
@@ -999,7 +999,7 @@ func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
 			}
 
 			arg.Index = uint64(a.index)
-			strVal := string(outputStr[:])
+			strVal := string(outputStr)
 			lenStrVal := len(strVal)
 			if lenStrVal > 0 && strVal[lenStrVal-1] == '\x00' {
 				strVal = strVal[0 : lenStrVal-1]

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -548,7 +548,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 		Index: 0,
 		Name:  "config_map",
 		Load: func(m *ebpf.Map, index uint32) error {
-			return m.Update(index, binBuf.Bytes()[:], ebpf.UpdateAny)
+			return m.Update(index, binBuf.Bytes(), ebpf.UpdateAny)
 		},
 	}
 	load.MapLoad = append(load.MapLoad, cfg)

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -115,7 +115,7 @@ func (k *observerUprobeSensor) LoadProbe(args sensors.LoadProbeArgs) error {
 			Index: 0,
 			Name:  "config_map",
 			Load: func(m *ebpf.Map, index uint32) error {
-				return m.Update(index, configData.Bytes()[:], ebpf.UpdateAny)
+				return m.Update(index, configData.Bytes(), ebpf.UpdateAny)
 			},
 		},
 		{

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -572,6 +572,7 @@ func getAnyChecker() ec.MultiEventChecker {
 	return ec.NewUnorderedEventChecker(ec.NewProcessKprobeChecker("anyKprobe"))
 }
 
+// nolint:unparam // perm always receives `0x770` but it's okay
 func testKprobeObjectFiltered(t *testing.T,
 	readHook string,
 	checker ec.MultiEventChecker,
@@ -1184,7 +1185,7 @@ func TestKprobeObjectFilterReturnValueGTOk(t *testing.T) {
 	path := dir + "/testfile"
 	openHook := testKprobeObjectFilterReturnValueGTHook(pidStr, path)
 
-	checker := func(dir string) *eventchecker.UnorderedEventChecker {
+	checker := func(_ string) *eventchecker.UnorderedEventChecker {
 		return ec.NewUnorderedEventChecker(
 			ec.NewProcessKprobeChecker("").
 				WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_openat"))).
@@ -1228,7 +1229,7 @@ func TestKprobeObjectFilterReturnValueLTOk(t *testing.T) {
 	path := dir + "/testfile"
 	openHook := testKprobeObjectFilterReturnValueLTHook(pidStr, path)
 
-	checker := func(dir string) *eventchecker.UnorderedEventChecker {
+	checker := func(_ string) *eventchecker.UnorderedEventChecker {
 		return ec.NewUnorderedEventChecker(
 			ec.NewProcessKprobeChecker("").
 				WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_openat"))).
@@ -2613,6 +2614,7 @@ func openFile(t *testing.T, file string) int {
 }
 
 // reads 32 bytes from a file, this will trigger a sys_read.
+// nolint:unparam // result is never used but it's okay
 func readFile(t *testing.T, file string) int {
 	fd := openFile(t, file)
 	var readBytes = make([]byte, 32)

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3068,45 +3068,45 @@ spec:
 func TestLoadKprobeSensor(t *testing.T) {
 	var sensorProgs = []tus.SensorProg{
 		// kprobe
-		0:  tus.SensorProg{Name: "generic_kprobe_event", Type: ebpf.Kprobe},
-		1:  tus.SensorProg{Name: "generic_kprobe_process_event0", Type: ebpf.Kprobe},
-		2:  tus.SensorProg{Name: "generic_kprobe_process_event1", Type: ebpf.Kprobe},
-		3:  tus.SensorProg{Name: "generic_kprobe_process_event2", Type: ebpf.Kprobe},
-		4:  tus.SensorProg{Name: "generic_kprobe_process_event3", Type: ebpf.Kprobe},
-		5:  tus.SensorProg{Name: "generic_kprobe_process_event4", Type: ebpf.Kprobe},
-		6:  tus.SensorProg{Name: "generic_kprobe_filter_arg1", Type: ebpf.Kprobe},
-		7:  tus.SensorProg{Name: "generic_kprobe_filter_arg2", Type: ebpf.Kprobe},
-		8:  tus.SensorProg{Name: "generic_kprobe_filter_arg3", Type: ebpf.Kprobe},
-		9:  tus.SensorProg{Name: "generic_kprobe_filter_arg4", Type: ebpf.Kprobe},
-		10: tus.SensorProg{Name: "generic_kprobe_filter_arg5", Type: ebpf.Kprobe},
-		11: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
-		12: tus.SensorProg{Name: "generic_kprobe_actions", Type: ebpf.Kprobe},
-		13: tus.SensorProg{Name: "generic_kprobe_output", Type: ebpf.Kprobe},
+		0:  {Name: "generic_kprobe_event", Type: ebpf.Kprobe},
+		1:  {Name: "generic_kprobe_process_event0", Type: ebpf.Kprobe},
+		2:  {Name: "generic_kprobe_process_event1", Type: ebpf.Kprobe},
+		3:  {Name: "generic_kprobe_process_event2", Type: ebpf.Kprobe},
+		4:  {Name: "generic_kprobe_process_event3", Type: ebpf.Kprobe},
+		5:  {Name: "generic_kprobe_process_event4", Type: ebpf.Kprobe},
+		6:  {Name: "generic_kprobe_filter_arg1", Type: ebpf.Kprobe},
+		7:  {Name: "generic_kprobe_filter_arg2", Type: ebpf.Kprobe},
+		8:  {Name: "generic_kprobe_filter_arg3", Type: ebpf.Kprobe},
+		9:  {Name: "generic_kprobe_filter_arg4", Type: ebpf.Kprobe},
+		10: {Name: "generic_kprobe_filter_arg5", Type: ebpf.Kprobe},
+		11: {Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
+		12: {Name: "generic_kprobe_actions", Type: ebpf.Kprobe},
+		13: {Name: "generic_kprobe_output", Type: ebpf.Kprobe},
 		// retkprobe
-		14: tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
+		14: {Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all kprobe programs
-		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+		{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
 		// all but generic_kprobe_output,generic_retkprobe_event
-		tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+		{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
 
 		// only retkprobe
-		tus.SensorMap{Name: "process_call_heap", Progs: []uint{14}},
+		{Name: "process_call_heap", Progs: []uint{14}},
 
 		// generic_kprobe_process_filter,generic_kprobe_filter_arg*,
 		// generic_kprobe_actions,generic_kprobe_output
-		tus.SensorMap{Name: "filter_map", Progs: []uint{6, 7, 8, 9, 10, 11, 12}},
+		{Name: "filter_map", Progs: []uint{6, 7, 8, 9, 10, 11, 12}},
 
 		// generic_kprobe_actions
-		tus.SensorMap{Name: "override_tasks", Progs: []uint{12}},
+		{Name: "override_tasks", Progs: []uint{12}},
 
 		// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
-		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 
 		// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
-		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 3, 4, 5, 12, 14}},
+		{Name: "fdinstall_map", Progs: []uint{1, 2, 3, 4, 5, 12, 14}},
 	}
 
 	if kernels.EnableLargeProgs() {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -407,15 +407,13 @@ func createTestFile(t *testing.T) (int, int, string) {
 	// Create file with hello world to read
 	fd, errno := syscall.Open("/tmp/testfile", syscall.O_CREAT|syscall.O_TRUNC|syscall.O_RDWR, 0x777)
 	if fd < 0 {
-		t.Logf("File open failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("File open failed: %s\n", errno)
 	}
 	t.Cleanup(func() { syscall.Close(fd) })
 	t.Cleanup(func() { os.Remove("/tmp/testfile") })
 	fd2, errno := syscall.Open("/tmp/testfile", syscall.O_RDWR, 0x770)
 	if fd2 < 0 {
-		t.Logf("File open fro read failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("File open fro read failed: %s\n", errno)
 	}
 	t.Cleanup(func() { syscall.Close(fd2) })
 	return fd, fd2, fmt.Sprint(fd2)
@@ -443,15 +441,13 @@ func runKprobeObjectRead(t *testing.T, readHook string, checker ec.MultiEventChe
 	hello := []byte("hello world")
 	n, errno := syscall.Write(fd, hello)
 	if n < 0 {
-		t.Logf("syscall.Write failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("syscall.Write failed: %s\n", errno)
 	}
 	syscall.Fsync(fd)
 	var readBytes = make([]byte, 100)
 	i, errno := syscall.Read(fd2, readBytes)
 	if i < 0 {
-		t.Logf("syscall.Read failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("syscall.Read failed: %s\n", errno)
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
@@ -584,8 +580,7 @@ func testKprobeObjectFiltered(t *testing.T,
 
 	if useMount == true {
 		if err := syscall.Mount("tmpfs", mntPath, "tmpfs", 0, ""); err != nil {
-			t.Logf("Mount failed: %s\n", err)
-			t.Skip()
+			t.Skipf("Mount failed: %s\n", err)
 		}
 		t.Cleanup(func() {
 			if err := syscall.Unmount(mntPath, 0); err != nil {
@@ -605,8 +600,7 @@ func testKprobeObjectFiltered(t *testing.T,
 	// Create file to open later
 	fd, errno := syscall.Open(filePath, syscall.O_CREAT|syscall.O_RDWR, 0x777)
 	if fd < 0 {
-		t.Logf("File open failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("File open failed: %s\n", errno)
 	}
 	syscall.Close(fd)
 
@@ -624,8 +618,7 @@ func testKprobeObjectFiltered(t *testing.T,
 	readyWG.Wait()
 	fd2, errno := syscall.Open(filePath, mode, perm)
 	if fd2 < 0 {
-		t.Logf("File open from read failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("File open from read failed: %s\n", errno)
 	}
 	t.Cleanup(func() { syscall.Close(fd2) })
 	data := "hello world"
@@ -1201,8 +1194,7 @@ func TestKprobeObjectFilterReturnValueGTOk(t *testing.T) {
 	// Create file to open later
 	fd, errno := syscall.Open(path, syscall.O_CREAT|syscall.O_RDWR, 0x777)
 	if fd < 0 {
-		t.Logf("File open failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("File open failed: %s\n", errno)
 	}
 	syscall.Close(fd)
 	defer func() { syscall.Unlink(path) }()
@@ -1256,8 +1248,7 @@ func TestKprobeObjectFilterReturnValueLTFail(t *testing.T) {
 	// Create file to open later
 	fd, errno := syscall.Open(path, syscall.O_CREAT|syscall.O_RDWR, 0x777)
 	if fd < 0 {
-		t.Logf("File open failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("File open failed: %s\n", errno)
 	}
 	syscall.Close(fd)
 	defer func() { syscall.Unlink(path) }()
@@ -1569,8 +1560,7 @@ func corePathTest(t *testing.T, filePath string, readHook string, writeChecker e
 	// Create file to open later
 	fd, errno := syscall.Open(filePath, syscall.O_CREAT|syscall.O_RDWR, 0x777)
 	if fd < 0 {
-		t.Logf("File open failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("File open failed: %s\n", errno)
 	}
 	syscall.Close(fd)
 
@@ -1589,8 +1579,7 @@ func corePathTest(t *testing.T, filePath string, readHook string, writeChecker e
 
 	fd2, errno := syscall.Open(filePath, syscall.O_RDWR, 0x770)
 	if fd2 < 0 {
-		t.Logf("File open from read failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("File open from read failed: %s\n", errno)
 	}
 	t.Cleanup(func() { syscall.Close(fd2) })
 	data := "hello world"
@@ -1610,12 +1599,10 @@ func testMultipleMountsFiltered(t *testing.T, readHook string) {
 		path = filepath.Join(path, fmt.Sprintf("tmp%d", i))
 		pathStack = append(pathStack, path)
 		if err := os.Mkdir(path, 0755); err != nil {
-			t.Logf("Mkdir failed: %s\n", err)
-			t.Skip()
+			t.Skipf("Mkdir failed: %s\n", err)
 		}
 		if err := syscall.Mount("tmpfs", path, "tmpfs", 0, ""); err != nil {
-			t.Logf("Mount failed: %s\n", err)
-			t.Skip()
+			t.Skipf("Mount failed: %s\n", err)
 		}
 	}
 	t.Cleanup(func() {
@@ -1649,8 +1636,7 @@ func testMultiplePathComponentsFiltered(t *testing.T, readHook string) {
 		path = filepath.Join(path, fmt.Sprintf("%d", i))
 		pathStack = append(pathStack, path)
 		if err := os.Mkdir(path, 0755); err != nil {
-			t.Logf("Mkdir failed: %s\n", err)
-			t.Skip()
+			t.Skipf("Mkdir failed: %s\n", err)
 		}
 	}
 	t.Cleanup(func() {
@@ -1689,20 +1675,17 @@ func testMultipleMountPathFiltered(t *testing.T, readHook string) {
 		path = filepath.Join(path, fmt.Sprintf("tmp%d", i))
 		pathStack = append(pathStack, path)
 		if err := os.Mkdir(path, 0755); err != nil {
-			t.Logf("Mkdir failed: %s\n", err)
-			t.Skip()
+			t.Skipf("Mkdir failed: %s\n", err)
 		}
 		if err := syscall.Mount("tmpfs", path, "tmpfs", 0, ""); err != nil {
-			t.Logf("Mount failed: %s\n", err)
-			t.Skip()
+			t.Skipf("Mount failed: %s\n", err)
 		}
 	}
 	for i := 0; i <= 16; i++ {
 		path = filepath.Join(path, fmt.Sprintf("%d", i))
 		dirStack = append(dirStack, path)
 		if err := os.Mkdir(path, 0755); err != nil {
-			t.Logf("Mkdir failed: %s\n", err)
-			t.Skip()
+			t.Skipf("Mkdir failed: %s\n", err)
 		}
 	}
 	t.Cleanup(func() {
@@ -2606,8 +2589,7 @@ spec:
 func openFile(t *testing.T, file string) int {
 	fd, errno := syscall.Open(file, syscall.O_RDONLY, 0)
 	if fd < 0 {
-		t.Logf("File open failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("File open failed: %s\n", errno)
 	}
 	t.Cleanup(func() { syscall.Close(fd) })
 	return fd
@@ -2620,8 +2602,7 @@ func readFile(t *testing.T, file string) int {
 	var readBytes = make([]byte, 32)
 	i, errno := syscall.Read(fd, readBytes)
 	if i < 0 {
-		t.Logf("syscall.Read failed: %s\n", errno)
-		t.Fatal()
+		t.Fatalf("syscall.Read failed: %s\n", errno)
 	}
 	return fd
 }

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2680,7 +2680,7 @@ func TestKprobeMatchArgsFileEqual(t *testing.T) {
 		argVals[3] = "/etc/shadow"
 	}
 
-	createCrdFile(t, getMatchArgsFileCrd("Equal", argVals[:]))
+	createCrdFile(t, getMatchArgsFileCrd("Equal", argVals))
 
 	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -2720,7 +2720,7 @@ func TestKprobeMatchArgsFilePostfix(t *testing.T) {
 		argVals[3] = "shadow"
 	}
 
-	createCrdFile(t, getMatchArgsFileCrd("Postfix", argVals[:]))
+	createCrdFile(t, getMatchArgsFileCrd("Postfix", argVals))
 
 	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -2760,7 +2760,7 @@ func TestKprobeMatchArgsFilePrefix(t *testing.T) {
 		argVals[3] = "/etc/s"
 	}
 
-	createCrdFile(t, getMatchArgsFileCrd("Prefix", argVals[:]))
+	createCrdFile(t, getMatchArgsFileCrd("Prefix", argVals))
 
 	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -2800,7 +2800,7 @@ func TestKprobeMatchArgsFdEqual(t *testing.T) {
 		argVals[3] = "/etc/shadow"
 	}
 
-	createCrdFile(t, getMatchArgsFdCrd("Equal", argVals[:]))
+	createCrdFile(t, getMatchArgsFdCrd("Equal", argVals))
 
 	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -2836,7 +2836,7 @@ func TestKprobeMatchArgsFdPostfix(t *testing.T) {
 		argVals[3] = "shadow"
 	}
 
-	createCrdFile(t, getMatchArgsFdCrd("Postfix", argVals[:]))
+	createCrdFile(t, getMatchArgsFdCrd("Postfix", argVals))
 
 	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -2872,7 +2872,7 @@ func TestKprobeMatchArgsFdPrefix(t *testing.T) {
 		argVals[3] = "/etc/s"
 	}
 
-	createCrdFile(t, getMatchArgsFdCrd("Prefix", argVals[:]))
+	createCrdFile(t, getMatchArgsFdCrd("Prefix", argVals))
 
 	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -223,7 +223,7 @@ func TestTracepointSelectors(t *testing.T) {
 					return nil
 				}
 
-				ret[whence] = ret[whence] + 1
+				ret[whence]++
 			}
 			return nil
 		})
@@ -350,7 +350,7 @@ func TestKprobeSelectors(t *testing.T) {
 					return nil
 				}
 
-				ret[whence] = ret[whence] + 1
+				ret[whence]++
 				return nil
 			}
 			return nil

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -340,10 +340,10 @@ func TestGenericTracepointRawSyscall(t *testing.T) {
 		Subsystem: "raw_syscalls",
 		Event:     "sys_enter",
 		Args: []v1alpha1.KProbeArg{
-			v1alpha1.KProbeArg{
+			{
 				Index: 4, /* id */
 			},
-			v1alpha1.KProbeArg{
+			{
 				Index: 5, /* args */
 			},
 		},
@@ -409,40 +409,40 @@ func TestGenericTracepointRawSyscall(t *testing.T) {
 
 func TestLoadTracepointSensor(t *testing.T) {
 	var sensorProgs = []tus.SensorProg{
-		0:  tus.SensorProg{Name: "generic_tracepoint_event", Type: ebpf.TracePoint},
-		1:  tus.SensorProg{Name: "generic_tracepoint_arg1", Type: ebpf.TracePoint},
-		2:  tus.SensorProg{Name: "generic_tracepoint_arg2", Type: ebpf.TracePoint},
-		3:  tus.SensorProg{Name: "generic_tracepoint_arg3", Type: ebpf.TracePoint},
-		4:  tus.SensorProg{Name: "generic_tracepoint_arg4", Type: ebpf.TracePoint},
-		5:  tus.SensorProg{Name: "generic_tracepoint_arg5", Type: ebpf.TracePoint},
-		6:  tus.SensorProg{Name: "generic_tracepoint_event0", Type: ebpf.TracePoint},
-		7:  tus.SensorProg{Name: "generic_tracepoint_event1", Type: ebpf.TracePoint},
-		8:  tus.SensorProg{Name: "generic_tracepoint_event2", Type: ebpf.TracePoint},
-		9:  tus.SensorProg{Name: "generic_tracepoint_event3", Type: ebpf.TracePoint},
-		10: tus.SensorProg{Name: "generic_tracepoint_event4", Type: ebpf.TracePoint},
-		11: tus.SensorProg{Name: "generic_tracepoint_filter", Type: ebpf.TracePoint},
-		12: tus.SensorProg{Name: "generic_tracepoint_actions", Type: ebpf.TracePoint},
-		13: tus.SensorProg{Name: "generic_tracepoint_output", Type: ebpf.TracePoint},
+		0:  {Name: "generic_tracepoint_event", Type: ebpf.TracePoint},
+		1:  {Name: "generic_tracepoint_arg1", Type: ebpf.TracePoint},
+		2:  {Name: "generic_tracepoint_arg2", Type: ebpf.TracePoint},
+		3:  {Name: "generic_tracepoint_arg3", Type: ebpf.TracePoint},
+		4:  {Name: "generic_tracepoint_arg4", Type: ebpf.TracePoint},
+		5:  {Name: "generic_tracepoint_arg5", Type: ebpf.TracePoint},
+		6:  {Name: "generic_tracepoint_event0", Type: ebpf.TracePoint},
+		7:  {Name: "generic_tracepoint_event1", Type: ebpf.TracePoint},
+		8:  {Name: "generic_tracepoint_event2", Type: ebpf.TracePoint},
+		9:  {Name: "generic_tracepoint_event3", Type: ebpf.TracePoint},
+		10: {Name: "generic_tracepoint_event4", Type: ebpf.TracePoint},
+		11: {Name: "generic_tracepoint_filter", Type: ebpf.TracePoint},
+		12: {Name: "generic_tracepoint_actions", Type: ebpf.TracePoint},
+		13: {Name: "generic_tracepoint_output", Type: ebpf.TracePoint},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all programs
-		tus.SensorMap{Name: "tp_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+		{Name: "tp_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
 
 		// all but generic_tracepoint_output
-		tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+		{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
 
 		// only generic_tracepoint_event*
-		tus.SensorMap{Name: "buffer_heap_map", Progs: []uint{6, 7, 8, 9, 10}},
+		{Name: "buffer_heap_map", Progs: []uint{6, 7, 8, 9, 10}},
 
 		// all but generic_tracepoint_event,generic_tracepoint_filter
-		tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{Name: "retprobe_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 
 		// generic_tracepoint_output
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{13}},
+		{Name: "tcpmon_map", Progs: []uint{13}},
 
 		// all kprobe but generic_tracepoint_filter
-		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 	}
 
 	if kernels.EnableLargeProgs() {

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -25,34 +25,34 @@ import (
 func TestUprobeLoad(t *testing.T) {
 	var sensorProgs = []tus.SensorProg{
 		// uprobe
-		0:  tus.SensorProg{Name: "generic_uprobe_event", Type: ebpf.Kprobe},
-		1:  tus.SensorProg{Name: "generic_uprobe_process_event0", Type: ebpf.Kprobe},
-		2:  tus.SensorProg{Name: "generic_uprobe_process_event1", Type: ebpf.Kprobe},
-		3:  tus.SensorProg{Name: "generic_uprobe_process_event2", Type: ebpf.Kprobe},
-		4:  tus.SensorProg{Name: "generic_uprobe_process_event3", Type: ebpf.Kprobe},
-		5:  tus.SensorProg{Name: "generic_uprobe_process_event4", Type: ebpf.Kprobe},
-		6:  tus.SensorProg{Name: "generic_uprobe_filter_arg1", Type: ebpf.Kprobe},
-		7:  tus.SensorProg{Name: "generic_uprobe_filter_arg2", Type: ebpf.Kprobe},
-		8:  tus.SensorProg{Name: "generic_uprobe_filter_arg3", Type: ebpf.Kprobe},
-		9:  tus.SensorProg{Name: "generic_uprobe_filter_arg4", Type: ebpf.Kprobe},
-		10: tus.SensorProg{Name: "generic_uprobe_filter_arg5", Type: ebpf.Kprobe},
-		11: tus.SensorProg{Name: "generic_uprobe_process_filter", Type: ebpf.Kprobe},
-		12: tus.SensorProg{Name: "generic_uprobe_actions", Type: ebpf.Kprobe},
-		13: tus.SensorProg{Name: "generic_uprobe_output", Type: ebpf.Kprobe},
+		0:  {Name: "generic_uprobe_event", Type: ebpf.Kprobe},
+		1:  {Name: "generic_uprobe_process_event0", Type: ebpf.Kprobe},
+		2:  {Name: "generic_uprobe_process_event1", Type: ebpf.Kprobe},
+		3:  {Name: "generic_uprobe_process_event2", Type: ebpf.Kprobe},
+		4:  {Name: "generic_uprobe_process_event3", Type: ebpf.Kprobe},
+		5:  {Name: "generic_uprobe_process_event4", Type: ebpf.Kprobe},
+		6:  {Name: "generic_uprobe_filter_arg1", Type: ebpf.Kprobe},
+		7:  {Name: "generic_uprobe_filter_arg2", Type: ebpf.Kprobe},
+		8:  {Name: "generic_uprobe_filter_arg3", Type: ebpf.Kprobe},
+		9:  {Name: "generic_uprobe_filter_arg4", Type: ebpf.Kprobe},
+		10: {Name: "generic_uprobe_filter_arg5", Type: ebpf.Kprobe},
+		11: {Name: "generic_uprobe_process_filter", Type: ebpf.Kprobe},
+		12: {Name: "generic_uprobe_actions", Type: ebpf.Kprobe},
+		13: {Name: "generic_uprobe_output", Type: ebpf.Kprobe},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all uprobe programs
-		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+		{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
 
 		// all but generic_uprobe_output
-		tus.SensorMap{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+		{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
 
 		// generic_uprobe_process_filter,generic_uprobe_filter_arg*,generic_uprobe_actions
-		tus.SensorMap{Name: "filter_map", Progs: []uint{6, 7, 8, 9, 10, 11, 12}},
+		{Name: "filter_map", Progs: []uint{6, 7, 8, 9, 10, 11, 12}},
 
 		// generic_uprobe_output
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{13}},
+		{Name: "tcpmon_map", Progs: []uint{13}},
 	}
 
 	if kernels.EnableLargeProgs() {

--- a/pkg/sensors/unloader/unloader.go
+++ b/pkg/sensors/unloader/unloader.go
@@ -24,6 +24,7 @@ type Unloader interface {
 // Useful when a loading operation needs to be unwinded due to an error.
 type ChainUnloader []Unloader
 
+// nolint:errname // using plural Error postfix
 type chainUnloaderErrors struct {
 	errors []error
 }

--- a/pkg/syscallinfo/syscallinfo.go
+++ b/pkg/syscallinfo/syscallinfo.go
@@ -44,7 +44,7 @@ var syscallIDs = func() map[string]int {
 }()
 
 func SyscallsNames() []string {
-	ret := make([]string, len(syscallNames))
+	ret := make([]string, 0, len(syscallNames))
 
 	for _, v := range syscallNames {
 		ret = append(ret, v)

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -114,26 +114,26 @@ func mergeSensorMaps(t *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []Se
 
 func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []SensorProg) ([]SensorMap, []SensorProg) {
 	var baseProgs = []SensorProg{
-		0: SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
-		1: SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
-		2: SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
-		3: SensorProg{Name: "execve_send", Type: ebpf.TracePoint},
+		0: {Name: "event_execve", Type: ebpf.TracePoint},
+		1: {Name: "event_exit", Type: ebpf.TracePoint},
+		2: {Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
+		3: {Name: "execve_send", Type: ebpf.TracePoint},
 	}
 
 	var baseMaps = []SensorMap{
 		// all programs
-		SensorMap{Name: "execve_map", Progs: []uint{0, 1, 2, 3}},
-		SensorMap{Name: "tcpmon_map", Progs: []uint{0, 1, 2, 3}},
+		{Name: "execve_map", Progs: []uint{0, 1, 2, 3}},
+		{Name: "tcpmon_map", Progs: []uint{0, 1, 2, 3}},
 
 		// all but event_execve
-		SensorMap{Name: "execve_map_stats", Progs: []uint{1, 2}},
+		{Name: "execve_map_stats", Progs: []uint{1, 2}},
 
 		// event_execve
-		SensorMap{Name: "names_map", Progs: []uint{0}},
-		SensorMap{Name: "tg_conf_map", Progs: []uint{0, 2}},
+		{Name: "names_map", Progs: []uint{0}},
+		{Name: "tg_conf_map", Progs: []uint{0, 2}},
 
 		// event_wake_up_new_task
-		SensorMap{Name: "execve_val", Progs: []uint{2}},
+		{Name: "execve_val", Progs: []uint{2}},
 	}
 
 	return mergeSensorMaps(t, sensorMaps, baseMaps, sensorProgs, baseProgs)

--- a/pkg/tracepoint/fieldtype.go
+++ b/pkg/tracepoint/fieldtype.go
@@ -118,7 +118,7 @@ func parseTy(tyFields []string) (interface{}, error) {
 		} else {
 			retTy = IntTy{Base: IntTyLong, Unsigned: unsigned}
 		}
-	case unsigned == true:
+	case unsigned:
 		// we are doing something wrong if we hit this because we are ignoring the unsigned qualifier
 		return nil, &ParseError{r: "unexpected unsigned"}
 	case ty == "u8":

--- a/pkg/tracepoint/tracepoint_test.go
+++ b/pkg/tracepoint/tracepoint_test.go
@@ -48,44 +48,44 @@ func TestTracepointLoadFormat(t *testing.T) {
 	}
 
 	fields := []FieldFormat{
-		FieldFormat{
+		{
 			FieldStr: "unsigned short common_type",
 			Offset:   0,
 			Size:     2,
 			IsSigned: false,
 		},
-		FieldFormat{
+		{
 			FieldStr: "unsigned char common_flags",
 			Offset:   2,
 			Size:     1,
 			IsSigned: false,
 		},
-		FieldFormat{
+		{
 			FieldStr: "unsigned char common_preempt_count",
 			Offset:   3,
 			Size:     1,
 			IsSigned: false,
 		},
-		FieldFormat{
+		{
 			FieldStr: "int common_pid",
 			Offset:   4,
 			Size:     4,
 			IsSigned: true,
 		},
-		FieldFormat{
+		{
 			FieldStr: "pid_t pid",
 			Offset:   8,
 			Size:     4,
 			IsSigned: true,
 		},
 		commField,
-		FieldFormat{
+		{
 			FieldStr: "unsigned long clone_flags",
 			Offset:   32,
 			Size:     8,
 			IsSigned: false,
 		},
-		FieldFormat{
+		{
 			FieldStr: "short oom_score_adj",
 			Offset:   40,
 			Size:     2,

--- a/pkg/vtuple/vtuple.go
+++ b/pkg/vtuple/vtuple.go
@@ -93,11 +93,11 @@ func CreateUDPv4(saddr [4]byte, sport uint16, daddr [4]byte, dport uint16) Impl 
 
 }
 
-type ErrorUnknownV4Protocol struct {
+type UnknownV4ProtocolError struct {
 	proto byte
 }
 
-func (e *ErrorUnknownV4Protocol) Error() string {
+func (e *UnknownV4ProtocolError) Error() string {
 	return fmt.Sprintf("unsupported protocol: %d", e.proto)
 }
 
@@ -106,7 +106,7 @@ func CreateVTupleV4(proto byte, saddr [4]byte, sport uint16, daddr [4]byte, dpor
 	switch proto {
 	case VT_TCP, VT_UDP:
 	default:
-		return Impl{}, &ErrorUnknownV4Protocol{proto: proto}
+		return Impl{}, &UnknownV4ProtocolError{proto: proto}
 	}
 
 	return Impl{

--- a/pkg/vtuplefilter/vtuplefilter.go
+++ b/pkg/vtuplefilter/vtuplefilter.go
@@ -107,7 +107,7 @@ type And struct {
 
 func (op *And) FilterFn(t vtuple.VTuple) bool {
 	for _, f := range op.fs {
-		if f.FilterFn(t) == false {
+		if !f.FilterFn(t) {
 			return false
 		}
 	} // NB: for 0 filters, AND returns true
@@ -124,7 +124,7 @@ type Or struct {
 
 func (op *Or) FilterFn(t vtuple.VTuple) bool {
 	for _, f := range op.fs {
-		if f.FilterFn(t) == true {
+		if f.FilterFn(t) {
 			return true
 		}
 	}

--- a/tests/e2e/helpers/dumpinfo.go
+++ b/tests/e2e/helpers/dumpinfo.go
@@ -368,12 +368,12 @@ func dumpBpftool(ctx context.Context, client klient.Client, exportDir, podNamesp
 func runBpftool(ctx context.Context, client klient.Client, exportDir, fname, podNamespace, podName, containerName string, args ...string) error {
 	out, err := RunCommand(ctx, client, podNamespace, podName, containerName, "bpftool", args...)
 	if err != nil {
-		klog.ErrorS(err, "failed to run bpftool")
+		return fmt.Errorf("failed to run bpftool: %w", err)
 	}
 
 	fname = filepath.Join(exportDir, fname)
 	if err := os.WriteFile(fname, out, os.FileMode(0o644)); err != nil {
-		klog.ErrorS(err, "failed to write to bpftool output file", "file", fname)
+		return fmt.Errorf("failed to write to bpftool output file %s: %w", fname, err)
 	}
 
 	return nil

--- a/tests/e2e/helpers/dumpinfo.go
+++ b/tests/e2e/helpers/dumpinfo.go
@@ -215,17 +215,17 @@ func dumpCheckers(ctx context.Context, exportDir string) {
 
 			yamlStr, err := checker.CheckerYaml()
 			if err != nil {
-				klog.ErrorS(err, "failed to dump checker yaml for %s", name)
+				klog.ErrorS(err, "failed to dump checker yaml", "name", name)
 			}
 
 			fname := filepath.Join(exportDir, fmt.Sprintf("%s.eventchecker.yaml", name))
 			if err := os.WriteFile(fname, []byte(yamlStr), os.FileMode(0o644)); err != nil {
-				klog.ErrorS(err, "failed to write checker yaml to file %s", fname, err)
+				klog.ErrorS(err, "failed to write checker yaml to file", "file", fname)
 			}
 
 			fname = filepath.Join(exportDir, fmt.Sprintf("%s.eventchecker.log", name))
 			if err := os.WriteFile(fname, checker.Logs(), os.FileMode(0o644)); err != nil {
-				klog.ErrorS(err, "failed to write checker logs to file %s", fname)
+				klog.ErrorS(err, "failed to write checker logs to file", "file", fname)
 			}
 		}
 		return

--- a/tests/e2e/helpers/dumpinfo.go
+++ b/tests/e2e/helpers/dumpinfo.go
@@ -289,7 +289,7 @@ func StartMetricsDumper(ctx context.Context, exportDir string, interval time.Dur
 	}()
 }
 
-// dumpGops dumps the gops heap and and memstats
+// dumpGops dumps the gops heap and memstats
 func dumpGops(port int, podName string, exportDir string) {
 	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", port))
 	if err != nil {

--- a/tests/e2e/helpers/portforward.go
+++ b/tests/e2e/helpers/portforward.go
@@ -154,7 +154,7 @@ func PortForwardPod(testenv env.Environment, pod *corev1.Pod, out, outErr *os.Fi
 
 		go func() {
 			if err := pfwd.ForwardPorts(); err != nil {
-				klog.ErrorS(fmt.Errorf("error during portforward: %w", err),
+				klog.ErrorS(err, "error during portforward",
 					"pod", pod.Name,
 					"namespace", pod.Namespace,
 					"ports", ports)

--- a/tests/e2e/install/tetragon/tetragon.go
+++ b/tests/e2e/install/tetragon/tetragon.go
@@ -60,8 +60,8 @@ func WithValuesFile(file string) Option {
 	return func(o *flags.HelmOptions) { o.ValuesFile = file }
 }
 
-func WithBTF(BTF string) Option {
-	return func(o *flags.HelmOptions) { o.BTF = BTF }
+func WithBTF(btf string) Option {
+	return func(o *flags.HelmOptions) { o.BTF = btf }
 }
 
 func WithHelmOptions(options map[string]string) Option {

--- a/tests/e2e/runners/runners.go
+++ b/tests/e2e/runners/runners.go
@@ -62,11 +62,9 @@ var DefaultRunner = Runner{
 	installTetragon: tetragon.Install(tetragon.WithHelmOptions(map[string]string{
 		"tetragon.exportAllowList": "",
 	})),
-	tetragonPortForward: func(testenv env.Environment) env.Func {
-		return helpers.PortForwardTetragonPods(testenv)
-	},
-	hasCalledInit:   false,
-	keepExportFiles: false,
+	tetragonPortForward: helpers.PortForwardTetragonPods,
+	hasCalledInit:       false,
+	keepExportFiles:     false,
 }
 
 func NewRunner() *Runner {
@@ -206,6 +204,7 @@ func (r *Runner) Run(m *testing.M) {
 		klog.Fatal("runner.Init() must be called")
 	}
 	defer r.cancelContext()
+	// nolint:gocritic // log.Fatal will exit without running defer but it's okay for ctx cancel
 	os.Exit(r.Environment.Run(m))
 }
 

--- a/tests/e2e/tests/skeleton/skeleton_test.go
+++ b/tests/e2e/tests/skeleton/skeleton_test.go
@@ -127,7 +127,7 @@ func TestSkeletonBasic(t *testing.T) {
 	runner.TestInParallel(t, runEventChecker, runWorkload)
 }
 
-// nolint:revive // ignore unused parameter because of comments
+// nolint:revive,unparam // ignore unused parameter because of comments
 func curlEventChecker(kernelVersion string) *checker.RPCChecker {
 	curlEventChecker := ec.NewUnorderedEventChecker(
 		// Checkers should be given a unique name. This shows up in the logs and can be


### PR DESCRIPTION
This is a follow-up of https://github.com/cilium/tetragon/pull/976 to enable new linters to increase the code quality, remove bugs and improve readability in a sustainable way.

Add the following linters and fix their alerts:
- **gosimple**: Linter for Go source code that specializes in simplifying code
- **typecheck**: Like the front-end of a Go compiler, parses and type-checks Go code
- **asciicheck**: Simple linter to check that your code does not contain non-ASCII identifiers
- **bidichk**: Checks for dangerous unicode character sequences
- **makezero**: Finds slice declarations with non-zero initial length **(found bugs)**
- **loggercheck**: Checks key value pairs for common logger libraries (kitlog,klog,logr,zap). **(found bugs)**
- **exportloopref**: Checks for pointers to enclosing loop variables. **(found bugs)**
- **dupword**: Checks for duplicate words in the source code
- **gofmt**: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification.
- **errname**: Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
- **gocritic**: Provides diagnostics that check for bugs, performance and style issues. Extensible without recompilation through dynamic rules. Dynamic rules are written declaratively with AST patterns, filters, report message and optional suggestion.
- **unparam**: Reports unused function parameters

I would love to enable these ones about errors, but those will be a followup cleanup PR since this is a lot of work:
- errcheck (this one is particularly important)
- nilnil
- nilerr
- errorlint

We still don't catch situations where we use the return value _before_ checking the error.

Added this issue for follow-up https://github.com/cilium/tetragon/issues/989.

Just for info the pattern used here, that defaults to error and rely on the function to return nil and override is a bit weird and led to an issue while removing useless "always nil" return value from functions:
https://github.com/cilium/tetragon/blob/557a6c93b1f71aed0af6da3c94323867426b2e97/pkg/sensors/manager.go#L60