### PR TITLE
Found unused functions

### DIFF
--- a/pkg/podinfo/podinfo.go
+++ b/pkg/podinfo/podinfo.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
+
 package podinfo
 
 import (
@@ -18,6 +19,8 @@ func getExecCommand(probe *coreV1.Probe) []string {
 	return nil
 }
 
+// Function not used
+
 func GetPodInfoOfIp(ip net.IP) *tetragon.Pod {
 	ciliumState := cilium.GetCiliumState()
 	ipcacheEntry, ok := ciliumState.GetIPCache().GetIPIdentity(ip)
@@ -31,6 +34,8 @@ func GetPodInfoOfIp(ip net.IP) *tetragon.Pod {
 		Container: nil,
 	}
 }
+
+// Function not used
 
 func GetProbes(pod *coreV1.Pod, containerStatus *coreV1.ContainerStatus) ([]string, []string) {
 	for _, container := range pod.Spec.Containers {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -63,6 +63,8 @@ func InitCache(w watcher.K8sResourceWatcher, size int) error {
 	}
 
 	nodeName = node.GetNodeNameForExport()
+
+	// Cilium state created but not used
 	ciliumState = cilium.GetCiliumState()
 	if ciliumState == nil {
 		return fmt.Errorf("ciliumState must be initialized before process cache")
@@ -332,6 +334,8 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 func Get(execId string) (*ProcessInternal, error) {
 	return procCache.get(execId)
 }
+
+// Function not used
 
 func GetProcessEndpoint(p *tetragon.Process) *hubblev1.Endpoint {
 	if p == nil {


### PR DESCRIPTION
While searching for cilium dependencies in tetragon, I found some unused function in pkg/podinfo/podinfo.go and pkg/process/process.go, should we remove them ?