### PR TITLE
logcapture: use T.Log instead of T.Logf

### DIFF
--- a/pkg/testutils/logcapture.go
+++ b/pkg/testutils/logcapture.go
@@ -5,6 +5,7 @@ package testutils
 
 import (
 	"io"
+	"strings"
 	"testing"
 
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
@@ -18,8 +19,11 @@ type LogCapturer struct {
 }
 
 func (tl LogCapturer) Write(p []byte) (n int, err error) {
-	tl.Logf((string)(p))
-	return len(p), nil
+	// Since we are calling T.Log() here, we want to avoid appending multiple "\n", so
+	// trim whatever was added by the inner logger.
+	s := strings.TrimRight(string(p), "\n")
+	tl.T.Log(s)
+	return len(s), nil
 }
 
 // CaptureLog redirects logrus output to testing.Log


### PR DESCRIPTION
The inner logrus logger is already taking care of formating, meaning that when we have an actual % character inside the resulting string,
we end up with potential formatting issues by attempting to use that string as a format string once again. This was causing some strange bugs in tests, such as the following:

    logcapture.go:23: time="2023-05-11T10:57:30-04:00" level=info msg="BPF events statistics: 72 received, 0%!e(MISSING)vents loss"

To fix this, we can use the plain T.Log() function instead of T.Logf() when writing to the LogCapturer.