### PR TITLE
renovate: ungroup Go minor updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,7 +69,13 @@
       ]
     },
     {
-      // not grouping major updates together
+      "matchPaths": [
+        ".github/workflows/**"
+      ],
+      "separateMinorPatch": false,
+    },
+    {
+      // not grouping Go minor and major updates together
       "matchFiles": [
         "go.mod",
         "go.sum"
@@ -85,6 +91,7 @@
       },
       "matchUpdateTypes": [
         "major",
+        "minor",
       ],
       matchBaseBranches: [
         "main"
@@ -107,7 +114,6 @@
         "executionMode": "branch"
       },
       "matchUpdateTypes": [
-        "minor",
         "patch",
         "digest",
         "pin",


### PR DESCRIPTION
Too many minor updates have issues to be merged to group them together. Also group patch and minor updates for GitHub actions.

In the state, this is impossible to merge: https://github.com/cilium/tetragon/pull/1176.