### PR TITLE
Renovate: Ignore digest updates for k8s dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -336,6 +336,7 @@
       "matchUpdateTypes": [
         "major",
         "minor",
+        "digest",
       ],
     }
   ],


### PR DESCRIPTION
Renovate is configured to ignore minor and major updated of k8s dependencies, because they need to be bumped together with Cilium. However, some k8s dependencies (`k8s.io/kube-openapi`) are not tagged with a version, but pinned by digest. Their updates are incompatible with other k8s deps, what's blocking updates of other Go dependencies, see #1372. This PR updates the Renovate config to ignore digest updates for k8s deps too.