### PR TITLE
tests: filter unit tests by PID + fix pidSet bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ kbuild
 latest.json
 strange.txt
 compile_commands.json
-contrib/tester-progs/sigkill-unprivileged-user-ns-tester
 /release
 
 # project tool artifacts

--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -922,7 +922,7 @@ AggregationOptions defines configuration options for aggregating events.
 | namespace | [string](#string) | repeated |  |
 | health_check | [google.protobuf.BoolValue](#google-protobuf-BoolValue) |  |  |
 | pid | [uint32](#uint32) | repeated |  |
-| pid_set | [uint32](#uint32) | repeated |  |
+| pid_set | [uint32](#uint32) | repeated | Filter by the PID of a process and any of its descendants. Note that this filter is intended for testing and development purposes only and should not be used in production. In particular, PID cycling in the OS over longer periods of time may cause unexpected events to pass this filter. |
 | event_set | [EventType](#tetragon-EventType) | repeated |  |
 | pod_regex | [string](#string) | repeated | Filter by process.pod.name field using RE2 regular expression syntax: https://github.com/google/re2/wiki/Syntax |
 | arguments_regex | [string](#string) | repeated | Filter by process.arguments field using RE2 regular expression syntax: https://github.com/google/re2/wiki/Syntax |

--- a/api/v1/tetragon/events.pb.go
+++ b/api/v1/tetragon/events.pb.go
@@ -162,8 +162,12 @@ type Filter struct {
 	Namespace   []string              `protobuf:"bytes,2,rep,name=namespace,proto3" json:"namespace,omitempty"`
 	HealthCheck *wrapperspb.BoolValue `protobuf:"bytes,3,opt,name=health_check,json=healthCheck,proto3" json:"health_check,omitempty"`
 	Pid         []uint32              `protobuf:"varint,4,rep,packed,name=pid,proto3" json:"pid,omitempty"`
-	PidSet      []uint32              `protobuf:"varint,5,rep,packed,name=pid_set,json=pidSet,proto3" json:"pid_set,omitempty"`
-	EventSet    []EventType           `protobuf:"varint,6,rep,packed,name=event_set,json=eventSet,proto3,enum=tetragon.EventType" json:"event_set,omitempty"`
+	// Filter by the PID of a process and any of its descendants. Note that this filter is
+	// intended for testing and development purposes only and should not be used in
+	// production. In particular, PID cycling in the OS over longer periods of time may
+	// cause unexpected events to pass this filter.
+	PidSet   []uint32    `protobuf:"varint,5,rep,packed,name=pid_set,json=pidSet,proto3" json:"pid_set,omitempty"`
+	EventSet []EventType `protobuf:"varint,6,rep,packed,name=event_set,json=eventSet,proto3,enum=tetragon.EventType" json:"event_set,omitempty"`
 	// Filter by process.pod.name field using RE2 regular expression syntax:
 	// https://github.com/google/re2/wiki/Syntax
 	PodRegex []string `protobuf:"bytes,7,rep,name=pod_regex,json=podRegex,proto3" json:"pod_regex,omitempty"`

--- a/api/v1/tetragon/events.proto
+++ b/api/v1/tetragon/events.proto
@@ -44,6 +44,10 @@ message Filter {
     repeated string namespace = 2;
     google.protobuf.BoolValue health_check = 3;
     repeated uint32 pid = 4;
+    // Filter by the PID of a process and any of its descendants. Note that this filter is
+    // intended for testing and development purposes only and should not be used in
+    // production. In particular, PID cycling in the OS over longer periods of time may
+    // cause unexpected events to pass this filter.
     repeated uint32 pid_set = 5;
     repeated EventType event_set = 6;
     // Filter by process.pod.name field using RE2 regular expression syntax:

--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -74,6 +74,8 @@ const (
 	keyEnablePolicyFilter      = "enable-policy-filter"
 	keyEnablePolicyFilterDebug = "enable-policy-filter-debug"
 
+	keyEnablePidSetFilter = "enable-pid-set-filter"
+
 	keyEnableMsgHandlingLatency = "enable-msg-handling-latency"
 )
 
@@ -132,6 +134,8 @@ func readAndSetFlags() {
 	option.Config.EnablePolicyFilter = viper.GetBool(keyEnablePolicyFilter)
 	option.Config.EnablePolicyFilterDebug = viper.GetBool(keyEnablePolicyFilterDebug)
 	option.Config.EnableMsgHandlingLatency = viper.GetBool(keyEnableMsgHandlingLatency)
+
+	option.Config.EnablePidSetFilter = viper.GetBool(keyEnablePidSetFilter)
 
 	// deprecation timeline: deprecated -> 0.10.0, removed -> 0.11.0
 	// manually handle the deprecation of --config-file

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -62,11 +62,11 @@ var (
 )
 
 func getExportFilters() ([]*tetragon.Filter, []*tetragon.Filter, error) {
-	allowList, err := filters.ParseFilterList(viper.GetString(keyExportAllowlist))
+	allowList, err := filters.ParseFilterList(viper.GetString(keyExportAllowlist), viper.GetBool(keyEnablePidSetFilter))
 	if err != nil {
 		return nil, nil, err
 	}
-	denyList, err := filters.ParseFilterList(viper.GetString(keyExportDenylist))
+	denyList, err := filters.ParseFilterList(viper.GetString(keyExportDenylist), viper.GetBool(keyEnablePidSetFilter))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -648,6 +648,9 @@ func execute() error {
 	// this is set to false by default.
 	flags.Bool(keyEnablePolicyFilter, false, "Enable policy filter code (beta)")
 	flags.Bool(keyEnablePolicyFilterDebug, false, "Enable policy filter debug messages")
+
+	// Provide option to enable the pidSet export filters.
+	flags.Bool(keyEnablePidSetFilter, false, "Enable pidSet export filters. Not recommended for production use")
 
 	flags.Bool(keyEnableMsgHandlingLatency, false, "Enable metrics for message handling latency")
 

--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -13,3 +13,4 @@ libuprobe.so
 uprobe-test-1
 uprobe-test-2
 lseek-pipe
+threads-tester

--- a/docs/content/en/docs/reference/grpc-api.md
+++ b/docs/content/en/docs/reference/grpc-api.md
@@ -541,7 +541,7 @@ AggregationOptions defines configuration options for aggregating events.
 | namespace | [string](#string) | repeated |  |
 | health_check | [google.protobuf.BoolValue](#google-protobuf-BoolValue) |  |  |
 | pid | [uint32](#uint32) | repeated |  |
-| pid_set | [uint32](#uint32) | repeated |  |
+| pid_set | [uint32](#uint32) | repeated | Filter by the PID of a process and any of its descendants. Note that this filter is intended for testing and development purposes only and should not be used in production. In particular, PID cycling in the OS over longer periods of time may cause unexpected events to pass this filter. |
 | event_set | [EventType](#tetragon-EventType) | repeated |  |
 | pod_regex | [string](#string) | repeated | Filter by process.pod.name field using RE2 regular expression syntax: https://github.com/google/re2/wiki/Syntax |
 | arguments_regex | [string](#string) | repeated | Filter by process.arguments field using RE2 regular expression syntax: https://github.com/google/re2/wiki/Syntax |

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -17,6 +17,7 @@ package filters
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 
@@ -27,7 +28,7 @@ import (
 )
 
 // ParseFilterList parses a list of process filters in JSON format into protobuf messages.
-func ParseFilterList(filters string) ([]*tetragon.Filter, error) {
+func ParseFilterList(filters string, enablePidSetFilters bool) ([]*tetragon.Filter, error) {
 	if filters == "" {
 		return nil, nil
 	}
@@ -40,6 +41,9 @@ func ParseFilterList(filters string) ([]*tetragon.Filter, error) {
 				break
 			}
 			return nil, err
+		}
+		if len(result.PidSet) != 0 && !enablePidSetFilters {
+			return nil, fmt.Errorf("pidSet filters use a best-effort approach for tracking PIDs and are intended for testing/development, not for production (pass the --enable-pid-set-filter to ignore)")
 		}
 		results = append(results, &result)
 	}

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -34,7 +34,7 @@ func TestParseFilterList(t *testing.T) {
 {"pid_set":[1]}
 {"event_set":["PROCESS_EXEC", "PROCESS_EXIT", "PROCESS_KPROBE", "PROCESS_TRACEPOINT"]}
 {"arguments_regex":["^--version$","^-a -b -c$"]}`
-	filterProto, err := ParseFilterList(f)
+	filterProto, err := ParseFilterList(f, true)
 	assert.NoError(t, err)
 	if diff := cmp.Diff(
 		[]*tetragon.Filter{
@@ -52,10 +52,13 @@ func TestParseFilterList(t *testing.T) {
 	); diff != "" {
 		t.Errorf("filter mismatch (-want +got):\n%s", diff)
 	}
-	_, err = ParseFilterList("invalid filter json")
+	_, err = ParseFilterList("invalid filter json", true)
 	assert.Error(t, err)
-	filterProto, err = ParseFilterList("")
+	filterProto, err = ParseFilterList("", true)
 	assert.NoError(t, err)
+	assert.Empty(t, filterProto)
+	filterProto, err = ParseFilterList(`{"pid_set":[1]}`, false)
+	assert.Error(t, err)
 	assert.Empty(t, filterProto)
 }
 

--- a/pkg/filters/pidSet.go
+++ b/pkg/filters/pidSet.go
@@ -18,52 +18,85 @@ import (
 	"context"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/logger"
 	v1 "github.com/cilium/tetragon/pkg/oldhubble/api/v1"
 	hubbleFilters "github.com/cilium/tetragon/pkg/oldhubble/filters"
 )
 
-/* pidSet is the set of pids we are interested in receiving events
- * for. This includes the pids listed in filter and any of their
- * children.
- */
-var pidSet map[uint32]bool
+// We could use an LRU here but we really don't want to evict old entries and risk failing
+// a test that uses this filter. Instead, we take the safer approach from the perspective
+// of testing and opt to grow the map indefinitely and log a warning if the size exceeeds
+// a pre-determined threshold. Since we have protections in place to prevent this filter
+// being used in production, this should be acceptable.
+type ChildCache = map[uint32]struct{}
 
-func filterByPidSet(pids []uint32) hubbleFilters.FilterFunc {
-	return func(ev *v1.Event) bool {
-		process := GetProcess(ev)
-		if process == nil {
-			return false
-		}
-		for _, pid := range pids {
-			if pid == process.Pid.GetValue() {
-				pidSet[pid] = true
-				return true
-			}
-		}
-		parent := GetParent(ev)
-		if parent == nil {
-			return false
-		}
-		if pidSet[parent.Pid.GetValue()] == true {
+func checkPidSetMembership(pid uint32, pidSet []uint32, childCache ChildCache) bool {
+	// Check the original pidSet. The reason for doing this separately is that we never
+	// want to drop the original pidSet from the cache. Keeping this separately in a slice
+	// is an easy way to achieve this.
+	for _, p := range pidSet {
+		if pid == p {
 			return true
 		}
-		for _, pid := range pids {
-			if pid == parent.Pid.GetValue() {
-				pidSet[pid] = true
-				return true
-			}
-		}
+	}
+	// Fall back to childCache to check children.
+	_, ok := childCache[pid]
+	return ok
+}
+
+func doFilterByPidSet(ev *v1.Event, pidSet []uint32, childCache ChildCache, childCacheWarning *int) bool {
+	process := GetProcess(ev)
+	if process == nil {
 		return false
+	}
+
+	// Check the process against our cache
+	pid := process.Pid.GetValue()
+	if checkPidSetMembership(pid, pidSet, childCache) {
+		return true
+	}
+
+	parent := GetParent(ev)
+	if parent == nil {
+		return false
+	}
+
+	// Check the parent against our cache
+	ppid := parent.Pid.GetValue()
+	if checkPidSetMembership(ppid, pidSet, childCache) {
+		// Add our own PID to the children cache so that we can match our future children.
+		childCache[pid] = struct{}{}
+		// If we exceeded the pre-determined warning limit, log a warning message and
+		// double it.
+		if len(childCache) == *childCacheWarning {
+			logger.GetLogger().Warnf("pidSet filter cache has exceeded %d entries. To prevent excess memory usage, consider disabling it.", childCacheWarning)
+			*childCacheWarning *= 2
+		}
+		return true
+	}
+
+	// No matches, return false
+	return false
+}
+
+func filterByPidSet(pidSet []uint32, childCache ChildCache, childCacheWarning int) hubbleFilters.FilterFunc {
+	return func(ev *v1.Event) bool {
+		return doFilterByPidSet(ev, pidSet, childCache, &childCacheWarning)
 	}
 }
 
+// PidSetFilter is a filter that matches on a process and all of its children by their
+// PID, up to maxChildCacheSize number of children.
 type PidSetFilter struct{}
 
 func (f *PidSetFilter) OnBuildFilter(_ context.Context, ff *tetragon.Filter) ([]hubbleFilters.FilterFunc, error) {
-	pidSet = make(map[uint32]bool)
 	var fs []hubbleFilters.FilterFunc
 	if ff.PidSet != nil {
-		fs = append(fs, filterByPidSet(ff.PidSet))
+		childCache := make(ChildCache)
+		childCacheWarning := 8192
+
+		pidSet := ff.PidSet
+		fs = append(fs, filterByPidSet(pidSet, childCache, childCacheWarning))
 	}
 	return fs, nil
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -72,6 +72,8 @@ type config struct {
 	EnablePolicyFilter      bool
 	EnablePolicyFilterDebug bool
 
+	EnablePidSetFilter bool
+
 	EnableMsgHandlingLatency bool
 }
 

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -141,7 +141,7 @@ func TestNamespaces(t *testing.T) {
 			WithParent(ec.NewProcessChecker()),
 	)
 
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserver error: %s", err)
 	}
@@ -159,7 +159,7 @@ func TestEventExecve(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("Failed to run observer: %s", err)
 	}
@@ -250,7 +250,7 @@ func TestEventExecveLongPath(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("Failed to run observer: %s", err)
 	}
@@ -274,7 +274,7 @@ func TestEventExecveLongArgs(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("Failed to run observer: %s", err)
 	}
@@ -397,7 +397,7 @@ func TestEventExecveLongPathLongArgs(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("Failed to run observer: %s", err)
 	}

--- a/pkg/sensors/exec/exit_test.go
+++ b/pkg/sensors/exec/exit_test.go
@@ -26,7 +26,7 @@ func TestExit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("Failed to run observer: %s", err)
 	}
@@ -141,7 +141,7 @@ func TestExitZombie(t *testing.T) {
 	defer cancel()
 
 	t.Logf("starting observer")
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -192,7 +192,7 @@ func TestExitCode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("Failed to run observer: %s", err)
 	}

--- a/pkg/sensors/exec/fork_test.go
+++ b/pkg/sensors/exec/fork_test.go
@@ -35,7 +35,7 @@ func TestFork(t *testing.T) {
 	defer testPipes.Close()
 
 	t.Logf("starting observer")
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}

--- a/pkg/sensors/exec/threads_test.go
+++ b/pkg/sensors/exec/threads_test.go
@@ -64,7 +64,7 @@ func TestCloneThreadsTester(t *testing.T) {
 	defer testPipes.Close()
 
 	t.Logf("starting observer")
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -175,7 +175,7 @@ func TestExecThreads(t *testing.T) {
 	defer testPipes.Close()
 
 	t.Logf("starting observer")
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}

--- a/pkg/sensors/test/checker_test.go
+++ b/pkg/sensors/test/checker_test.go
@@ -41,7 +41,7 @@ func TestTestChecker(t *testing.T) {
 	}
 	errorChecker := NewTestChecker(&dummyChecker)
 
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserver error: %s", err)
 	}

--- a/pkg/sensors/tracing/kprobe_amd64_test.go
+++ b/pkg/sensors/tracing/kprobe_amd64_test.go
@@ -64,7 +64,7 @@ spec:
 
 	createCrdFile(t, capabilityhook_)
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}

--- a/pkg/sensors/tracing/kprobe_copyfd_test.go
+++ b/pkg/sensors/tracing/kprobe_copyfd_test.go
@@ -69,7 +69,7 @@ func TestCopyFd(t *testing.T) {
 	specFname := makeSpecFile(pidStr)
 	t.Logf("pid is %s and spec file is %s", pidStr, specFname)
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, specFname, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, specFname, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}

--- a/pkg/sensors/tracing/kprobe_sigkill_test.go
+++ b/pkg/sensors/tracing/kprobe_sigkill_test.go
@@ -77,7 +77,7 @@ func TestKprobeSigkill(t *testing.T) {
 	specFname := makeSpecFile(pidStr)
 	t.Logf("child pid is %s and spec file is %s", pidStr, specFname)
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, specFname, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, specFname, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -165,7 +165,7 @@ func testUnprivilegedUsernsKill(t *testing.T, pidns bool) {
 	specFname := makeSpecFile(pidStr)
 	t.Logf("parent pid is %s and spec file is %s", pidStr, specFname)
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, specFname, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, specFname, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -93,7 +93,7 @@ spec:
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	_, err = observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	_, err = observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -139,7 +139,7 @@ spec:
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -183,7 +183,7 @@ func runKprobeObjectWriteRead(t *testing.T, writeReadHook string) {
 
 	checker := getTestKprobeObjectWRChecker(t)
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -434,7 +434,7 @@ func runKprobeObjectRead(t *testing.T, readHook string, checker ec.MultiEventChe
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -615,7 +615,7 @@ func testKprobeObjectFiltered(t *testing.T,
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -1166,7 +1166,7 @@ func testKprobeObjectFilteredReturnValue(t *testing.T,
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -1333,7 +1333,7 @@ spec:
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -1579,7 +1579,7 @@ func corePathTest(t *testing.T, filePath string, readHook string, writeChecker e
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -1825,7 +1825,7 @@ spec:
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -1878,7 +1878,7 @@ func runKprobeOverride(t *testing.T, hook string, checker ec.MultiEventChecker,
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -2050,7 +2050,7 @@ spec:
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	_, err = observer.GetDefaultObserverWithFileNoTest(t, context.Background(), testConfigFile, tus.Conf().TetragonLib, true)
+	_, err = observer.GetDefaultObserverWithFileNoTest(t, context.Background(), testConfigFile, tus.Conf().TetragonLib, true, observer.WithMyPid())
 	if err == nil {
 		t.Fatalf("GetDefaultObserverWithFileNoTest ok, should fail\n")
 	}
@@ -2075,7 +2075,7 @@ func runKprobeOverrideSignal(t *testing.T, hook string, checker ec.MultiEventChe
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -2321,7 +2321,7 @@ func runKprobe_char_iovec(t *testing.T, configHook string,
 	}
 
 	b := base.GetInitialSensor()
-	obs, err := observer.GetDefaultObserverWithWatchers(t, ctx, b, observer.WithConfig(testConfigFile), observer.WithLib(tus.Conf().TetragonLib))
+	obs, err := observer.GetDefaultObserverWithWatchers(t, ctx, b, observer.WithConfig(testConfigFile), observer.WithLib(tus.Conf().TetragonLib), observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithWatchers error: %s", err)
 	}
@@ -2682,7 +2682,7 @@ func TestKprobeMatchArgsFileEqual(t *testing.T) {
 
 	createCrdFile(t, getMatchArgsFileCrd("Equal", argVals[:]))
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -2722,7 +2722,7 @@ func TestKprobeMatchArgsFilePostfix(t *testing.T) {
 
 	createCrdFile(t, getMatchArgsFileCrd("Postfix", argVals[:]))
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -2762,7 +2762,7 @@ func TestKprobeMatchArgsFilePrefix(t *testing.T) {
 
 	createCrdFile(t, getMatchArgsFileCrd("Prefix", argVals[:]))
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -2802,7 +2802,7 @@ func TestKprobeMatchArgsFdEqual(t *testing.T) {
 
 	createCrdFile(t, getMatchArgsFdCrd("Equal", argVals[:]))
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -2838,7 +2838,7 @@ func TestKprobeMatchArgsFdPostfix(t *testing.T) {
 
 	createCrdFile(t, getMatchArgsFdCrd("Postfix", argVals[:]))
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -2874,7 +2874,7 @@ func TestKprobeMatchArgsFdPrefix(t *testing.T) {
 
 	createCrdFile(t, getMatchArgsFdCrd("Prefix", argVals[:]))
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -2938,7 +2938,7 @@ func TestKprobeMatchBinariesIn(t *testing.T) {
 
 	createCrdFile(t, getMatchBinariesCrd("In", []string{"/usr/bin/cat"}))
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -2968,7 +2968,7 @@ func TestKprobeMatchBinariesNotIn(t *testing.T) {
 
 	createCrdFile(t, getMatchBinariesCrd("NotIn", []string{"/usr/bin/tail"}))
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -3037,7 +3037,7 @@ spec:
 `
 	createCrdFile(t, hook)
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -3153,7 +3153,7 @@ spec:
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	sens, err = observer.GetDefaultSensorsWithFile(t, context.TODO(), testConfigFile, tus.Conf().TetragonLib)
+	sens, err = observer.GetDefaultSensorsWithFile(t, context.TODO(), testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -3177,7 +3177,7 @@ spec:
    syscall: true
 `
 
-	_, err := observer.GetDefaultObserverWithFile(t, ctx, "", tus.Conf().TetragonLib)
+	_, err := observer.GetDefaultObserverWithFile(t, ctx, "", tus.Conf().TetragonLib, observer.WithMyPid())
 	assert.NoError(t, err)
 
 	tp, err := tracingpolicy.PolicyFromYAML(testHook)
@@ -3206,7 +3206,7 @@ func testMaxData(t *testing.T, data []byte, checker *eventchecker.UnorderedEvent
 
 	option.Config.RBSize = 1024 * 1024
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}

--- a/pkg/sensors/tracing/loader_test.go
+++ b/pkg/sensors/tracing/loader_test.go
@@ -121,7 +121,7 @@ spec:
 
 	checker := ec.NewUnorderedEventChecker(loaderChecker)
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -81,7 +81,7 @@ spec:
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	sens, err = observer.GetDefaultSensorsWithFile(t, context.TODO(), testConfigFile, tus.Conf().TetragonLib)
+	sens, err = observer.GetDefaultSensorsWithFile(t, context.TODO(), testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -121,7 +121,7 @@ spec:
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -176,7 +176,7 @@ spec:
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
@@ -235,7 +235,7 @@ spec:
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/events.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/events.pb.go
@@ -162,8 +162,12 @@ type Filter struct {
 	Namespace   []string              `protobuf:"bytes,2,rep,name=namespace,proto3" json:"namespace,omitempty"`
 	HealthCheck *wrapperspb.BoolValue `protobuf:"bytes,3,opt,name=health_check,json=healthCheck,proto3" json:"health_check,omitempty"`
 	Pid         []uint32              `protobuf:"varint,4,rep,packed,name=pid,proto3" json:"pid,omitempty"`
-	PidSet      []uint32              `protobuf:"varint,5,rep,packed,name=pid_set,json=pidSet,proto3" json:"pid_set,omitempty"`
-	EventSet    []EventType           `protobuf:"varint,6,rep,packed,name=event_set,json=eventSet,proto3,enum=tetragon.EventType" json:"event_set,omitempty"`
+	// Filter by the PID of a process and any of its descendants. Note that this filter is
+	// intended for testing and development purposes only and should not be used in
+	// production. In particular, PID cycling in the OS over longer periods of time may
+	// cause unexpected events to pass this filter.
+	PidSet   []uint32    `protobuf:"varint,5,rep,packed,name=pid_set,json=pidSet,proto3" json:"pid_set,omitempty"`
+	EventSet []EventType `protobuf:"varint,6,rep,packed,name=event_set,json=eventSet,proto3,enum=tetragon.EventType" json:"event_set,omitempty"`
 	// Filter by process.pod.name field using RE2 regular expression syntax:
 	// https://github.com/google/re2/wiki/Syntax
 	PodRegex []string `protobuf:"bytes,7,rep,name=pod_regex,json=podRegex,proto3" json:"pod_regex,omitempty"`

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/events.proto
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/events.proto
@@ -44,6 +44,10 @@ message Filter {
     repeated string namespace = 2;
     google.protobuf.BoolValue health_check = 3;
     repeated uint32 pid = 4;
+    // Filter by the PID of a process and any of its descendants. Note that this filter is
+    // intended for testing and development purposes only and should not be used in
+    // production. In particular, PID cycling in the OS over longer periods of time may
+    // cause unexpected events to pass this filter.
     repeated uint32 pid_set = 5;
     repeated EventType event_set = 6;
     // Filter by process.pod.name field using RE2 regular expression syntax:


### PR DESCRIPTION
Fix pidSet filter so that it properly accounts for children of children. Update observer_test_helper to support adding export filters on protojson and update existing tests to filter by PID with a pidSet filter.