### PR TITLE
bpf: add DEBUG() macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,11 @@ ifeq ($(TARGET_ARCH),arm64)
 endif
 BPF_TARGET_ARCH ?= x86
 
+__BPF_DEBUG_FLAGS :=
 ifeq ($(DEBUG),1)
 	NOOPT=1
 	NOSTRIP=1
+	__BPF_DEBUG_FLAGS += DEBUG=1
 endif
 
 # GO_BUILD_LDFLAGS is initialized to empty use EXTRA_GO_BUILD_LDFLAGS to add link flags
@@ -147,11 +149,11 @@ tetragon-bpf: tetragon-bpf-container
 endif
 
 tetragon-bpf-local:
-	$(MAKE) -C ./bpf BPF_TARGET_ARCH=$(BPF_TARGET_ARCH) -j$(JOBS)
+	$(MAKE) -C ./bpf BPF_TARGET_ARCH=$(BPF_TARGET_ARCH) -j$(JOBS) $(__BPF_DEBUG_FLAGS)
 
 tetragon-bpf-container:
 	$(CONTAINER_ENGINE) rm tetragon-clang || true
-	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon:Z -u $$(id -u) -e BPF_TARGET_ARCH=$(BPF_TARGET_ARCH) --name tetragon-clang $(CLANG_IMAGE) $(MAKE) -C /tetragon/bpf -j$(JOBS)
+	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon:Z -u $$(id -u) -e BPF_TARGET_ARCH=$(BPF_TARGET_ARCH) --name tetragon-clang $(CLANG_IMAGE) $(MAKE) -C /tetragon/bpf -j$(JOBS) $(__BPF_DEBUG_FLAGS)
 	$(CONTAINER_ENGINE) rm tetragon-clang
 
 .PHONY: verify

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -48,7 +48,12 @@ FLAGS := -I. \
 	 -Wno-address-of-packed-member -Wno-compare-distinct-pointer-types -Wno-unknown-warning-option \
 	 -O2
 
-CLANG_FLAGS += $(FLAGS) -I $(LIBBPF) -I $(IDIR) -I $(LDIR) -target bpf -emit-llvm -g -D__TARGET_ARCH_$(BPF_TARGET_ARCH) -fdebug-default-version=4
+DEBUG ?= 0
+ifeq ($(DEBUG),1)
+	__DEBUG_FLAGS = -DTETRAGON_BPF_DEBUG
+endif
+
+CLANG_FLAGS += $(FLAGS) -I $(LIBBPF) -I $(IDIR) -I $(LDIR) -target bpf -emit-llvm -g -D__TARGET_ARCH_$(BPF_TARGET_ARCH) -fdebug-default-version=4 $(__DEBUG_FLAGS)
 LLC_FLAGS   := -march=bpf -mcpu=v2 -mattr=dwarfris
 LLC_FLAGS_ALU32 := -march=bpf -mcpu=v3 -mattr=dwarfris
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -49,4 +49,11 @@ struct bpf_map_def {
 #define BIT(nr)	    (1 << (nr))
 #define BIT_ULL(nr) (1ULL << (nr))
 
+#ifdef TETRAGON_BPF_DEBUG
+#include <bpf_tracing.h>
+#define DEBUG(__fmt, ...) bpf_printk(__fmt, ##__VA_ARGS__)
+#else
+#define DEBUG(__fmt, ...)
+#endif
+
 #endif // _MSG_COMMON__


### PR DESCRIPTION
The bpf_printk() helper is sometimes useful for debugging but we don't want to include it in production code since it makes programs incredibly slow. However, it's nice to have a consistent set of debugging messages we can lean on when it's time to investigate an issue on the BPF side.

This commit introduces a new DEBUG macro that is a NOP unless we set DEBUG=1 in the BPF Makefile, in which case it turns into a bpf_printk() call. This will enable us to over time build up and check in a suite of debugging statements for diagnosing problems during the development cycle without impeding performance in production contexts.