### PR TITLE
workflow: fix PR link checker to check local branch links

### DIFF
--- a/.github/workflows/check-links-pr.yaml
+++ b/.github/workflows/check-links-pr.yaml
@@ -22,6 +22,23 @@ jobs:
           hugo-version: '0.120.4'
           extended: true
 
+      - name: Replace GitHub main links with local branch
+        shell: bash
+        run: |
+          REPO=${{ github.event.pull_request.head.repo.full_name }}
+          BRANCH=${{ github.event.pull_request.head.ref }}
+
+          find docs/content/ -type f -name "*.md" -exec sed -i "s#/cilium/tetragon/tree/main#/$REPO/tree/$BRANCH#g" {} \;
+          sed -i "s#/cilium/tetragon/tree/main#/$REPO/tree/$BRANCH#g" README.md
+
+          find docs/content/ -type f -name "*.md" -exec sed -i "s#/cilium/tetragon/blob/main#/$REPO/blob/$BRANCH#g" {} \;
+          sed -i "s#/cilium/tetragon/blob/main#/$REPO/blob/$BRANCH#g" README.md
+
+          find docs/content/ -type f -name "*.md" -exec sed -i "s#/cilium/tetragon/main#/$REPO/$BRANCH#g" {} \;
+          sed -i "s#/cilium/tetragon/main#/$REPO/$BRANCH#g" README.md
+
+          git diff -U0
+
       - name: Serve the Hugo website
         working-directory: docs
         run: hugo server &
@@ -44,5 +61,3 @@ jobs:
         with:
           args: --config .github/lychee.toml --base http://localhost:1313 docs/content README.md
           fail: true
-          format: json
-


### PR DESCRIPTION
Tries to fix #1858

PR link checker was checking the GitHub links against main which might not exist when the PR has not been merged on main yet.

Unfortunately `lychee --remap` just searched and replaced and could not just replace some part of the URL so I did good old find/sed commands.