### PR TITLE
packages-e2e-tests: Don't fail fast

### DIFF
--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -10,6 +10,7 @@ jobs:
   standalone-tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           # We use the native arch build


### PR DESCRIPTION
Docker Hub keeps rate limiting buildjet runners. Set fail-fast to false so that ubuntu-22.04 runners can finish the job, and then we can re-trigger the failed buildjet job later.

Ref: https://github.com/cilium/tetragon/actions/runs/6355863531/job/17264805755?pr=1530
Ref: https://github.com/actions/runner-images/issues/1445#issuecomment-714832439