### PR TITLE
Dockerfiles: add explicit docker.io/library prefix

### DIFF
--- a/Dockerfile.clang
+++ b/Dockerfile.clang
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04@sha256:6120be6a2b7ce665d0cbddc3ce6eae60fe94637c6a66985312d1f02f63cc0bcd
+FROM docker.io/library/ubuntu:22.04@sha256:6120be6a2b7ce665d0cbddc3ce6eae60fe94637c6a66985312d1f02f63cc0bcd
 ARG VERSION=1:15.0.7-0ubuntu0.22.04.1
 RUN apt-get update
 RUN apt-get -y upgrade

--- a/Dockerfile.clang-format
+++ b/Dockerfile.clang-format
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04@sha256:6120be6a2b7ce665d0cbddc3ce6eae60fe94637c6a66985312d1f02f63cc0bcd
+FROM docker.io/library/ubuntu:22.04@sha256:6120be6a2b7ce665d0cbddc3ce6eae60fe94637c6a66985312d1f02f63cc0bcd
 
 RUN apt-get -y update
 RUN apt-get -y install clang-format-14

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@ FROM quay.io/cilium/cilium-bpftool@sha256:1832b32d118e7006ea2ce530b14ae5b28acd55
 COPY . ./
 
 
-FROM golang:1.20.5@sha256:344193a70dc3588452ea39b4a1e465a8d3c91f788ae053f7ee168cebf18e0a50
+FROM docker.io/library/golang:1.20.5@sha256:344193a70dc3588452ea39b4a1e465a8d3c91f788ae053f7ee168cebf18e0a50
 RUN apt-get update -y &&    \
     apt-get upgrade -y &&   \
     apt-get install -y      \


### PR DESCRIPTION
This was causing renovate to treat golang and docker.io/library/golang as two separate images.