### PR TITLE
Dockerfile.clang: Don't pin clang patch version

### DIFF
--- a/Dockerfile.clang
+++ b/Dockerfile.clang
@@ -1,9 +1,8 @@
 FROM docker.io/library/ubuntu:22.04@sha256:0bced47fffa3361afa981854fcabcd4577cd43cebbb808cea2b1f33a3dd7f508
-ARG VERSION=1:15.0.7-0ubuntu0.22.04.2
-RUN apt-get update && apt-get install -y --no-install-recommends                 \
-    clang-15=$VERSION libclang-common-15-dev=$VERSION libclang-cpp15=$VERSION    \
-    libllvm15=$VERSION llvm-15-linker-tools=$VERSION libclang1-15=$VERSION       \
-    llvm-15=$VERSION llvm-15-runtime=$VERSION llvm-15-linker-tools=$VERSION make \
+RUN apt-get update && apt-get install -y --no-install-recommends  \
+    clang-15 libclang-common-15-dev libclang-cpp15    	          \
+    libllvm15 llvm-15-linker-tools libclang1-15                   \
+    llvm-15 llvm-15-runtime llvm-15-linker-tools make             \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN ln -vsnf /usr/lib/llvm-15/bin/clang /usr/bin/clang
 RUN ln -vsnf /usr/lib/llvm-15/bin/llc /usr/bin/llc


### PR DESCRIPTION
I boldly assert that it's sufficient to specify the clang version by
using clang-15 package. This way we can pick up the latest security
release automatically. Otherwise this Dockerfile keeps breaking when
there is a new security release and the old package gets deleted.

Ref: https://github.com/cilium/tetragon/actions/runs/6355442579/job/17263533977#step:6:239
Ref: https://packages.ubuntu.com/jammy/clang-15

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>