### PR TITLE
tetragon-oci-hook: fix issue for containerd

### DIFF
--- a/contrib/rthooks/tetragon-oci-hook/cel_test.go
+++ b/contrib/rthooks/tetragon-oci-hook/cel_test.go
@@ -6,10 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	CelAllowKubeSystem = `!("io.kubernetes.pod.namespace" in annotations) || annotations["io.kubernetes.pod.namespace"] != "kube-system"`
-)
-
 func celUserExprNoError(t *testing.T, expr string) *celProg {
 	ret, err := celUserExpr(expr)
 	require.NoError(t, err)
@@ -39,6 +35,10 @@ func TestCel(t *testing.T) {
 		// expected value false: program will not fail because namespace is kube-system
 		{prog: celAllowNamespacesNoError(t, []string{"root", "kube-system"}), expectedVal: false, annotations: map[string]string{
 			"io.kubernetes.pod.namespace": "kube-system",
+		}},
+		// expected value false: program will not fail because namespace is kube-system
+		{prog: celAllowNamespacesNoError(t, []string{"root", "kube-system"}), expectedVal: false, annotations: map[string]string{
+			"io.kubernetes.cri.sandbox-namespace": "kube-system",
 		}},
 	}
 


### PR DESCRIPTION
containerd seems to be using a different label key for the container namespace than cri-o, which results in the fail detection of tetragon-oci-hook to not work properly because the teragon container cannot start.

While this can be fixed via appropriate arguments to the hook, we also want to have it working by default. So this patch:
 - changes the cel expression to support multiple keys
 - adds the key used by containerd (io.kubernetes.cri.sandbox-namespace) to the one used by cri-o (io.kubernetes.cri.sandbox-namespace).

The patch also adds a --debug option, and cleans up some dead code.

This issue was reported on slack by @akshay196.