### PR TITLE
gh/vmtests: use -main for latest version and add bpf-next

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -64,10 +64,10 @@ jobs:
         fail-fast: false
         matrix:
            kernel:
-              - '5.15'
-              - '5.10'
-              - '5.4'
-              - '4.19'
+              - '5.15-main'
+              - '5.10-main'
+              - '5.4-main'
+              - '4.19-main'
            group:
               - 0
     concurrency:
@@ -100,23 +100,28 @@ jobs:
         tar xf tetragon.tar -C go/src/github.com/cilium
 
     - name: test kernel ${{ matrix.kernel }}
-      if: ${{ matrix.kernel  != '4.19' }}
+      if: ${{ !startsWith(matrix.kernel, '4.19') }}
       run: |
         cd go/src/github.com/cilium/tetragon
         ./tests/vmtests/fetch-data.sh ${{ matrix.kernel }}
+        kimage=$(find tests/vmtests/test-data/kernels -path "*vmlinuz*" -type f)
+        echo "Using: kernel:$kimage"
         sudo ./tests/vmtests/tetragon-vmtests-run \
-                --kernel tests/vmtests/test-data/kernels/${{ matrix.kernel }}/boot/vmlinuz* \
+                --kernel ${kimage} \
                 --base tests/vmtests/test-data/images/base.qcow2 \
                 --testsfile ./tests/vmtests/test-group-${{ matrix.group }}
 
     - name: test kernel ${{ matrix.kernel }} with btf file
-      if: ${{ matrix.kernel  == '4.19' }}
+      if: ${{ startsWith(matrix.kernel, '4.19') }}
       run: |
         cd go/src/github.com/cilium/tetragon
         ./tests/vmtests/fetch-data.sh ${{ matrix.kernel }}
+        kimage=$(find tests/vmtests/test-data/kernels -path "*vmlinuz*" -type f)
+        btf=$(find tests/vmtests/test-data/kernels -path "*btf*" -type f)
+        echo "Using: kernel:$kimage bptf:$btf"
         sudo ./tests/vmtests/tetragon-vmtests-run \
-                --kernel tests/vmtests/test-data/kernels/${{ matrix.kernel }}/boot/vmlinuz* \
-                --btf-file tests/vmtests/test-data/kernels/${{ matrix.kernel }}/boot/btf-* \
+                --kernel ${kimage} \
+                --btf-file ${btf} \
                 --base tests/vmtests/test-data/images/base.qcow2 \
                 --testsfile ./tests/vmtests/test-group-${{ matrix.group }}
 

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -109,6 +109,7 @@ jobs:
         echo "Using: kernel:$kimage"
         sudo ./tests/vmtests/tetragon-vmtests-run \
                 --kernel ${kimage} \
+                --kernel-ver  ${{ matrix.kernel }} \
                 --base tests/vmtests/test-data/images/base.qcow2 \
                 --testsfile ./tests/vmtests/test-group-${{ matrix.group }}
 
@@ -122,6 +123,7 @@ jobs:
         echo "Using: kernel:$kimage bptf:$btf"
         sudo ./tests/vmtests/tetragon-vmtests-run \
                 --kernel ${kimage} \
+                --kernel-ver  ${{ matrix.kernel }} \
                 --btf-file ${btf} \
                 --base tests/vmtests/test-data/images/base.qcow2 \
                 --testsfile ./tests/vmtests/test-group-${{ matrix.group }}

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -64,6 +64,7 @@ jobs:
         fail-fast: false
         matrix:
            kernel:
+              - 'bpf-next-main'
               - '5.15-main'
               - '5.10-main'
               - '5.4-main'

--- a/cmd/tetragon-vmtests-run/main.go
+++ b/cmd/tetragon-vmtests-run/main.go
@@ -113,7 +113,7 @@ func main() {
 
 			dur := time.Since(t0).Round(time.Millisecond)
 			if results.nrFailedTests > 0 {
-				fmt.Printf("%d/%d tests failed 😞 (took: %s)\n", results.nrFailedTests, results.nrTests, dur)
+				fmt.Printf("%d/%d tests failed 😞 (took: %s, skipped:%d)\n", results.nrFailedTests, results.nrTests, dur, results.nrSkipedTests)
 				return errors.New("failed")
 			}
 
@@ -122,7 +122,7 @@ func main() {
 				return errors.New("failed")
 			}
 
-			fmt.Printf("All %d tests succeeded! 🎉🚢🍕 (took: %s)\n", results.nrTests, dur)
+			fmt.Printf("All %d tests succeeded! 🎉🚢🍕 (took: %s, skipped:%d)\n", results.nrTests, dur, results.nrSkipedTests)
 			return nil
 		},
 	}
@@ -145,6 +145,7 @@ func main() {
 	cmd.Flags().BoolVar(&rcnf.testerConf.KeepAllLogs, "keep-all-logs", false, "Normally, logs are kept only for failed tests. This switch keeps all logs.")
 	cmd.Flags().BoolVar(&rcnf.disableUnifiedCgroups, "disable-unified-cgroups", false, "boot with systemd.unified_cgroup_hierarchy=0.")
 	cmd.Flags().StringArrayVarP(&ports, "port", "p", nil, "Forward a port (hostport[:vmport[:tcp|udp]])")
+	cmd.Flags().StringVar(&rcnf.testerConf.KernelVer, "kernel-ver", "", "kenel version")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/tetragon-vmtests-run/run_tests.go
+++ b/cmd/tetragon-vmtests-run/run_tests.go
@@ -18,7 +18,7 @@ import (
 )
 
 type runTestsResults struct {
-	nrTests, nrFailedTests int
+	nrTests, nrFailedTests, nrSkipedTests int
 }
 
 func runTests(
@@ -65,6 +65,7 @@ func runTests(
 
 	var totalDuration time.Duration
 	errCnt := 0
+	skipCnt := 0
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
 	for _, r := range results {
@@ -73,6 +74,9 @@ func runTests(
 		if r.Error {
 			ok = "❌"
 			errCnt++
+		} else if r.Skip {
+			ok = "⏭️"
+			skipCnt++
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t(%s)\n", ok, r.Name, r.Duration.Round(time.Millisecond), totalDuration.Round(time.Millisecond))
 	}
@@ -81,5 +85,6 @@ func runTests(
 	return &runTestsResults{
 		nrTests:       len(results),
 		nrFailedTests: errCnt,
+		nrSkipedTests: skipCnt,
 	}, nil
 }

--- a/pkg/sensors/tracing/loader_test.go
+++ b/pkg/sensors/tracing/loader_test.go
@@ -86,7 +86,7 @@ func parseBuildId(filename string) ([]byte, error) {
 
 func TestLoader(t *testing.T) {
 	if !hasLoaderEvents() {
-		t.Skip("no support for lader events")
+		t.Skip("no support for loader events")
 	}
 
 	var doneWG, readyWG sync.WaitGroup

--- a/pkg/vmtests/skip.go
+++ b/pkg/vmtests/skip.go
@@ -1,0 +1,39 @@
+package vmtests
+
+import (
+	"regexp"
+)
+
+type skipRule struct {
+	TestNameRe string
+	testNameRe *regexp.Regexp
+
+	KernelRe string
+	kernelRe *regexp.Regexp
+}
+
+// We should probably have this in a json file, but for now we keep it here
+var rules = []skipRule{
+	skipRule{TestNameRe: "pkg.sensors.tracing.TestKprobeSkb", KernelRe: "bpf-next"},
+	skipRule{TestNameRe: "pkg.sensors.tracing.TestLoader", KernelRe: "bpf-next"},
+	skipRule{TestNameRe: "pkg.tracepoint.TestTracepointLoadFormat", KernelRe: "bpf-next"},
+}
+
+func init() {
+	for i := range rules {
+		r := &rules[i]
+		r.testNameRe = regexp.MustCompile(r.TestNameRe)
+		r.kernelRe = regexp.MustCompile(r.KernelRe)
+	}
+}
+
+func shouldSkip(cnf *Conf, testName string) bool {
+	for i := range rules {
+		r := &rules[i]
+		if r.kernelRe.MatchString(cnf.KernelVer) && r.testNameRe.MatchString(testName) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tests/vmtests/fetch-data.sh
+++ b/tests/vmtests/fetch-data.sh
@@ -12,7 +12,7 @@ DEST_DIR="tests/vmtests/test-data"
 
 if [ -z "$KERNEL_VERS" ]; then
 	echo "Usage: $0 <kver1> <kver2>"
-	echo "Example: $0 bpf-next 5.10"
+	echo "Example: $0 bpf-next 5.10-main"
 	exit 1
 fi
 
@@ -30,6 +30,6 @@ for ver in $KERNEL_VERS; do
 	img="$KERNIMG:$ver"
 	$CONTAINER_ENGINE pull $img
 	x=$($CONTAINER_ENGINE create $img)
-	$CONTAINER_ENGINE cp $x:/data/kernels/$ver  $DEST_DIR/kernels
+	$CONTAINER_ENGINE cp $x:/data/kernels  $DEST_DIR/
 	$CONTAINER_ENGINE rm $x
 done


### PR DESCRIPTION
Update the gh action for vmtetss to use the latest version for each kernel, which is designated as "-main".