### PR TITLE
tetragon: docs, fix modules policy library CRD link

### DIFF
--- a/docs/content/en/docs/policy-library/observability/_index.md
+++ b/docs/content/en/docs/policy-library/observability/_index.md
@@ -67,7 +67,7 @@ Understanding exactly what kernel modules are running in the cluster is crucial 
 
 ### Policy
 
-[module.yaml](https://raw.githubusercontent.com/cilium/tetragon/main/examples/policylibrary/module.yaml)
+[modules.yaml](https://raw.githubusercontent.com/cilium/tetragon/main/examples/policylibrary/modules.yaml)
 
 ### Example jq Filter
 


### PR DESCRIPTION
The module link had a typo so it created a 404 fix it.