### PR TITLE
Add three network policies

### DIFF
--- a/examples/tracingpolicy/dns-only-specified-servers.yaml
+++ b/examples/tracingpolicy/dns-only-specified-servers.yaml
@@ -1,0 +1,52 @@
+# This tracing policy 'dns-only-specified-servers' will report attempts
+# to make outbound TCP and UDP connections on port 53 to any IP address
+# other than those within the specified list (127.0.0.53), and will kill
+# the offending process.
+#
+# Description:
+#  Report and block outbound TCP and UDP connections to any DNS servers
+#  not in the approved list.
+#
+# In production, this could be used to force processes to only connect
+# to approved DNS servers and to treat transgressions as evidence of
+# malicious activity, resulting in the process being killed.
+#
+# The removal of the matchActions section would cause the policy to only
+# report transgressions and not kill the offending processes, which
+# might be useful in tracking poorly configured services without killing
+# processes.
+#
+# Note: This policy uses the ip_output hook (which is hit for every
+# outbound datagram) as this is required to identify matching UDP
+# datagrams. This hook handles both TCP and UDP protocols so no TCP-
+# specific (eg tcp_connect) hook is required in addition.
+
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "dns-only-specified-servers"
+spec:
+  kprobes:
+  - call: "ip_output"
+    syscall: false
+    args:
+    - index: 2
+      type: "skb"
+    selectors:
+    - matchArgs:
+      - index: 2
+        operator: "Protocol"
+        values:
+        - "IPPROTO_TCP"
+        - "IPPROTO_UDP"
+      - index: 2
+        operator: "DPort"
+        values:
+        - 53
+      - index: 2
+        operator: "NotDAddr"
+        values:
+        - "127.0.0.53"
+      matchActions:
+      - action: "Sigkill"
+

--- a/examples/tracingpolicy/tcp-connect-only-local-addrs.yaml
+++ b/examples/tracingpolicy/tcp-connect-only-local-addrs.yaml
@@ -1,0 +1,38 @@
+# This tracing policy 'connect-only-local-addrs' will report attempts
+# to make outbound TCP connections to any IP address other than those
+# within the 127.0.0.0/8 CIDR, from the binary /usr/bin/curl. In
+# addition it will also kill the offending curl process.
+#
+# Description:
+#  Report and block outbound TCP connections outside loopback from
+#  /usr/bin/curl.
+#
+# In production, this could be used to force processes to only connect
+# to their side cars on their local loopback, and to treat transgressions
+# as evidence of malicious activity, resulting in the process being
+# killed.
+
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "connect-only-local-addrs"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "NotDAddr"
+        values:
+        - "127.0.0.0/8"
+      matchBinaries:
+      - operator: "In"
+        values:
+        - "/usr/bin/curl"
+      matchActions:
+      - action: Sigkill
+

--- a/examples/tracingpolicy/tcp-connect-only-private-addrs.yaml
+++ b/examples/tracingpolicy/tcp-connect-only-private-addrs.yaml
@@ -1,0 +1,39 @@
+# This tracing policy 'connect-only-private-addrs' will report attempts
+# to make outbound TCP connections to any IP address other than those
+# within the private ranges or within the 127.0.0.0/8 CIDR, from the
+# binary /usr/bin/curl. In addition it will also kill the offending
+# curl process.
+#
+# Description:
+#  Report and block outbound TCP connections outside of private
+#  addresses and loopback from /usr/bin/curl.
+#
+# In production, this could be used to force services to only connect
+# to local services and services within the local cluster. Address ranges
+# can be tuned to match the environment. Transgressions will be regarded
+# as evidence of malicious activity, resulting in the process being
+# killed.
+
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "connect-only-private-addrs"
+spec:
+  kprobes:
+  - call: "tcp_connect"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "NotDAddr"
+        values:
+        - "10.0.0.0/8"
+        - "172.16.0.0/12"
+        - "192.168.0.0/16"
+        - "127.0.0.0/8"
+      matchActions:
+      - action: Sigkill
+


### PR DESCRIPTION
1. Only permit port 53 to specified DNS servers.
2. Only permit TCP connect to private addresses and loopback (enforce in-cluster communciation only) for specified processes.
3. Only permit TCP connect to loopback (enforce side car access only) for specified processes.

More details in the descriptions of each policy. Note these will require v0.11 or later.