### PR TITLE
docs: change baseURL in doc build workflow

### DIFF
--- a/.github/workflows/build-deploy-docs.yaml
+++ b/.github/workflows/build-deploy-docs.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build the Hugo website
         working-directory: docs
-        run: hugo --minify --baseURL "https://tetragon.cilium.io/"
+        run: hugo --minify --baseURL "https://cilium.github.io/tetragon/"
 
       - name: Upload artifact
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'


### PR DESCRIPTION
tetragon.cilium.io is going to be used for the homepage, served from a different website and do redirections from tetragon.cilium.io/docs to cilium.github.io/tetragon/docs.