### PR TITLE
btf: Add support to load symbols from kernel modules

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -78,6 +78,8 @@ const (
 	keyEnablePidSetFilter = "enable-pid-set-filter"
 
 	keyEnableMsgHandlingLatency = "enable-msg-handling-latency"
+
+	keyKmods = "kmods"
 )
 
 func readAndSetFlags() {
@@ -139,6 +141,8 @@ func readAndSetFlags() {
 	option.Config.EnablePidSetFilter = viper.GetBool(keyEnablePidSetFilter)
 
 	option.Config.TracingPolicyDir = viper.GetString(keyTracingPolicyDir)
+
+	option.Config.KMods = viper.GetStringSlice(keyKmods)
 
 	// deprecation timeline: deprecated -> 0.10.0, removed -> 0.11.0
 	// manually handle the deprecation of --config-file

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -762,6 +762,8 @@ func execute() error {
 
 	flags.Bool(keyEnableMsgHandlingLatency, false, "Enable metrics for message handling latency")
 
+	flags.StringSlice(keyKmods, []string{}, "List of kernel modules to load symbols from")
+
 	viper.BindPFlags(flags)
 	return rootCmd.Execute()
 }

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -4,9 +4,12 @@
 package btf
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/tetragon/pkg/defaults"
@@ -85,6 +88,57 @@ func observerFindBTF(lib, btf string) (string, error) {
 
 func NewBTF() (*btf.Spec, error) {
 	return btf.LoadSpec(btfFile)
+}
+
+func AddModulesToSpec(spec *btf.Spec, kmods []string) (*btf.Spec, error) {
+	allTypes := []btf.Type{}
+	modulePaths := []string{}
+
+	iter := spec.Iterate()
+	for iter.Next() {
+		allTypes = append(allTypes, iter.Type)
+	}
+
+	for _, module := range kmods {
+		path := filepath.Join("/sys/kernel/btf", module)
+		f, err := os.Open(path)
+		if err != nil {
+			logger.GetLogger().WithField("path", path).Warn("btf: Path does not exist")
+			continue
+		}
+		defer f.Close()
+
+		modulePaths = append(modulePaths, path)
+
+		modSpec, err := btf.LoadSplitSpecFromReader(f, spec)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load %s btf: %w", module, err)
+		}
+
+		iter := modSpec.Iterate()
+		for iter.Next() {
+			allTypes = append(allTypes, iter.Type)
+		}
+	}
+
+	logger.GetLogger().WithField("modules", strings.Join(modulePaths, " ")).Info("btf: Loaded symbols from modules")
+
+	b, err := btf.NewBuilder(allTypes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call btf.NewBuilder: %w", err)
+	}
+
+	raw, err := b.Marshal(nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call b.Marshal: %w", err)
+	}
+
+	spec, err = btf.LoadSpecFromReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("failed to call btf.LoadSpecFromReader: %w", err)
+	}
+
+	return spec, nil
 }
 
 func InitCachedBTF(lib, btf string) error {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -76,6 +76,8 @@ type config struct {
 	EnablePidSetFilter bool
 
 	EnableMsgHandlingLatency bool
+
+	KMods []string
 }
 
 var (

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/tetragon/pkg/arch"
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/btf"
+	cachedbtf "github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/idtable"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
@@ -293,6 +294,13 @@ func preValidateKprobes(name string, kprobes []v1alpha1.KProbeSpec) error {
 	btfobj, err := btf.NewBTF()
 	if err != nil {
 		return err
+	}
+
+	if len(option.Config.KMods) > 0 {
+		btfobj, err = cachedbtf.AddModulesToSpec(btfobj, option.Config.KMods)
+		if err != nil {
+			return fmt.Errorf("adding modules to spec failed: %w", err)
+		}
 	}
 
 	for i := range kprobes {


### PR DESCRIPTION
Adding a kprobe hook to a function that defined inside a module is not currently supported.

This commit adds support for that.

The user can use a command line argument --kmods to define the desired modules. Adding --kmods overlay,tls will search for btf files in /sys/kernel/btf/overlay and /sys/kernel/btf/tls.