### PR TITLE
Fix connect and datagram tracingpolicy examples

### DIFF
--- a/examples/tracingpolicy/datagram-with-selectors.yaml
+++ b/examples/tracingpolicy/datagram-with-selectors.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "datagram"
+spec:
+  kprobes:
+  - call: "__cgroup_bpf_run_filter_skb"
+    syscall: false
+    args:
+      - index: 0
+        type: sock
+      - index: 1
+        type: skb
+      - index: 2
+        type: int
+    selectors:
+      - matchArgs:
+        - index: 1
+          operator: "DAddr"
+          values:
+          - "127.0.0.1/8"
+        - index: 1
+          operator: "Protocol"
+          values:
+          - "IPPROTO_UDP"
+        matchActions:
+        - action: Post
+          rateLimit: 5

--- a/examples/tracingpolicy/datagram.yaml
+++ b/examples/tracingpolicy/datagram.yaml
@@ -13,16 +13,3 @@ spec:
         type: skb
       - index: 2
         type: int
-    selectors:
-      - matchArgs:
-        - index: 1
-          operator: "DAddr"
-          values:
-          - "127.0.0.1/8"
-        - index: 1
-          operator: "Protocol"
-          values:
-          - "IPPROTO_UDP"
-        matchActions:
-        - action: Post
-          rateLimit: 5

--- a/examples/tracingpolicy/tcp-connect-with-selectors.yaml
+++ b/examples/tracingpolicy/tcp-connect-with-selectors.yaml
@@ -1,0 +1,44 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "127.0.0.1/8"
+        - "192.168.0.0/16"
+  - call: "tcp_close"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "127.0.0.1/8"
+        - "192.168.0.0/16"
+  - call: "tcp_sendmsg"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    - index: 2
+      type: int
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "127.0.0.1/8"
+        - "192.168.0.0/16"

--- a/examples/tracingpolicy/tcp-connect.yaml
+++ b/examples/tracingpolicy/tcp-connect.yaml
@@ -9,25 +9,11 @@ spec:
     args:
     - index: 0
       type: "sock"
-    selectors:
-    - matchArgs:
-      - index: 0
-        operator: "DAddr"
-        values:
-        - "127.0.0.1/8"
-        - "192.168.0.0/16"
   - call: "tcp_close"
     syscall: false
     args:
     - index: 0
       type: "sock"
-    selectors:
-    - matchArgs:
-      - index: 0
-        operator: "DAddr"
-        values:
-        - "127.0.0.1/8"
-        - "192.168.0.0/16"
   - call: "tcp_sendmsg"
     syscall: false
     args:
@@ -35,10 +21,3 @@ spec:
       type: "sock"
     - index: 2
       type: int
-    selectors:
-    - matchArgs:
-      - index: 0
-        operator: "DAddr"
-        values:
-        - "127.0.0.1/8"
-        - "192.168.0.0/16"


### PR DESCRIPTION
The tcp-connect.yaml and datagram.yaml examples include selectors that match on components of the sock and skb data structures, notably DAddr. The current release does not yet support these selectors, unintentionally breaking their use with the latest release. They should, however, work with latest main, should that be compiled from source.

This commit moves the current examples to new file names and replaces the existing examples with versions that should work with the current release.