### PR TITLE
pids: clear process.parent_exec_id if process kernel is tetragon generated

### DIFF
--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -29,6 +29,10 @@ const (
 
 	// MsgUnixSize of msg
 	MsgUnixSize uint32 = 640
+
+	// Special values to identify entries related to kernel in the process cache
+	KernelBinary = "<kernel>"
+	KernelPid    = uint32(0)
 )
 
 type MsgExec struct {

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -33,8 +33,6 @@ import (
 const (
 	maxMapRetries = 4
 	mapRetryDelay = 1
-
-	kernelPid = uint32(0)
 )
 
 func stringToUTF8(s []byte) []byte {
@@ -81,18 +79,18 @@ type procs struct {
 }
 
 func procKernel() procs {
-	kernelArgs := []byte("<kernel>\u0000")
+	kernelArgs := []byte(fmt.Sprintf("%s\u0000", processapi.KernelBinary))
 	return procs{
 		psize:       uint32(processapi.MSG_SIZEOF_EXECVE + len(kernelArgs) + processapi.MSG_SIZEOF_CWD),
-		ppid:        kernelPid,
+		ppid:        processapi.KernelPid,
 		pnspid:      0,
 		pflags:      api.EventProcFS,
 		pktime:      1,
 		pargs:       kernelArgs,
 		size:        uint32(processapi.MSG_SIZEOF_EXECVE + len(kernelArgs) + processapi.MSG_SIZEOF_CWD),
 		uid:         0,
-		pid:         kernelPid,
-		tid:         kernelPid,
+		pid:         processapi.KernelPid,
+		tid:         processapi.KernelPid,
 		nspid:       0,
 		auid:        0,
 		flags:       api.EventProcFS,
@@ -241,12 +239,12 @@ func writeExecveMap(procs []procs) {
 	// execve lookup to map to a valid entry. So to simplify the kernel side
 	// and avoid having to add another branch of logic there to handle pid==0
 	// case we simply add it here.
-	m.Update(&execvemap.ExecveKey{Pid: kernelPid}, &execvemap.ExecveValue{
+	m.Update(&execvemap.ExecveKey{Pid: processapi.KernelPid}, &execvemap.ExecveValue{
 		Parent: processapi.MsgExecveKey{
-			Pid:   kernelPid,
+			Pid:   processapi.KernelPid,
 			Ktime: 1},
 		Process: processapi.MsgExecveKey{
-			Pid:   kernelPid,
+			Pid:   processapi.KernelPid,
 			Ktime: 1,
 		},
 	})


### PR DESCRIPTION
Tetragon generates processes with pid == 0 and pushes them into bpf execve_map and user space process cache to easy development, in case a kprobe is triggered without a process context... this makes it easy to support without hacking too much the code.

This situation made some tools show that pid == 0 is from <kernel> which is nice, however same tools may break since the generated event will have process.exec_id == process.parent_exec_id

Lets clear the process.parent_exec_id as suggested by William Findlay when returning the event, this allows to keep current logic in tetragon without modifying cache handling and offer a solution to other tools to easily identify that this is a tetragon kernel generated event that does not have a parent.