### PR TITLE
ringbufer: default to 1MiB  / core

### DIFF
--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	perCPUBufferBytes = 65535
+	perCPUBufferBytes = 1048576
 )
 
 var (
@@ -185,7 +185,7 @@ func (k *Observer) getRBSize(cpus int) int {
 	} else if option.Config.RBSize != 0 {
 		size = option.Config.RBSize
 	} else {
-		size = option.Config.RBSizeTotal / int(cpus)
+		size = option.Config.RBSizeTotal / cpus
 	}
 
 	cpuSize := perfBufferSize(size)

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -246,7 +246,7 @@ func AddFlags(flags *pflag.FlagSet) {
 
 	// Allow to specify perf ring buffer size
 	flags.String(KeyRBSizeTotal, "0", "Set perf ring buffer size in total for all cpus (default 65k per cpu, allows K/M/G suffix)")
-	flags.String(KeyRBSize, "0", "Set perf ring buffer size for single cpu (default 65k, allows K/M/G suffix)")
+	flags.String(KeyRBSize, "0", "Set perf ring buffer size for single cpu (default 1MiB, allows K/M/G suffix)")
 
 	// Provide option to remove existing pinned BPF programs and maps in Tetragon's
 	// observer dir on startup. Useful for doing upgrades/downgrades. Set to false to


### PR DESCRIPTION
This patch changes the default ringbuffer from 64K/core to 1MiB/core.

```release-note
Change default size of ringbuffer from 64K/core to 1MiB/core
```