### PR TITLE
tetragon: Switch v60 object defines to v61

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -28,11 +28,11 @@ PROCESS = bpf_execve_event.o bpf_execve_event_v53.o bpf_fork.o bpf_exit.o bpf_ge
 	  bpf_multi_kprobe_v53.o bpf_multi_retkprobe_v53.o \
 	  bpf_generic_tracepoint.o bpf_generic_tracepoint_v53.o \
 	  bpf_generic_uprobe.o bpf_generic_uprobe_v53.o \
-	  bpf_execve_event_v60.o \
-	  bpf_generic_kprobe_v60.o bpf_generic_retkprobe_v60.o \
-	  bpf_generic_tracepoint_v60.o \
-	  bpf_multi_kprobe_v60.o bpf_multi_retkprobe_v60.o \
-	  bpf_generic_uprobe_v60.o \
+	  bpf_execve_event_v61.o \
+	  bpf_generic_kprobe_v61.o bpf_generic_retkprobe_v61.o \
+	  bpf_generic_tracepoint_v61.o \
+	  bpf_multi_kprobe_v61.o bpf_multi_retkprobe_v61.o \
+	  bpf_generic_uprobe_v61.o \
 	  bpf_loader.o
 
 CGROUP = bpf_cgroup_mkdir.o bpf_cgroup_rmdir.o bpf_cgroup_release.o
@@ -92,7 +92,7 @@ endef
 # Generic build targets for each sub-dir
 
 $(eval $(call DEFINE_VARIANT,v53))
-$(eval $(call DEFINE_VARIANT,v60))
+$(eval $(call DEFINE_VARIANT,v61))
 
 # ALIGNCHECKER
 objs/%.ll: $(ALIGNCHECKERDIR)%.c
@@ -117,14 +117,14 @@ $(DEPSDIR)%.d: $(PROCESSDIR)%.c
 $(DEPSDIR)%_v53.d:
 	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
 
-objs/bpf_multi_kprobe_v60.ll objs/bpf_multi_retkprobe_v60.ll:
-	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__V60_BPF_PROG -D__MULTI_KPROBE -c $< -o $@
+objs/bpf_multi_kprobe_v61.ll objs/bpf_multi_retkprobe_v61.ll:
+	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__V61_BPF_PROG -D__MULTI_KPROBE -c $< -o $@
 
-objs/%_v60.ll:
-	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__V60_BPF_PROG -c $< -o $@
+objs/%_v61.ll:
+	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__V61_BPF_PROG -c $< -o $@
 
-$(DEPSDIR)%_v60.d:
-	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG  -D__V60_BPF_PROG -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
+$(DEPSDIR)%_v61.d:
+	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG  -D__V61_BPF_PROG -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
 
 # BPFTESTDIR
 objs/%.ll: $(BPFTESTDIR)%.c

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -224,8 +224,8 @@ cwd_read(struct cwd_read_data *data)
 	return 0;
 }
 
-#ifdef __V60_BPF_PROG
-static long cwd_read_v60(__u32 index, void *data)
+#ifdef __V61_BPF_PROG
+static long cwd_read_v61(__u32 index, void *data)
 {
 	return cwd_read(data);
 }
@@ -249,15 +249,15 @@ prepend_path(const struct path *path, const struct path *root, char *bf,
 	probe_read(&data.vfsmnt, sizeof(data.vfsmnt), _(&path->mnt));
 	data.mnt = real_mount(data.vfsmnt);
 
-#ifndef __V60_BPF_PROG
+#ifndef __V61_BPF_PROG
 #pragma unroll
 	for (int i = 0; i < PROBE_CWD_READ_ITERATIONS; ++i) {
 		if (cwd_read(&data))
 			break;
 	}
 #else
-	loop(PROBE_CWD_READ_ITERATIONS, cwd_read_v60, (void *)&data, 0);
-#endif /* __V60_BPF_PROG */
+	loop(PROBE_CWD_READ_ITERATIONS, cwd_read_v61, (void *)&data, 0);
+#endif /* __V61_BPF_PROG */
 
 	if (data.bptr == *buffer) {
 		*buflen = 0;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -927,7 +927,7 @@ copy_iov_iter(void *ctx, long off, unsigned long arg, int argm, struct msg_gener
 
 		size = __copy_char_buf(ctx, off, (unsigned long)buf, count, has_max_data(argm), e, data_heap);
 		break;
-#ifdef __V60_BPF_PROG
+#ifdef __V61_BPF_PROG
 	case ITER_UBUF:
 		tmp = _(&iov_iter->ubuf);
 		probe_read(&buf, sizeof(buf), tmp);
@@ -937,7 +937,7 @@ copy_iov_iter(void *ctx, long off, unsigned long arg, int argm, struct msg_gener
 
 		size = __copy_char_buf(ctx, off, (unsigned long)buf, count, has_max_data(argm), e, data_heap);
 		break;
-#endif // __V60_BPF_PROG
+#endif // __V61_BPF_PROG
 	default:
 		s = (int *)args_off(e, off);
 		s[0] = s[1] = 0;

--- a/contrib/verify/verify.sh
+++ b/contrib/verify/verify.sh
@@ -63,7 +63,7 @@ for obj in "$TETRAGONDIR"/*.o; do
 	fi
 
     # skip v6.0 objects check, because it is still not widely around
-	if [[ "$B" == *60.o ]]; then
+	if [[ "$B" == *61.o ]]; then
 		continue
 	fi
 

--- a/pkg/kernels/kernels.go
+++ b/pkg/kernels/kernels.go
@@ -120,12 +120,12 @@ func MinKernelVersion(kernel string) bool {
 	return false
 }
 
-func EnableV60Progs() bool {
+func EnableV61Progs() bool {
 	if option.Config.ForceSmallProgs {
 		return false
 	}
 	kernelVer, _, _ := GetKernelVersion(option.Config.KernelVersion, option.Config.ProcFS)
-	return (int64(kernelVer) >= KernelStringToNumeric("6.0.0"))
+	return (int64(kernelVer) >= KernelStringToNumeric("6.1.0"))
 }
 
 func EnableLargeProgs() bool {
@@ -146,8 +146,8 @@ func IsKernelVersionLessThan(version string) bool {
 
 // GenericKprobeObjs returns the generic kprobe and and generic retprobe objects
 func GenericKprobeObjs() (string, string) {
-	if EnableV60Progs() {
-		return "bpf_generic_kprobe_v60.o", "bpf_generic_retkprobe_v60.o"
+	if EnableV61Progs() {
+		return "bpf_generic_kprobe_v61.o", "bpf_generic_retkprobe_v61.o"
 	} else if EnableLargeProgs() {
 		return "bpf_generic_kprobe_v53.o", "bpf_generic_retkprobe_v53.o"
 	} else {

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -97,8 +97,8 @@ func GetInitialSensor() *sensors.Sensor {
 
 // ExecObj returns the exec object based on the kernel version
 func ExecObj() string {
-	if kernels.EnableV60Progs() {
-		return "bpf_execve_event_v60.o"
+	if kernels.EnableV61Progs() {
+		return "bpf_execve_event_v61.o"
 	} else if kernels.EnableLargeProgs() {
 		return "bpf_execve_event_v53.o"
 	} else {

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -201,9 +201,9 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 
 	loadProgName := "bpf_multi_kprobe_v53.o"
 	loadProgRetName := "bpf_multi_retkprobe_v53.o"
-	if kernels.EnableV60Progs() {
-		loadProgName = "bpf_multi_kprobe_v60.o"
-		loadProgRetName = "bpf_multi_retkprobe_v60.o"
+	if kernels.EnableV61Progs() {
+		loadProgName = "bpf_multi_kprobe_v61.o"
+		loadProgRetName = "bpf_multi_retkprobe_v61.o"
 	}
 
 	pinPath := sensors.PathJoin(sensorPath, "multi_kprobe")

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -355,8 +355,8 @@ func createGenericTracepointSensor(
 	}
 
 	progName := "bpf_generic_tracepoint.o"
-	if kernels.EnableV60Progs() {
-		progName = "bpf_generic_tracepoint_v60.o"
+	if kernels.EnableV61Progs() {
+		progName = "bpf_generic_tracepoint_v61.o"
 	} else if kernels.EnableLargeProgs() {
 		progName = "bpf_generic_tracepoint_v53.o"
 	}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -183,8 +183,8 @@ func createGenericUprobeSensor(
 	sensorPath := name
 
 	loadProgName := "bpf_generic_uprobe.o"
-	if kernels.EnableV60Progs() {
-		loadProgName = "bpf_generic_uprobe_v60.o"
+	if kernels.EnableV61Progs() {
+		loadProgName = "bpf_generic_uprobe_v61.o"
 	} else if kernels.EnableLargeProgs() {
 		loadProgName = "bpf_generic_uprobe_v53.o"
 	}


### PR DESCRIPTION
The new stable is v6.1, so let's have 'latest' objects based on that.