### PR TITLE
logging: change log level dynamically

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -125,7 +125,8 @@ func tetragonExecute() error {
 	defer cancel()
 
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, tgsyscall.SIGRTMIN_20)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, tgsyscall.SIGRTMIN_20,
+		tgsyscall.SIGRTMIN_21)
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	if err := logger.SetupLogging(option.Config.LogOpts, option.Config.Debug); err != nil {
@@ -235,6 +236,14 @@ func tetragonExecute() error {
 				} else {
 					logger.SetLogLevel(logrus.DebugLevel)
 					log.Infof("Received signal SIGRTMIN+20: switching from LogLevel '%s' to '%s'", currentLevel, logger.GetLogLevel())
+				}
+			case tgsyscall.SIGRTMIN_21: // SIGRTMIN+21
+				currentLevel := logger.GetLogLevel()
+				if currentLevel == logrus.TraceLevel {
+					log.Infof("Received signal SIGRTMIN+21: LogLevel is already '%s'", currentLevel)
+				} else {
+					logger.SetLogLevel(logrus.TraceLevel)
+					log.Infof("Received signal SIGRTMIN+21: switching from LogLevel '%s' to '%s'", currentLevel, logger.GetLogLevel())
 				}
 			}
 		}

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -126,7 +126,7 @@ func tetragonExecute() error {
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, tgsyscall.SIGRTMIN_20,
-		tgsyscall.SIGRTMIN_21)
+		tgsyscall.SIGRTMIN_21, tgsyscall.SIGRTMIN_22)
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	if err := logger.SetupLogging(option.Config.LogOpts, option.Config.Debug); err != nil {
@@ -219,6 +219,7 @@ func tetragonExecute() error {
 		obs.RemovePrograms()
 	}()
 
+	defaultLevel := logger.GetLogLevel()
 	go func(obs *observer.Observer) {
 		for {
 			s := <-sigs
@@ -245,6 +246,9 @@ func tetragonExecute() error {
 					logger.SetLogLevel(logrus.TraceLevel)
 					log.Infof("Received signal SIGRTMIN+21: switching from LogLevel '%s' to '%s'", currentLevel, logger.GetLogLevel())
 				}
+			case tgsyscall.SIGRTMIN_22: // SIGRTMIN+22
+				logger.SetLogLevel(defaultLevel)
+				log.Infof("Received signal SIGRTMIN+22: resetting original LogLevel '%s'", logger.GetLogLevel())
 			}
 		}
 	}(obs)

--- a/docs/content/en/docs/tutorials/debugging-tetragon.md
+++ b/docs/content/en/docs/tutorials/debugging-tetragon.md
@@ -1,0 +1,37 @@
+---
+title: "Debugging Tetragon"
+weight: 1
+icon: "overview"
+description: "Diagnosing Tetragon problems"
+---
+
+### Enable debug log level
+
+When debugging, it might be useful to change the log level. The default log level is controlled by the log-level option:
+
+* Enable debug level with `--log-level=debug`
+
+* Enable trace level with `--log-level=trace`
+
+### Change log level dynamically
+
+It is possible to change the log level dynamically by sending the corresponding signal to tetragon process.
+
+* Change log level to debug level by sending the `SIGRTMIN+20` signal to tetragon pid:
+
+  ```shell
+  sudo kill -s SIGRTMIN+20 $(pidof tetragon)
+  ```
+
+* Change log level to trace level by sending the `SIGRTMIN+21` signal to tetragon pid:
+
+  ```shell
+  sudo kill -s SIGRTMIN+21 $(pidof tetragon)
+  ```
+
+* To Restore the original log level send the `SIGRTMIN+22` signal to tetragon pid:
+
+  ```shell
+  sudo kill -s SIGRTMIN+22 $(pidof tetragon)
+  ```
+

--- a/pkg/logger/log.go
+++ b/pkg/logger/log.go
@@ -100,7 +100,7 @@ func GetLogLevel() logrus.Level {
 	return DefaultLogger.GetLevel()
 }
 
-func setLogLevel(logLevel logrus.Level) {
+func SetLogLevel(logLevel logrus.Level) {
 	DefaultLogger.SetLevel(logLevel)
 }
 
@@ -149,7 +149,7 @@ func SetupLogging(o LogOptions, debug bool) error {
 	if debug {
 		setLogLevelToDebug()
 	} else {
-		setLogLevel(o.getLogLevel())
+		SetLogLevel(o.getLogLevel())
 	}
 
 	// always suppress the default logger so libraries don't print things

--- a/pkg/tgsyscall/tgsyscall.go
+++ b/pkg/tgsyscall/tgsyscall.go
@@ -25,4 +25,5 @@ const (
 	 */
 	SIGRTMIN    = syscall.Signal(0x22) // SIGRTMIN
 	SIGRTMIN_20 = SIGRTMIN + 20        // SIGRTMIN+20 used to set log level to debug
+	SIGRTMIN_21 = SIGRTMIN + 21        // SIGRTMIN+21 used to set log level to trace
 )

--- a/pkg/tgsyscall/tgsyscall.go
+++ b/pkg/tgsyscall/tgsyscall.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+/*
+ * This package contains low-level operating system privimitives
+ * that are missing from the the default syscall package
+ */
+
+package tgsyscall
+
+import (
+	"syscall"
+)
+
+const (
+	/*
+	 * The real time signals can be used for application-defined
+	 * purpose.
+	 *
+	 * We avoid using first rt signals to easy debugging in case
+	 * inspecting logs as the first rt signals are heavily used by
+	 * nptl implementation to manage threads.
+	 *
+	 * https://man7.org/linux/man-pages/man7/signal.7.html
+	 */
+	SIGRTMIN    = syscall.Signal(0x22) // SIGRTMIN
+	SIGRTMIN_20 = SIGRTMIN + 20        // SIGRTMIN+20 used to set log level to debug
+)

--- a/pkg/tgsyscall/tgsyscall.go
+++ b/pkg/tgsyscall/tgsyscall.go
@@ -26,4 +26,5 @@ const (
 	SIGRTMIN    = syscall.Signal(0x22) // SIGRTMIN
 	SIGRTMIN_20 = SIGRTMIN + 20        // SIGRTMIN+20 used to set log level to debug
 	SIGRTMIN_21 = SIGRTMIN + 21        // SIGRTMIN+21 used to set log level to trace
+	SIGRTMIN_22 = SIGRTMIN + 22        // SIGRTMIN+22 restore original configured log level
 )


### PR DESCRIPTION
Allow to change log level dynamically which is handy for debugging problems.


sudo kill -s SIGRTMIN+20 $(pidof tetragon)
sudo kill -s SIGRTMIN+21 $(pidof tetragon)
sudo kill -s SIGRTMIN+22 $(pidof tetragon)
sudo kill -s SIGRTMIN+22 $(pidof tetragon)
    
output:
time="2023-06-02T13:14:31+02:00" level=info msg="Listening for events..."
time="2023-06-02T13:14:33+02:00" level=info msg="Received signal SIGRTMIN+20: switching from LogLevel 'info' to 'debug'"
time="2023-06-02T13:14:37+02:00" level=info msg="Received signal SIGRTMIN+21: switching from LogLevel 'debug' to 'trace'"
time="2023-06-02T13:14:40+02:00" level=trace msg="process_exec: no container ID due to cgroup name not being a compatible ID, ignoring." cgroup.id=13750 cgroup.name=vte-spawn-5c6c92b1-0631-48d7-855c-bc00f4b70255.scope process.binary=/usr/bin/pidof process.exec_id="OjE2MDExMDU5NDY0NzgxOjEzODMzOQ=="
time="2023-06-02T13:14:40+02:00" level=trace msg="process_exec: no container ID due to cgroup name not being a compatible ID, ignoring." cgroup.id=13750 cgroup.name=vte-spawn-5c6c92b1-0631-48d7-855c-bc00f4b70255.scope process.binary=/usr/bin/sudo process.exec_id="OjE2MDExMDgxNzM4MTE2OjEzODM0MA=="
time="2023-06-02T13:14:40+02:00" level=trace msg="process_exec: no container ID due to cgroup name not being a compatible ID, ignoring." cgroup.id=13750 cgroup.name=vte-spawn-5c6c92b1-0631-48d7-855c-bc00f4b70255.scope process.binary=/usr/bin/kill process.exec_id="OjE2MDExMTAxMjU2NTU4OjEzODM0Mg=="
time="2023-06-02T13:14:40+02:00" level=info msg="Received signal SIGRTMIN+22: resetting original LogLevel 'info'"
time="2023-06-02T13:14:42+02:00" level=info msg="Received signal SIGRTMIN+22: resetting original LogLevel 'info'"
