### PR TITLE
docs: update tetragon.io title

### DIFF
--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -1,6 +1,6 @@
 +++
-title = "Tetragon"
-linkTitle = "Tetragon"
+title = "Tetragon - eBPF-based Security Observability and Runtime Enforcement"
+linkTitle = "Tetragon - eBPF-based Security Observability and Runtime Enforcement"
 +++
 
 <div class="home">

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = "/"
-title = "Tetragon"
+title = "Tetragon - eBPF-based Security Observability and Runtime Enforcement"
 description = "eBPF-based Security Observability and Runtime Enforcement"
 
 # Language settings
@@ -45,7 +45,7 @@ anchor = "smart"
 
 [languages]
 [languages.en]
-title = "Tetragon"
+title = "Tetragon - eBPF-based Security Observability and Runtime Enforcement"
 description = "eBPF-based Security Observability and Runtime Enforcement"
 languageName ="English"
 # Weight used for sorting.


### PR DESCRIPTION
This PR updates the docs site to include the tetragon tagline in the title 