### PR TITLE
deps: add renovate to replace dependabot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,201 @@
+{
+  // self-hosted configuration
+  "username": "cilium-renovate[bot]",
+  "repositories": ["cilium/tetragon"],
+  "allowedPostUpgradeCommands": [
+    "^/tmp/install-buildx$", 
+    "^make codegen$", 
+    "^make generate$", 
+    "^install/kubernetes/test.sh$"
+  ],
+  // repository configuration
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":gitSignOff",
+    "helpers:pinGitHubActionDigests"
+  ],
+  // this ensures that the gitAuthor and gitSignOff fields match
+  "gitAuthor": "renovate[bot] <bot@renovateapp.com>",
+  "includePaths": [
+    ".github/workflows/**",
+    "go.mod",
+    "go.sum",
+    "api/go.mod",
+    "api/go.sum",
+    "pkg/k8s/go.mod",
+    "pkg/k8s/go.sum",
+    "Dockerfile*",
+    "install/kubernetes/values.yaml",
+  ],
+  postUpdateOptions: [
+    "gomodTidy"
+  ],
+  "pinDigests": true,
+  "ignorePresets": [":prHourlyLimit2"],
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true,
+  "separateMinorPatch": true,
+  "pruneStaleBranches": true,
+  "baseBranches": [
+    "main"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "labels": [
+    "kind/enhancement",
+    "priority/release-blocker"
+  ],
+  schedule: [
+    "on monday and friday"
+  ],
+  // about packageRules: To enable grouping, you configure the groupName field
+  // to something non-null.
+  "packageRules": [
+    {
+      "groupName": "all github action dependencies",
+      "groupSlug": "all-github-action",
+      "matchPaths": [
+        ".github/workflows/**"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "digest",
+        "patch",
+        "pin",
+        "pinDigest"
+      ]
+    },
+    {
+      // not grouping these together
+      // "groupName": "all go dependencies main",
+      // "groupSlug": "all-go-deps-main",
+      "matchFiles": [
+        "go.mod",
+        "go.sum"
+      ],
+      "postUpdateOptions": [
+        // update source import paths on major updates
+        "gomodUpdateImportPaths",
+      ],
+      postUpgradeTasks: {
+        "commands": ["/tmp/install-buildx", "make codegen", "make generate"],
+        "fileFilters": ["**/**"],
+        "executionMode": "branch"
+      },
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "digest",
+        "patch",
+        "pin",
+        "pinDigest"
+      ],
+      matchBaseBranches: [
+        "main"
+      ],
+    },
+    {
+      // grouping these together because the number of dependencies is limited
+      "groupName": "all API go dependencies main",
+      "groupSlug": "all-api-go-deps-main",
+      "matchFiles": [
+        "api/go.mod",
+        "api/go.sum"
+      ],
+      "postUpdateOptions": [
+        // update source import paths on major updates
+        "gomodUpdateImportPaths",
+      ],
+      postUpgradeTasks: {
+        "commands": ["/tmp/install-buildx", "make codegen", "make generate"],
+        "fileFilters": ["**/**"],
+        "executionMode": "branch"
+      },
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "digest",
+        "patch",
+        "pin",
+        "pinDigest"
+      ],
+      matchBaseBranches: [
+        "main"
+      ],
+    },
+    {
+      // not grouping these together
+      // "groupName": "all k8s pkg go dependencies main",
+      // "groupSlug": "all-k8s-pkg-go-deps-main",
+      "matchFiles": [
+        "pkg/k8s/go.mod",
+        "pkg/k8s/go.sum"
+      ],
+      "postUpdateOptions": [
+        // update source import paths on major updates
+        "gomodUpdateImportPaths",
+      ],
+      postUpgradeTasks: {
+        "commands": ["/tmp/install-buildx", "make codegen", "make generate"],
+        "fileFilters": ["**/**"],
+        "executionMode": "branch"
+      },
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "digest",
+        "patch",
+        "pin",
+        "pinDigest"
+      ],
+      matchBaseBranches: [
+        "main"
+      ],
+    },
+    {
+      // Images that directly use docker.io/library/golang for building.
+      "groupName": "golang-images",
+      "matchFiles": [
+        "Dockerfile",
+        "Makefile"
+      ]
+    },
+    {
+      "matchPackageNames": [
+        "docker.io/library/busybox"
+      ],
+      "matchPaths": [
+        "Dockerfile"
+      ],
+    },
+    {
+      "groupName": "Go",
+      "matchDepNames": [
+        "go",
+        "docker.io/library/golang"
+      ],
+    },
+    {
+      // Group golangci-lint updates to overrule grouping of version updates in the GHA files.
+      // Without this, golangci-lint updates are not in sync for GHA files and other usages.
+      "groupName": "golangci-lint",
+      "matchDepNames": [
+        "golangci/golangci-lint"
+      ]
+    },
+    {
+      "matchFiles": [
+        "install/kubernetes/values.yaml",
+      ],
+      // lint and generate files for helm chart
+      postUpgradeTasks: {
+        "commands": ["install/kubernetes/test.sh"],
+        "fileFilters": ["**/**"],
+        "executionMode": "branch"
+      }
+    }
+  ]
+}

--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -15,12 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      - name: Install kubeval
-        run: |
-          cd /tmp
-          wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
-          tar xf kubeval-linux-amd64.tar.gz
-          sudo cp kubeval /usr/local/bin
       - name: Run install/kubernetes/test.sh
         run: |
           cd install/kubernetes && ./test.sh

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -1,0 +1,21 @@
+name: Validate renovate configuration
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json5'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout configuration
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      # this step uses latest renovate slim release
+      - name: Validate configuration
+        run: >
+          docker run --rm --entrypoint "renovate-config-validator"
+          -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5"
+          renovate/renovate:slim "/renovate.json5"
+

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,68 @@
+name: Renovate
+on:
+  # runnig twice a day, around 11:00am CEST and 11:00am PST
+  schedule:
+    - cron: '0 9,18 * * *'
+  # allow to manually trigger this workflow
+  workflow_dispatch:
+    inputs:
+      renovate_log_level_debug:
+        type: boolean
+        default: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    env:
+      buildx_version: 'v0.10.5'
+    steps:
+      # we need special permission to be able to operate renovate (view, list,
+      # create issues, PR, etc.) and we use a GitHub application with fine
+      # grained permissions installed in the repository for that.
+      - name: Get token
+        id: get_token
+        uses: cilium/actions-app-token@350a14155dd9be79227f081310f4d77fdf792e76 # v0.21.0
+        with:
+          APP_PEM: ${{ secrets.CILIUM_RENOVATE_PEM }}
+          APP_ID: ${{ secrets.CILIUM_RENOVATE_APP_ID }}
+
+      # buildx is not installed in the renovate container image and we need it
+      # for the postUpgradeTasks's commands. We take advantage of the fact that
+      # the renovate GitHub action mounts the /tmp folder in the container to
+      # transfer the docker CLI plugin binary.
+      - name: Cache Buildx CLI plugin download
+        id: cache-buildx
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: /tmp/docker-buildx
+          key: ${{ runner.os }}-${{ env.buildx_version }}-buildx
+
+      - name: Download and set permissions for buildx
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o /tmp/docker-buildx https://github.com/docker/buildx/releases/download/${{ env.buildx_version }}/buildx-${{ env.buildx_version }}.linux-amd64
+          chmod +x /tmp/docker-buildx
+
+      # this is not strictly necessary but makes the renovate
+      # postUpgradeTasks's commands shorter and understandable.
+      - name: Create and set permissions for install buildx bash script
+        run: |
+          echo '#!/bin/bash' > /tmp/install-buildx
+          echo 'DIR="$HOME/.docker/cli-plugins"' >> /tmp/install-buildx
+          echo 'mkdir -p "$DIR" && ln -sf /tmp/docker-buildx "$DIR/docker-buildx"' >> /tmp/install-buildx
+          chmod +x /tmp/install-buildx
+
+      # renovate clones the repository again in its container fs but it needs
+      # the renovate configuration to start.
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@f9a5a67d4271f326b1e80695ea86dd9398b61d58 # v38.1.0
+        env:
+          LOG_LEVEL: ${{ github.event.inputs.renovate_log_level_debug == 'true' && 'DEBUG' || 'INFO' }}
+        with:
+          configurationFile: .github/renovate.json5
+          token: '${{ steps.get_token.outputs.app_token }}'
+          mount-docker-socket: true
+

--- a/install/kubernetes/test.sh
+++ b/install/kubernetes/test.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 shopt -s expand_aliases
 
+# make this script executable from anywhere
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR
+
 alias helm='docker run --rm -v $(pwd):/apps alpine/helm:3.3.4'
+alias kubeval='docker run --rm -i garethr/kubeval:0.15.0@sha256:6962d8ecbb7839637667f66e6703e6ebaae0c29dfe93a31d9968fba4324c7b8d'
 helm dependency update .
 helm lint . --with-subcharts
 helm template tetragon . | kubeval --strict --additional-schema-locations https://raw.githubusercontent.com/joshuaspence/kubernetes-json-schema/master


### PR DESCRIPTION
- run renovate self-hosted on GitHub action with a workflow in order to use PostUpgradeCommands to commit generated files in deps update PRs.
- install docker CLI plugin buildx in the renovate container in order for our PostUpgradeCommands to work.
- use 'cilium-renovate' GitHub application in order to generate a fine grain permissions token.
- group some deps update together in a single PR.
- add a workflow to validate configuration change in PRs.

I had to merge https://github.com/renovatebot/github-action/pull/749 to make our commands work in the renovate container.

This will provide us a lot more control over our deps update bot, and a lot more configuration settings (since we are running it ourselves on top of changing from dependabot to renovate).

When the renovate deployment works, we can disable Dependabot.