### PR TITLE
Add _total suffix to counter metrics that didn't have it 

### DIFF
--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -44,7 +44,7 @@ var (
 
 	HandlerErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "handler_errors",
+		Name:        "handler_errors_total",
 		Help:        "The total number of event handler errors. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"opcode", "error_type"})

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -16,26 +16,18 @@ import (
 type ErrorType string
 
 var (
-	// Parent process was not found in the pid map for a process without the clone flag.
-	NoParentNoClone ErrorType = "no_parent_no_clone"
 	// Process not found on get() call.
 	ProcessCacheMissOnGet ErrorType = "process_cache_miss_on_get"
 	// Process evicted from the cache.
 	ProcessCacheEvicted ErrorType = "process_cache_evicted"
 	// Process not found on remove() call.
 	ProcessCacheMissOnRemove ErrorType = "process_cache_miss_on_remove"
-	// Missing event handler.
-	UnhandledEvent ErrorType = "unhandled_event"
 	// Event cache podInfo retries failed.
 	EventCachePodInfoRetryFailed ErrorType = "event_cache_podinfo_retry_failed"
-	// Event cache endpoint retries failed.
-	EventCacheEndpointRetryFailed ErrorType = "event_cache_endpoint_retry_failed"
 	// Event cache failed to set process information for an event.
 	EventCacheProcessInfoFailed ErrorType = "event_cache_process_info_failed"
 	// Event cache failed to set parent information for an event.
 	EventCacheParentInfoFailed ErrorType = "event_cache_parent_info_failed"
-	// An exec event without parent info.
-	ExecMissingParent ErrorType = "exec_missing_parent"
 	// An event is missing process info.
 	EventMissingProcessInfo ErrorType = "event_missing_process_info"
 	// An error occurred in an event handler.

--- a/pkg/metrics/eventcachemetrics/eventcachemetrics.go
+++ b/pkg/metrics/eventcachemetrics/eventcachemetrics.go
@@ -12,13 +12,13 @@ import (
 var (
 	processInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "event_cache_process_info_errors",
+		Name:        "event_cache_process_info_errors_total",
 		Help:        "The total of times we failed to fetch cached process info for a given event type.",
 		ConstLabels: nil,
 	}, []string{"event_type"})
 	podInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "event_cache_pod_info_errors",
+		Name:        "event_cache_pod_info_errors_total",
 		Help:        "The total of times we failed to fetch cached pod info for a given event type.",
 		ConstLabels: nil,
 	}, []string{"event_type"})

--- a/pkg/metrics/eventcachemetrics/eventcachemetrics.go
+++ b/pkg/metrics/eventcachemetrics/eventcachemetrics.go
@@ -23,7 +23,8 @@ var (
 		ConstLabels: nil,
 	}, []string{"event_type"})
 	EventCacheCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name:        "event_cache_count",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "event_cache_accesses_total",
 		Help:        "The total number of Tetragon event cache accesses. For internal use only.",
 		ConstLabels: nil,
 	})

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -41,7 +41,7 @@ var (
 
 	policyStats = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "policy_stats",
+		Name:        "policy_events_total",
 		Help:        "Policy events calls observed.",
 		ConstLabels: nil,
 	}, []string{"policy", "hook", "namespace", "pod", "binary"})

--- a/pkg/metrics/kprobemetrics/kprobemetrics.go
+++ b/pkg/metrics/kprobemetrics/kprobemetrics.go
@@ -12,7 +12,7 @@ import (
 var (
 	MergeErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "generic_kprobe_merge_errors",
+		Name:        "generic_kprobe_merge_errors_total",
 		Help:        "The total number of failed attempts to merge a kprobe and kretprobe event.",
 		ConstLabels: nil,
 	}, []string{"curr_fn", "curr_type", "prev_fn", "prev_type"})
@@ -24,7 +24,7 @@ var (
 	})
 	MergePushed = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "generic_kprobe_merge_pushed",
+		Name:        "generic_kprobe_merge_pushed_total",
 		Help:        "The total number of pushed events for later merge.",
 		ConstLabels: nil,
 	})

--- a/pkg/metrics/mapmetrics/mapmetrics.go
+++ b/pkg/metrics/mapmetrics/mapmetrics.go
@@ -21,7 +21,7 @@ var (
 
 	MapDrops = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "map_drops",
+		Name:        "map_drops_total",
 		Help:        "The total number of entries dropped per LRU map.",
 		ConstLabels: nil,
 	}, []string{"map"})

--- a/pkg/metrics/processexecmetrics/processexecmetrics.go
+++ b/pkg/metrics/processexecmetrics/processexecmetrics.go
@@ -12,13 +12,13 @@ import (
 var (
 	MissingParentErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "exec_missing_parent_errors",
+		Name:        "exec_missing_parent_errors_total",
 		Help:        "The total of times a given parent exec id could not be found in an exec event.",
 		ConstLabels: nil,
 	}, []string{"parent_exec_id"})
 	SameExecIdErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "exec_parent_child_same_id_errors",
+		Name:        "exec_parent_child_same_id_errors_total",
 		Help:        "The total of times an error occurs due to a parent and child process have the same exec id.",
 		ConstLabels: nil,
 	}, []string{"exec_id"})

--- a/pkg/metrics/syscallmetrics/syscallmetrics.go
+++ b/pkg/metrics/syscallmetrics/syscallmetrics.go
@@ -14,7 +14,7 @@ import (
 var (
 	syscallStats = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "syscall_stats",
+		Name:        "syscalls_total",
 		Help:        "System calls observed.",
 		ConstLabels: nil,
 	}, []string{"syscall", "namespace", "pod", "binary"})

--- a/pkg/metrics/watchermetrics/watchermetrics.go
+++ b/pkg/metrics/watchermetrics/watchermetrics.go
@@ -18,13 +18,13 @@ const (
 var (
 	WatcherErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "watcher_errors",
+		Name:        "watcher_errors_total",
 		Help:        "The total number of errors for a given watcher type.",
 		ConstLabels: nil,
 	}, []string{"watcher", "error"})
 	WatcherEvents = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "watcher_events",
+		Name:        "watcher_events_total",
 		Help:        "The total number of events for a given watcher type.",
 		ConstLabels: nil,
 	}, []string{"watcher"})


### PR DESCRIPTION
For compatibility with the [OpenMetrics standard](https://github.com/OpenObservability/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#suffixes). This is a breaking change, but it shouldn't be painful - the semantics of the
metrics doesn't change, only the names.

While here, I renamed a few metrics to follow common naming conventions:
* event_cache_count -> tetragon_event_cache_accesses_total
* tetragon_policy_stats -> tetragon_policy_events_total
* tetragon_syscall_stats -> tetragon_syscalls_total

Admittedly, it's also not super necessary - using plain Prometheus you can scrape and query existing metrics just fine. Maybe there are/will be other systems that are pedantic about the standard, then this change will bring some benefits, but otherwise it's kinda compatibility for its own sake. Please shout if you think it's not worth it, but IMO this change is innocent enough to do it :)

I also removed unused label value constants from the `errormetrics` package. Let me know if I shouldn't do that - these vars are exported, but not used anywhere.

```release-note
All counter metrics that didn't have the _total suffix now have it.
```