### PR TITLE
Use 'go install' to install bom

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -117,15 +117,18 @@ jobs:
         run: |
           cosign sign quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
 
+      - name: Install Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: 'go.mod'
+
       - name: Install Bom
         shell: bash
         env:
           # renovate: datasource=github-releases depName=kubernetes-sigs/bom
           BOM_VERSION: v0.5.1
         run: |
-          curl -L https://github.com/kubernetes-sigs/bom/releases/download/${{ env.BOM_VERSION }}/bom-amd64-linux -o bom
-          sudo mv ./bom /usr/local/bin/bom
-          sudo chmod +x /usr/local/bin/bom
+          go install sigs.k8s.io/bom/cmd/bom@${{ env.BOM_VERSION }}
 
       - name: Generate SBOM
         shell: bash

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -73,15 +73,18 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v3.0.5
 
+      - name: Install Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: 'go.mod'
+
       - name: Install Bom
         shell: bash
         env:
           # renovate: datasource=github-releases depName=kubernetes-sigs/bom
           BOM_VERSION: v0.5.1
         run: |
-          curl -L https://github.com/kubernetes-sigs/bom/releases/download/${{ env.BOM_VERSION }}/bom-amd64-linux -o bom
-          sudo mv ./bom /usr/local/bin/bom
-          sudo chmod +x /usr/local/bin/bom
+          go install sigs.k8s.io/bom/cmd/bom@${{ env.BOM_VERSION }}
 
       # main branch pushes
       - name: CI Build (main)

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -87,16 +87,18 @@ jobs:
           cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
           cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
 
+     - name: Install Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: 'go.mod'
+
       - name: Install Bom
-        if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
         shell: bash
         env:
           # renovate: datasource=github-releases depName=kubernetes-sigs/bom
           BOM_VERSION: v0.5.1
         run: |
-          curl -L https://github.com/kubernetes-sigs/bom/releases/download/${{ env.BOM_VERSION }}/bom-amd64-linux -o bom
-          sudo mv ./bom /usr/local/bin/bom
-          sudo chmod +x /usr/local/bin/bom
+          go install sigs.k8s.io/bom/cmd/bom@${{ env.BOM_VERSION }}
 
       - name: Generate SBOM
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}


### PR DESCRIPTION
Use 'go install' to compile and install bom using the same Go version as
Tetragon to avoid getting this error:

    invalid go version '1.21.1': must match format 1.23

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>