### PR TITLE
matchArgs: Add Not{Equal, Prefix, Postfix} in fd, file, path types

### DIFF
--- a/bpf/process/types/operations.h
+++ b/bpf/process/types/operations.h
@@ -35,6 +35,9 @@ enum {
 	op_filter_notdportpriv = 23,
 	op_filter_notsaddr = 24,
 	op_filter_notdaddr = 25,
+	// file ops
+	op_filter_str_notprefix = 26,
+	op_filter_str_notpostfix = 27,
 };
 
 #endif // __OPERATIONS_H__

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -274,7 +274,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -497,7 +499,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -757,7 +761,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -980,7 +986,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -1113,7 +1121,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -1336,7 +1346,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -274,7 +274,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -497,7 +499,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -757,7 +761,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -980,7 +986,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -1113,7 +1121,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -1336,7 +1346,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -257,7 +257,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Mask
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;NotPrefix;Postfix;NotPostfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -228,6 +228,9 @@ const (
 	SelectorOpNotDportPriv = 23
 	SelectorOpNotSaddr     = 24
 	SelectorOpNotDaddr     = 25
+	// file ops
+	SelectorOpNotPrefix  = 26
+	SelectorOpNotPostfix = 27
 )
 
 func SelectorOp(op string) (uint32, error) {
@@ -238,7 +241,7 @@ func SelectorOp(op string) (uint32, error) {
 		return SelectorOpLT, nil
 	case "eq", "Equal":
 		return SelectorOpEQ, nil
-	case "neq":
+	case "neq", "NotEqual":
 		return SelectorOpNEQ, nil
 	case "In":
 		return SelectorOpIn, nil
@@ -246,8 +249,12 @@ func SelectorOp(op string) (uint32, error) {
 		return SelectorOpNotIn, nil
 	case "prefix", "Prefix":
 		return SelectorOpPrefix, nil
+	case "notprefix", "NotPrefix":
+		return SelectorOpNotPrefix, nil
 	case "postfix", "Postfix":
 		return SelectorOpPostfix, nil
+	case "notpostfix", "NotPostfix":
+		return SelectorOpNotPostfix, nil
 	case "InMap":
 		return SelectorInMap, nil
 	case "NotInMap":
@@ -494,6 +501,9 @@ func writeMatchValues(k *KernelSelectorState, values []string, ty, op uint32) er
 			WriteSelectorUint32(k, size)
 			WriteSelectorByteArray(k, value, size)
 		case argTypeString, argTypeCharBuf:
+			if op == SelectorOpNEQ || op == SelectorOpNotPrefix || op == SelectorOpNotPostfix {
+				return fmt.Errorf("MatchArgs types char_buf and string do not support operators NotEqual, NotPrefix, and NotPostfix")
+			}
 			value, size := ArgSelectorValue(v)
 			WriteSelectorUint32(k, size)
 			WriteSelectorByteArray(k, value, size)

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -274,7 +274,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -497,7 +499,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -757,7 +761,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -980,7 +986,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -1113,7 +1121,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -1336,7 +1346,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -274,7 +274,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -497,7 +499,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -757,7 +761,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -980,7 +986,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -1113,7 +1121,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT
@@ -1336,7 +1346,9 @@ spec:
                                   - Equal
                                   - NotEqual
                                   - Prefix
+                                  - NotPrefix
                                   - Postfix
+                                  - NotPostfix
                                   - GreaterThan
                                   - LessThan
                                   - GT

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -257,7 +257,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;Postfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Mask
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;NotPrefix;Postfix;NotPostfix;GreaterThan;LessThan;GT;LT;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Mask
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.


### PR DESCRIPTION
FIXES: https://github.com/cilium/tetragon/issues/1310