### PR TITLE
helm: Make operator imagePullPolicy configurable

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -98,7 +98,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
-| tetragonOperator.image | object | `{"override":null,"repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v0.11.0"}` | tetragon-operator image. |
+| tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v0.11.0"}` | tetragon-operator image. |
 | tetragonOperator.podInfo.enabled | bool | `false` | Enables the PodInfo CRD and the controller that reconciles PodInfo custom resources. |
 | tetragonOperator.skipCRDCreation | bool | `false` |  |
 | tolerations[0].operator | string | `"Exists"` |  |

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -81,7 +81,7 @@ Helm chart for Tetragon
 | tetragon.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
-| tetragonOperator.image | object | `{"override":null,"repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v0.11.0"}` | tetragon-operator image. |
+| tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v0.11.0"}` | tetragon-operator image. |
 | tetragonOperator.podInfo.enabled | bool | `false` | Enables the PodInfo CRD and the controller that reconciles PodInfo custom resources. |
 | tetragonOperator.skipCRDCreation | bool | `false` |  |
 | tolerations[0].operator | string | `"Exists"` |  |

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -23,6 +23,7 @@ spec:
           - serve
           - --config-dir=/etc/tetragon/operator.conf.d/
         image: "{{ if .Values.tetragonOperator.image.override }}{{ .Values.tetragonOperator.image.override }}{{ else }}{{ .Values.tetragonOperator.image.repository }}{{ .Values.tetragonOperator.image.suffix }}:{{ .Values.tetragonOperator.image.tag }}{{ end }}"
+        imagePullPolicy: {{ .Values.tetragonOperator.image.pullPolicy }}
         volumeMounts:
           - mountPath: /etc/tetragon/operator.conf.d/
             name: tetragon-operator-config

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -159,6 +159,7 @@ tetragonOperator:
     tag: v0.11.0
     # tetragon-operator image-digest
     suffix: ""
+    pullPolicy: IfNotPresent
   # Skip CRD creation.
   skipCRDCreation: false
   podInfo:


### PR DESCRIPTION
imagePullPolicy for the operator deployment can be now set in tetragonOperator.image.pullPolicy value, and defaults to IfNotPresent. Previously it defaulted to Always and couldn't be changed, what was problematic for example in local development.

```release-note
imagePullPolicy for the operator deployment can be set in tetragonOperator.image.pullPolicy Helm value and defaults to IfNotPresent.
```