### PR TITLE
Ignore `docs/**` in packages-e2e-tests.yaml

### DIFF
--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
     - "**.md"
+    - 'docs/**'
 
 jobs:
   standalone-tests:


### PR DESCRIPTION
Just noticed this check started in https://github.com/cilium/tetragon/pull/1377.