### PR TITLE
helm: add service monitor scrape interval config

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -97,6 +97,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.prometheus.port | int | `2112` | The port at which to expose metrics. |
 | tetragon.prometheus.serviceMonitor.enabled | bool | `false` | Whether to create a 'ServiceMonitor' resource targeting the 'tetragon' pods. |
 | tetragon.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
+| tetragon.prometheus.serviceMonitor.scrapeInterval | string | `"10s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
 | tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v1.0.0-rc.1"}` | tetragon-operator image. |

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -80,6 +80,7 @@ Helm chart for Tetragon
 | tetragon.prometheus.port | int | `2112` | The port at which to expose metrics. |
 | tetragon.prometheus.serviceMonitor.enabled | bool | `false` | Whether to create a 'ServiceMonitor' resource targeting the 'tetragon' pods. |
 | tetragon.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
+| tetragon.prometheus.serviceMonitor.scrapeInterval | string | `"10s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
 | tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","suffix":"","tag":"v1.0.0-rc.1"}` | tetragon-operator image. |

--- a/install/kubernetes/templates/servicemonitor.yaml
+++ b/install/kubernetes/templates/servicemonitor.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   endpoints:
     - honorLabels: true
-      interval: 10s
+      interval: {{ .Values.tetragon.prometheus.serviceMonitor.scrapeInterval }}
       path: /metrics
       port: metrics
       relabelings:

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -134,6 +134,8 @@ tetragon:
       enabled: false
       # -- The set of labels to place on the 'ServiceMonitor' resource.
       labelsOverride: {}
+      # -- Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used.
+      scrapeInterval: "10s"
   grpc:
     # -- Whether to enable exposing Tetragon gRPC.
     enabled: true


### PR DESCRIPTION
This commit was related to the service monitor scrape interval option.
I made a change to allow options to be injected via the values.yaml file.

fix: #1633 