### PR TITLE
Misc changes to the packages structure under pkg/metrics

### DIFF
--- a/cmd/tetragon/flags.go
+++ b/cmd/tetragon/flags.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/metrics/config"
+	"github.com/cilium/tetragon/pkg/metrics/metricsconfig"
 	"github.com/cilium/tetragon/pkg/option"
 
 	"github.com/spf13/viper"
@@ -113,7 +113,7 @@ func readAndSetFlags() {
 	option.Config.DataCacheSize = viper.GetInt(keyDataCacheSize)
 
 	option.Config.MetricsServer = viper.GetString(keyMetricsServer)
-	option.Config.MetricsLabelFilter = config.ParseMetricsLabelFilter(viper.GetString(keyMetricsLabelFilter))
+	option.Config.MetricsLabelFilter = metricsconfig.ParseMetricsLabelFilter(viper.GetString(keyMetricsLabelFilter))
 	option.Config.ServerAddress = viper.GetString(keyServerAddress)
 
 	option.Config.ExportFilename = viper.GetString(keyExportFilename)

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -32,7 +32,7 @@ import (
 	tetragonGrpc "github.com/cilium/tetragon/pkg/grpc"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics"
-	metricsconfig "github.com/cilium/tetragon/pkg/metrics/config"
+	"github.com/cilium/tetragon/pkg/metrics/metricsconfig"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"

--- a/pkg/metrics/consts/consts.go
+++ b/pkg/metrics/consts/consts.go
@@ -3,5 +3,6 @@
 
 package consts
 
-var MetricsNamespace = "tetragon"
+const MetricsNamespace = "tetragon"
+
 var KnownMetricLabelFilters = []string{"namespace", "workload", "pod", "binary"}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -7,29 +7,19 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
-	"time"
 
 	"golang.org/x/exp/slices"
 
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/cilium/tetragon/pkg/option"
-	"github.com/cilium/tetragon/pkg/podhooks"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 )
 
 var (
-	registry            *prometheus.Registry
-	registryOnce        sync.Once
-	metricsWithPod      []*prometheus.MetricVec
-	metricsWithPodMutex sync.RWMutex
-	podQueue            workqueue.DelayingInterface
-	podQueueOnce        sync.Once
-	deleteDelay         = 1 * time.Minute
+	registry     *prometheus.Registry
+	registryOnce sync.Once
 )
 
 type GranularCounter struct {
@@ -57,114 +47,6 @@ func (m *GranularCounter) ToProm() *prometheus.CounterVec {
 		m.counter = NewCounterVecWithPod(m.CounterOpts, m.labels)
 	})
 	return m.counter
-}
-
-// NewCounterVecWithPod is a wrapper around prometheus.NewCounterVec that also registers the metric
-// to be cleaned up when a pod is deleted. It should be used only to register metrics that have
-// "pod" and "namespace" labels.
-func NewCounterVecWithPod(opts prometheus.CounterOpts, labels []string) *prometheus.CounterVec {
-	metric := prometheus.NewCounterVec(opts, labels)
-	metricsWithPodMutex.Lock()
-	metricsWithPod = append(metricsWithPod, metric.MetricVec)
-	metricsWithPodMutex.Unlock()
-	return metric
-}
-
-// NewGaugeVecWithPod is a wrapper around prometheus.NewGaugeVec that also registers the metric
-// to be cleaned up when a pod is deleted. It should be used only to register metrics that have
-// "pod" and "namespace" labels.
-func NewGaugeVecWithPod(opts prometheus.GaugeOpts, labels []string) *prometheus.GaugeVec {
-	metric := prometheus.NewGaugeVec(opts, labels)
-	metricsWithPodMutex.Lock()
-	metricsWithPod = append(metricsWithPod, metric.MetricVec)
-	metricsWithPodMutex.Unlock()
-	return metric
-}
-
-// NewHistogramVecWithPod is a wrapper around prometheus.NewHistogramVec that also registers the metric
-// to be cleaned up when a pod is deleted. It should be used only to register metrics that have
-// "pod" and "namespace" labels.
-func NewHistogramVecWithPod(opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
-	metric := prometheus.NewHistogramVec(opts, labels)
-	metricsWithPodMutex.Lock()
-	metricsWithPod = append(metricsWithPod, metric.MetricVec)
-	metricsWithPodMutex.Unlock()
-	return metric
-}
-
-// RegisterPodDeleteHandler registers handler for deleting metrics associated
-// with deleted pods. Without it, Tetragon kept exposing stale metrics for
-// deleted pods. This was causing continuous increase in memory usage in
-// Tetragon agent as well as in the metrics scraper.
-func RegisterPodDeleteHandler() {
-	logger.GetLogger().Info("Registering pod delete handler for metrics")
-	podhooks.RegisterCallbacksAtInit(podhooks.Callbacks{
-		PodCallbacks: func(podInformer cache.SharedIndexInformer) {
-			podInformer.AddEventHandler(
-				cache.ResourceEventHandlerFuncs{
-					DeleteFunc: func(obj interface{}) {
-						var pod *corev1.Pod
-						switch concreteObj := obj.(type) {
-						case *corev1.Pod:
-							pod = concreteObj
-						case cache.DeletedFinalStateUnknown:
-							// Handle the case when the watcher missed the deletion event
-							// (e.g. due to a lost apiserver connection).
-							deletedObj, ok := concreteObj.Obj.(*corev1.Pod)
-							if !ok {
-								return
-							}
-							pod = deletedObj
-						default:
-							return
-						}
-						queue := GetPodQueue()
-						queue.AddAfter(pod, deleteDelay)
-					},
-				},
-			)
-		},
-	})
-}
-
-func GetPodQueue() workqueue.DelayingInterface {
-	podQueueOnce.Do(func() {
-		podQueue = workqueue.NewDelayingQueue()
-	})
-	return podQueue
-}
-
-func DeleteMetricsForPod(pod *corev1.Pod) {
-	for _, metric := range ListMetricsWithPod() {
-		metric.DeletePartialMatch(prometheus.Labels{
-			"pod":       pod.Name,
-			"namespace": pod.Namespace,
-		})
-	}
-}
-
-func ListMetricsWithPod() []*prometheus.MetricVec {
-	// NB: All additions to the list happen when registering metrics, so it's safe to just return
-	// the list here.
-	return metricsWithPod
-}
-
-func GetRegistry() *prometheus.Registry {
-	registryOnce.Do(func() {
-		registry = prometheus.NewRegistry()
-	})
-	return registry
-}
-
-func StartPodDeleteHandler() {
-	queue := GetPodQueue()
-	for {
-		pod, quit := queue.Get()
-		if quit {
-			return
-		}
-		DeleteMetricsForPod(pod.(*corev1.Pod))
-	}
 }
 
 func EnableMetrics(address string) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -6,24 +6,11 @@ package metrics_test
 import (
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
-	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/metrics"
-	"github.com/cilium/tetragon/pkg/metrics/config"
-	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/option"
 )
-
-var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
-	PolicyName: "fake-policy",
-}
 
 func TestFilterMetricLabels(t *testing.T) {
 	option.Config.MetricsLabelFilter = map[string]interface{}{
@@ -51,67 +38,4 @@ func TestFilterMetricLabels(t *testing.T) {
 		"binary":    nil,
 	}
 	assert.Equal(t, []string{"type", "syscall"}, metrics.FilterMetricLabels("type", "syscall"))
-}
-
-func TestPodDelete(t *testing.T) {
-	reg := metrics.GetRegistry()
-	config.InitAllMetrics(reg)
-
-	// Process four events, each one with different combination of pod/namespace.
-	// These events should be counted by multiple metrics with a "pod" label:
-	// * tetragon_events_total
-	// * tetragon_policy_events_total
-	// * tetragon_syscalls_total
-	for _, namespace := range []string{"fake-namespace", "other-namespace"} {
-		for _, pod := range []string{"fake-pod", "other-pod"} {
-			event := tetragon.GetEventsResponse{
-				Event: &tetragon.GetEventsResponse_ProcessTracepoint{
-					ProcessTracepoint: &tetragon.ProcessTracepoint{
-						Subsys: "raw_syscalls",
-						Event:  "sys_enter",
-						Process: &tetragon.Process{
-							Pod: &tetragon.Pod{
-								Namespace: namespace,
-								Name:      pod,
-							},
-						},
-						Args: []*tetragon.KprobeArgument{
-							{
-								Arg: &tetragon.KprobeArgument_LongArg{
-									LongArg: 0,
-								},
-							},
-						},
-					},
-				},
-			}
-			eventmetrics.ProcessEvent(&sampleMsgGenericTracepointUnix, &event)
-		}
-	}
-	checkMetricSeriesCount(t, reg, 4)
-
-	// Exactly one timeseries should be deleted for each metric (matching both
-	// pod name and namespace).
-	metrics.DeleteMetricsForPod(&corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "fake-pod",
-			Namespace: "fake-namespace",
-		},
-	})
-	checkMetricSeriesCount(t, reg, 3)
-}
-
-func checkMetricSeriesCount(t *testing.T, registry *prometheus.Registry, seriesCount int) {
-	metricFamilies, err := registry.Gather()
-	require.NoError(t, err)
-
-	metricNameToSeries := map[string]*io_prometheus_client.MetricFamily{}
-	for _, metricFamily := range metricFamilies {
-		metricNameToSeries[*metricFamily.Name] = metricFamily
-	}
-	for _, metric := range []string{"tetragon_events_total", "tetragon_policy_events_total", "tetragon_syscalls_total"} {
-		metricFamily := metricNameToSeries[metric]
-		require.NotNil(t, metricFamily)
-		assert.Len(t, metricFamily.Metric, seriesCount)
-	}
 }

--- a/pkg/metrics/metricsconfig/initmetrics.go
+++ b/pkg/metrics/metricsconfig/initmetrics.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
-package config
+package metricsconfig
 
 import (
 	"github.com/cilium/tetragon/pkg/eventcache"

--- a/pkg/metrics/metricsconfig/initmetrics.go
+++ b/pkg/metrics/metricsconfig/initmetrics.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/tetragon/pkg/metrics/kprobemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/mapmetrics"
 	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
-	pfmetrics "github.com/cilium/tetragon/pkg/metrics/policyfilter"
+	"github.com/cilium/tetragon/pkg/metrics/policyfiltermetrics"
 	"github.com/cilium/tetragon/pkg/metrics/processexecmetrics"
 	"github.com/cilium/tetragon/pkg/metrics/ratelimitmetrics"
 	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
@@ -36,7 +36,7 @@ func InitAllMetrics(registry *prometheus.Registry) {
 	kprobemetrics.InitMetrics(registry)
 	mapmetrics.InitMetrics(registry)
 	opcodemetrics.InitMetrics(registry)
-	pfmetrics.InitMetrics(registry)
+	policyfiltermetrics.InitMetrics(registry)
 	processexecmetrics.InitMetrics(registry)
 	ringbufmetrics.InitMetrics(registry)
 	ringbufqueuemetrics.InitMetrics(registry)

--- a/pkg/metrics/metricsconfig/initmetrics.go
+++ b/pkg/metrics/metricsconfig/initmetrics.go
@@ -25,8 +25,6 @@ import (
 	grpcmetrics "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-
-	"strings"
 )
 
 func InitAllMetrics(registry *prometheus.Registry) {
@@ -58,12 +56,4 @@ func InitAllMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	registry.MustRegister(grpcmetrics.NewServerMetrics())
 	version.InitMetrics(registry)
-}
-
-func ParseMetricsLabelFilter(labels string) map[string]interface{} {
-	result := make(map[string]interface{})
-	for _, label := range strings.Split(labels, ",") {
-		result[label] = nil
-	}
-	return result
 }

--- a/pkg/metrics/metricsconfig/labelfilter.go
+++ b/pkg/metrics/metricsconfig/labelfilter.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metricsconfig
+
+import "strings"
+
+func ParseMetricsLabelFilter(labels string) map[string]interface{} {
+	result := make(map[string]interface{})
+	for _, label := range strings.Split(labels, ",") {
+		result[label] = nil
+	}
+	return result
+}

--- a/pkg/metrics/metricwithpod.go
+++ b/pkg/metrics/metricwithpod.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/podhooks"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+var (
+	metricsWithPod      []*prometheus.MetricVec
+	metricsWithPodMutex sync.RWMutex
+	podQueue            workqueue.DelayingInterface
+	podQueueOnce        sync.Once
+	deleteDelay         = 1 * time.Minute
+)
+
+// NewCounterVecWithPod is a wrapper around prometheus.NewCounterVec that also registers the metric
+// to be cleaned up when a pod is deleted. It should be used only to register metrics that have
+// "pod" and "namespace" labels.
+func NewCounterVecWithPod(opts prometheus.CounterOpts, labels []string) *prometheus.CounterVec {
+	metric := prometheus.NewCounterVec(opts, labels)
+	metricsWithPodMutex.Lock()
+	metricsWithPod = append(metricsWithPod, metric.MetricVec)
+	metricsWithPodMutex.Unlock()
+	return metric
+}
+
+// NewGaugeVecWithPod is a wrapper around prometheus.NewGaugeVec that also registers the metric
+// to be cleaned up when a pod is deleted. It should be used only to register metrics that have
+// "pod" and "namespace" labels.
+func NewGaugeVecWithPod(opts prometheus.GaugeOpts, labels []string) *prometheus.GaugeVec {
+	metric := prometheus.NewGaugeVec(opts, labels)
+	metricsWithPodMutex.Lock()
+	metricsWithPod = append(metricsWithPod, metric.MetricVec)
+	metricsWithPodMutex.Unlock()
+	return metric
+}
+
+// NewHistogramVecWithPod is a wrapper around prometheus.NewHistogramVec that also registers the metric
+// to be cleaned up when a pod is deleted. It should be used only to register metrics that have
+// "pod" and "namespace" labels.
+func NewHistogramVecWithPod(opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	metric := prometheus.NewHistogramVec(opts, labels)
+	metricsWithPodMutex.Lock()
+	metricsWithPod = append(metricsWithPod, metric.MetricVec)
+	metricsWithPodMutex.Unlock()
+	return metric
+}
+
+// RegisterPodDeleteHandler registers handler for deleting metrics associated
+// with deleted pods. Without it, Tetragon kept exposing stale metrics for
+// deleted pods. This was causing continuous increase in memory usage in
+// Tetragon agent as well as in the metrics scraper.
+func RegisterPodDeleteHandler() {
+	logger.GetLogger().Info("Registering pod delete handler for metrics")
+	podhooks.RegisterCallbacksAtInit(podhooks.Callbacks{
+		PodCallbacks: func(podInformer cache.SharedIndexInformer) {
+			podInformer.AddEventHandler(
+				cache.ResourceEventHandlerFuncs{
+					DeleteFunc: func(obj interface{}) {
+						var pod *corev1.Pod
+						switch concreteObj := obj.(type) {
+						case *corev1.Pod:
+							pod = concreteObj
+						case cache.DeletedFinalStateUnknown:
+							// Handle the case when the watcher missed the deletion event
+							// (e.g. due to a lost apiserver connection).
+							deletedObj, ok := concreteObj.Obj.(*corev1.Pod)
+							if !ok {
+								return
+							}
+							pod = deletedObj
+						default:
+							return
+						}
+						queue := GetPodQueue()
+						queue.AddAfter(pod, deleteDelay)
+					},
+				},
+			)
+		},
+	})
+}
+
+func GetPodQueue() workqueue.DelayingInterface {
+	podQueueOnce.Do(func() {
+		podQueue = workqueue.NewDelayingQueue()
+	})
+	return podQueue
+}
+
+func DeleteMetricsForPod(pod *corev1.Pod) {
+	for _, metric := range ListMetricsWithPod() {
+		metric.DeletePartialMatch(prometheus.Labels{
+			"pod":       pod.Name,
+			"namespace": pod.Namespace,
+		})
+	}
+}
+
+func ListMetricsWithPod() []*prometheus.MetricVec {
+	// NB: All additions to the list happen when registering metrics, so it's safe to just return
+	// the list here.
+	return metricsWithPod
+}
+
+func GetRegistry() *prometheus.Registry {
+	registryOnce.Do(func() {
+		registry = prometheus.NewRegistry()
+	})
+	return registry
+}
+
+func StartPodDeleteHandler() {
+	queue := GetPodQueue()
+	for {
+		pod, quit := queue.Get()
+		if quit {
+			return
+		}
+		DeleteMetricsForPod(pod.(*corev1.Pod))
+	}
+}

--- a/pkg/metrics/metricwithpod_test.go
+++ b/pkg/metrics/metricwithpod_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/grpc/tracing"
+	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/config"
+	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
+)
+
+var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
+	PolicyName: "fake-policy",
+}
+
+func TestPodDelete(t *testing.T) {
+	reg := metrics.GetRegistry()
+	config.InitAllMetrics(reg)
+
+	// Process four events, each one with different combination of pod/namespace.
+	// These events should be counted by multiple metrics with a "pod" label:
+	// * tetragon_events_total
+	// * tetragon_policy_events_total
+	// * tetragon_syscalls_total
+	for _, namespace := range []string{"fake-namespace", "other-namespace"} {
+		for _, pod := range []string{"fake-pod", "other-pod"} {
+			event := tetragon.GetEventsResponse{
+				Event: &tetragon.GetEventsResponse_ProcessTracepoint{
+					ProcessTracepoint: &tetragon.ProcessTracepoint{
+						Subsys: "raw_syscalls",
+						Event:  "sys_enter",
+						Process: &tetragon.Process{
+							Pod: &tetragon.Pod{
+								Namespace: namespace,
+								Name:      pod,
+							},
+						},
+						Args: []*tetragon.KprobeArgument{
+							{
+								Arg: &tetragon.KprobeArgument_LongArg{
+									LongArg: 0,
+								},
+							},
+						},
+					},
+				},
+			}
+			eventmetrics.ProcessEvent(&sampleMsgGenericTracepointUnix, &event)
+		}
+	}
+	checkMetricSeriesCount(t, reg, 4)
+
+	// Exactly one timeseries should be deleted for each metric (matching both
+	// pod name and namespace).
+	metrics.DeleteMetricsForPod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-pod",
+			Namespace: "fake-namespace",
+		},
+	})
+	checkMetricSeriesCount(t, reg, 3)
+}
+
+func checkMetricSeriesCount(t *testing.T, registry *prometheus.Registry, seriesCount int) {
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	metricNameToSeries := map[string]*io_prometheus_client.MetricFamily{}
+	for _, metricFamily := range metricFamilies {
+		metricNameToSeries[*metricFamily.Name] = metricFamily
+	}
+	for _, metric := range []string{"tetragon_events_total", "tetragon_policy_events_total", "tetragon_syscalls_total"} {
+		metricFamily := metricNameToSeries[metric]
+		require.NotNil(t, metricFamily)
+		assert.Len(t, metricFamily.Metric, seriesCount)
+	}
+}

--- a/pkg/metrics/metricwithpod_test.go
+++ b/pkg/metrics/metricwithpod_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/metrics"
-	"github.com/cilium/tetragon/pkg/metrics/config"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/metricsconfig"
 )
 
 var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
@@ -26,7 +26,7 @@ var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
 
 func TestPodDelete(t *testing.T) {
 	reg := metrics.GetRegistry()
-	config.InitAllMetrics(reg)
+	metricsconfig.InitAllMetrics(reg)
 
 	// Process four events, each one with different combination of pod/namespace.
 	// These events should be counted by multiple metrics with a "pod" label:

--- a/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
+++ b/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
-package policfilter
+package policyfiltermetrics
 
 import (
 	"fmt"

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/encoder"
 	"github.com/cilium/tetragon/pkg/metrics"
-	metricsconfig "github.com/cilium/tetragon/pkg/metrics/config"
+	"github.com/cilium/tetragon/pkg/metrics/metricsconfig"
 	"github.com/cilium/tetragon/pkg/observer"
 	hubbleV1 "github.com/cilium/tetragon/pkg/oldhubble/api/v1"
 	hubbleCilium "github.com/cilium/tetragon/pkg/oldhubble/cilium"

--- a/pkg/policyfilter/rthooks/rthooks.go
+++ b/pkg/policyfilter/rthooks/rthooks.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/cgroups"
 	"github.com/cilium/tetragon/pkg/logger"
-	pfmetrics "github.com/cilium/tetragon/pkg/metrics/policyfilter"
+	"github.com/cilium/tetragon/pkg/metrics/policyfiltermetrics"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/rthooks"
 	"github.com/google/uuid"
@@ -103,7 +103,7 @@ func createContainerHook(_ context.Context, arg *rthooks.CreateContainerArg) err
 	if err := pfState.AddPodContainer(policyfilter.PodID(podID), namespace, pod.Labels, containerID, cgid); err != nil {
 		log.WithError(err).Warn("failed to update policy filter, aborting hook.")
 	}
-	pfmetrics.OpInc("rthooks", "add-container", err)
+	policyfiltermetrics.OpInc("rthooks", "add-container", err)
 
 	return nil
 }

--- a/pkg/policyfilter/state.go
+++ b/pkg/policyfilter/state.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cilium/tetragon/pkg/cgroups/fsscan"
 	"github.com/cilium/tetragon/pkg/labels"
 	"github.com/cilium/tetragon/pkg/logger"
-	pfmetrics "github.com/cilium/tetragon/pkg/metrics/policyfilter"
+	"github.com/cilium/tetragon/pkg/metrics/policyfiltermetrics"
 	"github.com/cilium/tetragon/pkg/podhooks"
 
 	"github.com/google/uuid"
@@ -290,7 +290,7 @@ func (m *state) getPodEventHandlers() cache.ResourceEventHandlerFuncs {
 				return
 			}
 			err := m.updatePodHandler(pod)
-			pfmetrics.OpInc("pod-handlers", "add", err)
+			policyfiltermetrics.OpInc("pod-handlers", "add", err)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			pod, ok := newObj.(*v1.Pod)
@@ -299,7 +299,7 @@ func (m *state) getPodEventHandlers() cache.ResourceEventHandlerFuncs {
 				return
 			}
 			err := m.updatePodHandler(pod)
-			pfmetrics.OpInc("pod-handlers", "update", err)
+			policyfiltermetrics.OpInc("pod-handlers", "update", err)
 		},
 		DeleteFunc: func(obj interface{}) {
 			// Remove all containers for this pod
@@ -322,7 +322,7 @@ func (m *state) getPodEventHandlers() cache.ResourceEventHandlerFuncs {
 					"namespace": namespace,
 				}).Warn("policyfilter, delete-pod handler: DelPod failed")
 			}
-			pfmetrics.OpInc("pod-handlers", "delete", err)
+			policyfiltermetrics.OpInc("pod-handlers", "delete", err)
 		},
 	}
 }


### PR DESCRIPTION
This PR contains a bunch of developer-facing breaking changes. See commits for details. I figured that it's worth doing them, as they will make future development easier and Tetragon is still before 1.0 release. But feel free to call me out if I shouldn't break package structure so freely :)

Initially I wanted also to merge the `pkg/metrics/consts` package into `pkg/metrics`, but I'm hitting import cycles. So I left this idea for now, I might revisit it when iterating on #1548 (although it doesn't seem that changes introduced there make it any simpler).

```release-note
Reorganize code under pkg/metrics. There are no functional changes, but it's a breaking change for developers.
```