### PR TITLE
Add veristat in the CI

### DIFF
--- a/.github/workflows/veristat-compare.yaml
+++ b/.github/workflows/veristat-compare.yaml
@@ -1,0 +1,32 @@
+name: Run veristat compare
+on:
+  pull_request:
+    paths:
+      - 'bpf/**'
+
+jobs:
+  veristat-compare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          path: branch
+
+      - name: Checkout base ref
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          path: base
+          ref: ${{ github.base_ref }}
+
+      - name: Build BPF programs
+        run: |
+          make -C branch tetragon-bpf
+          make -C base tetragon-bpf
+
+      - name: Run veristat comparison
+        uses: mtardy/veristat-action@35c8885118c1b3046f6a5fdedf1cc5670e584cf9 # v1.0.0
+        with:
+          compare: true
+          baseline-programs: "base/bpf/objs/*.o"
+          comparison-programs: "branch/bpf/objs/*.o"

--- a/.github/workflows/veristat.yaml
+++ b/.github/workflows/veristat.yaml
@@ -1,0 +1,26 @@
+name: Run veristat
+on:
+  push:
+    branches:
+      - main
+      - v*
+    paths:
+      - 'bpf/**'
+  pull_request:
+    paths:
+      - 'bpf/**'
+
+jobs:
+  veristat:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - name: Build BPF programs
+        run: make tetragon-bpf
+
+      - name: Run veristat
+        uses: mtardy/veristat-action@35c8885118c1b3046f6a5fdedf1cc5670e584cf9 # v1.0.0
+        with:
+          programs: "bpf/objs/*.o"


### PR DESCRIPTION
Fixes #892

We can restrict the run to PRs touching the `/bpf` folder.

Take a look at [this](https://github.com/cilium/tetragon/actions/runs/6561516593?pr=1610#summary-17821372896) and [that](https://github.com/cilium/tetragon/actions/runs/6561516598?pr=1610#summary-17821373428). More comparison examples [here](https://github.com/mtardy/veristat-action/actions/runs/6560133222#summary-17817130029).