### PR TITLE
operator: Call crd.RegisterCRDs() from operator deployment

### DIFF
--- a/install/kubernetes/templates/operator_clusterrole.yaml
+++ b/install/kubernetes/templates/operator_clusterrole.yaml
@@ -26,4 +26,23 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    resourceNames:
+      - tracingpolicies.cilium.io
+      - tracingpoliciesnamespaced.cilium.io
+      - podinfo.cilium.io
+    verbs:
+      - update
+      - get
+      - list
+      - watch
 {{- end }}

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -22,7 +22,12 @@ spec:
           - /usr/bin/tetragon-operator
         args:
           - serve
+          - --config-dir=/etc/tetragon/operator.conf.d/
         image: "{{ if .Values.tetragonOperator.image.override }}{{ .Values.tetragonOperator.image.override }}{{ else }}{{ .Values.tetragonOperator.image.repository }}{{ .Values.tetragonOperator.image.suffix }}:{{ .Values.tetragonOperator.image.tag }}{{ end }}"
+        volumeMounts:
+          - mountPath: /etc/tetragon/operator.conf.d/
+            name: tetragon-operator-config
+            readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -49,4 +54,8 @@ spec:
             memory: 64Mi
       serviceAccountName: {{ .Release.Name }}-operator-service-account
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: tetragon-operator-config
+          configMap:
+            name: {{ .Release.Name }}-operator-config
 {{- end }}

--- a/operator/cmd/common/common.go
+++ b/operator/cmd/common/common.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package common
+
+import (
+	"os"
+
+	"github.com/cilium/tetragon/operator/crd"
+	operatorOption "github.com/cilium/tetragon/operator/option"
+	"github.com/cilium/tetragon/pkg/cmdref"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func AddCommonFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	flags.String(operatorOption.CMDRef, "", "Path to cmdref output directory")
+	flags.MarkHidden(operatorOption.CMDRef)
+	flags.Bool(operatorOption.SkipCRDCreation, false, "When true, Kubernetes Custom Resource Definitions (CRDs) will not be created")
+	flags.String(operatorOption.KubeCfgPath, "", "Kubeconfig filepath to connect to k8s")
+	flags.String(operatorOption.ConfigDir, "", "Directory in which tetragon-operator-config configmap is mounted")
+	flags.Bool(operatorOption.SkipPodInfoCRD, false, "When true, PodInfo Custom Resource Definition (CRD) will not be created")
+}
+
+func Initialize(cmd *cobra.Command) {
+	// Populate option.Config with options from CLI.
+	operatorOption.ConfigPopulate()
+	cmdRefDir := viper.GetString(operatorOption.CMDRef)
+	if cmdRefDir != "" {
+		cmdref.GenMarkdown(cmd, cmdRefDir)
+		os.Exit(0)
+	}
+	crd.RegisterCRDs()
+}

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -10,10 +10,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/tetragon/operator/cmd/common"
 	"github.com/cilium/tetragon/operator/cmd/serve"
-	"github.com/cilium/tetragon/operator/crd"
 	operatorOption "github.com/cilium/tetragon/operator/option"
-	"github.com/cilium/tetragon/pkg/cmdref"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -28,14 +27,7 @@ func New() *cobra.Command {
 		Use:   binaryName,
 		Short: "Run " + binaryName,
 		Run: func(cmd *cobra.Command, args []string) {
-			// Populate option.Config with options from CLI.
-			operatorOption.ConfigPopulate()
-			cmdRefDir := viper.GetString(operatorOption.CMDRef)
-			if cmdRefDir != "" {
-				cmdref.GenMarkdown(cmd, cmdRefDir)
-				os.Exit(0)
-			}
-			crd.RegisterCRDs()
+			common.Initialize(cmd)
 		},
 	}
 
@@ -55,21 +47,8 @@ func New() *cobra.Command {
 		}
 	})
 
-	flags := rootCmd.Flags()
-
-	flags.String(operatorOption.CMDRef, "", "Path to cmdref output directory")
-	flags.MarkHidden(operatorOption.CMDRef)
-
-	flags.Bool(operatorOption.SkipCRDCreation, false, "When true, Kubernetes Custom Resource Definitions (CRDs) will not be created")
-
-	flags.String(operatorOption.KubeCfgPath, "", "Kubeconfig filepath to connect to k8s")
-
-	flags.String(operatorOption.ConfigDir, "", "Directory in which tetragon-operator-config configmap is mounted")
-
-	flags.Bool(operatorOption.SkipPodInfoCRD, false, "When true, PodInfo Custom Resource Definition (CRD) will not be created")
-
-	viper.BindPFlags(flags)
-
+	common.AddCommonFlags(rootCmd)
+	viper.BindPFlags(rootCmd.Flags())
 	rootCmd.AddCommand(serve.New())
 	return rootCmd
 }

--- a/operator/cmd/serve/serve.go
+++ b/operator/cmd/serve/serve.go
@@ -9,10 +9,11 @@ import (
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-
+	"github.com/cilium/tetragon/operator/cmd/common"
 	"github.com/cilium/tetragon/operator/podinfo"
 	ciliumiov1alpha1 "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -40,6 +41,7 @@ func New() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			log := logrusr.New(logging.DefaultLogger.WithField(logfields.LogSubsys, "operator"))
 			ctrl.SetLogger(log)
+			common.Initialize(cmd)
 			mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 				Scheme:                 scheme,
 				MetricsBindAddress:     metricsAddr,
@@ -88,5 +90,7 @@ func New() *cobra.Command {
 	cmd.Flags().BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	common.AddCommonFlags(&cmd)
+	viper.BindPFlags(cmd.Flags())
 	return &cmd
 }


### PR DESCRIPTION
- Refactor the CRD registration logic to a separate common package so that both the root and serve commands can call it.
- Mount tetragon-operator-config configmap for the operator deployment.