### PR TITLE
tetragon: get rid of some programs

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -23,7 +23,7 @@
 
 struct msg_selector_data {
 	__u64 curr;
-	__u64 pass;
+	bool pass;
 	bool active[MAX_CONFIGURED_SELECTORS];
 #ifdef __NS_CHANGES_FILTER
 	__u64 match_ns;

--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -49,7 +49,8 @@ struct msg_generic_kprobe {
 	unsigned long a0, a1, a2, a3, a4;
 	long argsoff[MAX_POSSIBLE_ARGS];
 	struct msg_selector_data sel;
-	__u32 idx;
+	__u32 idx; // attach cookie index
+	__u32 filter_tailcall_index; // recursion index for filter_read_arg/generic_process_event
 	int pass;
 };
 

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -99,6 +99,7 @@ generic_kprobe_start_process_filter(void *ctx)
 		msg->sel.active[i] = 0;
 	/* Initialize accept field to reject */
 	msg->sel.pass = false;
+	msg->filter_tailcall_index = 0;
 	task = (struct task_struct *)get_current_task();
 	/* Initialize namespaces to apply filters on them */
 	get_namespaces(&(msg->ns), task);
@@ -229,51 +230,15 @@ generic_kprobe_process_filter(void *ctx)
 // see also: MIN_FILTER_TAILCALL, MAX_FILTER_TAILCALL
 
 __attribute__((section("kprobe/6"), used)) int
-generic_kprobe_filter_arg1(void *ctx)
+generic_kprobe_filter_arg(void *ctx)
 {
-	return filter_read_arg(ctx, 0, (struct bpf_map_def *)&process_call_heap,
+	return filter_read_arg(ctx, (struct bpf_map_def *)&process_call_heap,
 			       (struct bpf_map_def *)&filter_map,
 			       (struct bpf_map_def *)&kprobe_calls,
 			       (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("kprobe/7"), used)) int
-generic_kprobe_filter_arg2(void *ctx)
-{
-	return filter_read_arg(ctx, 1, (struct bpf_map_def *)&process_call_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&kprobe_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("kprobe/8"), used)) int
-generic_kprobe_filter_arg3(void *ctx)
-{
-	return filter_read_arg(ctx, 2, (struct bpf_map_def *)&process_call_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&kprobe_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("kprobe/9"), used)) int
-generic_kprobe_filter_arg4(void *ctx)
-{
-	return filter_read_arg(ctx, 3, (struct bpf_map_def *)&process_call_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&kprobe_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("kprobe/10"), used)) int
-generic_kprobe_filter_arg5(void *ctx)
-{
-	return filter_read_arg(ctx, 4, (struct bpf_map_def *)&process_call_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&kprobe_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("kprobe/11"), used)) int
 generic_kprobe_actions(void *ctx)
 {
 	return generic_actions(ctx, (struct bpf_map_def *)&process_call_heap,
@@ -282,7 +247,7 @@ generic_kprobe_actions(void *ctx)
 			       (struct bpf_map_def *)&override_tasks);
 }
 
-__attribute__((section("kprobe/12"), used)) int
+__attribute__((section("kprobe/8"), used)) int
 generic_kprobe_output(void *ctx)
 {
 	return generic_output(ctx, (struct bpf_map_def *)&process_call_heap, MSG_OP_GENERIC_KPROBE);

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -113,7 +113,7 @@ generic_kprobe_start_process_filter(void *ctx)
 #endif
 
 	/* Tail call into filters. */
-	tail_call(ctx, &kprobe_calls, 5);
+	tail_call(ctx, &kprobe_calls, 2);
 	return 0;
 }
 
@@ -155,7 +155,7 @@ generic_kprobe_event(struct pt_regs *ctx)
 }
 
 __attribute__((section("kprobe/0"), used)) int
-generic_kprobe_process_event0(void *ctx)
+generic_kprobe_setup_event(void *ctx)
 {
 	return generic_process_event_and_setup(
 		ctx, (struct bpf_map_def *)&process_call_heap,
@@ -165,9 +165,9 @@ generic_kprobe_process_event0(void *ctx)
 }
 
 __attribute__((section("kprobe/1"), used)) int
-generic_kprobe_process_event1(void *ctx)
+generic_kprobe_process_event(void *ctx)
 {
-	return generic_process_event(ctx, 1,
+	return generic_process_event(ctx,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&kprobe_calls,
 				     (struct bpf_map_def *)&config_map,
@@ -175,36 +175,6 @@ generic_kprobe_process_event1(void *ctx)
 }
 
 __attribute__((section("kprobe/2"), used)) int
-generic_kprobe_process_event2(void *ctx)
-{
-	return generic_process_event(ctx, 2,
-				     (struct bpf_map_def *)&process_call_heap,
-				     (struct bpf_map_def *)&kprobe_calls,
-				     (struct bpf_map_def *)&config_map,
-				     (struct bpf_map_def *)data_heap_ptr);
-}
-
-__attribute__((section("kprobe/3"), used)) int
-generic_kprobe_process_event3(void *ctx)
-{
-	return generic_process_event(ctx, 3,
-				     (struct bpf_map_def *)&process_call_heap,
-				     (struct bpf_map_def *)&kprobe_calls,
-				     (struct bpf_map_def *)&config_map,
-				     (struct bpf_map_def *)data_heap_ptr);
-}
-
-__attribute__((section("kprobe/4"), used)) int
-generic_kprobe_process_event4(void *ctx)
-{
-	return generic_process_event(ctx, 4,
-				     (struct bpf_map_def *)&process_call_heap,
-				     (struct bpf_map_def *)&kprobe_calls,
-				     (struct bpf_map_def *)&config_map,
-				     (struct bpf_map_def *)data_heap_ptr);
-}
-
-__attribute__((section("kprobe/5"), used)) int
 generic_kprobe_process_filter(void *ctx)
 {
 	struct msg_generic_kprobe *msg;
@@ -217,7 +187,7 @@ generic_kprobe_process_filter(void *ctx)
 	ret = generic_process_filter(&msg->sel, &msg->current, &msg->ns,
 				     &msg->caps, &filter_map, msg->idx);
 	if (ret == PFILTER_CONTINUE)
-		tail_call(ctx, &kprobe_calls, 5);
+		tail_call(ctx, &kprobe_calls, 2);
 	else if (ret == PFILTER_ACCEPT)
 		tail_call(ctx, &kprobe_calls, 0);
 	/* If filter does not accept drop it. Ideally we would
@@ -229,7 +199,7 @@ generic_kprobe_process_filter(void *ctx)
 // Filter tailcalls: kprobe/6...kprobe/10
 // see also: MIN_FILTER_TAILCALL, MAX_FILTER_TAILCALL
 
-__attribute__((section("kprobe/6"), used)) int
+__attribute__((section("kprobe/3"), used)) int
 generic_kprobe_filter_arg(void *ctx)
 {
 	return filter_read_arg(ctx, (struct bpf_map_def *)&process_call_heap,
@@ -238,7 +208,7 @@ generic_kprobe_filter_arg(void *ctx)
 			       (struct bpf_map_def *)&config_map);
 }
 
-__attribute__((section("kprobe/7"), used)) int
+__attribute__((section("kprobe/4"), used)) int
 generic_kprobe_actions(void *ctx)
 {
 	return generic_actions(ctx, (struct bpf_map_def *)&process_call_heap,
@@ -247,7 +217,7 @@ generic_kprobe_actions(void *ctx)
 			       (struct bpf_map_def *)&override_tasks);
 }
 
-__attribute__((section("kprobe/8"), used)) int
+__attribute__((section("kprobe/5"), used)) int
 generic_kprobe_output(void *ctx)
 {
 	return generic_output(ctx, (struct bpf_map_def *)&process_call_heap, MSG_OP_GENERIC_KPROBE);

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -98,7 +98,7 @@ generic_kprobe_start_process_filter(void *ctx)
 	for (i = 0; i < MAX_CONFIGURED_SELECTORS; i++)
 		msg->sel.active[i] = 0;
 	/* Initialize accept field to reject */
-	msg->sel.pass = 0;
+	msg->sel.pass = false;
 	task = (struct task_struct *)get_current_task();
 	/* Initialize namespaces to apply filters on them */
 	get_namespaces(&(msg->ns), task);

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -113,7 +113,7 @@ generic_kprobe_start_process_filter(void *ctx)
 #endif
 
 	/* Tail call into filters. */
-	tail_call(ctx, &kprobe_calls, 2);
+	tail_call(ctx, &kprobe_calls, TAIL_CALL_FILTER);
 	return 0;
 }
 
@@ -187,7 +187,7 @@ generic_kprobe_process_filter(void *ctx)
 	ret = generic_process_filter(&msg->sel, &msg->current, &msg->ns,
 				     &msg->caps, &filter_map, msg->idx);
 	if (ret == PFILTER_CONTINUE)
-		tail_call(ctx, &kprobe_calls, 2);
+		tail_call(ctx, &kprobe_calls, TAIL_CALL_FILTER);
 	else if (ret == PFILTER_ACCEPT)
 		tail_call(ctx, &kprobe_calls, 0);
 	/* If filter does not accept drop it. Ideally we would
@@ -195,9 +195,6 @@ generic_kprobe_process_filter(void *ctx)
 	 */
 	return PFILTER_REJECT;
 }
-
-// Filter tailcalls: kprobe/6...kprobe/10
-// see also: MIN_FILTER_TAILCALL, MAX_FILTER_TAILCALL
 
 __attribute__((section("kprobe/3"), used)) int
 generic_kprobe_filter_arg(void *ctx)

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -180,6 +180,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 
 	msg->common.op = MSG_OP_GENERIC_TRACEPOINT;
 	msg->sel.curr = 0;
+	msg->filter_tailcall_index = 0;
 #pragma unroll
 	for (i = 0; i < MAX_CONFIGURED_SELECTORS; i++)
 		msg->sel.active[i] = 0;
@@ -265,51 +266,15 @@ generic_tracepoint_filter(void *ctx)
 // see also: MIN_FILTER_TAILCALL, MAX_FILTER_TAILCALL
 
 __attribute__((section("tracepoint/6"), used)) int
-generic_tracepoint_arg1(void *ctx)
+generic_tracepoint_arg(void *ctx)
 {
-	return filter_read_arg(ctx, 0, (struct bpf_map_def *)&tp_heap,
+	return filter_read_arg(ctx, (struct bpf_map_def *)&tp_heap,
 			       (struct bpf_map_def *)&filter_map,
 			       (struct bpf_map_def *)&tp_calls,
 			       (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("tracepoint/7"), used)) int
-generic_tracepoint_arg2(void *ctx)
-{
-	return filter_read_arg(ctx, 1, (struct bpf_map_def *)&tp_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&tp_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("tracepoint/8"), used)) int
-generic_tracepoint_arg3(void *ctx)
-{
-	return filter_read_arg(ctx, 2, (struct bpf_map_def *)&tp_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&tp_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("tracepoint/9"), used)) int
-generic_tracepoint_arg4(void *ctx)
-{
-	return filter_read_arg(ctx, 3, (struct bpf_map_def *)&tp_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&tp_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("tracepoint/10"), used)) int
-generic_tracepoint_arg5(void *ctx)
-{
-	return filter_read_arg(ctx, 4, (struct bpf_map_def *)&tp_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&tp_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("tracepoint/11"), used)) int
 generic_tracepoint_actions(void *ctx)
 {
 	return generic_actions(ctx, (struct bpf_map_def *)&tp_heap,
@@ -318,7 +283,7 @@ generic_tracepoint_actions(void *ctx)
 			       (void *)0);
 }
 
-__attribute__((section("tracepoint/12"), used)) int
+__attribute__((section("tracepoint/8"), used)) int
 generic_tracepoint_output(void *ctx)
 {
 	return generic_output(ctx, (struct bpf_map_def *)&tp_heap, MSG_OP_GENERIC_TRACEPOINT);

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -183,7 +183,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 #pragma unroll
 	for (i = 0; i < MAX_CONFIGURED_SELECTORS; i++)
 		msg->sel.active[i] = 0;
-	msg->sel.pass = 0;
+	msg->sel.pass = false;
 	task = (struct task_struct *)get_current_task();
 	/* Initialize namespaces to apply filters on them */
 	get_namespaces(&msg->ns, task);

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -196,51 +196,19 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 #ifdef __CAP_CHANGES_FILTER
 	msg->sel.match_cap = 0;
 #endif
-	tail_call(ctx, &tp_calls, 5);
+	tail_call(ctx, &tp_calls, 2);
 	return 0;
 }
 
-__attribute__((section("tracepoint/0"), used)) int
-generic_tracepoint_event0(void *ctx)
-{
-	return generic_process_event(ctx, 0, (struct bpf_map_def *)&tp_heap,
-				     (struct bpf_map_def *)&tp_calls,
-				     (struct bpf_map_def *)&config_map, 0);
-}
-
 __attribute__((section("tracepoint/1"), used)) int
-generic_tracepoint_event1(void *ctx)
+generic_tracepoint_process_event(void *ctx)
 {
-	return generic_process_event(ctx, 1, (struct bpf_map_def *)&tp_heap,
+	return generic_process_event(ctx, (struct bpf_map_def *)&tp_heap,
 				     (struct bpf_map_def *)&tp_calls,
 				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("tracepoint/2"), used)) int
-generic_tracepoint_event2(void *ctx)
-{
-	return generic_process_event(ctx, 2, (struct bpf_map_def *)&tp_heap,
-				     (struct bpf_map_def *)&tp_calls,
-				     (struct bpf_map_def *)&config_map, 0);
-}
-
-__attribute__((section("tracepoint/3"), used)) int
-generic_tracepoint_event3(void *ctx)
-{
-	return generic_process_event(ctx, 3, (struct bpf_map_def *)&tp_heap,
-				     (struct bpf_map_def *)&tp_calls,
-				     (struct bpf_map_def *)&config_map, 0);
-}
-
-__attribute__((section("tracepoint/4"), used)) int
-generic_tracepoint_event4(void *ctx)
-{
-	return generic_process_event(ctx, 4, (struct bpf_map_def *)&tp_heap,
-				     (struct bpf_map_def *)&tp_calls,
-				     (struct bpf_map_def *)&config_map, 0);
-}
-
-__attribute__((section("tracepoint/5"), used)) int
 generic_tracepoint_filter(void *ctx)
 {
 	struct msg_generic_kprobe *msg;
@@ -253,9 +221,9 @@ generic_tracepoint_filter(void *ctx)
 	ret = generic_process_filter(&msg->sel, &msg->current, &msg->ns,
 				     &msg->caps, &filter_map, msg->idx);
 	if (ret == PFILTER_CONTINUE)
-		tail_call(ctx, &tp_calls, 5);
+		tail_call(ctx, &tp_calls, 2);
 	else if (ret == PFILTER_ACCEPT)
-		tail_call(ctx, &tp_calls, 0);
+		tail_call(ctx, &tp_calls, 1);
 	/* If filter does not accept drop it. Ideally we would
 	 * log error codes for later review, TBD.
 	 */
@@ -265,7 +233,7 @@ generic_tracepoint_filter(void *ctx)
 // Filter tailcalls: tracepoint/6...tracepoint/10
 // see also: MIN_FILTER_TAILCALL, MAX_FILTER_TAILCALL
 
-__attribute__((section("tracepoint/6"), used)) int
+__attribute__((section("tracepoint/3"), used)) int
 generic_tracepoint_arg(void *ctx)
 {
 	return filter_read_arg(ctx, (struct bpf_map_def *)&tp_heap,
@@ -274,7 +242,7 @@ generic_tracepoint_arg(void *ctx)
 			       (struct bpf_map_def *)&config_map);
 }
 
-__attribute__((section("tracepoint/7"), used)) int
+__attribute__((section("tracepoint/4"), used)) int
 generic_tracepoint_actions(void *ctx)
 {
 	return generic_actions(ctx, (struct bpf_map_def *)&tp_heap,
@@ -283,7 +251,7 @@ generic_tracepoint_actions(void *ctx)
 			       (void *)0);
 }
 
-__attribute__((section("tracepoint/8"), used)) int
+__attribute__((section("tracepoint/5"), used)) int
 generic_tracepoint_output(void *ctx)
 {
 	return generic_output(ctx, (struct bpf_map_def *)&tp_heap, MSG_OP_GENERIC_TRACEPOINT);

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -196,7 +196,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 #ifdef __CAP_CHANGES_FILTER
 	msg->sel.match_cap = 0;
 #endif
-	tail_call(ctx, &tp_calls, 2);
+	tail_call(ctx, &tp_calls, TAIL_CALL_FILTER);
 	return 0;
 }
 
@@ -221,17 +221,14 @@ generic_tracepoint_filter(void *ctx)
 	ret = generic_process_filter(&msg->sel, &msg->current, &msg->ns,
 				     &msg->caps, &filter_map, msg->idx);
 	if (ret == PFILTER_CONTINUE)
-		tail_call(ctx, &tp_calls, 2);
+		tail_call(ctx, &tp_calls, TAIL_CALL_FILTER);
 	else if (ret == PFILTER_ACCEPT)
-		tail_call(ctx, &tp_calls, 1);
+		tail_call(ctx, &tp_calls, TAIL_CALL_PROCESS);
 	/* If filter does not accept drop it. Ideally we would
 	 * log error codes for later review, TBD.
 	 */
 	return PFILTER_REJECT;
 }
-
-// Filter tailcalls: tracepoint/6...tracepoint/10
-// see also: MIN_FILTER_TAILCALL, MAX_FILTER_TAILCALL
 
 __attribute__((section("tracepoint/3"), used)) int
 generic_tracepoint_arg(void *ctx)

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -89,7 +89,7 @@ generic_uprobe_start_process_filter(void *ctx)
 	if (!generic_process_filter_binary(config))
 		return 0;
 	/* Tail call into filters. */
-	tail_call(ctx, &uprobe_calls, 5);
+	tail_call(ctx, &uprobe_calls, 2);
 	return 0;
 }
 
@@ -100,7 +100,7 @@ generic_uprobe_event(struct pt_regs *ctx)
 }
 
 __attribute__((section("uprobe/0"), used)) int
-generic_uprobe_process_event0(void *ctx)
+generic_uprobe_setup_event(void *ctx)
 {
 	return generic_process_event_and_setup(
 		ctx, (struct bpf_map_def *)&process_call_heap,
@@ -109,42 +109,15 @@ generic_uprobe_process_event0(void *ctx)
 }
 
 __attribute__((section("uprobe/1"), used)) int
-generic_uprobe_process_event1(void *ctx)
+generic_uprobe_process_event(void *ctx)
 {
-	return generic_process_event(ctx, 1,
+	return generic_process_event(ctx,
 				     (struct bpf_map_def *)&process_call_heap,
 				     (struct bpf_map_def *)&uprobe_calls,
 				     (struct bpf_map_def *)&config_map, 0);
 }
 
 __attribute__((section("uprobe/2"), used)) int
-generic_uprobe_process_event2(void *ctx)
-{
-	return generic_process_event(ctx, 2,
-				     (struct bpf_map_def *)&process_call_heap,
-				     (struct bpf_map_def *)&uprobe_calls,
-				     (struct bpf_map_def *)&config_map, 0);
-}
-
-__attribute__((section("uprobe/3"), used)) int
-generic_uprobe_process_event3(void *ctx)
-{
-	return generic_process_event(ctx, 3,
-				     (struct bpf_map_def *)&process_call_heap,
-				     (struct bpf_map_def *)&uprobe_calls,
-				     (struct bpf_map_def *)&config_map, 0);
-}
-
-__attribute__((section("uprobe/4"), used)) int
-generic_uprobe_process_event4(void *ctx)
-{
-	return generic_process_event(ctx, 4,
-				     (struct bpf_map_def *)&process_call_heap,
-				     (struct bpf_map_def *)&uprobe_calls,
-				     (struct bpf_map_def *)&config_map, 0);
-}
-
-__attribute__((section("uprobe/5"), used)) int
 generic_uprobe_process_filter(void *ctx)
 {
 	struct msg_generic_kprobe *msg;
@@ -157,7 +130,7 @@ generic_uprobe_process_filter(void *ctx)
 	ret = generic_process_filter(&msg->sel, &msg->current, &msg->ns,
 				     &msg->caps, &filter_map, msg->idx);
 	if (ret == PFILTER_CONTINUE)
-		tail_call(ctx, &uprobe_calls, 5);
+		tail_call(ctx, &uprobe_calls, 2);
 	else if (ret == PFILTER_ACCEPT)
 		tail_call(ctx, &uprobe_calls, 0);
 	/* If filter does not accept drop it. Ideally we would
@@ -166,7 +139,7 @@ generic_uprobe_process_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
-__attribute__((section("uprobe/6"), used)) int
+__attribute__((section("uprobe/3"), used)) int
 generic_uprobe_filter_arg(void *ctx)
 {
 	return filter_read_arg(ctx, (struct bpf_map_def *)&process_call_heap,
@@ -175,7 +148,7 @@ generic_uprobe_filter_arg(void *ctx)
 			       (struct bpf_map_def *)&config_map);
 }
 
-__attribute__((section("uprobe/7"), used)) int
+__attribute__((section("uprobe/4"), used)) int
 generic_uprobe_actions(void *ctx)
 {
 	return generic_actions(ctx, (struct bpf_map_def *)&process_call_heap,
@@ -184,7 +157,7 @@ generic_uprobe_actions(void *ctx)
 			       (void *)0);
 }
 
-__attribute__((section("uprobe/8"), used)) int
+__attribute__((section("uprobe/5"), used)) int
 generic_uprobe_output(void *ctx)
 {
 	return generic_output(ctx, (struct bpf_map_def *)&process_call_heap, MSG_OP_GENERIC_UPROBE);

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -66,7 +66,7 @@ generic_uprobe_start_process_filter(void *ctx)
 	for (i = 0; i < MAX_CONFIGURED_SELECTORS; i++)
 		msg->sel.active[i] = 0;
 	/* Initialize accept field to reject */
-	msg->sel.pass = 0;
+	msg->sel.pass = false;
 	task = (struct task_struct *)get_current_task();
 	/* Initialize namespaces to apply filters on them */
 	get_namespaces(&msg->ns, task);

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -67,6 +67,7 @@ generic_uprobe_start_process_filter(void *ctx)
 		msg->sel.active[i] = 0;
 	/* Initialize accept field to reject */
 	msg->sel.pass = false;
+	msg->filter_tailcall_index = 0;
 	task = (struct task_struct *)get_current_task();
 	/* Initialize namespaces to apply filters on them */
 	get_namespaces(&msg->ns, task);
@@ -166,51 +167,15 @@ generic_uprobe_process_filter(void *ctx)
 }
 
 __attribute__((section("uprobe/6"), used)) int
-generic_uprobe_filter_arg1(void *ctx)
+generic_uprobe_filter_arg(void *ctx)
 {
-	return filter_read_arg(ctx, 0, (struct bpf_map_def *)&process_call_heap,
+	return filter_read_arg(ctx, (struct bpf_map_def *)&process_call_heap,
 			       (struct bpf_map_def *)&filter_map,
 			       (struct bpf_map_def *)&uprobe_calls,
 			       (struct bpf_map_def *)&config_map);
 }
 
 __attribute__((section("uprobe/7"), used)) int
-generic_uprobe_filter_arg2(void *ctx)
-{
-	return filter_read_arg(ctx, 1, (struct bpf_map_def *)&process_call_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&uprobe_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("uprobe/8"), used)) int
-generic_uprobe_filter_arg3(void *ctx)
-{
-	return filter_read_arg(ctx, 2, (struct bpf_map_def *)&process_call_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&uprobe_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("uprobe/9"), used)) int
-generic_uprobe_filter_arg4(void *ctx)
-{
-	return filter_read_arg(ctx, 3, (struct bpf_map_def *)&process_call_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&uprobe_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("uprobe/10"), used)) int
-generic_uprobe_filter_arg5(void *ctx)
-{
-	return filter_read_arg(ctx, 4, (struct bpf_map_def *)&process_call_heap,
-			       (struct bpf_map_def *)&filter_map,
-			       (struct bpf_map_def *)&uprobe_calls,
-			       (struct bpf_map_def *)&config_map);
-}
-
-__attribute__((section("uprobe/11"), used)) int
 generic_uprobe_actions(void *ctx)
 {
 	return generic_actions(ctx, (struct bpf_map_def *)&process_call_heap,
@@ -219,7 +184,7 @@ generic_uprobe_actions(void *ctx)
 			       (void *)0);
 }
 
-__attribute__((section("uprobe/12"), used)) int
+__attribute__((section("uprobe/8"), used)) int
 generic_uprobe_output(void *ctx)
 {
 	return generic_output(ctx, (struct bpf_map_def *)&process_call_heap, MSG_OP_GENERIC_UPROBE);

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -89,7 +89,7 @@ generic_uprobe_start_process_filter(void *ctx)
 	if (!generic_process_filter_binary(config))
 		return 0;
 	/* Tail call into filters. */
-	tail_call(ctx, &uprobe_calls, 2);
+	tail_call(ctx, &uprobe_calls, TAIL_CALL_FILTER);
 	return 0;
 }
 
@@ -130,7 +130,7 @@ generic_uprobe_process_filter(void *ctx)
 	ret = generic_process_filter(&msg->sel, &msg->current, &msg->ns,
 				     &msg->caps, &filter_map, msg->idx);
 	if (ret == PFILTER_CONTINUE)
-		tail_call(ctx, &uprobe_calls, 2);
+		tail_call(ctx, &uprobe_calls, TAIL_CALL_FILTER);
 	else if (ret == PFILTER_ACCEPT)
 		tail_call(ctx, &uprobe_calls, 0);
 	/* If filter does not accept drop it. Ideally we would

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -61,12 +61,12 @@ generic_process_event(void *ctx, struct bpf_map_def *heap_map,
 	/* Continue to process other arguments. */
 	if (index < 4) {
 		e->filter_tailcall_index = index + 1;
-		tail_call(ctx, tailcals, 1);
+		tail_call(ctx, tailcals, TAIL_CALL_PROCESS);
 	}
 
 	/* Last argument, go send.. */
 	e->filter_tailcall_index = 0;
-	tail_call(ctx, tailcals, 3);
+	tail_call(ctx, tailcals, TAIL_CALL_ARGS);
 	return 0;
 }
 

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3902,42 +3902,39 @@ func TestLoadKprobeSensor(t *testing.T) {
 	var sensorProgs = []tus.SensorProg{
 		// kprobe
 		0: tus.SensorProg{Name: "generic_kprobe_event", Type: ebpf.Kprobe},
-		1: tus.SensorProg{Name: "generic_kprobe_process_event0", Type: ebpf.Kprobe},
-		2: tus.SensorProg{Name: "generic_kprobe_process_event1", Type: ebpf.Kprobe},
-		3: tus.SensorProg{Name: "generic_kprobe_process_event2", Type: ebpf.Kprobe},
-		4: tus.SensorProg{Name: "generic_kprobe_process_event3", Type: ebpf.Kprobe},
-		5: tus.SensorProg{Name: "generic_kprobe_process_event4", Type: ebpf.Kprobe},
-		6: tus.SensorProg{Name: "generic_kprobe_filter_arg", Type: ebpf.Kprobe},
-		7: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
-		8: tus.SensorProg{Name: "generic_kprobe_actions", Type: ebpf.Kprobe},
-		9: tus.SensorProg{Name: "generic_kprobe_output", Type: ebpf.Kprobe},
+		1: tus.SensorProg{Name: "generic_kprobe_setup_event", Type: ebpf.Kprobe},
+		2: tus.SensorProg{Name: "generic_kprobe_process_event", Type: ebpf.Kprobe},
+		3: tus.SensorProg{Name: "generic_kprobe_filter_arg", Type: ebpf.Kprobe},
+		4: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
+		5: tus.SensorProg{Name: "generic_kprobe_actions", Type: ebpf.Kprobe},
+		6: tus.SensorProg{Name: "generic_kprobe_output", Type: ebpf.Kprobe},
 		// retkprobe
-		10: tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
-		11: tus.SensorProg{Name: "generic_retkprobe_output", Type: ebpf.Kprobe},
+		7: tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
+		8: tus.SensorProg{Name: "generic_retkprobe_output", Type: ebpf.Kprobe},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all kprobe programs
-		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8}},
 
 		// all but generic_kprobe_output
-		tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8}},
+		tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5}},
 
 		// generic_retkprobe_event
-		tus.SensorMap{Name: "retkprobe_calls", Progs: []uint{10}},
+		tus.SensorMap{Name: "retkprobe_calls", Progs: []uint{7}},
 
-		// generic_kprobe_process_filter,generic_kprobe_filter_arg*,
+		// generic_kprobe_process_filter,generic_kprobe_filter_arg,
 		// generic_kprobe_actions,generic_kprobe_output
-		tus.SensorMap{Name: "filter_map", Progs: []uint{6, 7, 8}},
+		tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}},
 
 		// generic_kprobe_actions
-		tus.SensorMap{Name: "override_tasks", Progs: []uint{8}},
+		tus.SensorMap{Name: "override_tasks", Progs: []uint{5}},
 
 		// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
-		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6}},
+		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3}},
 
 		// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
-		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 3, 4, 5, 8, 10}},
+		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 5, 7}},
 
 		// generic_kprobe_event
 		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
@@ -3945,19 +3942,19 @@ func TestLoadKprobeSensor(t *testing.T) {
 
 	if kernels.EnableLargeProgs() {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 3, 4, 5, 6, 7}})
 
 		// generic_kprobe_process_event*,generic_kprobe_output,generic_retkprobe_output
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 3, 4, 5, 9, 11}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 6, 8}})
 
 		// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "socktrack_map", Progs: []uint{1, 2, 3, 4, 5, 8, 10}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "socktrack_map", Progs: []uint{1, 2, 5, 7}})
 	} else {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 10}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 3, 4, 7}})
 
 		// generic_kprobe_output,generic_retkprobe_output
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{9, 11}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{6, 8}})
 	}
 
 	readHook := `

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3901,47 +3901,43 @@ spec:
 func TestLoadKprobeSensor(t *testing.T) {
 	var sensorProgs = []tus.SensorProg{
 		// kprobe
-		0:  tus.SensorProg{Name: "generic_kprobe_event", Type: ebpf.Kprobe},
-		1:  tus.SensorProg{Name: "generic_kprobe_process_event0", Type: ebpf.Kprobe},
-		2:  tus.SensorProg{Name: "generic_kprobe_process_event1", Type: ebpf.Kprobe},
-		3:  tus.SensorProg{Name: "generic_kprobe_process_event2", Type: ebpf.Kprobe},
-		4:  tus.SensorProg{Name: "generic_kprobe_process_event3", Type: ebpf.Kprobe},
-		5:  tus.SensorProg{Name: "generic_kprobe_process_event4", Type: ebpf.Kprobe},
-		6:  tus.SensorProg{Name: "generic_kprobe_filter_arg1", Type: ebpf.Kprobe},
-		7:  tus.SensorProg{Name: "generic_kprobe_filter_arg2", Type: ebpf.Kprobe},
-		8:  tus.SensorProg{Name: "generic_kprobe_filter_arg3", Type: ebpf.Kprobe},
-		9:  tus.SensorProg{Name: "generic_kprobe_filter_arg4", Type: ebpf.Kprobe},
-		10: tus.SensorProg{Name: "generic_kprobe_filter_arg5", Type: ebpf.Kprobe},
-		11: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
-		12: tus.SensorProg{Name: "generic_kprobe_actions", Type: ebpf.Kprobe},
-		13: tus.SensorProg{Name: "generic_kprobe_output", Type: ebpf.Kprobe},
+		0: tus.SensorProg{Name: "generic_kprobe_event", Type: ebpf.Kprobe},
+		1: tus.SensorProg{Name: "generic_kprobe_process_event0", Type: ebpf.Kprobe},
+		2: tus.SensorProg{Name: "generic_kprobe_process_event1", Type: ebpf.Kprobe},
+		3: tus.SensorProg{Name: "generic_kprobe_process_event2", Type: ebpf.Kprobe},
+		4: tus.SensorProg{Name: "generic_kprobe_process_event3", Type: ebpf.Kprobe},
+		5: tus.SensorProg{Name: "generic_kprobe_process_event4", Type: ebpf.Kprobe},
+		6: tus.SensorProg{Name: "generic_kprobe_filter_arg", Type: ebpf.Kprobe},
+		7: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
+		8: tus.SensorProg{Name: "generic_kprobe_actions", Type: ebpf.Kprobe},
+		9: tus.SensorProg{Name: "generic_kprobe_output", Type: ebpf.Kprobe},
 		// retkprobe
-		14: tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
-		15: tus.SensorProg{Name: "generic_retkprobe_output", Type: ebpf.Kprobe},
+		10: tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
+		11: tus.SensorProg{Name: "generic_retkprobe_output", Type: ebpf.Kprobe},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all kprobe programs
-		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
 
 		// all but generic_kprobe_output
-		tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+		tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8}},
 
 		// generic_retkprobe_event
-		tus.SensorMap{Name: "retkprobe_calls", Progs: []uint{14}},
+		tus.SensorMap{Name: "retkprobe_calls", Progs: []uint{10}},
 
 		// generic_kprobe_process_filter,generic_kprobe_filter_arg*,
 		// generic_kprobe_actions,generic_kprobe_output
-		tus.SensorMap{Name: "filter_map", Progs: []uint{6, 7, 8, 9, 10, 11, 12}},
+		tus.SensorMap{Name: "filter_map", Progs: []uint{6, 7, 8}},
 
 		// generic_kprobe_actions
-		tus.SensorMap{Name: "override_tasks", Progs: []uint{12}},
+		tus.SensorMap{Name: "override_tasks", Progs: []uint{8}},
 
 		// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
-		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6}},
 
 		// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
-		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 3, 4, 5, 12, 14}},
+		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 3, 4, 5, 8, 10}},
 
 		// generic_kprobe_event
 		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
@@ -3949,19 +3945,19 @@ func TestLoadKprobeSensor(t *testing.T) {
 
 	if kernels.EnableLargeProgs() {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10, 11, 12, 13, 14}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10}})
 
 		// generic_kprobe_process_event*,generic_kprobe_output,generic_retkprobe_output
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 3, 4, 5, 13, 15}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 3, 4, 5, 9, 11}})
 
 		// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "socktrack_map", Progs: []uint{1, 2, 3, 4, 5, 12, 14}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "socktrack_map", Progs: []uint{1, 2, 3, 4, 5, 8, 10}})
 	} else {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10, 11, 14}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 10}})
 
 		// generic_kprobe_output,generic_retkprobe_output
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{13, 15}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{9, 11}})
 	}
 
 	readHook := `

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -420,34 +420,30 @@ func TestLoadTracepointSensor(t *testing.T) {
 	var sensorProgs = []tus.SensorProg{
 		0: tus.SensorProg{Name: "generic_tracepoint_event", Type: ebpf.TracePoint},
 		1: tus.SensorProg{Name: "generic_tracepoint_arg", Type: ebpf.TracePoint},
-		2: tus.SensorProg{Name: "generic_tracepoint_event0", Type: ebpf.TracePoint},
-		3: tus.SensorProg{Name: "generic_tracepoint_event1", Type: ebpf.TracePoint},
-		4: tus.SensorProg{Name: "generic_tracepoint_event2", Type: ebpf.TracePoint},
-		5: tus.SensorProg{Name: "generic_tracepoint_event3", Type: ebpf.TracePoint},
-		6: tus.SensorProg{Name: "generic_tracepoint_event4", Type: ebpf.TracePoint},
-		7: tus.SensorProg{Name: "generic_tracepoint_filter", Type: ebpf.TracePoint},
-		8: tus.SensorProg{Name: "generic_tracepoint_actions", Type: ebpf.TracePoint},
-		9: tus.SensorProg{Name: "generic_tracepoint_output", Type: ebpf.TracePoint},
+		2: tus.SensorProg{Name: "generic_tracepoint_process_event", Type: ebpf.TracePoint},
+		3: tus.SensorProg{Name: "generic_tracepoint_filter", Type: ebpf.TracePoint},
+		4: tus.SensorProg{Name: "generic_tracepoint_actions", Type: ebpf.TracePoint},
+		5: tus.SensorProg{Name: "generic_tracepoint_output", Type: ebpf.TracePoint},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all programs
-		tus.SensorMap{Name: "tp_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		tus.SensorMap{Name: "tp_heap", Progs: []uint{0, 1, 2, 3, 4, 5}},
 
 		// all but generic_tracepoint_output
-		tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8}},
+		tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4}},
 
 		// only generic_tracepoint_event*
-		tus.SensorMap{Name: "buffer_heap_map", Progs: []uint{2, 3, 4, 5, 6}},
+		tus.SensorMap{Name: "buffer_heap_map", Progs: []uint{2}},
 
 		// all but generic_tracepoint_event,generic_tracepoint_filter
-		tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 3, 4, 5, 6}},
+		tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2}},
 
 		// generic_tracepoint_output
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{9}},
+		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{5}},
 
 		// all kprobe but generic_tracepoint_filter
-		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6}},
+		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2}},
 
 		// generic_tracepoint_event
 		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
@@ -455,10 +451,10 @@ func TestLoadTracepointSensor(t *testing.T) {
 
 	if kernels.EnableLargeProgs() {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 7, 8, 9}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 3, 4, 5}})
 	} else {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 7}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 3}})
 	}
 
 	readHook := `

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -418,40 +418,36 @@ func TestGenericTracepointRawSyscall(t *testing.T) {
 
 func TestLoadTracepointSensor(t *testing.T) {
 	var sensorProgs = []tus.SensorProg{
-		0:  tus.SensorProg{Name: "generic_tracepoint_event", Type: ebpf.TracePoint},
-		1:  tus.SensorProg{Name: "generic_tracepoint_arg1", Type: ebpf.TracePoint},
-		2:  tus.SensorProg{Name: "generic_tracepoint_arg2", Type: ebpf.TracePoint},
-		3:  tus.SensorProg{Name: "generic_tracepoint_arg3", Type: ebpf.TracePoint},
-		4:  tus.SensorProg{Name: "generic_tracepoint_arg4", Type: ebpf.TracePoint},
-		5:  tus.SensorProg{Name: "generic_tracepoint_arg5", Type: ebpf.TracePoint},
-		6:  tus.SensorProg{Name: "generic_tracepoint_event0", Type: ebpf.TracePoint},
-		7:  tus.SensorProg{Name: "generic_tracepoint_event1", Type: ebpf.TracePoint},
-		8:  tus.SensorProg{Name: "generic_tracepoint_event2", Type: ebpf.TracePoint},
-		9:  tus.SensorProg{Name: "generic_tracepoint_event3", Type: ebpf.TracePoint},
-		10: tus.SensorProg{Name: "generic_tracepoint_event4", Type: ebpf.TracePoint},
-		11: tus.SensorProg{Name: "generic_tracepoint_filter", Type: ebpf.TracePoint},
-		12: tus.SensorProg{Name: "generic_tracepoint_actions", Type: ebpf.TracePoint},
-		13: tus.SensorProg{Name: "generic_tracepoint_output", Type: ebpf.TracePoint},
+		0: tus.SensorProg{Name: "generic_tracepoint_event", Type: ebpf.TracePoint},
+		1: tus.SensorProg{Name: "generic_tracepoint_arg", Type: ebpf.TracePoint},
+		2: tus.SensorProg{Name: "generic_tracepoint_event0", Type: ebpf.TracePoint},
+		3: tus.SensorProg{Name: "generic_tracepoint_event1", Type: ebpf.TracePoint},
+		4: tus.SensorProg{Name: "generic_tracepoint_event2", Type: ebpf.TracePoint},
+		5: tus.SensorProg{Name: "generic_tracepoint_event3", Type: ebpf.TracePoint},
+		6: tus.SensorProg{Name: "generic_tracepoint_event4", Type: ebpf.TracePoint},
+		7: tus.SensorProg{Name: "generic_tracepoint_filter", Type: ebpf.TracePoint},
+		8: tus.SensorProg{Name: "generic_tracepoint_actions", Type: ebpf.TracePoint},
+		9: tus.SensorProg{Name: "generic_tracepoint_output", Type: ebpf.TracePoint},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all programs
-		tus.SensorMap{Name: "tp_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+		tus.SensorMap{Name: "tp_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
 
 		// all but generic_tracepoint_output
-		tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+		tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8}},
 
 		// only generic_tracepoint_event*
-		tus.SensorMap{Name: "buffer_heap_map", Progs: []uint{6, 7, 8, 9, 10}},
+		tus.SensorMap{Name: "buffer_heap_map", Progs: []uint{2, 3, 4, 5, 6}},
 
 		// all but generic_tracepoint_event,generic_tracepoint_filter
-		tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 3, 4, 5, 6}},
 
 		// generic_tracepoint_output
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{13}},
+		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{9}},
 
 		// all kprobe but generic_tracepoint_filter
-		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 3, 4, 5, 6}},
 
 		// generic_tracepoint_event
 		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
@@ -459,10 +455,10 @@ func TestLoadTracepointSensor(t *testing.T) {
 
 	if kernels.EnableLargeProgs() {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 2, 3, 4, 5, 11, 12, 13}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 7, 8, 9}})
 	} else {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 2, 3, 4, 5, 11}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 1, 7}})
 	}
 
 	readHook := `

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -25,45 +25,41 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUprobeLoad(t *testing.T) {
+func TestLoadUprobeSensor(t *testing.T) {
 	var sensorProgs = []tus.SensorProg{
 		// uprobe
-		0:  tus.SensorProg{Name: "generic_uprobe_event", Type: ebpf.Kprobe},
-		1:  tus.SensorProg{Name: "generic_uprobe_process_event0", Type: ebpf.Kprobe},
-		2:  tus.SensorProg{Name: "generic_uprobe_process_event1", Type: ebpf.Kprobe},
-		3:  tus.SensorProg{Name: "generic_uprobe_process_event2", Type: ebpf.Kprobe},
-		4:  tus.SensorProg{Name: "generic_uprobe_process_event3", Type: ebpf.Kprobe},
-		5:  tus.SensorProg{Name: "generic_uprobe_process_event4", Type: ebpf.Kprobe},
-		6:  tus.SensorProg{Name: "generic_uprobe_filter_arg1", Type: ebpf.Kprobe},
-		7:  tus.SensorProg{Name: "generic_uprobe_filter_arg2", Type: ebpf.Kprobe},
-		8:  tus.SensorProg{Name: "generic_uprobe_filter_arg3", Type: ebpf.Kprobe},
-		9:  tus.SensorProg{Name: "generic_uprobe_filter_arg4", Type: ebpf.Kprobe},
-		10: tus.SensorProg{Name: "generic_uprobe_filter_arg5", Type: ebpf.Kprobe},
-		11: tus.SensorProg{Name: "generic_uprobe_process_filter", Type: ebpf.Kprobe},
-		12: tus.SensorProg{Name: "generic_uprobe_actions", Type: ebpf.Kprobe},
-		13: tus.SensorProg{Name: "generic_uprobe_output", Type: ebpf.Kprobe},
+		0: tus.SensorProg{Name: "generic_uprobe_event", Type: ebpf.Kprobe},
+		1: tus.SensorProg{Name: "generic_uprobe_process_event0", Type: ebpf.Kprobe},
+		2: tus.SensorProg{Name: "generic_uprobe_process_event1", Type: ebpf.Kprobe},
+		3: tus.SensorProg{Name: "generic_uprobe_process_event2", Type: ebpf.Kprobe},
+		4: tus.SensorProg{Name: "generic_uprobe_process_event3", Type: ebpf.Kprobe},
+		5: tus.SensorProg{Name: "generic_uprobe_process_event4", Type: ebpf.Kprobe},
+		6: tus.SensorProg{Name: "generic_uprobe_filter_arg", Type: ebpf.Kprobe},
+		7: tus.SensorProg{Name: "generic_uprobe_process_filter", Type: ebpf.Kprobe},
+		8: tus.SensorProg{Name: "generic_uprobe_actions", Type: ebpf.Kprobe},
+		9: tus.SensorProg{Name: "generic_uprobe_output", Type: ebpf.Kprobe},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all uprobe programs
-		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
 
 		// all but generic_uprobe_output
-		tus.SensorMap{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+		tus.SensorMap{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8}},
 
 		// generic_uprobe_process_filter,generic_uprobe_filter_arg*,generic_uprobe_actions
-		tus.SensorMap{Name: "filter_map", Progs: []uint{6, 7, 8, 9, 10, 11, 12}},
+		tus.SensorMap{Name: "filter_map", Progs: []uint{6, 7, 8}},
 
 		// generic_uprobe_output
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{13}},
+		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{9}},
 	}
 
 	if kernels.EnableLargeProgs() {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10, 11, 12, 13}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9}})
 	} else {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9, 10, 11}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7}})
 	}
 
 	nopHook := `

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -29,37 +29,34 @@ func TestLoadUprobeSensor(t *testing.T) {
 	var sensorProgs = []tus.SensorProg{
 		// uprobe
 		0: tus.SensorProg{Name: "generic_uprobe_event", Type: ebpf.Kprobe},
-		1: tus.SensorProg{Name: "generic_uprobe_process_event0", Type: ebpf.Kprobe},
-		2: tus.SensorProg{Name: "generic_uprobe_process_event1", Type: ebpf.Kprobe},
-		3: tus.SensorProg{Name: "generic_uprobe_process_event2", Type: ebpf.Kprobe},
-		4: tus.SensorProg{Name: "generic_uprobe_process_event3", Type: ebpf.Kprobe},
-		5: tus.SensorProg{Name: "generic_uprobe_process_event4", Type: ebpf.Kprobe},
-		6: tus.SensorProg{Name: "generic_uprobe_filter_arg", Type: ebpf.Kprobe},
-		7: tus.SensorProg{Name: "generic_uprobe_process_filter", Type: ebpf.Kprobe},
-		8: tus.SensorProg{Name: "generic_uprobe_actions", Type: ebpf.Kprobe},
-		9: tus.SensorProg{Name: "generic_uprobe_output", Type: ebpf.Kprobe},
+		1: tus.SensorProg{Name: "generic_uprobe_setup_event", Type: ebpf.Kprobe},
+		2: tus.SensorProg{Name: "generic_uprobe_process_event", Type: ebpf.Kprobe},
+		3: tus.SensorProg{Name: "generic_uprobe_filter_arg", Type: ebpf.Kprobe},
+		4: tus.SensorProg{Name: "generic_uprobe_process_filter", Type: ebpf.Kprobe},
+		5: tus.SensorProg{Name: "generic_uprobe_actions", Type: ebpf.Kprobe},
+		6: tus.SensorProg{Name: "generic_uprobe_output", Type: ebpf.Kprobe},
 	}
 
 	var sensorMaps = []tus.SensorMap{
 		// all uprobe programs
-		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6}},
 
 		// all but generic_uprobe_output
-		tus.SensorMap{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8}},
+		tus.SensorMap{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5}},
 
 		// generic_uprobe_process_filter,generic_uprobe_filter_arg*,generic_uprobe_actions
-		tus.SensorMap{Name: "filter_map", Progs: []uint{6, 7, 8}},
+		tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}},
 
 		// generic_uprobe_output
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{9}},
+		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{6}},
 	}
 
 	if kernels.EnableLargeProgs() {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7, 8, 9}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 3, 4, 5, 6}})
 	} else {
 		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 6, 7}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{0, 3, 4}})
 	}
 
 	nopHook := `


### PR DESCRIPTION
There's no need for having separate programs for generic_kprobe_filter_arg* and 
generic_kprobe_process_event* function, we can have just one instance called
recursively by tail jump.


b4:
```
# bpftool prog | grep gener | wc -l
14
# bpftool prog | grep gener 
32411: kprobe  name generic_kprobe_process_event3  tag 75d7c429743eb535  gpl
32412: kprobe  name generic_kprobe_filter_arg1  tag 9279987579ba117c  gpl
32413: kprobe  name generic_kprobe_process_event2  tag bf3fbe433d43e592  gpl
32414: kprobe  name generic_kprobe_output  tag 9e772542ab44369a  gpl
32415: kprobe  name generic_kprobe_filter_arg3  tag dbdb3573c7575198  gpl
32416: kprobe  name generic_kprobe_filter_arg4  tag c23b95feefd79e4b  gpl
32417: kprobe  name generic_kprobe_actions  tag dc8cb05c20800b5e  gpl
32418: kprobe  name generic_kprobe_process_filter  tag e003f29c78cce2e5  gpl
32419: kprobe  name generic_kprobe_filter_arg5  tag 300d8c52de7283fc  gpl
32420: kprobe  name generic_kprobe_process_event1  tag 4edd789b7e6c92bc  gpl
32421: kprobe  name generic_kprobe_process_event0  tag 3e6a42c39a871a4e  gpl
32422: kprobe  name generic_kprobe_process_event4  tag f6488e866179c36e  gpl
32423: kprobe  name generic_kprobe_event  tag 7d4eae34b0f0fead  gpl
32424: kprobe  name generic_kprobe_filter_arg2  tag 7b198f43675e7f7e  gpl
```

after:

```
# bpftool prog | grep gener
32388: kprobe  name generic_kprobe_setup_event  tag d680ace8a020dc3c  gpl
32389: kprobe  name generic_kprobe_process_event  tag 77be0f878db0213e  gpl
32390: kprobe  name generic_kprobe_actions  tag d1a085e4d7462bad  gpl
32391: kprobe  name generic_kprobe_output  tag 9e772542ab44369a  gpl
32392: kprobe  name generic_kprobe_event  tag fc0939c83ba8b9a7  gpl
32393: kprobe  name generic_kprobe_process_filter  tag 88d09489695c97d1  gpl
32394: kprobe  name generic_kprobe_filter_arg  tag 2b1a7047e1a02adb  gpl
# bpftool prog | grep gener | wc -l
7
```