### PR TITLE
tetragon: Remove sensors on exit not programs

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -340,7 +340,7 @@ func tetragonExecute() error {
 	pm, err := tetragonGrpc.NewProcessManager(
 		ctx,
 		&cleanupWg,
-		observer.SensorManager,
+		observer.GetSensorManager(),
 		hookRunner)
 	if err != nil {
 		return err
@@ -358,7 +358,7 @@ func tetragonExecute() error {
 	obs.AddListener(pm)
 	saveInitInfo()
 	if option.Config.EnableK8s {
-		go crd.WatchTracePolicy(ctx, observer.SensorManager)
+		go crd.WatchTracePolicy(ctx, observer.GetSensorManager())
 	}
 
 	obs.LogPinnedBpf(observerDir)
@@ -375,7 +375,7 @@ func tetragonExecute() error {
 	// now that the base sensor was loaded, we can start the sensor manager
 	close(sensorMgWait)
 	sensorMgWait = nil
-	observer.SensorManager.LogSensorsAndProbes(ctx)
+	observer.GetSensorManager().LogSensorsAndProbes(ctx)
 
 	err = loadTpFromDir(ctx, option.Config.TracingPolicyDir)
 	if err != nil {
@@ -450,7 +450,7 @@ func addTracingPolicy(ctx context.Context, file string) error {
 		return err
 	}
 
-	err = observer.SensorManager.AddTracingPolicy(ctx, tp)
+	err = observer.GetSensorManager().AddTracingPolicy(ctx, tp)
 	if err != nil {
 		return err
 	}

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -227,7 +227,7 @@ func startBenchmarkExporter(ctx context.Context, obs *observer.Observer, summary
 	processManager, err := grpc.NewProcessManager(
 		ctx,
 		&wg,
-		observer.SensorManager,
+		observer.GetSensorManager(),
 		hookRunner)
 	if err != nil {
 		return err

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -401,6 +401,10 @@ func (k *Observer) RemovePrograms() {
 	RemovePrograms(option.Config.BpfDir, option.Config.MapDir)
 }
 
+func RemoveSensors(ctx context.Context) {
+	SensorManager.RemoveAllSensors(ctx)
+}
+
 // Log Active pinned BPF resources
 func (k *Observer) LogPinnedBpf(observerDir string) {
 	finfo, err := os.Stat(observerDir)

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -40,9 +40,6 @@ var (
 	eventHandler = make(map[uint8]func(r *bytes.Reader) ([]Event, error))
 
 	observerList []*Observer
-
-	/* SensorManager handles dynamic sensors loading / unloading. */
-	SensorManager *sensors.Manager
 )
 
 type Event notify.Message
@@ -342,9 +339,11 @@ func (k *Observer) Start(ctx context.Context) error {
 
 // InitSensorManager starts the sensor controller
 func (k *Observer) InitSensorManager(waitChan chan struct{}) error {
-	var err error
-	SensorManager, err = sensors.StartSensorManager(option.Config.BpfDir, option.Config.MapDir, waitChan)
-	return err
+	mgr, err := sensors.StartSensorManager(option.Config.BpfDir, option.Config.MapDir, waitChan)
+	if err != nil {
+		return err
+	}
+	return SetSensorManager(mgr)
 }
 
 func NewObserver(configFile string) *Observer {
@@ -402,7 +401,9 @@ func (k *Observer) RemovePrograms() {
 }
 
 func RemoveSensors(ctx context.Context) {
-	SensorManager.RemoveAllSensors(ctx)
+	if mgr := GetSensorManager(); mgr != nil {
+		mgr.RemoveAllSensors(ctx)
+	}
 }
 
 // Log Active pinned BPF resources

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -369,9 +369,10 @@ func loadExporter(tb testing.TB, ctx context.Context, obs *observer.Observer, op
 
 	// NB(kkourt): we use the global that was set up by InitSensorManager(). We should clean
 	// this up and remove/hide the global variable.
-	sensorManager := observer.SensorManager
+	sensorManager := observer.GetSensorManager()
 	tb.Cleanup(func() {
 		sensorManager.StopSensorManager(ctx)
+		observer.ResetSensorManager()
 	})
 
 	if oo.crd {
@@ -436,7 +437,7 @@ func loadObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor,
 	}
 
 	if tp != nil {
-		if err := observer.SensorManager.AddTracingPolicy(ctx, tp); err != nil {
+		if err := observer.GetSensorManager().AddTracingPolicy(ctx, tp); err != nil {
 			tb.Fatalf("SensorManager.AddTracingPolicy error: %s\n", err)
 		}
 	}

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -134,7 +134,6 @@ func testDone(tb testing.TB, obs *observer.Observer) {
 		}
 	}
 
-	obs.RemovePrograms()
 	obs.PrintStats()
 	obs.Remove()
 }
@@ -372,7 +371,7 @@ func loadExporter(tb testing.TB, ctx context.Context, obs *observer.Observer, op
 	// this up and remove/hide the global variable.
 	sensorManager := observer.SensorManager
 	tb.Cleanup(func() {
-		sensorManager.StopSensorManager(context.TODO())
+		sensorManager.StopSensorManager(ctx)
 	})
 
 	if oo.crd {
@@ -442,6 +441,10 @@ func loadObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor,
 		}
 	}
 
+	tb.Cleanup(func() {
+		observer.RemoveSensors(ctx)
+		base.Unload()
+	})
 	return nil
 }
 

--- a/pkg/observer/sensor_manager.go
+++ b/pkg/observer/sensor_manager.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package observer
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/cilium/tetragon/pkg/sensors"
+)
+
+var (
+	// SensorManager handles dynamic sensors loading / unloading, and is a global variable for
+	// now
+	sensorManager   *sensors.Manager
+	sensorManagerMu sync.Mutex
+)
+
+// ResetSensorManager resets the global sensorManager variable to nil. Intended only for testing.
+func ResetSensorManager() {
+	sensorManager = nil
+}
+
+func SetSensorManager(sm *sensors.Manager) error {
+	sensorManagerMu.Lock()
+	defer sensorManagerMu.Unlock()
+
+	if sensorManager != nil {
+		return fmt.Errorf("observer sensorManager already set")
+	}
+	sensorManager = sm
+	return nil
+}
+
+func GetSensorManager() *sensors.Manager {
+	sensorManagerMu.Lock()
+	defer sensorManagerMu.Unlock()
+	return sensorManager
+}

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -59,6 +59,12 @@ var (
 	/* Internal statistics for debugging */
 	ExecveStats        = program.MapBuilder("execve_map_stats", Execve)
 	ExecveJoinMapStats = program.MapBuilder("tg_execve_joined_info_map_stats", ExecveBprmCommit)
+
+	sensor = sensors.Sensor{
+		Name:  "__base__",
+		Progs: GetDefaultPrograms(),
+		Maps:  GetDefaultMaps(),
+	}
 )
 
 func GetExecveMap() *program.Map {
@@ -100,11 +106,7 @@ func GetDefaultMaps() []*program.Map {
 
 // GetInitialSensor returns the base sensor
 func GetInitialSensor() *sensors.Sensor {
-	return &sensors.Sensor{
-		Name:  "__base__",
-		Progs: GetDefaultPrograms(),
-		Maps:  GetDefaultMaps(),
-	}
+	return &sensor
 }
 
 // ExecObj returns the exec object based on the kernel version

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -589,9 +589,7 @@ func setupTgRuntimeConf(t *testing.T, trackingCgrpLevel, logLevel, hierarchyId, 
 }
 
 func setupObserver(ctx context.Context, t *testing.T) *tus.TestSensorManager {
-	testManager := tus.StartTestSensorManager(ctx, t)
-	observer.SensorManager = testManager.Manager
-
+	testManager := tus.GetTestSensorManager(ctx, t)
 	if err := observer.InitDataCache(1024); err != nil {
 		t.Fatalf("failed to call observer.InitDataCache %s", err)
 	}

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -502,7 +502,7 @@ func TestLoadInitialSensor(t *testing.T) {
 
 	tus.CheckSensorLoad([]*sensors.Sensor{sensor}, sensorMaps, sensorProgs, t)
 
-	sensors.UnloadAll()
+	sensor.Unload()
 }
 
 func TestDocker(t *testing.T) {

--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -369,3 +369,11 @@ func UnloadAll() {
 	AllPrograms = []*program.Program{}
 	AllMaps = []*program.Map{}
 }
+
+func UnloadSensors(sens []*Sensor) {
+	for i := range sens {
+		if err := sens[i].Unload(); err != nil {
+			logger.GetLogger().Warnf("Failed to unload sensor: %s", err)
+		}
+	}
+}

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -235,6 +235,20 @@ func (h *Manager) RemoveSensor(ctx context.Context, sensorName string) error {
 	return err
 }
 
+func (h *Manager) RemoveAllSensors(ctx context.Context) error {
+	retc := make(chan error)
+	op := &sensorRemove{
+		ctx:     ctx,
+		all:     true,
+		retChan: retc,
+	}
+
+	h.sensorCtl <- op
+	err := <-retc
+
+	return err
+}
+
 func (h *Manager) StopSensorManager(ctx context.Context) error {
 	retc := make(chan error)
 	op := &sensorCtlStop{
@@ -325,6 +339,7 @@ type sensorAdd struct {
 type sensorRemove struct {
 	ctx     context.Context
 	name    string
+	all     bool
 	retChan chan error
 }
 

--- a/pkg/sensors/test/lseek_test.go
+++ b/pkg/sensors/test/lseek_test.go
@@ -11,7 +11,6 @@ import (
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
-	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
@@ -77,8 +76,7 @@ func TestSensorLseekEnable(t *testing.T) {
 
 	sensor := GetTestSensor()
 
-	smanager := tus.StartTestSensorManager(ctx, t)
-	observer.SensorManager = smanager.Manager
+	smanager := tus.GetTestSensorManager(ctx, t)
 	smanager.AddAndEnableSensor(ctx, t, sensor, sensor.Name)
 
 	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3616,10 +3616,6 @@ spec:
  - call: "sys_write"
    syscall: true
 `
-	b := base.GetInitialSensor()
-	if err := b.Load(option.Config.BpfDir, option.Config.MapDir); err != nil {
-		return fmt.Errorf("load base sensor failed: %w", err)
-	}
 
 	tp, _ := tracingpolicy.FromYAML(testHook)
 	if tp == nil {
@@ -3630,7 +3626,11 @@ spec:
 	if err != nil {
 		return err
 	}
-	return sens.Load(option.Config.BpfDir, option.Config.MapDir)
+	err = sens.Load(option.Config.BpfDir, option.Config.MapDir)
+	if err != nil {
+		return err
+	}
+	return sens.Unload()
 }
 
 func TestKprobeBpfAttr(t *testing.T) {
@@ -3777,7 +3777,7 @@ spec:
 
 	tus.CheckSensorLoad(sens, sensorMaps, sensorProgs, t)
 
-	sensors.UnloadAll()
+	sensors.UnloadSensors(sens)
 }
 
 func TestFakeSyscallError(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_validation_test.go
+++ b/pkg/sensors/tracing/kprobe_validation_test.go
@@ -237,6 +237,7 @@ func TestKprobeValidationMissingReturnArg(t *testing.T) {
 
 	crd := `
 apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
 metadata:
   name: "missing-returnarg"
 spec:

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -116,7 +116,7 @@ func TestNamespacedPolicies(t *testing.T) {
 
 	tus.LoadSensor(t, base.GetInitialSensor())
 	tus.LoadSensor(t, testsensor.GetTestSensor())
-	sm := tus.StartTestSensorManager(ctx, t)
+	sm := tus.GetTestSensorManager(ctx, t)
 
 	// First, we create two lseek-pipe commands and add them to a different cgroup. See
 	// contrib/tester-progs/go/lseek-pipe for details of how lseek-pipe wowkrs, but basically it

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -75,7 +75,7 @@ func TestGenericTracepointSimple(t *testing.T) {
 		t.Fatalf("GetDefaultObserver error: %s", err)
 	}
 
-	sm := tus.StartTestSensorManager(ctx, t)
+	sm := tus.GetTestSensorManager(ctx, t)
 	// create and add sensor
 	sensor, err := createGenericTracepointSensor("GtpLseekTest", []GenericTracepointConf{lseekConf}, policyfilter.NoFilterID,
 		"policyName", []v1alpha1.ListSpec{})
@@ -135,7 +135,7 @@ func doTestGenericTracepointPidFilter(t *testing.T, conf GenericTracepointConf, 
 		t.Fatalf("GetDefaultObserver error: %s", err)
 	}
 
-	sm := tus.StartTestSensorManager(ctx, t)
+	sm := tus.GetTestSensorManager(ctx, t)
 	// create and add sensor
 	sensor, err := createGenericTracepointSensor("GtpLseekTest", []GenericTracepointConf{conf}, policyfilter.NoFilterID,
 		"policyName", []v1alpha1.ListSpec{})
@@ -528,7 +528,7 @@ func TestTracepointCloneThreads(t *testing.T) {
 		t.Fatalf("GetDefaultObserver error: %s", err)
 	}
 
-	sm := tus.StartTestSensorManager(ctx, t)
+	sm := tus.GetTestSensorManager(ctx, t)
 	// create and add sensor
 	sensor, err := createGenericTracepointSensor("GtpLseekTest", []GenericTracepointConf{lseekConf}, policyfilter.NoFilterID,
 		"policyName", []v1alpha1.ListSpec{})

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -492,7 +492,7 @@ spec:
 
 	tus.CheckSensorLoad(sens, sensorMaps, sensorProgs, t)
 
-	sensors.UnloadAll()
+	sensors.UnloadSensors(sens)
 }
 
 func TestTracepointCloneThreads(t *testing.T) {

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -92,7 +92,7 @@ spec:
 
 	tus.CheckSensorLoad(sens, sensorMaps, sensorProgs, t)
 
-	sensors.UnloadAll()
+	sensors.UnloadSensors(sens)
 }
 
 func TestUprobeGeneric(t *testing.T) {


### PR DESCRIPTION
The change loading and unloading sensors to be on the sensors level,
so instead of removing separate programs, we remove complete sensors.

This has benefit of triggering sensors' unload hooks.  