### PR TITLE
operator: Clean up Helm values

### DIFF
--- a/.github/workflows/podinfo-test.yaml
+++ b/.github/workflows/podinfo-test.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: Run go tests
       run: |
         helm upgrade --install tetragon ./install/kubernetes -n kube-system \
-          --set podWatcher.enabled=true \
+          --set tetragonOperator.podInfo.enabled=true \
           --set tetragonOperator.image.override=${{ steps.vars.outputs.operatorImage }}
         kubectl rollout status -n kube-system deployment/tetragon-operator
         go test --tags=integration -v ./operator/...

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -55,7 +55,6 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | podAnnotations | object | `{}` |  |
 | podLabelsOverride | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| podWatcher.enabled | bool | `false` |  |
 | selectorLabelsOverride | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
@@ -98,8 +97,8 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
-| tetragonOperator.enabled | bool | `true` | Enable the tetragon-operator component (required). |
 | tetragonOperator.image | object | `{"override":null,"repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v0.11.0"}` | tetragon-operator image. |
+| tetragonOperator.podInfo.enabled | bool | `false` | Enables the PodInfo CRD and the controller that reconciles PodInfo custom resources. |
 | tetragonOperator.skipCRDCreation | bool | `false` |  |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -38,7 +38,6 @@ Helm chart for Tetragon
 | podAnnotations | object | `{}` |  |
 | podLabelsOverride | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| podWatcher.enabled | bool | `false` |  |
 | selectorLabelsOverride | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
@@ -81,8 +80,8 @@ Helm chart for Tetragon
 | tetragon.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
-| tetragonOperator.enabled | bool | `true` | Enable the tetragon-operator component (required). |
 | tetragonOperator.image | object | `{"override":null,"repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v0.11.0"}` | tetragon-operator image. |
+| tetragonOperator.podInfo.enabled | bool | `false` | Enables the PodInfo CRD and the controller that reconciles PodInfo custom resources. |
 | tetragonOperator.skipCRDCreation | bool | `false` |  |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |

--- a/install/kubernetes/templates/_container_tetragon.tpl
+++ b/install/kubernetes/templates/_container_tetragon.tpl
@@ -81,7 +81,6 @@
 {{- end -}}
 
 {{- define "container.tetragon.init-operator" -}}
-{{- if .Values.tetragonOperator.enabled -}}
 - name: {{ include "container.tetragon.name" . }}-operator
   image: "{{ if .Values.tetragonOperator.image.override }}{{ .Values.tetragonOperator.image.override }}{{ else }}{{ .Values.tetragonOperator.image.repository }}{{ .Values.tetragonOperator.image.suffix }}:{{ .Values.tetragonOperator.image.tag }}{{ end }}"
   imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -91,5 +90,4 @@
     - mountPath: /etc/tetragon/operator.conf.d/
       name: tetragon-operator-config
       readOnly: true
-{{- end }}
 {{- end -}}

--- a/install/kubernetes/templates/daemonset.yaml
+++ b/install/kubernetes/templates/daemonset.yaml
@@ -96,11 +96,9 @@ spec:
         name: metadata-files
 {{- end }}
 {{- end }}
-{{- if .Values.tetragonOperator.enabled }}
       - name: tetragon-operator-config
         configMap:
           name: {{ .Release.Name }}-operator-config
-{{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/install/kubernetes/templates/operator_clusterrole.yaml
+++ b/install/kubernetes/templates/operator_clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.podWatcher.enabled }}
+{{- if .Values.serviceAccount.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/install/kubernetes/templates/operator_clusterrolebinding.yaml
+++ b/install/kubernetes/templates/operator_clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.podWatcher.enabled }}
+{{- if .Values.serviceAccount.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/install/kubernetes/templates/operator_configmap.yaml
+++ b/install/kubernetes/templates/operator_configmap.yaml
@@ -7,4 +7,4 @@ metadata:
   {{- include "tetragon-operator.labels" . | nindent 4 }}
 data:
   skip-crd-creation: {{ .Values.tetragonOperator.skipCRDCreation | quote }}
-  skip-tetragon-pod-crd: {{ not .Values.podWatcher.enabled | quote }}
+  skip-pod-info-crd: {{ not .Values.tetragonOperator.podInfo.enabled | quote }}

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.podWatcher.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -58,4 +57,4 @@ spec:
         - name: tetragon-operator-config
           configMap:
             name: {{ .Release.Name }}-operator-config
-{{- end }}
+

--- a/install/kubernetes/templates/operator_serviceaccount.yaml
+++ b/install/kubernetes/templates/operator_serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.podWatcher.enabled -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -148,11 +148,7 @@ tetragon:
   enablePolicyFilterDebug: false
   # Enable latency monitoring in message handling
   enableMsgHandlingLatency: false
-podWatcher:
-  enabled: false
 tetragonOperator:
-  # -- Enable the tetragon-operator component (required).
-  enabled: true
   # -- tetragon-operator image.
   image:
     override: ~
@@ -162,6 +158,10 @@ tetragonOperator:
     suffix: ""
   # Skip CRD creation.
   skipCRDCreation: false
+  podInfo:
+    # -- Enables the PodInfo CRD and the controller that reconciles PodInfo
+    # custom resources.
+    enabled: false
 export:
   # "stdout". "" to disable.
   mode: "stdout"

--- a/operator/cmd/serve/serve.go
+++ b/operator/cmd/serve/serve.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/tetragon/operator/cmd/common"
+	operatorOption "github.com/cilium/tetragon/operator/option"
 	"github.com/cilium/tetragon/operator/podinfo"
 	ciliumiov1alpha1 "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/spf13/cobra"
@@ -65,10 +66,12 @@ func New() *cobra.Command {
 				return fmt.Errorf("unable to start manager: %w", err)
 			}
 
-			if err = (&podinfo.Reconciler{
-				Client: mgr.GetClient(),
-			}).SetupWithManager(mgr); err != nil {
-				return fmt.Errorf("unable to create controller: %w %s %s", err, "controller", "podinfo")
+			if !operatorOption.Config.SkipPodInfoCRD {
+				if err = (&podinfo.Reconciler{
+					Client: mgr.GetClient(),
+				}).SetupWithManager(mgr); err != nil {
+					return fmt.Errorf("unable to create controller: %w %s %s", err, "controller", "podinfo")
+				}
 			}
 
 			if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
- Remove tetragonOperator.enabled. Tetragon daemonset won't start if
  this value is set to false.
- Rename podWatcher.enabled to tetragonOperator.podInfo.enabled to
  better indicate this enables PodInfo CRD.
- Always run Tetragon operator deployment. We are planning to remove the
  init container, so the operator needs to run unconditionally to create
  CRDs.
- Rename skip-tetragon-pod-crd to skip-pod-info-crd in tetragon-operator
  configmap. The operator is expecting skip-pod-info-crd flag.
- Don't start the PodInfo controller if tetragonOperator.podInfo.enabled
  is set to false.