### PR TITLE
tetragon: Add support to override security_ functions

### DIFF
--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -302,3 +302,20 @@ generic_kprobe_override(void *ctx)
 	map_delete_elem(&override_tasks, &id);
 	return 0;
 }
+
+/* Putting security_task_prctl in here to pass contrib/verify/verify.sh test,
+ * in normal run the function is set by tetragon dynamically.
+ */
+__attribute__((section("fmod_ret/security_task_prctl"), used)) long
+generic_fmodret_override(void *ctx)
+{
+	__u64 id = get_current_pid_tgid();
+	__s32 *error;
+
+	error = map_lookup_elem(&override_tasks, &id);
+	if (!error)
+		return 0;
+
+	map_delete_elem(&override_tasks, &id);
+	return (long)*error;
+}

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -160,6 +160,8 @@ func tetragonExecute() error {
 	log.WithField("version", version.Version).Info("Starting tetragon")
 	log.WithField("config", viper.AllSettings()).Info("config settings")
 
+	log.Info("BPF detected features: ", bpf.LogFeatures())
+
 	if option.Config.ForceLargeProgs && option.Config.ForceSmallProgs {
 		log.Fatalf("Can't specify --force-small-progs and --force-large-progs together")
 	}

--- a/examples/tracingpolicy/override-security.yaml
+++ b/examples/tracingpolicy/override-security.yaml
@@ -1,0 +1,16 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "syswritefollowfdpsswd"
+spec:
+  kprobes:
+  - call: "security_inode_mkdir"
+    syscall: false
+    selectors:
+    - matchBinaries:
+      - operator: "In"
+        values:
+        - "/usr/bin/bash"
+    - matchActions:
+      - action: Override
+        argError: -1

--- a/pkg/bpf/detect.go
+++ b/pkg/bpf/detect.go
@@ -7,6 +7,7 @@
 package bpf
 
 import (
+	"fmt"
 	"sync"
 	"unsafe"
 
@@ -142,4 +143,9 @@ func HasModifyReturn() bool {
 		modifyReturn.detected = detectModifyReturn()
 	})
 	return modifyReturn.detected
+}
+
+func LogFeatures() string {
+	return fmt.Sprintf("override_return: %t, buildid: %t, kprobe_multi: %t, fmodret: %t",
+		HasOverrideHelper(), HasBuildId(), HasKprobeMulti(), HasModifyReturn())
 }

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -271,6 +271,8 @@ func getDefaultObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor
 		testDone(tb, obs)
 	})
 
+	logger.GetLogger().Info("BPF detected features: ", bpf.LogFeatures())
+
 	obs.PerfConfig = bpf.DefaultPerfEventConfig()
 	obs.PerfConfig.MapName = filepath.Join(bpf.MapPrefixPath(), "tcpmon_map")
 	return obs, nil

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -125,16 +125,19 @@ func RawTracepointAttach(load *Program) AttachFunc {
 	}
 }
 
+func disableProg(coll *ebpf.CollectionSpec, name string) {
+	if spec, ok := coll.Programs[name]; ok {
+		spec.Type = ebpf.UnspecifiedProgram
+	}
+}
+
 func KprobeOpen(load *Program) OpenFunc {
 	return func(coll *ebpf.CollectionSpec) error {
 		// The generic_kprobe_override program is part of bpf_generic_kprobe.o object,
 		// so let's disable it if the override is not configured. Otherwise it gets
 		// loaded and bpftool will show it.
 		if !load.Override {
-			progOverrideSpec, ok := coll.Programs["generic_kprobe_override"]
-			if ok {
-				progOverrideSpec.Type = ebpf.UnspecifiedProgram
-			}
+			disableProg(coll, "generic_kprobe_override")
 		}
 		return nil
 	}

--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -74,7 +74,8 @@ type Program struct {
 	ErrorFatal bool
 
 	// Needs override bpf program
-	Override bool
+	Override        bool
+	OverrideFmodRet bool
 
 	// Type is the type of BPF program. For example, tc, skb, tracepoint,
 	// etc.

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -621,6 +621,19 @@ func addKprobe(funcName string, f *v1alpha1.KProbeSpec, in *addKprobeIn, selMaps
 		}
 	}
 
+	isSecurityFunc := strings.HasPrefix(funcName, "security_")
+
+	if selectors.HasOverride(f) {
+		if isSecurityFunc && in.useMulti {
+			return nil, fmt.Errorf("Error: can't override '%s' function with kprobe_multi, use --disable-kprobe-multi option",
+				funcName)
+		}
+		if isSecurityFunc && !bpf.HasModifyReturn() {
+			return nil, fmt.Errorf("Error: can't override '%s' function without fmodret support",
+				funcName)
+		}
+	}
+
 	argRetprobe = nil // holds pointer to arg for return handler
 
 	// Parse Arguments
@@ -806,6 +819,9 @@ func addKprobe(funcName string, f *v1alpha1.KProbeSpec, in *addKprobeIn, selMaps
 		"generic_kprobe").
 		SetLoaderData(kprobeEntry.tableId)
 	load.Override = kprobeEntry.hasOverride
+	if load.Override {
+		load.OverrideFmodRet = isSecurityFunc && bpf.HasModifyReturn()
+	}
 	out.progs = append(out.progs, load)
 
 	fdinstall := program.MapBuilderPin("fdinstall_map", sensors.PathJoin(in.sensorPath, "fdinstall_map"), load)
@@ -1001,6 +1017,7 @@ func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir, mapDir string, load *p
 	}
 
 	load.Override = len(data.Overrides) > 0
+	load.OverrideFmodRet = false
 	load.SetAttachData(data)
 
 	if err := program.LoadMultiKprobeProgram(bpfDir, mapDir, load, verbose); err == nil {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2207,6 +2207,68 @@ spec:
 	runKprobeOverride(t, openAtHook, checker, file.Name(), syscall.ENOENT, false)
 }
 
+func TestKprobeOverrideSecurity(t *testing.T) {
+	if !bpf.HasModifyReturn() {
+		t.Skip("skipping fmod_ret support is not available")
+	}
+
+	if !option.Config.DisableKprobeMulti && bpf.HasKprobeMulti() {
+		t.Skip("skipping fmod_ret does not work with kprobe multi")
+	}
+
+	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
+
+	file, err := os.CreateTemp(t.TempDir(), "kprobe-override-")
+	if err != nil {
+		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
+	}
+	defer assert.NoError(t, file.Close())
+
+	openAtHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "sys-openat-override"
+spec:
+  kprobes:
+  - call: "security_file_open"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "file"
+    returnArg:
+      type: "int"
+    selectors:
+    - matchPIDs:
+      - operator: In
+        followForks: true
+        values:
+        - ` + pidStr + `
+      matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "` + file.Name() + `"
+      matchActions:
+      - action: Override
+        argError: -2
+`
+
+	kpChecker := ec.NewProcessKprobeChecker("").
+		WithFunctionName(sm.Full("security_file_open")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithFileArg(ec.NewKprobeFileChecker().WithPath(sm.Full(file.Name()))),
+			)).
+		WithReturn(ec.NewKprobeArgumentChecker().WithIntArg(-2)).
+		WithAction(tetragon.KprobeAction_KPROBE_ACTION_OVERRIDE)
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	runKprobeOverride(t, openAtHook, checker, file.Name(), syscall.ENOENT, false)
+}
+
 func TestKprobeOverrideNopostAction(t *testing.T) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 


### PR DESCRIPTION
Adding support to override 'security_' kernel functions with
fmod_ret override program.

The fmod_ret program is specific and differs to kprobe override
program in following ways:

  1) it needs to be loaded with BTF ID of function it's attached to
  2) it's invoked from BPF trampoline which is executed as direct call
     after the ftrace trampoline is done

The 1) prevents us to have single program for multiple functions we
want to override, hence for this moment we allow to fmod_ret override
only in non kprobe_multi mode (--disable-kprobe-multi option).

This could be changed in future, but might imply some performance hits.

The 2) adds extra code paths execution compared to invoking kprobe override
program, so we are using fmod_ret override only for 'security_' functions
and kprobe override for the rest.
