### PR TITLE
Small fixes in example tracing policies

### DIFF
--- a/examples/tracingpolicy/cves/cve-2023-2640-overlayfs-ubuntu.yaml
+++ b/examples/tracingpolicy/cves/cve-2023-2640-overlayfs-ubuntu.yaml
@@ -37,6 +37,7 @@ spec:
     - index: 0
       type: "string"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchNamespaces:

--- a/examples/tracingpolicy/datagram-with-selectors.yaml
+++ b/examples/tracingpolicy/datagram-with-selectors.yaml
@@ -25,4 +25,4 @@ spec:
           - "IPPROTO_UDP"
         matchActions:
         - action: Post
-          rateLimit: 5
+          rateLimit: "5"

--- a/examples/tracingpolicy/datagram-with-sock-tracking.yaml
+++ b/examples/tracingpolicy/datagram-with-sock-tracking.yaml
@@ -12,6 +12,7 @@ spec:
         type: int
         label: "family"
     returnArg:
+      index: 0
       type: sock
     returnArgAction: TrackSock
     selectors:
@@ -19,7 +20,7 @@ spec:
         - index: 1
           operator: "Equal"
           values:
-          - 2
+          - "2"
   - call: "__sk_free"
     syscall: false
     args:
@@ -51,4 +52,4 @@ spec:
           - "IPPROTO_UDP"
         matchActions:
         - action: Post
-          rateLimit: 5
+          rateLimit: "5"

--- a/examples/tracingpolicy/datagram_518.yaml
+++ b/examples/tracingpolicy/datagram_518.yaml
@@ -24,6 +24,7 @@ spec:
       - index: 1
         type: int
     returnArg:
+      index: 0
       type: sock
     returnArgAction: TrackSock
     selectors:
@@ -31,8 +32,8 @@ spec:
         - index: 1
           operator: "Equal"
           values:
-          - 2
-          - 10
+          - "2"
+          - "10"
   - call: "__sk_free"
     syscall: false
     args:
@@ -43,8 +44,8 @@ spec:
         - index: 0
           operator: "Family"
           values:
-          - 2
-          - 10
+          - "2"
+          - "10"
       - matchActions:
         - action: UntrackSock
   - call: "sk_filter_trim_cap"

--- a/examples/tracingpolicy/dns-only-specified-servers.yaml
+++ b/examples/tracingpolicy/dns-only-specified-servers.yaml
@@ -42,7 +42,7 @@ spec:
       - index: 2
         operator: "DPort"
         values:
-        - 53
+        - "53"
       - index: 2
         operator: "NotDAddr"
         values:

--- a/examples/tracingpolicy/openat_write.yaml
+++ b/examples/tracingpolicy/openat_write.yaml
@@ -15,6 +15,7 @@ spec:
     - index: 2
       type: "int"
     returnArg:
+      index: 0
       type: int
     selectors:
     - matchArgs:
@@ -25,11 +26,11 @@ spec:
       - index: 2
         operator: "Mask"
         values:
-        - 0x40 # CREATE
-        - 0x1  # WRONLY
-        - 0x2  # RDWR
+        - "64" # CREATE (0x40)
+        - "1"  # WRONLY (0x01)
+        - "2"  # RDWR (0x02)
       matchReturnArgs:
       - index: 0
         operator: "GT"
         values:
-        - 0
+        - "0"

--- a/examples/tracingpolicy/sys_write_sigkill.yaml
+++ b/examples/tracingpolicy/sys_write_sigkill.yaml
@@ -72,4 +72,4 @@ spec:
         values:
         - "/tmp/passwd"
       matchActions:
-      - action: SigKill
+      - action: Sigkill

--- a/examples/tracingpolicy/tcp-accept.yaml
+++ b/examples/tracingpolicy/tcp-accept.yaml
@@ -10,8 +10,9 @@ spec:
     args:
     - index: 1
       type: int
-      label: "family"
+      label: "Family"
     returnArg:
+      index: 0
       type: sock
     returnArgAction: TrackSock
     selectors:
@@ -19,7 +20,7 @@ spec:
       - index: 1
         operator: "Equal"
         values:
-        - 2
+        - "2"
   - call: "__sk_free"
     syscall: false
     args:
@@ -28,7 +29,7 @@ spec:
     selectors:
     - matchArgs:
       - index: 0
-        operator: "family"
+        operator: "Family"
         values:
         - "AF_INET"
     - matchActions:
@@ -45,13 +46,13 @@ spec:
     selectors:
     - matchArgs:
       - index: 0
-        operator: "state"
+        operator: "State"
         values:
         - "TCP_SYN_RECV"
       - index: 1
         operator: "Equal"
         values:
-        - 1
+        - "1"
   - call: "tcp_close"
     syscall: false
     args:
@@ -70,6 +71,7 @@ spec:
     - index: 0
       type: "sock"
     returnArg:
+      index: 0
       type: sock
     returnArgAction: TrackSock
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -303,6 +303,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -530,6 +532,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -823,6 +827,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1050,6 +1056,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1187,6 +1195,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1414,6 +1424,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -303,6 +303,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -530,6 +532,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -823,6 +827,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1050,6 +1056,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1187,6 +1195,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1414,6 +1424,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/register.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/register.go
@@ -15,7 +15,7 @@ const (
 	// Used to determine if CRD needs to be updated in cluster
 	//
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "0.12.2"
+	CustomResourceDefinitionSchemaVersion = "0.12.3"
 
 	CRDVersion = "v1alpha1"
 

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -175,7 +175,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;NotPrefix;Postfix;NotPostfix;GreaterThan;LessThan;GT;LT;Mask;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Family;State
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;NotPrefix;Postfix;NotPostfix;GreaterThan;LessThan;GT;LT;Mask;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Family;State;InMap;NotInMap
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -303,6 +303,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -530,6 +532,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -823,6 +827,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1050,6 +1056,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1187,6 +1195,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1414,6 +1424,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -303,6 +303,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -530,6 +532,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -823,6 +827,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1050,6 +1056,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1187,6 +1195,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1414,6 +1424,8 @@ spec:
                                   - Protocol
                                   - Family
                                   - State
+                                  - InMap
+                                  - NotInMap
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/register.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/register.go
@@ -15,7 +15,7 @@ const (
 	// Used to determine if CRD needs to be updated in cluster
 	//
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "0.12.2"
+	CustomResourceDefinitionSchemaVersion = "0.12.3"
 
 	CRDVersion = "v1alpha1"
 

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -175,7 +175,7 @@ type ArgSelector struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument to apply fhe filter to.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;NotPrefix;Postfix;NotPostfix;GreaterThan;LessThan;GT;LT;Mask;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Family;State
+	// +kubebuilder:validation:Enum=Equal;NotEqual;Prefix;NotPrefix;Postfix;NotPostfix;GreaterThan;LessThan;GT;LT;Mask;SPort;NotSPort;SPortPriv;NotSportPriv;DPort;NotDPort;DPortPriv;NotDPortPriv;SAddr;NotSAddr;DAddr;NotDAddr;Protocol;Family;State;InMap;NotInMap
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.


### PR DESCRIPTION
This PR fixes all example tracing in https://github.com/cilium/tetragon/tree/main/examples/tracingpolicy to load in k8s.