### PR TITLE
tracing: check for empty returnArg

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -611,6 +611,9 @@ func addKprobe(funcName string, f *v1alpha1.KProbeSpec, in *addKprobeIn) (out *a
 	// instructs the BPF kretprobe program which type of copy to use. And
 	// argReturnPrinters tell golang printer piece how to print the event.
 	if f.Return {
+		if f.ReturnArg == nil {
+			return nil, fmt.Errorf("ReturnArg not specified with Return=true")
+		}
 		argType := gt.GenericTypeFromString(f.ReturnArg.Type)
 		if argType == gt.GenericInvalidType {
 			if f.ReturnArg.Type == "" {


### PR DESCRIPTION
If returnArg is empty, but return is true, the agent will crash with a sigsegv. This patch adds a check and returns an error.


Fixes: https://github.com/cilium/tetragon/issues/1490


```release-note:
fix segfault when return is specified without returnArg in a tracing policy
```