### PR TITLE
tetragon: Detect and use disassociate_ctty as exit probe if needed

### DIFF
--- a/bpf/process/bpf_exit.c
+++ b/bpf/process/bpf_exit.c
@@ -43,10 +43,28 @@ char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
  * we are the last one of the thread group.
  */
 __attribute__((section("kprobe/acct_process"), used)) int
-event_exit(struct pt_regs *ctx)
+event_exit_acct_process(struct pt_regs *ctx)
 {
 	__u64 pid_tgid = get_current_pid_tgid();
 
 	event_exit_send(ctx, pid_tgid >> 32);
+	return 0;
+}
+
+/*
+ * Hooking on acct_process kernel function, which is called on the task's
+ * exit path once the task is the last one in the group. It's stable since
+ * v4.19, so it's safe to hook for us.
+ *
+ * It's called with on_exit argument != 0 when called from do_exit
+ * function with same conditions like for acct_process described above.
+ */
+__attribute__((section("kprobe/disassociate_ctty"), used)) int
+event_exit_disassociate_ctty(struct pt_regs *ctx)
+{
+	int on_exit = (int)PT_REGS_PARM1_CORE(ctx);
+
+	if (on_exit)
+		event_exit_send(ctx, get_current_pid_tgid() >> 32);
 	return 0;
 }

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -278,6 +278,7 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 		kernelSymbols, err := ksyms.KernelSymbols()
 		if err != nil {
 			logger.GetLogger().WithError(err).Warn("stacktrace: failed to read kernel symbols")
+			continue
 		}
 		fnOffset, err := kernelSymbols.GetFnOffset(addr)
 		if err != nil {

--- a/pkg/ksyms/ksyms.go
+++ b/pkg/ksyms/ksyms.go
@@ -193,3 +193,12 @@ func (k *Ksyms) getFnOffset(addr uint64) (*FnOffset, error) {
 		Offset:  addr - sym.addr,
 	}, nil
 }
+
+func (k *Ksyms) IsAvailable(name string) bool {
+	for _, sym := range k.table {
+		if sym.name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -59,10 +59,9 @@ var (
 	StatsMap           = program.MapBuilder("tg_stats_map", Execve)
 
 	sensor = sensors.Sensor{
-		Name:  "__base__",
-		Progs: GetDefaultPrograms(),
-		Maps:  GetDefaultMaps(),
+		Name: "__base__",
 	}
+	sensorInit sync.Once
 )
 
 func GetExecveMap() *program.Map {
@@ -104,6 +103,10 @@ func GetDefaultMaps() []*program.Map {
 
 // GetInitialSensor returns the base sensor
 func GetInitialSensor() *sensors.Sensor {
+	sensorInit.Do(func() {
+		sensor.Progs = GetDefaultPrograms()
+		sensor.Maps = GetDefaultMaps()
+	})
 	return &sensor
 }
 

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -131,7 +131,7 @@ func mergeSensorMaps(t *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []Se
 func mergeInBaseSensorMaps(t *testing.T, sensorMaps []SensorMap, sensorProgs []SensorProg) ([]SensorMap, []SensorProg) {
 	var baseProgs = []SensorProg{
 		0: SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
-		1: SensorProg{Name: "event_exit", Type: ebpf.Kprobe},
+		1: SensorProg{Name: "event_exit", Type: ebpf.Kprobe, Match: ProgMatchPartial},
 		2: SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
 		3: SensorProg{Name: "execve_send", Type: ebpf.TracePoint},
 		4: SensorProg{Name: "tg_kp_bprm_committing_creds", Type: ebpf.Kprobe},


### PR DESCRIPTION
Adding support to use disassociate_ctty exit probe in case
acct_process is missing in kernel.
