### PR TITLE
helm: Don't create operator ClusterRoleBinding if podWatcher is disabled 

### DIFF
--- a/install/kubernetes/templates/operator_clusterrolebinding.yaml
+++ b/install/kubernetes/templates/operator_clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create }}
+{{- if and .Values.serviceAccount.create .Values.podWatcher.enabled }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
There are other issues in the Helm chart that I'd like to fix but let's start small.