### PR TITLE
cmd: Remove deprecated --config-file flag

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -36,7 +36,6 @@ const (
 	keyGopsAddr          = "gops-address"
 	keyEnableProcessCred = "enable-process-cred"
 	keyEnableProcessNs   = "enable-process-ns"
-	keyConfigFile        = "config-file"
 	keyTracingPolicy     = "tracing-policy"
 	keyTracingPolicyDir  = "tracing-policy-dir"
 
@@ -144,13 +143,6 @@ func readAndSetFlags() {
 
 	option.Config.KMods = viper.GetStringSlice(keyKmods)
 
-	// deprecation timeline: deprecated -> 0.10.0, removed -> 0.11.0
-	// manually handle the deprecation of --config-file
-	if viper.IsSet(keyConfigFile) {
-		log.Warnf("Flag --%s has been deprecated, please use --%s instead", keyConfigFile, keyTracingPolicy)
-		option.Config.TracingPolicy = viper.GetString(keyConfigFile)
-	}
-	// if both --config-file and --tracing-policy are set, the latter takes priority
 	if viper.IsSet(keyTracingPolicy) {
 		option.Config.TracingPolicy = viper.GetString(keyTracingPolicy)
 	}

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -711,10 +711,6 @@ func execute() error {
 
 	// Tracing policy file
 	flags.String(keyTracingPolicy, "", "Tracing policy file to load at startup")
-	// --config-file is the deprecated flag for the new --tracing-policy
-	// deprecation timeline: deprecated -> 0.10.0, removed -> 0.11.0
-	flags.String(keyConfigFile, "", "Configuration file to load from")
-	flags.MarkHidden(keyConfigFile)
 
 	flags.String(keyTracingPolicyDir, defaults.DefaultTpDir, "Directory from where to load Tracing Policies")
 


### PR DESCRIPTION
According to the code comments the `--config-file` flag should have been removed in the v0.11 release, but it hasn't been. Let's remove it before the next release.

Ref #651