### PR TITLE
tetragon: load tracingpolicies from directory

### DIFF
--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -1,0 +1,72 @@
+name: Packages e2e Tests
+
+on:
+  pull_request:
+    paths-ignore:
+    - "**.md"
+
+jobs:
+  standalone-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            arch: amd64
+
+    steps:
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@2a1a44ac4aa01993040736bd95bb470da1a38365 # v2.8.0
+
+      - name: Checkout Source Code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          submodules: true
+
+      - name: Getting version tag
+        id: tag
+        run: echo "tag=$(make version)" >> $GITHUB_OUTPUT
+
+      - name: Generate Tetragon Tarball
+        id: tetragon-tarball
+        run: make tarball
+
+      - name: Copy bpf.yaml tracing policy to /etc/tetragon/tetragon.tp.d/
+        run: |
+          sudo mkdir -p /etc/tetragon/tetragon.tp.d/
+          sudo cp examples/tracingpolicy/bpf.yaml /etc/tetragon/tetragon.tp.d/bpf.yaml
+
+      - name: Install Tetragon Tarball
+        run: |
+          tar zxvf tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz
+          sudo ./tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}/install.sh
+        working-directory: ./build/${{ matrix.arch }}/linux-tarball/
+
+      - name: Wait for Tetragon service
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 30
+          max_attempts: 5
+          retry_wait_seconds: 5
+          retry_on: error
+          command: |
+            sudo systemctl is-active tetragon
+            sudo tetra status
+
+      - name: Check Tetragon startup logs
+        run: sudo journalctl -b -u tetragon --no-pager
+
+      - name: Test Tetragon
+        run: |
+          sudo tetra status
+          sudo grep "tetra" /var/log/tetragon/tetragon.log
+          sudo tetra tracingpolicy list | grep bpf -
+          sudo tetra bugtool
+
+      - name: Uninstall Tetragon Tarball
+        run: |
+          sudo ./tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}/uninstall.sh
+        working-directory: ./build/${{ matrix.arch }}/linux-tarball/

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,8 @@ RUN curl -L https://github.com/libbpf/bpftool/releases/download/${BPFTOOL_TAG}/b
 FROM docker.io/library/alpine:3.18.2@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1 as base-build
 RUN apk add iproute2
 RUN mkdir /var/lib/tetragon/ && \
+    mkdir -p /etc/tetragon/tetragon.conf.d/ && \
+    mkdir -p /etc/tetragon/tetragon.tp.d/ && \
     apk add --no-cache --update bash
 COPY --from=tetragon-builder /go/src/github.com/cilium/tetragon/tetragon /usr/bin/
 COPY --from=tetragon-builder /go/src/github.com/cilium/tetragon/tetra /usr/bin/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -29,6 +29,8 @@ RUN apt-get update -y &&    \
 	strace              \
 	jq                  \
 	less
+RUN mkdir -p /etc/tetragon/tetragon.conf.d/ && \
+    mkdir -p /etc/tetragon/tetragon.tp.d/
 COPY --from=bpf-builder /go/src/github.com/cilium/tetragon/bpf/objs/*.o /var/lib/tetragon/
 COPY --from=bpftool  /bin/bpftool /usr/bin/
 WORKDIR /go/src/github.com/cilium/tetragon

--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -39,6 +39,7 @@ const (
 	keyEnableProcessNs   = "enable-process-ns"
 	keyConfigFile        = "config-file"
 	keyTracingPolicy     = "tracing-policy"
+	keyTracingPolicyDir  = "tracing-policy-dir"
 
 	keyCpuProfile = "cpuprofile"
 	keyMemProfile = "memprofile"
@@ -136,6 +137,8 @@ func readAndSetFlags() {
 	option.Config.EnableMsgHandlingLatency = viper.GetBool(keyEnableMsgHandlingLatency)
 
 	option.Config.EnablePidSetFilter = viper.GetBool(keyEnablePidSetFilter)
+
+	option.Config.TracingPolicyDir = viper.GetString(keyTracingPolicyDir)
 
 	// deprecation timeline: deprecated -> 0.10.0, removed -> 0.11.0
 	// manually handle the deprecation of --config-file

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -654,7 +654,7 @@ func startGopsServer() error {
 func execute() error {
 	rootCmd := &cobra.Command{
 		Use:   "tetragon",
-		Short: "Run the tetragon agent",
+		Short: "Tetragon - eBPF-based Security Observability and Runtime Enforcement",
 		Run: func(cmd *cobra.Command, args []string) {
 			readAndSetFlags()
 

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
 	pprofhttp "net/http/pprof"
@@ -13,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -132,6 +134,11 @@ func tetragonExecute() error {
 	if err := logger.SetupLogging(option.Config.LogOpts, option.Config.Debug); err != nil {
 		log.Fatal(err)
 	}
+
+	if filepath.IsAbs(option.Config.TracingPolicyDir) == false {
+		log.Fatalf("Failed path specified by --tracing-policy-dir '%q' is not absolute", option.Config.TracingPolicyDir)
+	}
+	option.Config.TracingPolicyDir = filepath.Clean(option.Config.TracingPolicyDir)
 
 	if option.Config.RBSize != 0 && option.Config.RBSizeTotal != 0 {
 		log.Fatalf("Can't specify --rb-size and --rb-size-total together")
@@ -278,8 +285,7 @@ func tetragonExecute() error {
 	obs.RemovePrograms()
 	os.Mkdir(defaults.DefaultRunDir, os.ModeDir)
 
-	err := btf.InitCachedBTF(option.Config.HubbleLib, option.Config.BTF)
-	if err != nil {
+	if err := btf.InitCachedBTF(option.Config.HubbleLib, option.Config.BTF); err != nil {
 		return err
 	}
 
@@ -361,14 +367,14 @@ func tetragonExecute() error {
 	sensorMgWait = nil
 	observer.SensorManager.LogSensorsAndProbes(ctx)
 
+	err = loadTpFromDir(ctx, option.Config.TracingPolicyDir)
+	if err != nil {
+		return err
+	}
+
 	// load sensor from tracing policy file
 	if len(option.Config.TracingPolicy) > 0 {
-		tp, err := tracingpolicy.PolicyFromYAMLFilename(option.Config.TracingPolicy)
-		if err != nil {
-			return err
-		}
-
-		err = observer.SensorManager.AddTracingPolicy(ctx, tp)
+		err = addTracingPolicy(ctx, option.Config.TracingPolicy)
 		if err != nil {
 			return err
 		}
@@ -380,6 +386,77 @@ func tetragonExecute() error {
 	}
 
 	return obs.Start(ctx)
+}
+
+func loadTpFromDir(ctx context.Context, dir string) error {
+	tpMaxDepth := 1
+	tpFS := os.DirFS(dir)
+
+	if dir == defaults.DefaultTpDir {
+		// If the default directory does not exist then do not fail
+		// Probably tetragon not fully installed, developers testing, etc
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			log.WithField("tracing-policy-dir", dir).Info("Loading Tracing Policies from directory ignored, directory does not exist")
+			return nil
+		}
+	}
+
+	err := fs.WalkDir(tpFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if strings.Count(path, string(os.PathSeparator)) >= tpMaxDepth {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		file := filepath.Join(dir, path)
+		st, err := os.Stat(file)
+		if err != nil {
+			return err
+		}
+
+		if st.Mode().IsRegular() == false {
+			return nil
+		}
+
+		return addTracingPolicy(ctx, file)
+	})
+
+	return err
+}
+
+func addTracingPolicy(ctx context.Context, file string) error {
+	f, err := filepath.Abs(filepath.Clean(file))
+	if err != nil {
+		return err
+	}
+
+	tp, err := tracingpolicy.PolicyFromYAMLFilename(f)
+	if err != nil {
+		return err
+	}
+
+	err = observer.SensorManager.AddTracingPolicy(ctx, tp)
+	if err != nil {
+		return err
+	}
+
+	namespace := ""
+	if tpNs, ok := tp.(tracingpolicy.TracingPolicyNamespaced); ok {
+		namespace = tpNs.TpNamespace()
+	}
+
+	logger.GetLogger().WithFields(logrus.Fields{
+		"TracingPolicy":      file,
+		"metadata.namespace": namespace,
+		"metadata.name":      tp.TpName(),
+	}).Info("Added TracingPolicy with success")
+
+	return nil
 }
 
 // Periodically log current status every 24 hours. For lost or error
@@ -635,6 +712,8 @@ func execute() error {
 	// deprecation timeline: deprecated -> 0.10.0, removed -> 0.11.0
 	flags.String(keyConfigFile, "", "Configuration file to load from")
 	flags.MarkHidden(keyConfigFile)
+
+	flags.String(keyTracingPolicyDir, defaults.DefaultTpDir, "Directory from where to load Tracing Policies")
 
 	// Options for debugging/development, not visible to users
 	flags.String(keyCpuProfile, "", "Store CPU profile into provided file")

--- a/docs/content/en/docs/getting-started/deployment/container.md
+++ b/docs/content/en/docs/getting-started/deployment/container.md
@@ -36,10 +36,58 @@ docker run --name tetragon --rm -d                  \
 ```
 
 {{< note >}}
-If Tetragon does not to start due to BTF issues, please refer to the
+If Tetragon does not start due to BTF issues, please refer to the
 [corresponding question in the FAQ]({{< ref "/docs/faq/#tetragon-failed-to-start-complaining-about-a-missing-btf-file" >}})
 for details and solutions.
 {{< /note >}}
+
+## Configuration
+
+There are multiple ways to set configuration options:
+
+1. Append Tetragon controlling settings at the end of the command
+
+    As an example set the file where to export JSON events with `--export-filename` argument:
+    ```shell
+    docker run --name tetragon --rm -d \
+        --pid=host --cgroupns=host --privileged \
+        -v /sys/kernel:/sys/kernel \
+        quay.io/cilium/tetragon:{{< latest-version >}} \
+        /usr/bin/tetragon --export-filename /var/log/tetragon/tetragon.log
+    ```
+
+    For a complete list of CLI arguments, please check [Tetragon daemon configuration](/docs/reference/tetragon-configuration).
+
+
+2. Environment variables
+
+    ```shell
+    docker run --name tetragon --rm -d \
+        --pid=host --cgroupns=host --privileged \
+        --env "TETRAGON_EXPORT_FILENAME=/var/log/tetragon/tetragon.log" \
+        -v /sys/kernel:/sys/kernel \
+        quay.io/cilium/tetragon:{{< latest-version >}}
+    ```
+
+    Every controlling setting can be set using environment variables. Prefix it with the key word `TETRAGON_` then upper case the controlling setting. As an example to set where to export JSON events: `--export-filename` will be `TETRAGON_EXPORT_FILENAME`.
+
+    For a complete list of all controlling settings, please check [tetragon daemon configuration](/docs/reference/tetragon-configuration).
+
+3. Configuration files mounted as volumes
+
+    On the host machine set the configuration drop-ins inside `/etc/tetragon/tetragon.conf.d/` directory according to the [configuration examples](/docs/reference/tetragon-configuration/#configuration-examples), then mount it as volume:
+
+    ```shell
+    docker run --name tetragon --rm -d \
+        --pid=host --cgroupns=host --privileged \
+        -v /sys/kernel:/sys/kernel \
+        -v /etc/tetragon/tetragon.conf.d/:/etc/tetragon/tetragon.conf.d/ \
+        quay.io/cilium/tetragon:{{< latest-version >}}
+    ```
+
+    This will map the `/etc/tetragon/tetragon.conf.d/` drop-in directory from the host into the container.
+
+See [Tetragon daemon configuration](/docs/reference/tetragon-configuration) reference for further details.
 
 ## What's next
 

--- a/docs/content/en/docs/getting-started/deployment/package.md
+++ b/docs/content/en/docs/getting-started/deployment/package.md
@@ -70,70 +70,9 @@ installed in `/usr/local/lib/tetragon/tetragon.conf.d/`. Local administrators
 can change the configuration by adding drop-ins inside
 `/etc/tetragon/tetragon.conf.d/` to override the default settings or use the
 command line flags. To restore default settings, remove any added configuration
-inside `/etc/tetragon/`. See the following section for details about the
-configuration precedence.
+inside `/etc/tetragon/tetragon.conf.d/`.
 
-### Configuration precedence
-
-The default controlling settings are set during compilation, so configuration
-is only needed when it is necessary to deviate from those defaults. In this
-case, Tetragon can load its controlling settings that are in [YAML format](https://yaml.org/)
-according to this order:
-
-1. From the drop-in configuration snippets inside the following directories
-   where each filename maps to one controlling setting and the content of the
-   file to its corresponding value:
-
-   - `/usr/lib/tetragon/tetragon.conf.d/*`
-   - `/usr/local/lib/tetragon/tetragon.conf.d/*`
-
-2. From the configuration file `/etc/tetragon/tetragon.yaml` if available,
-   overriding previous settings.
-
-3. From the drop-in configuration snippets inside
-   `/etc/tetragon/tetragon.conf.d/*`, similarly overriding previous settings.
-
-4. If the `config-dir` setting is set, Tetragon loads its settings from the
-   files inside the directory pointed by this option, overriding previous
-   controlling settings. The `config-dir` is also part of [Kubernetes
-   ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/).
-
-When reading configuration from directories, each filename maps to one
-controlling setting. If the same controlling setting is set multiple times,
-then the last value or content of that file overrides the previous ones.
-
-To summarize the configuration precedence:
-
-1. Drop-in directory pointed by `--config-dir`.
-
-2. Drop-in directory `/etc/tetragon/tetragon.conf.d/*`.
-
-3. Configuration file `/etc/tetragon/tetragon.yaml`.
-
-4. Drop-in directories:
-
-   - `/usr/local/lib/tetragon/tetragon.conf.d/*`
-   - `/usr/lib/tetragon/tetragon.conf.d/*`
-
-
-To clear a controlling setting that was set before, set it again to an empty
-value.
-
-Package managers can customize the configuration by installing drop-ins under
-`/usr/`. Configurations in `/etc/tetragon/` are strictly reserved for the local
-administrator, who may use this logic to override package managers or the
-default installed configuration.
-
-### Example file and directory
-
-The [examples/configuration/tetragon.yaml](https://github.com/cilium/tetragon/blob/main/examples/configuration/tetragon.yaml)
-file contains example entries showing the defaults as a guide to the
-administrator. Local overrides can be created by editing and copying this file
-into `/etc/tetragon/tetragon.yaml`, or by editing and copying "drop-ins" from
-the [examples/configuration/tetragon.conf.d](https://github.com/cilium/tetragon/tree/main/examples/configuration/tetragon.conf.d)
-directory into the `/etc/tetragon/tetragon.conf.d/` subdirectory. The latter is
-generally recommended. Defaults can be restored by simply deleting this file
-and all drop-ins.
+See [Tetragon daemon configuration](/docs/reference/tetragon-configuration) for further details.
 
 ## Upgrade
 

--- a/docs/content/en/docs/getting-started/deployment/package.md
+++ b/docs/content/en/docs/getting-started/deployment/package.md
@@ -135,41 +135,19 @@ sudo rm -fr /etc/tetragon/
 
 ## Operating
 
-### Restrict gRPC API access
-
-The gRPC API supports unix sockets, it can be set using one of the following methods:
-
-- Use the `--server-address` flag:
-
-   ```
-   --server-address unix:///var/run/tetragon/tetragon.sock
-   ```
-
-- Or use the drop-in configuration file `/etc/tetragon/tetragon.conf.d/server-address` containing:
-
-   ```
-   unix:///var/run/tetragon/tetragon.sock
-   ```
+### gRPC API access
 
 {{< note >}}
-Tetragon tarball by default listens to  `unix:///var/run/tetragon/tetragon.sock`
+Tetragon tarball by default listens on `unix:///var/run/tetragon/tetragon.sock`
 {{< /note >}}
 
-Then to access the gRPC API with `tetra` client, set `--server-address` to point to the corresponding address:
+To access the gRPC API with `tetra` client, set `--server-address` to point to the corresponding address:
 
    ```
    sudo tetra --server-address unix:///var/run/tetragon/tetragon.sock getevents
    ```
 
-{{< note >}}
-When reading events with the `tetra` client, if `--server-address` is not specified,
-it will try to detect if Tetragon daemon is running on the same host and use its
-`server-address` configuration.
-{{< /note >}}
-
-{{< caution >}}
-Ensure that you have enough privileges to open the gRPC unix socket since it is restricted to privileged users only.
-{{< /caution >}}
+See [restrict gRPC API access](/docs/reference/tetragon-configuration/#restrict-grpc-api-access) for further details.
 
 ### Tetragon Events
 

--- a/docs/content/en/docs/reference/tetragon-configuration.md
+++ b/docs/content/en/docs/reference/tetragon-configuration.md
@@ -1,0 +1,157 @@
+---
+title: "Tetragon Daemon Configuration"
+linkTitle: "Tetragon Daemon Configuration"
+description: "Configure Tetragon daemon"
+---
+
+Tetragon default controlling settings are set during compilation, so configuration
+is only needed when it is necessary to deviate from those defaults. This
+document lists those controlling settings and how they can be set
+as a CLI arguments or as configuration options from [YAML](https://yaml.org) files.
+
+## Tetragon Controlling Settings
+
+Tetragon CLI arguments:
+```text
+Tetragon - eBPF-based Security Observability and Runtime Enforcement
+
+Usage:
+  tetragon [flags]
+
+Flags:
+      --bpf-lib string                            Location of Tetragon libs (btf and bpf files) (default "/var/lib/tetragon/")
+      --btf string                                Location of btf
+      --cilium-bpf string                         Cilium BPF directory
+      --config-dir string                         Configuration directory that contains a file for each option
+      --data-cache-size int                       Size of the data events cache (default 1024)
+  -d, --debug                                     Enable debug messages. Equivalent to '--log-level=debug'
+      --disable-kprobe-multi                      Allow to disable kprobe multi interface
+      --enable-cilium-api                         Access Cilium API to associate Tetragon events with Cilium endpoints and DNS cache
+      --enable-export-aggregation                 Enable JSON export aggregation
+      --enable-k8s-api                            Access Kubernetes API to associate Tetragon events with Kubernetes pods
+      --enable-msg-handling-latency               Enable metrics for message handling latency
+      --enable-pid-set-filter                     Enable pidSet export filters. Not recommended for production use
+      --enable-policy-filter                      Enable policy filter code (beta)
+      --enable-policy-filter-debug                Enable policy filter debug messages
+      --enable-process-ancestors                  Include ancestors in process exec events (default true)
+      --enable-process-cred                       Enable process_cred events
+      --enable-process-ns                         Enable namespace information in process_exec and process_kprobe events
+      --event-queue-size uint                     Set the size of the internal event queue. (default 10000)
+      --export-aggregation-buffer-size uint       Aggregator channel buffer size (default 10000)
+      --export-aggregation-window-size duration   JSON export aggregation time window (default 15s)
+      --export-allowlist string                   JSON export allowlist
+      --export-denylist string                    JSON export denylist
+      --export-file-compress                      Compress rotated JSON export files
+      --export-file-max-backups int               Number of rotated JSON export files to retain (default 5)
+      --export-file-max-size-mb int               Size in MB for rotating JSON export files (default 10)
+      --export-file-rotation-interval duration    Interval at which to rotate JSON export files in addition to rotating them by size
+      --export-filename string                    Filename for JSON export. Disabled by default
+      --export-rate-limit int                     Rate limit (per minute) for event export. Set to -1 to disable (default -1)
+      --field-filters string                      Field filters for event exports
+      --force-large-progs                         Force loading large programs, even in kernels with < 5.3 versions
+      --force-small-progs                         Force loading small programs, even in kernels with >= 5.3 versions
+      --gops-address string                       gops server address (e.g. 'localhost:8118'). Disabled by default
+  -h, --help                                      help for tetragon
+      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
+      --kernel string                             Kernel version
+      --log-format string                         Set log format (default "text")
+      --log-level string                          Set log level (default "info")
+      --metrics-server string                     Metrics server address (e.g. ':2112'). Disabled by default
+      --netns-dir string                          Network namespace dir (default "/var/run/docker/netns/")
+      --process-cache-size int                    Size of the process cache (default 65536)
+      --procfs string                             Location of procfs to consume existing PIDs (default "/proc/")
+      --rb-size int                               Set perf ring buffer size for single cpu (default 65k)
+      --rb-size-total int                         Set perf ring buffer size in total for all cpus (default 65k per cpu)
+      --release-pinned-bpf                        Release all pinned BPF programs and maps in Tetragon BPF directory. Enabled by default. Set to false to disable (default true)
+      --server-address string                     gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock' (default "localhost:54321")
+      --tracing-policy string                     Tracing policy file to load at startup
+      --tracing-policy-dir string                 Directory from where to load Tracing Policies (default "/etc/tetragon/tetragon.tp.d/")
+      --verbose int                               set verbosity level for eBPF verifier dumps. Pass 0 for silent, 1 for truncated logs, 2 for a full dump
+```
+
+## Configuration precedence
+
+Tetragon controlling settings can also be loaded from [YAML](https://yaml.org/) configuration files according to this order:
+
+1. From the drop-in configuration snippets inside the following directories
+   where each filename maps to one controlling setting and the content of the
+   file to its corresponding value:
+
+   - `/usr/lib/tetragon/tetragon.conf.d/*`
+   - `/usr/local/lib/tetragon/tetragon.conf.d/*`
+
+2. From the configuration file `/etc/tetragon/tetragon.yaml` if available,
+   overriding previous settings.
+
+3. From the drop-in configuration snippets inside
+   `/etc/tetragon/tetragon.conf.d/*`, similarly overriding previous settings.
+
+4. If the `config-dir` setting is set, Tetragon loads its settings from the
+   files inside the directory pointed by this option, overriding previous
+   controlling settings. The `config-dir` is also part of [Kubernetes
+   ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/).
+
+When reading configuration from directories, each filename maps to one
+controlling setting. If the same controlling setting is set multiple times,
+then the last value or content of that file overrides the previous ones.
+
+To summarize the configuration precedence:
+
+1. Drop-in directory pointed by `--config-dir`.
+
+2. Drop-in directory `/etc/tetragon/tetragon.conf.d/*`.
+
+3. Configuration file `/etc/tetragon/tetragon.yaml`.
+
+4. Drop-in directories:
+
+   - `/usr/local/lib/tetragon/tetragon.conf.d/*`
+   - `/usr/lib/tetragon/tetragon.conf.d/*`
+
+{{< note >}}
+To clear a controlling setting that was set before, set it again to an empty
+value.
+
+Package managers can customize the configuration by installing drop-ins under
+`/usr/`. Configurations in `/etc/tetragon/` are strictly reserved for the local
+administrator, who may use this logic to override package managers or the
+default installed configuration.
+{{< /note >}}
+
+## Configuration examples
+
+The [examples/configuration/tetragon.yaml](https://github.com/cilium/tetragon/blob/main/examples/configuration/tetragon.yaml)
+file contains example entries showing the defaults as a guide to the
+administrator. Local overrides can be created by editing and copying this file
+into `/etc/tetragon/tetragon.yaml`, or by editing and copying "drop-ins" from
+the [examples/configuration/tetragon.conf.d](https://github.com/cilium/tetragon/tree/main/examples/configuration/tetragon.conf.d)
+directory into the `/etc/tetragon/tetragon.conf.d/` subdirectory. The latter is
+generally recommended.
+
+Each filename maps to a one controlling setting and the content of the file to
+its corresponding value. This is the recommended way.
+
+Changing configuration example:
+
+* `/etc/tetragon/tetragon.conf.d/bpf-lib` with a corresponding value of:
+
+   ```
+   /var/lib/tetragon/
+   ```
+
+* `/etc/tetragon/tetragon.conf.d/log-format` with a corresponding value of:
+
+   ```
+   text
+   ```
+
+* `/etc/tetragon/tetragon.conf.d/export-filename` with a corresponding value of:
+
+   ```
+   /var/log/tetragon/tetragon.log
+   ```
+
+{{< note >}}
+Defaults controlling settings can be restored by simply deleting `/etc/tetragon/tetragon.yaml`
+and all drop-ins under `/etc/tetragon/tetragon.conf.d/`
+{{< /note >}}

--- a/docs/content/en/docs/reference/tetragon-configuration.md
+++ b/docs/content/en/docs/reference/tetragon-configuration.md
@@ -187,3 +187,11 @@ it will try to detect if Tetragon daemon is running on the same host and use its
 {{< caution >}}
 Ensure that you have enough privileges to open the gRPC unix socket since it is restricted to privileged users only.
 {{< /caution >}}
+
+## Configure Tracing Policies location
+
+Tetragon daemon automatically loads [Tracing policies](/docs/concepts/tracing-policy) from the default `/etc/tetragon/tetragon.tp.d/` directory. Tracing policies can be organized in directories such: `/etc/tetragon/tetragon.tp.d/file-access`, `/etc/tetragon/tetragon.tp.d/network-access`, etc.
+
+The `--tracing-policy-dir` controlling setting can be used to change the default directory from where [Tracing policies](/docs/concepts/tracing-policy) are loaded.
+
+The `--tracing-policy` controlling setting can be used to specify the path of one tracing policy to load.

--- a/docs/content/en/docs/reference/tetragon-configuration.md
+++ b/docs/content/en/docs/reference/tetragon-configuration.md
@@ -155,3 +155,35 @@ Changing configuration example:
 Defaults controlling settings can be restored by simply deleting `/etc/tetragon/tetragon.yaml`
 and all drop-ins under `/etc/tetragon/tetragon.conf.d/`
 {{< /note >}}
+
+## Restrict gRPC API access
+
+The gRPC API supports unix sockets, it can be set using one of the following methods:
+
+- Use the `--server-address` flag:
+
+   ```
+   --server-address unix:///var/run/tetragon/tetragon.sock
+   ```
+
+- Or use the drop-in configuration file `/etc/tetragon/tetragon.conf.d/server-address` containing:
+
+   ```
+   unix:///var/run/tetragon/tetragon.sock
+   ```
+
+Then to access the gRPC API with `tetra` client, set `--server-address` to point to the corresponding address:
+
+   ```
+   sudo tetra --server-address unix:///var/run/tetragon/tetragon.sock getevents
+   ```
+
+{{< note >}}
+When reading events with the `tetra` client, if `--server-address` is not specified,
+it will try to detect if Tetragon daemon is running on the same host and use its
+`server-address` configuration.
+{{< /note >}}
+
+{{< caution >}}
+Ensure that you have enough privileges to open the gRPC unix socket since it is restricted to privileged users only.
+{{< /caution >}}

--- a/examples/sandbox/linux-namespaces/kill_unprivileged_user_namespace_in_pid_namespace.yaml
+++ b/examples/sandbox/linux-namespaces/kill_unprivileged_user_namespace_in_pid_namespace.yaml
@@ -1,8 +1,3 @@
-apiVersion: cilium.io/v1alpha1
-kind: TracingPolicy
-metadata:
-  name: "kill-unprivileged-user-namespace-in-pid-namespace"
-
 #
 # Adds ability to sandbox access to unprivileged user namespaces.
 #
@@ -32,6 +27,12 @@ metadata:
 #   Parent: (pid:306627) clone(CLONE_NEWUSER) TEST SUCCEEDED
 #
 
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "kill-unprivileged-user-namespace-in-pid-namespace"
+  annotations:
+    author: "Djalal Harouni"
 spec:
   kprobes:
   - call: "create_user_ns"

--- a/examples/tracingpolicy/bpf.yaml
+++ b/examples/tracingpolicy/bpf.yaml
@@ -1,7 +1,9 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
- name: "bpf"
+  name: "bpf"
+  annotations:
+    author: "Sarah Fujimori"
 spec:
  kprobes:
  # Bpf verifier check during program loads

--- a/examples/tracingpolicy/open_geturl.yaml
+++ b/examples/tracingpolicy/open_geturl.yaml
@@ -2,6 +2,8 @@ apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
   name: "url"
+  annotations:
+    author: "Kevin Sheldrake"
 spec:
   kprobes:
   - call: "fd_install"

--- a/install/linux-tarball/install.sh
+++ b/install/linux-tarball/install.sh
@@ -9,6 +9,7 @@ cp -vRf ${SRC_DIR}/usr/local/* /usr/local/
 cp -vf /usr/local/lib/tetragon/systemd/tetragon.service /usr/lib/systemd/system/tetragon.service
 
 install -d /etc/tetragon/tetragon.conf.d/
+install -d /etc/tetragon/tetragon.tp.d/
 
 systemctl daemon-reload
 systemctl enable tetragon

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -47,6 +47,9 @@ const (
 	// After initialization, InitInfoFile will contain a json representation of InitInfo
 	// Used by both client cli to guess unix socket address and by bugtool
 	InitInfoFile = DefaultRunDir + "tetragon-info.json"
+
+	// Default directory from where to load tracing policies.
+	DefaultTpDir = "/etc/tetragon/tetragon.tp.d"
 )
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -45,9 +45,10 @@ type config struct {
 	ProcessCacheSize int
 	DataCacheSize    int
 
-	MetricsServer string
-	ServerAddress string
-	TracingPolicy string
+	MetricsServer    string
+	ServerAddress    string
+	TracingPolicy    string
+	TracingPolicyDir string
 
 	ExportFilename             string
 	ExportFileMaxSizeMB        int

--- a/pkg/tracingpolicy/generictracingpolicy.go
+++ b/pkg/tracingpolicy/generictracingpolicy.go
@@ -15,7 +15,8 @@ import (
 )
 
 type Metadata struct {
-	Name string `yaml:"name"`
+	Name        string            `yaml:"name"`
+	Annotations map[string]string `yaml:"annotations"`
 }
 
 type GenericTracingPolicy struct {
@@ -67,8 +68,9 @@ func PolicyFromYAMLFilename(fileName string) (TracingPolicy, error) {
 }
 
 type MetadataNamespaced struct {
-	Name      string `yaml:"name"`
-	Namespace string `yaml:"namespace"`
+	Name        string            `yaml:"name"`
+	Namespace   string            `yaml:"namespace"`
+	Annotations map[string]string `yaml:"annotations"`
 }
 
 type GenericTracingPolicyNamespaced struct {


### PR DESCRIPTION
Load tracing policies from /etc/tetragon/tetragon.tp.d/
    
Allow to use 1 depth directory to organize tracing policies, example: file access, network access, etc...
    
Signed-off-by: Djalal Harouni <tixxdz@gmail.com>