### PR TITLE
tetragon: Use execve_map_get_noinit cgroup related code

### DIFF
--- a/bpf/cgroup/bpf_cgroup_events.h
+++ b/bpf/cgroup/bpf_cgroup_events.h
@@ -32,7 +32,7 @@ send_cgrp_event(struct bpf_raw_tracepoint_args *ctx,
 	path = (char *)ctx->args[1];
 	pid = (get_current_pid_tgid() >> 32);
 
-	curr = execve_map_get(pid);
+	curr = execve_map_get_noinit(pid);
 	if (curr) {
 		msg->common.ktime = curr->key.ktime;
 		msg->parent = curr->pkey;

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -227,7 +227,7 @@ execve_send(struct sched_execve_args *ctx)
 
 	pid = (get_current_pid_tgid() >> 32);
 
-	curr = execve_map_get(pid);
+	curr = execve_map_get_noinit(pid);
 	if (curr) {
 		event->cleanup_key = curr->key;
 #if defined(__NS_CHANGES_FILTER) || defined(__CAP_CHANGES_FILTER)

--- a/bpf/process/bpf_fork.c
+++ b/bpf/process/bpf_fork.c
@@ -46,7 +46,7 @@ BPF_KPROBE(event_wake_up_new_task, struct task_struct *task)
 		probe_read(&ppid, sizeof(ppid), _(&current_task->tgid));
 		/* If they share same thread group nothing todo... */
 		if (tgid != ppid) {
-			parent = execve_map_get(ppid);
+			parent = execve_map_get_noinit(ppid);
 			if (parent)
 				__set_task_cgrpid_tracker(config, current_task,
 							  parent, &error_flags);

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -606,7 +606,7 @@ __event_get_cgroup_info(struct task_struct *task,
 	memset(&msg->kube, 0, sizeof(struct msg_k8s));
 
 	pid = (get_current_pid_tgid() >> 32);
-	execve_val = execve_map_get(pid);
+	execve_val = execve_map_get_noinit(pid);
 	/* Even if execve_val is null we must continue collect information */
 
 	/* Check if cgroup configuration is set */

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -126,7 +126,7 @@ func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []S
 		SensorMap{Name: "tcpmon_map", Progs: []uint{0, 1, 2, 3}},
 
 		// all but event_execve
-		SensorMap{Name: "execve_map_stats", Progs: []uint{0, 1, 2, 3}},
+		SensorMap{Name: "execve_map_stats", Progs: []uint{1, 2}},
 
 		// event_execve
 		SensorMap{Name: "names_map", Progs: []uint{0}},


### PR DESCRIPTION
 hunt for execve_map leak showed few places that use 
execve_map_get instead of execve_map_get_noinit.

Even though it did not turn out to be the source of the leak,
we should use execve_map_get_noinit calls.

The execve_map_get is used only by fork sensor to create the 
stat record.
