### PR TITLE
Fix SKB test

### DIFF
--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4143,7 +4143,7 @@ metadata:
   name: "datagram"
 spec:
   kprobes:
-  - call: "__cgroup_bpf_run_filter_skb"
+  - call: "ip_send_skb"
     syscall: false
     args:
     - index: 1
@@ -4170,7 +4170,7 @@ metadata:
   name: "datagram"
 spec:
   kprobes:
-  - call: "__cgroup_bpf_run_filter_skb"
+  - call: "ip_send_skb"
     syscall: false
     args:
     - index: 1
@@ -4207,7 +4207,7 @@ spec:
 	res.LookupIP(context.Background(), "ip4", "ebpf.io")
 
 	kpChecker := ec.NewProcessKprobeChecker("datagram-checker").
-		WithFunctionName(sm.Full("__cgroup_bpf_run_filter_skb")).
+		WithFunctionName(sm.Full("ip_send_skb")).
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(

--- a/pkg/vmtests/skip.go
+++ b/pkg/vmtests/skip.go
@@ -14,7 +14,6 @@ type skipRule struct {
 
 // We should probably have this in a json file, but for now we keep it here
 var rules = []skipRule{
-	skipRule{TestNameRe: "pkg.sensors.tracing.TestKprobeSkb", KernelRe: "bpf-next"},
 	skipRule{TestNameRe: "pkg.sensors.tracing.TestLoader", KernelRe: "bpf-next"},
 	skipRule{TestNameRe: "pkg.tracepoint.TestTracepointLoadFormat", KernelRe: "bpf-next"},
 }


### PR DESCRIPTION
The TestKprobeSkb test in pkg/sensors/tracing/kprobe_test.go uses a hook that doesn't appear to be hit by sent/received TCP/UDP datagrams in bpf-next. As such, this test fails.

This commit replaces the hook in the test with ip_send_skb that gets hit for IPv4 UDP datagrams. This causes the test to succeed on kernels 4.19, 5.4, 5.10, 5.15 and (current at time of writing) bpf-next.

Fixes #1249 