### PR TITLE
process.GetPodInfo: Don't return Cilium endpoint

### DIFF
--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -173,7 +173,7 @@ func (msg *MsgExecveEventUnix) Retry(internal *process.ProcessInternal, ev notif
 	nspid := msg.Process.NSPID
 
 	if option.Config.EnableK8s && containerId != "" {
-		podInfo, _ = process.GetPodInfo(containerId, filename, args, nspid)
+		podInfo = process.GetPodInfo(containerId, filename, args, nspid)
 		if podInfo == nil {
 			errormetrics.ErrorTotalInc(errormetrics.EventCachePodInfoRetryFailed)
 			return eventcache.ErrFailedToGetPodInfo

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -59,10 +59,9 @@ func TestProcessManager_getPodInfo(t *testing.T) {
 	err = process.InitCache(watcher.NewFakeK8sWatcher(pods), 10)
 	assert.NoError(t, err)
 	defer process.FreeCache()
-	pod, endpoint := process.GetPodInfo("container-id-not-found", "", "", 0)
+	pod := process.GetPodInfo("container-id-not-found", "", "", 0)
 	assert.Nil(t, pod)
-	assert.Nil(t, endpoint)
-	pod, endpoint = process.GetPodInfo("aaaaaaa", "", "", 1234)
+	pod = process.GetPodInfo("aaaaaaa", "", "", 1234)
 	assert.Equal(t,
 		&tetragon.Pod{
 			Namespace: podA.Namespace,
@@ -81,7 +80,6 @@ func TestProcessManager_getPodInfo(t *testing.T) {
 				Pid: &wrapperspb.UInt32Value{Value: 1234},
 			},
 		}, pod)
-	assert.Nil(t, endpoint)
 }
 
 func TestProcessManager_getPodInfoMaybeExecProbe(t *testing.T) {
@@ -119,7 +117,7 @@ func TestProcessManager_getPodInfoMaybeExecProbe(t *testing.T) {
 	err = process.InitCache(watcher.NewFakeK8sWatcher(pods), 10)
 	assert.NoError(t, err)
 	defer process.FreeCache()
-	pod, endpoint := process.GetPodInfo("aaaaaaa", "/bin/command", "arg-a arg-b", 1234)
+	pod := process.GetPodInfo("aaaaaaa", "/bin/command", "arg-a arg-b", 1234)
 	assert.Equal(t,
 		&tetragon.Pod{
 			Namespace: podA.Namespace,
@@ -132,7 +130,6 @@ func TestProcessManager_getPodInfoMaybeExecProbe(t *testing.T) {
 				MaybeExecProbe: true,
 			},
 		}, pod)
-	assert.Nil(t, endpoint)
 }
 
 func TestProcessManager_GetProcessExec(t *testing.T) {

--- a/pkg/process/podinfo.go
+++ b/pkg/process/podinfo.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cilium/tetragon/pkg/filters"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
-	hubblev1 "github.com/cilium/tetragon/pkg/oldhubble/api/v1"
 	"github.com/cilium/tetragon/pkg/watcher"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -39,15 +38,15 @@ func getPodInfo(
 	binary string,
 	args string,
 	nspid uint32,
-) (*tetragon.Pod, *hubblev1.Endpoint) {
+) *tetragon.Pod {
 	if containerID == "" {
-		return nil, nil
+		return nil
 	}
 	pod, container, ok := w.FindContainer(containerID)
 	if !ok {
 		watchermetrics.GetWatcherErrors("k8s", watchermetrics.FailedToGetPodError).Inc()
 		logger.GetLogger().WithField("container id", containerID).Trace("failed to get pod")
-		return nil, nil
+		return nil
 	}
 	var startTime *timestamppb.Timestamp
 	livenessProbe, readinessProbe := getProbes(pod, container)
@@ -89,5 +88,5 @@ func getPodInfo(
 			StartTime:      startTime,
 			MaybeExecProbe: maybeExecProbe,
 		},
-	}, endpoint
+	}
 }

--- a/pkg/process/podinfo_test.go
+++ b/pkg/process/podinfo_test.go
@@ -46,7 +46,7 @@ func TestK8sWatcher_GetPodInfo(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset(&pod)
 	watcher := watcher.NewK8sWatcher(k8sClient, time.Hour)
 	pid := uint32(1)
-	podInfo, _ := getPodInfo(watcher, "abcd1234", "curl", "cilium.io", 1)
+	podInfo := getPodInfo(watcher, "abcd1234", "curl", "cilium.io", 1)
 	assert.True(t, proto.Equal(podInfo, &tetragon.Pod{
 		Namespace: pod.Namespace,
 		Name:      pod.Name,


### PR DESCRIPTION
The return value is always ignored, and it's only being used by unit tests.