### PR TITLE
vendor: fix cilium/tetragon replacement in api

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -25,4 +25,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/cilium/tetragon => ../../tetragon
+replace github.com/cilium/tetragon => ../

--- a/api/vendor/modules.txt
+++ b/api/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/cilium/tetragon v0.0.0-00010101000000-000000000000 => ../../tetragon
+# github.com/cilium/tetragon v0.0.0-00010101000000-000000000000 => ../
 ## explicit; go 1.21.3
 github.com/cilium/tetragon/pkg/matchers/bytesmatcher
 github.com/cilium/tetragon/pkg/matchers/listmatcher
@@ -143,4 +143,4 @@ gopkg.in/yaml.v3
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/cilium/tetragon => ../../tetragon
+# github.com/cilium/tetragon => ../


### PR DESCRIPTION
We had `../../tetragon` as the go mod replacement for the api module. But what happens when the directory name of the git repo isn't `tetragon`? We should handle this case, so change it to `..` directly.