### PR TITLE
CODEOWNERS: multiple fixes and move file in `.github`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,14 +2,17 @@
 * @cilium/tetragon
 
 # Request a review from William when codegen is edited
-cmd/protoc-gen-go-tetragon/ @willfindlay
+/cmd/protoc-gen-go-tetragon/ @willfindlay
 
 # Request a review from William when CI is edited
-.github/workflows/ @willfindlay
+/.github/workflows/ @willfindlay @cilium/tetragon
 
 # Request a review from kkourt when core sensor files are modified
-pkg/src/sensors/ @kkourt
+/pkg/src/sensors/ @kkourt
 
 # Request a review from mtardy when anything from docs is modified but do not
 # block on approval from anyone in the tetragon team
 /docs/ @mtardy @cilium/tetragon
+# Exclude some docs generated files from mtardy ownership
+/docs/content/en/docs/reference/grpc-api.md @cilium/tetragon
+/docs/content/en/docs/reference/helm-chart.md @cilium/tetragon


### PR DESCRIPTION
- Fix paths, indeed `path/` means that it will select `/path/` but also `/something/path/`. So I explicitely mentioned `/path/` for the entries.
- Exclude myself from some auto-generated docs files that are often modified.
- Add @cilium/tetragon owner to `/.github/workflows/` to ping William on workflow changes without blocking PRs.
- Move file into `/.github` since it's tied to GitHub and will reduce the amount of files in the root.

cc @willfindlay, tell me if you are satisfied with the changed I did to your line.