### PR TITLE
Revert "renovate: fix usage of dot in regexes"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,17 +25,17 @@
   ],
   "gitAuthor": "cilium-renovate[bot] <134692979+cilium-renovate[bot]@users.noreply.github.com>",
   "includePaths": [
-    "\\.github/renovate\\.json5",
-    "\\.github/workflows/**",
-    "go\\.mod",
-    "go\\.sum",
-    "api/go\\.mod",
-    "api/go\\.sum",
-    "pkg/k8s/go\\.mod",
-    "pkg/k8s/go\\.sum",
+    ".github/renovate.json5",
+    ".github/workflows/**",
+    "go.mod",
+    "go.sum",
+    "api/go.mod",
+    "api/go.sum",
+    "pkg/k8s/go.mod",
+    "pkg/k8s/go.sum",
     "Dockerfile*",
-    "install/kubernetes/values\\.yaml",
-    "Makefile\\.cli",
+    "install/kubernetes/values.yaml",
+    "Makefile.cli",
     "Makefile",
   ],
   "postUpdateOptions": [
@@ -67,7 +67,7 @@
       "groupName": "all github action dependencies",
       "groupSlug": "all-github-action",
       "matchFileNames": [
-        "\\.github/workflows/**"
+        ".github/workflows/**"
       ],
       "matchManagers": [
         "github-actions"
@@ -86,7 +86,7 @@
     },
     {
       "matchFileNames": [
-        "\\.github/workflows/**"
+        ".github/workflows/**"
       ],
       "matchManagers": [
         "github-actions"
@@ -96,8 +96,8 @@
     {
       // not grouping Go minor and major updates together
       "matchFileNames": [
-        "go\\.mod",
-        "go\\.sum"
+        "go.mod",
+        "go.sum"
       ],
       "postUpdateOptions": [
         // update source import paths on major updates
@@ -120,8 +120,8 @@
       "groupName": "all go dependencies main",
       "groupSlug": "all-go-deps-main",
       "matchFileNames": [
-        "go\\.mod",
-        "go\\.sum"
+        "go.mod",
+        "go.sum"
       ],
       "postUpdateOptions": [
         // update source import paths on major updates
@@ -147,8 +147,8 @@
       "groupName": "all API go dependencies main",
       "groupSlug": "all-api-go-deps-main",
       "matchFileNames": [
-        "api/go\\.mod",
-        "api/go\\.sum"
+        "api/go.mod",
+        "api/go.sum"
       ],
       "postUpdateOptions": [
         // update source import paths on major updates
@@ -174,8 +174,8 @@
     {
       // not grouping major updates together
       "matchFileNames": [
-        "pkg/k8s/go\\.mod",
-        "pkg/k8s/go\\.sum"
+        "pkg/k8s/go.mod",
+        "pkg/k8s/go.sum"
       ],
       "postUpdateOptions": [
         // update source import paths on major updates
@@ -197,8 +197,8 @@
       "groupName": "all k8s pkg go dependencies main",
       "groupSlug": "all-k8s-pkg-go-deps-main",
       "matchFileNames": [
-        "pkg/k8s/go\\.mod",
-        "pkg/k8s/go\\.sum"
+        "pkg/k8s/go.mod",
+        "pkg/k8s/go.sum"
       ],
       "postUpdateOptions": [
         // update source import paths on major updates
@@ -222,7 +222,7 @@
     },
     {
       "matchPackageNames": [
-        "docker\\.io/library/busybox"
+        "docker.io/library/busybox"
       ],
       "matchFileNames": [
         "Dockerfile"
@@ -239,7 +239,7 @@
       "groupName": "Go",
       "matchDepNames": [
         "go",
-        "docker\\.io/library/golang"
+        "docker.io/library/golang"
       ],
       // postUpgradeTasks is only for when the Go module directives are bumped
       "postUpgradeTasks": {
@@ -263,7 +263,7 @@
     },
     {
       "matchFileNames": [
-        "install/kubernetes/values\\.yaml",
+        "install/kubernetes/values.yaml",
       ],
       // lint and generate files for helm chart
       "postUpgradeTasks": {
@@ -291,8 +291,8 @@
       "matchPackageNames": ["docker.io/library/ubuntu"],
       "matchManagers": ["dockerfile"],
       "matchFileNames": [
-        "Dockerfile\\.clang",
-        "Dockerfile\\.clang-format"
+        "Dockerfile.clang",
+        "Dockerfile.clang-format"
       ],
       "enabled": false
     }


### PR DESCRIPTION
This partially reverts commit 9e6f21093791e9078c109e5ad7d05ca4343d759e.

I was wrong, most of the settings of renovates are not regexes and this breaks glob matching.