### PR TITLE
tetragon: Add missing selectors newBinVals setup

### DIFF
--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -79,6 +79,7 @@ func (k *KernelSelectorState) AddBinaryName(selIdx int, binary string) {
 	defer binMu.Unlock()
 	idx, ok := binVals[binary]
 	if ok {
+		k.newBinVals[idx] = binary
 		k.matchBinaries[selIdx].selNamesMap[idx] = 1
 		return
 	}


### PR DESCRIPTION
We need to update theselector's newBinVals even in case the binary is in the global cache. The selector's newBinVals data is used to update the data in names_map map.