### PR TITLE
helm: Fix selector labels for the operator deployment

### DIFF
--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "tetragon-operator.labels" . | nindent 6 }}
+      {{- include "tetragon-operator.selectorLabels" . | nindent 6 }}
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Use tetragon-operator.selectorLabels instead of tetragon-operator.labels for selector labels. tetragon-operator.labels contains the helm.sh/chart label which differs among different versions (e.g. tetragon-1.0.0-rc.1). Helm upgrade fails because spec.selector field is immutable.