### PR TITLE
tetragon: Switch to clang-15 in Dockerfile.clang

### DIFF
--- a/Dockerfile.clang
+++ b/Dockerfile.clang
@@ -1,11 +1,11 @@
 FROM ubuntu:22.04@sha256:dfd64a3b4296d8c9b62aa3309984f8620b98d87e47492599ee20739e8eb54fbf
-ARG VERSION=1:14.0.0-1ubuntu1
+ARG VERSION=1:15.0.7-0ubuntu0.22.04.1
 RUN apt-get update
 RUN apt-get -y upgrade
 RUN apt-cache search clang
-RUN apt show clang-14
-RUN apt-get install -y --no-install-recommends clang-14=$VERSION libclang-common-14-dev=$VERSION libclang-cpp14=$VERSION libllvm14=$VERSION llvm-14-linker-tools=$VERSION libclang1-14=$VERSION llvm-14=$VERSION llvm-14-runtime=$VERSION llvm-14-linker-tools=$VERSION make
-RUN ln -vsnf /usr/lib/llvm-14/bin/clang /usr/bin/clang
-RUN ln -vsnf /usr/lib/llvm-14/bin/llc /usr/bin/llc
+RUN apt show clang-15
+RUN apt-get install -y --no-install-recommends clang-15=$VERSION libclang-common-15-dev=$VERSION libclang-cpp15=$VERSION libllvm15=$VERSION llvm-15-linker-tools=$VERSION libclang1-15=$VERSION llvm-15=$VERSION llvm-15-runtime=$VERSION llvm-15-linker-tools=$VERSION make
+RUN ln -vsnf /usr/lib/llvm-15/bin/clang /usr/bin/clang
+RUN ln -vsnf /usr/lib/llvm-15/bin/llc /usr/bin/llc
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ image-codegen:
 
 .PHONY: image-clang
 image-clang:
-	$(CONTAINER_ENGINE) build -f Dockerfile.clang --build-arg VERSION=1:14.0.0-1ubuntu1 -t "cilium/clang:${DOCKER_IMAGE_TAG}" .
+	$(CONTAINER_ENGINE) build -f Dockerfile.clang --build-arg VERSION=1:15.0.7-0ubuntu0.22.04.1 -t "cilium/clang:${DOCKER_IMAGE_TAG}" .
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "${CONTAINER_ENGINE} push cilium/clang:$(DOCKER_IMAGE_TAG)"
 


### PR DESCRIPTION
Switching to clang-15 in Dockerfile.clang, the new version is 1:15.0.7-0ubuntu0.22.04.1.