### PR TITLE
renovate: enable automerge for pin/pinDigest and patch 

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -335,7 +335,7 @@
   ],
   // Those regexes manage version strings in variousfiles, similar to the
   // examples shown here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
-  "regexManagers": [
+  "customManagers": [
     {
       "customType": "regex",
       "fileMatch": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,6 +67,26 @@
   // to something non-null.
   "packageRules": [
     {
+      "matchPackageNames": [
+        "go", // golang version directive upgrade in go.mod
+      ],
+      "matchPackagePrefixes": [
+        "docker.io/library/", // official Docker images
+        "github.com/golang/", // Golang official org
+        "golang.org/x/", // Golang official experimental org
+        "google.golang.org/", // Google official repo for api/genproto/grpc/protobuf
+        "github.com/google/", // Google official github org
+        "k8s.io/", // Kubernetes official repo
+        "sigs.k8s.io/", // Kubernetes official SIG repo
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "pin",
+        "pinDigest"
+      ],
+      "automerge": true
+    },
+    {
       "groupName": "all github action dependencies",
       "groupSlug": "all-github-action",
       "matchFileNames": [


### PR DESCRIPTION
Let's agree on what it's reasonable to enable auto-merge! I propose:

```json5
   {
      "matchPackageNames": [
        "go", // golang version directive upgrade in go.mod
      ],
      "matchPackagePrefixes": [
        "docker.io/library/", // official Docker images
        "github.com/golang/", // Golang official org
        "golang.org/x/", // Golang official experimental org
        "google.golang.org/", // Google official repo for api/genproto/grpc/protobuf
        "github.com/google/", // Google official github org
        "k8s.io/", // Kubernetes official repo
        "sigs.k8s.io/", // Kubernetes official SIG repo
      ],
      "matchUpdateTypes": [
        "patch",
        "pin",
        "pinDigest"
      ],
      "automerge": true
    },
```