### PR TITLE
linters: add makezero and fix a related bug

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - staticcheck
     - unused
     - gosimple
+    - makezero
 
 linters-settings:
   goheader:

--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -283,12 +283,12 @@ func AvailableSyscalls() ([]string, error) {
 	}
 
 	ret := []string{}
-	for _, key := range syscallinfo.SyscallsNames() {
-		if key == "" {
-			continue
+	for key, value := range syscallinfo.SyscallsNames() {
+		if value == "" {
+			return nil, fmt.Errorf("syscall name for %q is empty", key)
 		}
 
-		sym, err := arch.AddSyscallPrefix(key)
+		sym, err := arch.AddSyscallPrefix(value)
 		if err != nil {
 			return nil, err
 		}
@@ -298,7 +298,7 @@ func AvailableSyscalls() ([]string, error) {
 			continue
 		}
 
-		ret = append(ret, key)
+		ret = append(ret, value)
 	}
 
 	return ret, nil
@@ -322,14 +322,14 @@ func GetSyscallsList() ([]string, error) {
 
 	var list []string
 
-	for _, key := range syscallinfo.SyscallsNames() {
+	for key, value := range syscallinfo.SyscallsNames() {
 		var fn *btf.Func
 
-		if key == "" {
-			continue
+		if value == "" {
+			return nil, fmt.Errorf("syscall name for %q is empty", key)
 		}
 
-		sym, err := arch.AddSyscallPrefix(key)
+		sym, err := arch.AddSyscallPrefix(value)
 		if err != nil {
 			return []string{}, err
 		}

--- a/pkg/reader/network/network.go
+++ b/pkg/reader/network/network.go
@@ -30,6 +30,7 @@ func GetIP(i [2]uint64, family uint16) net.IP {
 
 		binary.LittleEndian.PutUint64(a, i[0])
 		binary.LittleEndian.PutUint64(b, i[1])
+		// nolint:makezero // slices carefully manipulated like arrays
 		ip := append(a, b...)
 		return ip
 	}

--- a/pkg/syscallinfo/syscallinfo.go
+++ b/pkg/syscallinfo/syscallinfo.go
@@ -44,7 +44,7 @@ var syscallIDs = func() map[string]int {
 }()
 
 func SyscallsNames() []string {
-	ret := make([]string, len(syscallNames))
+	ret := make([]string, 0, len(syscallNames))
 
 	for _, v := range syscallNames {
 		ret = append(ret, v)


### PR DESCRIPTION
Makezero is a linter to ensure that slices are not initialized with non-zero length. Since in Go, we most of the time use append on the slice, initializing it with non-zero length can tend to create a slice full of zero that will clobber the beginning of the slice.

In the bug fixed here, we created a list with 300+ zeros and then append after them, only to skip the zero in the calling method. Usually we want to prealloc the slice with a capacity of len but a length of 0, i.e. replace make([]int, len(nums)) with make([]int, 0, len(nums)).  See more info here https://github.com/ashanbrown/makezero.