### PR TITLE
Watch k8s services

### DIFF
--- a/install/kubernetes/templates/clusterrole.yaml
+++ b/install/kubernetes/templates/clusterrole.yaml
@@ -10,6 +10,7 @@ rules:
       - ""
     resources:
       - pods
+      - services
     verbs:
       - get
       - list

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -535,6 +535,10 @@ func (f *fakeK8sWatcher) FindContainer(containerID string) (*corev1.Pod, *corev1
 	return &pod, &container, true
 }
 
+func (f *fakeK8sWatcher) FindServiceByIP(ip string) ([]*corev1.Service, error) {
+	return nil, fmt.Errorf("service with IP %s not found", ip)
+}
+
 // Used to wait for a process to start, we do a lookup on PROCFS because this
 // may be called before obs is created.
 func WaitForProcess(process string) error {

--- a/pkg/watcher/fake.go
+++ b/pkg/watcher/fake.go
@@ -33,6 +33,10 @@ func (watcher *FakeK8sWatcher) FindPod(podID string) (*corev1.Pod, error) {
 	return nil, fmt.Errorf("podID %s not found (in %d pods)", podID, len(watcher.pods))
 }
 
+func (watcher *FakeK8sWatcher) FindServiceByIP(ip string) ([]*corev1.Service, error) {
+	return nil, fmt.Errorf("service with IP %s not found", ip)
+}
+
 // AddPod adds a pod to the fake k8s watcher. This is intended for testing.
 func (watcher *FakeK8sWatcher) AddPod(pod *corev1.Pod) {
 	watcher.pods = append(watcher.pods, pod)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -25,10 +25,12 @@ const (
 	containerIDLen = 15
 	containerIdx   = "containers-ids"
 	podIdx         = "pod-ids"
+	serviceIPsIdx  = "service-ips"
 )
 
 var (
-	errNoPod = errors.New("object is not a *corev1.Pod")
+	errNoPod     = errors.New("object is not a *corev1.Pod")
+	errNoService = errors.New("object is not a *corev1.Service")
 )
 
 // K8sResourceWatcher defines an interface for accessing various resources from Kubernetes API.
@@ -38,11 +40,15 @@ type K8sResourceWatcher interface {
 
 	// Find a pod given the podID
 	FindPod(podID string) (*corev1.Pod, error)
+
+	// FindServiceByIP finds a service given the IP address.
+	FindServiceByIP(ip string) ([]*corev1.Service, error)
 }
 
 // K8sWatcher maintains a local cache of k8s resources.
 type K8sWatcher struct {
-	podInformer cache.SharedIndexInformer
+	podInformer     cache.SharedIndexInformer
+	serviceInformer cache.SharedIndexInformer
 }
 
 func podIndexFunc(obj interface{}) ([]string, error) {
@@ -100,6 +106,15 @@ func containerIndexFunc(obj interface{}) ([]string, error) {
 	return nil, fmt.Errorf("%w - found %T", errNoPod, obj)
 }
 
+// serviceIPIndexFunc indexes services by their IP addresses
+func serviceIPIndexFunc(obj interface{}) ([]string, error) {
+	switch t := obj.(type) {
+	case *corev1.Service:
+		return t.Spec.ClusterIPs, nil
+	}
+	return nil, fmt.Errorf("%w - found %T", errNoService, obj)
+}
+
 // NewK8sWatcher returns a pointer to an initialized K8sWatcher struct.
 func NewK8sWatcher(k8sClient kubernetes.Interface, stateSyncIntervalSec time.Duration) *K8sWatcher {
 	nodeName := os.Getenv("NODE_NAME")
@@ -123,12 +138,27 @@ func NewK8sWatcher(k8sClient kubernetes.Interface, stateSyncIntervalSec time.Dur
 		panic(err)
 	}
 
+	// can't share the same informer factory as pods because the pod informer filters by spec.nodeName field.
+	serviceInformerFactory := informers.NewSharedInformerFactory(k8sClient, stateSyncIntervalSec)
+	serviceInformer := serviceInformerFactory.Core().V1().Services().Informer()
+	err = serviceInformer.AddIndexers(map[string]cache.IndexFunc{
+		serviceIPsIdx: serviceIPIndexFunc,
+	})
+	if err != nil {
+		// Panic during setup since this should never fail, if it fails is a
+		// developer mistake.
+		panic(err)
+	}
+
 	podhooks.InstallHooks(podInformer)
 
 	k8sInformerFactory.Start(wait.NeverStop)
 	k8sInformerFactory.WaitForCacheSync(wait.NeverStop)
+	serviceInformerFactory.Start(wait.NeverStop)
+	serviceInformerFactory.WaitForCacheSync(wait.NeverStop)
 	logger.GetLogger().WithField("num_pods", len(podInformer.GetStore().ListKeys())).Info("Initialized pod cache")
-	return &K8sWatcher{podInformer: podInformer}
+	logger.GetLogger().WithField("num_services", len(serviceInformer.GetStore().ListKeys())).Info("Initialized service cache")
+	return &K8sWatcher{podInformer, serviceInformer}
 }
 
 // FindContainer implements K8sResourceWatcher.FindContainer.
@@ -210,4 +240,23 @@ func findContainer(containerID string, pods []interface{}) (*corev1.Pod, *corev1
 		}
 	}
 	return nil, nil, false
+}
+
+func (watcher *K8sWatcher) FindServiceByIP(ip string) ([]*corev1.Service, error) {
+	objs, err := watcher.serviceInformer.GetIndexer().ByIndex(serviceIPsIdx, ip)
+	if err != nil {
+		return nil, fmt.Errorf("watcher returned: %w", err)
+	}
+	if len(objs) == 0 {
+		return nil, fmt.Errorf("service with IP %s not found", ip)
+	}
+	var services []*corev1.Service
+	for _, obj := range objs {
+		service, ok := obj.(*corev1.Service)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type %t", objs[0])
+		}
+		services = append(services, service)
+	}
+	return services, nil
 }

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package watcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestFindServiceByIP(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := fake.NewSimpleClientset()
+	watcher := NewK8sWatcher(k8sClient, 60*time.Second)
+	svc1 := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc1"},
+		Spec:       v1.ServiceSpec{ClusterIPs: []string{"1.1.1.1"}},
+	}
+	svc2 := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc2"},
+		Spec:       v1.ServiceSpec{ClusterIPs: []string{"2.2.2.2"}},
+	}
+	svc3 := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc3"},
+		Spec:       v1.ServiceSpec{ClusterIPs: []string{"3.3.3.3", "4.4.4.4"}},
+	}
+	_, err := k8sClient.CoreV1().Services("my-ns").Create(ctx, &svc1, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = k8sClient.CoreV1().Services("my-ns").Create(ctx, &svc2, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = k8sClient.CoreV1().Services("my-ns").Create(ctx, &svc3, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.Eventually(t, func() bool { return len(watcher.serviceInformer.GetStore().List()) == 3 }, 10*time.Second, 1*time.Second)
+	res, err := watcher.FindServiceByIP("1.1.1.1")
+	assert.NoError(t, err)
+	assert.Len(t, res, 1)
+	assert.Equal(t, "svc1", res[0].Name)
+	res, err = watcher.FindServiceByIP("4.4.4.4")
+	assert.NoError(t, err)
+	assert.Len(t, res, 1)
+	assert.Equal(t, "svc3", res[0].Name)
+}


### PR DESCRIPTION
Cache k8s services and index them by IP addresses when --enable-k8s-api
flag is specified. This allows Tetragon to associate IP addresses with
k8s services in network events.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>