### PR TITLE
cmd/tetra: retry failed gRPC connections with exponential backoff

### DIFF
--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -44,7 +43,7 @@ func CliRunErr(fn func(ctx context.Context, cli tetragon.FineGuidanceSensorsClie
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	connCtx, connCancel := context.WithTimeout(ctx, 10*time.Second)
+	connCtx, connCancel := context.WithTimeout(ctx, viper.GetDuration(KeyTimeout))
 	defer connCancel()
 
 	var conn *grpc.ClientConn

--- a/cmd/tetra/common/flags.go
+++ b/cmd/tetra/common/flags.go
@@ -9,4 +9,5 @@ const (
 	KeyOutput        = "output"         // string
 	KeyTty           = "tty-encode"     // string
 	KeyServerAddress = "server-address" // string
+	KeyTimeout       = "timeout"        // duration
 )

--- a/cmd/tetra/common/flags.go
+++ b/cmd/tetra/common/flags.go
@@ -10,4 +10,5 @@ const (
 	KeyTty           = "tty-encode"     // string
 	KeyServerAddress = "server-address" // string
 	KeyTimeout       = "timeout"        // duration
+	KeyRetries       = "retries"        // int
 )

--- a/cmd/tetra/main.go
+++ b/cmd/tetra/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/cilium/tetragon/cmd/tetra/common"
 	"github.com/cilium/tetragon/pkg/logger"
@@ -40,6 +41,7 @@ func New() *cobra.Command {
 	flags := rootCmd.PersistentFlags()
 	flags.BoolP(common.KeyDebug, "d", false, "Enable debug messages")
 	flags.String(common.KeyServerAddress, "localhost:54321", "gRPC server address")
+	flags.Duration(common.KeyTimeout, 10*time.Second, "Connection timeout")
 	viper.BindPFlags(flags)
 	return rootCmd
 }

--- a/cmd/tetra/main.go
+++ b/cmd/tetra/main.go
@@ -42,6 +42,7 @@ func New() *cobra.Command {
 	flags.BoolP(common.KeyDebug, "d", false, "Enable debug messages")
 	flags.String(common.KeyServerAddress, "localhost:54321", "gRPC server address")
 	flags.Duration(common.KeyTimeout, 10*time.Second, "Connection timeout")
+	flags.Int(common.KeyRetries, 0, "Connection retries with exponential backoff")
 	viper.BindPFlags(flags)
 	return rootCmd
 }


### PR DESCRIPTION
This PR adds two new command line options:

- `--timeout` allows the user to configure the desired gRPC connection timeout, instead of hard coding it at 10 seconds
- `--retries` sets the number of attempts we should make to connect to the gRPC server with exponential backoff 