### PR TITLE
Add tetragon operator deployment into the helm chart

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -55,6 +55,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | podAnnotations | object | `{}` |  |
 | podLabelsOverride | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| podWatcher.enabled | bool | `false` |  |
 | selectorLabelsOverride | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -38,6 +38,7 @@ Helm chart for Tetragon
 | podAnnotations | object | `{}` |  |
 | podLabelsOverride | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| podWatcher.enabled | bool | `false` |  |
 | selectorLabelsOverride | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/install/kubernetes/templates/clusterrole.yaml
+++ b/install/kubernetes/templates/clusterrole.yaml
@@ -44,6 +44,7 @@ rules:
     resourceNames:
       - tracingpolicies.cilium.io
       - tracingpoliciesnamespaced.cilium.io
+      - tetragonpods.cilium.io
     verbs:
       - update
       - get

--- a/install/kubernetes/templates/operator_clusterrole.yaml
+++ b/install/kubernetes/templates/operator_clusterrole.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.serviceAccount.create .Values.podWatcher.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{.Chart.Name}}-operator
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - tetragonpods
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+{{- end }}

--- a/install/kubernetes/templates/operator_clusterrolebinding.yaml
+++ b/install/kubernetes/templates/operator_clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.serviceAccount.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name }}-operator-rolebinding
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}-operator-role
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Chart.Name }}-operator-service-account
+{{- end }}

--- a/install/kubernetes/templates/operator_configmap.yaml
+++ b/install/kubernetes/templates/operator_configmap.yaml
@@ -7,3 +7,4 @@ metadata:
   {{- include "tetragon-operator.labels" . | nindent 4 }}
 data:
   skip-crd-creation: {{ .Values.tetragonOperator.skipCRDCreation | quote }}
+  skip-tetragon-pod-crd: {{ not .Values.podWatcher.enabled | quote }}

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.podWatcher.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels: 
+    {{- include "tetragon-operator.labels" . | nindent 4 }}
+  name: {{ .Chart.Name }}-operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tetragon-operator.labels" . | nindent 6 }}
+  replicas: 1
+  template:
+    metadata:
+      labels: 
+        {{- include "tetragon-operator.labels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}-operator
+        command:
+          - /usr/bin/tetragon-operator
+        args:
+          - serve
+        image: "{{ if .Values.tetragonOperator.image.override }}{{ .Values.tetragonOperator.image.override }}{{ else }}{{ .Values.tetragonOperator.image.repository }}{{ .Values.tetragonOperator.image.suffix }}:{{ .Values.tetragonOperator.image.tag }}{{ end }}"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      serviceAccountName: {{ .Chart.Name }}-operator-service-account
+      terminationGracePeriodSeconds: 10
+{{- end }}

--- a/install/kubernetes/templates/operator_serviceaccount.yaml
+++ b/install/kubernetes/templates/operator_serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.serviceAccount.create .Values.podWatcher.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}-operator-service-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -148,6 +148,8 @@ tetragon:
   enablePolicyFilterDebug: false
   # Enable latency monitoring in message handling
   enableMsgHandlingLatency: false
+podWatcher:
+  enabled: false
 tetragonOperator:
   # -- Enable the tetragon-operator component (required).
   enabled: true


### PR DESCRIPTION
In this PR:

- Added service account, role bindings and cluster roles for the tetragon operator deployment.
- This is disabled by default, to enable it, set the podWatcher.enabled field to true.