### PR TITLE
renovate: fix the way we manually install Go inside the runner

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,9 +12,10 @@
     "^/tmp/install-buildx$", 
     "^make codegen$", 
     "^make generate$", 
+    "^make vendor$",
     "^install/kubernetes/test.sh$",
     "^go mod vendor$",
-    "^install-tool golang [0-9]\\.[0-9]+\\.[0-9]+$"
+    "^install-tool golang \\$\\(grep -oP '\\^go \\\\K\\.\\+' go\\.mod\\)$"
   ],
   // repository configuration
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
@@ -198,8 +199,7 @@
         // We need to trigger a golang install manually here because in some
         // cases it might not be preinstalled, see:
         // https://github.com/renovatebot/renovate/discussions/23485
-        // renovate: datasource=golang-version depName=go
-        "commands": ["install-tool golang 1.21.2", "go mod vendor"],
+        "commands": ["install-tool golang $(grep -oP '^go \\K.+' go.mod)", "make vendor"],
         "fileFilters": ["**/**"],
         "executionMode": "branch"
       },
@@ -355,15 +355,6 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?)\\s+GO_IMAGE[[:blank:]]*=[[:blank:]]*(?<depName>.*?):(?<currentValue>[^\\s]*)"
-      ]
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^\\.github/renovate\\.json5$"
-      ],
-      "matchStrings": [
-        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+install-tool golang (?<currentValue>[^'\"]*)"
       ]
     },
     {


### PR DESCRIPTION
This is a follow-up of https://github.com/cilium/tetragon/pull/1579 because https://github.com/cilium/tetragon/pull/1577 is broken.

This simplifies a49c4bc2ce6128800ca9b00825954f6b6d6bc0f4 that causes issues in the case of the new Go toolchain feature. It was manually installing a version off-by-one, like 1.21.2 for 1.21.3 present in the just updated go.mod and thus triggering the automatic download of the 1.21.3 toolchain. But in the renovate container env, GOSUMDB is set to off for some reason which blocks the download of the toolchain.

This simplifies the manual install by reading the go.mod file to determine the correct version, allowing to remove the bump of the number in the renovate config itself.