### PR TITLE
ci: check docs links fixes and configuration

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,0 +1,11 @@
+verbose = "info"
+
+exclude = [
+  # this application is down from time to time
+  'cilium.herokuapp.com', 
+  # the relative link in README is implicit,
+  # see https://github.blog/2013-01-31-relative-links-in-markup-files/
+  'docs/assets/icons/logo.*\.svg', 
+  # the virtualbox website sends 500 regularly
+  'virtualbox.org'
+]

--- a/.github/workflows/check-links-cron.yaml
+++ b/.github/workflows/check-links-cron.yaml
@@ -25,7 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          args: --base https://tetragon.cilium.io docs/content README.md
+          args: --config .github/lychee.toml --base https://tetragon.io docs/content README.md
 
       # to avoid automated spam, try to find an existing open issue before opening a new one
       - name: Search for existing issue number

--- a/.github/workflows/check-links-pr.yaml
+++ b/.github/workflows/check-links-pr.yaml
@@ -3,6 +3,7 @@ name: Check docs links
 on:
   pull_request:
     paths:
+      - 'README.md'
       - 'docs/content/**.md'
       - '.github/workflows/check-links-pr.yaml'
 
@@ -41,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          args: --base http://localhost:1313 --exclude cilium.herokuapp.com docs/content
+          args: --config .github/lychee.toml --base http://localhost:1313 docs/content README.md
           fail: true
           format: json
 


### PR DESCRIPTION
This commits adds a new config for the link checker lychee. This should reduce the noise from some false negatives or un-reliable websites. It also makes the config less different between PR and main branch checks.