### PR TITLE
Arg validation: Add mappings for sock and skb

### DIFF
--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -219,6 +219,16 @@ func typesCompatible(specTy string, kernelTy string) bool {
 		case "struct module *":
 			return true
 		}
+	case "sock":
+		switch kernelTy {
+		case "struct sock *":
+			return true
+		}
+	case "skb":
+		switch kernelTy {
+		case "struct sk_buff *":
+			return true
+		}
 	}
 
 	return false


### PR DESCRIPTION
Kprobe arguments of type "sock" and "skb" are valid but fail BTF validation because the function prototypes report "struct sock *" and "struct sk_buff *" types.

This commit adds validation to remove warnings that these types in the policy don't match the types in the function prototypes.

```release-note
Adds validation for sock and skb types
```