### PR TITLE
helm: Don't mount /var/lib/tetragon/metadata

### DIFF
--- a/install/kubernetes/templates/_container_tetragon.tpl
+++ b/install/kubernetes/templates/_container_tetragon.tpl
@@ -26,10 +26,6 @@
     {{- with .Values.tetragon.extraVolumeMounts }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if not .Values.tetragon.btf }}
-    - mountPath: /var/lib/tetragon/metadata
-      name: metadata-files
-    {{- end }}
     - mountPath: /etc/tetragon/tetragon.conf.d/
       name: tetragon-config
       readOnly: true

--- a/install/kubernetes/templates/daemonset.yaml
+++ b/install/kubernetes/templates/daemonset.yaml
@@ -93,10 +93,6 @@ spec:
         hostPath:
           path: {{ .Values.tetragon.hostProcPath }}
           type: Directory
-{{- if not .Values.tetragon.btf }}
-      - emptyDir: {}
-        name: metadata-files
-{{- end }}
 {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
It's not needed, there is nothing populating this directory.