### PR TITLE
v0.8 backports 20230627

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -525,8 +525,8 @@ __copy_char_buf(long off, unsigned long arg, unsigned long bytes,
 	int err;
 
 	/* Bound bytes <4095 to ensure bytes does not read past end of buffer */
-	rd_bytes = bytes;
-	rd_bytes &= 0xfff;
+	rd_bytes = bytes < 0x1000 ? bytes : 0xfff;
+	asm volatile("%[rd_bytes] &= 0xfff;\n" ::[rd_bytes] "+r"(rd_bytes) :);
 	err = probe_read(&s[2], rd_bytes, (char *)arg);
 	if (err < 0)
 		return return_error(s, char_buf_pagefault);

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -589,9 +589,10 @@ func execute() error {
 	flags.Int(keyRBSizeTotal, 0, "Set perf ring buffer size in total for all cpus (default 65k per cpu)")
 	flags.Int(keyRBSize, 0, "Set perf ring buffer size for single cpu (default 65k)")
 
-	// Provide option to remove existing pinned BPF programs and maps in
-	// Tetragon's observer dir. Useful for doing upgrades/downgrades.
-	flags.Bool(keyReleasePinnedBPF, false, "Release all pinned BPF programs and maps in Tetragon BPF directory")
+	// Provide option to remove existing pinned BPF programs and maps in Tetragon's
+	// observer dir on startup. Useful for doing upgrades/downgrades. Set to false to
+	// disable.
+	flags.Bool(keyReleasePinnedBPF, true, "Release all pinned BPF programs and maps in Tetragon BPF directory. Enabled by default. Set to false to disable")
 
 	viper.BindPFlags(flags)
 	return rootCmd.Execute()

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -144,14 +144,17 @@ func OpenMap(name string) (*Map, error) {
 
 	info, err := GetMapInfo(os.Getpid(), fd)
 	if err != nil {
+		unix.Close(fd)
 		return nil, err
 	}
 
 	if info.MapType == 0 {
+		unix.Close(fd)
 		return nil, fmt.Errorf("Unable to determine map type")
 	}
 
 	if info.KeySize == 0 {
+		unix.Close(fd)
 		return nil, fmt.Errorf("Unable to determine map key size")
 	}
 

--- a/pkg/observer/observer_stats.go
+++ b/pkg/observer/observer_stats.go
@@ -47,38 +47,43 @@ func (s *statValue) DeepCopyMapValue() bpf.MapValue {
 	return v
 }
 
+func updateMapMetric(name string) {
+	pin := filepath.Join(option.Config.MapDir, name)
+	pinStats := pin + "_stats"
+
+	mapLinkStats, err := bpf.OpenMap(pinStats)
+	if err != nil {
+		return
+	}
+	defer mapLinkStats.Close()
+	mapLink, err := bpf.OpenMap(pin)
+	if err != nil {
+		return
+	}
+	defer mapLink.Close()
+
+	zeroKey := &statKey{}
+	value, err := mapLinkStats.Lookup(zeroKey)
+	if err != nil {
+		return
+	}
+
+	v, ok := value.DeepCopyMapValue().(*statValue)
+	if !ok {
+		return
+	}
+
+	sum := int64(0)
+	for cpu := int(0); cpu < runtime.NumCPU(); cpu++ {
+		sum += v.Value[cpu]
+	}
+	mapmetrics.MapSizeSet(name, int(mapLink.MapInfo.MaxEntries), float64(sum))
+}
+
 func (k *Observer) startUpdateMapMetrics() {
 	update := func() {
 		for _, m := range sensors.AllMaps {
-			pin := filepath.Join(option.Config.MapDir, m.Name)
-			pinStats := pin + "_stats"
-
-			mapLinkStats, err := bpf.OpenMap(pinStats)
-			if err != nil {
-				continue
-			}
-			mapLink, err := bpf.OpenMap(pin)
-			if err != nil {
-				continue
-			}
-
-			zeroKey := &statKey{}
-			value, err := mapLinkStats.Lookup(zeroKey)
-			if err != nil {
-				continue
-			}
-
-			v, ok := value.DeepCopyMapValue().(*statValue)
-			if !ok {
-				continue
-			}
-			sum := int64(0)
-			for cpu := int(0); cpu < runtime.NumCPU(); cpu++ {
-				sum += v.Value[cpu]
-			}
-			mapmetrics.MapSizeSet(m.Name, int(mapLink.MapInfo.MaxEntries), float64(sum))
-			mapLink.Close()
-			mapLinkStats.Close()
+			updateMapMetric(m.Name)
 		}
 	}
 

--- a/pkg/observer/observer_stats.go
+++ b/pkg/observer/observer_stats.go
@@ -28,7 +28,7 @@ func (k *statKey) String() string            { return fmt.Sprintf("key=%d", k.Ke
 func (k *statKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 func (k *statKey) NewValue() bpf.MapValue {
 	return &statValue{
-		Value: make([]int64, runtime.NumCPU()),
+		Value: make([]int64, bpf.GetNumPossibleCPUs()),
 	}
 }
 func (k *statKey) DeepCopyMapKey() bpf.MapKey { return &statKey{k.Key} }
@@ -41,7 +41,7 @@ func (s *statValue) GetValuePtr() unsafe.Pointer {
 }
 func (s *statValue) DeepCopyMapValue() bpf.MapValue {
 	v := &statValue{
-		Value: make([]int64, runtime.NumCPU()),
+		Value: make([]int64, len(s.Value)),
 	}
 	copy(v.Value, s.Value)
 	return v


### PR DESCRIPTION
Backports:

Commits for  https://github.com/cilium/tetragon/pull/564:
  *  18d0775f7b5b6f3f02928ec33b890b25f46e5209 tetragon: ensure char_buf args copy size

Commits for  https://github.com/cilium/tetragon/pull/689:
   * 4af9c7fafde69771e6039ef4781ce5a4875f83ce tetragon: set default value of release-pinned-bpf to true

Commits for https://github.com/cilium/tetragon/pull/1090:
   * 590a5244555c56b0e9384f1782b2ff075c03eac4 bpf: OpenMap do not leak fd
   * 2df044e2fd2e55c855803b43c7946f9f4c263da3 observer_stats: use GetNumPossibleCPUs()
   * 0ffc6c636150d6efc42b9bbc681fb0239d3f40b1 updateMapMetric: close maps on errors
   * ~8f19ada3e1f48cded023088fb5eb24fe5d4c4cdd testObserverOptions: remove unused pretty field~ (:x: had a conflict and was not backported)
