### PR TITLE
process: Add a function to access K8sResourceWatcher

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -355,3 +355,9 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 func Get(execId string) (*ProcessInternal, error) {
 	return procCache.get(execId)
 }
+
+// GetK8s returns K8sResourceWatcher. You must call InitCache before calling this function to ensure
+// that k8s has been initialized.
+func GetK8s() watcher.K8sResourceWatcher {
+	return k8s
+}


### PR DESCRIPTION
Add a function that returns K8sResourceWatcher. This makes it easier for users of the process package to associate process information with Kubernetes resources.