### PR TITLE
Revert "Update module github.com/pelletier/go-toml/v2 to v2.1.0"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
-	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.sum
+++ b/go.sum
@@ -646,8 +646,8 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
-github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
+github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
+github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
@@ -781,6 +781,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/vendor/github.com/pelletier/go-toml/v2/.goreleaser.yaml
+++ b/vendor/github.com/pelletier/go-toml/v2/.goreleaser.yaml
@@ -18,7 +18,6 @@ builds:
       - linux_amd64
       - linux_arm64
       - linux_arm
-      - linux_riscv64
       - windows_amd64
       - windows_arm64
       - windows_arm
@@ -38,7 +37,6 @@ builds:
       - linux_amd64
       - linux_arm64
       - linux_arm
-      - linux_riscv64
       - windows_amd64
       - windows_arm64
       - windows_arm
@@ -57,7 +55,6 @@ builds:
     targets:
       - linux_amd64
       - linux_arm64
-      - linux_riscv64
       - linux_arm
       - windows_amd64
       - windows_arm64

--- a/vendor/github.com/pelletier/go-toml/v2/LICENSE
+++ b/vendor/github.com/pelletier/go-toml/v2/LICENSE
@@ -1,7 +1,6 @@
 The MIT License (MIT)
 
-go-toml v2
-Copyright (c) 2021 - 2023 Thomas Pelletier
+Copyright (c) 2013 - 2022 Thomas Pelletier, Eric Anderton
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vendor/github.com/pelletier/go-toml/v2/README.md
+++ b/vendor/github.com/pelletier/go-toml/v2/README.md
@@ -45,15 +45,16 @@ to check for typos. [See example in the documentation][strict].
 
 ### Contextualized errors
 
-When most decoding errors occur, go-toml returns [`DecodeError`][decode-err],
+When most decoding errors occur, go-toml returns [`DecodeError`][decode-err]),
 which contains a human readable contextualized version of the error. For
 example:
 
 ```
-1| [server]
-2| path = 100
- |        ~~~ cannot decode TOML integer into struct field toml_test.Server.Path of type string
-3| port = 50
+2| key1 = "value1"
+3| key2 = "missing2"
+ | ~~~~ missing field
+4| key3 = "missing3"
+5| key4 = "value4"
 ```
 
 [decode-err]: https://pkg.go.dev/github.com/pelletier/go-toml/v2#DecodeError
@@ -71,26 +72,6 @@ representation.
 [tld]: https://pkg.go.dev/github.com/pelletier/go-toml/v2#LocalDate
 [tlt]: https://pkg.go.dev/github.com/pelletier/go-toml/v2#LocalTime
 [tldt]: https://pkg.go.dev/github.com/pelletier/go-toml/v2#LocalDateTime
-
-### Commented config
-
-Since TOML is often used for configuration files, go-toml can emit documents
-annotated with [comments and commented-out values][comments-example]. For
-example, it can generate the following file:
-
-```toml
-# Host IP to connect to.
-host = '127.0.0.1'
-# Port of the remote server.
-port = 4242
-
-# Encryption parameters (optional)
-# [TLS]
-# cipher = 'AEAD-AES128-GCM-SHA256'
-# version = 'TLS 1.3'
-```
-
-[comments-example]: https://pkg.go.dev/github.com/pelletier/go-toml/v2#example-Marshal-Commented
 
 ## Getting started
 
@@ -516,19 +497,26 @@ is not necessary anymore.
 
 V1 used to provide multiple struct tags: `comment`, `commented`, `multiline`,
 `toml`, and `omitempty`. To behave more like the standard library, v2 has merged
-`toml`, `multiline`, `commented`, and `omitempty`. For example:
+`toml`, `multiline`, and `omitempty`. For example:
 
 ```go
 type doc struct {
 	// v1
-	F string `toml:"field" multiline:"true" omitempty:"true" commented:"true"`
+	F string `toml:"field" multiline:"true" omitempty:"true"`
 	// v2
-	F string `toml:"field,multiline,omitempty,commented"`
+	F string `toml:"field,multiline,omitempty"`
 }
 ```
 
 Has a result, the `Encoder.SetTag*` methods have been removed, as there is just
 one tag now.
+
+
+#### `commented` tag has been removed
+
+There is no replacement for the `commented` tag. This feature would be better
+suited in a proper document model for go-toml v2, which has been [cut from
+scope][nodoc] at the moment.
 
 #### `Encoder.ArraysWithOneElementPerLine` has been renamed
 

--- a/vendor/github.com/pelletier/go-toml/v2/ci.sh
+++ b/vendor/github.com/pelletier/go-toml/v2/ci.sh
@@ -79,7 +79,6 @@ cover() {
     go test -covermode=atomic  -coverpkg=./... -coverprofile=coverage.out.tmp ./...
     cat coverage.out.tmp | grep -v fuzz | grep -v testsuite | grep -v tomltestgen | grep -v gotoml-test-decoder > coverage.out
     go tool cover -func=coverage.out
-    echo "Coverage profile for ${branch}: ${dir}/coverage.out" >&2
     popd
 
     if [ "${branch}" != "HEAD" ]; then

--- a/vendor/github.com/pelletier/go-toml/v2/decode.go
+++ b/vendor/github.com/pelletier/go-toml/v2/decode.go
@@ -318,7 +318,7 @@ func parseFloat(b []byte) (float64, error) {
 	if cleaned[0] == '+' || cleaned[0] == '-' {
 		start = 1
 	}
-	if cleaned[start] == '0' && len(cleaned) > start+1 && isDigit(cleaned[start+1]) {
+	if cleaned[start] == '0' && isDigit(cleaned[start+1]) {
 		return 0, unstable.NewParserError(b, "float integer part cannot have leading zeroes")
 	}
 

--- a/vendor/github.com/pelletier/go-toml/v2/unstable/parser.go
+++ b/vendor/github.com/pelletier/go-toml/v2/unstable/parser.go
@@ -1013,7 +1013,6 @@ func (p *Parser) parseIntOrFloatOrDateTime(b []byte) (reference, []byte, error) 
 		return p.builder.Push(Node{
 			Kind: Float,
 			Data: b[:3],
-			Raw:  p.Range(b[:3]),
 		}), b[3:], nil
 	case 'n':
 		if !scanFollowsNan(b) {
@@ -1023,7 +1022,6 @@ func (p *Parser) parseIntOrFloatOrDateTime(b []byte) (reference, []byte, error) 
 		return p.builder.Push(Node{
 			Kind: Float,
 			Data: b[:3],
-			Raw:  p.Range(b[:3]),
 		}), b[3:], nil
 	case '+', '-':
 		return p.scanIntOrFloat(b)
@@ -1148,7 +1146,6 @@ func (p *Parser) scanIntOrFloat(b []byte) (reference, []byte, error) {
 		return p.builder.Push(Node{
 			Kind: Integer,
 			Data: b[:i],
-			Raw:  p.Range(b[:i]),
 		}), b[i:], nil
 	}
 
@@ -1172,7 +1169,6 @@ func (p *Parser) scanIntOrFloat(b []byte) (reference, []byte, error) {
 				return p.builder.Push(Node{
 					Kind: Float,
 					Data: b[:i+3],
-					Raw:  p.Range(b[:i+3]),
 				}), b[i+3:], nil
 			}
 
@@ -1184,7 +1180,6 @@ func (p *Parser) scanIntOrFloat(b []byte) (reference, []byte, error) {
 				return p.builder.Push(Node{
 					Kind: Float,
 					Data: b[:i+3],
-					Raw:  p.Range(b[:i+3]),
 				}), b[i+3:], nil
 			}
 
@@ -1207,7 +1202,6 @@ func (p *Parser) scanIntOrFloat(b []byte) (reference, []byte, error) {
 	return p.builder.Push(Node{
 		Kind: kind,
 		Data: b[:i],
-		Raw:  p.Range(b[:i]),
 	}), b[i:], nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -606,7 +606,7 @@ github.com/opentracing/opentracing-go/log
 # github.com/pelletier/go-toml v1.9.5
 ## explicit; go 1.12
 github.com/pelletier/go-toml
-# github.com/pelletier/go-toml/v2 v2.1.0
+# github.com/pelletier/go-toml/v2 v2.0.8
 ## explicit; go 1.16
 github.com/pelletier/go-toml/v2
 github.com/pelletier/go-toml/v2/internal/characters


### PR DESCRIPTION
This reverts commit 8d27aec379cabd2dc81c0ad21155bb7288fa7f66. This commit bumped the indirect dependency and not the direct project dependency.