### PR TITLE
refactor: Move readConfig{Dir,File} to the option package

### DIFF
--- a/cmd/tetragon/conf.go
+++ b/cmd/tetragon/conf.go
@@ -3,9 +3,6 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/cilium/tetragon/pkg/option"
@@ -22,45 +19,6 @@ var (
 	}
 )
 
-func readConfigFile(path string, file string) error {
-	filePath := filepath.Join(path, file)
-	st, err := os.Stat(filePath)
-	if err != nil {
-		return err
-	}
-	if st.Mode().IsRegular() == false {
-		return fmt.Errorf("failed to read config file '%s' not a regular file", file)
-	}
-
-	viper.AddConfigPath(path)
-	err = viper.MergeInConfig()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func readConfigDir(path string) error {
-	st, err := os.Stat(path)
-	if err != nil {
-		return err
-	}
-	if st.IsDir() == false {
-		return fmt.Errorf("'%s' is not a directory", path)
-	}
-
-	cm, err := option.ReadDirConfig(path)
-	if err != nil {
-		return err
-	}
-	if err := viper.MergeConfigMap(cm); err != nil {
-		return fmt.Errorf("merge config failed %v", err)
-	}
-
-	return nil
-}
-
 func readConfigSettings(defaultConfDir string, defaultConfDropIn string, dropInsDir []string) {
 	viper.SetEnvPrefix("tetragon")
 	replacer := strings.NewReplacer("-", "_")
@@ -73,24 +31,24 @@ func readConfigSettings(defaultConfDir string, defaultConfDropIn string, dropIns
 
 	// Read default drop-ins directories
 	for _, dir := range dropInsDir {
-		readConfigDir(dir)
+		option.ReadConfigDir(dir)
 	}
 
 	// Look into cwd first, this is needed for quick development only
-	readConfigFile(".", "tetragon.yaml")
+	option.ReadConfigFile(".", "tetragon.yaml")
 
 	// Look for /etc/tetragon/tetragon.yaml
-	readConfigFile(defaultConfDir, "tetragon.yaml")
+	option.ReadConfigFile(defaultConfDir, "tetragon.yaml")
 
 	// Look into default /etc/tetragon/tetragon.conf.d/ now
-	readConfigDir(defaultConfDropIn)
+	option.ReadConfigDir(defaultConfDropIn)
 
 	// Read now the passed key --config-dir
 	if viper.IsSet(keyConfigDir) {
 		configDir := viper.GetString(keyConfigDir)
 		// viper.IsSet could return true on an empty string reset
 		if configDir != "" {
-			err := readConfigDir(configDir)
+			err := option.ReadConfigDir(configDir)
 			if err != nil {
 				log.WithField(keyConfigDir, configDir).WithError(err).Fatal("Failed to read config from directory")
 			} else {


### PR DESCRIPTION
Move readConfig{Dir,File} to the option package. I'd like to use these functions to read tetragon operator configurations.

Ref: #794