### PR TITLE
workflows: split static checks to parallelize jobs

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -6,43 +6,54 @@ on:
       - v*
     paths-ignore:
       - 'docs/**'
+      - '**.md'
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - '**.md'
 
 jobs:
-  static-checks:
+  golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
       - name: Install Go
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           # renovate: datasource=golang-version depName=go
           go-version: '1.20.6'
-      - name: Run static checks
+
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         with:
           # renovate: datasource=docker depName=docker.io/golangci/golangci-lint
           version: v1.53.3
           args: --config=.golangci.yml --verbose
           skip-cache: true
+
+  format:
+    runs-on: ubuntu-latest 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Install Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.20.6'
+
       - name: Check gofmt formatting
         run: |
           go fmt ./...
           git diff --exit-code || (echo "gofmt checks failed. Please run 'go -w fmt ./...', and submit your changes"; exit 1)
-      - name: Check module vendoring
-        run: |
-          make vendor
-          echo "git status --porcelain:" `git status --porcelain`
-          test -z "$(git status --porcelain)" || (echo "Module vendoring checks failed. Please run 'make vendor', and submit your changes"; exit 1)
+
       - name: Build clang-format Docker image
-        run: |
-          docker build -f Dockerfile.clang-format -t "isovalent/clang-format:latest" .
+        run: docker build -f Dockerfile.clang-format -t "isovalent/clang-format:latest" .
+
       - name: Verify clang-format on BPF code
-        id: clang_format
         run: |
           set -o pipefail
           find bpf -name '*.c' -o -name '*.h' -not -path 'bpf/include/vmlinux.h' \
@@ -51,9 +62,30 @@ jobs:
           if [ $? != 0 ]; then
             echo "clang-format checks failed. Please run 'make format' and submit your changes."; exit 1
           fi
+
+  vendoring:
+    runs-on: ubuntu-latest 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Install Go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.20.6'
+
+      - name: Check module vendoring
+        run: |
+          make vendor
+          echo "git status --porcelain:" `git status --porcelain`
+          test -z "$(git status --porcelain)" || (echo "Module vendoring checks failed. Please run 'make vendor', and submit your changes"; exit 1)
+
+  build-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
       - name: Build CLI release binaries
-        run: |
-          make cli-release
-      - name: Build Tarball
-        run: |
-          make tarball
+        run: make cli-release


### PR DESCRIPTION
Also remove make tarball since it now has its own workflow file: packages-e2e-tests.yaml.

This speeds up static checks feedback a lot.