### PR TITLE
pkg/filters: make field filters work with snake case fields

### DIFF
--- a/pkg/filters/fields_test.go
+++ b/pkg/filters/fields_test.go
@@ -610,3 +610,9 @@ func TestSlimExecEventsFieldFilterExample(t *testing.T) {
 		}
 	}
 }
+
+func TestParseFieldFilterList(t *testing.T) {
+	filters, err := ParseFieldFilterList(`{"event_set": ["PROCESS_EXEC"], "fields": "process.start_time", "action": "INCLUDE"}`)
+	assert.NoError(t, err, "must parse")
+	assert.Equal(t, filters[0].Fields.Paths[0], "process.start_time")
+}


### PR DESCRIPTION
Protobuf does not support snake case in the JSON representation of FieldMasks. This is a problem for us because our canonical representation of fields is in snake_case and we don't want to create confusion. To make things consistent, this patch introduces a hack to perform the snake case to camel case conversion just before we unmarshal from JSON.

```release-note
Field filters for masking event export fields now support path names defined in snake_case as well as camelCase.
```