### PR TITLE
helm: update livenessProbe to retry 5 times before failing

### DIFF
--- a/install/kubernetes/templates/_container_tetragon.tpl
+++ b/install/kubernetes/templates/_container_tetragon.tpl
@@ -68,12 +68,15 @@
 {{- end }}
 {{- if .Values.tetragon.grpc.enabled }}
   livenessProbe:
+     timeoutSeconds: 60
      exec:
        command:
        - tetra
        - status
        - --server-address
        - {{ .Values.tetragon.grpc.address }}
+       - --retries
+       - "5"
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
We noticed issues in testing where gRPC queries would sometimes spuriously time out, causing our livenessProbe to fail and the Tetragon pod to restart. 7f2edda4 and 4f4feb8c introduced new configuration values in our CLI to allow it to re-attempt the connection in case of failure. Update our livenessProbe in helm to use these new configuration values so that we can re-attempt the connection.