### PR TITLE
golangci-lint: increase timeout and enable caching

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -12,6 +12,10 @@ on:
       - 'docs/**'
       - '**.md'
 
+permissions:
+  # For golangci/golangci-lint to have read access to pull request for `only-new-issues` option.
+  contents: read
+
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest
@@ -24,6 +28,8 @@ jobs:
         with:
           # renovate: datasource=golang-version depName=go
           go-version: '1.20.7'
+          # using golangci-lint cache instead
+          cache: false
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
@@ -31,7 +37,6 @@ jobs:
           # renovate: datasource=docker depName=docker.io/golangci/golangci-lint
           version: v1.53.3
           args: --config=.golangci.yml --verbose
-          skip-cache: true
 
   format:
     runs-on: ubuntu-latest 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # See https://golangci-lint.run/usage/configuration/ for available options.
 # Also https://github.com/cilium/cilium/blob/master/.golangci.yaml as a reference.
 run:
-  timeout: 5m
+  timeout: 10m
 
 output:
   format: tab


### PR DESCRIPTION
Caching was disabled for stuff that might not apply anymore: golangci/golangci-lint-action#153
We were timing out on the analysis so this might help.