### PR TITLE
tetragon: remove unnecessary GetProcessCopy()

### DIFF
--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -62,7 +62,7 @@ func HandleGenericInternal(ev notify.Event, pid uint32, tid *uint32, timestamp u
 	var err error
 
 	if parent != nil {
-		ev.SetParent(parent.GetProcessCopy())
+		ev.SetParent(parent.UnsafeGetProcess())
 	} else {
 		errormetrics.ErrorTotalInc(errormetrics.EventCacheParentInfoFailed)
 		err = ErrFailedToGetParentInfo

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -237,7 +237,7 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 		process.UpdateEventProcessTid(tetragonEvent.Process, &event.Tid)
 	}
 	if parent != nil {
-		tetragonEvent.Parent = parent.GetProcessCopy()
+		tetragonEvent.Parent = tetragonParent
 	}
 
 	return tetragonEvent
@@ -334,10 +334,9 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 	if proc != nil {
 		tetragonEvent.Process = proc.GetProcessCopy()
 		// Use the bpf recorded TID to update the event
+		// The cost to get this is relatively high because it requires a
+		// deep copyo of the process in order to safely modify it.
 		process.UpdateEventProcessTid(tetragonEvent.Process, &msg.Tid)
-	}
-	if parent != nil {
-		tetragonEvent.Parent = parent.GetProcessCopy()
 	}
 
 	return &tetragon.GetEventsResponse{
@@ -557,10 +556,6 @@ func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {
 		// Use the bpf recorded TID to update the event
 		process.UpdateEventProcessTid(tetragonEvent.Process, &event.Tid)
 	}
-	if parent != nil {
-		tetragonEvent.Parent = parent.GetProcessCopy()
-	}
-
 	return tetragonEvent
 }
 


### PR DESCRIPTION
GetProcessCopy is required when we need to modify the Process info. This is done primarily to update the Tid to reflect the caller of a system call or kprobe.

Most other cases shouldn't need to get a fully copy of the process object. The reason a copy is needed in the modification case is to avoid having a writer updating the object while the GRPC stream handler or JSON writer are marshalling the data which can corrupt the streaming logic. This results in either broken messages in JSON export file or the GRPC stream failing.