### PR TITLE
String: Increase prefix size from 128 to 256 chars

### DIFF
--- a/bpf/process/string_maps.h
+++ b/bpf/process/string_maps.h
@@ -138,7 +138,7 @@ struct {
 	__uint(value_size, 512);
 } string_maps_ro_zero SEC(".maps");
 
-#define STRING_PREFIX_MAX_LENGTH 128
+#define STRING_PREFIX_MAX_LENGTH 256
 
 struct string_prefix_lpm_trie {
 	__u32 prefixlen;

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -32,7 +32,7 @@ const (
 	stringMapsKeyIncSize   = 24
 	StringMapsNumSubMaps   = 6
 	MaxStringMapsSize      = 6*stringMapsKeyIncSize + 1
-	StringPrefixMaxLength  = 128
+	StringPrefixMaxLength  = 256
 	StringPostfixMaxLength = 128
 )
 

--- a/pkg/sensors/tracing/selectors.go
+++ b/pkg/sensors/tracing/selectors.go
@@ -436,7 +436,7 @@ func populateStringPrefixFilterMap(
 	innerSpec := &ebpf.MapSpec{
 		Name:       innerName,
 		Type:       ebpf.LPMTrie,
-		KeySize:    4 + selectors.StringPrefixMaxLength, // NB: KernelLpmTrieStringPrefix consists of 32bit prefix and 128 byte data
+		KeySize:    4 + selectors.StringPrefixMaxLength, // NB: KernelLpmTrieStringPrefix consists of 32bit prefix and 256 byte data
 		ValueSize:  uint32(1),
 		MaxEntries: maxEntries,
 		Flags:      bpf.BPF_F_NO_PREALLOC,


### PR DESCRIPTION
The file prefix limit was originally 256 characters. When the code was converted to use LMP TRIE maps, the limit was set to 128 characters.

This commit changes the prefix limit from 128 to 256 characters.

```release-note
Increases the character limit for prefix matches from 128 to 256.
```
