### PR TITLE
contrib: add a Docker images digest checker

### DIFF
--- a/.github/workflows/digestcheck.yaml
+++ b/.github/workflows/digestcheck.yaml
@@ -1,0 +1,29 @@
+name: Check images digest for multi-arch
+
+on:
+  pull_request:
+    paths:
+      - '**[dD]ockerfile**'
+      - '.github/workflow/digestcheck.yaml'
+      - 'contrib/digestcheck.sh'
+      - '!**vendor**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+    - name: Install crane
+      env:
+        VERSION: "v0.15.2"
+      run: |
+        curl -sL "https://github.com/google/go-containerregistry/releases/download/$VERSION/go-containerregistry_Linux_x86_64.tar.gz" > go-containerregistry.tar.gz
+        tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
+      
+    - name: Check digests
+      env:
+        TERM: xterm-color
+      run: ./contrib/digestcheck.sh ${{ github.workspace }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN if [ $BUILDARCH != $TARGETARCH ]; \
     else make tetragon-image LOCAL_CLANG=1 VERSION=$TETRAGON_VERSION TARGET_ARCH=$TARGETARCH; fi
 
 # Third builder (cross-)compile a stripped gops
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20.5-alpine@sha256:e7cc33118f807c67d9f2dfc811cc2cc8b79b3687d0b4ac891dd59bb2a5e4a8d3 as gops
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20.5-alpine@sha256:fd9d9d7194ec40a9a6ae89fcaef3e47c47de7746dd5848ab5343695dbbd09f8c as gops
 ARG TARGETARCH
 RUN apk add --no-cache binutils git \
  && git clone https://github.com/google/gops /go/src/github.com/google/gops \

--- a/contrib/digestcheck.sh
+++ b/contrib/digestcheck.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+usage () {
+    echo "This tool scans the provided directory for Dockerfiles and compares the"
+    echo "images sha256 digests specified with the multi-architecture ones that"
+    echo "might be available in order to improve compatibility."
+    echo ""
+    echo "Usage:"
+    echo -e "\t$0 (directory)"
+    echo ""
+    echo "Examples:"
+    echo -e "\t$0 ."
+    echo -e "\t$0 \$(git rev-parse --show-toplevel)"
+    echo ""
+    echo "Return value:"
+    echo -e "\tOn overall success, the script returns 0. On error of any image"
+    echo -e "\tdigest, the script returns 1. A warning is not considered as"
+    echo -e "\tan error."
+}
+
+if [ -z "$1" ]; then
+    usage
+    exit 1
+fi
+
+RED=$(tput setaf 1)
+GREEN=$(tput setaf 2)
+YELLOW=$(tput setaf 3)
+BLUE=$(tput setaf 4)
+NC=$(tput sgr0)
+
+images=$(grep -n -r --include='*[dD]ockerfile*' --exclude='*vendor*' 'FROM' $1 | grep -E '\b\S+@\S+\b')
+
+exit_code=0
+
+if ! command -v "crane" >/dev/null 2>&1; then
+    echo "crane could not be found, please install crane: https://github.com/google/go-containerregistry/tree/main/cmd/crane."
+    exit 1
+fi
+
+IFS=$'\n'
+for image_meta in $images; do
+    image=$(echo $image_meta | grep -Eo '\b\S+@\S+\b')
+    line=$(echo $image_meta | cut -d':' -f2)
+    file=$(echo $image_meta | cut -d':' -f1)
+    echo -e "Checking ${BLUE}$image${NC}"
+    echo -e "From file $file, line $line"
+
+    name=$(echo $image | cut -d'@' -f1)
+    sha=$(echo $image | cut -d'@' -f2)
+
+    multiarch_sha=$(crane digest --platform all $name)
+    if [ $? -ne 0 ]; then
+        echo -e "${YELLOW}warning${NC}: retrieving the desired sha256 digest failed, please verify that tag of image '$name' exists and is valid.\n"
+        continue
+    fi
+
+    if [ "$sha" == "$multiarch_sha" ]; then
+        echo -e "${GREEN}success${NC}: sha256 digests are matching\n"
+    else
+        # when sha256 are not matching, there could be two main reasons:
+        #   - the image was updated and the last version of that tag has a new digest
+        #   - this is the sha256 of an arch-specific version while a multi-arch version exists
+        # to determine this, we need the mediaType available in the manifest
+
+        # this counts as an image pull and can be subject to rate limit
+        image_manifest=$(crane manifest $image)
+        if [ $? -ne 0 ]; then
+            echo "${RED}error${NC}: manifest pull of $image failed"
+            exit_code=1
+            continue
+        fi
+        local_type=$(echo $image_manifest | jq -r '.mediaType')
+        echo -e "\tlocal mediaType: $local_type"
+        echo $local_type | grep -q list
+        repo=$?
+
+        # this counts as an image pull and can be subject to rate limit
+        name_manifest=$(crane manifest $name)
+        if [ $? -ne 0 ]; then
+            echo "${RED}error${NC}: manifest pull of $name failed"
+            exit_code=1
+            continue
+        fi
+        remote_type=$(echo $name_manifest | jq -r '.mediaType')
+        echo -e "\tlast mediaType:  $remote_type"
+        echo $remote_type | grep -q list
+        last=$?
+
+        if [ "$repo" != "$last" ]; then
+            # It could be a false positive if the image tag was recently updated to support multi-arch
+            echo -e "${RED}error${NC}: sha256 digests mismatch, multi-arch version available for that tag\n\twant: $multiarch_sha\n\tgot:  $sha\n"
+            exit_code=1
+        else
+            echo -e "${YELLOW}warning${NC}: sha256 digests mismatch, digest could be updated for that tag\n\twant: $multiarch_sha\n\tgot:  $sha\n"
+        fi
+    fi
+done
+
+exit $exit_code
+


### PR DESCRIPTION
Add a shell script and its workflow to automatically detect when we use arch-restricted Docker images when we could use multi-arch ones.