### PR TITLE
sock/skb: Add IPv6 Support

### DIFF
--- a/bpf/process/addr_lpm_maps.h
+++ b/bpf/process/addr_lpm_maps.h
@@ -25,4 +25,23 @@ struct {
 		});
 } addr4lpm_maps SEC(".maps");
 
+struct addr6_lpm_trie {
+	__u32 prefix;
+	__u32 addr[4];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, ADDR_LPM_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+			__uint(max_entries, 1);
+			__type(key, __u8[20]); // Need to specify as byte array as wouldn't take struct as key type
+			__type(value, __u8);
+			__uint(map_flags, BPF_F_NO_PREALLOC);
+		});
+} addr6lpm_maps SEC(".maps");
+
 #endif // ADDR_LPM_MAPS_H__

--- a/bpf/process/types/skb.h
+++ b/bpf/process/types/skb.h
@@ -16,6 +16,104 @@ struct skb_type {
 	__u32 secpath_olen;
 };
 
+/* The IPv6 specification states that the following headers are valid
+ * after the fixed header (up to 1 of each, except Destination Options,
+ * which is up to 2):
+ * Hop-by-Hop Options (0)
+ * Routing (43)
+ * Fragment (44)
+ * Authentication Header (51)
+ * Destination Options (60)
+ * Encapsulation Security Payload Header (50)
+ * Mobilty Header (135)
+ * UDP Header (IPPROTO_UDP)
+ * TCP Header (IPPROTO_TCP)
+ * ICMP6 (IPPROTO_ICMP6)
+ *
+ * We choose to ignore Encapsulating Security Payload (ESP) because
+ * of complexity (future requirement), Mobility (n/a), Host Identity
+ * Protocol (replaces IP addresses), Shim6 Protocol (n/a), and the
+ * Reserved header types. If we come across one of these headers, we
+ * will return 0 to indicate failure (and no transport header). Otherwise,
+ * we will skip other headers and return the offset of the transport
+ * payload.
+ */
+
+struct ipv6extension {
+	u16 ip_off;
+	u16 byte_len;
+	u8 header_count;
+	u8 curr;
+	u8 next;
+	u8 len;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, int);
+	__type(value, struct ipv6extension);
+	__uint(max_entries, 1);
+} tg_ipv6_ext_heap SEC(".maps");
+
+static inline __attribute__((always_inline)) u8
+get_ip6_protocol(u16 *payload_off, struct ipv6hdr *ip, u16 network_header_off,
+		 void *skb_head)
+{
+	struct ipv6extension *e;
+	int zero = 0;
+	u8 header_count;
+
+	e = map_lookup_elem(&tg_ipv6_ext_heap, &zero);
+	if (!e)
+		return 0;
+
+	e->ip_off = network_header_off;
+	e->curr = 255;
+	e->len = 0;
+	if (probe_read(&e->next, sizeof(e->next), _(&ip->nexthdr)) < 0)
+		return 0;
+
+// Maximum 7 valid extensions.
+#pragma unroll
+	for (header_count = 0; header_count < 7; header_count++) {
+		// Correct the length parameter, depending on current extension.
+		switch (e->curr) {
+		case 255:
+			// Fixed header.
+			e->byte_len = sizeof(struct ipv6hdr);
+			break;
+		case 0:
+		case 43:
+		case 60:
+			e->byte_len = (e->len * 8) + 8;
+			break;
+		case 44:
+			e->byte_len = 8;
+			break;
+		case 51:
+			e->byte_len = (e->len * 4) + 8;
+			break;
+		}
+
+		// Move to next extension.
+		e->ip_off += e->byte_len;
+		// If next is transport (or an unhandled header, e.g. ESP or Mobility), return it and the optional offset.
+		if (e->next != 0 && e->next != 43 && e->next != 44 && e->next != 51 && e->next != 60) {
+			if (payload_off)
+				*payload_off = e->ip_off;
+			return e->next;
+		}
+		e->curr = e->next;
+		// Read next header and current length.
+		if (probe_read(&e->next, 2,
+			       skb_head + e->ip_off) < 0) {
+			return 0;
+		}
+	}
+	// Not found transport header.
+	return 0;
+}
+
 /* set_event_from_skb(skb)
  *
  * Populate the event args with the SKB 5-tuple when supported. Currently,
@@ -26,6 +124,8 @@ set_event_from_skb(struct skb_type *event, struct sk_buff *skb)
 {
 	unsigned char *skb_head = 0;
 	u16 l3_off;
+	typeof(skb->transport_header) l4_off;
+	u8 protocol;
 
 	probe_read(&skb_head, sizeof(skb_head), _(&skb->head));
 	probe_read(&l3_off, sizeof(l3_off), _(&skb->network_header));
@@ -36,61 +136,70 @@ set_event_from_skb(struct skb_type *event, struct sk_buff *skb)
 
 	u8 ip_ver = iphdr_byte0 >> 4;
 	if (ip_ver == 4) { // IPv4
-		u8 v4_prot;
-		probe_read(&v4_prot, 1, _(&ip->protocol));
-
-		event->tuple.protocol = v4_prot;
-
+		probe_read(&protocol, 1, _(&ip->protocol));
+		event->tuple.protocol = protocol;
 		event->tuple.family = AF_INET;
-
-		probe_read(&event->tuple.saddr, sizeof(event->tuple.saddr), _(&ip->saddr));
-		probe_read(&event->tuple.daddr, sizeof(event->tuple.daddr), _(&ip->daddr));
-		typeof(skb->transport_header) l4_off;
+		event->tuple.saddr[0] = 0;
+		event->tuple.saddr[1] = 0;
+		event->tuple.daddr[0] = 0;
+		event->tuple.daddr[1] = 0;
+		probe_read(&event->tuple.saddr, IPV4LEN, _(&ip->saddr));
+		probe_read(&event->tuple.daddr, IPV4LEN, _(&ip->daddr));
 		probe_read(&l4_off, sizeof(l4_off), _(&skb->transport_header));
-		if (v4_prot == IPPROTO_TCP) { // TCP
-			struct tcphdr *tcp =
-				(struct tcphdr *)(skb_head + l4_off);
-			probe_read(&event->tuple.sport, sizeof(event->tuple.sport),
-				   _(&tcp->source));
-			probe_read(&event->tuple.dport, sizeof(event->tuple.dport),
-				   _(&tcp->dest));
-		} else if (v4_prot == IPPROTO_UDP) { // UDP
-			struct udphdr *udp =
-				(struct udphdr *)(skb_head + l4_off);
-			probe_read(&event->tuple.sport, sizeof(event->tuple.sport),
-				   _(&udp->source));
-			probe_read(&event->tuple.dport, sizeof(event->tuple.dport),
-				   _(&udp->dest));
-		}
-		event->tuple.sport = bpf_ntohs(event->tuple.sport);
-		event->tuple.dport = bpf_ntohs(event->tuple.dport);
-
-		if (bpf_core_field_exists(skb->active_extensions)) {
-			struct sec_path *sp;
-			struct skb_ext *ext;
-			u64 offset;
-
-#define SKB_EXT_SEC_PATH 1 // TBD do this with BTF
-			probe_read(&ext, sizeof(ext), _(&skb->extensions));
-			if (ext) {
-				probe_read(&offset, sizeof(offset),
-					   _(&ext->offset[SKB_EXT_SEC_PATH]));
-				sp = (void *)ext + (offset << 3);
-
-				probe_read(&event->secpath_len,
-					   sizeof(event->secpath_len),
-					   _(&sp->len));
-				probe_read(&event->secpath_olen,
-					   sizeof(event->secpath_olen),
-					   _(&sp->olen));
-			}
-		}
-		return 0;
 	} else if (ip_ver == 6) {
-		return -1;
+		struct ipv6hdr *ip6 = (struct ipv6hdr *)(skb_head + l3_off);
+
+		protocol = get_ip6_protocol(&l4_off, ip6, l3_off, skb_head);
+		event->tuple.protocol = protocol;
+		event->tuple.family = AF_INET6;
+		probe_read(&event->tuple.saddr, IPV6LEN, _(&ip6->saddr));
+		probe_read(&event->tuple.daddr, IPV6LEN, _(&ip6->daddr));
+	} else {
+		// This is not IP, so we don't know how to parse further.
+		return -22;
 	}
 
-	// This is not IP, so we don't know how to parse further.
-	return -22;
+	if (protocol == IPPROTO_TCP) { // TCP
+		struct tcphdr *tcp =
+			(struct tcphdr *)(skb_head + l4_off);
+		probe_read(&event->tuple.sport, sizeof(event->tuple.sport),
+			   _(&tcp->source));
+		probe_read(&event->tuple.dport, sizeof(event->tuple.dport),
+			   _(&tcp->dest));
+	} else if (protocol == IPPROTO_UDP) { // UDP
+		struct udphdr *udp =
+			(struct udphdr *)(skb_head + l4_off);
+		probe_read(&event->tuple.sport, sizeof(event->tuple.sport),
+			   _(&udp->source));
+		probe_read(&event->tuple.dport, sizeof(event->tuple.dport),
+			   _(&udp->dest));
+	} else {
+		event->tuple.sport = 0;
+		event->tuple.dport = 0;
+	}
+	event->tuple.sport = bpf_ntohs(event->tuple.sport);
+	event->tuple.dport = bpf_ntohs(event->tuple.dport);
+
+	if (bpf_core_field_exists(skb->active_extensions)) {
+		struct sec_path *sp;
+		struct skb_ext *ext;
+		u64 offset;
+
+#define SKB_EXT_SEC_PATH 1 // TBD do this with BTF
+		probe_read(&ext, sizeof(ext), _(&skb->extensions));
+		if (ext) {
+			probe_read(&offset, sizeof(offset),
+				   _(&ext->offset[SKB_EXT_SEC_PATH]));
+			sp = (void *)ext + (offset << 3);
+
+			probe_read(&event->secpath_len,
+				   sizeof(event->secpath_len),
+				   _(&sp->len));
+			probe_read(&event->secpath_olen,
+				   sizeof(event->secpath_olen),
+				   _(&sp->olen));
+		}
+	}
+	return 0;
 }
 #endif // __SKB_H__

--- a/bpf/process/types/tuple.h
+++ b/bpf/process/types/tuple.h
@@ -7,13 +7,39 @@
 #define AF_INET	 2
 #define AF_INET6 10
 
+#define IPV4LEN 4
+#define IPV6LEN 16
+
 struct tuple_type {
-	__u32 saddr;
-	__u32 daddr;
+	__u64 saddr[2];
+	__u64 daddr[2];
 	__u16 sport;
 	__u16 dport;
 	__u16 protocol;
 	__u16 family;
 };
+
+static inline __attribute__((always_inline)) void
+write_ipv6_addr_from_ipv4(u64 *dest, u32 src)
+{
+	dest[0] = src;
+	dest[1] = 0;
+}
+
+static inline __attribute__((always_inline)) void
+write_ipv6_addr(u64 *dest, u64 *src)
+{
+	dest[0] = src[0];
+	dest[1] = src[1];
+}
+
+static inline __attribute__((always_inline)) void
+write_ipv6_addr32(u32 *dest, u32 *src)
+{
+	dest[0] = src[0];
+	dest[1] = src[1];
+	dest[2] = src[2];
+	dest[3] = src[3];
+}
 
 #endif // __TUPLE_H__

--- a/docs/content/en/docs/concepts/tracing-policy.md
+++ b/docs/content/en/docs/concepts/tracing-policy.md
@@ -1418,7 +1418,7 @@ There are different types supported for each operator. In case of `matchArgs`:
 * NotDPort - Not Destination Port
 * DPortPriv - Destination Port is Privileged (0-1023)
 * NotDPortPriv - Destination Port is Not Privileged (Not 0-1023)
-* SAddr - Source Address, can be IPv4 address or IPv4 CIDR (for ex 1.2.3.4/24)
+* SAddr - Source Address, can be IPv4/6 address or IPv4/6 CIDR (for ex 1.2.3.4/24 or 2a1:56::1/128)
 * NotSAddr - Not Source Address
 * DAddr - Destination Address
 * NotDAddr - Not Destination Address
@@ -1504,7 +1504,7 @@ as trailing.
 
 The operators relating to ports, addresses and protocol are used with sock or skb
 types. Port operators can accept a range of ports specified as `min:max` as well
-as lists of individual ports. Address operators can accept IPv4 CIDR ranges as well
+as lists of individual ports. Address operators can accept IPv4/6 CIDR ranges as well
 as lists of individual addresses.
 
 The `Protocol` operator can accept integer values to match against, or the equivalent
@@ -1513,8 +1513,7 @@ TCP can be specified as either `IPPROTO_TCP` or 6.
 
 The `Family` operator can accept integer values to match against or the equivalent
 AF_ enumeration. For example, IPv4 can be specified as either `AF_INET` or 2; IPv6
-can be specified as either `AF_INET6` or 10. (Please note that IPv6 support is
-currently very limited, but will be improved in the future.)
+can be specified as either `AF_INET6` or 10.
 
 The `State` operator can accept integer values to match against or the equivalent
 TCP_ enumeration. For example, an established socket can be matched with

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -153,8 +153,8 @@ func (m MsgGenericKprobeArgSize) IsReturnArg() bool {
 }
 
 type MsgGenericKprobeTuple struct {
-	Saddr    uint32
-	Daddr    uint32
+	Saddr    [2]uint64
+	Daddr    [2]uint64
 	Sport    uint16
 	Dport    uint16
 	Protocol uint16

--- a/pkg/reader/network/network.go
+++ b/pkg/reader/network/network.go
@@ -5,14 +5,32 @@ package network
 import (
 	"encoding/binary"
 	"net"
+
+	"golang.org/x/sys/unix"
 )
 
 func SwapByte(b uint16) uint16 {
 	return (b << 8) | (b >> 8)
 }
 
-func GetIP(i uint32) net.IP {
+func GetIPv4(i uint32) net.IP {
 	ip := make(net.IP, 4)
 	binary.LittleEndian.PutUint32(ip, i)
 	return ip
+}
+
+func GetIP(i [2]uint64, family uint16) net.IP {
+	switch family {
+	case unix.AF_INET:
+		return GetIPv4(uint32(i[0]))
+	case unix.AF_INET6:
+		a := make([]byte, 8)
+		b := make([]byte, 8)
+
+		binary.LittleEndian.PutUint64(a, i[0])
+		binary.LittleEndian.PutUint64(b, i[1])
+		ip := append(a, b...)
+		return ip
+	}
+	return nil
 }

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -31,6 +31,11 @@ type KernelLpmTrie4 struct {
 	addr   uint32
 }
 
+type KernelLpmTrie6 struct {
+	prefix uint32
+	addr   [16]byte
+}
+
 type KernelSelectorState struct {
 	off uint32     // offset into encoding
 	e   [4096]byte // kernel encoding of selectors
@@ -40,6 +45,9 @@ type KernelSelectorState struct {
 
 	// addr4Maps are used to populate IPv4 address LpmTrie maps for sock and skb operators
 	addr4Maps []map[KernelLpmTrie4]struct{}
+
+	// addr6Maps are used to populate IPv6 address LpmTrie maps for sock and skb operators
+	addr6Maps []map[KernelLpmTrie6]struct{}
 
 	matchBinaries map[int]*MatchBinariesMappings // matchBinaries mappings (one per selector)
 	newBinVals    map[uint32]string              // these should be added in the names_map
@@ -102,6 +110,10 @@ func (k *KernelSelectorState) Addr4Maps() []map[KernelLpmTrie4]struct{} {
 	return k.addr4Maps
 }
 
+func (k *KernelSelectorState) Addr6Maps() []map[KernelLpmTrie6]struct{} {
+	return k.addr6Maps
+}
+
 // ValueMapsMaxEntries returns the maximum entries over all maps
 func (k *KernelSelectorState) ValueMapsMaxEntries() int {
 	maxEntries := 1
@@ -117,6 +129,17 @@ func (k *KernelSelectorState) ValueMapsMaxEntries() int {
 func (k *KernelSelectorState) Addr4MapsMaxEntries() int {
 	maxEntries := 1
 	for _, vm := range k.addr4Maps {
+		if l := len(vm); l > maxEntries {
+			maxEntries = l
+		}
+	}
+	return maxEntries
+}
+
+// Addr6MapsMaxEntries returns the maximum entries over all maps
+func (k *KernelSelectorState) Addr6MapsMaxEntries() int {
+	maxEntries := 1
+	for _, vm := range k.addr6Maps {
 		if l := len(vm); l > maxEntries {
 			maxEntries = l
 		}
@@ -181,8 +204,22 @@ func (k *KernelSelectorState) newValueMap() (uint32, map[[8]byte]struct{}) {
 	return uint32(mapid), k.valueMaps[mapid]
 }
 
-func (k *KernelSelectorState) newAddr4Map() (uint32, map[KernelLpmTrie4]struct{}) {
+func (k *KernelSelectorState) createAddr4Map() map[KernelLpmTrie4]struct{} {
+	return map[KernelLpmTrie4]struct{}{}
+}
+
+func (k *KernelSelectorState) insertAddr4Map(addr4map map[KernelLpmTrie4]struct{}) uint32 {
 	mapid := len(k.addr4Maps)
-	k.addr4Maps = append(k.addr4Maps, map[KernelLpmTrie4]struct{}{})
-	return uint32(mapid), k.addr4Maps[mapid]
+	k.addr4Maps = append(k.addr4Maps, addr4map)
+	return uint32(mapid)
+}
+
+func (k *KernelSelectorState) createAddr6Map() map[KernelLpmTrie6]struct{} {
+	return map[KernelLpmTrie6]struct{}{}
+}
+
+func (k *KernelSelectorState) insertAddr6Map(addr6map map[KernelLpmTrie6]struct{}) uint32 {
+	mapid := len(k.addr6Maps)
+	k.addr6Maps = append(k.addr6Maps, addr6map)
+	return uint32(mapid)
 }

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -418,6 +418,15 @@ func createGenericTracepointSensor(
 		}
 		maps = append(maps, addr4FilterMaps)
 
+		addr6FilterMaps := program.MapBuilderPin("addr6lpm_maps", sensors.PathJoin(pinPath, "addr6lpm_maps"), prog0)
+		if !kernels.MinKernelVersion("5.9") {
+			// Versions before 5.9 do not allow inner maps to have different sizes.
+			// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+			maxEntries := tp.selectors.Addr6MapsMaxEntries()
+			addr6FilterMaps.SetInnerMaxEntries(maxEntries)
+		}
+		maps = append(maps, addr6FilterMaps)
+
 		selNamesMap := program.MapBuilderPin("sel_names_map", sensors.PathJoin(pinPath, "sel_names_map"), prog0)
 		maps = append(maps, selNamesMap)
 	}


### PR DESCRIPTION
The sock and skb types currently support IPv4 addresses and CIDRs, and in fact the whole subsystem assumes network operations are only IPv4 or AF_INET.

This commit adds IPv6 support by allowing IPv6 addresses and CIDRs to be specified for arg matching for sock and skb types; collects IPv6 addresses from sockets and datagrams where the family is AF_INET6; and reports said addresses correctly in user space.