### PR TITLE
fork-tester: remove connect to 8.8.8.8

### DIFF
--- a/contrib/tester-progs/fork-tester.c
+++ b/contrib/tester-progs/fork-tester.c
@@ -13,29 +13,10 @@
 // NB: global pipe for child 2 to notify parent that it has finished.
 int Pipe[2];
 
-// connect to 8.8.8.8:53 (and then close the socket)
 void client_run()
 {
-	int fd;
-
-	fd = socket(AF_INET, SOCK_STREAM, 0);
-	if (fd == -1) {
-		perror("socket");
-		exit(1);
-	}
-
-	printf("child 2 (pid:%d, ppid:%d) connecting to 8.8.8.8:53\n", getpid(), getppid());
-	long ip8888 =  8 | (8<<8) | (8<<16) | (8<<24);
-	struct sockaddr_in srv_addr = {
-		.sin_family = AF_INET,
-		.sin_addr = {.s_addr = htonl(ip8888)},
-		.sin_port = htons(53)
-	};
-	if (connect(fd, (struct sockaddr *)&srv_addr, sizeof(srv_addr)) == -1) {
-		perror("connect");
-		exit(1);
-	}
-	close(fd);
+	// just print a message
+	printf("child 2 (pid:%d, ppid:%d) starts\n", getpid(), getppid());
 	printf("child 2 done\n");
 	return;
 }

--- a/pkg/sensors/exec/fork_test.go
+++ b/pkg/sensors/exec/fork_test.go
@@ -59,7 +59,7 @@ func TestFork(t *testing.T) {
 		t.Fatalf("failed to parse child1 PID")
 	}
 	if fti.child2Pid == 0 {
-		t.Fatalf("failed to parse child1 PID")
+		t.Fatalf("failed to parse child2 PID")
 	}
 
 	binCheck := ec.NewProcessChecker().
@@ -81,7 +81,7 @@ type forkTesterInfo struct {
 var (
 	child1Re = regexp.MustCompile(`child 1 \(pid:(\d+)\) exits`)
 	// NB: ppid must be 1, to ensure that child 2 is orphan and has been inherited by init
-	child2Re = regexp.MustCompile(`child 2 \(pid:(\d+), ppid:1\) connecting to 8.8.8.8:53`)
+	child2Re = regexp.MustCompile(`child 2 \(pid:(\d+), ppid:1\) starts`)
 )
 
 func (fti *forkTesterInfo) ParseLine(l string) error {
@@ -105,7 +105,7 @@ const sampleForkTesterOutput = `
 parent: (pid:118413, ppid:118401) starts
 child 1 (pid:118414) exits
 parent: (pid:118413, ppid:118401) starts
-child 2 (pid:118415, ppid:1) connecting to 8.8.8.8:53
+child 2 (pid:118415, ppid:1) starts
 child 2 done
 parent: (pid:118413, ppid:118401) starts
 parent: (pid:118413) child (118414) exited with: 0


### PR DESCRIPTION
Connecting to 8.8.8.8, might cause the test to fail. Instead, just print a message.

There was a `TestFork` failure on `main`: https://github.com/cilium/tetragon/actions/runs/7008794565/job/19066214778#step:6:1164

> ❌	pkg.sensors.exec.TestFork						9.772s	(1m25.943s)

Looking at the logs, the problem was that the connect operation failed:

>     cmd.go:100: stdout>: parent: (pid:1607, ppid:1601) starts
>     cmd.go:100: stdout>: child 1 (pid:1608) exits
>     cmd.go:100: stdout>: parent: (pid:1607, ppid:1601) starts
>     cmd.go:100: stdout>: child 2 (pid:1609, ppid:1) connecting to 8.8.8.8:53
>     cmd.go:100: stdout>: parent: (pid:1607, ppid:1601) starts
>     cmd.go:100: stderr>: connect: Network is unreachable
>     cmd.go:100: stdout>: parent: (pid:1607) child (1608) exited with: 0

Remove the connect to avoid such flakes.