### PR TITLE
tetragon: Detect large program with feature check

### DIFF
--- a/pkg/kernels/kernels.go
+++ b/pkg/kernels/kernels.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/option"
 
 	"golang.org/x/sys/unix"
@@ -137,8 +138,7 @@ func EnableLargeProgs() bool {
 	if option.Config.ForceLargeProgs {
 		return true
 	}
-	kernelVer, _, _ := GetKernelVersion(option.Config.KernelVersion, option.Config.ProcFS)
-	return (int64(kernelVer) >= KernelStringToNumeric("5.3.0"))
+	return bpf.HasProgramLargeSize() && bpf.HasSignalHelper()
 }
 
 func IsKernelVersionLessThan(version string) bool {

--- a/pkg/sensors/tracing/killer_test.go
+++ b/pkg/sensors/tracing/killer_test.go
@@ -58,6 +58,9 @@ func TestKillerOverride(t *testing.T) {
 	if !bpf.HasOverrideHelper() {
 		t.Skip("skipping killer test, bpf_override_return helper not available")
 	}
+	if !bpf.HasSignalHelper() {
+		t.Skip("skipping killer test, bpf_send_signal helper not available")
+	}
 
 	test := testutils.RepoRootPath("contrib/tester-progs/killer-tester")
 	configHook := `
@@ -117,6 +120,9 @@ spec:
 func TestKillerSignal(t *testing.T) {
 	if !bpf.HasOverrideHelper() {
 		t.Skip("skipping killer test, bpf_override_return helper not available")
+	}
+	if !bpf.HasSignalHelper() {
+		t.Skip("skipping killer test, bpf_send_signal helper not available")
 	}
 
 	test := testutils.RepoRootPath("contrib/tester-progs/killer-tester")


### PR DESCRIPTION
currently we detect large programs with kernel version check (>=5.3.0)
but some kernels (rhel) have many backports on top of older versions

adding large program feature check and using it to load large programs