### PR TITLE
docs: fix link in README and remove unreliable link to busybox

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ and generates events enriched with Linux and Kubernetes metadata:
    about these events on the [TracingPolicy concept page](https://tetragon.cilium.io/docs/concepts/tracing-policy/)
    and discover [multiple use cases](https://tetragon.cilium.io/docs/use-cases/) like:
    - [🌏 network observability](https://tetragon.cilium.io/docs/use-cases/network-observability/)
-   - [📂 file access](https://tetragon.cilium.io/docs/use-cases/file-access/)
+   - [📂 filename access](https://tetragon.cilium.io/docs/use-cases/filename-access/)
    - [🔑 credentials monitoring](https://tetragon.cilium.io/docs/use-cases/linux-process-credentials/)
    - [🔓 privileged execution](https://tetragon.cilium.io/docs/use-cases/process-lifecycle/privileged-execution/)
 

--- a/docs/content/en/docs/use-cases/process-lifecycle/advanced-process-execution.md
+++ b/docs/content/en/docs/use-cases/process-lifecycle/advanced-process-execution.md
@@ -157,7 +157,7 @@ events contain the binary being executed. In the above case they are:
 
 - `function_name`: where we are hooking into the kernel to read the binary that is being executed.
 - `file_arg`: that includes the `path` being executed, and here it is `/bin/busybox` that is the real
-   binary being executed, since on the `xwing` pod the container is running [busybox](https://busybox.net/).
+   binary being executed, since on the `xwing` pod the container is running busybox.
    The binary `/usr/bin/id -> /bin/busybox` points to busybox.
 
 


### PR DESCRIPTION
Extremely 😇 PR.

Busybox website has proven to be unreliable and has been generating noise on the link detector:
- https://github.com/cilium/tetragon/issues/1374
- https://github.com/cilium/tetragon/issues/1360
- https://github.com/cilium/tetragon/issues/1338