### PR TITLE
tetragon-oci-hook: statically linked binary

### DIFF
--- a/contrib/rthooks/minikube-containerd-install-hook.sh
+++ b/contrib/rthooks/minikube-containerd-install-hook.sh
@@ -15,7 +15,7 @@ echo "temporary directory: $xdir"
 
 set -x
 
-go build -o $LOCALHOOK  $SCRIPTPATH/tetragon-oci-hook
+CGO_ENABLED=0 go build -o $LOCALHOOK  $SCRIPTPATH/tetragon-oci-hook
 
 mapfile -d '' JQCMD << EOF
 . += { "hooks": {


### PR DESCRIPTION
Build `tetradon-oci-hook` statically-linked binary. It ensures binary is exected in minikube environment without linking errors.