### PR TITLE
Add tetragon-operator-config ConfigMap

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -99,6 +99,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.securityContext.privileged | bool | `true` |  |
 | tetragonOperator.enabled | bool | `true` | Enable the tetragon-operator component (required). |
 | tetragonOperator.image | object | `{"override":null,"repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v0.10.0"}` | tetragon-operator image. |
+| tetragonOperator.skipCRDCreation | bool | `false` |  |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |
 

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -82,6 +82,7 @@ Helm chart for Tetragon
 | tetragon.securityContext.privileged | bool | `true` |  |
 | tetragonOperator.enabled | bool | `true` | Enable the tetragon-operator component (required). |
 | tetragonOperator.image | object | `{"override":null,"repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v0.10.0"}` | tetragon-operator image. |
+| tetragonOperator.skipCRDCreation | bool | `false` |  |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |
 

--- a/install/kubernetes/templates/_container_tetragon.tpl
+++ b/install/kubernetes/templates/_container_tetragon.tpl
@@ -82,5 +82,11 @@
 - name: {{ include "container.tetragon.name" . }}-operator
   image: "{{ if .Values.tetragonOperator.image.override }}{{ .Values.tetragonOperator.image.override }}{{ else }}{{ .Values.tetragonOperator.image.repository }}{{ .Values.tetragonOperator.image.suffix }}:{{ .Values.tetragonOperator.image.tag }}{{ end }}"
   imagePullPolicy: {{ .Values.imagePullPolicy }}
+  args:
+    - --config-dir=/etc/tetragon/operator.conf.d/
+  volumeMounts:
+    - mountPath: /etc/tetragon/operator.conf.d/
+      name: tetragon-operator-config
+      readOnly: true
 {{- end }}
 {{- end -}}

--- a/install/kubernetes/templates/daemonset.yaml
+++ b/install/kubernetes/templates/daemonset.yaml
@@ -96,6 +96,11 @@ spec:
         name: metadata-files
 {{- end }}
 {{- end }}
+{{- if .Values.tetragonOperator.enabled }}
+      - name: tetragon-operator-config
+        configMap:
+          name: {{ .Chart.Name }}-operator-config
+{{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/install/kubernetes/templates/operator_configmap.yaml
+++ b/install/kubernetes/templates/operator_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-operator-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+data:
+  skip-crd-creation: {{ .Values.tetragonOperator.skipCRDCreation | quote }}

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -158,6 +158,8 @@ tetragonOperator:
     tag: v0.10.0
     # tetragon-operator image-digest
     suffix: ""
+  # Skip CRD creation.
+  skipCRDCreation: false
 export:
   # "stdout". "" to disable.
   mode: "stdout"

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	operatorOption "github.com/cilium/tetragon/operator/option"
+	"github.com/cilium/tetragon/pkg/option"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -33,6 +34,15 @@ func initializeFlags() {
 		viper.SetEnvKeyReplacer(replacer)
 		viper.SetEnvPrefix(operatorOption.TetragonOpEnvPrefix)
 		viper.AutomaticEnv()
+		configDir := viper.GetString(operatorOption.ConfigDir)
+		if configDir != "" {
+			err := option.ReadConfigDir(configDir)
+			if err != nil {
+				log.WithField(operatorOption.ConfigDir, configDir).WithError(err).Fatal("Failed to read config from directory")
+			} else {
+				log.WithField(operatorOption.ConfigDir, configDir).Info("Loaded config from directory")
+			}
+		}
 	})
 
 	flags := rootCmd.Flags()
@@ -44,6 +54,8 @@ func initializeFlags() {
 
 	flags.String(operatorOption.KubeCfgPath, "", "Kubeconfig filepath to connect to k8s")
 
+	flags.String(operatorOption.ConfigDir, "", "Directory in which tetragon-operator-config configmap is mounted")
+
 	viper.BindPFlags(flags)
 }
 
@@ -51,4 +63,5 @@ func initializeFlags() {
 func configPopulate() {
 	operatorOption.Config.SkipCRDCreation = viper.GetBool(operatorOption.SkipCRDCreation)
 	operatorOption.Config.KubeCfgPath = viper.GetString(operatorOption.KubeCfgPath)
+	operatorOption.Config.ConfigDir = viper.GetString(operatorOption.ConfigDir)
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -84,7 +85,10 @@ func operatorExecute() {
 		log.WithError(err).Fatal("Unable to check k8s version")
 	}
 
-	log.Infof("Tetragon Operator: %s", version.Version)
+	log.WithFields(logrus.Fields{
+		"config":  fmt.Sprintf("%+v", operatorOption.Config),
+		"version": version.Version,
+	}).Info("Starting Tetragon Operator")
 	capabilities := k8sversion.Capabilities()
 	if !capabilities.MinimalVersionMet {
 		log.Fatalf("Minimal kubernetes version not met: %s < %s",

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -26,6 +26,9 @@ const (
 
 	// KubeCfgPath is the path to a kubeconfig file
 	KubeCfgPath = "kube-config"
+
+	// ConfigDir specifies the directory in which tetragon-operator-config configmap is mounted.
+	ConfigDir = "config-dir"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -36,6 +39,9 @@ type OperatorConfig struct {
 
 	// KubeCfgPath allows users to specify a kubeconfig file to be used by the operator
 	KubeCfgPath string
+
+	// ConfigDir specifies the directory in which tetragon-operator-config configmap is mounted.
+	ConfigDir string
 }
 
 // Config represents the operator configuration.


### PR DESCRIPTION
- Add tetragon-operator-config ConfigMap.
- Add tetragonOperator.skipCRDCreation Helm value.
- Mount the ConfigMap to /etc/tetragon/operator.conf.d/ and load the
  config from the directory.
- Log the config at the startup.

Ref: #794

sample log output:
```
level=info msg="Loaded config from directory" config-dir=/etc/tetragon/operator.conf.d/ subsys=tetragon-operator
level=info msg="Starting Tetragon Operator" config="&{SkipCRDCreation:false KubeCfgPath: ConfigDir:/etc/tetragon/operator.conf.d/}" subsys=tetragon-operator version=v0.10.0-145-g8b2a7e8f
level=info msg="CRD (CustomResourceDefinition) is installed and up-to-date" name=TracingPolicy/v1alpha1 subsys=k8s
level=info msg="CRD (CustomResourceDefinition) is installed and up-to-date" name=TracingPolicyNamespaced/v1alpha1 subsys=k8s
level=info msg="Initialization complete" subsys=tetragon-operator
```