### PR TITLE
tetragon: Add stats support for errors

### DIFF
--- a/pkg/metrics/mapmetrics/mapmetrics.go
+++ b/pkg/metrics/mapmetrics/mapmetrics.go
@@ -24,16 +24,28 @@ var (
 		Help:        "The total number of entries dropped per LRU map.",
 		ConstLabels: nil,
 	}, []string{"map"})
+
+	MapErrors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   consts.MetricsNamespace,
+		Name:        "map_errors_total",
+		Help:        "The total number of entries dropped per LRU map.",
+		ConstLabels: nil,
+	}, []string{"map"})
 )
 
 func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(MapSize)
 	registry.MustRegister(MapDrops)
+	registry.MustRegister(MapErrors)
 }
 
 // Get a new handle on a mapSize metric for a mapName and totalCapacity
 func GetMapSize(mapName string, totalCapacity int) prometheus.Gauge {
 	return MapSize.WithLabelValues(mapName, fmt.Sprint(totalCapacity))
+}
+
+func GetMapErrors(mapName string) prometheus.Gauge {
+	return MapErrors.WithLabelValues(mapName)
 }
 
 // Increment a mapSize metric for a mapName and totalCapacity
@@ -44,6 +56,10 @@ func MapSizeInc(mapName string, totalCapacity int) {
 // Set a mapSize metric to size for a mapName and totalCapacity
 func MapSizeSet(mapName string, totalCapacity int, size float64) {
 	GetMapSize(mapName, totalCapacity).Set(size)
+}
+
+func MapErrorSet(mapName string, errTotal float64) {
+	GetMapErrors(mapName).Set(errTotal)
 }
 
 func MapDropInc(mapName string) {


### PR DESCRIPTION
Maps have an associated _stats map that is used to keep total number of entries values. Lets use the stats maps to also store any errors that map updates/deletes may have encountered.