### PR TITLE
cves:exploit: prevent cve-2023-2640 overlayfs exploit on ubuntu

### DIFF
--- a/examples/tracingpolicy/cves/cve-2023-2640-overlayfs-ubuntu.yaml
+++ b/examples/tracingpolicy/cves/cve-2023-2640-overlayfs-ubuntu.yaml
@@ -1,0 +1,54 @@
+# https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2640
+#
+# Description
+#  On Ubuntu kernels carrying both c914c0e27eb0 and
+#  "UBUNTU: SAUCE: overlayfs: Skip permission checking for trusted.overlayfs.* xattrs",
+#  an unprivileged user may set privileged extended attributes on the mounted files,
+#  leading them to be set on the upper files without the appropriate security checks.
+#
+# Affected ubuntu kernel version:
+#  6.2.0
+#  5.19.0 tested on kernel 5.19.0-46
+#  ...
+#
+# Prevention:
+#  Prevents copying up security.capability xattr on overlayfs from a user namespace,
+#  making it a nop.
+#
+# Prerequisites
+#  Needs a kernel with a CONFIG_BPF_KPROBE_OVERRIDE=y
+#
+# Doing "getcap upper/binary" will display empty file capabilities.
+#
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "cve-2023-2460-overlayfs-ubuntu"
+    #annotations:
+      #url: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2640
+      #description: "Prevents copying up security.capability xattr on overlayfs from a user namespace."
+      #author: "Djalal Harouni"
+spec:
+  kprobes:
+  - call: "security_inode_copy_up_xattr"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "string"
+    returnArg:
+      type: "int"
+    selectors:
+    - matchNamespaces:
+      - namespace: User
+        operator: NotIn
+        values:
+        - "host_ns"
+      matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "security.capability\0"
+      matchActions:
+      - action: Override
+        argError: 1  # Override with 1 avoids copying up security.capability, with -1 the copy up fails.


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2640

Prevents copying up security.capability xattr on overlayfs from a user namespace, making it a nop.