### PR TITLE
pkg:process: clean up functions that read/write processes into the cache 

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -108,12 +108,12 @@ func (pi *ProcessInternal) AddPodInfo(pod *tetragon.Pod) {
 	pi.mu.Unlock()
 }
 
-func (pi *ProcessInternal) GetProcess() *tetragon.Process {
+func (pi *ProcessInternal) getProcess() *tetragon.Process {
 	pi.mu.Lock()
 	return pi.process
 }
 
-func (pi *ProcessInternal) PutProcess() {
+func (pi *ProcessInternal) putProcess() {
 	pi.mu.Unlock()
 }
 
@@ -122,8 +122,8 @@ func (pi *ProcessInternal) UnsafeGetProcess() *tetragon.Process {
 }
 
 func (pi *ProcessInternal) AnnotateProcess(cred, ns bool) error {
-	process := pi.GetProcess()
-	defer pi.PutProcess()
+	process := pi.getProcess()
+	defer pi.putProcess()
 	if process == nil {
 		return fmt.Errorf("Process is nil")
 	}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -80,6 +80,7 @@ func FreeCache() {
 	procCache = nil
 }
 
+// GetProcessCopy() duplicates tetragon.Process and returns it
 func (pi *ProcessInternal) GetProcessCopy() *tetragon.Process {
 	if pi.process == nil {
 		return nil
@@ -91,7 +92,9 @@ func (pi *ProcessInternal) GetProcessCopy() *tetragon.Process {
 	return proc
 }
 
-func (pi *ProcessInternal) GetProcessInternalCopy() *ProcessInternal {
+// cloneInternalProcessCopy() duplicates ProcessInternal, sets its refcnt to 1
+// and returns it
+func (pi *ProcessInternal) cloneInternalProcessCopy() *ProcessInternal {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
 	return &ProcessInternal{
@@ -287,7 +290,7 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 		return err
 	}
 	parent.RefInc()
-	pi := parent.GetProcessInternalCopy()
+	pi := parent.cloneInternalProcessCopy()
 	if pi.process != nil {
 		pi.process.ParentExecId = parentExecId
 		pi.process.ExecId = GetProcessID(event.PID, event.Ktime)

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -136,10 +136,6 @@ func (pi *ProcessInternal) AnnotateProcess(cred, ns bool) error {
 	return nil
 }
 
-func (pi *ProcessInternal) UnsafeGetProcessCap() *tetragon.Capabilities {
-	return pi.capabilities
-}
-
 func (pi *ProcessInternal) RefDec() {
 	procCache.refDec(pi)
 }
@@ -149,8 +145,7 @@ func (pi *ProcessInternal) RefInc() {
 }
 
 func (pi *ProcessInternal) RefGet() uint32 {
-	ref := atomic.LoadUint32(&pi.refcnt)
-	return ref
+	return atomic.LoadUint32(&pi.refcnt)
 }
 
 // UpdateEventProcessTID Updates the Process.Tid of the event on the fly.


### PR DESCRIPTION
This set cleans up package process:
- Remove unused functions
- Do not export getProcess()/putProcess() functions to make it easy to read where we are taking locks or references on processes
- Rename some functions that where sharing the GetProcess() to be more explicit about they do. 

Signed-off-by: Djalal Harouni <tixxdz@gmail.com>