### PR TITLE
vmtests: bump timeout and start multiple job for builds

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build tetragon
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     concurrency:
       group: ${{ github.ref }}-vmtest-build
       cancel-in-progress: true
@@ -39,7 +39,7 @@ jobs:
         GOPATH: /home/runner/work/tetragon/tetragon/go
       run: |
         cd go/src/github.com/cilium/tetragon/
-        make tetragon-bpf tester-progs test-compile
+        make -j3 tetragon-bpf tester-progs test-compile
         make -C tests/vmtests
 
     - name: Split tests
@@ -54,7 +54,7 @@ jobs:
         tar cz --exclude='tetragon/.git' -f /tmp/tetragon.tar ./tetragon
 
     - name: upload build
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
          name: tetragon-build
          path: /tmp/tetragon.tar


### PR DESCRIPTION
The action was timing out: taking around 11min to build, 2min to create the archive, upload was more than 6/7min thus triggering the 20min limit.