### PR TITLE
Modify Operator cluster role

### DIFF
--- a/install/kubernetes/templates/operator_clusterrolebinding.yaml
+++ b/install/kubernetes/templates/operator_clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Chart.Name }}-operator-role
+  name: {{ .Chart.Name }}-operator
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
this commit:
- changes the name of operator cluster role to match the name in cluster role binding.