### PR TITLE
tetragon: Use pull_request_target event for e2e CI tests

### DIFF
--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -1,7 +1,7 @@
 name: Packages e2e Tests
 
 on:
-  pull_request:
+  pull_request_target:
     paths-ignore:
     - "**.md"
     - 'docs/**'


### PR DESCRIPTION
As suggested by Mahe, so it can run properly on fork-ed repos.