### PR TITLE
Convert string and char_buf matches to hash look ups

### DIFF
--- a/bpf/process/string_maps.h
+++ b/bpf/process/string_maps.h
@@ -171,7 +171,7 @@ struct {
 #ifdef __LARGE_BPF_PROG
 #define STRING_POSTFIX_MAX_MATCH_LENGTH STRING_POSTFIX_MAX_LENGTH
 #else
-#define STRING_POSTFIX_MAX_MATCH_LENGTH 40
+#define STRING_POSTFIX_MAX_MATCH_LENGTH 96
 #endif
 
 struct string_postfix_lpm_trie {

--- a/bpf/process/string_maps.h
+++ b/bpf/process/string_maps.h
@@ -166,4 +166,38 @@ struct {
 	__uint(value_size, sizeof(struct string_prefix_lpm_trie));
 } string_prefix_maps_heap SEC(".maps");
 
+#define STRING_POSTFIX_MAX_LENGTH 128
+#define STRING_POSTFIX_MAX_MASK	  (STRING_POSTFIX_MAX_LENGTH - 1)
+#ifdef __LARGE_BPF_PROG
+#define STRING_POSTFIX_MAX_MATCH_LENGTH STRING_POSTFIX_MAX_LENGTH
+#else
+#define STRING_POSTFIX_MAX_MATCH_LENGTH 40
+#endif
+
+struct string_postfix_lpm_trie {
+	__u32 prefixlen;
+	__u8 data[STRING_POSTFIX_MAX_LENGTH];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+			__uint(max_entries, 1);
+			__type(key, __u8[sizeof(struct string_postfix_lpm_trie)]); // Need to specify as byte array as wouldn't take struct as key type
+			__type(value, __u8);
+			__uint(map_flags, BPF_F_NO_PREALLOC);
+		});
+} string_postfix_maps SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct string_postfix_lpm_trie));
+} string_postfix_maps_heap SEC(".maps");
+
 #endif // STRING_MAPS_H__

--- a/bpf/process/string_maps.h
+++ b/bpf/process/string_maps.h
@@ -138,4 +138,32 @@ struct {
 	__uint(value_size, 512);
 } string_maps_ro_zero SEC(".maps");
 
+#define STRING_PREFIX_MAX_LENGTH 128
+
+struct string_prefix_lpm_trie {
+	__u32 prefixlen;
+	__u8 data[STRING_PREFIX_MAX_LENGTH];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+			__uint(max_entries, 1);
+			__type(key, __u8[sizeof(struct string_prefix_lpm_trie)]); // Need to specify as byte array as wouldn't take struct as key type
+			__type(value, __u8);
+			__uint(map_flags, BPF_F_NO_PREALLOC);
+		});
+} string_prefix_maps SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct string_prefix_lpm_trie));
+} string_prefix_maps_heap SEC(".maps");
+
 #endif // STRING_MAPS_H__

--- a/bpf/process/string_maps.h
+++ b/bpf/process/string_maps.h
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright Authors of Cilium */
+
+#ifndef STRING_MAPS_H__
+#define STRING_MAPS_H__
+
+#define STRING_MAPS_OUTER_MAX_ENTRIES 8
+
+/*
+ * To facilitate an arbitrary number of strings that can be matched on, string matching
+ * uses a hash look up. The problem with this is that the key to a hash has to be a fixed
+ * size, so if the maximum string length is 128 bytes, then all stored strings will be
+ * 128 bytes long (padded with 0s) and the string to be looked up also has to be padded
+ * with 0s to 128 bytes. This means that a short string will be hashed as if it is 128
+ * bytes long.
+ *
+ * The BPF hash maps use jhash for key hashing. See include/linux/jhash.h. This requires
+ * approximately 1 CPU cycle per byte, so in the example above, hashing every string,
+ * regardless of length, will take ~128 cycles, which is clearly inefficient. See
+ * https://fosdem.org/2023/schedule/event/bpf_hashing/ for details.
+ *
+ * jhash hashes in 12 byte blocks (3 x u32). For all lengths >12, a number of 12 byte
+ * blocks are hashed, and the remainder is hashed using a combination of single byte
+ * loads/shifts, followed by a final mix. It appears that the most efficient use of
+ * jhash is with lengths equal to 12k + 1, minimising the number of single byte loads/
+ * shifts.
+ *
+ * In order to reduce the amount of hashing of padded 0s, we opt to store string matches
+ * in multiple hashes, with increasing key sizes, where the key size is one more than a
+ * multiple of 12. Each string to be stored is placed in the hash that has the smallest
+ * key size that can accommodate it (and is padded to the key size). Strings to be looked
+ * up are equally padded to the smallest key size that can accommodate them, and then
+ * looked up in the related map.
+ *
+ * The chosen key sizes are 25, 49, 73, 97, 121, 145 (6 maps).
+ *
+ * In order to distinguish between character buffers that end in 0s and similar buffers
+ * that are padded with 0s, each string will be prefixed by its length stored in a
+ * single byte.
+ */
+#define STRING_MAPS_KEY_INC_SIZE 24
+#define STRING_MAPS_SIZE_0	 1 * STRING_MAPS_KEY_INC_SIZE + 1
+#define STRING_MAPS_SIZE_1	 2 * STRING_MAPS_KEY_INC_SIZE + 1
+#define STRING_MAPS_SIZE_2	 3 * STRING_MAPS_KEY_INC_SIZE + 1
+#define STRING_MAPS_SIZE_3	 4 * STRING_MAPS_KEY_INC_SIZE + 1
+#define STRING_MAPS_SIZE_4	 5 * STRING_MAPS_KEY_INC_SIZE + 1
+#define STRING_MAPS_SIZE_5	 6 * STRING_MAPS_KEY_INC_SIZE + 1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_HASH);
+			__uint(max_entries, 1);
+			__type(key, __u8[STRING_MAPS_SIZE_0]);
+			__type(value, __u8);
+		});
+} string_maps_0 SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_HASH);
+			__uint(max_entries, 1);
+			__type(key, __u8[STRING_MAPS_SIZE_1]);
+			__type(value, __u8);
+		});
+} string_maps_1 SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_HASH);
+			__uint(max_entries, 1);
+			__type(key, __u8[STRING_MAPS_SIZE_2]);
+			__type(value, __u8);
+		});
+} string_maps_2 SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_HASH);
+			__uint(max_entries, 1);
+			__type(key, __u8[STRING_MAPS_SIZE_3]);
+			__type(value, __u8);
+		});
+} string_maps_3 SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_HASH);
+			__uint(max_entries, 1);
+			__type(key, __u8[STRING_MAPS_SIZE_4]);
+			__type(value, __u8);
+		});
+} string_maps_4 SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
+	__uint(key_size, sizeof(__u32));
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_HASH);
+			__uint(max_entries, 1);
+			__type(key, __u8[STRING_MAPS_SIZE_5]);
+			__type(value, __u8);
+		});
+} string_maps_5 SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, 512);
+} string_maps_heap SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, 512);
+} string_maps_ro_zero SEC(".maps");
+
+#endif // STRING_MAPS_H__

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -867,15 +867,24 @@ static inline __attribute__((always_inline)) bool is_not_operator(__u32 op)
 static inline __attribute__((always_inline)) long
 filter_file_buf(struct file_buf *filter, struct string_buf *args)
 {
-	char *values = (char *)filter + sizeof(struct file_buf); // all values are after the header
-	__u32 next, remain = filter->total_sz - sizeof(__u32) - sizeof(__u32);
-	long i, match;
+	long match;
 
 	/* There are cases where file pointer may not contain a path.
 	 * An example is using an unnamed pipe. This is not a match.
 	 */
 	if (args->len == 0)
 		return 0;
+
+	switch (filter->op) {
+	case op_filter_eq:
+	case op_filter_neq:
+		match = filter_char_buf_equal((struct selector_arg_filter *)filter, args->buf, args->len);
+		return is_not_operator(filter->op) ? !match : match;
+	}
+
+	char *values = (char *)filter + sizeof(struct file_buf); // all values are after the header
+	__u32 next, remain = filter->total_sz - sizeof(__u32) - sizeof(__u32);
+	long i;
 
 #ifndef __LARGE_BPF_PROG
 #pragma unroll

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -819,41 +819,6 @@ struct string_buf {
 	char buf[];
 };
 
-#define FILTER_FILE_MATCH   0
-#define FILTER_FILE_NOMATCH 1
-
-static inline __attribute__((always_inline)) long
-__filter_file_buf(struct string_buf *value, struct string_buf *args, __u32 op)
-{
-	__u32 v = value->len, a = args->len;
-	int err;
-
-	if (op == op_filter_eq || op == op_filter_neq) {
-		if (v != a)
-			goto skip_string;
-	} else if (op == op_filter_str_prefix || op == op_filter_str_notprefix) {
-		if (a < v)
-			goto skip_string;
-	} else if (op == op_filter_str_postfix || op == op_filter_str_notpostfix) {
-		err = rcmpbytes(value->buf, args->buf, v - 1, a - 1);
-		if (!err)
-			return FILTER_FILE_MATCH;
-		goto skip_string;
-	}
-	err = cmpbytes(value->buf, args->buf, v);
-	if (!err)
-		return FILTER_FILE_MATCH;
-skip_string:
-	return FILTER_FILE_NOMATCH;
-}
-
-struct file_buf {
-	__u32 index; // index of filter
-	__u32 op; // op_filter_eq, op_filter_str_prefix, or op_filter_str_postfix
-	__u32 total_sz; // size of all values (len + bytes) + sizeof(total_sz) + sizeof(type)
-	__u32 type; // path_ty, file_ty, or fd_ty
-};
-
 static inline __attribute__((always_inline)) bool is_not_operator(__u32 op)
 {
 	return (op == op_filter_neq || op == op_filter_str_notprefix || op == op_filter_str_notpostfix);
@@ -865,9 +830,9 @@ static inline __attribute__((always_inline)) bool is_not_operator(__u32 op)
  * a reverse search.
  */
 static inline __attribute__((always_inline)) long
-filter_file_buf(struct file_buf *filter, struct string_buf *args)
+filter_file_buf(struct selector_arg_filter *filter, struct string_buf *args)
 {
-	long match;
+	long match = 0;
 
 	/* There are cases where file pointer may not contain a path.
 	 * An example is using an unnamed pipe. This is not a match.
@@ -878,33 +843,19 @@ filter_file_buf(struct file_buf *filter, struct string_buf *args)
 	switch (filter->op) {
 	case op_filter_eq:
 	case op_filter_neq:
-		match = filter_char_buf_equal((struct selector_arg_filter *)filter, args->buf, args->len);
-		return is_not_operator(filter->op) ? !match : match;
+		match = filter_char_buf_equal(filter, args->buf, args->len);
+		break;
+	case op_filter_str_prefix:
+	case op_filter_str_notprefix:
+		match = filter_char_buf_prefix(filter, args->buf, args->len);
+		break;
+	case op_filter_str_postfix:
+	case op_filter_str_notpostfix:
+		match = filter_char_buf_postfix(filter, args->buf, args->len);
+		break;
 	}
 
-	char *values = (char *)filter + sizeof(struct file_buf); // all values are after the header
-	__u32 next, remain = filter->total_sz - sizeof(__u32) - sizeof(__u32);
-	long i;
-
-#ifndef __LARGE_BPF_PROG
-#pragma unroll
-#endif
-	for (i = 0; i < MAX_MATCH_FILE_VALUES; ++i) {
-		struct string_buf *value = (struct string_buf *)values;
-
-		match = __filter_file_buf(value, args, filter->op);
-		if (match == FILTER_FILE_MATCH)
-			return is_not_operator(filter->op) ? 0 : 1;
-
-		next = value->len + sizeof(struct string_buf);
-		remain -= next;
-		if (remain == 0)
-			goto done_filter_file;
-		values += (next & 0x7f);
-	}
-
-done_filter_file:
-	return is_not_operator(filter->op);
+	return is_not_operator(filter->op) ? !match : match;
 }
 
 struct ip_ver {
@@ -1561,7 +1512,7 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
 			args += 4;
 		case file_ty:
 		case path_ty:
-			pass &= filter_file_buf((struct file_buf *)filter, (struct string_buf *)args);
+			pass &= filter_file_buf(filter, (struct string_buf *)args);
 			break;
 		case string_type:
 			/* for strings, we just encode the length */

--- a/examples/tracingpolicy/hardlink-observe.yaml
+++ b/examples/tracingpolicy/hardlink-observe.yaml
@@ -22,4 +22,4 @@ spec:
       - index: 1
         operator: "Equal"
         values:
-        - "/etc/passwd\0"
+        - "/etc/passwd"

--- a/examples/tracingpolicy/hardlink-override.yaml
+++ b/examples/tracingpolicy/hardlink-override.yaml
@@ -22,7 +22,7 @@ spec:
       - index: 1
         operator: "Equal"
         values:
-        - "/etc/passwd\0"
+        - "/etc/passwd"
       matchActions:
       - action: Override
         argError: -1

--- a/examples/tracingpolicy/openat_write.yaml
+++ b/examples/tracingpolicy/openat_write.yaml
@@ -21,7 +21,7 @@ spec:
       - index: 1
         operator: "Equal"
         values:
-        - "/etc/passwd\0"
+        - "/etc/passwd"
       - index: 2
         operator: "Mask"
         values:

--- a/examples/tracingpolicy/symlink-observe.yaml
+++ b/examples/tracingpolicy/symlink-observe.yaml
@@ -18,4 +18,4 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - "/etc/passwd\0"
+        - "/etc/passwd"

--- a/examples/tracingpolicy/symlink-override.yaml
+++ b/examples/tracingpolicy/symlink-override.yaml
@@ -18,7 +18,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - "/etc/passwd\0"
+        - "/etc/passwd"
       matchActions:
       - action: Override
         argError: -1

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -692,17 +692,23 @@ func writeMatchValues(k *KernelSelectorState, values []string, ty, op uint32) er
 			if err != nil {
 				return fmt.Errorf("writeMatchStrings error: %w", err)
 			}
-			return nil
+		case SelectorOpPrefix, SelectorOpNotPrefix:
+			err := writePrefixStrings(k, values)
+			if err != nil {
+				return fmt.Errorf("writePrefixStrings error: %w", err)
+			}
+		case SelectorOpPostfix, SelectorOpNotPostfix:
+			err := writePostfixStrings(k, values, ty)
+			if err != nil {
+				return fmt.Errorf("writePostfixStrings error: %w", err)
+			}
 		}
+		return nil
 	}
 
 	for _, v := range values {
 		base := getBase(v)
 		switch ty {
-		case argTypeFd, argTypeFile, argTypePath:
-			value, size := ArgSelectorValue(v)
-			WriteSelectorUint32(k, size)
-			WriteSelectorByteArray(k, value, size)
 		case argTypeS32, argTypeInt, argTypeSizet:
 			i, err := strconv.ParseInt(v, base, 32)
 			if err != nil {

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -685,6 +685,15 @@ func writeMatchValues(k *KernelSelectorState, values []string, ty, op uint32) er
 			}
 		}
 		return nil
+	case argTypeFd, argTypeFile, argTypePath:
+		switch op {
+		case SelectorOpEQ, SelectorOpNEQ:
+			err := writeMatchStrings(k, values, ty)
+			if err != nil {
+				return fmt.Errorf("writeMatchStrings error: %w", err)
+			}
+			return nil
+		}
 	}
 
 	for _, v := range values {

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -225,13 +225,17 @@ func TestParseMatchArg(t *testing.T) {
 	expected1 := []byte{
 		0x01, 0x00, 0x00, 0x00, // Index == 1
 		0x03, 0x00, 0x00, 0x00, // operator == equal
-		18, 0x00, 0x00, 0x00, // length == 18
+		32, 0x00, 0x00, 0x00, // length == 32
 		0x06, 0x00, 0x00, 0x00, // value type == string
-		0x06, 0x00, 0x00, 0x00, // value length == 6
-		102, 111, 111, 98, 97, 114, // value ascii "foobar"
+		0x00, 0x00, 0x00, 0x00, // map ID for strings <25
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 25-48
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 49-72
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 73-96
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 97-120
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 121-144
 	}
 	if err := ParseMatchArg(k, arg1, sig); err != nil || bytes.Equal(expected1, k.e[0:k.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected1, k.e[0:k.off], arg1)
+		t.Errorf("parseMatchArg: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected1, k.e[0:k.off], arg1)
 	}
 
 	nextArg := k.off
@@ -304,9 +308,9 @@ func TestParseMatchArg(t *testing.T) {
 
 	if kernels.EnableLargeProgs() { // multiple match args are supported only in kernels >= 5.4
 		length := []byte{
-			74, 0x00, 0x00, 0x00,
+			88, 0x00, 0x00, 0x00,
 			24, 0x00, 0x00, 0x00,
-			50, 0x00, 0x00, 0x00,
+			64, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
@@ -316,7 +320,7 @@ func TestParseMatchArg(t *testing.T) {
 		arg12 := []v1alpha1.ArgSelector{*arg1, *arg2}
 		ks := &KernelSelectorState{off: 0}
 		if err := ParseMatchArgs(ks, arg12, sig); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
-			t.Errorf("parseMatchArgs: error %v expected %v bytes %v parsing %v\n", err, expected3, ks.e[0:k.off], arg3)
+			t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected3, ks.e[0:k.off], arg3)
 		}
 	}
 }
@@ -571,11 +575,11 @@ func TestInitKernelSelectors(t *testing.T) {
 	}
 
 	expected_selsize_small := []byte{
-		0xe6, 0x00, 0x00, 0x00, // size = pids + args + actions + namespaces + capabilities  + 4
+		0xf4, 0x00, 0x00, 0x00, // size = pids + args + actions + namespaces + capabilities  + 4
 	}
 
 	expected_selsize_large := []byte{
-		0x1a, 0x01, 0x00, 0x00, // size = pids + args + actions + namespaces + namespacesChanges + capabilities + capabilityChanges + 4
+		0x28, 0x01, 0x00, 0x00, // size = pids + args + actions + namespaces + namespacesChanges + capabilities + capabilityChanges + 4
 	}
 
 	expected_filters := []byte{
@@ -660,9 +664,9 @@ func TestInitKernelSelectors(t *testing.T) {
 
 	expected_last_large := []byte{
 		// arg header
-		74, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 4
+		88, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 4
 		24, 0x00, 0x00, 0x00, // arg[0] offset
-		50, 0x00, 0x00, 0x00, // arg[1] offset
+		64, 0x00, 0x00, 0x00, // arg[1] offset
 		0x00, 0x00, 0x00, 0x00, // arg[2] offset
 		0x00, 0x00, 0x00, 0x00, // arg[3] offset
 		0x00, 0x00, 0x00, 0x00, // arg[4] offset
@@ -670,10 +674,14 @@ func TestInitKernelSelectors(t *testing.T) {
 		//arg1 size = 26
 		0x01, 0x00, 0x00, 0x00, // Index == 1
 		0x03, 0x00, 0x00, 0x00, // operator == equal
-		18, 0x00, 0x00, 0x00, // length == 18
+		32, 0x00, 0x00, 0x00, // length == 32
 		0x06, 0x00, 0x00, 0x00, // value type == string
-		0x06, 0x00, 0x00, 0x00, // value length == 6
-		102, 111, 111, 98, 97, 114, // value ascii "foobar"
+		0x00, 0x00, 0x00, 0x00, // map ID for strings <25
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 25-48
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 49-72
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 73-96
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 97-120
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 121-144
 
 		//arg2 size = 24
 		0x02, 0x00, 0x00, 0x00, // Index == 2
@@ -694,7 +702,7 @@ func TestInitKernelSelectors(t *testing.T) {
 
 	expected_last_small := []byte{
 		// arg header
-		50, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 4
+		64, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 4
 		24, 0x00, 0x00, 0x00, // arg[0] offset
 		0x00, 0x00, 0x00, 0x00, // arg[1] offset
 		0x00, 0x00, 0x00, 0x00, // arg[2] offset
@@ -704,10 +712,14 @@ func TestInitKernelSelectors(t *testing.T) {
 		//arg1 size = 26
 		0x01, 0x00, 0x00, 0x00, // Index == 1
 		0x03, 0x00, 0x00, 0x00, // operator == equal
-		18, 0x00, 0x00, 0x00, // length == 18
+		32, 0x00, 0x00, 0x00, // length == 32
 		0x06, 0x00, 0x00, 0x00, // value type == string
-		0x06, 0x00, 0x00, 0x00, // value length == 6
-		102, 111, 111, 98, 97, 114, // value ascii "foobar"
+		0x00, 0x00, 0x00, 0x00, // map ID for strings <25
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 25-48
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 49-72
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 73-96
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 97-120
+		0xff, 0xff, 0xff, 0xff, // map ID for strings 121-144
 
 		// actions header
 		24, 0x00, 0x00, 0x00, // size = (2 * sizeof(uint32) * number of actions) + args + 4

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -27,14 +27,14 @@ func (k *MatchBinariesMappings) GetBinSelNamesMap() map[uint32]uint32 {
 	return k.selNamesMap
 }
 
-type KernelLpmTrie4 struct {
-	prefix uint32
-	addr   uint32
+type KernelLPMTrie4 struct {
+	prefixLen uint32
+	addr      uint32
 }
 
-type KernelLpmTrie6 struct {
-	prefix uint32
-	addr   [16]byte
+type KernelLPMTrie6 struct {
+	prefixLen uint32
+	addr      [16]byte
 }
 
 type ValueMap struct {
@@ -46,9 +46,10 @@ type ValueReader interface {
 }
 
 const (
-	stringMapsKeyIncSize = 24
-	StringMapsNumSubMaps = 6
-	MaxStringMapsSize    = 6*stringMapsKeyIncSize + 1
+	stringMapsKeyIncSize  = 24
+	StringMapsNumSubMaps  = 6
+	MaxStringMapsSize     = 6*stringMapsKeyIncSize + 1
+	StringPrefixMaxLength = 128
 )
 
 var (
@@ -63,6 +64,11 @@ var (
 type StringMapLists [StringMapsNumSubMaps][]map[[MaxStringMapsSize]byte]struct{}
 type SelectorStringMaps [StringMapsNumSubMaps]map[[MaxStringMapsSize]byte]struct{}
 
+type KernelLPMTrieStringPrefix struct {
+	prefixLen uint32
+	data      [StringPrefixMaxLength]byte
+}
+
 type KernelSelectorState struct {
 	off uint32     // offset into encoding
 	e   [4096]byte // kernel encoding of selectors
@@ -71,10 +77,10 @@ type KernelSelectorState struct {
 	valueMaps []ValueMap
 
 	// addr4Maps are used to populate IPv4 address LpmTrie maps for sock and skb operators
-	addr4Maps []map[KernelLpmTrie4]struct{}
+	addr4Maps []map[KernelLPMTrie4]struct{}
 
 	// addr6Maps are used to populate IPv6 address LpmTrie maps for sock and skb operators
-	addr6Maps []map[KernelLpmTrie6]struct{}
+	addr6Maps []map[KernelLPMTrie6]struct{}
 
 	matchBinaries map[int]*MatchBinariesMappings // matchBinaries mappings (one per selector)
 	newBinVals    map[uint32]string              // these should be added in the names_map
@@ -82,6 +88,9 @@ type KernelSelectorState struct {
 	listReader ValueReader
 	// stringMaps are used to populate string and char buf matches
 	stringMaps StringMapLists
+
+	// stringPrefixMaps are used to populate string and char buf prefix matches
+	stringPrefixMaps []map[KernelLPMTrieStringPrefix]struct{}
 }
 
 func NewKernelSelectorState(listReader ValueReader) *KernelSelectorState {
@@ -138,16 +147,20 @@ func (k *KernelSelectorState) ValueMaps() []ValueMap {
 	return k.valueMaps
 }
 
-func (k *KernelSelectorState) Addr4Maps() []map[KernelLpmTrie4]struct{} {
+func (k *KernelSelectorState) Addr4Maps() []map[KernelLPMTrie4]struct{} {
 	return k.addr4Maps
 }
 
-func (k *KernelSelectorState) Addr6Maps() []map[KernelLpmTrie6]struct{} {
+func (k *KernelSelectorState) Addr6Maps() []map[KernelLPMTrie6]struct{} {
 	return k.addr6Maps
 }
 
 func (k *KernelSelectorState) StringMaps(subMap int) []map[[MaxStringMapsSize]byte]struct{} {
 	return k.stringMaps[subMap]
+}
+
+func (k *KernelSelectorState) StringPrefixMaps() []map[KernelLPMTrieStringPrefix]struct{} {
+	return k.stringPrefixMaps
 }
 
 // ValueMapsMaxEntries returns the maximum entries over all maps
@@ -187,6 +200,17 @@ func (k *KernelSelectorState) Addr6MapsMaxEntries() int {
 func (k *KernelSelectorState) StringMapsMaxEntries(subMap int) int {
 	maxEntries := 1
 	for _, vm := range k.stringMaps[subMap] {
+		if l := len(vm); l > maxEntries {
+			maxEntries = l
+		}
+	}
+	return maxEntries
+}
+
+// StringPrefixMapsMaxEntries returns the maximum entries over all maps
+func (k *KernelSelectorState) StringPrefixMapsMaxEntries() int {
+	maxEntries := 1
+	for _, vm := range k.stringPrefixMaps {
 		if l := len(vm); l > maxEntries {
 			maxEntries = l
 		}
@@ -282,21 +306,21 @@ func (k *KernelSelectorState) newValueMap() (uint32, ValueMap) {
 	return uint32(mapid), k.valueMaps[mapid]
 }
 
-func (k *KernelSelectorState) createAddr4Map() map[KernelLpmTrie4]struct{} {
-	return map[KernelLpmTrie4]struct{}{}
+func (k *KernelSelectorState) createAddr4Map() map[KernelLPMTrie4]struct{} {
+	return map[KernelLPMTrie4]struct{}{}
 }
 
-func (k *KernelSelectorState) insertAddr4Map(addr4map map[KernelLpmTrie4]struct{}) uint32 {
+func (k *KernelSelectorState) insertAddr4Map(addr4map map[KernelLPMTrie4]struct{}) uint32 {
 	mapid := len(k.addr4Maps)
 	k.addr4Maps = append(k.addr4Maps, addr4map)
 	return uint32(mapid)
 }
 
-func (k *KernelSelectorState) createAddr6Map() map[KernelLpmTrie6]struct{} {
-	return map[KernelLpmTrie6]struct{}{}
+func (k *KernelSelectorState) createAddr6Map() map[KernelLPMTrie6]struct{} {
+	return map[KernelLPMTrie6]struct{}{}
 }
 
-func (k *KernelSelectorState) insertAddr6Map(addr6map map[KernelLpmTrie6]struct{}) uint32 {
+func (k *KernelSelectorState) insertAddr6Map(addr6map map[KernelLPMTrie6]struct{}) uint32 {
 	mapid := len(k.addr6Maps)
 	k.addr6Maps = append(k.addr6Maps, addr6map)
 	return uint32(mapid)
@@ -352,4 +376,10 @@ func (k *KernelSelectorState) insertStringMaps(stringMaps SelectorStringMaps) [S
 	}
 
 	return details
+}
+
+func (k *KernelSelectorState) newStringPrefixMap() (uint32, map[KernelLPMTrieStringPrefix]struct{}) {
+	mapid := len(k.stringPrefixMaps)
+	k.stringPrefixMaps = append(k.stringPrefixMaps, map[KernelLPMTrieStringPrefix]struct{}{})
+	return uint32(mapid), k.stringPrefixMaps[mapid]
 }

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -46,10 +46,11 @@ type ValueReader interface {
 }
 
 const (
-	stringMapsKeyIncSize  = 24
-	StringMapsNumSubMaps  = 6
-	MaxStringMapsSize     = 6*stringMapsKeyIncSize + 1
-	StringPrefixMaxLength = 128
+	stringMapsKeyIncSize   = 24
+	StringMapsNumSubMaps   = 6
+	MaxStringMapsSize      = 6*stringMapsKeyIncSize + 1
+	StringPrefixMaxLength  = 128
+	StringPostfixMaxLength = 128
 )
 
 var (
@@ -67,6 +68,11 @@ type SelectorStringMaps [StringMapsNumSubMaps]map[[MaxStringMapsSize]byte]struct
 type KernelLPMTrieStringPrefix struct {
 	prefixLen uint32
 	data      [StringPrefixMaxLength]byte
+}
+
+type KernelLPMTrieStringPostfix struct {
+	prefixLen uint32
+	data      [StringPostfixMaxLength]byte
 }
 
 type KernelSelectorState struct {
@@ -91,6 +97,8 @@ type KernelSelectorState struct {
 
 	// stringPrefixMaps are used to populate string and char buf prefix matches
 	stringPrefixMaps []map[KernelLPMTrieStringPrefix]struct{}
+	// stringPostfixMaps are used to populate string and char buf postfix matches
+	stringPostfixMaps []map[KernelLPMTrieStringPostfix]struct{}
 }
 
 func NewKernelSelectorState(listReader ValueReader) *KernelSelectorState {
@@ -163,6 +171,10 @@ func (k *KernelSelectorState) StringPrefixMaps() []map[KernelLPMTrieStringPrefix
 	return k.stringPrefixMaps
 }
 
+func (k *KernelSelectorState) StringPostfixMaps() []map[KernelLPMTrieStringPostfix]struct{} {
+	return k.stringPostfixMaps
+}
+
 // ValueMapsMaxEntries returns the maximum entries over all maps
 func (k *KernelSelectorState) ValueMapsMaxEntries() int {
 	maxEntries := 1
@@ -211,6 +223,17 @@ func (k *KernelSelectorState) StringMapsMaxEntries(subMap int) int {
 func (k *KernelSelectorState) StringPrefixMapsMaxEntries() int {
 	maxEntries := 1
 	for _, vm := range k.stringPrefixMaps {
+		if l := len(vm); l > maxEntries {
+			maxEntries = l
+		}
+	}
+	return maxEntries
+}
+
+// StringPostfixMapsMaxEntries returns the maximum entries over all maps
+func (k *KernelSelectorState) StringPostfixMapsMaxEntries() int {
+	maxEntries := 1
+	for _, vm := range k.stringPostfixMaps {
 		if l := len(vm); l > maxEntries {
 			maxEntries = l
 		}
@@ -298,6 +321,17 @@ func ArgStringSelectorValue(v string, removeNul bool) ([MaxStringMapsSize]byte, 
 	return ret, paddedLen + 1, nil
 }
 
+func ArgPostfixSelectorValue(v string, removeNul bool) ([]byte, uint32) {
+	if removeNul {
+		// Remove any trailing nul characters ("\0" or 0x00)
+		for v[len(v)-1] == 0 {
+			v = v[0 : len(v)-1]
+		}
+	}
+	b := []byte(v)
+	return b, uint32(len(b))
+}
+
 func (k *KernelSelectorState) newValueMap() (uint32, ValueMap) {
 	mapid := len(k.valueMaps)
 	vm := ValueMap{}
@@ -382,4 +416,10 @@ func (k *KernelSelectorState) newStringPrefixMap() (uint32, map[KernelLPMTrieStr
 	mapid := len(k.stringPrefixMaps)
 	k.stringPrefixMaps = append(k.stringPrefixMaps, map[KernelLPMTrieStringPrefix]struct{}{})
 	return uint32(mapid), k.stringPrefixMaps[mapid]
+}
+
+func (k *KernelSelectorState) newStringPostfixMap() (uint32, map[KernelLPMTrieStringPostfix]struct{}) {
+	mapid := len(k.stringPostfixMaps)
+	k.stringPostfixMaps = append(k.stringPostfixMaps, map[KernelLPMTrieStringPostfix]struct{}{})
+	return uint32(mapid), k.stringPostfixMaps[mapid]
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -251,6 +251,11 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 		maps = append(maps, stringFilterMap[string_map_index])
 	}
 
+	stringPrefixFilterMaps := program.MapBuilderPin("string_prefix_maps", sensors.PathJoin(pinPath, "string_prefix_maps"), load)
+	// NB: code depends on multi kprobe links which was merged in 5.17, so the expectation is
+	// that we do not need to SetInnerMaxEntries() here.
+	maps = append(maps, stringPrefixFilterMaps)
+
 	retProbe := program.MapBuilderPin("retprobe_map", sensors.PathJoin(pinPath, "retprobe_map"), load)
 	maps = append(maps, retProbe)
 
@@ -770,6 +775,15 @@ func addKprobe(funcName string, f *v1alpha1.KProbeSpec, in *addKprobeIn) (out *a
 		}
 		out.maps = append(out.maps, stringFilterMap[string_map_index])
 	}
+
+	stringPrefixFilterMaps := program.MapBuilderPin("string_prefix_maps", sensors.PathJoin(pinPath, "string_prefix_maps"), load)
+	if !kernels.MinKernelVersion("5.9") {
+		// Versions before 5.9 do not allow inner maps to have different sizes.
+		// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+		maxEntries := kprobeEntry.loadArgs.selectors.StringPrefixMapsMaxEntries()
+		stringPrefixFilterMaps.SetInnerMaxEntries(maxEntries)
+	}
+	out.maps = append(out.maps, stringPrefixFilterMaps)
 
 	retProbe := program.MapBuilderPin("retprobe_map", sensors.PathJoin(pinPath, "retprobe_map"), load)
 	out.maps = append(out.maps, retProbe)

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -440,6 +440,15 @@ func createGenericTracepointSensor(
 			maps = append(maps, stringFilterMap)
 		}
 
+		stringPrefixFilterMaps := program.MapBuilderPin("string_prefix_maps", sensors.PathJoin(pinPath, "string_prefix_maps"), prog0)
+		if !kernels.MinKernelVersion("5.9") {
+			// Versions before 5.9 do not allow inner maps to have different sizes.
+			// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+			maxEntries := tp.selectors.StringPrefixMapsMaxEntries()
+			stringPrefixFilterMaps.SetInnerMaxEntries(maxEntries)
+		}
+		maps = append(maps, stringPrefixFilterMaps)
+
 		selNamesMap := program.MapBuilderPin("sel_names_map", sensors.PathJoin(pinPath, "sel_names_map"), prog0)
 		maps = append(maps, selNamesMap)
 	}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -449,6 +449,15 @@ func createGenericTracepointSensor(
 		}
 		maps = append(maps, stringPrefixFilterMaps)
 
+		stringPostfixFilterMaps := program.MapBuilderPin("string_postfix_maps", sensors.PathJoin(pinPath, "string_postfix_maps"), prog0)
+		if !kernels.MinKernelVersion("5.9") {
+			// Versions before 5.9 do not allow inner maps to have different sizes.
+			// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+			maxEntries := tp.selectors.StringPostfixMapsMaxEntries()
+			stringPostfixFilterMaps.SetInnerMaxEntries(maxEntries)
+		}
+		maps = append(maps, stringPostfixFilterMaps)
+
 		selNamesMap := program.MapBuilderPin("sel_names_map", sensors.PathJoin(pinPath, "sel_names_map"), prog0)
 		maps = append(maps, selNamesMap)
 	}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -428,6 +428,18 @@ func createGenericTracepointSensor(
 		}
 		maps = append(maps, addr6FilterMaps)
 
+		for string_map_index := 0; string_map_index < selectors.StringMapsNumSubMaps; string_map_index++ {
+			stringFilterMap := program.MapBuilderPin(fmt.Sprintf("string_maps_%d", string_map_index),
+				sensors.PathJoin(pinPath, fmt.Sprintf("string_maps_%d", string_map_index)), prog0)
+			if !kernels.MinKernelVersion("5.9") {
+				// Versions before 5.9 do not allow inner maps to have different sizes.
+				// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+				maxEntries := tp.selectors.StringMapsMaxEntries(string_map_index)
+				stringFilterMap.SetInnerMaxEntries(maxEntries)
+			}
+			maps = append(maps, stringFilterMap)
+		}
+
 		selNamesMap := program.MapBuilderPin("sel_names_map", sensors.PathJoin(pinPath, "sel_names_map"), prog0)
 		maps = append(maps, selNamesMap)
 	}

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -1969,7 +1969,10 @@ func TestMultipleMountPath(t *testing.T) {
 
 func TestMultipleMountPathFiltered(t *testing.T) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
-	readHook := testKprobeObjectFileWriteFilteredHook(pidStr, "/tmp2/tmp3/tmp4/tmp5/0/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16")
+	readHook := testKprobeObjectFileWriteFilteredHook(pidStr, "/7/8/9/10/11/12/13/14/15/16")
+	if kernels.EnableLargeProgs() {
+		readHook = testKprobeObjectFileWriteFilteredHook(pidStr, "/tmp2/tmp3/tmp4/tmp5/0/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16")
+	}
 	testMultipleMountPathFiltered(t, readHook)
 }
 

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -1155,7 +1155,17 @@ spec:
 	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770)
 }
 
-func TestKprobeObjectPostfixOpen(t *testing.T) {
+// String matches should not require the '\0' null character on the end.
+// Any '\0' null characters should be handled gracefully.
+// Test with and without the null character.
+func testKprobeObjectPostfixOpenFileName(withNull bool) string {
+	if withNull {
+		return `testfile\0`
+	}
+	return `testfile`
+}
+
+func testKprobeObjectPostfixOpen(t *testing.T, withNull bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := `
@@ -1184,9 +1194,17 @@ spec:
       - index: 1
         operator: "Postfix"
         values:
-        - "testfile\0"
+        - "` + testKprobeObjectPostfixOpenFileName(withNull) + `"
 `
 	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
+}
+
+func TestKprobeObjectPostfixOpen(t *testing.T) {
+	testKprobeObjectPostfixOpen(t, false)
+}
+
+func TestKprobeObjectPostfixOpenWithNull(t *testing.T) {
+	testKprobeObjectPostfixOpen(t, true)
 }
 
 func testKprobeObjectFilterModeOpenHook(pidStr string, mode int, valueFmt string) string {

--- a/pkg/sensors/tracing/selectors.go
+++ b/pkg/sensors/tracing/selectors.go
@@ -83,6 +83,12 @@ func selectorsMaploads(ks *selectors.KernelSelectorState, pinPathPrefix string, 
 			Load: func(outerMap *ebpf.Map, index uint32) error {
 				return populateStringFilterMaps(ks, pinPathPrefix, outerMap, 5)
 			},
+		}, {
+			Index: 0,
+			Name:  "string_prefix_maps",
+			Load: func(outerMap *ebpf.Map, index uint32) error {
+				return populateStringPrefixFilterMaps(ks, pinPathPrefix, outerMap)
+			},
 		},
 	}
 }
@@ -171,7 +177,7 @@ func populateAddr4FilterMap(
 	pinPathPrefix string,
 	outerMap *ebpf.Map,
 	innerID uint32,
-	innerData map[selectors.KernelLpmTrie4]struct{},
+	innerData map[selectors.KernelLPMTrie4]struct{},
 	maxEntries uint32,
 ) error {
 	innerName := fmt.Sprintf("addr4filter_map_%d", innerID)
@@ -231,7 +237,7 @@ func populateAddr6FilterMap(
 	pinPathPrefix string,
 	outerMap *ebpf.Map,
 	innerID uint32,
-	innerData map[selectors.KernelLpmTrie6]struct{},
+	innerData map[selectors.KernelLPMTrie6]struct{},
 	maxEntries uint32,
 ) error {
 	innerName := fmt.Sprintf("addr6filter_map_%d", innerID)
@@ -365,5 +371,65 @@ func populateBinariesMaps(
 			return fmt.Errorf("failed to insert %s: %w", innerName, err)
 		}
 	}
+	return nil
+}
+
+func populateStringPrefixFilterMaps(
+	k *selectors.KernelSelectorState,
+	pinPathPrefix string,
+	outerMap *ebpf.Map,
+) error {
+	maxEntries := k.StringPrefixMapsMaxEntries()
+	for i, am := range k.StringPrefixMaps() {
+		nrEntries := uint32(len(am))
+		// Versions before 5.9 do not allow inner maps to have different sizes.
+		// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
+		if !kernels.MinKernelVersion("5.9") {
+			nrEntries = uint32(maxEntries)
+		}
+		err := populateStringPrefixFilterMap(pinPathPrefix, outerMap, uint32(i), am, nrEntries)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func populateStringPrefixFilterMap(
+	pinPathPrefix string,
+	outerMap *ebpf.Map,
+	innerID uint32,
+	innerData map[selectors.KernelLPMTrieStringPrefix]struct{},
+	maxEntries uint32,
+) error {
+	innerName := fmt.Sprintf("string_prefix_map_%d", innerID)
+	innerSpec := &ebpf.MapSpec{
+		Name:       innerName,
+		Type:       ebpf.LPMTrie,
+		KeySize:    4 + selectors.StringPrefixMaxLength, // NB: KernelLpmTrieStringPrefix consists of 32bit prefix and 128 byte data
+		ValueSize:  uint32(1),
+		MaxEntries: maxEntries,
+		Flags:      bpf.BPF_F_NO_PREALLOC,
+	}
+	innerMap, err := ebpf.NewMapWithOptions(innerSpec, ebpf.MapOptions{
+		PinPath: sensors.PathJoin(pinPathPrefix, innerName),
+	})
+	if err != nil {
+		return fmt.Errorf("creating innerMap %s failed: %w", innerName, err)
+	}
+	defer innerMap.Close()
+
+	one := uint8(1)
+	for val := range innerData {
+		err := innerMap.Update(val, one, 0)
+		if err != nil {
+			return fmt.Errorf("failed to insert value into %s: %w", innerName, err)
+		}
+	}
+
+	if err := outerMap.Update(uint32(innerID), uint32(innerMap.FD()), 0); err != nil {
+		return fmt.Errorf("failed to insert %s: %w", innerName, err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Currently string, char buf, file, fd, and path matchers (equal, prefix, postfix, plus the 'not' equivalents for file, fd and path) are all written in BPF using loops to inspect (potentially) every character in the strings to be matched.

This series (see commits for details) converts all these matchers to hash map look ups, using a set of 6 hash maps of varying sizes for equal matches, and LPM TRIE maps for prefix and postfix look ups. In addition, the 'not' equivalents are implemented for string and char buf.

The default string lengths for the matches has been set at 128 bytes, but could be increased to an arbitrary size for equals, and up to 256 bytes for prefix and postfix. For small programs (<5.3), the postfix limit (which is bounded by a byte-by-byte reverse copy) has been raised from 40 chars to 96 chars. For large programs, the postfix limit is set at 128 chars (raised from 50 chars).