### PR TITLE
backports/v0.8: Revert: tetragon: Switch exit tracepoint to __put_task_struct kprobe

### DIFF
--- a/bpf/process/bpf_exit.c
+++ b/bpf/process/bpf_exit.c
@@ -7,22 +7,11 @@
 
 char _license[] __attribute__((section("license"), used)) = "GPL";
 
-__attribute__((section("kprobe/__put_task_struct"), used)) int
-event_exit(struct pt_regs *ctx)
+__attribute__((section("tracepoint/sys_exit"), used)) int
+event_exit(struct sched_execve_args *ctx)
 {
-	struct task_struct *task =
-		(struct task_struct *)PT_REGS_PARM1_CORE(ctx);
-	__u32 pid, tgid;
+	__u64 pid_tgid = get_current_pid_tgid();
 
-	pid = BPF_CORE_READ(task, pid);
-	tgid = BPF_CORE_READ(task, tgid);
-
-	/* We are only tracking group leaders so if tgid is not
-	 * the same as the pid then this is an untracked child
-	 * and we can skip the lookup/insert/delete cycle that
-	 * would otherwise occur.
-	 */
-	if (pid == tgid)
-		event_exit_send(ctx, tgid, task);
+	event_exit_send(ctx, pid_tgid);
 	return 0;
 }

--- a/bpf/process/bpf_exit.h
+++ b/bpf/process/bpf_exit.h
@@ -15,9 +15,21 @@ struct {
 } exit_heap_map SEC(".maps");
 
 static inline __attribute__((always_inline)) void
-event_exit_send(void *ctx, __u32 tgid, struct task_struct *task)
+event_exit_send(struct sched_execve_args *ctx, __u64 current)
 {
 	struct execve_map_value *enter;
+	__u32 pid, tgid;
+
+	pid = current & 0xFFFFffff;
+	tgid = current >> 32;
+
+	/* We are only tracking group leaders so if tgid is not
+	 * the same as the pid then this is an untracked child
+	 * and we can skip the lookup/insert/delete cycle that
+	 * would otherwise occur.
+	 */
+	if (pid != tgid)
+		return;
 
 	/* It is safe to do a map_lookup_event() here because
 	 * we must have captured the execve case in order for an
@@ -31,6 +43,8 @@ event_exit_send(void *ctx, __u32 tgid, struct task_struct *task)
 	if (!enter)
 		return;
 	if (enter->key.ktime) {
+		struct task_struct *task =
+			(struct task_struct *)get_current_task();
 		size_t size = sizeof(struct msg_exit);
 		struct msg_exit *exit;
 		int zero = 0;

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -28,10 +28,10 @@ var (
 
 	Exit = program.Builder(
 		"bpf_exit.o",
-		"__put_task_struct",
-		"kprobe/__put_task_struct",
+		"sched/sched_process_exit",
+		"tracepoint/sys_exit",
 		"event_exit",
-		"kprobe",
+		"tracepoint",
 	)
 
 	Fork = program.Builder(

--- a/pkg/sensors/exec/exit_test.go
+++ b/pkg/sensors/exec/exit_test.go
@@ -2,20 +2,16 @@ package exec
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"sync"
 	"testing"
-	"time"
 
-	"github.com/cilium/tetragon/api/v1/tetragon"
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,69 +49,70 @@ func TestExit(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestExitLeader(t *testing.T) {
-	var doneWG, readyWG sync.WaitGroup
-	defer doneWG.Wait()
+// FIXME: Disable that for now as we revert https://github.com/cilium/tetragon/commit/1a37adf4bd400733292900335bf246f4263622bf
+// func TestExitLeader(t *testing.T) {
+// 	var doneWG, readyWG sync.WaitGroup
+// 	defer doneWG.Wait()
 
-	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
-	defer cancel()
+// 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+// 	defer cancel()
 
-	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
-	if err != nil {
-		t.Fatalf("Failed to run observer: %s", err)
-	}
-	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
-	readyWG.Wait()
+// 	obs, err := observer.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
+// 	if err != nil {
+// 		t.Fatalf("Failed to run observer: %s", err)
+// 	}
+// 	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+// 	readyWG.Wait()
 
-	testExitLeader := testutils.ContribPath("tester-progs/exit-leader")
+// testExitLeader := testutils.ContribPath("tester-progs/exit-leader")
 
-	var startTime, exitTime time.Time
+// 	var startTime, exitTime time.Time
 
-	// The test executes 'exit-leader' benary which spawns a thread and
-	// exits the leader immediately while the new thread continues to
-	// run for 3 seconds and exits. We verify that we get exit event 3
-	// seconds after the start.
+// 	// The test executes 'exit-leader' benary which spawns a thread and
+// 	// exits the leader immediately while the new thread continues to
+// 	// run for 3 seconds and exits. We verify that we get exit event 3
+// 	// seconds after the start.
 
-	nextCheck := func(event ec.Event, l *logrus.Logger) (bool, error) {
-		switch ev := event.(type) {
-		case *tetragon.ProcessExec:
-			if ev.Process.Binary == testExitLeader {
-				startTime = ev.Process.StartTime.AsTime()
-			}
-			return false, nil
-		case *tetragon.ProcessExit:
-			if ev.Process.Binary == testExitLeader {
-				exitTime = ev.Time.AsTime()
-			}
-			return false, nil
-		}
-		return false, nil
-	}
+// 	nextCheck := func(event ec.Event, l *logrus.Logger) (bool, error) {
+// 		switch ev := event.(type) {
+// 		case *tetragon.ProcessExec:
+// 			if ev.Process.Binary == testExitLeader {
+// 				startTime = ev.Process.StartTime.AsTime()
+// 			}
+// 			return false, nil
+// 		case *tetragon.ProcessExit:
+// 			if ev.Process.Binary == testExitLeader {
+// 				exitTime = ev.Time.AsTime()
+// 			}
+// 			return false, nil
+// 		}
+// 		return false, nil
+// 	}
 
-	finalCheck := func(l *logrus.Logger) error {
-		delta := exitTime.Sub(startTime)
+// 	finalCheck := func(l *logrus.Logger) error {
+// 		delta := exitTime.Sub(startTime)
 
-		fmt.Printf("execTime %v\n", startTime)
-		fmt.Printf("exitTime %v\n", exitTime)
-		fmt.Printf("delta %v\n", delta)
+// 		fmt.Printf("execTime %v\n", startTime)
+// 		fmt.Printf("exitTime %v\n", exitTime)
+// 		fmt.Printf("delta %v\n", delta)
 
-		if delta < 3*time.Second {
-			return fmt.Errorf("unexpected delta < 3 seconds")
-		}
-		return nil
-	}
+// 		if delta < 3*time.Second {
+// 			return fmt.Errorf("unexpected delta < 3 seconds")
+// 		}
+// 		return nil
+// 	}
 
-	checker := &ec.FnEventChecker{
-		NextCheckFn:  nextCheck,
-		FinalCheckFn: finalCheck,
-	}
+// 	checker := &ec.FnEventChecker{
+// 		NextCheckFn:  nextCheck,
+// 		FinalCheckFn: finalCheck,
+// 	}
 
-	if err := exec.Command(testExitLeader).Run(); err != nil {
-		t.Fatalf("Failed to execute test binary: %s\n", err)
-	}
+// 	if err := exec.Command(testExitLeader).Run(); err != nil {
+// 		t.Fatalf("Failed to execute test binary: %s\n", err)
+// 	}
 
-	if err := jsonchecker.JsonTestCheck(t, checker); err != nil {
-		t.Logf("error: %s", err)
-		t.Fail()
-	}
-}
+// if err := jsonchecker.JsonTestCheck(t, checker); err != nil {
+// 	t.Logf("error: %s", err)
+// 	t.Fail()
+// }
+// }

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -115,7 +115,7 @@ func mergeSensorMaps(t *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []Se
 func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []SensorProg) ([]SensorMap, []SensorProg) {
 	var baseProgs = []SensorProg{
 		0: SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
-		1: SensorProg{Name: "event_exit", Type: ebpf.Kprobe},
+		1: SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
 		2: SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
 		3: SensorProg{Name: "execve_send", Type: ebpf.TracePoint},
 	}


### PR DESCRIPTION
[upstream commit: fbeb302fd684a5652714049aaa48c8bcc594ad33]

Previously, we moved the exit hook from a tracepoint to kprobe/__put_task_struct because of some issues (more details in
https://github.com/cilium/tetragon/pull/558).

On the other hand, with the new kprobe we have seen cases where the kprobe is interrupted (and aborted) which means that we missed close events.

As a first step, we revert https://github.com/cilium/tetragon/commit/1a37adf4bd400733292900335bf246f4263622bf until we find a better hook point.

This commit also disables TestExitLeader and TestExitZombie due to failures from reverting the previous commit.