### PR TITLE
tetra policyfilter command

### DIFF
--- a/cmd/tetra/commands_linux.go
+++ b/cmd/tetra/commands_linux.go
@@ -6,6 +6,7 @@ package main
 import (
 	"github.com/cilium/tetragon/cmd/tetra/bugtool"
 	"github.com/cilium/tetragon/cmd/tetra/dump"
+	"github.com/cilium/tetragon/cmd/tetra/policyfilter"
 	"github.com/cilium/tetragon/cmd/tetra/tracingpolicy"
 	"github.com/spf13/cobra"
 )
@@ -15,4 +16,5 @@ func addCommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(bugtool.New())
 	rootCmd.AddCommand(tracingpolicy.New())
 	rootCmd.AddCommand(dump.New())
+	rootCmd.AddCommand(policyfilter.New())
 }

--- a/cmd/tetra/dump/dump.go
+++ b/cmd/tetra/dump/dump.go
@@ -107,6 +107,7 @@ func dumpPolicyfilterState(fname string) {
 		logger.GetLogger().WithError(err).Fatal("Failed to open policyfilter map")
 		return
 	}
+	defer m.Close()
 
 	data, err := m.Dump()
 	if err != nil {

--- a/cmd/tetra/dump/dump.go
+++ b/cmd/tetra/dump/dump.go
@@ -60,7 +60,7 @@ func policyfilterCmd() *cobra.Command {
 		Short: "dump policyfilter state",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
-			dumpPolicyfilterState(mapFname)
+			PolicyfilterState(mapFname)
 		},
 	}
 
@@ -101,7 +101,7 @@ func dumpExecveMap(fname string) {
 	}
 }
 
-func dumpPolicyfilterState(fname string) {
+func PolicyfilterState(fname string) {
 	m, err := policyfilter.OpenMap(fname)
 	if err != nil {
 		logger.GetLogger().WithError(err).Fatal("Failed to open policyfilter map")

--- a/cmd/tetra/policyfilter/policyfilter.go
+++ b/cmd/tetra/policyfilter/policyfilter.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package policyfilter
+
+import (
+	"path/filepath"
+	"strconv"
+
+	"github.com/cilium/tetragon/cmd/tetra/dump"
+	"github.com/cilium/tetragon/pkg/cgroups"
+	"github.com/cilium/tetragon/pkg/defaults"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/policyfilter"
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	ret := &cobra.Command{
+		Use:          "policyfilter",
+		Short:        "manage policyfilter map (only for debugging)",
+		Hidden:       true,
+		SilenceUsage: true,
+	}
+
+	ret.AddCommand(
+		dumpCmd(),
+		addCommand(),
+	)
+
+	return ret
+}
+
+func dumpCmd() *cobra.Command {
+	mapFname := filepath.Join(defaults.DefaultMapRoot, defaults.DefaultMapPrefix, policyfilter.MapName)
+	ret := &cobra.Command{
+		Use:   "dump",
+		Short: "dump policyfilter state",
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			dump.PolicyfilterState(mapFname)
+		},
+	}
+
+	flags := ret.Flags()
+	flags.StringVar(&mapFname, "map-fname", mapFname, "policyfilter map filename")
+	return ret
+}
+
+func addCommand() *cobra.Command {
+	var argType string
+	mapFname := filepath.Join(defaults.DefaultMapRoot, defaults.DefaultMapPrefix, policyfilter.MapName)
+	ret := &cobra.Command{
+		Use:   "add [policy id] [cgroup]",
+		Short: "add policyfilter entry",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			x, err := strconv.ParseUint(args[0], 10, 32)
+			if err != nil {
+				logger.GetLogger().WithError(err).Fatal("Failed to parse policy id")
+			}
+			polID := policyfilter.PolicyID(x)
+
+			var cgID uint64
+			switch argType {
+			case "file":
+				cgID, err = cgroups.GetCgroupIdFromPath(args[1])
+			case "id":
+				cgID, err = strconv.ParseUint(args[1], 10, 32)
+			default:
+				logger.GetLogger().WithField("type", argType).WithError(err).Fatal("Unknown type")
+			}
+
+			if err != nil {
+				logger.GetLogger().WithError(err).Fatal("Failed to parse cgroup")
+			}
+
+			addCgroup(mapFname, polID, policyfilter.CgroupID(cgID))
+		},
+	}
+
+	flags := ret.Flags()
+	flags.StringVar(&argType, "arg-type", "file", "cgroup type (id,file)")
+	flags.StringVar(&mapFname, "map-fname", mapFname, "policyfilter map filename")
+	return ret
+}
+
+func addCgroup(fname string, polID policyfilter.PolicyID, cgID policyfilter.CgroupID) {
+	m, err := policyfilter.OpenMap(fname)
+	if err != nil {
+		logger.GetLogger().WithError(err).Fatal("Failed to open policyfilter map")
+		return
+	}
+	defer m.Close()
+
+	err = m.AddCgroup(polID, cgID)
+	if err != nil {
+		logger.GetLogger().WithError(err).Fatal("Failed to add cgroup id")
+	}
+
+}


### PR DESCRIPTION
Add a new policyfilter tetra command.  We add two sub-commands:
dump (which is the same as tetra dump policyfilter) and add to add
entries to the map. This is strictly for development/debugging, so we
mark the command hidden.