### PR TITLE
Rename argRateLimit to rateLimit

### DIFF
--- a/examples/tracingpolicy/datagram.yaml
+++ b/examples/tracingpolicy/datagram.yaml
@@ -23,3 +23,6 @@ spec:
           operator: "Protocol"
           values:
           - "IPPROTO_UDP"
+        matchActions:
+        - action: Post
+          rateLimit: 5

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -225,18 +225,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action
@@ -681,18 +681,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action
@@ -1012,18 +1012,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -225,18 +225,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action
@@ -681,18 +681,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action
@@ -1012,18 +1012,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -285,7 +285,7 @@ type ActionSelector struct {
 	// +kubebuilder:validation:Optional
 	// A time period within which repeated messages will not be posted. Can be specified in seconds (default or with
 	// 's' suffix), minutes ('m' suffix) or hours ('h' suffix).
-	ArgRateLimit string `json:"argRateLimit"`
+	RateLimit string `json:"rateLimit"`
 }
 
 type TracepointSpec struct {

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -225,18 +225,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action
@@ -681,18 +681,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action
@@ -1012,18 +1012,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -225,18 +225,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action
@@ -681,18 +681,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action
@@ -1012,18 +1012,18 @@ spec:
                                     action
                                   format: int32
                                   type: integer
-                                argRateLimit:
-                                  description: A time period within which repeated
-                                    messages will not be posted. Can be specified
-                                    in seconds (default or with 's' suffix), minutes
-                                    ('m' suffix) or hours ('h' suffix).
-                                  type: string
                                 argSig:
                                   description: A signal number for signal action
                                   format: int32
                                   type: integer
                                 argUrl:
                                   description: A URL for the getUrl action
+                                  type: string
+                                rateLimit:
+                                  description: A time period within which repeated
+                                    messages will not be posted. Can be specified
+                                    in seconds (default or with 's' suffix), minutes
+                                    ('m' suffix) or hours ('h' suffix).
                                   type: string
                               required:
                               - action

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -285,7 +285,7 @@ type ActionSelector struct {
 	// +kubebuilder:validation:Optional
 	// A time period within which repeated messages will not be posted. Can be specified in seconds (default or with
 	// 's' suffix), minutes ('m' suffix) or hours ('h' suffix).
-	ArgRateLimit string `json:"argRateLimit"`
+	RateLimit string `json:"rateLimit"`
 }
 
 type TracepointSpec struct {


### PR DESCRIPTION
In the previous commit, the rate limit parameter to matchActions was incorrectly specified as argRateLimit (but was correct in documentation). This commit changes that parameter to the correct rateLimit. No releases have occurred since the commit. This change shouldn't have a detrimental or regressive effect. Also, updated the example datagram.yaml tracing policy to include the rateLimit parameter.

Also fixes a potential overflow in the rateLimit argument.