### PR TITLE
observer_test_helper: make helpers generic over TB

### DIFF
--- a/pkg/testutils/logcapture.go
+++ b/pkg/testutils/logcapture.go
@@ -14,7 +14,7 @@ import (
 )
 
 type LogCapturer struct {
-	*testing.T
+	TB  testing.TB
 	Log *logrus.Logger
 }
 
@@ -22,19 +22,19 @@ func (tl LogCapturer) Write(p []byte) (n int, err error) {
 	// Since we are calling T.Log() here, we want to avoid appending multiple "\n", so
 	// trim whatever was added by the inner logger.
 	s := strings.TrimRight(string(p), "\n")
-	tl.T.Log(s)
+	tl.TB.Log(s)
 	return len(s), nil
 }
 
 // CaptureLog redirects logrus output to testing.Log
-func CaptureLog(t *testing.T, l *logrus.Logger) {
+func CaptureLog(tb testing.TB, l *logrus.Logger) {
 	lc := &LogCapturer{
-		T:   t,
+		TB:  tb,
 		Log: l,
 	}
 
 	origOut := logrus.StandardLogger().Out
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		l.SetOutput(origOut)
 	})
 


### PR DESCRIPTION
The testing package supports additional test types, such as fuzzing and bench testing. However, our existing observer test helpers were designed only to work with unit tests. To support additional test types, modify the observer test helpers to use the generic testing.TB interface instead of testing.T. This should facilitate writing fuzz tests and benchmarks for Tetragon in the future.