### PR TITLE
tracing: Add policy for file monitoring

### DIFF
--- a/docs/content/en/docs/tetragon-events/generic-tracing/file-access.md
+++ b/docs/content/en/docs/tetragon-events/generic-tracing/file-access.md
@@ -12,118 +12,166 @@ kernel, giving you the ability to monitor every file a process opens, reads,
 writes, and closes throughout its lifecycle.
 
 In this example, we can monitor if a process inside a Kubernetes workload performs
-an open, close, read or write in the `/etc/` directory. The policy may further
+an read or write in the `/etc/` directory. The policy may further
 specify additional directories or specific files if needed.
 
-As a first step, let's apply the following `TracingPolicy`:
+As a first step, let's apply the following `TracingPolicy` (```file_monitoring_filtered.yaml``` contains an example for filtering read/write accesses):
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/cilium/tetragon/main/examples/tracingpolicy/sys_write_follow_fd_prefix.yaml
+kubectl apply -f https://raw.githubusercontent.com/cilium/tetragon/main/examples/tracingpolicy/file_monitoring.yaml
 ```
 
+This tracing policy contains three kprobe hooks. The first kprobe hook monitors different ways to do I/O to files. These include:
+
+- Using `read`/`write` family system calls. These include: `read`, `readv`, `pread64`, `preadv`, `preadv2`, `write`, `writev`, `pwrite64`, `pwritev`, and `pwritev2` system calls.
+- Optimized ways to copy files inside kernel. These include: `copy_file_range`, `sendfile`, and `splice` system calls.- Asynchronous ways to do I/O. These include [`io_uring`](https://man.archlinux.org/man/io_uring.7.en) and [`aio`](https://man7.org/linux/man-pages/man7/aio.7.html).
+- `fallocate` system call and its variants.
+The second kprobe hook tracks `mmap` calls (including read/write flags) to files that we monitor. The third hook monitors `truncate` system call and its variants.
+
 As a second step, let's start monitoring the events from the `xwing` pod:
+
 ```bash
 kubectl logs -n kube-system -l app.kubernetes.io/name=tetragon -c export-stdout -f | tetra getevents -o compact --namespace default --pod xwing
 ```
 
 In another terminal, `kubectl exec` into the `xwing` pod:
+
 ```bash
 kubectl exec -it xwing -- /bin/bash
 ```
+
 and edit the `/etc/passwd` file:
+
 ```bash
 vi /etc/passwd
 ```
 
 If you observe, the output in the first terminal should be:
+
 ```bash
+🚀 process default/xwing /bin/bash
+📚 read    default/xwing /bin/bash /etc/passwd
+📚 read    default/xwing /bin/bash /etc/passwd
+💥 exit    default/xwing /bin/bash  127
 🚀 process default/xwing /usr/bin/vi /etc/passwd
-📬 open    default/xwing /usr/bin/vi /etc/passwd
-📚 read    default/xwing /usr/bin/vi /etc/passwd 1269 bytes
-📪 close   default/xwing /usr/bin/vi /etc/passwd
-📬 open    default/xwing /usr/bin/vi /etc/passwd
-📝 write   default/xwing /usr/bin/vi /etc/passwd 1277 bytes
+📚 read    default/xwing /usr/bin/vi /etc/passwd
+📚 read    default/xwing /usr/bin/vi /etc/passwd
+📝 write   default/xwing /usr/bin/vi /etc/passwd
+📝 write   default/xwing /usr/bin/vi /etc/passwd
+📝 trunc   default/xwing /usr/bin/vi /etc/passwd
 💥 exit    default/xwing /usr/bin/vi /etc/passwd 0
 ```
 
-Note, that open and close are only generated for `/etc/` files because of eBPF in kernel
+Note, that read and writes are only generated for `/etc/` files because of eBPF in kernel
 filtering. The default CRD additionally filters events associated with the
 pod init process to filter init noise from pod start.
 
 Similarly to the previous example, reviewing the JSON events provides
 additional data. An example `process_kprobe` event observing a write can be:
 
-<details><summary> Process Kprobe Event </summary>
-<p>
+### Process Kprobe Event
 
 ```json
 {
-   "process_kprobe":{
-      "process":{
-         "exec_id":"a2luZC1jb250cm9sLXBsYW5lOjE1MDA0MzM3MDE1MDI6MTkxNjM=",
-         "pid":19163,
-         "uid":0,
-         "cwd":"/",
-         "binary":"/usr/bin/vi",
-         "arguments":"/etc/passwd",
-         "flags":"execve rootcwd clone",
-         "start_time":"2022-05-26T22:05:13.894Z",
-         "auid":4294967295,
-         "pod":{
-            "namespace":"default",
-            "name":"xwing",
-            "container":{
-               "id":"containerd://4b0df5a137260a6b95cbf6443bb2f4b0c9309e6ccb3d8afdbc3da8fff40c0778",
-               "name":"spaceship",
-               "image":{
-                  "id":"docker.io/tgraf/netperf@sha256:8e86f744bfea165fd4ce68caa05abc96500f40130b857773186401926af7e9e6",
-                  "name":"docker.io/tgraf/netperf:latest"
-               },
-               "start_time":"2022-05-26T21:58:11Z",
-               "pid":25
-            }
-         },
-         "docker":"4b0df5a137260a6b95cbf6443bb2f4b",
-         "parent_exec_id":"a2luZC1jb250cm9sLXBsYW5lOjEyMDQ1NTIzMTUwNjY6MTc1NDI=",
-         "refcnt":1
+  "process_kprobe": {
+    "process": {
+      "exec_id": "a2luZC1jb250cm9sLXBsYW5lOjMyMDY2OTEyNDkyMTA4MToyMDk3ODM=",
+      "pid": 209783,
+      "uid": 0,
+      "cwd": "/",
+      "binary": "/usr/bin/vi",
+      "arguments": "/etc/passwd",
+      "flags": "execve rootcwd clone",
+      "start_time": "2023-06-26T11:23:43.774969054Z",
+      "auid": 4294967295,
+      "pod": {
+        "namespace": "default",
+        "name": "xwing",
+        "container": {
+          "id": "containerd://1f1d1ed09d56f04c17857cc5154f11d22d738b04b28941accd08569183caa4b5",
+          "name": "spaceship",
+          "image": {
+            "id": "docker.io/tgraf/netperf@sha256:8e86f744bfea165fd4ce68caa05abc96500f40130b857773186401926af7e9e6",
+            "name": "docker.io/tgraf/netperf:latest"
+          },
+          "start_time": "2023-06-26T11:11:01Z",
+          "pid": 37
+        },
+        "pod_labels": {
+          "app.kubernetes.io/name": "xwing",
+          "class": "xwing",
+          "org": "alliance"
+        }
       },
-      "parent":{
-
+      "docker": "1f1d1ed09d56f04c17857cc5154f11d",
+      "parent_exec_id": "a2luZC1jb250cm9sLXBsYW5lOjMyMDY2MDM3OTEzODY1MzoyMDk3NTE=",
+      "refcnt": 1,
+      "tid": 209783
+    },
+    "parent": {
+      "exec_id": "a2luZC1jb250cm9sLXBsYW5lOjMyMDY2MDM3OTEzODY1MzoyMDk3NTE=",
+      "pid": 209751,
+      "uid": 0,
+      "cwd": "/",
+      "binary": "/bin/bash",
+      "flags": "execve rootcwd clone",
+      "start_time": "2023-06-26T11:23:35.029187062Z",
+      "auid": 4294967295,
+      "pod": {
+        "namespace": "default",
+        "name": "xwing",
+        "container": {
+          "id": "containerd://1f1d1ed09d56f04c17857cc5154f11d22d738b04b28941accd08569183caa4b5",
+          "name": "spaceship",
+          "image": {
+            "id": "docker.io/tgraf/netperf@sha256:8e86f744bfea165fd4ce68caa05abc96500f40130b857773186401926af7e9e6",
+            "name": "docker.io/tgraf/netperf:latest"
+          },
+          "start_time": "2023-06-26T11:11:01Z",
+          "pid": 28
+        },
+        "pod_labels": {
+          "app.kubernetes.io/name": "xwing",
+          "class": "xwing",
+          "org": "alliance"
+        }
       },
-      "function_name":"__x64_sys_write",
-      "args":[
-         {
-            "file_arg":{
-               "path":"/etc/passwd"
-            }
-         },
-         {
-            "bytes_arg":"cm9vdDp4OjA6MDpyb290Oi9yb290Oi9iaW4vYXNoCm5hdGFsaWEKYmluOng6MToxOmJpbjovYmluOi9zYmluL25vbG9naW4KZGFlbW9uOng6MjoyOmRhZW1vbjovc2Jpbjovc2Jpbi9ub2xvZ2luCmFkbTp4OjM6NDphZG06L3Zhci9hZG06L3NiaW4vbm9sb2dpbgpscDp4OjQ6NzpscDovdmFyL3Nwb29sL2xwZDovc2Jpbi9ub2xvZ2luCnN5bmM6eDo1OjA6c3luYzovc2JpbjovYmluL3N5bmMKc2h1dGRvd246eDo2OjA6c2h1dGRvd246L3NiaW46L3NiaW4vc2h1dGRvd24KaGFsdDp4Ojc6MDpoYWx0Oi9zYmluOi9zYmluL2hhbHQKbWFpbDp4Ojg6MTI6bWFpbDovdmFyL3Nwb29sL21haWw6L3NiaW4vbm9sb2dpbgpuZXdzOng6OToxMzpuZXdzOi91c3IvbGliL25ld3M6L3NiaW4vbm9sb2dpbgp1dWNwOng6MTA6MTQ6dXVjcDovdmFyL3Nwb29sL3V1Y3BwdWJsaWM6L3NiaW4vbm9sb2dpbgpvcGVyYXRvcjp4OjExOjA6b3BlcmF0b3I6L3Jvb3Q6L2Jpbi9zaAptYW46eDoxMzoxNTptYW46L3Vzci9tYW46L3NiaW4vbm9sb2dpbgpwb3N0bWFzdGVyOng6MTQ6MTI6cG9zdG1hc3RlcjovdmFyL3Nwb29sL21haWw6L3NiaW4vbm9sb2dpbgpjcm9uOng6MTY6MTY6Y3JvbjovdmFyL3Nwb29sL2Nyb246L3NiaW4vbm9sb2dpbgpmdHA6eDoyMToyMTo6L3Zhci9saWIvZnRwOi9zYmluL25vbG9naW4Kc3NoZDp4OjIyOjIyOnNzaGQ6L2Rldi9udWxsOi9zYmluL25vbG9naW4KYXQ6eDoyNToyNTphdDovdmFyL3Nwb29sL2Nyb24vYXRqb2JzOi9zYmluL25vbG9naW4Kc3F1aWQ6eDozMTozMTpTcXVpZDovdmFyL2NhY2hlL3NxdWlkOi9zYmluL25vbG9naW4KeGZzOng6MzM6MzM6WCBGb250IFNlcnZlcjovZXRjL1gxMS9mczovc2Jpbi9ub2xvZ2luCmdhbWVzOng6MzU6MzU6Z2FtZXM6L3Vzci9nYW1lczovc2Jpbi9ub2xvZ2luCnBvc3RncmVzOng6NzA6NzA6Oi92YXIvbGliL3Bvc3RncmVzcWw6L2Jpbi9zaApudXQ6eDo4NDo4NDpudXQ6L3Zhci9zdGF0ZS9udXQ6L3NiaW4vbm9sb2dpbgpjeXJ1czp4Ojg1OjEyOjovdXNyL2N5cnVzOi9zYmluL25vbG9naW4KdnBvcG1haWw6eDo4OTo4OTo6L3Zhci92cG9wbWFpbDovc2Jpbi9ub2xvZ2luCm50cDp4OjEyMzoxMjM6TlRQOi92YXIvZW1wdHk6L3NiaW4vbm9sb2dpbgpzbW1zcDp4OjIwOToyMDk6c21tc3A6L3Zhci9zcG9vbC9tcXVldWU6L3NiaW4vbm9sb2dpbgpndWVzdDp4OjQwNToxMDA6Z3Vlc3Q6L2Rldi9udWxsOi9zYmluL25vbG9naW4Kbm9ib2R5Ong6NjU1MzQ6NjU1MzQ6bm9ib2R5Oi86L3NiaW4vbm9sb2dpbgo="
-         },
-         {
-            "size_arg":"1277"
-         }
-      ],
-      "action":"KPROBE_ACTION_POST"
-   },
-   "node_name":"kind-control-plane",
-   "time":"2022-05-26T22:05:25.962Z"
+      "docker": "1f1d1ed09d56f04c17857cc5154f11d",
+      "parent_exec_id": "a2luZC1jb250cm9sLXBsYW5lOjMyMDY2MDM0NTk5MzM2NToyMDk3NDE=",
+      "refcnt": 2,
+      "tid": 209751
+    },
+    "function_name": "security_file_permission",
+    "args": [
+      {
+        "file_arg": {
+          "path": "/etc/passwd"
+        }
+      },
+      {
+        "int_arg": 2
+      }
+    ],
+    "return": {
+      "int_arg": 0
+    },
+    "action": "KPROBE_ACTION_POST"
+  },
+  "node_name": "kind-control-plane",
+  "time": "2023-06-26T11:23:49.019160599Z"
 }
 ```
-
-</p></details>
 
 In addition to the Kubernetes Identity
 and process metadata from exec events, `process_kprobe` events contain
 the arguments of the observed system call. In the above case they are
 
-* `path`: the observed file path
-* `bytes_arg`: content of the observed file encoded in base64
-* `size_arg`: size of the observed file in bytes
+- `file_arg.path`: the observed file path
+- `int_arg`: is the type of the operation (2 for a write and 4 for a read)
+- `return.int_arg`: is 0 if the operation is allowed
 
 To disable the `TracingPolicy` run:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/cilium/tetragon/main/examples/tracingpolicy/sys_write_follow_fd_prefix.yaml
+kubectl delete -f https://raw.githubusercontent.com/cilium/tetragon/main/examples/tracingpolicy/file_monitoring.yaml
 ```
-

--- a/examples/tracingpolicy/file_monitoring.yaml
+++ b/examples/tracingpolicy/file_monitoring.yaml
@@ -1,0 +1,60 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "file-monitoring"
+spec:
+  kprobes:
+  - call: "security_file_permission"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "file" # (struct file *) used for getting the path
+    - index: 1
+      type: "int" # 0x04 is MAY_READ, 0x02 is MAY_WRITE
+    returnArg:
+      index: 0
+      type: "int"
+    returnArgAction: "Post"
+    selectors:
+    - matchArgs:      
+      - index: 0
+        operator: "Prefix"
+        values:
+        - "/etc/" # the files that we care
+  - call: "security_mmap_file"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "file" # (struct file *) used for getting the path
+    - index: 1
+      type: "uint32" # the prot flags PROT_READ(0x01), PROT_WRITE(0x02), PROT_EXEC(0x04)
+    - index: 2
+      type: "nop" # the mmap flags (i.e. MAP_SHARED, ...)
+    returnArg:
+      index: 0
+      type: "int"
+    returnArgAction: "Post"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Prefix"
+        values:
+        - "/etc/" # the files that we care
+  - call: "security_path_truncate"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "path" # (struct path *) used for getting the path
+    returnArg:
+      index: 0
+      type: "int"
+    returnArgAction: "Post"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Prefix"
+        values:
+        - "/etc/" # the files that we care

--- a/examples/tracingpolicy/file_monitoring_filtered.yaml
+++ b/examples/tracingpolicy/file_monitoring_filtered.yaml
@@ -1,0 +1,68 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "file-monitoring-filtered"
+spec:
+  kprobes:
+  - call: "security_file_permission"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "file" # (struct file *) used for getting the path
+    - index: 1
+      type: "int" # 0x04 is MAY_READ, 0x02 is MAY_WRITE
+    returnArg:
+      index: 0
+      type: "int"
+    returnArgAction: "Post"
+    selectors:
+    - matchArgs:      
+      - index: 0
+        operator: "Equal"
+        values:
+        - "/etc/passwd" # the files that we care
+      - index: 1
+        operator: "Equal"
+        values:
+        - "2" # MAY_WRITE
+  - call: "security_mmap_file"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "file" # (struct file *) used for getting the path
+    - index: 1
+      type: "uint32" # the prot flags PROT_READ(0x01), PROT_WRITE(0x02), PROT_EXEC(0x04)
+    - index: 2
+      type: "nop" # the mmap flags (i.e. MAP_SHARED, ...)
+    returnArg:
+      index: 0
+      type: "int"
+    returnArgAction: "Post"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "/etc/passwd" # the files that we care
+      - index: 1
+        operator: "Mask"
+        values:
+        - "2" # PROT_WRITE
+  - call: "security_path_truncate"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "path" # (struct path *) used for getting the path
+    returnArg:
+      index: 0
+      type: "int"
+    returnArgAction: "Post"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "/etc/passwd" # the files that we care

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -287,6 +287,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -501,6 +502,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -753,6 +755,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -967,6 +970,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1091,6 +1095,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1305,6 +1310,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -287,6 +287,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -501,6 +502,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -753,6 +755,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -967,6 +970,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1091,6 +1095,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1305,6 +1310,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -256,7 +256,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;DPort;SAddr;DAddr;Protocol
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;DPort;SAddr;DAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -287,6 +287,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -501,6 +502,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -753,6 +755,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -967,6 +970,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1091,6 +1095,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1305,6 +1310,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -287,6 +287,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -501,6 +502,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -753,6 +755,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -967,6 +970,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1091,6 +1095,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1305,6 +1310,7 @@ spec:
                                   - SAddr
                                   - DAddr
                                   - Protocol
+                                  - Mask
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -256,7 +256,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;DPort;SAddr;DAddr;Protocol
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;DPort;SAddr;DAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.


### PR DESCRIPTION
This PR updates the file access use case. We use 3 new hooks to provide better visibility and remove the need to have `followfd` actions. This is done by using more appropriate hooks deeper in the kernel stack. 

These hooks are responsible to monitor read/write accesses (including different ways to do I/O), mmap calls to files that we care about, and `truncate` system calls. 

This PR also updates the encoder to pretty print these new hooks and also updates the documentation.