### PR TITLE
Pass Namespace in metrics options instead of prefixing metric names

### DIFF
--- a/pkg/grpc/tracing/stats.go
+++ b/pkg/grpc/tracing/stats.go
@@ -8,7 +8,8 @@ import (
 
 var (
 	LoaderStats = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "process_loader_stats",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "process_loader_stats",
 		Help:        "Process Loader event statistics. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"count"})

--- a/pkg/metrics/consts/consts.go
+++ b/pkg/metrics/consts/consts.go
@@ -3,4 +3,4 @@
 
 package consts
 
-var MetricNamePrefix = "tetragon_"
+var MetricsNamespace = "tetragon"

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -44,13 +44,15 @@ var (
 
 var (
 	ErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "errors_total",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "errors_total",
 		Help:        "The total number of Tetragon errors. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
 
 	HandlerErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "handler_errors",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "handler_errors",
 		Help:        "The total number of event handler errors. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"opcode", "error_type"})

--- a/pkg/metrics/eventcachemetrics/eventcachemetrics.go
+++ b/pkg/metrics/eventcachemetrics/eventcachemetrics.go
@@ -11,12 +11,14 @@ import (
 
 var (
 	processInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "event_cache_process_info_errors",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "event_cache_process_info_errors",
 		Help:        "The total of times we failed to fetch cached process info for a given event type.",
 		ConstLabels: nil,
 	}, []string{"event_type"})
 	podInfoErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "event_cache_pod_info_errors",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "event_cache_pod_info_errors",
 		Help:        "The total of times we failed to fetch cached pod info for a given event type.",
 		ConstLabels: nil,
 	}, []string{"event_type"})

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -21,23 +21,27 @@ import (
 
 var (
 	EventsProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "events_total",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "events_total",
 		Help:        "The total number of Tetragon events",
 		ConstLabels: nil,
 	}, []string{"type", "namespace", "pod", "binary"})
 	FlagCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "flags_total",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "flags_total",
 		Help:        "The total number of Tetragon flags. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"type"})
 	NotifyOverflowedEvents = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "notify_overflowed_events",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "notify_overflowed_events",
 		Help:        "The total number of events dropped because listener buffer was full",
 		ConstLabels: nil,
 	}, nil)
 
 	policyStats = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "policy_stats",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "policy_stats",
 		Help:        "Policy events calls observed.",
 		ConstLabels: nil,
 	}, []string{"policy", "hook", "namespace", "pod", "binary"})

--- a/pkg/metrics/kprobemetrics/kprobemetrics.go
+++ b/pkg/metrics/kprobemetrics/kprobemetrics.go
@@ -11,17 +11,20 @@ import (
 
 var (
 	MergeErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "generic_kprobe_merge_errors",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "generic_kprobe_merge_errors",
 		Help:        "The total number of failed attempts to merge a kprobe and kretprobe event.",
 		ConstLabels: nil,
 	}, []string{"curr_fn", "curr_type", "prev_fn", "prev_type"})
 	MergeOkTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "generic_kprobe_merge_ok_total",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "generic_kprobe_merge_ok_total",
 		Help:        "The total number of successful attempts to merge a kprobe and kretprobe event.",
 		ConstLabels: nil,
 	})
 	MergePushed = promauto.NewCounter(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "generic_kprobe_merge_pushed",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "generic_kprobe_merge_pushed",
 		Help:        "The total number of pushed events for later merge.",
 		ConstLabels: nil,
 	})

--- a/pkg/metrics/mapmetrics/mapmetrics.go
+++ b/pkg/metrics/mapmetrics/mapmetrics.go
@@ -13,13 +13,15 @@ import (
 
 var (
 	MapSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "map_in_use_gauge",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "map_in_use_gauge",
 		Help:        "The total number of in-use entries per map.",
 		ConstLabels: nil,
 	}, []string{"map", "total"})
 
 	MapDrops = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "map_drops",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "map_drops",
 		Help:        "The total number of entries dropped per LRU map.",
 		ConstLabels: nil,
 	}, []string{"map"})

--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -13,13 +13,15 @@ import (
 
 var (
 	MsgOpsCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "msg_op_total",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "msg_op_total",
 		Help:        "The total number of times we encounter a given message opcode. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"msg_op"})
 
 	LatencyStats = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        consts.MetricNamePrefix + "handling_latency",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "handling_latency",
 		Help:        "The latency of handling messages in us.",
 		Buckets:     []float64{50, 100, 500, 1000, 10000, 100000}, // 50us, 100us, 500us, 1ms, 10ms, 100ms
 		ConstLabels: nil,

--- a/pkg/metrics/policyfilter/policyfilter.go
+++ b/pkg/metrics/policyfilter/policyfilter.go
@@ -15,7 +15,8 @@ import (
 
 var (
 	PolicyFilterOpMetrics = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "policyflter_metrics_total",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "policyflter_metrics_total",
 		Help:        "Policy filter metrics. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"subsys", "op", "error_type"})

--- a/pkg/metrics/processexecmetrics/processexecmetrics.go
+++ b/pkg/metrics/processexecmetrics/processexecmetrics.go
@@ -11,12 +11,14 @@ import (
 
 var (
 	MissingParentErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "exec_missing_parent_errors",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "exec_missing_parent_errors",
 		Help:        "The total of times a given parent exec id could not be found in an exec event.",
 		ConstLabels: nil,
 	}, []string{"parent_exec_id"})
 	SameExecIdErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "exec_parent_child_same_id_errors",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "exec_parent_child_same_id_errors",
 		Help:        "The total of times an error occurs due to a parent and child process have the same exec id.",
 		ConstLabels: nil,
 	}, []string{"exec_id"})

--- a/pkg/metrics/ringbufmetrics/ringbufmetrics.go
+++ b/pkg/metrics/ringbufmetrics/ringbufmetrics.go
@@ -11,17 +11,20 @@ import (
 
 var (
 	PerfEventReceived = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_received",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "ringbuf_perf_event_received",
 		Help:        "The total number of Tetragon ringbuf perf events received.",
 		ConstLabels: nil,
 	}, nil)
 	PerfEventLost = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_lost",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "ringbuf_perf_event_lost",
 		Help:        "The total number of Tetragon ringbuf perf events lost.",
 		ConstLabels: nil,
 	}, nil)
 	PerfEventErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        consts.MetricNamePrefix + "ringbuf_perf_event_errors",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "ringbuf_perf_event_errors",
 		Help:        "The total number of Tetragon ringbuf perf event error count.",
 		ConstLabels: nil,
 	}, nil)

--- a/pkg/metrics/syscallmetrics/syscallmetrics.go
+++ b/pkg/metrics/syscallmetrics/syscallmetrics.go
@@ -13,7 +13,8 @@ import (
 
 var (
 	syscallStats = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "syscall_stats",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "syscall_stats",
 		Help:        "System calls observed.",
 		ConstLabels: nil,
 	}, []string{"syscall", "namespace", "pod", "binary"})

--- a/pkg/metrics/watchermetrics/watchermetrics.go
+++ b/pkg/metrics/watchermetrics/watchermetrics.go
@@ -17,12 +17,14 @@ const (
 
 var (
 	WatcherErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "watcher_errors",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "watcher_errors",
 		Help:        "The total number of errors for a given watcher type.",
 		ConstLabels: nil,
 	}, []string{"watcher", "error"})
 	WatcherEvents = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        consts.MetricNamePrefix + "watcher_events",
+		Namespace:   consts.MetricsNamespace,
+		Name:        "watcher_events",
 		Help:        "The total number of events for a given watcher type.",
 		ConstLabels: nil,
 	}, []string{"watcher"})


### PR DESCRIPTION
This is a non-functional change.