### PR TITLE
selector fixes

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Run static checks
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         with:
-          version: v1.52.2
+          version: v1.53.3
           args: --config=.golangci.yml --verbose
           skip-cache: true
       - name: Check gofmt formatting

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GO_IMAGE_LDFLAGS=$(GO_LDFLAGS_STATIC)
 GO_OPERATOR_IMAGE_LDFLAGS="-X 'github.com/cilium/tetragon/pkg/version.Version=$(VERSION)' -s -w"
 
 
-GOLANGCILINT_WANT_VERSION = 1.52.2
+GOLANGCILINT_WANT_VERSION = 1.53.3
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 
 # Do a parallel build with multiple jobs, based on the number of CPUs online

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -90,6 +90,17 @@ func (k *KernelSelectorState) ValueMaps() []map[[8]byte]struct{} {
 	return k.valueMaps
 }
 
+// ValueMapsMaxEntries returns the maximum entries over all maps
+func (k *KernelSelectorState) ValueMapsMaxEntries() int {
+	maxEntries := 1
+	for _, vm := range k.valueMaps {
+		if l := len(vm); l > maxEntries {
+			maxEntries = l
+		}
+	}
+	return maxEntries
+}
+
 func WriteSelectorInt32(k *KernelSelectorState, v int32) {
 	binary.LittleEndian.PutUint32(k.e[k.off:], uint32(v))
 	k.off += 4

--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -275,7 +275,7 @@ func observerLoadInstance(bpfDir, mapDir, ciliumDir string, load *program.Progra
 	} else {
 		err = loadInstance(bpfDir, mapDir, ciliumDir, load, version, option.Config.Verbosity)
 		if err != nil && load.ErrorFatal {
-			return fmt.Errorf("failed prog %s kern_version %d LoadKprobeProgram: %w",
+			return fmt.Errorf("failed prog %s kern_version %d loadInstance: %w",
 				load.Name, version, err)
 		}
 	}

--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -206,6 +206,12 @@ func (s *Sensor) loadMaps(mapDir string) error {
 			mapSpec.MaxEntries = max
 		}
 
+		if innerMax, ok := m.Prog.MaxEntriesInnerMap[mapSpec.Name]; ok {
+			if innerMs := mapSpec.InnerMap; innerMs != nil {
+				mapSpec.InnerMap.MaxEntries = innerMax
+			}
+		}
+
 		if err := m.LoadOrCreatePinnedMap(pinPath, mapSpec); err != nil {
 			return fmt.Errorf("failed to load map '%s' for sensor '%s': %w", m.Name, s.Name, err)
 		}

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -405,6 +405,13 @@ func doLoadProgram(
 		if max, ok := load.MaxEntriesMap[ms.Name]; ok {
 			ms.MaxEntries = max
 		}
+
+		if innerMax, ok := load.MaxEntriesInnerMap[ms.Name]; ok {
+			if ms.InnerMap == nil {
+				return nil, fmt.Errorf("no inner map for %s", ms.Name)
+			}
+			ms.InnerMap.MaxEntries = innerMax
+		}
 	}
 
 	// Find all the maps referenced by the program, so we'll rewrite only

--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -171,3 +171,7 @@ func LoadOrCreatePinnedMap(pinPath string, mapSpec *ebpf.MapSpec) (*ebpf.Map, er
 func (m *Map) SetMaxEntries(max int) {
 	m.Prog.MaxEntriesMap[m.Name] = uint32(max)
 }
+
+func (m *Map) SetInnerMaxEntries(max int) {
+	m.Prog.MaxEntriesInnerMap[m.Name] = uint32(max)
+}

--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -14,20 +14,21 @@ func Builder(
 	ty string,
 ) *Program {
 	return &Program{
-		Name:          objFile,
-		Attach:        attach,
-		Label:         label,
-		PinPath:       pinFile,
-		RetProbe:      false,
-		ErrorFatal:    true,
-		Override:      false,
-		Type:          ty,
-		LoadState:     Idle(),
-		LoaderData:    struct{}{},
-		MapLoad:       nil,
-		unloader:      nil,
-		PinMap:        make(map[string]string),
-		MaxEntriesMap: make(map[string]uint32),
+		Name:               objFile,
+		Attach:             attach,
+		Label:              label,
+		PinPath:            pinFile,
+		RetProbe:           false,
+		ErrorFatal:         true,
+		Override:           false,
+		Type:               ty,
+		LoadState:          Idle(),
+		LoaderData:         struct{}{},
+		MapLoad:            nil,
+		unloader:           nil,
+		PinMap:             make(map[string]string),
+		MaxEntriesMap:      make(map[string]uint32),
+		MaxEntriesInnerMap: make(map[string]uint32),
 	}
 }
 
@@ -96,7 +97,8 @@ type Program struct {
 	// available when program.KeepCollection is true
 	LC *LoadedCollection
 
-	MaxEntriesMap map[string]uint32
+	MaxEntriesMap      map[string]uint32
+	MaxEntriesInnerMap map[string]uint32
 }
 
 func (p *Program) SetRetProbe(ret bool) *Program {

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -401,6 +401,12 @@ func createGenericTracepointSensor(
 		maps = append(maps, filterMap)
 
 		argFilterMaps := program.MapBuilderPin("argfilter_maps", sensors.PathJoin(pinPath, "argfilter_maps"), prog0)
+		if !kernels.MinKernelVersion("5.9") {
+			// Versions before 5.9 do not allow inner maps to have different sizes.
+			// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+			maxEntries := tp.selectors.ValueMapsMaxEntries()
+			argFilterMaps.SetInnerMaxEntries(maxEntries)
+		}
 		maps = append(maps, argFilterMaps)
 
 		selNamesMap := program.MapBuilderPin("sel_names_map", sensors.PathJoin(pinPath, "sel_names_map"), prog0)

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -108,6 +108,15 @@ var testCases = []struct {
 		},
 	},
 	{
+		// NB: this needs to be first
+		specOperator:   "InMap",
+		specFilterVals: [][]int{{8888, 8889}, {4442, 4443, 4444}},
+		tests: []testCase{
+			{lseekOpsVals: []int{4444, 4445}, expectedArgs: map[uint64]int{4444: 1}},
+			{lseekOpsVals: []int{4443, 8889}, expectedArgs: map[uint64]int{4443: 1, 8889: 1}},
+		},
+	},
+	{
 		specOperator:   "InMap",
 		specFilterVals: [][]int{{4443}, {9999}},
 		tests: []testCase{

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/arch"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
-	"github.com/cilium/tetragon/pkg/idtable"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/observer"
@@ -34,20 +33,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
-
-func tpSpecReload(t *testing.T, tpSensor *sensors.Sensor, tpSpec *v1alpha1.TracepointSpec) {
-	if len(tpSensor.Progs) != 1 {
-		t.Fatalf("unexpected progs size: %d", len(tpSensor.Progs))
-	}
-
-	tpProg := tpSensor.Progs[0]
-	if err := ReloadGenericTracepointSelectors(tpProg, tpSpec); err != nil {
-		t.Fatalf("failed to reload tracepoint prog: %s", err)
-	}
-	if len(tpSensor.Progs) != 1 {
-		t.Fatalf("unexpected progs size: %d", len(tpSensor.Progs))
-	}
-}
 
 // loadGenericSensorTest loads a tracing sensor for testing
 func loadGenericSensorTest(t *testing.T, spec *v1alpha1.TracingPolicySpec) *sensors.Sensor {
@@ -232,26 +217,21 @@ func TestTracepointSelectors(t *testing.T) {
 		}
 	}
 
-	tpSensor := loadGenericSensorTest(t, makeSpec(t, testCases[0].specFilterVals, testCases[0].specOperator))
-	t0 := time.Now()
-	loadElapsed := time.Since(t0)
-	t.Logf("loading sensors took: %s\n", loadElapsed)
-	for i, tcs := range testCases {
+	for _, tcs := range testCases {
 		tName := fmt.Sprintf("spec:%s%v", tcs.specOperator, tcs.specFilterVals)
 		t.Run(tName, func(t *testing.T) {
-			t.Logf("%d", i)
 			testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
+			t.Logf("Running %s", tName)
+			t0 := time.Now()
 			spec := makeSpec(t, tcs.specFilterVals, tcs.specOperator)
-			if i != 0 {
-				tpSpecReload(t, tpSensor, &spec.Tracepoints[0])
-			}
-
+			tpSensor := loadGenericSensorTest(t, spec)
+			loadElapsed := time.Since(t0)
+			t.Logf("loading sensors (tpSensor: %p)  took: %s\n", tpSensor, loadElapsed)
 			for _, tc := range tcs.tests {
 				runAndCheck(t, ctx, fmt.Sprintf("lseekValls:%v", tc.lseekOpsVals), lseekTestOps(tc.lseekOpsVals), tc.expectedArgs)
 			}
 		})
 	}
-
 }
 
 func selectorsFromWhenceVals(t *testing.T, filterWhenceVals [][]int, whenceIdx uint32, filterOperator string) []v1alpha1.KProbeSelector {
@@ -360,28 +340,22 @@ func TestKprobeSelectors(t *testing.T) {
 		}
 	}
 
-	t0 := time.Now()
-	kpSensor := loadGenericSensorTest(t, makeSpec(t, testCases[0].specFilterVals, testCases[0].specOperator))
-	loadElapsed := time.Since(t0)
-	t.Logf("loading sensors (kpSensor: %p)  took: %s\n", kpSensor, loadElapsed)
-	for i, tcs := range testCases {
+	for _, tcs := range testCases {
 		tName := fmt.Sprintf("spec:%s%v", tcs.specOperator, tcs.specFilterVals)
 		t.Run(tName, func(t *testing.T) {
-			t.Logf("%d", i)
 			testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
-			spec := makeSpec(t, tcs.specFilterVals, tcs.specOperator)
-			if i != 0 {
-				// Create URL and FQDN tables to store URLs and FQDNs for this kprobe
-				var argActionTable idtable.Table
+			t.Logf("Running %s", tName)
 
-				if err := ReloadGenericKprobeSelectors(kpSensor, &spec.KProbes[0], &argActionTable); err != nil {
-					t.Fatalf("failed to reload kprobe prog: %s", err)
-				}
-			}
+			t0 := time.Now()
+			spec := makeSpec(t, tcs.specFilterVals, tcs.specOperator)
+			kpSensor := loadGenericSensorTest(t, spec)
+			loadElapsed := time.Since(t0)
+			t.Logf("loading sensors (kpSensor: %p)  took: %s\n", kpSensor, loadElapsed)
 
 			for _, tc := range tcs.tests {
 				runAndCheck(t, ctx, fmt.Sprintf("lseekValls:%v", tc.lseekOpsVals), lseekTestOps(tc.lseekOpsVals), tc.expectedArgs)
 			}
 		})
 	}
+
 }


### PR DESCRIPTION
When setting multiple inner maps in argfilter_maps of different sizes,
loading the data into the maps fails for 5.4 and 4.19 kernels.

We attribute this failure to these kernels not having
https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/,
which allows the outer map to be updated with an inner map of different
sizes. This change was introduced in 5.9

This PR:

1. Introduces a MaxEntriesInnerMap filed in the programs, which allows
   us to override the max entries defined in the bpf code. We follow
   this approach since there is already a MaxEntries field for a similar
   purpose.
2. Sets this field using SetMaxEntries in both generic kprobes and
   tracepoints. For this to work, we had to move the parsing of the
   kernel selectors earlier. This happens only for
   kerrnels < 5.9
3. Modifies the loading code so that it checks this entry when we load a
   new map.
4. Modifies the code that creates the inner map to use a single
   max_entry for all inner maps for kernels < 5.9.
5. Adds a test case in the selectors tests. For the test case to work,
   we had to modify the test to reload the programs every time/