### PR TITLE
[v0.9] update cosign

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -80,7 +80,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign sign quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
+          cosign sign -y quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
 
       - name: Install Bom
         if: github.event_name == 'push'
@@ -112,7 +112,7 @@ jobs:
           docker_build_release_digest="${{ steps.docker_build_release.outputs.digest }}"
           image_name="quay.io/${{ github.repository_owner }}/clang:${docker_build_release_digest/:/-}.sbom"
           docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign "quay.io/${{ github.repository_owner }}/clang@${docker_build_release_sbom_digest}"
+          cosign sign -y "quay.io/${{ github.repository_owner }}/clang@${docker_build_release_sbom_digest}"
 
       - name: Image Release Digest
         if: github.event_name == 'push'

--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install Cosign
         if: github.event_name == 'push'
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Sign Container Image
         if: github.event_name == 'push' && steps.tag-in-repositories.outputs.exists == 'false'

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -71,7 +71,7 @@ jobs:
           echo "TETRAGON_VERSION=$(make version)" >> $GITHUB_ENV
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Install Bom
         shell: bash

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -102,7 +102,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main.outputs.digest }}
+          cosign sign -y quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main.outputs.digest }}
 
       - name: Generate SBOM
         if: github.event_name == 'push'
@@ -126,7 +126,7 @@ jobs:
           docker_build_ci_main_digest="${{ steps.docker_build_ci_main.outputs.digest }}"
           image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_ci_main_digest/:/-}.sbom"
           docker_build_ci_main_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_ci_main_sbom_digest}"
+          cosign sign -y "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_ci_main_sbom_digest}"
 
       - name: CI Image Releases digests (main)
         if: github.event_name == 'push'
@@ -156,7 +156,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr.outputs.digest }}
+          cosign sign -y quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_pr.outputs.digest }}
 
       - name: Generate SBOM
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
@@ -180,7 +180,7 @@ jobs:
           docker_build_ci_pr_digest="${{ steps.docker_build_ci_pr.outputs.digest }}"
           image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_ci_pr_digest/:/-}.sbom"
           docker_build_ci_pr_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_ci_pr_sbom_digest}"
+          cosign sign -y "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_ci_pr_sbom_digest}"
 
       - name: CI Image Releases digests (PR)
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -84,8 +84,8 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
-          cosign sign quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
+          cosign sign -y quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
+          cosign sign -y quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
 
       - name: Install Bom
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install Cosign
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 
       - name: Sign Container Image
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}


### PR DESCRIPTION
CI is broken on 0.9, due to cosign.

This will fail, so we need to merge to check that it actually works.
 

Backports of:
 * https://github.com/cilium/tetragon/commit/20bd368b10d1614140ec5237b7600e0d9aaf7eb7
 * https://github.com/cilium/tetragon/commit/3fff37afdfc7927f21143166b5513317cc7bcbb7
 
 
 See the same for 0.10: https://github.com/cilium/tetragon/pull/1694