### PR TITLE
tetra: add .exe suffix for Windows binaries

### DIFF
--- a/Makefile.cli
+++ b/Makefile.cli
@@ -30,6 +30,7 @@ cli-local-release: cli-clean
 				;; \
 			windows) \
 				ARCHS='arm64 amd64'; \
+				EXT='.exe'; \
 				;; \
 		esac; \
 		for ARCH in $$ARCHS; do \


### PR DESCRIPTION
Fixes https://github.com/cilium/tetragon/issues/1194.