### PR TITLE
policyfilter: Fix tracing policy unloading when disabled

### DIFF
--- a/pkg/policyfilter/dummy.go
+++ b/pkg/policyfilter/dummy.go
@@ -5,8 +5,6 @@
 package policyfilter
 
 import (
-	"fmt"
-
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/tetragon/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -16,11 +14,11 @@ type dummy struct {
 }
 
 func (s *dummy) AddPolicy(polID PolicyID, namespace string, podSelector *slimv1.LabelSelector) error {
-	return fmt.Errorf("policyfilter is disabled")
+	return nil
 }
 
 func (s *dummy) DelPolicy(polID PolicyID) error {
-	return fmt.Errorf("policyfilter is disabled")
+	return nil
 }
 
 func (s *dummy) AddPodContainer(podID PodID, namespace string, podLabels labels.Labels, containerID string, cgIDp CgroupID) error {


### PR DESCRIPTION
There is an issue when we delete/update tracing policies in the case where policyfilter is disabled. An example:

load a tracing policy:
```
$ kubectl apply -f examples/tracingpolicy/file_monitoring.yaml tracingpolicy.cilium.io/file-monitoring created
$ kubectl get tracingpolicies
NAME              AGE
file-monitoring   9s
$ kubectl logs -n kube-system ds/tetragon -c tetragon
[all good here]
```

And now try to remove that:
```
$ kubectl delete -f examples/tracingpolicy/file_monitoring.yaml tracingpolicy.cilium.io "file-monitoring" deleted
$ kubectl get tracingpolicies
No resources found
$ kubectl logs -n kube-system ds/tetragon -c tetragon 
time="2023-07-04T07:22:31Z" level=info msg="map was unloaded" map=retprobe_map pin=gkp-sensor-2-gkp-1-retprobe_map 
time="2023-07-04T07:22:31Z" level=info msg="map was unloaded" map=config_map pin=gkp-sensor-2-gkp-1-retprobe_config_map 
time="2023-07-04T07:22:31Z" level=warning msg="delete tracing policy failed" error="policyfilter is disabled"
```

Although get tracingpolicies returns "No resources found", when we try to load again the same tracing policy we get an error: 
```
$ kubectl apply -f examples/tracingpolicy/file_monitoring.yaml tracingpolicy.cilium.io/file-monitoring created
$ kubectl logs -n kube-system ds/tetragon -c tetragon 
time="2023-07-04T07:22:31Z" level=info msg="map was unloaded" map=retprobe_map pin=gkp-sensor-2-gkp-1-retprobe_map 
time="2023-07-04T07:22:31Z" level=info msg="map was unloaded" map=config_map pin=gkp-sensor-2-gkp-1-retprobe_config_map 
time="2023-07-04T07:22:31Z" level=warning msg="delete tracing policy failed" error="policyfilter is disabled" time="2023-07-04T07:23:11Z" level=info msg="adding tracing policy" info="file-monitoring (object:1/f5b657d2-0e22-4c23-ac29-4ffa7a2a886a) (type:/)" name=file-monitoring 
time="2023-07-04T07:23:11Z" level=warning msg="adding tracing policy failed" error="failed to add tracing policy file-monitoring, a sensor collection with the name already exists"
```

The issue is that in pkg/policyfilter/dummy.go (which is used when policyfilter is disabled) we return an error on AddPolicy and DelPolicy, which in turn return an error in deleteTracingPolicy() (pkg/watcher/crd/watcher.go) and makes the sensor removal to fail. The same applies when we update an existing tracing policy.

To fix that we simply return nil in AddPolicy and DelPolicy (pkg/policyfilter/dummy.go) which is reasonable as we don't have to take any action in the case where policyfilter is disabled.