### PR TITLE
contrib: Support upgrade in install-tetragon.sh

### DIFF
--- a/contrib/localdev/bootstrap-kind-cluster.sh
+++ b/contrib/localdev/bootstrap-kind-cluster.sh
@@ -1,13 +1,13 @@
 #! /bin/bash
 
 error() {
-    echo $@ 1>&2
+    echo "$@" 1>&2
     exit 1
 }
 
 set -eu
 
-PROJECT_ROOT="$(realpath $(dirname "${BASH_SOURCE[0]}")/../..)"
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 cd "$PROJECT_ROOT"
 source contrib/localdev/conf
 


### PR DESCRIPTION
Using `helm upgrade --install` instead of `helm install` makes it possible to use the same script for both installing and upgrading Tetragon in a Kubernetes cluster.

Also added a timeout for `kubectl rollout status` command to prevent the script from handing forever.