### PR TITLE
Delete metrics for deleted pods

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -295,6 +295,8 @@ func tetragonExecute() error {
 
 	if option.Config.MetricsServer != "" {
 		go metrics.EnableMetrics(option.Config.MetricsServer)
+		// Handler must be registered before the watcher is started
+		metrics.RegisterPodDeleteHandler()
 	}
 
 	// Probe runtime configuration and do not fail on errors

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -295,6 +295,7 @@ func tetragonExecute() error {
 
 	if option.Config.MetricsServer != "" {
 		go metrics.EnableMetrics(option.Config.MetricsServer)
+		go metrics.StartPodDeleteHandler()
 		// Handler must be registered before the watcher is started
 		metrics.RegisterPodDeleteHandler()
 	}

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -31,6 +31,7 @@ import (
 	tetragonGrpc "github.com/cilium/tetragon/pkg/grpc"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics"
+	metricsconfig "github.com/cilium/tetragon/pkg/metrics/config"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
@@ -295,6 +296,7 @@ func tetragonExecute() error {
 
 	if option.Config.MetricsServer != "" {
 		go metrics.EnableMetrics(option.Config.MetricsServer)
+		metricsconfig.InitAllMetrics(metrics.GetRegistry())
 		go metrics.StartPodDeleteHandler()
 		// Handler must be registered before the watcher is started
 		metrics.RegisterPodDeleteHandler()

--- a/pkg/metrics/config/initmetrics.go
+++ b/pkg/metrics/config/initmetrics.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package config
+
+import (
+	"github.com/cilium/tetragon/pkg/grpc/tracing"
+	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/eventcachemetrics"
+	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/kprobemetrics"
+	"github.com/cilium/tetragon/pkg/metrics/mapmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
+	pfmetrics "github.com/cilium/tetragon/pkg/metrics/policyfilter"
+	"github.com/cilium/tetragon/pkg/metrics/processexecmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/syscallmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func InitAllMetrics(registry *prometheus.Registry) {
+	errormetrics.InitMetrics(registry)
+	eventcachemetrics.InitMetrics(registry)
+	eventmetrics.InitMetrics(registry)
+	kprobemetrics.InitMetrics(registry)
+	mapmetrics.InitMetrics(registry)
+	opcodemetrics.InitMetrics(registry)
+	pfmetrics.InitMetrics(registry)
+	processexecmetrics.InitMetrics(registry)
+	ringbufmetrics.InitMetrics(registry)
+	syscallmetrics.InitMetrics(registry)
+	watchermetrics.InitMetrics(registry)
+	observer.InitMetrics(registry)
+	tracing.InitMetrics(registry)
+}

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -53,6 +53,14 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(policyStats)
 }
 
+// ListMetricsWithPod returns a list of metrics with "pod" and "namespace" labels.
+func ListMetricsWithPod() []*prometheus.MetricVec {
+	return []*prometheus.MetricVec{
+		EventsProcessed.MetricVec,
+		policyStats.MetricVec,
+	}
+}
+
 func GetProcessInfo(process *tetragon.Process) (binary, pod, namespace string) {
 	if process != nil {
 		binary = process.Binary

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/filters"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
 	"github.com/cilium/tetragon/pkg/metrics/syscallmetrics"
@@ -19,7 +20,7 @@ import (
 )
 
 var (
-	EventsProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
+	EventsProcessed = metrics.NewCounterVecWithPod(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
 		Name:        "events_total",
 		Help:        "The total number of Tetragon events",
@@ -38,7 +39,7 @@ var (
 		ConstLabels: nil,
 	})
 
-	policyStats = prometheus.NewCounterVec(prometheus.CounterOpts{
+	policyStats = metrics.NewCounterVecWithPod(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
 		Name:        "policy_events_total",
 		Help:        "Policy events calls observed.",
@@ -51,14 +52,6 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(FlagCount)
 	registry.MustRegister(NotifyOverflowedEvents)
 	registry.MustRegister(policyStats)
-}
-
-// ListMetricsWithPod returns a list of metrics with "pod" and "namespace" labels.
-func ListMetricsWithPod() []*prometheus.MetricVec {
-	return []*prometheus.MetricVec{
-		EventsProcessed.MetricVec,
-		policyStats.MetricVec,
-	}
 }
 
 func GetProcessInfo(process *tetragon.Process) (binary, pod, namespace string) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/logger"
@@ -20,9 +21,70 @@ import (
 	"github.com/cilium/tetragon/pkg/metrics/syscallmetrics"
 	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
 	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/podhooks"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
+
+var (
+	metricsWithPod []*prometheus.MetricVec
+	once           sync.Once
+)
+
+// RegisterPodDeleteHandler registers handler for deleting metrics associated
+// with deleted pods. Without it, Tetragon kept exposing stale metrics for
+// deleted pods. This was causing continuous increase in memory usage in
+// Tetragon agent as well as in the metrics scraper.
+func RegisterPodDeleteHandler() {
+	logger.GetLogger().Info("Registering pod delete handler for metrics")
+	podhooks.RegisterCallbacksAtInit(podhooks.Callbacks{
+		PodCallbacks: func(podInformer cache.SharedIndexInformer) {
+			podInformer.AddEventHandler(
+				cache.ResourceEventHandlerFuncs{
+					DeleteFunc: func(obj interface{}) {
+						var pod *corev1.Pod
+						switch concreteObj := obj.(type) {
+						case *corev1.Pod:
+							pod = concreteObj
+						case cache.DeletedFinalStateUnknown:
+							// Handle the case when the watcher missed the deletion event
+							// (e.g. due to a lost apiserver connection).
+							deletedObj, ok := concreteObj.Obj.(*corev1.Pod)
+							if !ok {
+								return
+							}
+							pod = deletedObj
+						default:
+							return
+						}
+						DeleteMetricsForPod(pod)
+					},
+				},
+			)
+		},
+	})
+}
+
+// ListMetricsWithPod returns the global list of all metrics that have "pod"
+// and "namespace" labels, initializing it if needed.
+func ListMetricsWithPod() []*prometheus.MetricVec {
+	once.Do(func() {
+		metricsWithPod = append(metricsWithPod, eventmetrics.ListMetricsWithPod()...)
+		metricsWithPod = append(metricsWithPod, syscallmetrics.ListMetricsWithPod()...)
+	})
+	return metricsWithPod
+}
+
+func DeleteMetricsForPod(pod *corev1.Pod) {
+	for _, metric := range ListMetricsWithPod() {
+		metric.DeletePartialMatch(prometheus.Labels{
+			"pod":       pod.Name,
+			"namespace": pod.Namespace,
+		})
+	}
+}
 
 func InitAllMetrics(registry *prometheus.Registry) {
 	errormetrics.InitMetrics(registry)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/grpc/tracing"
+	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
+)
+
+var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
+	PolicyName: "fake-policy",
+}
+
+func TestPodDelete(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	InitAllMetrics(reg)
+
+	// Process four events, each one with different combination of pod/namespace.
+	// These events should be counted by multiple metrics with a "pod" label:
+	// * tetragon_events_total
+	// * tetragon_policy_events_total
+	// * tetragon_syscalls_total
+	for _, namespace := range []string{"fake-namespace", "other-namespace"} {
+		for _, pod := range []string{"fake-pod", "other-pod"} {
+			event := tetragon.GetEventsResponse{
+				Event: &tetragon.GetEventsResponse_ProcessTracepoint{
+					ProcessTracepoint: &tetragon.ProcessTracepoint{
+						Subsys: "raw_syscalls",
+						Event:  "sys_enter",
+						Process: &tetragon.Process{
+							Pod: &tetragon.Pod{
+								Namespace: namespace,
+								Name:      pod,
+							},
+						},
+						Args: []*tetragon.KprobeArgument{
+							{
+								Arg: &tetragon.KprobeArgument_LongArg{
+									LongArg: 0,
+								},
+							},
+						},
+					},
+				},
+			}
+			eventmetrics.ProcessEvent(&sampleMsgGenericTracepointUnix, &event)
+		}
+	}
+	checkMetricSeriesCount(t, reg, 4)
+
+	// Exactly one timeseries should be deleted for each metric (matching both
+	// pod name and namespace).
+	DeleteMetricsForPod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-pod",
+			Namespace: "fake-namespace",
+		},
+	})
+	checkMetricSeriesCount(t, reg, 3)
+}
+
+func checkMetricSeriesCount(t *testing.T, registry *prometheus.Registry, seriesCount int) {
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	metricNameToSeries := map[string]*io_prometheus_client.MetricFamily{}
+	for _, metricFamily := range metricFamilies {
+		metricNameToSeries[*metricFamily.Name] = metricFamily
+	}
+	for _, metric := range []string{"tetragon_events_total", "tetragon_policy_events_total", "tetragon_syscalls_total"} {
+		metricFamily := metricNameToSeries[metric]
+		require.NotNil(t, metricFamily)
+		assert.Len(t, metricFamily.Metric, seriesCount)
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
-package metrics
+package metrics_test
 
 import (
 	"testing"
@@ -15,6 +15,8 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
+	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/config"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 )
 
@@ -23,8 +25,8 @@ var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
 }
 
 func TestPodDelete(t *testing.T) {
-	reg := prometheus.NewRegistry()
-	InitAllMetrics(reg)
+	reg := metrics.GetRegistry()
+	config.InitAllMetrics(reg)
 
 	// Process four events, each one with different combination of pod/namespace.
 	// These events should be counted by multiple metrics with a "pod" label:
@@ -61,7 +63,7 @@ func TestPodDelete(t *testing.T) {
 
 	// Exactly one timeseries should be deleted for each metric (matching both
 	// pod name and namespace).
-	DeleteMetricsForPod(&corev1.Pod{
+	metrics.DeleteMetricsForPod(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "fake-pod",
 			Namespace: "fake-namespace",

--- a/pkg/metrics/syscallmetrics/syscallmetrics.go
+++ b/pkg/metrics/syscallmetrics/syscallmetrics.go
@@ -23,6 +23,13 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(syscallStats)
 }
 
+// ListMetricsWithPod returns a list of metrics with "pod" and "namespace" labels.
+func ListMetricsWithPod() []*prometheus.MetricVec {
+	return []*prometheus.MetricVec{
+		syscallStats.MetricVec,
+	}
+}
+
 func Handle(event interface{}) {
 	ev, ok := event.(*tetragon.GetEventsResponse)
 	if !ok {

--- a/pkg/metrics/syscallmetrics/syscallmetrics.go
+++ b/pkg/metrics/syscallmetrics/syscallmetrics.go
@@ -5,13 +5,14 @@ package syscallmetrics
 
 import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/cilium/tetragon/pkg/syscallinfo"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
-	syscallStats = prometheus.NewCounterVec(prometheus.CounterOpts{
+	syscallStats = metrics.NewCounterVecWithPod(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
 		Name:        "syscalls_total",
 		Help:        "System calls observed.",
@@ -21,13 +22,6 @@ var (
 
 func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(syscallStats)
-}
-
-// ListMetricsWithPod returns a list of metrics with "pod" and "namespace" labels.
-func ListMetricsWithPod() []*prometheus.MetricVec {
-	return []*prometheus.MetricVec{
-		syscallStats.MetricVec,
-	}
 }
 
 func Handle(event interface{}) {

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/encoder"
 	"github.com/cilium/tetragon/pkg/metrics"
+	metricsconfig "github.com/cilium/tetragon/pkg/metrics/config"
 	"github.com/cilium/tetragon/pkg/observer"
 	hubbleV1 "github.com/cilium/tetragon/pkg/oldhubble/api/v1"
 	hubbleCilium "github.com/cilium/tetragon/pkg/oldhubble/cilium"
@@ -281,6 +282,7 @@ func getDefaultObserverSensors(t *testing.T, ctx context.Context, base *sensors.
 	// a lot of code changes in a lot of a files.
 	if !metricsEnabled {
 		go metrics.EnableMetrics(metricsAddr)
+		metricsconfig.InitAllMetrics(metrics.GetRegistry())
 		metricsEnabled = true
 	}
 

--- a/pkg/podhooks/podhooks.go
+++ b/pkg/podhooks/podhooks.go
@@ -15,15 +15,16 @@ type Callbacks struct {
 	PodCallbacks func(podInformer cache.SharedIndexInformer)
 }
 
-// RegisterCallbacksAtInit registers callbacks (should be called at init())
+// RegisterCallbacksAtInit registers callbacks.
+// Must be called before InstallHooks and callers need to be serialized externally.
 func RegisterCallbacksAtInit(cbs Callbacks) {
 	if !allowRegister {
-		panic("podhooks.RegisterCallbacksAtInit must be called only in init()")
+		panic("podhooks.RegisterCallbacksAtInit must be called before podhooks.InstallHooks()")
 	}
 	allCallbacks = append(allCallbacks, cbs)
 }
 
-// runHooks executes all registered callbacks
+// InstallHooks executes all registered callbacks
 func InstallHooks(podInformer cache.SharedIndexInformer) {
 	allowRegister = false
 	for _, cbs := range allCallbacks {


### PR DESCRIPTION
Some of the exposed metrics have "pod" label, which contains the name of the
monitored pod. So far when a pod got deleted, Tetragon kept exposing stale
metrics for it. This was causing continuous increase in memory usage in
Tetragon agent as well as in the metrics scraper.

This PR fixes the issue. Now if metrics and k8s API are both enabled then
an additional pod hook gets registered that on pod deletion deletes metrics
associated with it.

```release-note
When a pod gets deleted, Tetragon stops exposing metrics associated with it.
```