### PR TITLE
Add rate limiting to events

### DIFF
--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -820,6 +820,20 @@ executed directly in the kernel BPF code while `GetUrl` and `DnsLookup` are
 happening in userspace after the reception of events.
 {{< /note >}}
 
+All actions can be rate limited by adding the rateLimit parameter with a
+time value. This value defaults to seconds, but post-fixing 'm' or 'h' will
+cause the value to be interpreted in minutes or hours. When this parameter is
+specified for an action, that action will check if the same action has fired
+within the time window, with the same inspected arguments. (Only the first 16
+bytes of each inspected argument is used in the matching. Only supported on
+kernels v5.3 onwards.)
+
+```yaml
+matchActions:
+- action: Post
+  rateLimit: 5m
+```
+
 ##### Sigkill action
 
 `Sigkill` action terminates synchronously the process that made the call that

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -219,6 +219,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
@@ -666,6 +672,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
@@ -991,6 +1003,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -219,6 +219,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
@@ -666,6 +672,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
@@ -991,6 +1003,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -279,6 +279,10 @@ type ActionSelector struct {
 	// +kubebuilder:validation:Optional
 	// A signal number for signal action
 	ArgSig uint32 `json:"argSig"`
+	// +kubebuilder:validation:Optional
+	// A time period within which repeated messages will not be posted. Can be specified in seconds (default or with
+	// 's' suffix), minutes ('m' suffix) or hours ('h' suffix).
+	ArgRateLimit string `json:"argRateLimit"`
 }
 
 type TracepointSpec struct {

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -414,6 +414,7 @@ func TestParseMatchAction(t *testing.T) {
 	k := &KernelSelectorState{off: 0}
 	expected1 := []byte{
 		0x00, 0x00, 0x00, 0x00, // Action = "post"
+		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
 	}
 	if err := ParseMatchAction(k, act1, &actionArgTable); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
 		t.Errorf("parseMatchAction: error %v expected %v bytes %v parsing %v\n", err, expected1, k.e[0:k.off], act1)
@@ -423,8 +424,9 @@ func TestParseMatchAction(t *testing.T) {
 	// test multiple actions.
 	expected2 := []byte{
 		0x00, 0x00, 0x00, 0x00, // Action = "post"
+		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
 	}
-	length := []byte{12, 0x00, 0x00, 0x00}
+	length := []byte{20, 0x00, 0x00, 0x00}
 	expected := append(length, expected1[:]...)
 	expected = append(expected, expected2[:]...)
 
@@ -526,11 +528,11 @@ func TestInitKernelSelectors(t *testing.T) {
 	}
 
 	expected_selsize_small := []byte{
-		0xe2, 0x00, 0x00, 0x00, // size = pids + args + actions + namespaces + capabilities  + 4
+		0xea, 0x00, 0x00, 0x00, // size = pids + args + actions + namespaces + capabilities  + 4
 	}
 
 	expected_selsize_large := []byte{
-		22, 0x01, 0x00, 0x00, // size = pids + args + actions + namespaces + namespacesChanges + capabilities + capabilityChanges + 4
+		0x1e, 0x01, 0x00, 0x00, // size = pids + args + actions + namespaces + namespacesChanges + capabilities + capabilityChanges + 4
 	}
 
 	expected_filters := []byte{
@@ -639,9 +641,11 @@ func TestInitKernelSelectors(t *testing.T) {
 		0x02, 0x00, 0x00, 0x00, // value 2
 
 		// actions header
-		20, 0x00, 0x00, 0x00, // size = (sizeof(uint32) * number of actions)  + 4
+		28, 0x00, 0x00, 0x00, // size = (2 * sizeof(uint32) * number of actions) + args + 4
 		0x00, 0x00, 0x00, 0x00, // post to userspace
+		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
 		0x01, 0x00, 0x00, 0x00, // fdinstall
+		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
 		0x00, 0x00, 0x00, 0x00, // arg index of fd
 		0x01, 0x00, 0x00, 0x00, // arg index of string filename
 	}
@@ -664,9 +668,11 @@ func TestInitKernelSelectors(t *testing.T) {
 		102, 111, 111, 98, 97, 114, // value ascii "foobar"
 
 		// actions header
-		20, 0x00, 0x00, 0x00, // size = (sizeof(uint32) * number of actions)  + 4
+		28, 0x00, 0x00, 0x00, // size = (2 * sizeof(uint32) * number of actions) + args + 4
 		0x00, 0x00, 0x00, 0x00, // post to userspace
+		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
 		0x01, 0x00, 0x00, 0x00, // fdinstall
+		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
 		0x00, 0x00, 0x00, 0x00, // arg index of fd
 		0x01, 0x00, 0x00, 0x00, // arg index of string filename
 	}

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -219,6 +219,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
@@ -666,6 +672,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
@@ -991,6 +1003,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -219,6 +219,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
@@ -666,6 +672,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
@@ -991,6 +1003,12 @@ spec:
                                     action
                                   format: int32
                                   type: integer
+                                argRateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
+                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -279,6 +279,10 @@ type ActionSelector struct {
 	// +kubebuilder:validation:Optional
 	// A signal number for signal action
 	ArgSig uint32 `json:"argSig"`
+	// +kubebuilder:validation:Optional
+	// A time period within which repeated messages will not be posted. Can be specified in seconds (default or with
+	// 's' suffix), minutes ('m' suffix) or hours ('h' suffix).
+	ArgRateLimit string `json:"argRateLimit"`
 }
 
 type TracepointSpec struct {


### PR DESCRIPTION
Some hooks can generate the same events many times repeated. This can
fill logs and doesn't always provide useful information. This series
adds rate limiting so that events with the same data are not generated
until a specified time limit has passed.
    
This is implemented by building a hash key out of the function ID,
action, and the first 16 bytes of each of the arguments that are
retrieved. This key maps to the last time that the event with this key
was sent. Each new event is checked to see if it is new (in which case
it is sent and an mapping created to the current time), if it is a
repeat but long enough ago (event is sent and mapping is updated to
current time), or if it is a recent repeat, in which case nothing
happens.