### PR TITLE
tetragon: Switch to clang 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LOCAL_CLANG ?= 0
 LOCAL_CLANG_FORMAT ?= 0
 FORMAT_FIND_FLAGS ?= -name '*.c' -o -name '*.h' -not -path 'bpf/include/vmlinux.h' -not -path 'bpf/include/api.h' -not -path 'bpf/libbpf/*'
 NOOPT ?= 0
-CLANG_IMAGE = quay.io/cilium/clang:aeaada5cf60efe8d0e772d032fe3cc2bc613739c@sha256:b440ae7b3591a80ffef8120b2ac99e802bbd31dee10f5f15a48566832ae0866f
+CLANG_IMAGE = quay.io/cilium/clang:0428db28c441718a750e9c8376612ed3464aed7d@sha256:a60613382fa0dcaefa68f9d1d288672c56dd7b14822732637f4f80b436acc2dc
 TESTER_PROGS_DIR = "contrib/tester-progs"
 # Extra flags to pass to test binary
 EXTRA_TESTFLAGS ?=


### PR DESCRIPTION
Using new clang 15 to compile bpf code.