### PR TITLE
docs: split Tracing Policy concept page into subpages

### DIFF
--- a/docs/assets/scss/page-info.scss
+++ b/docs/assets/scss/page-info.scss
@@ -6,7 +6,7 @@
   margin: 2rem 0;
   padding: 20px 16px;
   padding-bottom: 20px;
-  border: none !important;
+  border: thin dashed lightgray;
 
   p {
     margin: 12px 0;

--- a/docs/content/en/docs/concepts/k8s-filtering.md
+++ b/docs/content/en/docs/concepts/k8s-filtering.md
@@ -11,7 +11,7 @@ This is currently a beta feature.
 
 ## Motivation
 
-Tetragon is configured via [TracingPolicies]({{< ref "docs/concepts/tracing-policy" >}}). Broadly
+Tetragon is configured via [TracingPolicies]({{< ref "/docs/concepts/tracing-policy" >}}). Broadly
 speaking, TracingPolicies define _what_ situations Tetragon should react to and _how_. The _what_
 can be, for example, specific system calls with specific argument values. The _how_ defines what
 action the Tetragon agent should perform when the specified situation occurs. The most common action

--- a/docs/content/en/docs/concepts/tracing-policy/_index.md
+++ b/docs/content/en/docs/concepts/tracing-policy/_index.md
@@ -1,0 +1,35 @@
+---
+title: "Tracing Policy"
+icon: "overview"
+weight: 3
+description: "Documentation for the TracingPolicy custom resource"
+---
+
+Tetragon's `TracingPolicy` is a user-configurable Kubernetes custom resource (CR) that
+allows users to trace arbitrary events in the kernel and optionally define
+actions to take on a match. Policies consist of a hook point (kprobes,
+tracepoints, and uprobes are supported), and selectors for in-kernel filtering
+and specifying actions. For more details, see
+[hook points page]({{< ref "/docs/concepts/tracing-policy/hooks" >}}) and the
+[selectors page]({{< ref "/docs/concepts/tracing-policy/selectors" >}}).
+
+{{< caution >}}
+`TracingPolicy` allows for powerful, yet low-level configuration and, as such,
+requires knowledge about the Linux kernel and containers to avoid unexpected
+issues such as TOCTU bugs.
+{{< /caution >}}
+
+For the complete custom resource definition (CRD) refer to the YAML file
+[`cilium.io_tracingpolicies.yaml`](https://github.com/cilium/tetragon/blob/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml).
+One practical way to explore the CRD is to use `kubectl explain` against a
+Kubernetes API server on which it is installed, for example `kubectl explain
+tracingpolicy.spec.kprobes` provides field-specific documentation and details
+on kprobe spec.
+
+Tracing Policies can be loaded and unloaded at runtime in Tetragon, or on
+startup using flags.
+- With Kubernetes, you can use `kubectl` to add and remove a `TracingPolicy`.
+- You can use `tetra` gRPC CLI to add and remove a `TracingPolicy`.
+- You can use the `--tracing-policy` and `--tracing-policy-dir` flags, see more
+  in the [daemon configuration page]({{< ref "/docs/reference/tetragon-configuration#configure-tracing-policies-location" >}}).
+

--- a/docs/content/en/docs/concepts/tracing-policy/example.md
+++ b/docs/content/en/docs/concepts/tracing-policy/example.md
@@ -1,0 +1,153 @@
+---
+title: "Example"
+icon: "tutorials"
+weight: 1
+description: "Learn the basics of Tracing Policy via an example"
+---
+
+
+To discover `TracingPolicy`, let's understand via an example that will be
+explained, part by part, in this document:
+
+{{< warning >}}
+This policy is for illustration purposes only and should not be used to
+restrict access to certain files. It can be easily bypassed by, for example,
+using hard links.
+{{< /warning >}}
+
+```yaml
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "fd-install"
+spec:
+  kprobes:
+  - call: "fd_install"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "file"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "/tmp/tetragon"
+      matchActions:
+      - action: Sigkill
+```
+
+## Required fields
+
+```yaml
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "fd-install"
+```
+
+The first part follows a common pattern among all Cilium Policies or more
+widely [Kubernetes object](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/).
+It first declares the Kubernetes API used, then the kind of Kubernetes object
+it is in this API and an arbitrary name for the object, that has to comply with
+[Kubernetes naming convention](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/).
+
+## Hook point
+
+```yaml
+spec:
+  kprobes:
+  - call: "fd_install"
+    syscall: false
+    args:
+    - index: 0
+      type: "int"
+    - index: 1
+      type: "file"
+```
+
+The beginning of the specification describe the hook point to use, here we are
+using a kprobe, hooking on the kernel function `fd_install`. That's the kernel
+function that gets called when a new file descriptor needs to be created. We
+indicate that it's not a syscall, but a regular kernel function. Then we
+specify the argument of the specified function symbol to be able to extract
+them, and optionally perform filtering on them.
+
+See the [hook points page]({{< ref "/docs/concepts/tracing-policy/hooks" >}})
+for further information on the various hook points available and arguments.
+
+## Selectors
+
+```yaml
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "/tmp/tetragon"
+      matchActions:
+      - action: Sigkill
+```
+
+Selectors allow you to filter on the events to extract only a subset of the
+events based on different properties and optionally take an enforcement action.
+
+In the example, we filter on the argument at index 1, passing a `file` struct
+to the function. Tetragon has the knowledge on how to apply the `Equal`
+operator over a Linux kernel `file` struct and you can basically match on the
+path of the file.
+
+Then we add the `Sigkill` action, meaning, that any match of the selector
+should send a SIGKILL signal to the process that initiated the event.
+
+Learn more about the various selectors in the dedicated
+[selectors page]({{< ref "/docs/concepts/tracing-policy/selectors" >}}).
+
+## Policy effect
+
+First, let's create the `/tmp/tetragon` file with some content:
+```shell-session
+echo eBPF! > /tmp/tetragon
+```
+
+Starting Tetragon with the above `TracingPolicy`, for example putting the
+policy in the `example.yaml` file, compiling the project locally and starting
+Tetragon with (you can do similar things with container image releases, see the
+docker run command in the [Try Tetragon on Linux guide]({{< ref
+"/docs/getting-started/try-tetragon-linux#observability-with-tracingpolicy" >}}):
+```shell-session
+sudo ./tetragon --bpf-lib bpf/objs --tracing-policy example.yaml
+```
+
+{{< note >}}
+Stop tetragon with <kbd>Ctrl</kbd>+<kbd>C</kbd> to disable the policy and
+remove the BPF programs.
+{{< /note >}}
+
+Reading the `/tmp/tetragon` file with `cat`:
+```shell-session
+cat /tmp/tetragon
+```
+
+Should result in the following events:
+```
+🚀 process  /usr/bin/cat /tmp/tetragon
+📬 open     /usr/bin/cat /tmp/tetragon
+💥 exit     /usr/bin/cat /tmp/tetragon SIGKILL
+```
+
+And the shell will return:
+```
+Killed
+```
+
+## See more
+
+For more examples of tracing policies, take a look at the
+[examples/tracingpolicy](https://github.com/cilium/tetragon/tree/main/examples/tracingpolicy)
+folder in the Tetragon repository. Also read the following sections on
+[hook points]({{< ref "/docs/concepts/tracing-policy/hooks" >}}) and
+[selectors]({{< ref "/docs/concepts/tracing-policy/selectors" >}}).
+

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -1,409 +1,26 @@
 ---
-title: "Tracing Policy"
+title: "Selectors"
 icon: "overview"
 weight: 3
-description: "Documentation for the TracingPolicy custom resource"
+description: "Perform in-kernel BPF filtering and actions on events"
 ---
 
-`TracingPolicy` is a user-configurable Kubernetes custom resource (CR) that
-allows users to trace arbitrary events in the kernel and optionally define
-actions to take on a match, for enforcement for example. Currently, two types
-of events are supported: kprobes and tracepoints, but others may be added in
-the future (e.g., uprobes) by following a similar approach.
-
-Note that `TracingPolicy` can be considered low-level since they require
-knowledge about the Linux kernel and containers to be written correctly. In the
-future, we are considering to add a high-level `RuntimeSecurityPolicy` which
-would take this complexity away.
-
-For the complete custom resource definition (CRD) refer to the YAML file
-[`cilium.io_tracingpolicies.yaml`](https://github.com/cilium/tetragon/blob/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml).
-One practical way to explore the CRD is to use `kubectl explain` against a
-Kubernetes API server on which it is installed, for example `kubectl explain
-tracingpolicy.spec.kprobes` provides field-specific documentation and details
-on kprobe spec.
-
-{{< note >}}
-For bare metal or VM use cases without Kubernetes, the same YAML configuration
-can be passed via a flag to the Tetragon binary (using `--tracing-policy`) or
-via the `tetra` CLI to load the policies via gRPC.
-{{< /note >}}
-
-### Getting started with Tracing Policy
-
-To keep the Cilium Policy Definitions unified, the `TracingPolicy` follows the
-same CR logic and semantics that you might be familiar with from other Cilium
-concepts, like `CiliumNetworkPolicy`.
-
-To discover `TracingPolicy`, let's understand via an example that will be
-explained in this document:
-
-```yaml
-apiVersion: cilium.io/v1alpha1
-kind: TracingPolicy
-metadata:
-  name: "fd-install"
-spec:
-  kprobes:
-  - call: "fd_install"
-    syscall: false
-    args:
-    - index: 0
-      type: "int"
-    - index: 1
-      type: "file"
-    selectors:
-    - matchArgs:
-      - index: 1
-        operator: "Equal"
-        values:
-        - "/etc/passwd"
-        - "/etc/shadow"
-```
-
-#### Required fields
-
-The first part follows a common pattern among all Cilium Policies or more
-widely [Kubernetes object](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/).
-It first declares the Kubernetes API used, then the kind of Kubernetes object
-it is in this API and an arbitrary name for the object, that has to comply with
-[Kubernetes naming convention](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/).
-
-```yaml
-apiVersion: cilium.io/v1alpha1
-kind: TracingPolicy
-metadata:
-  name: "fd-install"
-```
-
-#### Specification
-
-The `spec` or `specification` can be composed of `kprobes` or `tracepoints` at
-the moment. It describes the arbitrary event in the kernel that will be traced.
-
-##### Kprobes
-
-Kprobes enables you to dynamically break into any kernel routine and collect
-debugging and performance information non-disruptively. kprobes are highly
-tight to your kernel version and might not be portable since the kernel symbols
-depend on your build.
-
-Conveniently, you can list all kernel symbols reading the `/proc/kallsyms`
-file. For example to search for the `write` syscall kernel function, you can
-execute `sudo grep sys_write /proc/kallsyms`, the output should be similar to
-this, minus the architecture specific prefixes.
-
-```
-ffffdeb14ea712e0 T __arm64_sys_writev
-ffffdeb14ea73010 T ksys_write
-ffffdeb14ea73140 T __arm64_sys_write
-ffffdeb14eb5a460 t proc_sys_write
-ffffdeb15092a700 d _eil_addr___arm64_sys_writev
-ffffdeb15092a740 d _eil_addr___arm64_sys_write
-```
-
-You can see that the exact name of the symbol for the write syscall on our
-kernel version is `__arm64_sys_write`. Note that on `x86_64`, the prefix should
-be `__x64_` instead of `__arm64_`.
-
-{{< caution >}}
-Kernel symbols contain an architecture specific prefix when they refer to
-syscall symbols. To write portable tracing policies, i.e. policies that can run
-on multiple architectures, just use the symbol name without the prefix.
-
-For example, instead of writing `call: "__arm64_sys_write"` or `call:
-"__x64_sys_write"`, just write `call: "sys_write"`, Tetragon will adapt and add
-the correct prefix based on the architecture of the underlying machine. Note
-that the event generated as output currently includes the prefix.
-{{< /caution >}}
-
-In our example, we will explore a `kprobe` hooking into the
-[`fd_install`](https://elixir.bootlin.com/linux/v6.1.9/source/fs/file.c#L602)
-kernel function. The `fd_install` kernel function is called each time a file
-descriptor is installed into the file descriptor table of a process, typically
-referenced within system calls like `open` or `openat`. Hooking `fd_install`
-has its benefits and limitations, which are out of the scope of this document.
-
-```yaml
-spec:
-  kprobes:
-  - call: "fd_install"
-    syscall: false
-```
-
-{{< note >}}
-Notice the `syscall` field, specific to a `kprobe` spec, with default value
-`false`, that indicates whether Tetragon will hook a syscall or just a regular
-kernel function. Tetragon needs this information because syscall and kernel
-function use a [different ABI](https://gitlab.com/x86-psABIs/x86-64-ABI).
-{{< /note >}}
-
-
-As usual, kprobes calls can be defined independently in different policies,
-or together in the same Policy. For example, we can define trace multiple
-kprobes under the same tracing policy:
-```yaml
-spec:
-  kprobes:
-  - call: "sys_read"
-    syscall: true
-    # [...]
-  - call: "sys_write"
-    syscall: true
-    # [...]
-```
-
-##### Tracepoints
-
-A tracepoint placed in the Linux kernel code provides a hook to call a function
-that you can provide at runtime using Tetragon. Tracepoints have the advantage
-of being stable across kernel versions and thus more portable than kprobes.
-
-To see the list of tracepoints available on your kernel, you can list them
-using `sudo ls /sys/kernel/debug/tracing/events`, the output should be similar
-to this.
-
-```
-alarmtimer    ext4            iommu           page_pool     sock
-avc           fib             ipi             pagemap       spi
-block         fib6            irq             percpu        swiotlb
-bpf_test_run  filelock        jbd2            power         sync_trace
-bpf_trace     filemap         kmem            printk        syscalls
-bridge        fs_dax          kvm             pwm           task
-btrfs         ftrace          libata          qdisc         tcp
-cfg80211      gpio            lock            ras           tegra_apb_dma
-cgroup        hda             mctp            raw_syscalls  thermal
-clk           hda_controller  mdio            rcu           thermal_power_allocator
-cma           hda_intel       migrate         regmap        thermal_pressure
-compaction    header_event    mmap            regulator     thp
-cpuhp         header_page     mmap_lock       rpm           timer
-cros_ec       huge_memory     mmc             rpmh          tlb
-dev           hwmon           module          rseq          tls
-devfreq       i2c             mptcp           rtc           udp
-devlink       i2c_slave       napi            sched         vmscan
-dma_fence     initcall        neigh           scmi          wbt
-drm           interconnect    net             scsi          workqueue
-emulation     io_uring        netlink         signal        writeback
-enable        iocost          oom             skb           xdp
-error_report  iomap           page_isolation  smbus         xhci-hcd
-```
-
-You can then choose the subsystem that you want to trace, and look the
-tracepoint you want to use and its format. For example, if we choose the
-`netif_receive_skb` tracepoints from the `net` subsystem, we can read its
-format with `sudo cat /sys/kernel/debug/tracing/events/net/netif_receive_skb/format`,
-the output should be similar to the following.
-
-```
-name: netif_receive_skb
-ID: 1398
-format:
-        field:unsigned short common_type;       offset:0;       size:2; signed:0;
-        field:unsigned char common_flags;       offset:2;       size:1; signed:0;
-        field:unsigned char common_preempt_count;       offset:3;       size:1; signed:0;
-        field:int common_pid;   offset:4;       size:4; signed:1;
-
-        field:void * skbaddr;   offset:8;       size:8; signed:0;
-        field:unsigned int len; offset:16;      size:4; signed:0;
-        field:__data_loc char[] name;   offset:20;      size:4; signed:0;
-
-print fmt: "dev=%s skbaddr=%px len=%u", __get_str(name), REC->skbaddr, REC->len
-```
-
-Similarly to kprobes, tracepoints can also hook into system calls. For more
-details, see the `raw_syscalls` and `syscalls` subysystems.
-
-### Arguments
-
-A call contains an `args` field which a list of function arguments to include
-in the trace output. Indeed the BPF code that runs on the hook point requires
-information about the types of arguments of the function being traced to
-properly read, print and filter on its arguments. Currently, this information
-needs to be provided by the user under the `args` section. For the [available
-types](https://github.com/cilium/tetragon/blob/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml#L64-L88),
-see directly in the `TracingPolicy` CRD.
-
-Following our example, here is the part that defines the arguments:
-```yaml
-args:
-- index: 0
-  type: "int"
-- index: 1
-  type: "file"
-```
-
-Each argument can optionally include a 'label' parameter, which will be included
-in the output. This can be used to annotate the arguments to help with understanding
-and processing the output. As an example, here is the same definition, with an
-appropriate label on the int argument:
-```yaml
-args:
-- index: 0
-  type: "int"
-  label: "FD"
-- index: 1
-  type: "file"
-```
-
-To properly read and hook onto the `fd_install(unsigned int fd, struct file
-*file)` function, the YAML snippet above tells the BPF code that the first
-argument is an `int` and the second argument is a `file`, which is the
-[`struct file`](https://elixir.bootlin.com/linux/latest/source/include/linux/fs.h#L940)
-of the kernel. In this way, the BPF code and its printer can properly collect
-and print the arguments.
-
-These types are sorted by the `index` field, where you can specify the order.
-The indexing starts with 0. So, `index: 0` means, this is going to be the first
-argument of the function, `index: 1` means this is going to be the second
-argument of the function, etc.
-
-Note that for some args types, `char_buf` and `char_iovec`, there are
-additional fields named `returnCopy` and `sizeArgIndex` available:
-- `returnCopy` indicates that the corresponding argument should be read later (when
-  the kretprobe for the symbol is triggered) because it might not be populated
-  when the kprobe is triggered at the entrance of the function. For example, a
-  buffer supplied to `read(2)` won't have content until kretprobe is triggered.
-- `sizeArgIndex` indicates the (1-based, see warning below) index of the arguments
-  that represents the size of the `char_buf` or `iovec`. For example, for
-  `write(2)`, the third argument, `size_t count` is the number of `char`
-  element that we can read from the `const void *buf` pointer from the second
-  argument. Similarly, if we would like to capture the `__x64_sys_writev(long,
-  iovec *, vlen)` syscall, then `iovec` has a size of `vlen`, which is going to
-  be the third argument.
-
-{{< caution >}}
-`sizeArgIndex` is inconsistent at the moment and does not take the index, but
-the number of the index (or index + 1). So if the size is the third argument,
-index 2, the value should be 3.
-{{< /caution >}}
-
-These flags can be combined, see the example below.
-
-```yaml
-- call: "sys_write"
-  syscall: true
-  args:
-  - index: 0
-    type: "int"
-  - index: 1
-    type: "char_buf"
-    returnCopy: true
-    sizeArgIndex: 3
-  - index: 2
-    type: "size_t"
-```
-
-Note that you can specify which arguments you would like to print from a
-specific syscall. For example if you don't care about the file descriptor,
-which is the first `int` argument with `index: 0` and just want the `char_buf`,
-what is written, then you can leave this section out and just define:
-
-```yaml
-args:
-- index: 1
-  type: "char_buf"
-  returnCopy: true
-  sizeArgIndex: 3
-- index: 2
-  type: "size_t"
-```
-This tells the printer to skip printing the `int` arg because it's not useful.
-
-For `char_buf` type up to the 4096 bytes are stored. Data with bigger size are
-cut and returned as truncated bytes.
-
-You can specify `maxData` flag for `char_buf` type to read maximum possible data
-(currently 327360 bytes), like:
-
-```yaml
-args:
-- index: 1
-  type: "char_buf"
-  maxData: true
-  sizeArgIndex: 3
-- index: 2
-  type: "size_t"
-```
-
-This field is only used for `char_buff` data. When this value is false (default),
-the bpf program will fetch at most 4096 bytes.  In later kernels (>=5.4) tetragon
-supports fetching up to 327360 bytes if this flag is turned on.
-
-The `maxData` flag does not work with `returnCopy` flag at the moment, so it's
-usable only for syscalls/functions that do not require return probe to read the
-data.
-
-### Return Values
-
-A `TracingPolicy` can specify that the return value should be reported in the
-tracing output. To do this, the `return` parameter of the call needs to be set to
-`true`, and the `returnArg` parameter needs to be set to specify the `type` of the
-return argument. For example:
-
-```yaml
-  - call: "sk_alloc"
-    syscall: false
-    return: true
-    args:
-      - index: 1
-        type: int
-        label: "family"
-    returnArg:
-      type: sock
-```
-
-In this case, the `sk_alloc` hook is specified to return a value of type `sock`
-(a pointer to a `struct sock`). Whenever the `sk_alloc` hook is hit, not only
-will it report the `family` parameter in index 1, it will also report the socket
-that was created.
-
-#### Return Values Socket Tracking
-
-A unique feature of a `sock` being returned from a hook such as `sk_alloc` is that
-the socket it refers to can be tracked. Most networking hooks in the network stack
-are run in a context that is not that of the process that owns the socket for which
-the actions relate; this is because networking happens asynchronously and not
-entirely in-line with the process. The `sk_alloc` hook does, however, occur in the
-context of the process, such that the task, the PID, and the TGID are of the process
-that requested that the socket was created.
-
-Specifying socket tracking tells Tetragon to store a mapping between the socket
-and the process' PID and TGID; and to use that mapping when it sees the socket in a
-`sock` argument in another hook to replace the PID and TGID of the context with the
-process that actually owns the socket. This can be done by adding a `returnArgAction`
-to the call. Available actions are `TrackSock` and `UntrackSock`.
-See [`TrackSock`](#tracksock-action) and [`UntrackSock`](#untracksock-action).
-
-```yaml
-  - call: "sk_alloc"
-    syscall: false
-    return: true
-    args:
-      - index: 1
-        type: int
-        label: "family"
-    returnArg:
-      type: sock
-    returnArgAction: TrackSock
-```
-
-Socket tracking is only available on kernels >=5.3.
-
-### Selectors
+Selectors are a way to perform in-kernel BPF filtering on the events to
+export, or on the events on which to apply an action.
 
 A `TracingPolicy` can contain from 0 to 5 selectors. A selector is composed of
 1 or more filters. The available filters are the following:
-- [`matchArgs`](#arguments-filter)
-- [`matchReturnArgs`](#return-args-filter)
-- [`matchPIDs`](#pids-filter)
-- [`matchBinaries`](#binaries-filter)
-- [`matchNamespaces`](#namespaces-filter)
-- [`matchCapabilities`](#capabilities-filter)
-- [`matchNamespaceChanges`](#namespace-changes-filter)
-- [`matchCapabilityChanges`](#capability-changes-filter)
-- [`matchActions`](#actions-filter)
+- [`matchArgs`](#arguments-filter): filter on the value of arguments.
+- [`matchReturnArgs`](#return-args-filter): filter on the return value.
+- [`matchPIDs`](#pids-filter): filter on PID.
+- [`matchBinaries`](#binaries-filter): filter on binary path.
+- [`matchNamespaces`](#namespaces-filter): filter on Linux namespaces.
+- [`matchCapabilities`](#capabilities-filter): filter on Linux capabilities.
+- [`matchNamespaceChanges`](#namespace-changes-filter): filter on Linux namespaces changes.
+- [`matchCapabilityChanges`](#capability-changes-filter): filter on Linux capabilities changes.
+- [`matchActions`](#actions-filter): apply an action on selector matching.
 
-#### Arguments filter
+## Arguments filter
 
 Arguments filters can be specified under the `matchArgs` field and provide
 filtering based on the value of the function's argument.
@@ -466,7 +83,7 @@ with the previous example.
     - "/etc"
 ```
 
-#### Return args filter
+## Return args filter
 
 Arguments filters can be specified under the `returnMatchArgs` field and
 provide filtering based on the value of the function return value. It allows
@@ -490,7 +107,7 @@ A use case for this would be to detect the failed access to certain files, like
 `/etc/shadow`. Doing `cat /etc/shadow` will use a `openat` syscall that will
 returns `-1` for a failed attempt with an unprivileged user.
 
-#### PIDs filter
+## PIDs filter
 
 PIDs filters can be specified under the `matchPIDs` field and provide filtering
 based on the value of host pid of the process. For example, the following
@@ -526,7 +143,7 @@ created by `kubectl exec` are not children of PID 1.
     - 1
 ```
 
-#### Binaries filter
+## Binaries filter
 
 Binary filters can be specified under the `matchBinaries` field and provide
 filtering based on the value of a certain binary name. For example, the
@@ -589,7 +206,7 @@ while the whole `kprobe` call is the following:
       - "3"
 ```
 
-#### Namespaces filter
+## Namespaces filter
 
 Namespaces filters can be specified under the `matchNamespaces` field and
 provide filtering of calls based on Linux namespace. You can specify the
@@ -788,7 +405,7 @@ Here we have a single selector. This CRD will match if:
 `[`binary == /bin/cat `AND` arg1 == /etc/shadow `AND` `(`MntNs == host `AND`
 NetNs == host`)` `]`
 
-#### Capabilities filter
+## Capabilities filter
 
 Capabilities filters can be specified under the `matchCapabilities` field and
 provide filtering of calls based on Linux capabilities in the specific sets.
@@ -816,7 +433,7 @@ This will match if: [`Effective` capabilities contain `CAP_CHOWN`] OR
 1. There is no limit in the number of capabilities listed under `values`.
 2. Only one `type` field can be specified under `matchCapabilities`.
 
-#### Namespace changes filter
+## Namespace changes filter
 
 Namespace changes filter can be specified under the `matchNamespaceChanges`
 field and provide filtering based on calls that are changing Linux namespaces.
@@ -846,7 +463,7 @@ be used to test this feature. See a
 [demonstration example](https://github.com/cilium/tetragon/blob/main/examples/tracingpolicy/match_namespace_changes.yaml)
 of this feature.
 
-#### Capability changes filter
+## Capability changes filter
 
 Capability changes filter can be specified under the `matchCapabilityChanges`
 field and provide filtering based on calls that are changing Linux capabilities.
@@ -867,7 +484,7 @@ matchCapabilityChanges:
 See a [demonstration example](https://github.com/cilium/tetragon/blob/main/examples/tracingpolicy/match_capability_changes.yaml)
 of this feature.
 
-#### Actions filter
+## Actions filter
 
 Actions filters are a list of actions that execute when an appropriate selector
 matches. They are defined under `matchActions` and currently, the following
@@ -906,7 +523,7 @@ matchActions:
   rateLimit: 5m
 ```
 
-##### Sigkill action
+### Sigkill action
 
 `Sigkill` action terminates synchronously the process that made the call that
 matches the appropriate selectors from the kernel. In the example below, every
@@ -942,7 +559,7 @@ process is spawned in the container PID namespace and is not a child of PID 1.
     - action: Sigkill
 ```
 
-##### Signal action
+### Signal action
 
 `Signal` action sends specified signal to current process. The signal number
 is specified with `argSig` value.
@@ -979,7 +596,7 @@ The difference is to use the signal action with `SIGKILL(9)` signal.
       argSig: 9
 ```
 
-##### Override action
+### Override action
 
 `Override` action allows to modify the return value of call. While `Sigkill`
 will terminate the entire process responsible for making the call, `Override`
@@ -1031,7 +648,7 @@ For kernel developers: if you want to override your kernel functions then
 ensure they properly follow the [Error Injectable Functions](https://docs.kernel.org/fault-injection/fault-injection.html#error-injectable-functions) guide.
 {{< /caution >}}
 
-##### FollowFD action
+### FollowFD action
 
 The `FollowFD` action allows to create a mapping using a BPF map between file
 descriptors numbers and filenames. It however needs to maintain a state
@@ -1067,7 +684,7 @@ This action uses the dedicated `argFd` and `argName` fields to get respectively
 the index of the file descriptor argument and the index of the name argument in
 the call.
 
-##### UnfollowFD action
+### UnfollowFD action
 
 The `UnfollowFD` action takes a file descriptor from a system call and deletes
 the corresponding entry from the BPF map, where it was put under the `FollowFD`
@@ -1115,7 +732,7 @@ there should be a matching `UnfollowFD` block, otherwise the BPF map will be
 broken.
 {{< /caution >}}
 
-##### CopyFD action
+### CopyFD action
 
 The `CopyFD` action is specific to duplication of file descriptor use cases.
 Similary to `FollowFD`, it takes an `argFd` and `argName` arguments. It can
@@ -1156,7 +773,7 @@ See the following example for illustration:
       argName: 1
 ```
 
-##### GetUrl action
+### GetUrl action
 
 The `GetUrl` action can be used to perform a remote interaction such as
 triggering Thinkst canaries or any system that can be triggered via an URL
@@ -1169,7 +786,7 @@ matchActions:
   argUrl: http://ebpf.io
 ```
 
-##### DnsLookup action
+### DnsLookup action
 
 The `DnsLookup` action can be used to perform a remote interaction such as
 triggering Thinkst canaries or any system that can be triggered via an DNS
@@ -1181,13 +798,13 @@ matchActions:
   argFqdn: ebpf.io
 ```
 
-##### Post action
+### Post action
 
 The `Post` action is intended to create an event but at the moment should be
 considered as deprecated as all `TracingPolicy` will generate an event by
 default.
 
-##### NoPost action
+### NoPost action
 
 The `NoPost` action can be used to suppress the event to be generated, but at
 the same time all its defined actions are performed.
@@ -1225,7 +842,7 @@ generate any event about that.
     - action: NoPost
 ```
 
-##### TrackSock action
+### TrackSock action
 
 The `TrackSock` action allows to create a mapping using a BPF map between sockets
 and processes. It however needs to maintain a state
@@ -1238,7 +855,7 @@ value of `sk_alloc` as described above.
 
 Socket tracking is only available on kernel >=5.3.
 
-##### UntrackSock action
+### UntrackSock action
 
 The `UntrackSock` action takes a struct sock pointer from a function call and deletes
 the corresponding entry from the BPF map, where it was put under the `TrackSock`
@@ -1280,7 +897,7 @@ broken.
 
 Socket tracking is only available on kernel >=5.3.
 
-### Selector Semantics
+## Selector Semantics
 
 The `selector` semantics of the `CiliumTracingPolicy` follows the standard
 Kubernetes semantics and the principles that are used by Cilium to create a
@@ -1310,7 +927,7 @@ giving the expression:
 (pid in {pid1, pid2, pid3} AND arg0=fdstring1)
 ```
 
-#### Multiple values
+### Multiple values
 
 When multiple values are given, we apply the `OR` operation between them. In
 case of having multiple values under the `matchPIDs` selector, if any value
@@ -1363,7 +980,7 @@ selectors:
     - "/etc/shadow"
 ```
 
-#### Multiple operators
+### Multiple operators
 
 When multiple operators are supported under `matchPIDs` or `matchArgs`, they
 are logically `AND` together. In case if we have multiple operators under
@@ -1412,7 +1029,7 @@ Then we would build the following expression on the BPF side
 (pid in {pid1, pid2, pid3} AND arg0=1 AND arg2 < 500)
 ```
 
-##### Operator types
+#### Operator types
 
 There are different types supported for each operator. In case of `matchArgs`:
 
@@ -1592,7 +1209,7 @@ of `{binary0, binary1, binary2}`:
     - "binary2"
 ```
 
-#### Multiple selectors
+### Multiple selectors
 
 When multiple selectors are configured they are logically `OR`d together.
 ```yaml
@@ -1633,7 +1250,11 @@ The above would be executed in kernel as:
 (pid in {pid1, pid2, pid3} AND arg0=2)
 ```
 
-##### Limitations
+### Limitations
+
+{{% pageinfo %}}
+Those limitations might be outdated, see [issue #709](https://github.com/cilium/tetragon/issues/709).
+{{% /pageinfo %}}
 
 Because BPF must be bounded we have to place limits on how many selectors can
 exist.
@@ -1643,3 +1264,4 @@ exist.
 - Max MatchArgs per selector 5 (one per index)
 - Max MatchArg Values per MatchArgs 1 (limiting initial implementation can bump
   to 16 or so)
+

--- a/docs/content/en/docs/getting-started/try-tetragon-linux.md
+++ b/docs/content/en/docs/getting-started/try-tetragon-linux.md
@@ -103,7 +103,7 @@ example, used to implement enforcement.
 
 {{< note >}}
 For more details about TracingPolicies and how to write them, refer to the
-[TracingPolicy documentation]({{< ref "docs/concepts/tracing-policy" >}}).
+[TracingPolicy documentation]({{< ref "/docs/concepts/tracing-policy" >}}).
 {{< /note >}}
 
 ### Observability with TracingPolicy
@@ -394,5 +394,5 @@ file using `cat ./tracing_policy.yaml` will bypass the policies presented here.
 ## What's next
 
 - Try Tetragon in [Kubernetes environments]({{< ref "docs/getting-started/kubernetes-quickstart-guide" >}}).
-- Learn more about [TracingPolicy]({{< ref "docs/concepts/tracing-policy" >}}).
+- Learn more about [TracingPolicy]({{< ref "/docs/concepts/tracing-policy" >}}).
 - See more use cases for observability in the [Use cases section]({{< ref "docs/use-cases" >}}).


### PR DESCRIPTION
Now the Tracing Policy documentation splits into three pages:
- an example of policy, shortly explained
- a hook point page about how to use kprobes, tracepoints, etc.
- a selector page about filters and actions

See [preview](https://deploy-preview-1377--tetragon.netlify.app/docs/concepts/tracing-policy/).