### PR TITLE
Events: Support events from kernel and init

### DIFF
--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -203,6 +203,12 @@ func (ec *Cache) Needed(proc *tetragon.Process) bool {
 	if proc == nil {
 		return true
 	}
+	// Pid=0 is the kernel; Pid=1 is the init process.
+	// For both, we will not receive any execve events or k8s watcher info
+	// to enrich the events, so the cache is not needed for these.
+	if proc.Pid.Value <= 1 {
+		return false
+	}
 	if option.Config.EnableK8s {
 		if proc.Docker != "" && proc.Pod == nil {
 			return true

--- a/pkg/ktime/ktime.go
+++ b/pkg/ktime/ktime.go
@@ -38,7 +38,10 @@ func NanoTimeSince(ktime int64) (time.Duration, error) {
 }
 func DecodeKtime(ktime int64, monotonic bool) (time.Time, error) {
 	var clk int32
-	if monotonic {
+	// If ktime == 0, then we should report the boot time.
+	// This is easiest done by subtracting the boottime clock
+	// from the current time.
+	if monotonic && ktime > 0 {
 		clk = int32(unix.CLOCK_MONOTONIC)
 	} else {
 		clk = int32(unix.CLOCK_BOOTTIME)


### PR DESCRIPTION
Tetragon supports events from user space processes. These processes are stored in the execve map and in the process cache. Events that arrive in the agent without all the information they need, or arrive before the execve event arrives, are placed temporarily in the event cache, such that the information is likely to be available shortly after, and this information can then be added to the event before it is processed.

The process cache has an entry for PID=1 (init) in order to provide parent process information for daemons and orphaned processes. If, in the future, we generate events for the init process or for the kernel itself, then these will be identified as missing information and will be placed in the event cache. Unfortunately, no extra information will become available for these processes (PID=0 and PID=1) so this just delays the events from being processed.

This commit shortcuts the event cache when PID=0 or PID=1, and handles a process start time of 0 (boot time) gracefully.