### PR TITLE
renovate: rename correctly the lvh image name in config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -275,18 +275,19 @@
     },
     {
       "matchDepNames": [
-        "quay.io/lvh-images/kind"
+        "quay.io/lvh-images/kernel-images"
       ],
       // LVH uses custom versioning for its images, need to match those kinds of tags:
       // - bpf-next-20230914.012459
       // - 5.15-20230912.232842
+      // - 5.19-20230912.232842@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
       "versioning": "regex:^((?<compatibility>[a-z-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
       "groupName": "all lvh-images main",
       "groupSlug": "all-lvh-images-main",
       "matchPackageNames": [
-        "quay.io/lvh-images/kind"
+        "quay.io/lvh-images/kernel-images"
       ],
       "matchUpdateTypes": [
         "digest",
@@ -300,7 +301,7 @@
       // do not allow any updates for major.minor for LVH, they will be done by maintainers
       "enabled": false,
       "matchPackageNames": [
-        "quay.io/lvh-images/kind"
+        "quay.io/lvh-images/kernel-images"
       ],
       "matchUpdateTypes": [
         "major",
@@ -390,7 +391,7 @@
         // # renovate: datasource=golang-version depName=go
         // go: '1.20.8'
         //
-        // # renovate: datasource=docker depName=quay.io/lvh-images/kind
+        // # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
         // - 'bpf-next-20230912.113936'
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+ ['\"]?(?<currentValue>[^'\"\\s]*)"
       ]


### PR DESCRIPTION
In the last patch, I changed the image name in the workflow comments but forgot to reflect that change in the config.