### PR TITLE
renovate: add release-note/dependency label to PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,8 +54,8 @@
     "enabled": true
   },
   "labels": [
-    "kind/enhancement",
-    "release-blocker"
+    "release-blocker",
+    "release-note/dependency"
   ],
   "schedule": [
     "on monday"


### PR DESCRIPTION
See https://github.com/cilium/tetragon/pull/1384#issuecomment-1704986391 and https://github.com/cilium/tetragon/pull/1384#issuecomment-1705460667.

Already created this label https://github.com/cilium/tetragon/labels/release-note%2Fdependency (but renovate creates if needed anyway).

Should this be plural `release-note/dependencies`?