### PR TITLE
Infinite ports and CIDRs

### DIFF
--- a/bpf/process/addr_lpm_maps.h
+++ b/bpf/process/addr_lpm_maps.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Cilium */
+
+#ifndef ADDR_LPM_MAPS_H__
+#define ADDR_LPM_MAPS_H__
+
+#define ADDR_LPM_MAPS_OUTER_MAX_ENTRIES 8
+
+struct addr4_lpm_trie {
+	__u32 prefix;
+	__u32 addr;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, ADDR_LPM_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+			__uint(max_entries, 1);
+			__type(key, __u8[8]); // Need to specify as byte array as wouldn't take struct as key type
+			__type(value, __u8);
+			__uint(map_flags, BPF_F_NO_PREALLOC);
+		});
+} addr4lpm_maps SEC(".maps");
+
+#endif // ADDR_LPM_MAPS_H__

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -751,10 +751,14 @@ filter_inet(struct selector_arg_filter *filter, char *args)
 		break;
 	case op_filter_sport:
 	case op_filter_notsport:
+	case op_filter_sportpriv:
+	case op_filter_notsportpriv:
 		port = tuple->sport;
 		break;
 	case op_filter_dport:
 	case op_filter_notdport:
+	case op_filter_dportpriv:
+	case op_filter_notdportpriv:
 		port = tuple->dport;
 		break;
 	case op_filter_protocol:
@@ -770,6 +774,12 @@ filter_inet(struct selector_arg_filter *filter, char *args)
 	case op_filter_notsport:
 	case op_filter_notdport:
 		return filter_32ty_map(filter, (char *)&port);
+	case op_filter_sportpriv:
+	case op_filter_dportpriv:
+		return port < 1024;
+	case op_filter_notsportpriv:
+	case op_filter_notdportpriv:
+		return port >= 1024;
 	}
 
 #pragma unroll

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -750,9 +750,11 @@ filter_inet(struct selector_arg_filter *filter, char *args)
 		addr = tuple->daddr;
 		break;
 	case op_filter_sport:
+	case op_filter_notsport:
 		port = tuple->sport;
 		break;
 	case op_filter_dport:
+	case op_filter_notdport:
 		port = tuple->dport;
 		break;
 	case op_filter_protocol:
@@ -765,6 +767,8 @@ filter_inet(struct selector_arg_filter *filter, char *args)
 	switch (filter->op) {
 	case op_filter_sport:
 	case op_filter_dport:
+	case op_filter_notsport:
+	case op_filter_notdport:
 		return filter_32ty_map(filter, (char *)&port);
 	}
 
@@ -1093,6 +1097,8 @@ filter_32ty_map(struct selector_arg_filter *filter, char *args)
 	case op_filter_dport:
 		return !!pass;
 	case op_filter_notinmap:
+	case op_filter_notsport:
+	case op_filter_notdport:
 		return !pass;
 	}
 	return 0;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -737,6 +737,9 @@ filter_addr4_map(struct selector_arg_filter *filter, __u32 addr)
 	case op_filter_saddr:
 	case op_filter_daddr:
 		return !!pass;
+	case op_filter_notsaddr:
+	case op_filter_notdaddr:
+		return !pass;
 	}
 	return 0;
 }
@@ -771,9 +774,11 @@ filter_inet(struct selector_arg_filter *filter, char *args)
 
 	switch (filter->op) {
 	case op_filter_saddr:
+	case op_filter_notsaddr:
 		addr = tuple->saddr;
 		break;
 	case op_filter_daddr:
+	case op_filter_notdaddr:
 		addr = tuple->daddr;
 		break;
 	case op_filter_sport:
@@ -809,6 +814,8 @@ filter_inet(struct selector_arg_filter *filter, char *args)
 		return port >= 1024;
 	case op_filter_saddr:
 	case op_filter_daddr:
+	case op_filter_notsaddr:
+	case op_filter_notdaddr:
 		return filter_addr4_map(filter, addr);
 	}
 

--- a/bpf/process/types/operations.h
+++ b/bpf/process/types/operations.h
@@ -27,6 +27,8 @@ enum {
 	op_filter_sport = 15,
 	op_filter_dport = 16,
 	op_filter_protocol = 17,
+	op_filter_notsport = 18,
+	op_filter_notdport = 19,
 };
 
 #endif // __OPERATIONS_H__

--- a/bpf/process/types/operations.h
+++ b/bpf/process/types/operations.h
@@ -29,6 +29,10 @@ enum {
 	op_filter_protocol = 17,
 	op_filter_notsport = 18,
 	op_filter_notdport = 19,
+	op_filter_sportpriv = 20,
+	op_filter_notsportpriv = 21,
+	op_filter_dportpriv = 22,
+	op_filter_notdportpriv = 23,
 };
 
 #endif // __OPERATIONS_H__

--- a/bpf/process/types/operations.h
+++ b/bpf/process/types/operations.h
@@ -33,6 +33,8 @@ enum {
 	op_filter_notsportpriv = 21,
 	op_filter_dportpriv = 22,
 	op_filter_notdportpriv = 23,
+	op_filter_notsaddr = 24,
+	op_filter_notdaddr = 25,
 };
 
 #endif // __OPERATIONS_H__

--- a/docs/content/en/docs/concepts/tracing-policy.md
+++ b/docs/content/en/docs/concepts/tracing-policy.md
@@ -1408,6 +1408,21 @@ There are different types supported for each operator. In case of `matchArgs`:
 * Prefix
 * Postfix
 * Mask
+* GreaterThan (aka GT)
+* LessThan (aka LT)
+* SPort - Source Port
+* NotSPort - Not Source Port
+* SPortPriv - Source Port is Privileged (0-1023)
+* NotSPortPriv - Source Port is Not Privileged (Not 0-1023)
+* DPort - Destination Port
+* NotDPort - Not Destination Port
+* DPortPriv - Destination Port is Privileged (0-1023)
+* NotDPortPriv - Destination Port is Not Privileged (Not 0-1023)
+* SAddr - Source Address, can be IPv4 address or IPv4 CIDR (for ex 1.2.3.4/24)
+* NotSAddr - Not Source Address
+* DAddr - Destination Address
+* NotDAddr - Not Destination Address
+* Protocol
 
 The operator types `Equal` and `NotEqual` are used to test whether the certain
 argument of a system call is equal to the defined value in the CR.
@@ -1481,9 +1496,14 @@ arg & 1 OR arg & 0x200
 The value can be specified as hexadecimal (with 0x prefix) octal (with 0 prefix)
 or decimal value (no prefix).
 
-The type `Prefix` checks if the certain argument starts with the defined value,
-while the type `Postfix` compares if the argument matches to the defined value
+The operator `Prefix` checks if the certain argument starts with the defined value,
+while the operator `Postfix` compares if the argument matches to the defined value
 as trailing.
+
+The operators relating to ports, addresses and protocol are used with sock or skb
+types. Port operators can accept a range of ports specified as `min:max` as well
+as lists of individual ports. Address operators can accept IPv4 CIDR ranges as well
+as lists of individual addresses.
 
 In case of `matchPIDs`:
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -288,7 +288,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -509,7 +511,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -767,7 +771,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -988,7 +994,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -1119,7 +1127,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -1340,7 +1350,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -281,8 +281,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -498,8 +502,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -752,8 +760,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -969,8 +981,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1096,8 +1112,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1313,8 +1333,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -280,7 +280,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -495,7 +497,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -747,7 +751,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -962,7 +968,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1087,7 +1095,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1302,7 +1312,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -288,7 +288,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -509,7 +511,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -767,7 +771,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -988,7 +994,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -1119,7 +1127,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -1340,7 +1350,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -281,8 +281,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -498,8 +502,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -752,8 +760,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -969,8 +981,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1096,8 +1112,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1313,8 +1333,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -280,7 +280,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -495,7 +497,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -747,7 +751,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -962,7 +968,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1087,7 +1095,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1302,7 +1312,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -257,7 +257,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;DPort;NotDPort;SAddr;DAddr;Protocol;Mask
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;DAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -257,7 +257,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;DPort;SAddr;DAddr;Protocol;Mask
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;DPort;NotDPort;SAddr;DAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -257,7 +257,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;DAddr;Protocol;Mask
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -220,6 +220,8 @@ const (
 	SelectorOpSport    = 15
 	SelectorOpDport    = 16
 	SelectorOpProtocol = 17
+	SelectorOpNotSport = 18
+	SelectorOpNotDport = 19
 )
 
 func SelectorOp(op string) (uint32, error) {
@@ -256,6 +258,10 @@ func SelectorOp(op string) (uint32, error) {
 		return SelectorOpDport, nil
 	case "protocol", "Protocol":
 		return SelectorOpProtocol, nil
+	case "notsport", "NotSport", "NotSPort":
+		return SelectorOpNotSport, nil
+	case "notdport", "NotDport", "NotDPort":
+		return SelectorOpNotDport, nil
 	}
 
 	return 0, fmt.Errorf("Unknown op '%s'", op)
@@ -521,7 +527,7 @@ func ParseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 		if err != nil {
 			return fmt.Errorf("writeMatchRangesInMap error: %w", err)
 		}
-	case SelectorOpSport, SelectorOpDport:
+	case SelectorOpSport, SelectorOpDport, SelectorOpNotSport, SelectorOpNotDport:
 		if ty != argTypeSock && ty != argTypeSkb {
 			return fmt.Errorf("sock/skb operators specified for non-sock/skb type")
 		}

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -226,6 +226,8 @@ const (
 	SelectorOpNotSportPriv = 21
 	SelectorOpDportPriv    = 22
 	SelectorOpNotDportPriv = 23
+	SelectorOpNotSaddr     = 24
+	SelectorOpNotDaddr     = 25
 )
 
 func SelectorOp(op string) (uint32, error) {
@@ -256,6 +258,10 @@ func SelectorOp(op string) (uint32, error) {
 		return SelectorOpSaddr, nil
 	case "daddr", "Daddr", "DAddr":
 		return SelectorOpDaddr, nil
+	case "notsaddr", "NotSaddr", "NotSAddr":
+		return SelectorOpNotSaddr, nil
+	case "notdaddr", "NotDaddr", "NotDAddr":
+		return SelectorOpNotDaddr, nil
 	case "sport", "Sport", "SPort":
 		return SelectorOpSport, nil
 	case "dport", "Dport", "DPort":
@@ -563,7 +569,7 @@ func ParseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 		if err != nil {
 			return fmt.Errorf("writeMatchRangesInMap error: %w", err)
 		}
-	case SelectorOpSaddr, SelectorOpDaddr:
+	case SelectorOpSaddr, SelectorOpDaddr, SelectorOpNotSaddr, SelectorOpNotDaddr:
 		if ty != argTypeSock && ty != argTypeSkb {
 			return fmt.Errorf("sock/skb operators specified for non-sock/skb type")
 		}

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -215,13 +215,17 @@ const (
 	SelectorOpMASK = 12
 
 	// socket ops
-	SelectorOpSaddr    = 13
-	SelectorOpDaddr    = 14
-	SelectorOpSport    = 15
-	SelectorOpDport    = 16
-	SelectorOpProtocol = 17
-	SelectorOpNotSport = 18
-	SelectorOpNotDport = 19
+	SelectorOpSaddr        = 13
+	SelectorOpDaddr        = 14
+	SelectorOpSport        = 15
+	SelectorOpDport        = 16
+	SelectorOpProtocol     = 17
+	SelectorOpNotSport     = 18
+	SelectorOpNotDport     = 19
+	SelectorOpSportPriv    = 20
+	SelectorOpNotSportPriv = 21
+	SelectorOpDportPriv    = 22
+	SelectorOpNotDportPriv = 23
 )
 
 func SelectorOp(op string) (uint32, error) {
@@ -262,6 +266,14 @@ func SelectorOp(op string) (uint32, error) {
 		return SelectorOpNotSport, nil
 	case "notdport", "NotDport", "NotDPort":
 		return SelectorOpNotDport, nil
+	case "sportpriv", "SportPriv", "SPortPriv":
+		return SelectorOpSportPriv, nil
+	case "dportpriv", "DportPriv", "DPortPriv":
+		return SelectorOpDportPriv, nil
+	case "notsportpriv", "NotSportPriv", "NotSPortPriv":
+		return SelectorOpNotSportPriv, nil
+	case "notdportpriv", "NotDportPriv", "NotDPortPriv":
+		return SelectorOpNotDportPriv, nil
 	}
 
 	return 0, fmt.Errorf("Unknown op '%s'", op)
@@ -534,6 +546,11 @@ func ParseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 		err := writeMatchRangesInMap(k, arg.Values, argTypeU64) // force type for ports as ty is sock/skb
 		if err != nil {
 			return fmt.Errorf("writeMatchRangesInMap error: %w", err)
+		}
+	case SelectorOpSportPriv, SelectorOpDportPriv, SelectorOpNotSportPriv, SelectorOpNotDportPriv:
+		// These selectors do not take any values, but we do check that they are only used for sock/skb.
+		if ty != argTypeSock && ty != argTypeSkb {
+			return fmt.Errorf("sock/skb operators specified for non-sock/skb type")
 		}
 	default:
 		err = writeMatchValues(k, arg.Values, ty, op)

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -342,28 +342,66 @@ func argSelectorType(arg *v1alpha1.ArgSelector, sig []v1alpha1.KProbeArg) (uint3
 	return 0, fmt.Errorf("argFilter for unknown index")
 }
 
-func writeMatchValuesInMap(k *KernelSelectorState, values []string, ty uint32) error {
+func writeMatchRangesInMap(k *KernelSelectorState, values []string, ty uint32) error {
 	mid, m := k.newValueMap()
 	for _, v := range values {
-		var val [8]byte
+		// We store the start and end of the range as uint64s for unsigned values, and as int64s
+		// for signed values. This is to allow both a signed range from -5 to 5, and also an
+		// unsigned range where at least limit exceeds max(int64). If we only stored the range
+		// limits as uint64s, then the range from -5 to 5 would be interpretted as being from
+		// 5 to uint64(-5), which is the literal opposite of what was intended. If we only stored
+		// the range as int64s, then we couldn't correctly accommodate values that exceed max(int64),
+		// for similar reasons.
+		var uRangeVal [2]uint64
+		var sRangeVal [2]int64
+		rangeStr := strings.Split(v, ":")
+		if len(rangeStr) > 2 {
+			return fmt.Errorf("MatchArgs value %s invalid: range should be 'min:max'", v)
+		} else if len(rangeStr) == 1 {
+			// If only one value in the string, e.g. "5", then add it a second time to simulate
+			// a range that starts and ends with itself, e.g. as if "5:5" had been specified.
+			rangeStr = append(rangeStr, rangeStr[0])
+		}
+		for idx := 0; idx < 2; idx++ {
+			switch ty {
+			case argTypeS64, argTypeInt:
+				i, err := strconv.ParseInt(rangeStr[idx], 10, 64)
+				if err != nil {
+					return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
+				}
+				sRangeVal[idx] = i
+
+			case argTypeU64:
+				i, err := strconv.ParseUint(rangeStr[idx], 10, 64)
+				if err != nil {
+					return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
+				}
+				uRangeVal[idx] = i
+			default:
+				return fmt.Errorf("Unknown type: %d", ty)
+			}
+		}
 		switch ty {
 		case argTypeS64, argTypeInt:
-			i, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
+			if sRangeVal[0] > sRangeVal[1] {
+				sRangeVal[0], sRangeVal[1] = sRangeVal[1], sRangeVal[0]
 			}
-			binary.LittleEndian.PutUint64(val[:], uint64(i))
-		case argTypeU64:
-			i, err := strconv.ParseUint(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
+			for val := sRangeVal[0]; val <= sRangeVal[1]; val++ {
+				var valByte [8]byte
+				binary.LittleEndian.PutUint64(valByte[:], uint64(val))
+				m[valByte] = struct{}{}
 			}
-			binary.LittleEndian.PutUint64(val[:], uint64(i))
-		default:
-			return fmt.Errorf("Unknown type: %d", ty)
-		}
-		m[val] = struct{}{}
 
+		case argTypeU64:
+			if uRangeVal[0] > uRangeVal[1] {
+				uRangeVal[0], uRangeVal[1] = uRangeVal[1], uRangeVal[0]
+			}
+			for val := uRangeVal[0]; val <= uRangeVal[1]; val++ {
+				var valByte [8]byte
+				binary.LittleEndian.PutUint64(valByte[:], val)
+				m[valByte] = struct{}{}
+			}
+		}
 	}
 	// write the map id into the selector
 	WriteSelectorUint32(k, mid)
@@ -438,12 +476,6 @@ func writeMatchValues(k *KernelSelectorState, values []string, ty, op uint32) er
 			WriteSelectorUint64(k, uint64(i))
 		case argTypeSock, argTypeSkb:
 			switch op {
-			case SelectorOpSport, SelectorOpDport:
-				i, err := strconv.ParseUint(v, base, 32)
-				if err != nil {
-					return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
-				}
-				WriteSelectorUint32(k, uint32(i))
 			case SelectorOpSaddr, SelectorOpDaddr:
 				addr, mask, err := parseAddr(v)
 				if err != nil {
@@ -485,9 +517,17 @@ func ParseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 	WriteSelectorUint32(k, ty)
 	switch op {
 	case SelectorInMap, SelectorNotInMap:
-		err := writeMatchValuesInMap(k, arg.Values, ty)
+		err := writeMatchRangesInMap(k, arg.Values, ty)
 		if err != nil {
-			return fmt.Errorf("writeMatchValuesInMap error: %w", err)
+			return fmt.Errorf("writeMatchRangesInMap error: %w", err)
+		}
+	case SelectorOpSport, SelectorOpDport:
+		if ty != argTypeSock && ty != argTypeSkb {
+			return fmt.Errorf("sock/skb operators specified for non-sock/skb type")
+		}
+		err := writeMatchRangesInMap(k, arg.Values, argTypeU64) // force type for ports as ty is sock/skb
+		if err != nil {
+			return fmt.Errorf("writeMatchRangesInMap error: %w", err)
 		}
 	default:
 		err = writeMatchValues(k, arg.Values, ty, op)

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -147,6 +147,18 @@ func TestSelectorOp(t *testing.T) {
 	if op, err := SelectorOp("foo"); op != 0 || err == nil {
 		t.Errorf("selectorOp: expected error actual %d %v\n", op, err)
 	}
+	if op, err := SelectorOp("SAddr"); op != SelectorOpSaddr || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpSaddr, op, err)
+	}
+	if op, err := SelectorOp("DAddr"); op != SelectorOpDaddr || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpDaddr, op, err)
+	}
+	if op, err := SelectorOp("NotSAddr"); op != SelectorOpNotSaddr || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpNotSaddr, op, err)
+	}
+	if op, err := SelectorOp("NotDAddr"); op != SelectorOpNotDaddr || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpNotDaddr, op, err)
+	}
 }
 
 func TestPidSelectorFlags(t *testing.T) {

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -126,6 +126,12 @@ func TestSelectorOp(t *testing.T) {
 	if op, err := SelectorOp("DPort"); op != SelectorOpDport || err != nil {
 		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpDport, op, err)
 	}
+	if op, err := SelectorOp("NotSPort"); op != SelectorOpNotSport || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpNotSport, op, err)
+	}
+	if op, err := SelectorOp("NotDPort"); op != SelectorOpNotDport || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpNotDport, op, err)
+	}
 	if op, err := SelectorOp("foo"); op != 0 || err == nil {
 		t.Errorf("selectorOp: expected error actual %d %v\n", op, err)
 	}

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -132,6 +132,18 @@ func TestSelectorOp(t *testing.T) {
 	if op, err := SelectorOp("NotDPort"); op != SelectorOpNotDport || err != nil {
 		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpNotDport, op, err)
 	}
+	if op, err := SelectorOp("SPortPriv"); op != SelectorOpSportPriv || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpSportPriv, op, err)
+	}
+	if op, err := SelectorOp("DPortPriv"); op != SelectorOpDportPriv || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpDportPriv, op, err)
+	}
+	if op, err := SelectorOp("NotSPortPriv"); op != SelectorOpNotSportPriv || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpNotSportPriv, op, err)
+	}
+	if op, err := SelectorOp("NotDPortPriv"); op != SelectorOpNotDportPriv || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpNotDportPriv, op, err)
+	}
 	if op, err := SelectorOp("foo"); op != 0 || err == nil {
 		t.Errorf("selectorOp: expected error actual %d %v\n", op, err)
 	}

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -240,14 +240,9 @@ func TestParseMatchArg(t *testing.T) {
 	expected3 := []byte{
 		0x05, 0x00, 0x00, 0x00, // Index == 5
 		13, 0x00, 0x00, 0x00, // operator == saddr
-		32, 0x00, 0x00, 0x00, // length == 32
+		12, 0x00, 0x00, 0x00, // length == 32
 		0x07, 0x00, 0x00, 0x00, // value type == sock
-		127, 0, 0, 1, // IP address = 127.0.0.1
-		0xff, 0xff, 0xff, 0xff, // mask len = 32
-		10, 1, 2, 0, // IP address = 10.1.2.0 masked from 10.1.2.3
-		0xff, 0xff, 0xff, 0x00, // mask len = 24
-		192, 168, 240, 0, // IP address = 192.168.240.0 masked from 192.168.254.254
-		0xff, 0xff, 0xf0, 0x00, // mask len = 20
+		0x00, 0x00, 0x00, 0x00, // Addr4LPM mapid = 0
 	}
 	if err := ParseMatchArg(k, arg3, sig); err != nil || bytes.Equal(expected3, k.e[nextArg:k.off]) == false {
 		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected3, k.e[nextArg:k.off], arg3)

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -120,6 +120,12 @@ func TestSelectorOp(t *testing.T) {
 	if op, err := SelectorOp("NotIn"); op != SelectorOpNotIn || err != nil {
 		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpNotIn, op, err)
 	}
+	if op, err := SelectorOp("SPort"); op != SelectorOpSport || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpSport, op, err)
+	}
+	if op, err := SelectorOp("DPort"); op != SelectorOpDport || err != nil {
+		t.Errorf("selectorOp: expected %d actual %d %v\n", SelectorOpDport, op, err)
+	}
 	if op, err := SelectorOp("foo"); op != 0 || err == nil {
 		t.Errorf("selectorOp: expected error actual %d %v\n", op, err)
 	}
@@ -234,11 +240,9 @@ func TestParseMatchArg(t *testing.T) {
 	expected4 := []byte{
 		0x06, 0x00, 0x00, 0x00, // Index == 6
 		15, 0x00, 0x00, 0x00, // operator == sport
-		20, 0x00, 0x00, 0x00, // length == 20
+		12, 0x00, 0x00, 0x00, // length == 12
 		0x05, 0x00, 0x00, 0x00, // value type == skb
-		0x91, 0x1f, 0, 0, // port = 8081
-		25, 0, 0, 0, // port = 25
-		0x69, 0x7a, 0, 0, // port = 31337
+		0x00, 0x00, 0x00, 0x00, // argfilter mapid = 0
 	}
 	if err := ParseMatchArg(k, arg4, sig); err != nil || bytes.Equal(expected4, k.e[nextArg:k.off]) == false {
 		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected4, k.e[nextArg:k.off], arg4)
@@ -248,7 +252,7 @@ func TestParseMatchArg(t *testing.T) {
 	arg5 := &v1alpha1.ArgSelector{Index: 7, Operator: "Protocol", Values: []string{"3", "IPPROTO_UDP", "IPPROTO_TCP"}}
 	expected5 := []byte{
 		0x07, 0x00, 0x00, 0x00, // Index == 6
-		17, 0x00, 0x00, 0x00, // operator == sport
+		17, 0x00, 0x00, 0x00, // operator == protocol
 		20, 0x00, 0x00, 0x00, // length == 20
 		0x05, 0x00, 0x00, 0x00, // value type == skb
 		3, 0x00, 0x00, 0x00, // protocol = 3

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -226,6 +226,11 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 	// that we do not need to SetInnerMaxEntries() here.
 	maps = append(maps, argFilterMaps)
 
+	addr4FilterMaps := program.MapBuilderPin("addr4lpm_maps", sensors.PathJoin(pinPath, "addr4lpm_maps"), load)
+	// NB: code depends on multi kprobe links which was merged in 5.17, so the expectation is
+	// that we do not need to SetInnerMaxEntries() here.
+	maps = append(maps, addr4FilterMaps)
+
 	retProbe := program.MapBuilderPin("retprobe_map", sensors.PathJoin(pinPath, "retprobe_map"), load)
 	maps = append(maps, retProbe)
 
@@ -589,6 +594,15 @@ func createGenericKprobeSensor(
 			argFilterMaps.SetInnerMaxEntries(maxEntries)
 		}
 		maps = append(maps, argFilterMaps)
+
+		addr4FilterMaps := program.MapBuilderPin("addr4lpm_maps", sensors.PathJoin(pinPath, "addr4lpm_maps"), load)
+		if !kernels.MinKernelVersion("5.9") {
+			// Versions before 5.9 do not allow inner maps to have different sizes.
+			// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+			maxEntries := kprobeEntry.loadArgs.selectors.Addr4MapsMaxEntries()
+			addr4FilterMaps.SetInnerMaxEntries(maxEntries)
+		}
+		maps = append(maps, addr4FilterMaps)
 
 		retProbe := program.MapBuilderPin("retprobe_map", sensors.PathJoin(pinPath, "retprobe_map"), load)
 		maps = append(maps, retProbe)

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -409,6 +409,15 @@ func createGenericTracepointSensor(
 		}
 		maps = append(maps, argFilterMaps)
 
+		addr4FilterMaps := program.MapBuilderPin("addr4lpm_maps", sensors.PathJoin(pinPath, "addr4lpm_maps"), prog0)
+		if !kernels.MinKernelVersion("5.9") {
+			// Versions before 5.9 do not allow inner maps to have different sizes.
+			// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+			maxEntries := tp.selectors.Addr4MapsMaxEntries()
+			addr4FilterMaps.SetInnerMaxEntries(maxEntries)
+		}
+		maps = append(maps, addr4FilterMaps)
+
 		selNamesMap := program.MapBuilderPin("sel_names_map", sensors.PathJoin(pinPath, "sel_names_map"), prog0)
 		maps = append(maps, selNamesMap)
 	}

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3404,7 +3404,11 @@ spec:
 }
 
 func miniTcpNopServer(c chan<- bool) {
-	conn, err := net.Listen("tcp4", "127.0.0.1:9919")
+	miniTcpNopServerWithPort(c, 9919)
+}
+
+func miniTcpNopServerWithPort(c chan<- bool, port int) {
+	conn, err := net.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		panic(err)
 	}
@@ -3414,7 +3418,7 @@ func miniTcpNopServer(c chan<- bool) {
 	conn.Close()
 }
 
-func TestKprobeSock(t *testing.T) {
+func TestKprobeSockBasic(t *testing.T) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -3486,7 +3490,6 @@ spec:
 	assert.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
 	assert.NoError(t, err)
-	//conn.Close()
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -3494,8 +3497,630 @@ spec:
 			WithValues(
 				ec.NewKprobeArgumentChecker().WithSockArg(ec.NewKprobeSockChecker().
 					WithDaddr(sm.Full("127.0.0.1")).
-					WithDport(9919).
-					WithProtocol(sm.Full("IPPROTO_TCP")),
+					WithDport(9919),
+				),
+			))
+
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobeSockNotPort(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	hookFull := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "127.0.0.1"
+      - index: 0
+        operator: "NotDPort"
+        values:
+        - "9918"
+      - index: 0
+        operator: "Protocol"
+        values:
+        - "IPPROTO_TCP"
+`
+	hookPart := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "NotDPort"
+        values:
+        - "9918"
+`
+
+	if kernels.EnableLargeProgs() {
+		createCrdFile(t, hookFull)
+	} else {
+		createCrdFile(t, hookPart)
+	}
+
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	tcpReady := make(chan bool)
+	go miniTcpNopServer(tcpReady)
+	<-tcpReady
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
+	assert.NoError(t, err)
+	_, err = net.DialTCP("tcp", nil, addr)
+	assert.NoError(t, err)
+
+	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
+		WithFunctionName(sm.Full("tcp_connect")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithSockArg(ec.NewKprobeSockChecker().
+					WithDaddr(sm.Full("127.0.0.1")).
+					WithDport(9919),
+				),
+			))
+
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobeSockMultiplePorts(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	hookFull := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "127.0.0.1"
+      - index: 0
+        operator: "DPort"
+        values:
+        - "9910"
+        - "9919"
+        - "9925"
+      - index: 0
+        operator: "Protocol"
+        values:
+        - "IPPROTO_TCP"
+`
+	hookPart := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DPort"
+        values:
+        - "9910"
+        - "9919"
+        - "9925"
+`
+
+	if kernels.EnableLargeProgs() {
+		createCrdFile(t, hookFull)
+	} else {
+		createCrdFile(t, hookPart)
+	}
+
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	tcpReady := make(chan bool)
+	go miniTcpNopServer(tcpReady)
+	<-tcpReady
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
+	assert.NoError(t, err)
+	_, err = net.DialTCP("tcp", nil, addr)
+	assert.NoError(t, err)
+
+	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
+		WithFunctionName(sm.Full("tcp_connect")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithSockArg(ec.NewKprobeSockChecker().
+					WithDaddr(sm.Full("127.0.0.1")).
+					WithDport(9919),
+				),
+			))
+
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobeSockPortRange(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	hookFull := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "127.0.0.1"
+      - index: 0
+        operator: "DPort"
+        values:
+        - "9910:9920"
+      - index: 0
+        operator: "Protocol"
+        values:
+        - "IPPROTO_TCP"
+`
+	hookPart := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DPort"
+        values:
+        - "9910:9920"
+`
+
+	if kernels.EnableLargeProgs() {
+		createCrdFile(t, hookFull)
+	} else {
+		createCrdFile(t, hookPart)
+	}
+
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	tcpReady := make(chan bool)
+	go miniTcpNopServer(tcpReady)
+	<-tcpReady
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
+	assert.NoError(t, err)
+	_, err = net.DialTCP("tcp", nil, addr)
+	assert.NoError(t, err)
+
+	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
+		WithFunctionName(sm.Full("tcp_connect")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithSockArg(ec.NewKprobeSockChecker().
+					WithDaddr(sm.Full("127.0.0.1")).
+					WithDport(9919),
+				),
+			))
+
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobeSockPrivPorts(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	hookFull := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "127.0.0.1"
+      - index: 0
+        operator: "DPortPriv"
+      - index: 0
+        operator: "Protocol"
+        values:
+        - "IPPROTO_TCP"
+`
+	hookPart := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DPortPriv"
+`
+
+	if kernels.EnableLargeProgs() {
+		createCrdFile(t, hookFull)
+	} else {
+		createCrdFile(t, hookPart)
+	}
+
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	tcpReady := make(chan bool)
+	go miniTcpNopServerWithPort(tcpReady, 1020)
+	<-tcpReady
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:1020")
+	assert.NoError(t, err)
+	_, err = net.DialTCP("tcp", nil, addr)
+	assert.NoError(t, err)
+
+	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
+		WithFunctionName(sm.Full("tcp_connect")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithSockArg(ec.NewKprobeSockChecker().
+					WithDaddr(sm.Full("127.0.0.1")).
+					WithDport(1020),
+				),
+			))
+
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobeSockNotPrivPorts(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	hookFull := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "127.0.0.1"
+      - index: 0
+        operator: "NotDPortPriv"
+      - index: 0
+        operator: "Protocol"
+        values:
+        - "IPPROTO_TCP"
+`
+	hookPart := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "NotDPortPriv"
+`
+
+	if kernels.EnableLargeProgs() {
+		createCrdFile(t, hookFull)
+	} else {
+		createCrdFile(t, hookPart)
+	}
+
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	tcpReady := make(chan bool)
+	go miniTcpNopServer(tcpReady)
+	<-tcpReady
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
+	assert.NoError(t, err)
+	_, err = net.DialTCP("tcp", nil, addr)
+	assert.NoError(t, err)
+
+	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
+		WithFunctionName(sm.Full("tcp_connect")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithSockArg(ec.NewKprobeSockChecker().
+					WithDaddr(sm.Full("127.0.0.1")).
+					WithDport(9919),
+				),
+			))
+
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobeSockNotCIDR(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	hookFull := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "NotDAddr"
+        values:
+        - "10.0.0.0/8"
+      - index: 0
+        operator: "DPort"
+        values:
+        - "9919"
+      - index: 0
+        operator: "Protocol"
+        values:
+        - "IPPROTO_TCP"
+`
+	hookPart := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "NotDaddr"
+        values:
+        - "10.0.0.0/8"
+`
+
+	if kernels.EnableLargeProgs() {
+		createCrdFile(t, hookFull)
+	} else {
+		createCrdFile(t, hookPart)
+	}
+
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	tcpReady := make(chan bool)
+	go miniTcpNopServer(tcpReady)
+	<-tcpReady
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
+	assert.NoError(t, err)
+	_, err = net.DialTCP("tcp", nil, addr)
+	assert.NoError(t, err)
+
+	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
+		WithFunctionName(sm.Full("tcp_connect")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithSockArg(ec.NewKprobeSockChecker().
+					WithDaddr(sm.Full("127.0.0.1")).
+					WithDport(9919),
+				),
+			))
+
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobeSockMultipleCIDRs(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	hookFull := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "10.0.0.1"
+        - "127.0.0.1"
+        - "172.16.0.0/16"
+      - index: 0
+        operator: "DPort"
+        values:
+        - "9919"
+      - index: 0
+        operator: "Protocol"
+        values:
+        - "IPPROTO_TCP"
+`
+	hookPart := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tcp-connect"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DAddr"
+        values:
+        - "10.0.0.1"
+        - "127.0.0.1"
+        - "172.16.0.0/16"
+`
+
+	if kernels.EnableLargeProgs() {
+		createCrdFile(t, hookFull)
+	} else {
+		createCrdFile(t, hookPart)
+	}
+
+	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	tcpReady := make(chan bool)
+	go miniTcpNopServer(tcpReady)
+	<-tcpReady
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
+	assert.NoError(t, err)
+	_, err = net.DialTCP("tcp", nil, addr)
+	assert.NoError(t, err)
+
+	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
+		WithFunctionName(sm.Full("tcp_connect")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithSockArg(ec.NewKprobeSockChecker().
+					WithDaddr(sm.Full("127.0.0.1")).
+					WithDport(9919),
 				),
 			))
 

--- a/pkg/sensors/tracing/selectors.go
+++ b/pkg/sensors/tracing/selectors.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/selectors"
 	"github.com/cilium/tetragon/pkg/sensors"
@@ -27,6 +28,12 @@ func selectorsMaploads(ks *selectors.KernelSelectorState, pinPathPrefix string, 
 			Name:  "argfilter_maps",
 			Load: func(outerMap *ebpf.Map, index uint32) error {
 				return populateArgFilterMaps(ks, pinPathPrefix, outerMap)
+			},
+		}, {
+			Index: 0,
+			Name:  "addr4lpm_maps",
+			Load: func(outerMap *ebpf.Map, index uint32) error {
+				return populateAddr4FilterMaps(ks, pinPathPrefix, outerMap)
 			},
 		}, {
 			Index: 0,
@@ -85,6 +92,66 @@ func populateArgFilterMap(
 	one := uint8(1)
 	for val := range innerData {
 		err := innerMap.Update(val[:], one, 0)
+		if err != nil {
+			return fmt.Errorf("failed to insert value into %s: %w", innerName, err)
+		}
+	}
+
+	if err := outerMap.Update(uint32(innerID), uint32(innerMap.FD()), 0); err != nil {
+		return fmt.Errorf("failed to insert %s: %w", innerName, err)
+	}
+
+	return nil
+}
+
+func populateAddr4FilterMaps(
+	k *selectors.KernelSelectorState,
+	pinPathPrefix string,
+	outerMap *ebpf.Map,
+) error {
+	maxEntries := k.Addr4MapsMaxEntries()
+	for i, am := range k.Addr4Maps() {
+		nrEntries := uint32(len(am))
+		// Versions before 5.9 do not allow inner maps to have different sizes.
+		// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+		if !kernels.MinKernelVersion("5.9") {
+			nrEntries = uint32(maxEntries)
+		}
+		err := populateAddr4FilterMap(pinPathPrefix, outerMap, uint32(i), am, nrEntries)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func populateAddr4FilterMap(
+	pinPathPrefix string,
+	outerMap *ebpf.Map,
+	innerID uint32,
+	innerData map[selectors.KernelLpmTrie4]struct{},
+	maxEntries uint32,
+) error {
+	innerName := fmt.Sprintf("addr4filter_map_%d", innerID)
+	innerSpec := &ebpf.MapSpec{
+		Name:       innerName,
+		Type:       ebpf.LPMTrie,
+		KeySize:    8, // NB: KernelLpmTrie4 consists of 32bit prefix and 32bit address
+		ValueSize:  uint32(1),
+		MaxEntries: maxEntries,
+		Flags:      bpf.BPF_F_NO_PREALLOC,
+	}
+	innerMap, err := ebpf.NewMapWithOptions(innerSpec, ebpf.MapOptions{
+		PinPath: sensors.PathJoin(pinPathPrefix, innerName),
+	})
+	if err != nil {
+		return fmt.Errorf("creating innerMap %s failed: %w", innerName, err)
+	}
+	defer innerMap.Close()
+
+	one := uint8(1)
+	for val := range innerData {
+		err := innerMap.Update(val, one, 0)
 		if err != nil {
 			return fmt.Errorf("failed to insert value into %s: %w", innerName, err)
 		}

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -288,7 +288,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -509,7 +511,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -767,7 +771,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -988,7 +994,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -1119,7 +1127,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -1340,7 +1350,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -281,8 +281,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -498,8 +502,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -752,8 +760,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -969,8 +981,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1096,8 +1112,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1313,8 +1333,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -280,7 +280,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -495,7 +497,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -747,7 +751,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -962,7 +968,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1087,7 +1095,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1302,7 +1312,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -288,7 +288,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -509,7 +511,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -767,7 +771,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -988,7 +994,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -1119,7 +1127,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string
@@ -1340,7 +1350,9 @@ spec:
                                   - DPortPriv
                                   - NotDPortPriv
                                   - SAddr
+                                  - NotSAddr
                                   - DAddr
+                                  - NotDAddr
                                   - Protocol
                                   - Mask
                                   type: string

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -281,8 +281,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -498,8 +502,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -752,8 +760,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -969,8 +981,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1096,8 +1112,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1313,8 +1333,12 @@ spec:
                                   - LT
                                   - SPort
                                   - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
                                   - DPort
                                   - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
                                   - SAddr
                                   - DAddr
                                   - Protocol

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -280,7 +280,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -495,7 +497,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -747,7 +751,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -962,7 +968,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1087,7 +1095,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol
@@ -1302,7 +1312,9 @@ spec:
                                   - GT
                                   - LT
                                   - SPort
+                                  - NotSPort
                                   - DPort
+                                  - NotDPort
                                   - SAddr
                                   - DAddr
                                   - Protocol

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -257,7 +257,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;DPort;NotDPort;SAddr;DAddr;Protocol;Mask
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;DAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -257,7 +257,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;DPort;SAddr;DAddr;Protocol;Mask
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;DPort;NotDPort;SAddr;DAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -257,7 +257,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;DAddr;Protocol;Mask
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.


### PR DESCRIPTION
This series adds functionality to socket matching for sock and skb types. Previously, ports and CIDRs could be specified, but only a limited number would be accepted, due to complexity issues surrounding checking members of lists. This series uses an argfilter map to specify ports so that theoretically any number could be specified, and a new addr4filter map to specify IPv4 CIDRs, that are matched using a longest prefix match TRIE map.

In addition, ports can now be specified as ranges using the 'min:max' format, and new operators SPortPriv and DPortPriv were added to specify the range of privileged ports, from 0 to 1023 inclusive. On top of that, all port and address operators now can be prefixed with the Not keyword to create an inverse match, e.g. NotSAddr, and these can be combined with their positive equivalents to remove entires from a larger set.