### PR TITLE
workflows: add independent go-version for setup-go actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -415,7 +415,11 @@
         "^\\.github/workflows/[^/]+\\.ya?ml$"
       ],
       "matchStrings": [
-        // this regex is used to match:
+        // this regex is used to match both:
+        //
+        // # renovate: datasource=golang-version depName=go
+        // go: '1.21.4'
+        //
         // # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
         // - 'bpf-next-20230912.113936'
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+ ['\"]?(?<currentValue>[^'\"\\s]*)"

--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -120,7 +120,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.21.5'
 
       - name: Install Bom
         shell: bash

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -93,7 +93,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.21.5'
 
       - name: Install Bom
         shell: bash

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -90,7 +90,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.21.5'
 
       - name: Install Bom
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}

--- a/.github/workflows/generated-files.yaml
+++ b/.github/workflows/generated-files.yaml
@@ -18,7 +18,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.21.1'
       - name: Go version
         run: go version
       - name: Validate that generated files are up to date.

--- a/.github/workflows/generated-files.yaml
+++ b/.github/workflows/generated-files.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           # renovate: datasource=golang-version depName=go
-          go-version: '1.21.1'
+          go-version: '1.21.5'
       - name: Go version
         run: go version
       - name: Validate that generated files are up to date.

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         # renovate: datasource=golang-version depName=go
-        go-version: '1.21.1'
+        go-version: '1.21.5'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version-file: 'go/src/github.com/cilium/tetragon/go.mod'
+        # renovate: datasource=golang-version depName=go
+        go-version: '1.21.1'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/lint-codeql.yml
+++ b/.github/workflows/lint-codeql.yml
@@ -57,7 +57,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version-file: 'go.mod'
+        # renovate: datasource=golang-version depName=go
+        go-version: '1.21.5'
     - name: Initialize CodeQL
       uses: github/codeql-action/init@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
       with:

--- a/.github/workflows/podinfo-test.yaml
+++ b/.github/workflows/podinfo-test.yaml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         # renovate: datasource=golang-version depName=go
-        go-version: '1.21.1'
+        go-version: '1.21.5'
 
     - name: Install Kind and create cluster
       uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0

--- a/.github/workflows/podinfo-test.yaml
+++ b/.github/workflows/podinfo-test.yaml
@@ -38,7 +38,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version-file: 'go.mod'
+        # renovate: datasource=golang-version depName=go
+        go-version: '1.21.1'
 
     - name: Install Kind and create cluster
       uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         # renovate: datasource=golang-version depName=go
-        go-version: '1.21.1'
+        go-version: '1.21.5'
 
     - name: Set Up Job Variables
       id: vars

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -34,7 +34,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version-file: 'go/src/github.com/cilium/tetragon/go.mod'
+        # renovate: datasource=golang-version depName=go
+        go-version: '1.21.1'
 
     - name: Set Up Job Variables
       id: vars

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.21.1'
           # using golangci-lint cache instead
           cache: false
 
@@ -46,7 +47,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.21.1'
 
       - name: Check gofmt formatting
         run: |
@@ -75,7 +77,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.21.1'
 
       - name: Check module vendoring
         run: |

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           # renovate: datasource=golang-version depName=go
-          go-version: '1.21.1'
+          go-version: '1.21.5'
           # using golangci-lint cache instead
           cache: false
 
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           # renovate: datasource=golang-version depName=go
-          go-version: '1.21.1'
+          go-version: '1.21.5'
 
       - name: Check gofmt formatting
         run: |
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           # renovate: datasource=golang-version depName=go
-          go-version: '1.21.1'
+          go-version: '1.21.5'
 
       - name: Check module vendoring
         run: |

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -18,15 +18,16 @@ jobs:
       group: ${{ github.ref }}-vmtest-build
       cancel-in-progress: true
     steps:
+    - name: Install Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      with:
+        # renovate: datasource=golang-version depName=go
+        go-version: '1.21.1'
+
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: go/src/github.com/cilium/tetragon/
-
-    - name: Install Go
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-      with:
-        go-version-file: 'go/src/github.com/cilium/tetragon/go.mod'
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -18,16 +18,16 @@ jobs:
       group: ${{ github.ref }}-vmtest-build
       cancel-in-progress: true
     steps:
-    - name: Install Go
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-      with:
-        # renovate: datasource=golang-version depName=go
-        go-version: '1.21.1'
-
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: go/src/github.com/cilium/tetragon/
+
+    - name: Install Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      with:
+        # renovate: datasource=golang-version depName=go
+        go-version: '1.21.5'
 
     - name: Install build dependencies
       run: |


### PR DESCRIPTION
This reverts commit https://github.com/cilium/tetragon/commit/dd5ddc26585820afd0e4b84a2675e482c8dae236.

This was a good idea but https://github.com/cilium/tetragon/pull/1748 impacts this as we no longer update the patch version in the go.mod directive. Thus the CI is running outdated Go versions.