### PR TITLE
doc: replace dead links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Refer to the [official documentation of Tetragon](https://tetragon.cilium.io/doc
 
 To get started with Tetragon, take a look at the [getting started
 guides](https://tetragon.cilium.io/docs/getting-started/) to:
-- [Try Tetragon on Kubernetes](https://tetragon.cilium.io/docs/getting-started/kubernetes-quickstart-guide/)
-- [Try Tetragon on Linux](https://tetragon.cilium.io/docs/getting-started/try-tetragon-linux/)
-- [Deploy Tetragon](https://tetragon.cilium.io/docs/getting-started/deployment/)
-- [Install the Tetra CLI](https://tetragon.cilium.io/docs/getting-started/install-tetra-cli/)
+- [Try Tetragon on Kubernetes](https://tetragon.io/docs/getting-started/install-k8s/)
+- [Try Tetragon on Linux](https://tetragon.io/docs/getting-started/install-docker/)
+- [Deploy Tetragon](https://tetragon.io/docs/installation/)
+- [Install the Tetra CLI](https://tetragon.io/docs/installation/tetra-cli/)
 
 Tetragon is able to observe critical hooks in the kernel through its sensors
 and generates events enriched with Linux and Kubernetes metadata:


### PR DESCRIPTION
There are dead links in the Getting Started section of the README. 

This patch fixes this by:

1. Replacing all the dead links with the corresponding updated link in the documentation. 

Fixes: #1653