### PR TITLE
event checker: Don't use the word "failure" for pending checks

### DIFF
--- a/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -174,7 +174,7 @@ func (checker *UnorderedEventChecker) NextEventCheck(event Event, logger *logrus
 			return true, nil
 		}
 		if logger != nil {
-			logger.Infof("UnorderedEventChecker: checking pending %d/%d: failure: %s", idx, pending, err)
+			logger.Infof("UnorderedEventChecker: checking pending %d/%d: %s", idx, pending, err)
 		}
 		idx++
 	}

--- a/cmd/protoc-gen-go-tetragon/eventchecker/multichecker.go
+++ b/cmd/protoc-gen-go-tetragon/eventchecker/multichecker.go
@@ -172,7 +172,7 @@ func generateUnorderedEventChecker(g *protogen.GeneratedFile) error {
                 return true, nil
             }
             if logger != nil {
-                logger.Infof("UnorderedEventChecker: checking pending %d/%d: failure: %s", idx, pending, err)
+                logger.Infof("UnorderedEventChecker: checking pending %d/%d: %s", idx, pending, err)
             }
             idx++
         }

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -174,7 +174,7 @@ func (checker *UnorderedEventChecker) NextEventCheck(event Event, logger *logrus
 			return true, nil
 		}
 		if logger != nil {
-			logger.Infof("UnorderedEventChecker: checking pending %d/%d: failure: %s", idx, pending, err)
+			logger.Infof("UnorderedEventChecker: checking pending %d/%d: %s", idx, pending, err)
 		}
 		idx++
 	}


### PR DESCRIPTION
Avoid using the word "failure" for pending checks to make it easier to locate actual failures in the log.