### PR TITLE
ci: fix CI for external contributors

### DIFF
--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -37,7 +37,11 @@ jobs:
         id: tag
         run: echo "tag=$(make version)" >> $GITHUB_OUTPUT
 
+      # Logging into Docker Hub makes the job less flaky, but it relies on repo secrets so
+      # does not work for external contributors. Let's compromise and do this for internal
+      # PRs at least (for now). We can always improve the situation later.
       - name: Login to Docker Hub
+        if: ${{ github.event.pull_request.head.repo.full_name == 'cilium/tetragon' }}
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME_CI }}


### PR DESCRIPTION
One of our CI jobs recently started relying on a repo secret to log into Docker Hub. This is not strictly necessary, but was done to make the job less flaky, since we were hitting rate limits on Docker's API server. However, this actually broke the workflow for external contributors, since forks do not have access to repo secrets.

It would be a significant security challenge to make this work for external contributors, so I'm leaving this as future work for now. Instead, let's fix the more immediate problem by simply only attempting a login when the PR comes from within the Cilium org.