### PR TITLE
bpf: remove cgrpid_tracker

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -302,7 +302,6 @@ struct execve_map_value {
 	__u32 nspid;
 	__u32 binary;
 	__u32 pad;
-	__u64 cgrpid_tracker; /* Pinned Cgroup ID Tracker */
 	struct msg_ns ns;
 	struct msg_capabilities caps;
 } __attribute__((packed)) __attribute__((aligned(8)));

--- a/bpf/process/policy_filter.h
+++ b/bpf/process/policy_filter.h
@@ -26,23 +26,21 @@ struct {
 static inline __attribute__((always_inline)) bool
 policy_filter_check(u32 policy_id)
 {
-	__u32 pid;
 	void *policy_map;
-	struct execve_map_value *curr;
+	__u64 cgroupid;
 
 	if (!policy_id)
 		return true;
-
-	pid = (get_current_pid_tgid() >> 32);
-	curr = execve_map_get_noinit(pid);
-	if (!curr || curr->cgrpid_tracker == 0)
-		return false;
 
 	policy_map = map_lookup_elem(&policy_filter_maps, &policy_id);
 	if (!policy_map)
 		return false;
 
-	return map_lookup_elem(policy_map, &curr->cgrpid_tracker);
+	cgroupid = tg_get_current_cgroup_id();
+	if (!cgroupid)
+		return false;
+
+	return map_lookup_elem(policy_map, &cgroupid);
 }
 
 #endif /* POLICY_FILTER_MAPS_H__ */

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -129,7 +129,6 @@ func (msg *MsgCgroupEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 				"cgroup.event":       op.String(),
 				"PID":                msg.PID,
 				"NSPID":              msg.NSPID,
-				"cgroup.IDTracker":   msg.CgrpidTracker,
 				"cgroup.ID":          msg.Cgrpid,
 				"cgroup.state":       st,
 				"cgroup.hierarchyID": msg.CgrpData.HierarchyId,

--- a/pkg/sensors/exec/execvemap/execve.go
+++ b/pkg/sensors/exec/execvemap/execve.go
@@ -12,13 +12,12 @@ type ExecveKey struct {
 }
 
 type ExecveValue struct {
-	Process       processapi.MsgExecveKey    `align:"key"`
-	Parent        processapi.MsgExecveKey    `align:"pkey"`
-	Flags         uint32                     `align:"flags"`
-	Nspid         uint32                     `align:"nspid"`
-	Binary        uint32                     `align:"binary"`
-	Pad           uint32                     `align:"pad"`
-	CgrpIdTracker uint64                     `align:"cgrpid_tracker"`
-	Namespaces    processapi.MsgNamespaces   `align:"ns"`
-	Capabilities  processapi.MsgCapabilities `align:"caps"`
+	Process      processapi.MsgExecveKey    `align:"key"`
+	Parent       processapi.MsgExecveKey    `align:"pkey"`
+	Flags        uint32                     `align:"flags"`
+	Nspid        uint32                     `align:"nspid"`
+	Binary       uint32                     `align:"binary"`
+	Pad          uint32                     `align:"pad"`
+	Namespaces   processapi.MsgNamespaces   `align:"ns"`
+	Capabilities processapi.MsgCapabilities `align:"caps"`
 }

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3731,6 +3731,9 @@ func TestLoadKprobeSensor(t *testing.T) {
 
 		// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
 		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 3, 4, 5, 12, 14}},
+
+		// generic_kprobe_event
+		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
 	}
 
 	if kernels.EnableLargeProgs() {

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -452,6 +452,9 @@ func TestLoadTracepointSensor(t *testing.T) {
 
 		// all kprobe but generic_tracepoint_filter
 		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+
+		// generic_tracepoint_event
+		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
 	}
 
 	if kernels.EnableLargeProgs() {

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -131,7 +131,7 @@ func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []S
 
 		// event_execve
 		SensorMap{Name: "names_map", Progs: []uint{0}},
-		SensorMap{Name: "tg_conf_map", Progs: []uint{0, 2}},
+		SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
 
 		// event_wake_up_new_task
 		SensorMap{Name: "execve_val", Progs: []uint{2}},


### PR DESCRIPTION
There is an issue with the cgroup tracker id (details can be found below). This issue causes policyfilter to misbehave. Furthermore, the original intention behind the cgroup tracker id was never implemented and so it currently serves no purpose. Its only user is the policyfilter.

This patch removes the cgroup tracker id, and, instead, computes the cgroup id at the time of the policyfilter check. For most common setups (cgroupv2) the overhead of doing so is negligible. Computing the cgroup id at the time of check is more reliable and also simplifies the code.

More details can be found below.

We have a namespaced policy installed that mathes connect() calls to 8.8.8.8, and execute the following on a pod in the same namespace:

`kubectl exec -it nonqos-demo -- curl 8.8.8.8`

We observe two things:
 * there is no event from the policy (as we were expecting)
 * the cgroup tracker id of the curl process is the same as the parent runc process (which should not be the case)

The exec event we get from curl has:
 .process.pid: 244958
 .process.binary: /usr/bin/curl
 .parent.pid: 244948
 .parent.binary: /usr/bin/runc

Looking at the cgroup tracker id in the execve map for these two pids we see:
"cgrpid_tracker": 2371
"cgrpid_tracker": 2371

Which means that the cgroup id tracker is not correct, and the curl process will not be matched by the policy.

The issue might arise from the fact that in the wake_up_new_task(), computing the cgroup tracker id, uses get_current_cgroup_id(). We are, however, still in the parent so the get_current_cgroup_id() helper will return the cgroup of the parent, not of the child (which is what we want).

To simplify the code complexity (both from the perspective of understandabiliuty but also verification complexity), we instead remove the tracker id and retrieve the current cgroup id at the time of the check. This is much simpler, and not less efficient for the common case (cgroupv2).

Following the same steps with a version build with the current patch, produces an event as expected.