### PR TITLE
proc_reader: avoid warning for pid=0

### DIFF
--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -143,9 +143,11 @@ func pushExecveEvents(p procs) {
 	m.Kube.NetNS = 0
 	m.Kube.Cid = 0
 	m.Kube.Cgrpid = 0
-	m.Kube.Docker, err = procsDockerId(p.pid)
-	if err != nil {
-		logger.GetLogger().WithError(err).Warn("Procfs execve event pods/ identifier error")
+	if p.pid > 0 {
+		m.Kube.Docker, err = procsDockerId(p.pid)
+		if err != nil {
+			logger.GetLogger().WithError(err).Warn("Procfs execve event pods/ identifier error")
+		}
 	}
 
 	m.Parent.Pid = p.ppid


### PR DESCRIPTION
In some cases, we try to get the docker of pid=0, which fails and produces the following warning:
time="2023-10-04T10:27:14Z" level=warning msg="Procfs execve event pods/ identifier error" error="open /procRoot/0/cgroup: no such file or directory"

This warning is confusing, so avoid it by not calling the relevant code for pid=0.