### PR TITLE
renovate: fix renovate upgrade of Go toolchain

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -187,13 +187,6 @@
         "Dockerfile"
       ],
     },
-    // Upgrade the Go module directive, see:
-    // https://docs.renovatebot.com/modules/versioning/#go-modules-directive-versioning
-    // depName is 'go' so it will be group with the 'Go' groupName
-    {
-      "matchDatasources": ["golang-version"],
-      "rangeStrategy": "bump",
-    },
     {
       "groupName": "Go",
       "matchDepNames": [
@@ -349,11 +342,7 @@
         "^\\.github/workflows/[^/]+\\.ya?ml$"
       ],
       "matchStrings": [
-        // this regex is used to match both:
-        //
-        // # renovate: datasource=golang-version depName=go
-        // go: '1.20.8'
-        //
+        // this regex is used to match:
         // # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
         // - 'bpf-next-20230912.113936'
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+ ['\"]?(?<currentValue>[^'\"\\s]*)"
@@ -384,6 +373,16 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+GOLANGCILINT_WANT_VERSION[[:blank:]]*=[[:blank:]]*(?<currentValue>[^\\s]*)"
+      ]
+    },
+    {
+      "customType": "regex",
+      // match all go.mod in all subfolders
+      "fileMatch": [
+        "go\\.mod$"
+      ],
+      "matchStrings": [
+        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)"
       ]
     }
   ]

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,5 +1,6 @@
 module github.com/cilium/tetragon/api
 
+// renovate: datasource=golang-version depName=go
 go 1.21.1
 
 require (

--- a/contrib/rthooks/tetragon-oci-hook/go.mod
+++ b/contrib/rthooks/tetragon-oci-hook/go.mod
@@ -1,5 +1,6 @@
 module github.com/cilium/tetragon/contrib/rthooks/tetragon-oci-hook
 
+// renovate: datasource=golang-version depName=go
 go 1.21.1
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/cilium/tetragon
 
+// renovate: datasource=golang-version depName=go
 go 1.21.1
 
 require (

--- a/pkg/k8s/go.mod
+++ b/pkg/k8s/go.mod
@@ -1,5 +1,6 @@
 module github.com/cilium/tetragon/pkg/k8s
 
+// renovate: datasource=golang-version depName=go
 go 1.21.1
 
 require (


### PR DESCRIPTION
PR #1536 broke "renovate update Go toolchain in a single PR" from #1259 because in the actual state it could only bump the go directive from minor versions, not bumping the patch needed by the workflows github actions reading that version.

From cilium/cilium@2f7e2f33659776a1c2adcf80111f69d6debdd850: According to [1] as of Go 1.21 we either need to specify the full toolchain version in the `go` directive or add a `toolchain` directive with the concrete toolchain version. Opt for the former and make sure it's kept up to date by renovate bot.

[1] golang/go#62278 (comment)