### PR TITLE
refactor: Clean up unused stuff

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -304,7 +304,7 @@ func tetragonExecute() error {
 	if err != nil {
 		return err
 	}
-	ciliumState, err := cilium.InitCiliumState(ctx, option.Config.EnableCilium)
+	_, err = cilium.InitCiliumState(ctx, option.Config.EnableCilium)
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,6 @@ func tetragonExecute() error {
 	pm, err := tetragonGrpc.NewProcessManager(
 		ctx,
 		&cleanupWg,
-		ciliumState,
 		observer.SensorManager,
 		hookRunner)
 	if err != nil {

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -227,7 +227,6 @@ func startBenchmarkExporter(ctx context.Context, obs *observer.Observer, summary
 	processManager, err := grpc.NewProcessManager(
 		ctx,
 		&wg,
-		cilium.GetFakeCiliumState(),
 		observer.SensorManager,
 		hookRunner)
 	if err != nil {

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/tetragon/pkg/eventcache"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
-	"github.com/cilium/tetragon/pkg/oldhubble/cilium"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/reader/notify"
@@ -26,23 +25,20 @@ type ProcessManager struct {
 	nodeName string
 	Server   *server.Server
 	// synchronize access to the listeners map.
-	mux         sync.Mutex
-	listeners   map[server.Listener]struct{}
-	ciliumState *cilium.State
+	mux       sync.Mutex
+	listeners map[server.Listener]struct{}
 }
 
 // NewProcessManager returns a pointer to an initialized ProcessManager struct.
 func NewProcessManager(
 	ctx context.Context,
 	wg *sync.WaitGroup,
-	ciliumState *cilium.State,
 	manager *sensors.Manager,
 	hookRunner *rthooks.Runner,
 ) (*ProcessManager, error) {
 	pm := &ProcessManager{
-		nodeName:    node.GetNodeNameForExport(),
-		ciliumState: ciliumState,
-		listeners:   make(map[server.Listener]struct{}),
+		nodeName:  node.GetNodeNameForExport(),
+		listeners: make(map[server.Listener]struct{}),
 	}
 
 	pm.Server = server.NewServer(ctx, wg, pm, manager, hookRunner)

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -160,7 +160,6 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 	_, err = NewProcessManager(
 		context.Background(),
 		&wg,
-		cilium.GetFakeCiliumState(),
 		nil,
 		&rthooks.Runner{})
 	assert.NoError(t, err)

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -349,7 +349,6 @@ func GetDefaultObserverWithFileNoTest(t *testing.T, ctx context.Context, file, l
 
 func loadExporter(t *testing.T, ctx context.Context, obs *observer.Observer, opts *testExporterOptions, oo *testObserverOptions) error {
 	watcher := opts.watcher
-	ciliumState := opts.ciliumState
 	processCacheSize := 32768
 	dataCacheSize := 1024
 
@@ -397,7 +396,7 @@ func loadExporter(t *testing.T, ctx context.Context, obs *observer.Observer, opt
 	option.Config.EnableProcessNs = true
 	option.Config.EnableProcessCred = true
 	option.Config.EnableCilium = false
-	processManager, err := tetragonGrpc.NewProcessManager(ctx, &cancelWg, ciliumState, sensorManager, hookRunner)
+	processManager, err := tetragonGrpc.NewProcessManager(ctx, &cancelWg, sensorManager, hookRunner)
 	if err != nil {
 		return err
 	}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -355,19 +355,3 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 func Get(execId string) (*ProcessInternal, error) {
 	return procCache.get(execId)
 }
-
-func GetProcessEndpoint(p *tetragon.Process) *hubblev1.Endpoint {
-	if p == nil {
-		return nil
-	}
-	if p.Docker == "" {
-		return nil
-	}
-	pod, _, ok := k8s.FindContainer(p.Docker)
-	if !ok {
-		logger.GetLogger().WithField("container id", p.Docker).Trace("failed to get pod")
-		return nil
-	}
-	endpoint, _ := cilium.GetCiliumState().GetEndpointsHandler().GetEndpointByPodName(pod.Namespace, pod.Name)
-	return endpoint
-}


### PR DESCRIPTION
- Remove ciliumState field from ProcessManager
- Delete GetProcessEndpoint()

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>
