### PR TITLE
Fix TestKprobeMatchArgsNonPrefix test

### DIFF
--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3249,11 +3249,11 @@ spec:
 
 	createCrdFile(t, configHook)
 
-	obs, err := observer.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observer.WithMyPid())
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
-	observer.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()
 
 	// read 4 files


### PR DESCRIPTION
We didn't rebase https://github.com/cilium/tetragon/pull/1325 after merging
https://github.com/cilium/tetragon/commit/822e2da104233a546765f399b0ba3877a8c7d1fc so this makes TestKprobeMatchArgsNonPrefix introduced in that PR to broke builds in main branch.

This patch fixes that issue.