### PR TITLE
docs: add a "install tetra CLI" guide to getting started

### DIFF
--- a/docs/content/en/docs/getting-started/configuration.md
+++ b/docs/content/en/docs/getting-started/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-weight: 5
+weight: 6
 description: "Tetragon configuration files and options"
 ---
 

--- a/docs/content/en/docs/getting-started/install-tetra-cli.md
+++ b/docs/content/en/docs/getting-started/install-tetra-cli.md
@@ -1,0 +1,107 @@
+---
+title: "Install tetra CLI"
+weight: 5
+description: "To interact with Tetragon, install the Tetragon client CLI tetra"
+---
+
+This guide presents various methods to install `tetra` in your environment.
+
+## Install the latest release
+
+### Autodetect your environment
+
+This shell script autodetects the OS and the architecture, downloads the
+archive of the binary and its SHA 256 digest, compares that the actual digest
+with the supposed one, installs the binary, and removes the download artifacts.
+
+{{< note >}}
+This installation method requires a working Go toolchain, `curl(1)`, and the
+`sha256sum(1)` utilities. For Go, see how to [install the latest Go release](https://go.dev/doc/install)
+and for the curl and checksum utility, it is usually distributed in common
+Linux distribution but you can usually find them respectively under the package
+`curl` and `coreutils`.
+{{< /note >}}
+
+```shell
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+curl -L --remote-name-all https://github.com/cilium/tetragon/releases/latest/download/tetra-${GOOS}-${GOARCH}.tar.gz{,.sha256sum}
+sha256sum --check tetra-${GOOS}-${GOARCH}.tar.gz.sha256sum
+sudo tar -C /usr/local/bin -xzvf tetra-${GOOS}-${GOARCH}.tar.gz
+rm tetra-${GOOS}-${GOARCH}.tar.gz{,.sha256sum}
+```
+
+### Quick install for each environment
+
+This installation method retrieves the adapted archived for your environment,
+extract it and install it in the `/usr/local/bin` directory.
+
+{{< note >}}
+This installation method requires only `curl(1)` that should be already
+installed in your environment, otherwise you can usually find it under the
+`curl` package.
+{{< /note >}}
+
+{{< note >}}
+The architecture amd64 is also referred to as x86_64 or Intel, and arm64 is also
+referred to as aarch64 or Apple Silicon for Mac computers.
+{{< /note >}}
+
+{{< tabpane persistLang=false >}}
+
+{{< tab header="Linux amd64" lang="shell" >}}
+curl -LO https://github.com/cilium/tetragon/releases/latest/download/tetra-linux-amd64.tar.gz | tar -xz
+mv tetra /usr/local/bin
+{{< /tab >}}
+
+{{< tab header="Linux arm64" lang="shell" >}}
+curl -LO https://github.com/cilium/tetragon/releases/latest/download/tetra-linux-arm64.tar.gz | tar -xz
+mv tetra /usr/local/bin
+{{< /tab >}}
+
+{{< tab header="macOS amd64" lang="shell" >}}
+curl -LO https://github.com/cilium/tetragon/releases/latest/download/tetra-darwin-amd64.tar.gz | tar -xz
+mv tetra /usr/local/bin
+{{< /tab >}}
+
+{{< tab header="macOS arm64" lang="shell" >}}
+curl -LO https://github.com/cilium/tetragon/releases/latest/download/tetra-darwin-arm64.tar.gz | tar -xz
+mv tetra /usr/local/bin
+{{< /tab >}}
+
+{{< tab header="Windows amd64" lang="shell" >}}
+curl -LO https://github.com/cilium/tetragon/releases/latest/download/tetra-windows-amd64.tar.gz | tar -xz
+mv tetra /usr/local/bin
+{{< /tab >}}
+
+{{< tab header="Windows arm64" lang="shell" >}}
+curl -LO https://github.com/cilium/tetragon/releases/latest/download/tetra-windows-arm64.tar.gz | tar -xz
+mv tetra /usr/local/bin
+{{< /tab >}}
+{{< /tabpane >}}
+
+### Install using homebrew
+
+[Homebrew](https://brew.sh/) is a package manager for macOS and Linux.
+[A formulae is available](https://formulae.brew.sh/formula/tetra#default) to
+fetch precompiled binaries. You can also use it to build from sources (using the
+`--build-from-source` flag) with a Go dependency.
+
+```shell
+brew install tetra
+```
+
+## Install a specific release
+
+You can retrieve the release of `tetra` along the release of Tetragon on GitHub
+at the following URL: https://github.com/cilium/tetragon/releases.
+
+To download a specific release you can use the following script, replacing the
+`OS`, `ARCH` and `TAG` values with your desired options.
+
+```shell
+OS=linux
+ARCH=amd64
+TAG=v0.9.0
+curl -LO https://github.com/cilium/tetragon/releases/download/${TAG}/tetra-${OS}-${ARCH}.tar.gz | tar -xz
+```


### PR DESCRIPTION
I know the guide is overlapping with the existing https://tetragon.cilium.io/docs/getting-started/explore-security-observability-events/ page, but this will be revamped (and the part about tetra CLI will be removed).

[Preview here](https://deploy-preview-991--tetragon.netlify.app/docs/getting-started/install-tetra-cli/)