### PR TITLE
metrics: Show the latency needed to handle a msg per op

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -73,6 +73,8 @@ const (
 
 	keyEnablePolicyFilter      = "enable-policy-filter"
 	keyEnablePolicyFilterDebug = "enable-policy-filter-debug"
+
+	keyEnableMsgHandlingLatency = "enable-msg-handling-latency"
 )
 
 func readAndSetFlags() {
@@ -129,6 +131,7 @@ func readAndSetFlags() {
 	option.Config.ReleasePinned = viper.GetBool(keyReleasePinnedBPF)
 	option.Config.EnablePolicyFilter = viper.GetBool(keyEnablePolicyFilter)
 	option.Config.EnablePolicyFilterDebug = viper.GetBool(keyEnablePolicyFilterDebug)
+	option.Config.EnableMsgHandlingLatency = viper.GetBool(keyEnableMsgHandlingLatency)
 
 	// deprecation timeline: deprecated -> 0.10.0, removed -> 0.11.0
 	// manually handle the deprecation of --config-file

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -649,6 +649,8 @@ func execute() error {
 	flags.Bool(keyEnablePolicyFilter, false, "Enable policy filter code (beta)")
 	flags.Bool(keyEnablePolicyFilterDebug, false, "Enable policy filter debug messages")
 
+	flags.Bool(keyEnableMsgHandlingLatency, false, "Enable metrics for message handling latency")
+
 	viper.BindPFlags(flags)
 	return rootCmd.Execute()
 }

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -48,6 +48,7 @@ Helm chart for Tetragon
 | tetragon.commandOverride | list | `[]` |  |
 | tetragon.enableCiliumAPI | bool | `false` |  |
 | tetragon.enableK8sAPI | bool | `true` |  |
+| tetragon.enableMsgHandlingLatency | bool | `false` |  |
 | tetragon.enablePolicyFilter | bool | `false` |  |
 | tetragon.enablePolicyFilterDebug | bool | `false` |  |
 | tetragon.enableProcessCred | bool | `false` |  |

--- a/install/kubernetes/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/templates/tetragon_configmap.yaml
@@ -52,3 +52,6 @@ data:
 {{- if .Values.tetragon.enablePolicyFilterDebug }}
   enable-policy-filter-debug: "true"
 {{- end }}
+{{- if .Values.tetragon.enableMsgHandlingLatency }}
+  enable-msg-handling-latency: "true"
+{{- end }}

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -146,6 +146,8 @@ tetragon:
   enablePolicyFilter: false
   # Enable policy filter debug messages.
   enablePolicyFilterDebug: false
+  # Enable latency monitoring in message handling
+  enableMsgHandlingLatency: false
 tetragonOperator:
   # -- Enable the tetragon-operator component (required).
   enabled: true

--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -17,6 +17,13 @@ var (
 		Help:        "The total number of times we encounter a given message opcode. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"msg_op"})
+
+	LatencyStats = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        consts.MetricNamePrefix + "handling_latency",
+		Help:        "The latency of handling messages in us.",
+		Buckets:     []float64{50, 100, 500, 1000, 10000, 100000}, // 50us, 100us, 500us, 1ms, 10ms, 100ms
+		ConstLabels: nil,
+	}, []string{"op"})
 )
 
 // Get a new handle on a msgOpsCount metric for an OpCode

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -122,7 +122,10 @@ func HandlePerfData(data []byte) (byte, []Event, error) {
 }
 
 func (k *Observer) receiveEvent(data []byte) {
-	timer := time.Now()
+	var timer time.Time
+	if option.Config.EnableMsgHandlingLatency {
+		timer = time.Now()
+	}
 	atomic.AddUint64(&k.recvCntr, 1)
 	op, events, err := HandlePerfData(data)
 	opcodemetrics.OpTotalInc(int(op))
@@ -142,7 +145,9 @@ func (k *Observer) receiveEvent(data []byte) {
 	for _, event := range events {
 		k.observerListeners(event)
 	}
-	opcodemetrics.LatencyStats.WithLabelValues(fmt.Sprint(op)).Observe(float64(time.Since(timer).Microseconds()))
+	if option.Config.EnableMsgHandlingLatency {
+		opcodemetrics.LatencyStats.WithLabelValues(fmt.Sprint(op)).Observe(float64(time.Since(timer).Microseconds()))
+	}
 }
 
 // Gets final size for single perf ring buffer rounded from

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -71,6 +71,8 @@ type config struct {
 
 	EnablePolicyFilter      bool
 	EnablePolicyFilterDebug bool
+
+	EnableMsgHandlingLatency bool
 }
 
 var (


### PR DESCRIPTION
Example:
```
# HELP tetragon_handling_latency The latency of handling messages in us.
# TYPE tetragon_handling_latency histogram
tetragon_handling_latency_bucket{op="23",le="50"} 3613
tetragon_handling_latency_bucket{op="23",le="100"} 4126
tetragon_handling_latency_bucket{op="23",le="500"} 4130
tetragon_handling_latency_bucket{op="23",le="1000"} 4130
tetragon_handling_latency_bucket{op="23",le="+Inf"} 4131
tetragon_handling_latency_sum{op="23"} 106430
tetragon_handling_latency_count{op="23"} 4131
tetragon_handling_latency_bucket{op="24",le="50"} 3572
tetragon_handling_latency_bucket{op="24",le="100"} 3608
tetragon_handling_latency_bucket{op="24",le="500"} 3610
tetragon_handling_latency_bucket{op="24",le="1000"} 3610
tetragon_handling_latency_bucket{op="24",le="+Inf"} 3610
tetragon_handling_latency_sum{op="24"} 56959
tetragon_handling_latency_count{op="24"} 3610
tetragon_handling_latency_bucket{op="5",le="50"} 1390
tetragon_handling_latency_bucket{op="5",le="100"} 3473
tetragon_handling_latency_bucket{op="5",le="500"} 3610
tetragon_handling_latency_bucket{op="5",le="1000"} 3610
tetragon_handling_latency_bucket{op="5",le="+Inf"} 3610
tetragon_handling_latency_sum{op="5"} 216082
tetragon_handling_latency_count{op="5"} 3610
tetragon_handling_latency_bucket{op="7",le="50"} 2895
tetragon_handling_latency_bucket{op="7",le="100"} 4106
tetragon_handling_latency_bucket{op="7",le="500"} 4124
tetragon_handling_latency_bucket{op="7",le="1000"} 4124
tetragon_handling_latency_bucket{op="7",le="+Inf"} 4124
tetragon_handling_latency_sum{op="7"} 162039
tetragon_handling_latency_count{op="7"} 4124```