### PR TITLE
e2e: Fix logger in e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	k8s.io/apimachinery v0.28.4
 	k8s.io/client-go v0.28.4
 	k8s.io/code-generator v0.28.4
-	k8s.io/klog/v2 v2.100.1
+	k8s.io/klog/v2 v2.110.1
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/controller-tools v0.13.0
@@ -83,7 +83,7 @@ require (
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -239,10 +239,9 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
-github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
+github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-logr/zapr v1.2.4 h1:QHVo+6stLbfJmYGkQ7uGHUCu5hnAFAj6mDe6Ea0SeOo=
@@ -1417,8 +1416,8 @@ k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.8.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
-k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
-k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
+k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 h1:LyMgNKD2P8Wn1iAwQU5OhxCKlKJy0sHc+PcDwFB24dQ=
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=

--- a/tests/e2e/runners/runners.go
+++ b/tests/e2e/runners/runners.go
@@ -17,6 +17,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/textlogger"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
@@ -134,9 +136,15 @@ func (r *Runner) Init() *Runner {
 	}
 	r.hasCalledInit = true
 
+	config := textlogger.NewConfig(
+		textlogger.Verbosity(4), // Matches Kubernetes "debug" level.
+		textlogger.Output(os.Stdout),
+	)
+	log.SetLogger(textlogger.NewLogger(config))
+
 	cfg, err := envconf.NewFromFlags()
 	if err != nil {
-		klog.Fatalf("Failed to configure test environment: %w", err)
+		klog.Fatalf("Failed to configure test environment")
 	}
 	klog.Info("IMPORTANT: Tetragon e2e tests require parallel tests enabled. User preferences will be ignored.")
 	cfg = cfg.WithParallelTestEnabled()

--- a/vendor/github.com/go-logr/logr/SECURITY.md
+++ b/vendor/github.com/go-logr/logr/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to go-logr-security@googlegroups.com
+- send us a [private vulnerability report](https://github.com/go-logr/logr/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+We ask that you give us 90 days to work on a fix before public exposure.

--- a/vendor/github.com/go-logr/logr/slogr/sloghandler.go
+++ b/vendor/github.com/go-logr/logr/slogr/sloghandler.go
@@ -1,0 +1,168 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slogr
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/go-logr/logr"
+)
+
+type slogHandler struct {
+	// May be nil, in which case all logs get discarded.
+	sink logr.LogSink
+	// Non-nil if sink is non-nil and implements SlogSink.
+	slogSink SlogSink
+
+	// groupPrefix collects values from WithGroup calls. It gets added as
+	// prefix to value keys when handling a log record.
+	groupPrefix string
+
+	// levelBias can be set when constructing the handler to influence the
+	// slog.Level of log records. A positive levelBias reduces the
+	// slog.Level value. slog has no API to influence this value after the
+	// handler got created, so it can only be set indirectly through
+	// Logger.V.
+	levelBias slog.Level
+}
+
+var _ slog.Handler = &slogHandler{}
+
+// groupSeparator is used to concatenate WithGroup names and attribute keys.
+const groupSeparator = "."
+
+// GetLevel is used for black box unit testing.
+func (l *slogHandler) GetLevel() slog.Level {
+	return l.levelBias
+}
+
+func (l *slogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return l.sink != nil && (level >= slog.LevelError || l.sink.Enabled(l.levelFromSlog(level)))
+}
+
+func (l *slogHandler) Handle(ctx context.Context, record slog.Record) error {
+	if l.slogSink != nil {
+		// Only adjust verbosity level of log entries < slog.LevelError.
+		if record.Level < slog.LevelError {
+			record.Level -= l.levelBias
+		}
+		return l.slogSink.Handle(ctx, record)
+	}
+
+	// No need to check for nil sink here because Handle will only be called
+	// when Enabled returned true.
+
+	kvList := make([]any, 0, 2*record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		if attr.Key != "" {
+			kvList = append(kvList, l.addGroupPrefix(attr.Key), attr.Value.Resolve().Any())
+		}
+		return true
+	})
+	if record.Level >= slog.LevelError {
+		l.sinkWithCallDepth().Error(nil, record.Message, kvList...)
+	} else {
+		level := l.levelFromSlog(record.Level)
+		l.sinkWithCallDepth().Info(level, record.Message, kvList...)
+	}
+	return nil
+}
+
+// sinkWithCallDepth adjusts the stack unwinding so that when Error or Info
+// are called by Handle, code in slog gets skipped.
+//
+// This offset currently (Go 1.21.0) works for calls through
+// slog.New(NewSlogHandler(...)).  There's no guarantee that the call
+// chain won't change. Wrapping the handler will also break unwinding. It's
+// still better than not adjusting at all....
+//
+// This cannot be done when constructing the handler because NewLogr needs
+// access to the original sink without this adjustment. A second copy would
+// work, but then WithAttrs would have to be called for both of them.
+func (l *slogHandler) sinkWithCallDepth() logr.LogSink {
+	if sink, ok := l.sink.(logr.CallDepthLogSink); ok {
+		return sink.WithCallDepth(2)
+	}
+	return l.sink
+}
+
+func (l *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if l.sink == nil || len(attrs) == 0 {
+		return l
+	}
+
+	copy := *l
+	if l.slogSink != nil {
+		copy.slogSink = l.slogSink.WithAttrs(attrs)
+		copy.sink = copy.slogSink
+	} else {
+		kvList := make([]any, 0, 2*len(attrs))
+		for _, attr := range attrs {
+			if attr.Key != "" {
+				kvList = append(kvList, l.addGroupPrefix(attr.Key), attr.Value.Resolve().Any())
+			}
+		}
+		copy.sink = l.sink.WithValues(kvList...)
+	}
+	return &copy
+}
+
+func (l *slogHandler) WithGroup(name string) slog.Handler {
+	if l.sink == nil {
+		return l
+	}
+	copy := *l
+	if l.slogSink != nil {
+		copy.slogSink = l.slogSink.WithGroup(name)
+		copy.sink = l.slogSink
+	} else {
+		copy.groupPrefix = copy.addGroupPrefix(name)
+	}
+	return &copy
+}
+
+func (l *slogHandler) addGroupPrefix(name string) string {
+	if l.groupPrefix == "" {
+		return name
+	}
+	return l.groupPrefix + groupSeparator + name
+}
+
+// levelFromSlog adjusts the level by the logger's verbosity and negates it.
+// It ensures that the result is >= 0. This is necessary because the result is
+// passed to a logr.LogSink and that API did not historically document whether
+// levels could be negative or what that meant.
+//
+// Some example usage:
+//     logrV0 := getMyLogger()
+//     logrV2 := logrV0.V(2)
+//     slogV2 := slog.New(slogr.NewSlogHandler(logrV2))
+//     slogV2.Debug("msg") // =~ logrV2.V(4) =~ logrV0.V(6)
+//     slogV2.Info("msg")  // =~  logrV2.V(0) =~ logrV0.V(2)
+//     slogv2.Warn("msg")  // =~ logrV2.V(-4) =~ logrV0.V(0)
+func (l *slogHandler) levelFromSlog(level slog.Level) int {
+	result := -level
+	result += l.levelBias // in case the original logr.Logger had a V level
+	if result < 0 {
+		result = 0 // because logr.LogSink doesn't expect negative V levels
+	}
+	return int(result)
+}

--- a/vendor/github.com/go-logr/logr/slogr/slogr.go
+++ b/vendor/github.com/go-logr/logr/slogr/slogr.go
@@ -1,0 +1,108 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package slogr enables usage of a slog.Handler with logr.Logger as front-end
+// API and of a logr.LogSink through the slog.Handler and thus slog.Logger
+// APIs.
+//
+// See the README in the top-level [./logr] package for a discussion of
+// interoperability.
+package slogr
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/go-logr/logr"
+)
+
+// NewLogr returns a logr.Logger which writes to the slog.Handler.
+//
+// The logr verbosity level is mapped to slog levels such that V(0) becomes
+// slog.LevelInfo and V(4) becomes slog.LevelDebug.
+func NewLogr(handler slog.Handler) logr.Logger {
+	if handler, ok := handler.(*slogHandler); ok {
+		if handler.sink == nil {
+			return logr.Discard()
+		}
+		return logr.New(handler.sink).V(int(handler.levelBias))
+	}
+	return logr.New(&slogSink{handler: handler})
+}
+
+// NewSlogHandler returns a slog.Handler which writes to the same sink as the logr.Logger.
+//
+// The returned logger writes all records with level >= slog.LevelError as
+// error log entries with LogSink.Error, regardless of the verbosity level of
+// the logr.Logger:
+//
+//	logger := <some logr.Logger with 0 as verbosity level>
+//	slog.New(NewSlogHandler(logger.V(10))).Error(...) -> logSink.Error(...)
+//
+// The level of all other records gets reduced by the verbosity
+// level of the logr.Logger and the result is negated. If it happens
+// to be negative, then it gets replaced by zero because a LogSink
+// is not expected to handled negative levels:
+//
+//	slog.New(NewSlogHandler(logger)).Debug(...) -> logger.GetSink().Info(level=4, ...)
+//	slog.New(NewSlogHandler(logger)).Warning(...) -> logger.GetSink().Info(level=0, ...)
+//	slog.New(NewSlogHandler(logger)).Info(...) -> logger.GetSink().Info(level=0, ...)
+//	slog.New(NewSlogHandler(logger.V(4))).Info(...) -> logger.GetSink().Info(level=4, ...)
+func NewSlogHandler(logger logr.Logger) slog.Handler {
+	if sink, ok := logger.GetSink().(*slogSink); ok && logger.GetV() == 0 {
+		return sink.handler
+	}
+
+	handler := &slogHandler{sink: logger.GetSink(), levelBias: slog.Level(logger.GetV())}
+	if slogSink, ok := handler.sink.(SlogSink); ok {
+		handler.slogSink = slogSink
+	}
+	return handler
+}
+
+// SlogSink is an optional interface that a LogSink can implement to support
+// logging through the slog.Logger or slog.Handler APIs better. It then should
+// also support special slog values like slog.Group. When used as a
+// slog.Handler, the advantages are:
+//
+//   - stack unwinding gets avoided in favor of logging the pre-recorded PC,
+//     as intended by slog
+//   - proper grouping of key/value pairs via WithGroup
+//   - verbosity levels > slog.LevelInfo can be recorded
+//   - less overhead
+//
+// Both APIs (logr.Logger and slog.Logger/Handler) then are supported equally
+// well. Developers can pick whatever API suits them better and/or mix
+// packages which use either API in the same binary with a common logging
+// implementation.
+//
+// This interface is necessary because the type implementing the LogSink
+// interface cannot also implement the slog.Handler interface due to the
+// different prototype of the common Enabled method.
+//
+// An implementation could support both interfaces in two different types, but then
+// additional interfaces would be needed to convert between those types in NewLogr
+// and NewSlogHandler.
+type SlogSink interface {
+	logr.LogSink
+
+	Handle(ctx context.Context, record slog.Record) error
+	WithAttrs(attrs []slog.Attr) SlogSink
+	WithGroup(name string) SlogSink
+}

--- a/vendor/github.com/go-logr/logr/slogr/slogsink.go
+++ b/vendor/github.com/go-logr/logr/slogr/slogsink.go
@@ -1,0 +1,122 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slogr
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+var (
+	_ logr.LogSink          = &slogSink{}
+	_ logr.CallDepthLogSink = &slogSink{}
+	_ Underlier             = &slogSink{}
+)
+
+// Underlier is implemented by the LogSink returned by NewLogr.
+type Underlier interface {
+	// GetUnderlying returns the Handler used by the LogSink.
+	GetUnderlying() slog.Handler
+}
+
+const (
+	// nameKey is used to log the `WithName` values as an additional attribute.
+	nameKey = "logger"
+
+	// errKey is used to log the error parameter of Error as an additional attribute.
+	errKey = "err"
+)
+
+type slogSink struct {
+	callDepth int
+	name      string
+	handler   slog.Handler
+}
+
+func (l *slogSink) Init(info logr.RuntimeInfo) {
+	l.callDepth = info.CallDepth
+}
+
+func (l *slogSink) GetUnderlying() slog.Handler {
+	return l.handler
+}
+
+func (l *slogSink) WithCallDepth(depth int) logr.LogSink {
+	newLogger := *l
+	newLogger.callDepth += depth
+	return &newLogger
+}
+
+func (l *slogSink) Enabled(level int) bool {
+	return l.handler.Enabled(context.Background(), slog.Level(-level))
+}
+
+func (l *slogSink) Info(level int, msg string, kvList ...interface{}) {
+	l.log(nil, msg, slog.Level(-level), kvList...)
+}
+
+func (l *slogSink) Error(err error, msg string, kvList ...interface{}) {
+	l.log(err, msg, slog.LevelError, kvList...)
+}
+
+func (l *slogSink) log(err error, msg string, level slog.Level, kvList ...interface{}) {
+	var pcs [1]uintptr
+	// skip runtime.Callers, this function, Info/Error, and all helper functions above that.
+	runtime.Callers(3+l.callDepth, pcs[:])
+
+	record := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	if l.name != "" {
+		record.AddAttrs(slog.String(nameKey, l.name))
+	}
+	if err != nil {
+		record.AddAttrs(slog.Any(errKey, err))
+	}
+	record.Add(kvList...)
+	l.handler.Handle(context.Background(), record)
+}
+
+func (l slogSink) WithName(name string) logr.LogSink {
+	if l.name != "" {
+		l.name = l.name + "/"
+	}
+	l.name += name
+	return &l
+}
+
+func (l slogSink) WithValues(kvList ...interface{}) logr.LogSink {
+	l.handler = l.handler.WithAttrs(kvListToAttrs(kvList...))
+	return &l
+}
+
+func kvListToAttrs(kvList ...interface{}) []slog.Attr {
+	// We don't need the record itself, only its Add method.
+	record := slog.NewRecord(time.Time{}, 0, "", 0)
+	record.Add(kvList...)
+	attrs := make([]slog.Attr, 0, record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs = append(attrs, attr)
+		return true
+	})
+	return attrs
+}

--- a/vendor/k8s.io/klog/v2/.golangci.yaml
+++ b/vendor/k8s.io/klog/v2/.golangci.yaml
@@ -1,0 +1,6 @@
+linters:
+  disable-all: true
+  enable: # sorted alphabetical
+    - gofmt
+    - misspell
+    - revive

--- a/vendor/k8s.io/klog/v2/internal/buffer/buffer.go
+++ b/vendor/k8s.io/klog/v2/internal/buffer/buffer.go
@@ -30,14 +30,16 @@ import (
 var (
 	// Pid is inserted into log headers. Can be overridden for tests.
 	Pid = os.Getpid()
+
+	// Time, if set, will be used instead of the actual current time.
+	Time *time.Time
 )
 
 // Buffer holds a single byte.Buffer for reuse. The zero value is ready for
 // use. It also provides some helper methods for output formatting.
 type Buffer struct {
 	bytes.Buffer
-	Tmp  [64]byte // temporary byte array for creating headers.
-	next *Buffer
+	Tmp [64]byte // temporary byte array for creating headers.
 }
 
 var buffers = sync.Pool{
@@ -122,6 +124,9 @@ func (buf *Buffer) FormatHeader(s severity.Severity, file string, line int, now 
 
 	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
 	// It's worth about 3X. Fprintf is hard.
+	if Time != nil {
+		now = *Time
+	}
 	_, month, day := now.Date()
 	hour, minute, second := now.Clock()
 	// Lmmdd hh:mm:ss.uuuuuu threadid file:line]
@@ -157,6 +162,9 @@ func (buf *Buffer) SprintHeader(s severity.Severity, now time.Time) string {
 
 	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
 	// It's worth about 3X. Fprintf is hard.
+	if Time != nil {
+		now = *Time
+	}
 	_, month, day := now.Date()
 	hour, minute, second := now.Clock()
 	// Lmmdd hh:mm:ss.uuuuuu threadid file:line]

--- a/vendor/k8s.io/klog/v2/internal/clock/clock.go
+++ b/vendor/k8s.io/klog/v2/internal/clock/clock.go
@@ -39,16 +39,6 @@ type Clock interface {
 	// Sleep sleeps for the provided duration d.
 	// Consider making the sleep interruptible by using 'select' on a context channel and a timer channel.
 	Sleep(d time.Duration)
-	// Tick returns the channel of a new Ticker.
-	// This method does not allow to free/GC the backing ticker. Use
-	// NewTicker from WithTicker instead.
-	Tick(d time.Duration) <-chan time.Time
-}
-
-// WithTicker allows for injecting fake or real clocks into code that
-// needs to do arbitrary things based on time.
-type WithTicker interface {
-	Clock
 	// NewTicker returns a new Ticker.
 	NewTicker(time.Duration) Ticker
 }
@@ -66,7 +56,7 @@ type WithDelayedExecution interface {
 // WithTickerAndDelayedExecution allows for injecting fake or real clocks
 // into code that needs Ticker and AfterFunc functionality
 type WithTickerAndDelayedExecution interface {
-	WithTicker
+	Clock
 	// AfterFunc executes f in its own goroutine after waiting
 	// for d duration and returns a Timer whose channel can be
 	// closed by calling Stop() on the Timer.
@@ -79,7 +69,7 @@ type Ticker interface {
 	Stop()
 }
 
-var _ = WithTicker(RealClock{})
+var _ Clock = RealClock{}
 
 // RealClock really calls time.Now()
 type RealClock struct{}
@@ -113,13 +103,6 @@ func (RealClock) AfterFunc(d time.Duration, f func()) Timer {
 	return &realTimer{
 		timer: time.AfterFunc(d, f),
 	}
-}
-
-// Tick is the same as time.Tick(d)
-// This method does not allow to free/GC the backing ticker. Use
-// NewTicker instead.
-func (RealClock) Tick(d time.Duration) <-chan time.Time {
-	return time.Tick(d)
 }
 
 // NewTicker returns a new Ticker.

--- a/vendor/k8s.io/klog/v2/internal/serialize/keyvalues.go
+++ b/vendor/k8s.io/klog/v2/internal/serialize/keyvalues.go
@@ -172,73 +172,6 @@ func KVListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
 	Formatter{}.KVListFormat(b, keysAndValues...)
 }
 
-// KVFormat serializes one key/value pair into the provided buffer.
-// A space gets inserted before the pair.
-func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
-	b.WriteByte(' ')
-	// Keys are assumed to be well-formed according to
-	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
-	// for the sake of performance. Keys with spaces,
-	// special characters, etc. will break parsing.
-	if sK, ok := k.(string); ok {
-		// Avoid one allocation when the key is a string, which
-		// normally it should be.
-		b.WriteString(sK)
-	} else {
-		b.WriteString(fmt.Sprintf("%s", k))
-	}
-
-	// The type checks are sorted so that more frequently used ones
-	// come first because that is then faster in the common
-	// cases. In Kubernetes, ObjectRef (a Stringer) is more common
-	// than plain strings
-	// (https://github.com/kubernetes/kubernetes/pull/106594#issuecomment-975526235).
-	switch v := v.(type) {
-	case textWriter:
-		writeTextWriterValue(b, v)
-	case fmt.Stringer:
-		writeStringValue(b, StringerToString(v))
-	case string:
-		writeStringValue(b, v)
-	case error:
-		writeStringValue(b, ErrorToString(v))
-	case logr.Marshaler:
-		value := MarshalerToValue(v)
-		// A marshaler that returns a string is useful for
-		// delayed formatting of complex values. We treat this
-		// case like a normal string. This is useful for
-		// multi-line support.
-		//
-		// We could do this by recursively formatting a value,
-		// but that comes with the risk of infinite recursion
-		// if a marshaler returns itself. Instead we call it
-		// only once and rely on it returning the intended
-		// value directly.
-		switch value := value.(type) {
-		case string:
-			writeStringValue(b, value)
-		default:
-			f.formatAny(b, value)
-		}
-	case []byte:
-		// In https://github.com/kubernetes/klog/pull/237 it was decided
-		// to format byte slices with "%+q". The advantages of that are:
-		// - readable output if the bytes happen to be printable
-		// - non-printable bytes get represented as unicode escape
-		//   sequences (\uxxxx)
-		//
-		// The downsides are that we cannot use the faster
-		// strconv.Quote here and that multi-line output is not
-		// supported. If developers know that a byte array is
-		// printable and they want multi-line output, they can
-		// convert the value to string before logging it.
-		b.WriteByte('=')
-		b.WriteString(fmt.Sprintf("%+q", v))
-	default:
-		f.formatAny(b, v)
-	}
-}
-
 func KVFormat(b *bytes.Buffer, k, v interface{}) {
 	Formatter{}.KVFormat(b, k, v)
 }
@@ -251,6 +184,10 @@ func (f Formatter) formatAny(b *bytes.Buffer, v interface{}) {
 		b.WriteString(f.AnyToStringHook(v))
 		return
 	}
+	formatAsJSON(b, v)
+}
+
+func formatAsJSON(b *bytes.Buffer, v interface{}) {
 	encoder := json.NewEncoder(b)
 	l := b.Len()
 	if err := encoder.Encode(v); err != nil {

--- a/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_no_slog.go
+++ b/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_no_slog.go
@@ -1,0 +1,97 @@
+//go:build !go1.21
+// +build !go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serialize
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
+
+// KVFormat serializes one key/value pair into the provided buffer.
+// A space gets inserted before the pair.
+func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
+	// This is the version without slog support. Must be kept in sync with
+	// the version in keyvalues_slog.go.
+
+	b.WriteByte(' ')
+	// Keys are assumed to be well-formed according to
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
+	// for the sake of performance. Keys with spaces,
+	// special characters, etc. will break parsing.
+	if sK, ok := k.(string); ok {
+		// Avoid one allocation when the key is a string, which
+		// normally it should be.
+		b.WriteString(sK)
+	} else {
+		b.WriteString(fmt.Sprintf("%s", k))
+	}
+
+	// The type checks are sorted so that more frequently used ones
+	// come first because that is then faster in the common
+	// cases. In Kubernetes, ObjectRef (a Stringer) is more common
+	// than plain strings
+	// (https://github.com/kubernetes/kubernetes/pull/106594#issuecomment-975526235).
+	switch v := v.(type) {
+	case textWriter:
+		writeTextWriterValue(b, v)
+	case fmt.Stringer:
+		writeStringValue(b, StringerToString(v))
+	case string:
+		writeStringValue(b, v)
+	case error:
+		writeStringValue(b, ErrorToString(v))
+	case logr.Marshaler:
+		value := MarshalerToValue(v)
+		// A marshaler that returns a string is useful for
+		// delayed formatting of complex values. We treat this
+		// case like a normal string. This is useful for
+		// multi-line support.
+		//
+		// We could do this by recursively formatting a value,
+		// but that comes with the risk of infinite recursion
+		// if a marshaler returns itself. Instead we call it
+		// only once and rely on it returning the intended
+		// value directly.
+		switch value := value.(type) {
+		case string:
+			writeStringValue(b, value)
+		default:
+			f.formatAny(b, value)
+		}
+	case []byte:
+		// In https://github.com/kubernetes/klog/pull/237 it was decided
+		// to format byte slices with "%+q". The advantages of that are:
+		// - readable output if the bytes happen to be printable
+		// - non-printable bytes get represented as unicode escape
+		//   sequences (\uxxxx)
+		//
+		// The downsides are that we cannot use the faster
+		// strconv.Quote here and that multi-line output is not
+		// supported. If developers know that a byte array is
+		// printable and they want multi-line output, they can
+		// convert the value to string before logging it.
+		b.WriteByte('=')
+		b.WriteString(fmt.Sprintf("%+q", v))
+	default:
+		f.formatAny(b, v)
+	}
+}

--- a/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_slog.go
+++ b/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_slog.go
@@ -1,0 +1,155 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serialize
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/go-logr/logr"
+)
+
+// KVFormat serializes one key/value pair into the provided buffer.
+// A space gets inserted before the pair.
+func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
+	// This is the version without slog support. Must be kept in sync with
+	// the version in keyvalues_slog.go.
+
+	b.WriteByte(' ')
+	// Keys are assumed to be well-formed according to
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
+	// for the sake of performance. Keys with spaces,
+	// special characters, etc. will break parsing.
+	if sK, ok := k.(string); ok {
+		// Avoid one allocation when the key is a string, which
+		// normally it should be.
+		b.WriteString(sK)
+	} else {
+		b.WriteString(fmt.Sprintf("%s", k))
+	}
+
+	// The type checks are sorted so that more frequently used ones
+	// come first because that is then faster in the common
+	// cases. In Kubernetes, ObjectRef (a Stringer) is more common
+	// than plain strings
+	// (https://github.com/kubernetes/kubernetes/pull/106594#issuecomment-975526235).
+	//
+	// slog.LogValuer does not need to be handled here because the handler will
+	// already have resolved such special values to the final value for logging.
+	switch v := v.(type) {
+	case textWriter:
+		writeTextWriterValue(b, v)
+	case slog.Value:
+		// This must come before fmt.Stringer because slog.Value implements
+		// fmt.Stringer, but does not produce the output that we want.
+		b.WriteByte('=')
+		generateJSON(b, v)
+	case fmt.Stringer:
+		writeStringValue(b, StringerToString(v))
+	case string:
+		writeStringValue(b, v)
+	case error:
+		writeStringValue(b, ErrorToString(v))
+	case logr.Marshaler:
+		value := MarshalerToValue(v)
+		// A marshaler that returns a string is useful for
+		// delayed formatting of complex values. We treat this
+		// case like a normal string. This is useful for
+		// multi-line support.
+		//
+		// We could do this by recursively formatting a value,
+		// but that comes with the risk of infinite recursion
+		// if a marshaler returns itself. Instead we call it
+		// only once and rely on it returning the intended
+		// value directly.
+		switch value := value.(type) {
+		case string:
+			writeStringValue(b, value)
+		default:
+			f.formatAny(b, value)
+		}
+	case slog.LogValuer:
+		value := slog.AnyValue(v).Resolve()
+		if value.Kind() == slog.KindString {
+			writeStringValue(b, value.String())
+		} else {
+			b.WriteByte('=')
+			generateJSON(b, value)
+		}
+	case []byte:
+		// In https://github.com/kubernetes/klog/pull/237 it was decided
+		// to format byte slices with "%+q". The advantages of that are:
+		// - readable output if the bytes happen to be printable
+		// - non-printable bytes get represented as unicode escape
+		//   sequences (\uxxxx)
+		//
+		// The downsides are that we cannot use the faster
+		// strconv.Quote here and that multi-line output is not
+		// supported. If developers know that a byte array is
+		// printable and they want multi-line output, they can
+		// convert the value to string before logging it.
+		b.WriteByte('=')
+		b.WriteString(fmt.Sprintf("%+q", v))
+	default:
+		f.formatAny(b, v)
+	}
+}
+
+// generateJSON has the same preference for plain strings as KVFormat.
+// In contrast to KVFormat it always produces valid JSON with no line breaks.
+func generateJSON(b *bytes.Buffer, v interface{}) {
+	switch v := v.(type) {
+	case slog.Value:
+		switch v.Kind() {
+		case slog.KindGroup:
+			// Format as a JSON group. We must not involve f.AnyToStringHook (if there is any),
+			// because there is no guarantee that it produces valid JSON.
+			b.WriteByte('{')
+			for i, attr := range v.Group() {
+				if i > 0 {
+					b.WriteByte(',')
+				}
+				b.WriteString(strconv.Quote(attr.Key))
+				b.WriteByte(':')
+				generateJSON(b, attr.Value)
+			}
+			b.WriteByte('}')
+		case slog.KindLogValuer:
+			generateJSON(b, v.Resolve())
+		default:
+			// Peel off the slog.Value wrapper and format the actual value.
+			generateJSON(b, v.Any())
+		}
+	case fmt.Stringer:
+		b.WriteString(strconv.Quote(StringerToString(v)))
+	case logr.Marshaler:
+		generateJSON(b, MarshalerToValue(v))
+	case slog.LogValuer:
+		generateJSON(b, slog.AnyValue(v).Resolve().Any())
+	case string:
+		b.WriteString(strconv.Quote(v))
+	case error:
+		b.WriteString(strconv.Quote(v.Error()))
+	default:
+		formatAsJSON(b, v)
+	}
+}

--- a/vendor/k8s.io/klog/v2/internal/sloghandler/sloghandler_slog.go
+++ b/vendor/k8s.io/klog/v2/internal/sloghandler/sloghandler_slog.go
@@ -1,0 +1,96 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sloghandler
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2/internal/severity"
+)
+
+func Handle(_ context.Context, record slog.Record, groups string, printWithInfos func(file string, line int, now time.Time, err error, s severity.Severity, msg string, kvList []interface{})) error {
+	now := record.Time
+	if now.IsZero() {
+		// This format doesn't support printing entries without a time.
+		now = time.Now()
+	}
+
+	// slog has numeric severity levels, with 0 as default "info", negative for debugging, and
+	// positive with some pre-defined levels for more important. Those ranges get mapped to
+	// the corresponding klog levels where possible, with "info" the default that is used
+	// also for negative debug levels.
+	level := record.Level
+	s := severity.InfoLog
+	switch {
+	case level >= slog.LevelError:
+		s = severity.ErrorLog
+	case level >= slog.LevelWarn:
+		s = severity.WarningLog
+	}
+
+	var file string
+	var line int
+	if record.PC != 0 {
+		// Same as https://cs.opensource.google/go/x/exp/+/642cacee:slog/record.go;drc=642cacee5cc05231f45555a333d07f1005ffc287;l=70
+		fs := runtime.CallersFrames([]uintptr{record.PC})
+		f, _ := fs.Next()
+		if f.File != "" {
+			file = f.File
+			if slash := strings.LastIndex(file, "/"); slash >= 0 {
+				file = file[slash+1:]
+			}
+			line = f.Line
+		}
+	} else {
+		file = "???"
+		line = 1
+	}
+
+	kvList := make([]interface{}, 0, 2*record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		kvList = appendAttr(groups, kvList, attr)
+		return true
+	})
+
+	printWithInfos(file, line, now, nil, s, record.Message, kvList)
+	return nil
+}
+
+func Attrs2KVList(groups string, attrs []slog.Attr) []interface{} {
+	kvList := make([]interface{}, 0, 2*len(attrs))
+	for _, attr := range attrs {
+		kvList = appendAttr(groups, kvList, attr)
+	}
+	return kvList
+}
+
+func appendAttr(groups string, kvList []interface{}, attr slog.Attr) []interface{} {
+	var key string
+	if groups != "" {
+		key = groups + "." + attr.Key
+	} else {
+		key = attr.Key
+	}
+	return append(kvList, key, attr.Value)
+}

--- a/vendor/k8s.io/klog/v2/internal/verbosity/verbosity.go
+++ b/vendor/k8s.io/klog/v2/internal/verbosity/verbosity.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2013 Google Inc. All Rights Reserved.
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package verbosity
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// New returns a struct that implements -v and -vmodule support. Changing and
+// checking these settings is thread-safe, with all concurrency issues handled
+// internally.
+func New() *VState {
+	vs := new(VState)
+
+	// The two fields must have a pointer to the overal struct for their
+	// implementation of Set.
+	vs.vmodule.vs = vs
+	vs.verbosity.vs = vs
+
+	return vs
+}
+
+// Value is an extension that makes it possible to use the values in pflag.
+type Value interface {
+	flag.Value
+	Type() string
+}
+
+func (vs *VState) V() Value {
+	return &vs.verbosity
+}
+
+func (vs *VState) VModule() Value {
+	return &vs.vmodule
+}
+
+// VState contains settings and state. Some of its fields can be accessed
+// through atomic read/writes, in other cases a mutex must be held.
+type VState struct {
+	mu sync.Mutex
+
+	// These flags are modified only under lock, although verbosity may be fetched
+	// safely using atomic.LoadInt32.
+	vmodule   moduleSpec // The state of the -vmodule flag.
+	verbosity levelSpec  // V logging level, the value of the -v flag/
+
+	// pcs is used in V to avoid an allocation when computing the caller's PC.
+	pcs [1]uintptr
+	// vmap is a cache of the V Level for each V() call site, identified by PC.
+	// It is wiped whenever the vmodule flag changes state.
+	vmap map[uintptr]Level
+	// filterLength stores the length of the vmodule filter chain. If greater
+	// than zero, it means vmodule is enabled. It may be read safely
+	// using sync.LoadInt32, but is only modified under mu.
+	filterLength int32
+}
+
+// Level must be an int32 to support atomic read/writes.
+type Level int32
+
+type levelSpec struct {
+	vs *VState
+	l  Level
+}
+
+// get returns the value of the level.
+func (l *levelSpec) get() Level {
+	return Level(atomic.LoadInt32((*int32)(&l.l)))
+}
+
+// set sets the value of the level.
+func (l *levelSpec) set(val Level) {
+	atomic.StoreInt32((*int32)(&l.l), int32(val))
+}
+
+// String is part of the flag.Value interface.
+func (l *levelSpec) String() string {
+	return strconv.FormatInt(int64(l.l), 10)
+}
+
+// Get is part of the flag.Getter interface. It returns the
+// verbosity level as int32.
+func (l *levelSpec) Get() interface{} {
+	return int32(l.l)
+}
+
+// Type is part of pflag.Value.
+func (l *levelSpec) Type() string {
+	return "Level"
+}
+
+// Set is part of the flag.Value interface.
+func (l *levelSpec) Set(value string) error {
+	v, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return err
+	}
+	l.vs.mu.Lock()
+	defer l.vs.mu.Unlock()
+	l.vs.set(Level(v), l.vs.vmodule.filter, false)
+	return nil
+}
+
+// moduleSpec represents the setting of the -vmodule flag.
+type moduleSpec struct {
+	vs     *VState
+	filter []modulePat
+}
+
+// modulePat contains a filter for the -vmodule flag.
+// It holds a verbosity level and a file pattern to match.
+type modulePat struct {
+	pattern string
+	literal bool // The pattern is a literal string
+	level   Level
+}
+
+// match reports whether the file matches the pattern. It uses a string
+// comparison if the pattern contains no metacharacters.
+func (m *modulePat) match(file string) bool {
+	if m.literal {
+		return file == m.pattern
+	}
+	match, _ := filepath.Match(m.pattern, file)
+	return match
+}
+
+func (m *moduleSpec) String() string {
+	// Lock because the type is not atomic. TODO: clean this up.
+	// Empty instances don't have and don't need a lock (can
+	// happen when flag uses introspection).
+	if m.vs != nil {
+		m.vs.mu.Lock()
+		defer m.vs.mu.Unlock()
+	}
+	var b bytes.Buffer
+	for i, f := range m.filter {
+		if i > 0 {
+			b.WriteRune(',')
+		}
+		fmt.Fprintf(&b, "%s=%d", f.pattern, f.level)
+	}
+	return b.String()
+}
+
+// Get is part of the (Go 1.2)  flag.Getter interface. It always returns nil for this flag type since the
+// struct is not exported.
+func (m *moduleSpec) Get() interface{} {
+	return nil
+}
+
+// Type is part of pflag.Value
+func (m *moduleSpec) Type() string {
+	return "pattern=N,..."
+}
+
+var errVmoduleSyntax = errors.New("syntax error: expect comma-separated list of filename=N")
+
+// Set will sets module value
+// Syntax: -vmodule=recordio=2,file=1,gfs*=3
+func (m *moduleSpec) Set(value string) error {
+	var filter []modulePat
+	for _, pat := range strings.Split(value, ",") {
+		if len(pat) == 0 {
+			// Empty strings such as from a trailing comma can be ignored.
+			continue
+		}
+		patLev := strings.Split(pat, "=")
+		if len(patLev) != 2 || len(patLev[0]) == 0 || len(patLev[1]) == 0 {
+			return errVmoduleSyntax
+		}
+		pattern := patLev[0]
+		v, err := strconv.ParseInt(patLev[1], 10, 32)
+		if err != nil {
+			return errors.New("syntax error: expect comma-separated list of filename=N")
+		}
+		if v < 0 {
+			return errors.New("negative value for vmodule level")
+		}
+		if v == 0 {
+			continue // Ignore. It's harmless but no point in paying the overhead.
+		}
+		// TODO: check syntax of filter?
+		filter = append(filter, modulePat{pattern, isLiteral(pattern), Level(v)})
+	}
+	m.vs.mu.Lock()
+	defer m.vs.mu.Unlock()
+	m.vs.set(m.vs.verbosity.l, filter, true)
+	return nil
+}
+
+// isLiteral reports whether the pattern is a literal string, that is, has no metacharacters
+// that require filepath.Match to be called to match the pattern.
+func isLiteral(pattern string) bool {
+	return !strings.ContainsAny(pattern, `\*?[]`)
+}
+
+// set sets a consistent state for V logging.
+// The mutex must be held.
+func (vs *VState) set(l Level, filter []modulePat, setFilter bool) {
+	// Turn verbosity off so V will not fire while we are in transition.
+	vs.verbosity.set(0)
+	// Ditto for filter length.
+	atomic.StoreInt32(&vs.filterLength, 0)
+
+	// Set the new filters and wipe the pc->Level map if the filter has changed.
+	if setFilter {
+		vs.vmodule.filter = filter
+		vs.vmap = make(map[uintptr]Level)
+	}
+
+	// Things are consistent now, so enable filtering and verbosity.
+	// They are enabled in order opposite to that in V.
+	atomic.StoreInt32(&vs.filterLength, int32(len(filter)))
+	vs.verbosity.set(l)
+}
+
+// Enabled checks whether logging is enabled at the given level. This must be
+// called with depth=0 when the caller of enabled will do the logging and
+// higher values when more stack levels need to be skipped.
+//
+// The mutex will be locked only if needed.
+func (vs *VState) Enabled(level Level, depth int) bool {
+	// This function tries hard to be cheap unless there's work to do.
+	// The fast path is two atomic loads and compares.
+
+	// Here is a cheap but safe test to see if V logging is enabled globally.
+	if vs.verbosity.get() >= level {
+		return true
+	}
+
+	// It's off globally but vmodule may still be set.
+	// Here is another cheap but safe test to see if vmodule is enabled.
+	if atomic.LoadInt32(&vs.filterLength) > 0 {
+		// Now we need a proper lock to use the logging structure. The pcs field
+		// is shared so we must lock before accessing it. This is fairly expensive,
+		// but if V logging is enabled we're slow anyway.
+		vs.mu.Lock()
+		defer vs.mu.Unlock()
+		if runtime.Callers(depth+2, vs.pcs[:]) == 0 {
+			return false
+		}
+		// runtime.Callers returns "return PCs", but we want
+		// to look up the symbolic information for the call,
+		// so subtract 1 from the PC. runtime.CallersFrames
+		// would be cleaner, but allocates.
+		pc := vs.pcs[0] - 1
+		v, ok := vs.vmap[pc]
+		if !ok {
+			v = vs.setV(pc)
+		}
+		return v >= level
+	}
+	return false
+}
+
+// setV computes and remembers the V level for a given PC
+// when vmodule is enabled.
+// File pattern matching takes the basename of the file, stripped
+// of its .go suffix, and uses filepath.Match, which is a little more
+// general than the *? matching used in C++.
+// Mutex is held.
+func (vs *VState) setV(pc uintptr) Level {
+	fn := runtime.FuncForPC(pc)
+	file, _ := fn.FileLine(pc)
+	// The file is something like /a/b/c/d.go. We want just the d.
+	file = strings.TrimSuffix(file, ".go")
+	if slash := strings.LastIndex(file, "/"); slash >= 0 {
+		file = file[slash+1:]
+	}
+	for _, filter := range vs.vmodule.filter {
+		if filter.match(file) {
+			vs.vmap[pc] = filter.level
+			return filter.level
+		}
+	}
+	vs.vmap[pc] = 0
+	return 0
+}

--- a/vendor/k8s.io/klog/v2/k8s_references_slog.go
+++ b/vendor/k8s.io/klog/v2/k8s_references_slog.go
@@ -1,0 +1,39 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"log/slog"
+)
+
+func (ref ObjectRef) LogValue() slog.Value {
+	if ref.Namespace != "" {
+		return slog.GroupValue(slog.String("name", ref.Name), slog.String("namespace", ref.Namespace))
+	}
+	return slog.GroupValue(slog.String("name", ref.Name))
+}
+
+var _ slog.LogValuer = ObjectRef{}
+
+func (ks kobjSlice) LogValue() slog.Value {
+	return slog.AnyValue(ks.MarshalLog())
+}
+
+var _ slog.LogValuer = kobjSlice{}

--- a/vendor/k8s.io/klog/v2/klog.go
+++ b/vendor/k8s.io/klog/v2/klog.go
@@ -415,7 +415,7 @@ func init() {
 	logging.stderrThreshold = severityValue{
 		Severity: severity.ErrorLog, // Default stderrThreshold is ERROR.
 	}
-	commandLine.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false)")
+	commandLine.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true)")
 	commandLine.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	commandLine.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
 
@@ -518,9 +518,7 @@ type settings struct {
 func (s settings) deepCopy() settings {
 	// vmodule is a slice and would be shared, so we have copy it.
 	filter := make([]modulePat, len(s.vmodule.filter))
-	for i := range s.vmodule.filter {
-		filter[i] = s.vmodule.filter[i]
-	}
+	copy(filter, s.vmodule.filter)
 	s.vmodule.filter = filter
 
 	if s.logger != nil {
@@ -657,16 +655,15 @@ func (l *loggingT) header(s severity.Severity, depth int) (*buffer.Buffer, strin
 			}
 		}
 	}
-	return l.formatHeader(s, file, line), file, line
+	return l.formatHeader(s, file, line, timeNow()), file, line
 }
 
 // formatHeader formats a log header using the provided file name and line number.
-func (l *loggingT) formatHeader(s severity.Severity, file string, line int) *buffer.Buffer {
+func (l *loggingT) formatHeader(s severity.Severity, file string, line int, now time.Time) *buffer.Buffer {
 	buf := buffer.GetBuffer()
 	if l.skipHeaders {
 		return buf
 	}
-	now := timeNow()
 	buf.FormatHeader(s, file, line, now)
 	return buf
 }
@@ -676,6 +673,10 @@ func (l *loggingT) println(s severity.Severity, logger *logWriter, filter LogFil
 }
 
 func (l *loggingT) printlnDepth(s severity.Severity, logger *logWriter, filter LogFilter, depth int, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintln(args...) // cause vet to treat this function like fmt.Println
+	}
+
 	buf, file, line := l.header(s, depth)
 	// If a logger is set and doesn't support writing a formatted buffer,
 	// we clear the generated header as we rely on the backing
@@ -696,7 +697,15 @@ func (l *loggingT) print(s severity.Severity, logger *logWriter, filter LogFilte
 }
 
 func (l *loggingT) printDepth(s severity.Severity, logger *logWriter, filter LogFilter, depth int, args ...interface{}) {
+	if false {
+		_ = fmt.Sprint(args...) //  // cause vet to treat this function like fmt.Print
+	}
+
 	buf, file, line := l.header(s, depth)
+	l.printWithInfos(buf, file, line, s, logger, filter, depth+1, args...)
+}
+
+func (l *loggingT) printWithInfos(buf *buffer.Buffer, file string, line int, s severity.Severity, logger *logWriter, filter LogFilter, depth int, args ...interface{}) {
 	// If a logger is set and doesn't support writing a formatted buffer,
 	// we clear the generated header as we rely on the backing
 	// logger implementation to print headers.
@@ -719,6 +728,10 @@ func (l *loggingT) printf(s severity.Severity, logger *logWriter, filter LogFilt
 }
 
 func (l *loggingT) printfDepth(s severity.Severity, logger *logWriter, filter LogFilter, depth int, format string, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintf(format, args...) // cause vet to treat this function like fmt.Printf
+	}
+
 	buf, file, line := l.header(s, depth)
 	// If a logger is set and doesn't support writing a formatted buffer,
 	// we clear the generated header as we rely on the backing
@@ -741,7 +754,7 @@ func (l *loggingT) printfDepth(s severity.Severity, logger *logWriter, filter Lo
 // alsoLogToStderr is true, the log message always appears on standard error; it
 // will also appear in the log file unless --logtostderr is set.
 func (l *loggingT) printWithFileLine(s severity.Severity, logger *logWriter, filter LogFilter, file string, line int, alsoToStderr bool, args ...interface{}) {
-	buf := l.formatHeader(s, file, line)
+	buf := l.formatHeader(s, file, line, timeNow())
 	// If a logger is set and doesn't support writing a formatted buffer,
 	// we clear the generated header as we rely on the backing
 	// logger implementation to print headers.
@@ -759,7 +772,7 @@ func (l *loggingT) printWithFileLine(s severity.Severity, logger *logWriter, fil
 	l.output(s, logger, buf, 2 /* depth */, file, line, alsoToStderr)
 }
 
-// if loggr is specified, will call loggr.Error, otherwise output with logging module.
+// if logger is specified, will call logger.Error, otherwise output with logging module.
 func (l *loggingT) errorS(err error, logger *logWriter, filter LogFilter, depth int, msg string, keysAndValues ...interface{}) {
 	if filter != nil {
 		msg, keysAndValues = filter.FilterS(msg, keysAndValues)
@@ -771,7 +784,7 @@ func (l *loggingT) errorS(err error, logger *logWriter, filter LogFilter, depth 
 	l.printS(err, severity.ErrorLog, depth+1, msg, keysAndValues...)
 }
 
-// if loggr is specified, will call loggr.Info, otherwise output with logging module.
+// if logger is specified, will call logger.Info, otherwise output with logging module.
 func (l *loggingT) infoS(logger *logWriter, filter LogFilter, depth int, msg string, keysAndValues ...interface{}) {
 	if filter != nil {
 		msg, keysAndValues = filter.FilterS(msg, keysAndValues)
@@ -783,7 +796,7 @@ func (l *loggingT) infoS(logger *logWriter, filter LogFilter, depth int, msg str
 	l.printS(nil, severity.InfoLog, depth+1, msg, keysAndValues...)
 }
 
-// printS is called from infoS and errorS if loggr is not specified.
+// printS is called from infoS and errorS if logger is not specified.
 // set log severity by s
 func (l *loggingT) printS(err error, s severity.Severity, depth int, msg string, keysAndValues ...interface{}) {
 	// Only create a new buffer if we don't have one cached.
@@ -796,7 +809,7 @@ func (l *loggingT) printS(err error, s severity.Severity, depth int, msg string,
 		serialize.KVListFormat(&b.Buffer, "err", err)
 	}
 	serialize.KVListFormat(&b.Buffer, keysAndValues...)
-	l.printDepth(s, logging.logger, nil, depth+1, &b.Buffer)
+	l.printDepth(s, nil, nil, depth+1, &b.Buffer)
 	// Make the buffer available for reuse.
 	buffer.PutBuffer(b)
 }
@@ -873,6 +886,9 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 		if logger.writeKlogBuffer != nil {
 			logger.writeKlogBuffer(data)
 		} else {
+			if len(data) > 0 && data[len(data)-1] == '\n' {
+				data = data[:len(data)-1]
+			}
 			// TODO: set 'severity' and caller information as structured log info
 			// keysAndValues := []interface{}{"severity", severityName[s], "file", file, "line", line}
 			if s == severity.ErrorLog {
@@ -897,7 +913,7 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 					l.exit(err)
 				}
 			}
-			l.file[severity.InfoLog].Write(data)
+			_, _ = l.file[severity.InfoLog].Write(data)
 		} else {
 			if l.file[s] == nil {
 				if err := l.createFiles(s); err != nil {
@@ -907,20 +923,20 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 			}
 
 			if l.oneOutput {
-				l.file[s].Write(data)
+				_, _ = l.file[s].Write(data)
 			} else {
 				switch s {
 				case severity.FatalLog:
-					l.file[severity.FatalLog].Write(data)
+					_, _ = l.file[severity.FatalLog].Write(data)
 					fallthrough
 				case severity.ErrorLog:
-					l.file[severity.ErrorLog].Write(data)
+					_, _ = l.file[severity.ErrorLog].Write(data)
 					fallthrough
 				case severity.WarningLog:
-					l.file[severity.WarningLog].Write(data)
+					_, _ = l.file[severity.WarningLog].Write(data)
 					fallthrough
 				case severity.InfoLog:
-					l.file[severity.InfoLog].Write(data)
+					_, _ = l.file[severity.InfoLog].Write(data)
 				}
 			}
 		}
@@ -946,7 +962,7 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 		logExitFunc = func(error) {} // If we get a write error, we'll still exit below.
 		for log := severity.FatalLog; log >= severity.InfoLog; log-- {
 			if f := l.file[log]; f != nil { // Can be nil if -logtostderr is set.
-				f.Write(trace)
+				_, _ = f.Write(trace)
 			}
 		}
 		l.mu.Unlock()
@@ -1102,7 +1118,7 @@ const flushInterval = 5 * time.Second
 // flushDaemon periodically flushes the log file buffers.
 type flushDaemon struct {
 	mu       sync.Mutex
-	clock    clock.WithTicker
+	clock    clock.Clock
 	flush    func()
 	stopC    chan struct{}
 	stopDone chan struct{}
@@ -1110,7 +1126,7 @@ type flushDaemon struct {
 
 // newFlushDaemon returns a new flushDaemon. If the passed clock is nil, a
 // clock.RealClock is used.
-func newFlushDaemon(flush func(), tickClock clock.WithTicker) *flushDaemon {
+func newFlushDaemon(flush func(), tickClock clock.Clock) *flushDaemon {
 	if tickClock == nil {
 		tickClock = clock.RealClock{}
 	}
@@ -1201,8 +1217,8 @@ func (l *loggingT) flushAll() {
 	for s := severity.FatalLog; s >= severity.InfoLog; s-- {
 		file := l.file[s]
 		if file != nil {
-			file.Flush() // ignore error
-			file.Sync()  // ignore error
+			_ = file.Flush() // ignore error
+			_ = file.Sync()  // ignore error
 		}
 	}
 	if logging.loggerOptions.flush != nil {
@@ -1281,9 +1297,7 @@ func (l *loggingT) setV(pc uintptr) Level {
 	fn := runtime.FuncForPC(pc)
 	file, _ := fn.FileLine(pc)
 	// The file is something like /a/b/c/d.go. We want just the d.
-	if strings.HasSuffix(file, ".go") {
-		file = file[:len(file)-3]
-	}
+	file = strings.TrimSuffix(file, ".go")
 	if slash := strings.LastIndex(file, "/"); slash >= 0 {
 		file = file[slash+1:]
 	}

--- a/vendor/k8s.io/klog/v2/klog_file.go
+++ b/vendor/k8s.io/klog/v2/klog_file.go
@@ -109,8 +109,8 @@ func create(tag string, t time.Time, startup bool) (f *os.File, filename string,
 		f, err := openOrCreate(fname, startup)
 		if err == nil {
 			symlink := filepath.Join(dir, link)
-			os.Remove(symlink)        // ignore err
-			os.Symlink(name, symlink) // ignore err
+			_ = os.Remove(symlink)        // ignore err
+			_ = os.Symlink(name, symlink) // ignore err
 			return f, fname, nil
 		}
 		lastErr = err

--- a/vendor/k8s.io/klog/v2/klogr.go
+++ b/vendor/k8s.io/klog/v2/klogr.go
@@ -22,6 +22,11 @@ import (
 	"k8s.io/klog/v2/internal/serialize"
 )
 
+const (
+	// nameKey is used to log the `WithName` values as an additional attribute.
+	nameKey = "logger"
+)
+
 // NewKlogr returns a logger that is functionally identical to
 // klogr.NewWithOptions(klogr.FormatKlog), i.e. it passes through to klog. The
 // difference is that it uses a simpler implementation.
@@ -32,10 +37,15 @@ func NewKlogr() Logger {
 // klogger is a subset of klogr/klogr.go. It had to be copied to break an
 // import cycle (klogr wants to use klog, and klog wants to use klogr).
 type klogger struct {
-	level     int
 	callDepth int
-	prefix    string
-	values    []interface{}
+
+	// hasPrefix is true if the first entry in values is the special
+	// nameKey key/value. Such an entry gets added and later updated in
+	// WithName.
+	hasPrefix bool
+
+	values []interface{}
+	groups string
 }
 
 func (l *klogger) Init(info logr.RuntimeInfo) {
@@ -44,34 +54,40 @@ func (l *klogger) Init(info logr.RuntimeInfo) {
 
 func (l *klogger) Info(level int, msg string, kvList ...interface{}) {
 	merged := serialize.MergeKVs(l.values, kvList)
-	if l.prefix != "" {
-		msg = l.prefix + ": " + msg
-	}
 	// Skip this function.
 	VDepth(l.callDepth+1, Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
 }
 
 func (l *klogger) Enabled(level int) bool {
-	// Skip this function and logr.Logger.Info where Enabled is called.
-	return VDepth(l.callDepth+2, Level(level)).Enabled()
+	return VDepth(l.callDepth+1, Level(level)).Enabled()
 }
 
 func (l *klogger) Error(err error, msg string, kvList ...interface{}) {
 	merged := serialize.MergeKVs(l.values, kvList)
-	if l.prefix != "" {
-		msg = l.prefix + ": " + msg
-	}
 	ErrorSDepth(l.callDepth+1, err, msg, merged...)
 }
 
 // WithName returns a new logr.Logger with the specified name appended.  klogr
-// uses '/' characters to separate name elements.  Callers should not pass '/'
+// uses '.' characters to separate name elements.  Callers should not pass '.'
 // in the provided name string, but this library does not actually enforce that.
 func (l klogger) WithName(name string) logr.LogSink {
-	if len(l.prefix) > 0 {
-		l.prefix = l.prefix + "/"
+	if l.hasPrefix {
+		// Copy slice and modify value. No length checks and type
+		// assertions are needed because hasPrefix is only true if the
+		// first two elements exist and are key/value strings.
+		v := make([]interface{}, 0, len(l.values))
+		v = append(v, l.values...)
+		prefix, _ := v[1].(string)
+		v[1] = prefix + "." + name
+		l.values = v
+	} else {
+		// Preprend new key/value pair.
+		v := make([]interface{}, 0, 2+len(l.values))
+		v = append(v, nameKey, name)
+		v = append(v, l.values...)
+		l.values = v
+		l.hasPrefix = true
 	}
-	l.prefix += name
 	return &l
 }
 

--- a/vendor/k8s.io/klog/v2/klogr_slog.go
+++ b/vendor/k8s.io/klog/v2/klogr_slog.go
@@ -1,0 +1,96 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package klog
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr/slogr"
+
+	"k8s.io/klog/v2/internal/buffer"
+	"k8s.io/klog/v2/internal/serialize"
+	"k8s.io/klog/v2/internal/severity"
+	"k8s.io/klog/v2/internal/sloghandler"
+)
+
+func (l *klogger) Handle(ctx context.Context, record slog.Record) error {
+	if logging.logger != nil {
+		if slogSink, ok := logging.logger.GetSink().(slogr.SlogSink); ok {
+			// Let that logger do the work.
+			return slogSink.Handle(ctx, record)
+		}
+	}
+
+	return sloghandler.Handle(ctx, record, l.groups, slogOutput)
+}
+
+// slogOutput corresponds to several different functions in klog.go.
+// It goes through some of the same checks and formatting steps before
+// it ultimately converges by calling logging.printWithInfos.
+func slogOutput(file string, line int, now time.Time, err error, s severity.Severity, msg string, kvList []interface{}) {
+	// See infoS.
+	if logging.logger != nil {
+		// Taking this path happens when klog has a logger installed
+		// as backend which doesn't support slog. Not good, we have to
+		// guess about the call depth and drop the actual location.
+		logger := logging.logger.WithCallDepth(2)
+		if s > severity.ErrorLog {
+			logger.Error(err, msg, kvList...)
+		} else {
+			logger.Info(msg, kvList...)
+		}
+		return
+	}
+
+	// See printS.
+	b := buffer.GetBuffer()
+	b.WriteString(strconv.Quote(msg))
+	if err != nil {
+		serialize.KVListFormat(&b.Buffer, "err", err)
+	}
+	serialize.KVListFormat(&b.Buffer, kvList...)
+
+	// See print + header.
+	buf := logging.formatHeader(s, file, line, now)
+	logging.printWithInfos(buf, file, line, s, nil, nil, 0, &b.Buffer)
+
+	buffer.PutBuffer(b)
+}
+
+func (l *klogger) WithAttrs(attrs []slog.Attr) slogr.SlogSink {
+	clone := *l
+	clone.values = serialize.WithValues(l.values, sloghandler.Attrs2KVList(l.groups, attrs))
+	return &clone
+}
+
+func (l *klogger) WithGroup(name string) slogr.SlogSink {
+	clone := *l
+	if clone.groups != "" {
+		clone.groups += "." + name
+	} else {
+		clone.groups = name
+	}
+	return &clone
+}
+
+var _ slogr.SlogSink = &klogger{}

--- a/vendor/k8s.io/klog/v2/textlogger/options.go
+++ b/vendor/k8s.io/klog/v2/textlogger/options.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package textlogger
+
+import (
+	"flag"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"k8s.io/klog/v2/internal/verbosity"
+)
+
+// Config influences logging in a text logger. To make this configurable via
+// command line flags, instantiate this once per program and use AddFlags to
+// bind command line flags to the instance before passing it to NewTestContext.
+//
+// Must be constructed with NewConfig.
+type Config struct {
+	vstate *verbosity.VState
+	co     configOptions
+}
+
+// Verbosity returns a value instance that can be used to query (via String) or
+// modify (via Set) the verbosity threshold. This is thread-safe and can be
+// done at runtime.
+func (c *Config) Verbosity() flag.Value {
+	return c.vstate.V()
+}
+
+// VModule returns a value instance that can be used to query (via String) or
+// modify (via Set) the vmodule settings. This is thread-safe and can be done
+// at runtime.
+func (c *Config) VModule() flag.Value {
+	return c.vstate.VModule()
+}
+
+// ConfigOption implements functional parameters for NewConfig.
+type ConfigOption func(co *configOptions)
+
+type configOptions struct {
+	verbosityFlagName string
+	vmoduleFlagName   string
+	verbosityDefault  int
+	fixedTime         *time.Time
+	output            io.Writer
+}
+
+// VerbosityFlagName overrides the default -v for the verbosity level.
+func VerbosityFlagName(name string) ConfigOption {
+	return func(co *configOptions) {
+
+		co.verbosityFlagName = name
+	}
+}
+
+// VModulFlagName overrides the default -vmodule for the per-module
+// verbosity levels.
+func VModuleFlagName(name string) ConfigOption {
+	return func(co *configOptions) {
+		co.vmoduleFlagName = name
+	}
+}
+
+// Verbosity overrides the default verbosity level of 0.
+// See https://github.com/kubernetes/community/blob/9406b4352fe2d5810cb21cc3cb059ce5886de157/contributors/devel/sig-instrumentation/logging.md#logging-conventions
+// for log level conventions in Kubernetes.
+func Verbosity(level int) ConfigOption {
+	return func(co *configOptions) {
+		co.verbosityDefault = level
+	}
+}
+
+// Output overrides stderr as the output stream.
+func Output(output io.Writer) ConfigOption {
+	return func(co *configOptions) {
+		co.output = output
+	}
+}
+
+// FixedTime overrides the actual time with a fixed time. Useful only for testing.
+//
+// # Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func FixedTime(ts time.Time) ConfigOption {
+	return func(co *configOptions) {
+		co.fixedTime = &ts
+	}
+}
+
+// NewConfig returns a configuration with recommended defaults and optional
+// modifications. Command line flags are not bound to any FlagSet yet.
+func NewConfig(opts ...ConfigOption) *Config {
+	c := &Config{
+		vstate: verbosity.New(),
+		co: configOptions{
+			verbosityFlagName: "v",
+			vmoduleFlagName:   "vmodule",
+			verbosityDefault:  0,
+			output:            os.Stderr,
+		},
+	}
+	for _, opt := range opts {
+		opt(&c.co)
+	}
+
+	// Cannot fail for this input.
+	_ = c.Verbosity().Set(strconv.FormatInt(int64(c.co.verbosityDefault), 10))
+	return c
+}
+
+// AddFlags registers the command line flags that control the configuration.
+func (c *Config) AddFlags(fs *flag.FlagSet) {
+	fs.Var(c.Verbosity(), c.co.verbosityFlagName, "number for the log level verbosity of the testing logger")
+	fs.Var(c.VModule(), c.co.vmoduleFlagName, "comma-separated list of pattern=N log level settings for files matching the patterns")
+}

--- a/vendor/k8s.io/klog/v2/textlogger/textlogger.go
+++ b/vendor/k8s.io/klog/v2/textlogger/textlogger.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Intel Coporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package textlogger contains an implementation of the logr interface
+// which is producing the exact same output as klog.
+package textlogger
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2/internal/buffer"
+	"k8s.io/klog/v2/internal/serialize"
+	"k8s.io/klog/v2/internal/severity"
+	"k8s.io/klog/v2/internal/verbosity"
+)
+
+var (
+	// TimeNow is used to retrieve the current time. May be changed for testing.
+	TimeNow = time.Now
+)
+
+const (
+	// nameKey is used to log the `WithName` values as an additional attribute.
+	nameKey = "logger"
+)
+
+// NewLogger constructs a new logger.
+//
+// Verbosity can be modified at any time through the Config.V and
+// Config.VModule API.
+func NewLogger(c *Config) logr.Logger {
+	return logr.New(&tlogger{
+		values: nil,
+		config: c,
+	})
+}
+
+type tlogger struct {
+	callDepth int
+
+	// hasPrefix is true if the first entry in values is the special
+	// nameKey key/value. Such an entry gets added and later updated in
+	// WithName.
+	hasPrefix bool
+
+	values []interface{}
+	groups string
+	config *Config
+}
+
+func (l *tlogger) Init(info logr.RuntimeInfo) {
+	l.callDepth = info.CallDepth
+}
+
+func (l *tlogger) WithCallDepth(depth int) logr.LogSink {
+	newLogger := *l
+	newLogger.callDepth += depth
+	return &newLogger
+}
+
+func (l *tlogger) Enabled(level int) bool {
+	return l.config.vstate.Enabled(verbosity.Level(level), 1+l.callDepth)
+}
+
+func (l *tlogger) Info(_ int, msg string, kvList ...interface{}) {
+	l.print(nil, severity.InfoLog, msg, kvList)
+}
+
+func (l *tlogger) Error(err error, msg string, kvList ...interface{}) {
+	l.print(err, severity.ErrorLog, msg, kvList)
+}
+
+func (l *tlogger) print(err error, s severity.Severity, msg string, kvList []interface{}) {
+	// Determine caller.
+	// +1 for this frame, +1 for Info/Error.
+	_, file, line, ok := runtime.Caller(l.callDepth + 2)
+	if !ok {
+		file = "???"
+		line = 1
+	} else {
+		if slash := strings.LastIndex(file, "/"); slash >= 0 {
+			file = file[slash+1:]
+		}
+	}
+
+	l.printWithInfos(file, line, time.Now(), err, s, msg, kvList)
+}
+
+func (l *tlogger) printWithInfos(file string, line int, now time.Time, err error, s severity.Severity, msg string, kvList []interface{}) {
+	// Only create a new buffer if we don't have one cached.
+	b := buffer.GetBuffer()
+	defer buffer.PutBuffer(b)
+
+	// Format header.
+	if l.config.co.fixedTime != nil {
+		now = *l.config.co.fixedTime
+	}
+	b.FormatHeader(s, file, line, now)
+
+	// The message is always quoted, even if it contains line breaks.
+	// If developers want multi-line output, they should use a small, fixed
+	// message and put the multi-line output into a value.
+	b.WriteString(strconv.Quote(msg))
+	if err != nil {
+		serialize.KVFormat(&b.Buffer, "err", err)
+	}
+	serialize.MergeAndFormatKVs(&b.Buffer, l.values, kvList)
+	if b.Len() == 0 || b.Bytes()[b.Len()-1] != '\n' {
+		b.WriteByte('\n')
+	}
+	_, _ = l.config.co.output.Write(b.Bytes())
+}
+
+func (l *tlogger) WriteKlogBuffer(data []byte) {
+	_, _ = l.config.co.output.Write(data)
+}
+
+// WithName returns a new logr.Logger with the specified name appended.  klogr
+// uses '/' characters to separate name elements.  Callers should not pass '/'
+// in the provided name string, but this library does not actually enforce that.
+func (l *tlogger) WithName(name string) logr.LogSink {
+	clone := *l
+	if l.hasPrefix {
+		// Copy slice and modify value. No length checks and type
+		// assertions are needed because hasPrefix is only true if the
+		// first two elements exist and are key/value strings.
+		v := make([]interface{}, 0, len(l.values))
+		v = append(v, l.values...)
+		prefix, _ := v[1].(string)
+		v[1] = prefix + "." + name
+		clone.values = v
+	} else {
+		// Preprend new key/value pair.
+		v := make([]interface{}, 0, 2+len(l.values))
+		v = append(v, nameKey, name)
+		v = append(v, l.values...)
+		clone.values = v
+		clone.hasPrefix = true
+	}
+	return &clone
+}
+
+func (l *tlogger) WithValues(kvList ...interface{}) logr.LogSink {
+	clone := *l
+	clone.values = serialize.WithValues(l.values, kvList)
+	return &clone
+}
+
+// KlogBufferWriter is implemented by the textlogger LogSink.
+type KlogBufferWriter interface {
+	// WriteKlogBuffer takes a pre-formatted buffer prepared by klog and
+	// writes it unchanged to the output stream. Can be used with
+	// klog.WriteKlogBuffer when setting a logger through
+	// klog.SetLoggerWithOptions.
+	WriteKlogBuffer([]byte)
+}
+
+var _ logr.LogSink = &tlogger{}
+var _ logr.CallDepthLogSink = &tlogger{}
+var _ KlogBufferWriter = &tlogger{}

--- a/vendor/k8s.io/klog/v2/textlogger/textlogger_slog.go
+++ b/vendor/k8s.io/klog/v2/textlogger/textlogger_slog.go
@@ -1,0 +1,52 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package textlogger
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/go-logr/logr/slogr"
+
+	"k8s.io/klog/v2/internal/serialize"
+	"k8s.io/klog/v2/internal/sloghandler"
+)
+
+func (l *tlogger) Handle(ctx context.Context, record slog.Record) error {
+	return sloghandler.Handle(ctx, record, l.groups, l.printWithInfos)
+}
+
+func (l *tlogger) WithAttrs(attrs []slog.Attr) slogr.SlogSink {
+	clone := *l
+	clone.values = serialize.WithValues(l.values, sloghandler.Attrs2KVList(l.groups, attrs))
+	return &clone
+}
+
+func (l *tlogger) WithGroup(name string) slogr.SlogSink {
+	clone := *l
+	if clone.groups != "" {
+		clone.groups += "." + name
+	} else {
+		clone.groups = name
+	}
+	return &clone
+}
+
+var _ slogr.SlogSink = &tlogger{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -320,10 +320,11 @@ github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.7.0
 ## explicit; go 1.17
 github.com/fsnotify/fsnotify
-# github.com/go-logr/logr v1.2.4
-## explicit; go 1.16
+# github.com/go-logr/logr v1.3.0
+## explicit; go 1.18
 github.com/go-logr/logr
 github.com/go-logr/logr/funcr
+github.com/go-logr/logr/slogr
 # github.com/go-logr/stdr v1.2.2
 ## explicit; go 1.16
 github.com/go-logr/stdr
@@ -1565,7 +1566,7 @@ k8s.io/gengo/generator
 k8s.io/gengo/namer
 k8s.io/gengo/parser
 k8s.io/gengo/types
-# k8s.io/klog/v2 v2.100.1
+# k8s.io/klog/v2 v2.110.1
 ## explicit; go 1.13
 k8s.io/klog/v2
 k8s.io/klog/v2/internal/buffer
@@ -1573,6 +1574,9 @@ k8s.io/klog/v2/internal/clock
 k8s.io/klog/v2/internal/dbg
 k8s.io/klog/v2/internal/serialize
 k8s.io/klog/v2/internal/severity
+k8s.io/klog/v2/internal/sloghandler
+k8s.io/klog/v2/internal/verbosity
+k8s.io/klog/v2/textlogger
 # k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9
 ## explicit; go 1.19
 k8s.io/kube-openapi/cmd/openapi-gen/args


### PR DESCRIPTION
In e2e tests we can see the following error:
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed. Detected at:
	>  goroutine 1 [running]:
	>  runtime/debug.Stack()
	>  	/opt/hostedtoolcache/go/1.21.4/x64/src/runtime/debug/stack.go:24 +0x5e
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go:60 +0xcd
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc00027f740, {0x1ef22f6, 0x14})
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/controller-runtime/pkg/log/deleg.go:147 +0x45
	>  github.com/go-logr/logr.Logger.WithName({{0x2208298, 0xc00027f740}, 0x0}, {0x1ef22f6?, 0x0?})
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/github.com/go-logr/logr/logr.go:336 +0x3d
	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x0?, {0x0, 0xc0002c2f50, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/controller-runtime/pkg/client/client.go:122 +0xec
	>  sigs.k8s.io/controller-runtime/pkg/client.New(0x50?, {0x0, 0xc0002c2f50, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/controller-runtime/pkg/client/client.go:103 +0x7d
	>  sigs.k8s.io/e2e-framework/klient/k8s/resources.New(0xc000804240)
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/e2e-framework/klient/k8s/resources/resources.go:61 +0x79
	>  sigs.k8s.io/e2e-framework/klient.New(0xc000804240)
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/e2e-framework/klient/client.go:51 +0x18
	>  sigs.k8s.io/e2e-framework/klient.NewWithKubeConfigFile({0xc0000e45c0?, 0x1b232c0?})
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/e2e-framework/klient/client.go:64 +0x32
	>  sigs.k8s.io/e2e-framework/pkg/envconf.(*Config).Client(0xc00007e380)
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/e2e-framework/pkg/envconf/config.go:137 +0x3c
	>  sigs.k8s.io/e2e-framework/pkg/envfuncs.CreateKindClusterWithConfig.func1({0x2202bc8, 0xc00001fd10}, 0xc00007e380)
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/e2e-framework/pkg/envfuncs/kind_funcs.go:92 +0x27c
	>  github.com/cilium/tetragon/tests/e2e/runners.glob..func1.MaybeCreateTempKindCluster.func1({0x2202bc8, 0xc00001fd10}, 0x1d34ca0?)
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/tests/e2e/helpers/cluster.go:149 +0x17e
	>  sigs.k8s.io/e2e-framework/pkg/env.(*action).run(0xc000285040?, {0x2202bc8?, 0xc00001fd10?}, 0xc00007e380)
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/e2e-framework/pkg/env/action.go:135 +0xe3
	>  sigs.k8s.io/e2e-framework/pkg/env.(*testEnv).Run(0xc00027f6c0, 0x0?)
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/vendor/sigs.k8s.io/e2e-framework/pkg/env/env.go:369 +0x152
	>  github.com/cilium/tetragon/tests/e2e/runners.(*Runner).Run(0xc00027f6c0?, 0xc0006063b0?)
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/tests/e2e/runners/runners.go:210 +0xc8
	>  github.com/cilium/tetragon/tests/e2e/tests/labels_test.TestMain(0x1ed51c0?)
	>  	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/tests/e2e/tests/labels/labels_test.go:92 +0xeb
	>  main.main()
	>  	_testmain.go:83 +0x1e6
```

Example: https://github.com/cilium/tetragon/actions/runs/6961675044/job/18943783744

This PR fixes that.