### PR TITLE
v0.9 backports 20230627

### DIFF
--- a/bpf/process/bpf_exit.c
+++ b/bpf/process/bpf_exit.c
@@ -7,11 +7,57 @@
 
 char _license[] __attribute__((section("license"), used)) = "GPL";
 
-__attribute__((section("tracepoint/sys_exit"), used)) int
-event_exit(struct sched_execve_args *ctx)
+/*
+ * Hooking on do_task_dead kernel function, which is the last one the
+ * task would execute after exiting. It's stable since v4.19, so it's
+ * safe to hook for us.
+ *
+ * To find out if we are the last thread of execution in the task we
+ * use current->signal->live counter (thanks Djalal! ;-) )
+ *
+ * It's initialized for thread leader:
+ *
+ *   clone {
+ *     copy_process
+ *       copy_signal
+ *         atomic_set(&sig->live, 1);
+ *   }
+ *
+ * Incremented for each new thread:
+ *
+ *   clone {
+ *     copy_process
+ *       atomic_inc(&current->signal->live);
+ *     ...
+ *     wake_up_new_task
+ *   }
+ *
+ * Decremented for each exiting thread:
+ *
+ *   do_exit {
+ *     atomic_dec_and_test(&tsk->signal->live);
+ *     ...
+ *     do_task_dead
+ *       __schedule
+ *       BUG
+ *   }
+ *
+ * If task->signal->live == 0 we are the last thread of execution and we
+ * won't race with another clone, because there's no other thread to call
+ * it (current thread is in do_exit).
+ */
+__attribute__((section("kprobe/do_task_dead"), used)) int
+event_exit(struct pt_regs *ctx)
 {
+	struct task_struct *task = (struct task_struct *)get_current_task();
 	__u64 pid_tgid = get_current_pid_tgid();
+	struct signal_struct *signal;
+	atomic_t live;
 
-	event_exit_send(ctx, pid_tgid);
+	probe_read(&signal, sizeof(signal), _(&task->signal));
+	probe_read(&live, sizeof(live), _(&signal->live));
+
+	if (live.counter == 0)
+		event_exit_send(ctx, pid_tgid >> 32);
 	return 0;
 }

--- a/bpf/process/bpf_exit.h
+++ b/bpf/process/bpf_exit.h
@@ -17,21 +17,9 @@ struct {
 	__type(value, struct msg_exit);
 } exit_heap_map SEC(".maps");
 
-static inline __attribute__((always_inline)) void event_exit_send(struct sched_execve_args *ctx, __u64 current)
+static inline __attribute__((always_inline)) void event_exit_send(void *ctx, __u32 tgid)
 {
 	struct execve_map_value *enter;
-	__u32 pid, tgid;
-
-	pid = current & 0xFFFFffff;
-	tgid = current >> 32;
-
-	/* We are only tracking group leaders so if tgid is not
-	 * the same as the pid then this is an untracked child
-	 * and we can skip the lookup/insert/delete cycle that
-	 * would otherwise occur.
-	 */
-	if (pid != tgid)
-		return;
 
 	/* It is safe to do a map_lookup_event() here because
 	 * we must have captured the execve case in order for an

--- a/contrib/tester-progs/exit-leader.c
+++ b/contrib/tester-progs/exit-leader.c
@@ -5,13 +5,29 @@
 #include <stdlib.h>
 #include <sys/syscall.h>
 
+#define gettid() (int) syscall(SYS_gettid)
+
 static void *worker(void *ctx)
 {
-	int cnt = 3;
+	unsigned long cnt = (unsigned long) ctx;
+	pthread_t th;
+	int err;
+
+	fprintf(stderr, "worker %d:%d cnt %lu\n", getpid(), gettid(), cnt);
+
+	if (cnt == 2 || cnt == 4) {
+		err = pthread_create(&th, NULL, worker, (void *) (cnt + 1));
+		if (err) {
+			perror("pthread_create");
+			return NULL;
+		}
+	}
 
 	while (cnt--) {
 		sleep(1);
 	}
+
+	fprintf(stderr, "exit %d:%d\n", getpid(), gettid());
 	return NULL;
 }
 
@@ -20,10 +36,18 @@ int main(void)
 	pthread_t th;
 	int err;
 
-	err = pthread_create(&th, NULL, worker, NULL);
+	err = pthread_create(&th, NULL, worker, (void *) 2);
 	if (err) {
 		perror("pthread_create");
 		return -1;
 	}
+	err = pthread_create(&th, NULL, worker, (void *) 4);
+	if (err) {
+		perror("pthread_create");
+		return -1;
+	}
+
+	sleep(3);
+	fprintf(stderr, "exit %d:%d\n", getpid(), gettid());
 	syscall(SYS_exit, 0);
 }

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -144,14 +144,17 @@ func OpenMap(name string) (*Map, error) {
 
 	info, err := GetMapInfo(os.Getpid(), fd)
 	if err != nil {
+		unix.Close(fd)
 		return nil, err
 	}
 
 	if info.MapType == 0 {
+		unix.Close(fd)
 		return nil, fmt.Errorf("Unable to determine map type")
 	}
 
 	if info.KeySize == 0 {
+		unix.Close(fd)
 		return nil, fmt.Errorf("Unable to determine map key size")
 	}
 

--- a/pkg/observer/observer_stats.go
+++ b/pkg/observer/observer_stats.go
@@ -47,38 +47,43 @@ func (s *statValue) DeepCopyMapValue() bpf.MapValue {
 	return v
 }
 
+func updateMapMetric(name string) {
+	pin := filepath.Join(option.Config.MapDir, name)
+	pinStats := pin + "_stats"
+
+	mapLinkStats, err := bpf.OpenMap(pinStats)
+	if err != nil {
+		return
+	}
+	defer mapLinkStats.Close()
+	mapLink, err := bpf.OpenMap(pin)
+	if err != nil {
+		return
+	}
+	defer mapLink.Close()
+
+	zeroKey := &statKey{}
+	value, err := mapLinkStats.Lookup(zeroKey)
+	if err != nil {
+		return
+	}
+
+	v, ok := value.DeepCopyMapValue().(*statValue)
+	if !ok {
+		return
+	}
+
+	sum := int64(0)
+	for cpu := int(0); cpu < runtime.NumCPU(); cpu++ {
+		sum += v.Value[cpu]
+	}
+	mapmetrics.MapSizeSet(name, int(mapLink.MapInfo.MaxEntries), float64(sum))
+}
+
 func (k *Observer) startUpdateMapMetrics() {
 	update := func() {
 		for _, m := range sensors.AllMaps {
-			pin := filepath.Join(option.Config.MapDir, m.Name)
-			pinStats := pin + "_stats"
-
-			mapLinkStats, err := bpf.OpenMap(pinStats)
-			if err != nil {
-				continue
-			}
-			mapLink, err := bpf.OpenMap(pin)
-			if err != nil {
-				continue
-			}
-
-			zeroKey := &statKey{}
-			value, err := mapLinkStats.Lookup(zeroKey)
-			if err != nil {
-				continue
-			}
-
-			v, ok := value.DeepCopyMapValue().(*statValue)
-			if !ok {
-				continue
-			}
-			sum := int64(0)
-			for cpu := int(0); cpu < runtime.NumCPU(); cpu++ {
-				sum += v.Value[cpu]
-			}
-			mapmetrics.MapSizeSet(m.Name, int(mapLink.MapInfo.MaxEntries), float64(sum))
-			mapLink.Close()
-			mapLinkStats.Close()
+			updateMapMetric(m.Name)
 		}
 	}
 

--- a/pkg/observer/observer_stats.go
+++ b/pkg/observer/observer_stats.go
@@ -28,7 +28,7 @@ func (k *statKey) String() string            { return fmt.Sprintf("key=%d", k.Ke
 func (k *statKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 func (k *statKey) NewValue() bpf.MapValue {
 	return &statValue{
-		Value: make([]int64, runtime.NumCPU()),
+		Value: make([]int64, bpf.GetNumPossibleCPUs()),
 	}
 }
 func (k *statKey) DeepCopyMapKey() bpf.MapKey { return &statKey{k.Key} }
@@ -41,7 +41,7 @@ func (s *statValue) GetValuePtr() unsafe.Pointer {
 }
 func (s *statValue) DeepCopyMapValue() bpf.MapValue {
 	v := &statValue{
-		Value: make([]int64, runtime.NumCPU()),
+		Value: make([]int64, len(s.Value)),
 	}
 	copy(v.Value, s.Value)
 	return v

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -22,10 +22,10 @@ var (
 
 	Exit = program.Builder(
 		"bpf_exit.o",
-		"sched/sched_process_exit",
-		"tracepoint/sys_exit",
+		"do_task_dead",
+		"kprobe/do_task_dead",
 		"event_exit",
-		"tracepoint",
+		"kprobe",
 	)
 
 	Fork = program.Builder(

--- a/pkg/sensors/exec/exit_test.go
+++ b/pkg/sensors/exec/exit_test.go
@@ -99,8 +99,8 @@ func TestExitLeader(t *testing.T) {
 		fmt.Printf("exitTime %v\n", exitTime)
 		fmt.Printf("delta %v\n", delta)
 
-		if delta < 3*time.Second {
-			return fmt.Errorf("unexpected delta < 3 seconds")
+		if delta < 5*time.Second {
+			return fmt.Errorf("unexpected delta < 5 seconds")
 		}
 		return nil
 	}

--- a/pkg/sensors/exec/exit_test.go
+++ b/pkg/sensors/exec/exit_test.go
@@ -54,8 +54,6 @@ func TestExit(t *testing.T) {
 }
 
 func TestExitLeader(t *testing.T) {
-	t.Skip("due to github.com/cilium/tetragon/pull/987")
-
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -132,8 +130,6 @@ func TestExitLeader(t *testing.T) {
 //
 // In our test we check that the parent of the /bin/echo command is the exit-tester program.
 func TestExitZombie(t *testing.T) {
-	t.Skip("due to github.com/cilium/tetragon/pull/987")
-
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -115,7 +115,7 @@ func mergeSensorMaps(t *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []Se
 func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []SensorProg) ([]SensorMap, []SensorProg) {
 	var baseProgs = []SensorProg{
 		0: SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
-		1: SensorProg{Name: "event_exit", Type: ebpf.TracePoint},
+		1: SensorProg{Name: "event_exit", Type: ebpf.Kprobe},
 		2: SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
 		3: SensorProg{Name: "execve_send", Type: ebpf.TracePoint},
 	}


### PR DESCRIPTION
Commits for pr https://github.com/cilium/tetragon/pull/1012 (tetragon: Use do_task_dead probe for exit sensor):
   * efbcfa149c2c5f19fdb331bb6bec1c1271e45d5f tetragon: Use do_task_dead probe for exit
   * 0646c56a75284f802829345615647e66934802cb tetragon: Add more thread to TestExitLeader

Commits for pr https://github.com/cilium/tetragon/pull/1090 (Fix memory corruption bug):
   * 590a5244555c56b0e9384f1782b2ff075c03eac4 bpf: OpenMap do not leak fd
   * 2df044e2fd2e55c855803b43c7946f9f4c263da3 observer_stats: use GetNumPossibleCPUs()
   * 0ffc6c636150d6efc42b9bbc681fb0239d3f40b1 updateMapMetric: close maps on errors
   * ~8f19ada3e1f48cded023088fb5eb24fe5d4c4cdd testObserverOptions: remove unused pretty field~ was not backported, due to conflicts
