### PR TITLE
pkg/bench: disable BPF stats collection at the end of execution

### DIFF
--- a/pkg/bench/trace.go
+++ b/pkg/bench/trace.go
@@ -45,7 +45,9 @@ func RunTraceBench(args *Arguments) (summary *Summary) {
 	summary = newSummary(args)
 	summary.StartTime = time.Now()
 
-	EnableBpfStats()
+	disable := EnableBpfStats()
+	defer disable()
+
 	oldBpfStats := GetBpfStats()
 
 	var bench TraceBench


### PR DESCRIPTION
Turning on BPF stats collection causes overhead, so it makes sense to turn it off at the end of benchmarking. On newer kernels we can use ebpf.EnableStats as a safer interface.