### PR TITLE
bugfix: Use shared string maps in kprobe-multi

### DIFF
--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -14,3 +14,5 @@ uprobe-test-1
 uprobe-test-2
 lseek-pipe
 threads-tester
+bench-reader
+threads-exit

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1258,7 +1258,7 @@ func parseSelector(
 //
 // For some examples, see kernel_test.go
 func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg, actionArgTable *idtable.Table) ([4096]byte, error) {
-	kernelSelectors, err := InitKernelSelectorState(selectors, args, actionArgTable, nil)
+	kernelSelectors, err := InitKernelSelectorState(selectors, args, actionArgTable, nil, nil)
 	if err != nil {
 		return [4096]byte{}, err
 	}
@@ -1266,8 +1266,8 @@ func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KP
 }
 
 func InitKernelSelectorState(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg,
-	actionArgTable *idtable.Table, listReader ValueReader) (*KernelSelectorState, error) {
-	kernelSelectors := NewKernelSelectorState(listReader)
+	actionArgTable *idtable.Table, listReader ValueReader, maps *KernelSelectorMaps) (*KernelSelectorState, error) {
+	kernelSelectors := NewKernelSelectorState(listReader, maps)
 
 	WriteSelectorUint32(kernelSelectors, uint32(len(selectors)))
 	soff := make([]uint32, len(selectors))

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -221,7 +221,7 @@ func TestParseMatchArg(t *testing.T) {
 	}
 
 	arg1 := &v1alpha1.ArgSelector{Index: 1, Operator: "Equal", Values: []string{"foobar"}}
-	k := &KernelSelectorState{off: 0}
+	k := NewKernelSelectorState(nil, nil)
 	expected1 := []byte{
 		0x01, 0x00, 0x00, 0x00, // Index == 1
 		0x03, 0x00, 0x00, 0x00, // operator == equal
@@ -318,7 +318,7 @@ func TestParseMatchArg(t *testing.T) {
 		expected3 := append(length, expected1[:]...)
 		expected3 = append(expected3, expected2[:]...)
 		arg12 := []v1alpha1.ArgSelector{*arg1, *arg2}
-		ks := &KernelSelectorState{off: 0}
+		ks := NewKernelSelectorState(nil, nil)
 		if err := ParseMatchArgs(ks, arg12, sig); err != nil || bytes.Equal(expected3, ks.e[0:ks.off]) == false {
 			t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected3, ks.e[0:k.off], arg3)
 		}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -508,7 +508,7 @@ func (tp *genericTracepoint) InitKernelSelectors(lists []v1alpha1.ListSpec) erro
 		}
 	}
 
-	selectors, err := selectors.InitKernelSelectorState(selSelectors, selArgs, &tp.actionArgs, &listReader{lists})
+	selectors, err := selectors.InitKernelSelectorState(selSelectors, selArgs, &tp.actionArgs, &listReader{lists}, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -200,7 +200,7 @@ func createGenericUprobeSensor(
 		}
 
 		// Parse Filters into kernel filter logic
-		uprobeSelectorState, err := selectors.InitKernelSelectorState(spec.Selectors, args, nil, nil)
+		uprobeSelectorState, err := selectors.InitKernelSelectorState(spec.Selectors, args, nil, nil, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR first introduces a test showing that we have a bug in the case of kprobe-multi, which uses matchArgs where both use maps to do string operations.

The problem is due to overriding string maps after processing each kprobe. To fix that we use shared maps for all selectors for all attach points in the case of kprobe-multi.

Non kprobe-multi cases and tracepoints/uprobes work exactly as before.