### PR TITLE
Add common types to CRD argument parsing

### DIFF
--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -44,13 +44,13 @@ func GenericTypeFromString(arg string) int {
 		return GenericStringType
 	case "int":
 		return GenericIntType
-	case "uint64":
+	case "uint64", "unsigned long", "ulong":
 		return GenericU64Type
 	case "uint32":
 		return GenericU32Type
-	case "sint64":
+	case "sint64", "int64", "long":
 		return GenericS64Type
-	case "sint32":
+	case "sint32", "int32":
 		return GenericS32Type
 	case "skb":
 		return GenericSkbType


### PR DESCRIPTION
Kprobe and tracepoint arguments can be specified with a type. In some cases some common types – int64, int32, long, unsigned long and long – were missing from the mapping from their string representations to the internal type enum. This caused warnings to be displayed if these types were used in a CRD to specify the types of arguments.

This commit adds these common types.