### PR TITLE
tetragon: Enable parallel build for bpf objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ GO_OPERATOR_IMAGE_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(
 GOLANGCILINT_WANT_VERSION = 1.52.2
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
+# Do a parallel build with multiple jobs, based on the number of CPUs online
+# in this system: 'make -j8' on a 8-CPU system, etc.
+#
+# (To override it, run 'make JOBS=1' and similar.)
+#
+JOBS ?= $(shell nproc)
 
 .PHONY: all
 all: tetragon-bpf tetragon tetra tetragon-alignchecker test-compile tester-progs protoc-gen-go-tetragon tetragon-bench
@@ -112,7 +118,7 @@ tetragon-bpf-local:
 
 tetragon-bpf-container:
 	$(CONTAINER_ENGINE) rm tetragon-clang || true
-	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon:Z -u $$(id -u) -e BPF_TARGET_ARCH=$(BPF_TARGET_ARCH) --name tetragon-clang $(CLANG_IMAGE) $(MAKE) -C /tetragon/bpf
+	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon:Z -u $$(id -u) -e BPF_TARGET_ARCH=$(BPF_TARGET_ARCH) --name tetragon-clang $(CLANG_IMAGE) $(MAKE) -C /tetragon/bpf -j$(JOBS)
 	$(CONTAINER_ENGINE) rm tetragon-clang
 
 .PHONY: verify


### PR DESCRIPTION
To speed up the build, stolen from perf tool makefiles.

By default the bpf build is now parallel with -j<nr_cpus> option.

It's possible to specify -j argument with JOBS variable, which can be also used to switch it off with 'make JOBS=1'.