### PR TITLE
fix: add `kind: TracingPolicy` on new kprobe validation test

### DIFF
--- a/pkg/sensors/tracing/kprobe_validation_test.go
+++ b/pkg/sensors/tracing/kprobe_validation_test.go
@@ -237,6 +237,7 @@ func TestKprobeValidationMissingReturnArg(t *testing.T) {
 
 	crd := `
 apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
 metadata:
   name: "missing-returnarg"
 spec:


### PR DESCRIPTION
A PR that ensures the validity of all TracingPolicy was merged just before a PR adding this test, thus breaking the validity of Tracing Policies.