### PR TITLE
fix goroutines leaking in tests

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -37,7 +37,6 @@ type Exporter struct {
 	encoder     ExportEncoder
 	closer      io.Closer
 	rateLimiter *ratelimit.RateLimiter
-	done        chan bool
 }
 
 func NewExporter(
@@ -48,7 +47,7 @@ func NewExporter(
 	closer io.Closer,
 	rateLimiter *ratelimit.RateLimiter,
 ) *Exporter {
-	return &Exporter{ctx, request, server, encoder, closer, rateLimiter, make(chan bool)}
+	return &Exporter{ctx, request, server, encoder, closer, rateLimiter}
 }
 
 func (e *Exporter) Start() {
@@ -60,7 +59,6 @@ func (e *Exporter) Start() {
 				logger.GetLogger().WithError(err).Error("Failed to start JSON exporter")
 			}
 		}
-		e.done <- true
 	}()
 	readyWG.Wait()
 }

--- a/pkg/observer/observer_test_helper.go
+++ b/pkg/observer/observer_test_helper.go
@@ -327,8 +327,15 @@ func loadExporter(t *testing.T, ctx context.Context, obs *Observer, opts *testEx
 		return err
 	}
 
+	// NB(kkourt): we use the global that was set up by InitSensorManager(). We should clean
+	// this up and remove/hide the global variable.
+	sensorManager := SensorManager
+	t.Cleanup(func() {
+		sensorManager.StopSensorManager(context.TODO())
+	})
+
 	if oo.crd {
-		crd.WatchTracePolicy(ctx, SensorManager)
+		crd.WatchTracePolicy(ctx, sensorManager)
 	}
 
 	if err := btf.InitCachedBTF(option.Config.HubbleLib, ""); err != nil {
@@ -360,7 +367,7 @@ func loadExporter(t *testing.T, ctx context.Context, obs *Observer, opts *testEx
 	option.Config.EnableProcessNs = true
 	option.Config.EnableProcessCred = true
 	option.Config.EnableCilium = false
-	processManager, err := tetragonGrpc.NewProcessManager(ctx, &cancelWg, ciliumState, SensorManager, hookRunner)
+	processManager, err := tetragonGrpc.NewProcessManager(ctx, &cancelWg, ciliumState, sensorManager, hookRunner)
 	if err != nil {
 		return err
 	}

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -47,6 +47,7 @@ func (pc *Cache) cacheGarbageCollector() {
 			case <-pc.stopChan:
 				ticker.Stop()
 				pc.cache.Purge()
+				return
 			case <-ticker.C:
 				newQueue = newQueue[:0]
 				for _, p := range deleteQueue {

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -16,9 +16,10 @@ import (
 )
 
 type Cache struct {
-	cache      *lru.Cache[string, *ProcessInternal]
-	deleteChan chan *ProcessInternal
-	stopChan   chan bool
+	cache           *lru.Cache[string, *ProcessInternal]
+	deleteChan      chan *ProcessInternal
+	stopChan        chan bool
+	metricsStopChan chan bool
 }
 
 // garbage collection states
@@ -123,6 +124,7 @@ func (pc *Cache) refInc(p *ProcessInternal) {
 
 func (pc *Cache) Purge() {
 	pc.stopChan <- true
+	pc.metricsStopChan <- true
 }
 
 func NewCache(
@@ -144,11 +146,14 @@ func NewCache(
 		mapmetrics.MapSizeSet("processLru", processCacheSize, float64(pm.cache.Len()))
 	}
 	ticker := time.NewTicker(60 * time.Second)
+	pm.metricsStopChan = make(chan bool)
 	go func() {
 		for {
 			select {
 			case <-ticker.C:
 				update()
+			case <-pm.metricsStopChan:
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
We are leaking goroutines in testing.

This was reproduced via running the tests with a small timeout:
```
$ sudo $(which go) test ./pkg/sensors/tracing -test.v -test.failfast -bpf-lib $(pwd)/bpf/objs -test.timeout 1m
```

And observing the resulting stack traces.

Before the patch:
```
      1         /home/kkourt/src/tetragon/pkg/eventcache/eventcache.go:155 +0x112
     18         /home/kkourt/src/tetragon/pkg/exporter/exporter.go:63 +0xca
     19         /home/kkourt/src/tetragon/pkg/process/cache.go:149 +0x30
     19         /home/kkourt/src/tetragon/pkg/process/cache.go:46 +0x105
     19         /home/kkourt/src/tetragon/pkg/sensors/manager.go:57 +0xea
      1         /home/kkourt/src/tetragon/pkg/server/server.go:156 +0x727
```

After the patch:
```
      1         /home/kkourt/src/tetragon/pkg/eventcache/eventcache.go:155 +0x112
      1         /home/kkourt/src/tetragon/pkg/process/cache.go:152 +0x85
      1         /home/kkourt/src/tetragon/pkg/process/cache.go:47 +0xfd
      1         /home/kkourt/src/tetragon/pkg/sensors/manager.go:57 +0xea
      1         /home/kkourt/src/tetragon/pkg/server/server.go:156 +0x727
```


Fixes: https://github.com/cilium/tetragon/issues/1039