### PR TITLE
Make ReturnArgAction optional

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -186,11 +186,8 @@ spec:
                       - type
                       type: object
                     returnArgAction:
-                      description: An action to perform on the return argument.
-                      enum:
-                      - Post
-                      - TrackSock
-                      - UntrackSock
+                      description: 'An action to perform on the return argument. Available
+                        actions are: Post;TrackSock;UntrackSock'
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -523,7 +520,6 @@ spec:
                       type: boolean
                   required:
                   - call
-                  - returnArgAction
                   type: object
                 type: array
               loader:

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -186,11 +186,8 @@ spec:
                       - type
                       type: object
                     returnArgAction:
-                      description: An action to perform on the return argument.
-                      enum:
-                      - Post
-                      - TrackSock
-                      - UntrackSock
+                      description: 'An action to perform on the return argument. Available
+                        actions are: Post;TrackSock;UntrackSock'
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -523,7 +520,6 @@ spec:
                       type: boolean
                   required:
                   - call
-                  - returnArgAction
                   type: object
                 type: array
               loader:

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -120,8 +120,9 @@ type KProbeSpec struct {
 	// +kubebuilder:validation:Optional
 	// A return argument to include in the trace output.
 	ReturnArg KProbeArg `json:"returnArg"`
-	// +kubebuilder:validation:Enum=Post;TrackSock;UntrackSock
+	// +kubebuilder:validation:Optional
 	// An action to perform on the return argument.
+	// Available actions are: Post;TrackSock;UntrackSock
 	ReturnArgAction string `json:"returnArgAction"`
 	// +kubebuilder:validation:Optional
 	// Selectors to apply before producing trace output. Selectors are ORed.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -186,11 +186,8 @@ spec:
                       - type
                       type: object
                     returnArgAction:
-                      description: An action to perform on the return argument.
-                      enum:
-                      - Post
-                      - TrackSock
-                      - UntrackSock
+                      description: 'An action to perform on the return argument. Available
+                        actions are: Post;TrackSock;UntrackSock'
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -523,7 +520,6 @@ spec:
                       type: boolean
                   required:
                   - call
-                  - returnArgAction
                   type: object
                 type: array
               loader:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -186,11 +186,8 @@ spec:
                       - type
                       type: object
                     returnArgAction:
-                      description: An action to perform on the return argument.
-                      enum:
-                      - Post
-                      - TrackSock
-                      - UntrackSock
+                      description: 'An action to perform on the return argument. Available
+                        actions are: Post;TrackSock;UntrackSock'
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -523,7 +520,6 @@ spec:
                       type: boolean
                   required:
                   - call
-                  - returnArgAction
                   type: object
                 type: array
               loader:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -120,8 +120,9 @@ type KProbeSpec struct {
 	// +kubebuilder:validation:Optional
 	// A return argument to include in the trace output.
 	ReturnArg KProbeArg `json:"returnArg"`
-	// +kubebuilder:validation:Enum=Post;TrackSock;UntrackSock
+	// +kubebuilder:validation:Optional
 	// An action to perform on the return argument.
+	// Available actions are: Post;TrackSock;UntrackSock
 	ReturnArgAction string `json:"returnArgAction"`
 	// +kubebuilder:validation:Optional
 	// Selectors to apply before producing trace output. Selectors are ORed.


### PR DESCRIPTION
The ReturnArgAction was added to the KProbeSpec to allow actions to be taken on the return values from hooked functions. It was specified as an enumeration in order to constrain its use to the supported actions, namely: Post, TrackSock and UntrackSock. This has the unintended consequence of making it non-optional through K8S validation.

This commit makes the ReturnArgAction optional.