### PR TITLE
docs: Update the link to the cosign installation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ This should be sufficient to create a Kind cluster and run Tetragon. For more in
 
 ### Prerequisites
 
-You will need to [install cosign](https://docs.sigstore.dev/cosign/installation/).
+You will need to [install cosign](https://docs.sigstore.dev/system_config/installation/).
 
 ### Verify Signed Container Images
 

--- a/docs/content/en/docs/tutorials/verify-tetragon-image-signatures.md
+++ b/docs/content/en/docs/tutorials/verify-tetragon-image-signatures.md
@@ -7,7 +7,7 @@ description: "Learn how to verify Tetragon container images signatures."
 
 ### Prerequisites
 
-You will need to [install cosign](https://docs.sigstore.dev/cosign/installation/).
+You will need to [install cosign](https://docs.sigstore.dev/system_config/installation/).
 
 ### Verify Signed Container Images
 


### PR DESCRIPTION
https://docs.sigstore.dev/cosign/installation/ is returning 404 now. Let's use https://docs.sigstore.dev/system_config/installation/ instead.