### PR TITLE
Helm: Added various configuration options for the Tetragon Operator Deployment

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -29,20 +29,8 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | daemonSetAnnotations | object | `{}` |  |
 | daemonSetLabelsOverride | object | `{}` |  |
 | dnsPolicy | string | `"Default"` |  |
-| enabled | bool | `true` |  |
-| export.filenames[0] | string | `"tetragon.log"` |  |
-| export.mode | string | `"stdout"` |  |
-| export.resources | object | `{}` |  |
-| export.securityContext | object | `{}` |  |
-| export.stdout.argsOverride | list | `[]` |  |
-| export.stdout.commandOverride | list | `[]` |  |
-| export.stdout.enabledArgs | bool | `true` |  |
-| export.stdout.enabledCommand | bool | `true` |  |
-| export.stdout.extraEnv | list | `[]` |  |
-| export.stdout.extraVolumeMounts | list | `[]` |  |
-| export.stdout.image.override | string | `nil` |  |
-| export.stdout.image.repository | string | `"quay.io/cilium/hubble-export-stdout"` |  |
-| export.stdout.image.tag | string | `"v1.0.3"` |  |
+| enabled | bool | `true` | Global settings |
+| export | object | `{"filenames":["tetragon.log"],"mode":"stdout","resources":{},"securityContext":{},"stdout":{"argsOverride":[],"commandOverride":[],"enabledArgs":true,"enabledCommand":true,"extraEnv":[],"extraVolumeMounts":[],"image":{"override":null,"repository":"quay.io/cilium/hubble-export-stdout","tag":"v1.0.3"}}}` | Tetragon event settings |
 | exportDirectory | string | `"/var/run/cilium/tetragon"` |  |
 | exportFileCreationInterval | string | `"120s"` |  |
 | extraConfigmapMounts | list | `[]` |  |
@@ -56,7 +44,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | podLabels | object | `{}` |  |
 | podLabelsOverride | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| priorityClassName | string | `""` |  |
+| priorityClassName | string | `""` | Tetragon agent settings |
 | selectorLabelsOverride | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
@@ -102,9 +90,21 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.prometheus.serviceMonitor.scrapeInterval | string | `"10s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
+| tetragonOperator | object | `{"affinity":{},"annotations":{},"extraLabels":{},"extraPodLabels":{},"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.0.0"},"nodeSelector":{},"podAnnotations":{},"podInfo":{"enabled":false},"podSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}},"priorityClassName":"","resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"skipCRDCreation":false,"strategy":{},"tolerations":[{"operator":"Exists"}]}` | Tetragon Operator settings |
+| tetragonOperator.annotations | object | `{}` | Annotations for the Tetragon Operator Deployment. |
+| tetragonOperator.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment. |
+| tetragonOperator.extraPodLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment Pods. |
+| tetragonOperator.extraVolumes | list | `[]` | Extra volumes for the Tetragon Operator Deployment. |
 | tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.0.0"}` | tetragon-operator image. |
+| tetragonOperator.nodeSelector | object | `{}` | Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules. |
+| tetragonOperator.podAnnotations | object | `{}` | Annotations for the Tetragon Operator Deployment Pods. |
 | tetragonOperator.podInfo.enabled | bool | `false` | Enables the PodInfo CRD and the controller that reconciles PodInfo custom resources. |
-| tetragonOperator.skipCRDCreation | bool | `false` |  |
+| tetragonOperator.podSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | securityContext for the Tetragon Operator Deployment Pod container. |
+| tetragonOperator.priorityClassName | string | `""` | priorityClassName for the Tetragon Operator Deployment Pods. |
+| tetragonOperator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | resources for the Tetragon Operator Deployment Pod container. |
+| tetragonOperator.securityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pods. |
+| tetragonOperator.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | tetragon-operator service account. |
+| tetragonOperator.strategy | object | `{}` | resources for the Tetragon Operator Deployment update strategy |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |
 

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -12,20 +12,8 @@ Helm chart for Tetragon
 | daemonSetAnnotations | object | `{}` |  |
 | daemonSetLabelsOverride | object | `{}` |  |
 | dnsPolicy | string | `"Default"` |  |
-| enabled | bool | `true` |  |
-| export.filenames[0] | string | `"tetragon.log"` |  |
-| export.mode | string | `"stdout"` |  |
-| export.resources | object | `{}` |  |
-| export.securityContext | object | `{}` |  |
-| export.stdout.argsOverride | list | `[]` |  |
-| export.stdout.commandOverride | list | `[]` |  |
-| export.stdout.enabledArgs | bool | `true` |  |
-| export.stdout.enabledCommand | bool | `true` |  |
-| export.stdout.extraEnv | list | `[]` |  |
-| export.stdout.extraVolumeMounts | list | `[]` |  |
-| export.stdout.image.override | string | `nil` |  |
-| export.stdout.image.repository | string | `"quay.io/cilium/hubble-export-stdout"` |  |
-| export.stdout.image.tag | string | `"v1.0.3"` |  |
+| enabled | bool | `true` | Global settings |
+| export | object | `{"filenames":["tetragon.log"],"mode":"stdout","resources":{},"securityContext":{},"stdout":{"argsOverride":[],"commandOverride":[],"enabledArgs":true,"enabledCommand":true,"extraEnv":[],"extraVolumeMounts":[],"image":{"override":null,"repository":"quay.io/cilium/hubble-export-stdout","tag":"v1.0.3"}}}` | Tetragon event settings |
 | exportDirectory | string | `"/var/run/cilium/tetragon"` |  |
 | exportFileCreationInterval | string | `"120s"` |  |
 | extraConfigmapMounts | list | `[]` |  |
@@ -39,7 +27,7 @@ Helm chart for Tetragon
 | podLabels | object | `{}` |  |
 | podLabelsOverride | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| priorityClassName | string | `""` |  |
+| priorityClassName | string | `""` | Tetragon agent settings |
 | selectorLabelsOverride | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
@@ -85,9 +73,21 @@ Helm chart for Tetragon
 | tetragon.prometheus.serviceMonitor.scrapeInterval | string | `"10s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
+| tetragonOperator | object | `{"affinity":{},"annotations":{},"extraLabels":{},"extraPodLabels":{},"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.0.0"},"nodeSelector":{},"podAnnotations":{},"podInfo":{"enabled":false},"podSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}},"priorityClassName":"","resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"skipCRDCreation":false,"strategy":{},"tolerations":[{"operator":"Exists"}]}` | Tetragon Operator settings |
+| tetragonOperator.annotations | object | `{}` | Annotations for the Tetragon Operator Deployment. |
+| tetragonOperator.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment. |
+| tetragonOperator.extraPodLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment Pods. |
+| tetragonOperator.extraVolumes | list | `[]` | Extra volumes for the Tetragon Operator Deployment. |
 | tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.0.0"}` | tetragon-operator image. |
+| tetragonOperator.nodeSelector | object | `{}` | Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules. |
+| tetragonOperator.podAnnotations | object | `{}` | Annotations for the Tetragon Operator Deployment Pods. |
 | tetragonOperator.podInfo.enabled | bool | `false` | Enables the PodInfo CRD and the controller that reconciles PodInfo custom resources. |
-| tetragonOperator.skipCRDCreation | bool | `false` |  |
+| tetragonOperator.podSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | securityContext for the Tetragon Operator Deployment Pod container. |
+| tetragonOperator.priorityClassName | string | `""` | priorityClassName for the Tetragon Operator Deployment Pods. |
+| tetragonOperator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | resources for the Tetragon Operator Deployment Pod container. |
+| tetragonOperator.securityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pods. |
+| tetragonOperator.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | tetragon-operator service account. |
+| tetragonOperator.strategy | object | `{}` | resources for the Tetragon Operator Deployment update strategy |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |
 

--- a/install/kubernetes/templates/_helpers.tpl
+++ b/install/kubernetes/templates/_helpers.tpl
@@ -47,3 +47,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "container.tetragon.name" -}}
 {{- print "tetragon" -}}
 {{- end }}
+
+{{/*
+ServiceAccounts
+*/}}
+{{- define "tetragon.serviceAccount" -}}
+{{- if .Values.serviceAccount.name -}}
+{{- printf "%s" .Values.serviceAccount.name -}}
+{{- else -}}
+{{- printf "%s" .Release.Name -}}
+{{- end -}}
+{{- end }}
+
+{{- define "tetragon-operator.serviceAccount" -}}
+{{- if .Values.tetragonOperator.serviceAccount.name -}}
+{{- printf  "%s" .Values.tetragonOperator.serviceAccount.name -}}
+{{- else -}}
+{{- printf  "%s-operator-service-account" .Release.Name -}}
+{{- end -}}
+{{- end }}

--- a/install/kubernetes/templates/clusterrolebinding.yml
+++ b/install/kubernetes/templates/clusterrolebinding.yml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
-    name: {{ .Release.Name }}
+    name: {{ include "tetragon.serviceAccount" . }}
 {{- end }}

--- a/install/kubernetes/templates/daemonset.yaml
+++ b/install/kubernetes/templates/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ .Release.Name }}
+      serviceAccountName: {{ include "tetragon.serviceAccount" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 6 }}

--- a/install/kubernetes/templates/operator_clusterrolebinding.yaml
+++ b/install/kubernetes/templates/operator_clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
-    name: {{ .Release.Name }}-operator-service-account
+    name: {{ include "tetragon-operator.serviceAccount" . }}
 {{- end }}

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -42,6 +42,9 @@ spec:
           - mountPath: /etc/tetragon/operator.conf.d/
             name: tetragon-operator-config
             readOnly: true
+          {{- with .Values.tetragonOperator.extraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- with .Values.tetragonOperator.podSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
@@ -91,6 +94,9 @@ spec:
         - name: tetragon-operator-config
           configMap:
             name: {{ .Release.Name }}-operator-config
+      {{- with .Values.tetragonOperator.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- with .Values.tetragonOperator.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -28,11 +28,10 @@ spec:
           - mountPath: /etc/tetragon/operator.conf.d/
             name: tetragon-operator-config
             readOnly: true
+        {{- with .Values.tetragonOperator.podSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - "ALL"
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -52,6 +51,10 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+      {{- with .Values.tetragonOperator.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tetragonOperator.priorityClassName }}
       priorityClassName: "{{ . }}"
       {{- end }}

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -44,13 +44,10 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{- with .Values.tetragonOperator.resources }}
         resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
       {{- with .Values.tetragonOperator.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -52,6 +52,9 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+      {{- with .Values.tetragonOperator.priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   {{- end }}
   labels: 
     {{- include "tetragon-operator.labels" . | nindent 4 }}
+    {{- with .Values.tetragonOperator.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ .Release.Name }}-operator
   namespace: {{ .Release.Namespace }}
 spec:
@@ -22,6 +25,9 @@ spec:
       {{- end }}
       labels: 
         {{- include "tetragon-operator.labels" . | nindent 8 }}
+        {{- with .Values.tetragonOperator.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Release.Name }}-operator

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -52,6 +52,10 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "tetragon-operator.serviceAccount" . }}
       terminationGracePeriodSeconds: 10
       volumes:

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -1,6 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  {{- with .Values.tetragonOperator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels: 
     {{- include "tetragon-operator.labels" . | nindent 4 }}
   name: {{ .Release.Name }}-operator
@@ -12,6 +16,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.tetragonOperator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels: 
         {{- include "tetragon-operator.labels" . | nindent 8 }}
     spec:

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -65,4 +65,7 @@ spec:
         - name: tetragon-operator-config
           configMap:
             name: {{ .Release.Name }}-operator-config
-
+{{- with .Values.tetragonOperator.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+{{- end }}

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -59,6 +59,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tetragonOperator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tetragonOperator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tetragonOperator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "tetragon-operator.serviceAccount" . }}
       terminationGracePeriodSeconds: 10
       volumes:

--- a/install/kubernetes/templates/operator_deployment.yaml
+++ b/install/kubernetes/templates/operator_deployment.yaml
@@ -52,7 +52,7 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      serviceAccountName: {{ .Release.Name }}-operator-service-account
+      serviceAccountName: {{ include "tetragon-operator.serviceAccount" . }}
       terminationGracePeriodSeconds: 10
       volumes:
         - name: tetragon-operator-config

--- a/install/kubernetes/templates/operator_serviceaccount.yaml
+++ b/install/kubernetes/templates/operator_serviceaccount.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.tetragonOperator.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-operator-service-account
+  name: {{ include "tetragon-operator.serviceAccount" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tetragon-operator.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.tetragonOperator.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/install/kubernetes/templates/serviceaccount.yaml
+++ b/install/kubernetes/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "tetragon.serviceAccount" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tetragon.labels" . | nindent 4 }}

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -168,9 +168,10 @@ tetragonOperator:
   annotations: {}
   # -- Annotations for the Tetragon Operator Deployment Pods.
   podAnnotations: {}
-  annotations: {}
-  # -- Annotations for the Tetragon Operator Deployment Pods
-  podAnnotations: {}
+  # -- Extra labels to be added on the Tetragon Operator Deployment.
+  extraLabels: {}
+  # -- Extra labels to be added on the Tetragon Operator Deployment Pods.
+  extraPodLabels: {}
   # -- priorityClassName for the Tetragon Operator Deployment Pods.
   priorityClassName: ""
   # -- tetragon-operator service account.

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -1,7 +1,10 @@
+# -- Global settings
 enabled: true
-imagePullPolicy: IfNotPresent
-priorityClassName: ""
 imagePullSecrets: []
+
+# -- Tetragon agent settings
+priorityClassName: ""
+imagePullPolicy: IfNotPresent
 serviceAccount:
   create: true
   annotations: {}
@@ -158,6 +161,8 @@ tetragon:
   # host, the path is /proc. Exceptions to this are environments like kind, where the runtime itself
   # does not run on the host.
   hostProcPath: "/proc"
+
+# -- Tetragon Operator settings
 tetragonOperator:
   # -- tetragon-operator service account.
   serviceAccount:
@@ -176,6 +181,8 @@ tetragonOperator:
     # -- Enables the PodInfo CRD and the controller that reconciles PodInfo
     # custom resources.
     enabled: false
+
+# -- Tetragon event settings
 export:
   # "stdout". "" to disable.
   mode: "stdout"

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -164,6 +164,8 @@ tetragon:
 
 # -- Tetragon Operator settings
 tetragonOperator:
+  # -- priorityClassName for the Tetragon Operator Deployment Pods.
+  priorityClassName: ""
   # -- tetragon-operator service account.
   serviceAccount:
     create: true

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -164,6 +164,13 @@ tetragon:
 
 # -- Tetragon Operator settings
 tetragonOperator:
+  # -- Annotations for the Tetragon Operator Deployment.
+  annotations: {}
+  # -- Annotations for the Tetragon Operator Deployment Pods.
+  podAnnotations: {}
+  annotations: {}
+  # -- Annotations for the Tetragon Operator Deployment Pods
+  podAnnotations: {}
   # -- priorityClassName for the Tetragon Operator Deployment Pods.
   priorityClassName: ""
   # -- tetragon-operator service account.

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -189,6 +189,11 @@ tetragonOperator:
       memory: 64Mi
   # -- resources for the Tetragon Operator Deployment update strategy
   strategy: {}
+  # -- Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules.
+  nodeSelector: {}
+  tolerations:
+    - operator: Exists
+  affinity: {}
   # -- tetragon-operator image.
   image:
     override: ~

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -159,6 +159,11 @@ tetragon:
   # does not run on the host.
   hostProcPath: "/proc"
 tetragonOperator:
+  # -- tetragon-operator service account.
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
   # -- tetragon-operator image.
   image:
     override: ~

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -208,6 +208,9 @@ tetragonOperator:
     repository: quay.io/cilium/tetragon-operator
     tag: v1.0.0
     pullPolicy: IfNotPresent
+  # -- Extra volumes for the Tetragon Operator Deployment.
+  extraVolumes: []
+  extraVolumeMounts: []
   # Skip CRD creation.
   skipCRDCreation: false
   podInfo:

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -169,6 +169,7 @@ tetragonOperator:
     create: true
     annotations: {}
     name: ""
+
   # -- tetragon-operator image.
   image:
     override: ~

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -187,6 +187,8 @@ tetragonOperator:
     requests:
       cpu: 10m
       memory: 64Mi
+  # -- resources for the Tetragon Operator Deployment update strategy
+  strategy: {}
   # -- tetragon-operator image.
   image:
     override: ~

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -179,6 +179,14 @@ tetragonOperator:
     capabilities:
       drop:
         - "ALL"
+  # -- resources for the Tetragon Operator Deployment Pod container.
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
   # -- tetragon-operator image.
   image:
     override: ~

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -171,7 +171,14 @@ tetragonOperator:
     create: true
     annotations: {}
     name: ""
-
+  # -- securityContext for the Tetragon Operator Deployment Pods.
+  securityContext: {}
+  # -- securityContext for the Tetragon Operator Deployment Pod container.
+  podSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - "ALL"
   # -- tetragon-operator image.
   image:
     override: ~


### PR DESCRIPTION
I have added multiple configuration options for the Tetragon Operator Deployment, which are often crucial for enterprise-grade deployments that need to happen within certain security boundaries.

According to my current understanding, this should not break anything for existing users. The only chance I see a breakage happen is when somebody already configured `.Values.serviceAccount.name` in the past. The thing is, this value was never considered, and the SA was simply named `{{ .Release.Name }}` or `{{ .Release.Name }}-operator-service-account`. With this change, it would suddenly be considered for the actual SA naming.

- helm: Added extraVolumes support for the Tetragon Operator
- helm: Added extra labels for the Tetragon Operator Deployment and Pods
- helm: Added configurable annotations for the Tetragon Operator Deployment and Pods
- helm: Made the placement of Tetragon Operator Deployment Pods configurable
- helm: Made update strategy configurable for the Tetragon Operator Deployment 
- helm: Made resource configurable for the Tetragon Operator Deployment
- helm: Added pod/container securityContext to the Tetragon Operator Deployment
- helm: Added priorityClassName to the Tetragon Operator Deployment
- helm: Added imagePullSecret to the Tetragon Operator Deployment

Fixes: https://github.com/cilium/tetragon/issues/1761