### PR TITLE
metrics: Switch from gauges to counters

### DIFF
--- a/pkg/bench/summary.go
+++ b/pkg/bench/summary.go
@@ -51,14 +51,7 @@ func (s *Summary) Dump() {
 	}
 }
 
-func getGaugeValue(gauge prometheus.Gauge) int {
-	// Yep, this does seem to be the only way to read it.
-	var d dto.Metric
-	gauge.Write(&d)
-	return int(*d.Gauge.Value)
-}
-
-func getMetricValue(counter prometheus.Counter) int {
+func getCounterValue(counter prometheus.Counter) int {
 	var d dto.Metric
 	counter.Write(&d)
 	return int(*d.Counter.Value)
@@ -83,12 +76,12 @@ func (s *Summary) PrettyPrint() {
 
 	if !s.Args.Baseline {
 		fmt.Printf("Ring buffer:        received=%d, lost=%d, errors=%d\n",
-			getGaugeValue(ringbufmetrics.PerfEventReceived.WithLabelValues()),
-			getGaugeValue(ringbufmetrics.PerfEventLost.WithLabelValues()),
-			getGaugeValue(ringbufmetrics.PerfEventErrors.WithLabelValues()))
+			getCounterValue(ringbufmetrics.PerfEventReceived),
+			getCounterValue(ringbufmetrics.PerfEventLost),
+			getCounterValue(ringbufmetrics.PerfEventErrors))
 
-		mergePushed := getMetricValue(kprobemetrics.MergePushed)
-		mergeOkTotal := getMetricValue(kprobemetrics.MergeOkTotal)
+		mergePushed := getCounterValue(kprobemetrics.MergePushed)
+		mergeOkTotal := getCounterValue(kprobemetrics.MergeOkTotal)
 		fmt.Printf("Merged events:      pushed=%d, ok=%d, errors=%d\n",
 			mergePushed, mergeOkTotal, mergePushed-mergeOkTotal)
 	}
@@ -153,9 +146,9 @@ func (s *Summary) CSVPrint(path, name string) error {
 
 	if !s.Args.Baseline {
 		records = [][]string{
-			{"Received", fmt.Sprintf("%d", getGaugeValue(ringbufmetrics.PerfEventReceived.WithLabelValues()))},
-			{"Lost", fmt.Sprintf("%d", getGaugeValue(ringbufmetrics.PerfEventLost.WithLabelValues()))},
-			{"Errors", fmt.Sprintf("%d", getGaugeValue(ringbufmetrics.PerfEventErrors.WithLabelValues()))},
+			{"Received", fmt.Sprintf("%d", getCounterValue(ringbufmetrics.PerfEventReceived))},
+			{"Lost", fmt.Sprintf("%d", getCounterValue(ringbufmetrics.PerfEventLost))},
+			{"Errors", fmt.Sprintf("%d", getCounterValue(ringbufmetrics.PerfEventErrors))},
 		}
 		w.WriteAll(records)
 	}

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -32,12 +32,12 @@ var (
 		Help:        "The total number of Tetragon flags. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
-	NotifyOverflowedEvents = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	NotifyOverflowedEvents = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "notify_overflowed_events",
+		Name:        "notify_overflowed_events_total",
 		Help:        "The total number of events dropped because listener buffer was full",
 		ConstLabels: nil,
-	}, nil)
+	})
 
 	policyStats = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,

--- a/pkg/metrics/ringbufmetrics/ringbufmetrics.go
+++ b/pkg/metrics/ringbufmetrics/ringbufmetrics.go
@@ -10,52 +10,22 @@ import (
 )
 
 var (
-	PerfEventReceived = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	PerfEventReceived = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "ringbuf_perf_event_received",
+		Name:        "ringbuf_perf_event_received_total",
 		Help:        "The total number of Tetragon ringbuf perf events received.",
 		ConstLabels: nil,
-	}, nil)
-	PerfEventLost = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	})
+	PerfEventLost = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "ringbuf_perf_event_lost",
+		Name:        "ringbuf_perf_event_lost_total",
 		Help:        "The total number of Tetragon ringbuf perf events lost.",
 		ConstLabels: nil,
-	}, nil)
-	PerfEventErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	})
+	PerfEventErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "ringbuf_perf_event_errors",
-		Help:        "The total number of Tetragon ringbuf perf event error count.",
+		Name:        "ringbuf_perf_event_errors_total",
+		Help:        "The total number of errors when reading the Tetragon ringbuf.",
 		ConstLabels: nil,
-	}, nil)
+	})
 )
-
-// Get a new handle on the metric for received events
-func GetReceived() prometheus.Gauge {
-	return PerfEventReceived.WithLabelValues()
-}
-
-// Get a new handle on the metric for received events
-func ReceivedSet(val float64) {
-	GetReceived().Set(val)
-}
-
-// Get a new handle on the metric for lost events
-func GetLost() prometheus.Gauge {
-	return PerfEventLost.WithLabelValues()
-}
-
-// Get a new handle on the metric for lost events
-func LostSet(val float64) {
-	GetLost().Set(val)
-}
-
-// Get a new handle on the metric for ringbuf errors
-func GetErrors() prometheus.Gauge {
-	return PerfEventErrors.WithLabelValues()
-}
-
-// Get a new handle on the metric for ringbuf errors
-func ErrorsSet(val float64) {
-	GetErrors().Set(val)
-}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -92,7 +92,7 @@ func (l *getEventsListener) Notify(res *tetragon.GetEventsResponse) {
 	case l.events <- res:
 	default:
 		// events channel is full: drop the event so that we do not block everything
-		eventmetrics.NotifyOverflowedEvents.WithLabelValues().Inc()
+		eventmetrics.NotifyOverflowedEvents.Inc()
 	}
 }
 


### PR DESCRIPTION
The following metrics:
* tetragon_notify_overflowed_events
* tetragon_ringbuf_perf_event_received
* tetragon_ringbuf_perf_event_lost
* tetragon_ringbuf_perf_event_errors

are conceptually counters, not gauges, so I changed the metric type to reflect
that. Also added a `_total` suffix to all of them, for compatibility with the
OpenMetrics standard. This is a breaking change, but it shouldn't be painful - the semantics of the metrics doesn't change, only the names.

Admittedly, it's also not super necessary - using plain Prometheus you can scrape and query existing metrics just fine. Maybe there are/will be other systems that are pedantic about the standard, then this change will bring some benefits, but otherwise it's kinda compatibility for its own sake. Please shout if you think it's not worth it, but IMO this change is innocent enough to do it :)

```release-note
The following gauge metrics: tetragon_notify_overflowed_events, tetragon_ringbuf_perf_event_received, tetragon_ringbuf_perf_event_lost, tetragon_ringbuf_perf_event_errors are now counter and have a _total suffix.
```