### PR TITLE
ci: minor refactor to build-images job

### DIFF
--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -59,16 +59,25 @@ jobs:
             echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Checkout Source Code
+      - name: Checkout master branch
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           persist-credentials: false
-          ref: ${{ steps.tag.outputs.tag }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
 
       - name: Get version
         run: |
           echo "TETRAGON_VERSION=$(make version)" >> $GITHUB_ENV
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          persist-credentials: false
+          ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v3.0.5


### PR DESCRIPTION
We don't want to run `make version` in the context of a PR branch, so run it from master before checking out the PR branch.