### PR TITLE
tetragon: Remove unnecessary computation line

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -57,7 +57,6 @@ generic_process_event(void *ctx, int index, struct bpf_map_def *heap_map,
 		tail_call(ctx, tailcals, index + 1);
 
 	/* Last argument, go send.. */
-	total += generic_kprobe_common_size();
 	tail_call(ctx, tailcals, 6);
 	return 0;
 }


### PR DESCRIPTION
It's leftover from latest refactoring [1].

[1] 8d8af6d7907d tetragon: Refactor generic_process_event* functions
