### PR TITLE
tetragon: Adding missing tid setup to HandleGenericEvent

### DIFF
--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -360,7 +360,7 @@ func (msg *MsgExitEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*
 }
 
 func (msg *MsgExitEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev)
+	return eventcache.HandleGenericEvent(internal, ev, &msg.Info.Tid)
 }
 
 func (msg *MsgExitEventUnix) HandleMessage() *tetragon.GetEventsResponse {

--- a/pkg/grpc/test/test.go
+++ b/pkg/grpc/test/test.go
@@ -31,7 +31,7 @@ func (msg *MsgTestEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*
 }
 
 func (msg *MsgTestEventUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev)
+	return eventcache.HandleGenericEvent(internal, ev, nil)
 }
 
 func (msg *MsgTestEventUnix) HandleMessage() *tetragon.GetEventsResponse {

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -247,7 +247,7 @@ func (msg *MsgGenericTracepointUnix) RetryInternal(ev notify.Event, timestamp ui
 }
 
 func (msg *MsgGenericTracepointUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev)
+	return eventcache.HandleGenericEvent(internal, ev, &msg.Tid)
 }
 
 func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse {
@@ -357,7 +357,7 @@ func (msg *MsgGenericKprobeUnix) RetryInternal(ev notify.Event, timestamp uint64
 }
 
 func (msg *MsgGenericKprobeUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev)
+	return eventcache.HandleGenericEvent(internal, ev, &msg.Tid)
 }
 
 func (msg *MsgGenericKprobeUnix) HandleMessage() *tetragon.GetEventsResponse {
@@ -444,7 +444,7 @@ func (msg *MsgProcessLoaderUnix) RetryInternal(ev notify.Event, timestamp uint64
 
 func (msg *MsgProcessLoaderUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
 	LoaderMetricInc(LoaderResolvedRetry)
-	return eventcache.HandleGenericEvent(internal, ev)
+	return eventcache.HandleGenericEvent(internal, ev, nil)
 }
 
 func (msg *MsgProcessLoaderUnix) HandleMessage() *tetragon.GetEventsResponse {
@@ -490,7 +490,7 @@ func (msg *MsgGenericUprobeUnix) RetryInternal(ev notify.Event, timestamp uint64
 }
 
 func (msg *MsgGenericUprobeUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev)
+	return eventcache.HandleGenericEvent(internal, ev, &msg.Tid)
 }
 
 func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {


### PR DESCRIPTION
We set tid for process part of the event to the tid value
we received from kprobe/uprobe/tracepoint event.

We missed it in HandleGenericEvent which is called from
Retry eventcache callback.
