### PR TITLE
server: fix another segfault related to field filters

### DIFF
--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/tetragon/pkg/ktime"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/eventcachemetrics"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
 	readerexec "github.com/cilium/tetragon/pkg/reader/exec"
@@ -65,6 +66,11 @@ func GetProcessExec(event *MsgExecveEventUnix, useCache bool) *tetragon.ProcessE
 	tetragonEvent := &tetragon.ProcessExec{
 		Process: tetragonProcess,
 		Parent:  tetragonParent,
+	}
+
+	if tetragonProcess.Pid == nil {
+		eventcachemetrics.EventCacheError("GetProcessExec: nil Process.Pid").Inc()
+		return nil
 	}
 
 	if useCache {
@@ -385,6 +391,12 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 		Status:  code,
 		Time:    ktime.ToProto(event.Common.Ktime),
 	}
+
+	if tetragonProcess.Pid == nil {
+		eventcachemetrics.EventCacheError("GetProcessExit: nil Process.Pid").Inc()
+		return nil
+	}
+
 	ec := eventcache.Get()
 	if ec != nil &&
 		(ec.Needed(tetragonProcess) ||

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -5,6 +5,7 @@ package tracing
 import (
 	"fmt"
 
+	"github.com/cilium/tetragon/pkg/metrics/eventcachemetrics"
 	"github.com/cilium/tetragon/pkg/reader/kernel"
 	"golang.org/x/sys/unix"
 
@@ -304,6 +305,11 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 		PolicyName:   event.PolicyName,
 	}
 
+	if tetragonProcess.Pid == nil {
+		eventcachemetrics.EventCacheError("GetProcessKprobe: nil Process.Pid").Inc()
+		return nil
+	}
+
 	if ec := eventcache.Get(); ec != nil &&
 		(ec.Needed(tetragonProcess) ||
 			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
@@ -411,6 +417,11 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 		Args:       tetragonArgs,
 		PolicyName: msg.PolicyName,
 		Action:     kprobeAction(msg.Action),
+	}
+
+	if tetragonProcess.Pid == nil {
+		eventcachemetrics.EventCacheError("GetProcessTracepoint: nil Process.Pid").Inc()
+		return nil
 	}
 
 	if ec := eventcache.Get(); ec != nil &&
@@ -532,6 +543,11 @@ func GetProcessLoader(msg *MsgProcessLoaderUnix) *tetragon.ProcessLoader {
 		tetragonProcess = process.UnsafeGetProcess()
 	}
 
+	if tetragonProcess.Pid == nil {
+		eventcachemetrics.EventCacheError("GetProcessLoader: nil Process.Pid").Inc()
+		return nil
+	}
+
 	if ec := eventcache.Get(); ec != nil &&
 		(ec.Needed(tetragonProcess) || (tetragonProcess.Pid.Value > 1)) {
 		tetragonEvent := &ProcessLoaderNotify{}
@@ -637,6 +653,11 @@ func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {
 		Path:       event.Path,
 		Symbol:     event.Symbol,
 		PolicyName: event.PolicyName,
+	}
+
+	if tetragonProcess.Pid == nil {
+		eventcachemetrics.EventCacheError("GetProcessUprobe: nil Process.Pid").Inc()
+		return nil
 	}
 
 	if ec := eventcache.Get(); ec != nil &&

--- a/pkg/metrics/eventcachemetrics/eventcachemetrics.go
+++ b/pkg/metrics/eventcachemetrics/eventcachemetrics.go
@@ -27,12 +27,19 @@ var (
 		Help:        "The total number of Tetragon event cache accesses. For internal use only.",
 		ConstLabels: nil,
 	})
+	eventCacheErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   consts.MetricsNamespace,
+		Name:        "event_cache_errors_total",
+		Help:        "The total of errors encountered while fetching process exec information from the cache.",
+		ConstLabels: nil,
+	}, []string{"error"})
 )
 
 func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(processInfoErrors)
 	registry.MustRegister(podInfoErrors)
 	registry.MustRegister(EventCacheCount)
+	registry.MustRegister(eventCacheErrorsTotal)
 }
 
 // Get a new handle on an processInfoErrors metric for an eventType
@@ -43,4 +50,9 @@ func ProcessInfoError(eventType string) prometheus.Counter {
 // Get a new handle on an processInfoErrors metric for an eventType
 func PodInfoError(eventType string) prometheus.Counter {
 	return podInfoErrors.WithLabelValues(eventType)
+}
+
+// Get a new handle on an processInfoErrors metric for an eventType
+func EventCacheError(err string) prometheus.Counter {
+	return eventCacheErrorsTotal.WithLabelValues(err)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -166,14 +166,13 @@ func (s *Server) GetEventsWG(request *tetragon.GetEventsRequest, server tetragon
 			// Filter the GetEventsResponse fields
 			filters := filters.FieldFiltersFromGetEventsRequest(request)
 			filterEvent := event
-			if len(filters) > 0 && filterEvent.GetProcessExec() != nil { // this is an exec event and we have fieldFilters
-				// We need a copy of the exec event as modifing the original message
-				// can cause issues in the process cache (we keep a copy of that message there).
-				filterEvent = proto.Clone(event).(*tetragon.GetEventsResponse)
-			}
+
 			for _, filter := range filters {
-				// we need not to change res
-				// maybe only for exec events
+				// We need a copy of the exec or exit event as modifing the original message
+				// can cause issues in the process cache (we keep a copy of that message there).
+				if filter.NeedsCopy(filterEvent) && filterEvent == event {
+					filterEvent = proto.Clone(event).(*tetragon.GetEventsResponse)
+				}
 				filter.Filter(filterEvent)
 			}
 


### PR DESCRIPTION
Commit 1 fixes the bug, commit 2 adds a nil check and a metric to catch if a similar situation happens in the future.

```release-note
Fix a segmentation fault related to filtering out pid information with field filters
```