### PR TITLE
gh: update cosign installer

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -108,7 +108,7 @@ jobs:
             quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v3.0.5
+        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Sign Container Image
         if: steps.tag-in-repositories.outputs.exists == 'false'

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v3.0.5
+        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - test*
     paths-ignore:
       - 'docs/**'
 
@@ -97,7 +98,7 @@ jobs:
 
       # main branch pushes
       - name: CI Build (main)
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         id: docker_build_ci_main
         with:
@@ -111,6 +112,22 @@ jobs:
           tags: |
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:latest
+
+      # non-main branch pushes
+      - name: CI Build (non-main)
+        if: ${{ github.event_name == 'push' && github.ref_name != 'main' }}
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        id: docker_build_ci_main
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            TETRAGON_VERSION=${{ env.TETRAGON_VERSION }}
+          tags: |
+            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
 
       - name: Sign Container Image
         if: github.event_name == 'push'

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install Cosign
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v3.0.5
+        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Sign Container Image
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}


### PR DESCRIPTION
Cosign is broken in `main`, which means that our CI is also broken.

Try to fix it.

error:

```
Run sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
Run #!/bin/bash
INFO: Downloading bootstrap version 'v1.13.1' of cosign to verify version to be installed...
      https://storage.googleapis.com/cosign-releases/v1.13.1/cosign-linux-amd64
ERROR: Unable to validate cosign version: 'v1.13.1'
Error: Process completed with exit code 1.
```