### PR TITLE
docs: add privacy-aware GoatCounter analytics

### DIFF
--- a/docs/layouts/partials/hooks/head-end.html
+++ b/docs/layouts/partials/hooks/head-end.html
@@ -1,0 +1,6 @@
+<script>
+    if (window.location.host !== 'tetragon.io')
+        window.goatcounter = {no_onload: true}
+</script>
+<script data-goatcounter="https://tetragon.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>


### PR DESCRIPTION
In order to have visibility and improve our documentation, I would like to add an open-source analytic tool: GoatCounter (see https://www.goatcounter.com/) to the documentation website.

GoatCounter is an open source web analytics platform available as a free donation-supported hosted service or self-hosted app. It aims to offer easy to use and meaningful privacy-friendly web analytics as an alternative to Google Analytics or Matomo.

It's privacy-aware; it doesn’t track users with unique identifiers and doesn't need a GDPR notice. Fine-grained control over which data is collected.

For now we use the non-commercial free hosted solution but we can consider donating or self-hosting if this is useful for us in the future.