### PR TITLE
ci: replace buildjet arm64 runners with actuated ones

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, buildjet-2vcpu-ubuntu-2204-arm ]
+        os: [ ubuntu-20.04, actuated-arm64-4cpu-8gb ]
     steps:
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get install libelf-dev netcat-traditional libcap-dev gcc
+        sudo apt-get -y install libelf-dev netcat-traditional libcap-dev gcc
 
         sudo sed -i '/secure_path/d' /etc/sudoers
         sudo sed -i '/env_reset/d' /etc/sudoers
@@ -40,6 +40,8 @@ jobs:
 
     - name: Install bpftool
       uses: mtardy/setup-bpftool@adeab4f9332cc28db56064a93911860d0775665b # v1.0.3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Ensure BPF programs pass verifier
       run: |

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -22,8 +22,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     strategy:
+      fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, buildjet-4vcpu-ubuntu-2204-arm ]
+        os: [ ubuntu-22.04, actuated-arm64-4cpu-16gb ]
     steps:
     - name: Checkout Code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
The CNCF signed a contract with Actuated to provide free arm64 runners
to CNCF project: see https://actuated.dev/blog/arm-ci-cncf-ampere.

After some trial and error we managed to compile a kernel for the
runners using Firecracker that works with BPF and especially Tetragon.
Only limitation is that they are running 5.10 for now and there is no
nested virtualization. But good news is that we can get more CPU and
more RAM for free!

Note: I know that I didn't change the buildjet runner for `Packages e2e Tests / standalone-tests (buildjet-2vcpu-ubuntu-2204-arm, arm64, arm64)`, but this should be eventually removed as `make tarball` now work with cross-compilation and we should not need a native runner here.
