### PR TITLE
Use Go stdlib instead of golang.org/x/exp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20230621221334-77712cff8739
 	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.12.0
 	golang.org/x/time v0.3.0
@@ -167,6 +166,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.16.0 // indirect
 	go.uber.org/dig v1.17.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect

--- a/operator/podinfo/podinfo_controller.go
+++ b/operator/podinfo/podinfo_controller.go
@@ -5,11 +5,11 @@ package podinfo
 
 import (
 	"context"
+	"maps"
 	"reflect"
 
 	ciliumiov1alpha1 "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/process"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/ftrace/ftrace.go
+++ b/pkg/ftrace/ftrace.go
@@ -7,9 +7,8 @@ import (
 	"bufio"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 func readLines(path string) ([]string, error) {
@@ -42,8 +41,8 @@ func ReadAvailFuncs(pattern string) ([]string, error) {
 		}
 	}
 
-	slices.Sort[string](list)
-	list = slices.Compact[[]string, string](list)
+	slices.Sort(list)
+	list = slices.Compact(list)
 
 	var r *regexp.Regexp
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,10 +6,9 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/consts"


### PR DESCRIPTION
Tetragon uses slices and maps functions from `golang.org/x/exp`. In Go 1.21 they
are a part of the Go standard library, so let's import them from there instead.