### PR TITLE
Avoid requiring the latest Go toolchain patch version to build

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -305,6 +305,30 @@
     },
     // ignore deps section
     {
+      // Avoid updating patch releases of golang in go.mod
+      "enabled": false,
+      // could use "**/go.mod" but /docs has a go.mod
+      "matchFileNames": [
+        "go.mod",
+        "api/go.mod",
+        "pkg/k8s/go.mod",
+        "contrib/rthooks/tetragon-oci-hook/go.mod",
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      matchBaseBranches: [
+        "main",
+        "v1.0"
+      ]
+    },
+    {
       // do not allow any updates for major.minor for LVH, they will be done by maintainers
       "enabled": false,
       "matchPackageNames": [

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,7 +1,7 @@
 module github.com/cilium/tetragon/api
 
 // renovate: datasource=golang-version depName=go
-go 1.21.4
+go 1.21.0
 
 require (
 	github.com/cilium/tetragon v0.0.0-00010101000000-000000000000

--- a/api/vendor/modules.txt
+++ b/api/vendor/modules.txt
@@ -1,5 +1,5 @@
 # github.com/cilium/tetragon v0.0.0-00010101000000-000000000000 => ../
-## explicit; go 1.21.4
+## explicit; go 1.21.0
 github.com/cilium/tetragon/pkg/matchers/bytesmatcher
 github.com/cilium/tetragon/pkg/matchers/listmatcher
 github.com/cilium/tetragon/pkg/matchers/stringmatcher

--- a/contrib/rthooks/tetragon-oci-hook/go.mod
+++ b/contrib/rthooks/tetragon-oci-hook/go.mod
@@ -1,7 +1,7 @@
 module github.com/cilium/tetragon/contrib/rthooks/tetragon-oci-hook
 
 // renovate: datasource=golang-version depName=go
-go 1.21.4
+go 1.21.0
 
 require (
 	github.com/cilium/lumberjack/v2 v2.3.0

--- a/contrib/rthooks/tetragon-oci-hook/vendor/modules.txt
+++ b/contrib/rthooks/tetragon-oci-hook/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/cilium/ebpf/link
 ## explicit; go 1.13
 github.com/cilium/lumberjack/v2
 # github.com/cilium/tetragon/api v0.0.0-00010101000000-000000000000 => ../../../api
-## explicit; go 1.21.4
+## explicit; go 1.21.0
 github.com/cilium/tetragon/api/v1/tetragon
 # github.com/coreos/go-systemd/v22 v22.3.2
 ## explicit; go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cilium/tetragon
 
 // renovate: datasource=golang-version depName=go
-go 1.21.4
+go 1.21.0
 
 require (
 	github.com/bombsimon/logrusr/v4 v4.1.0

--- a/pkg/k8s/go.mod
+++ b/pkg/k8s/go.mod
@@ -1,7 +1,7 @@
 module github.com/cilium/tetragon/pkg/k8s
 
 // renovate: datasource=golang-version depName=go
-go 1.21.4
+go 1.21.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -227,13 +227,13 @@ github.com/cilium/proxy/go/envoy/type/tracing/v3
 github.com/cilium/proxy/go/envoy/type/v3
 github.com/cilium/proxy/pkg/policy/api/kafka
 # github.com/cilium/tetragon/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.21.4
+## explicit; go 1.21.0
 github.com/cilium/tetragon/api/v1/tetragon
 github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker
 github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/yaml
 github.com/cilium/tetragon/api/v1/tetragon/codegen/helpers
 # github.com/cilium/tetragon/pkg/k8s v0.0.0-00010101000000-000000000000 => ./pkg/k8s
-## explicit; go 1.21.4
+## explicit; go 1.21.0
 github.com/cilium/tetragon/pkg/k8s/apis/cilium.io
 github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client
 github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1


### PR DESCRIPTION
Port of https://github.com/cilium/cilium/pull/28686. We are seeing issues in the CI as well https://github.com/cilium/tetragon/actions/runs/6853112156/job/18633190187?pr=1747.