### PR TITLE
fieldfilters: fix regression with missing top-level info and add test

### DIFF
--- a/pkg/fieldfilters/fields_test.go
+++ b/pkg/fieldfilters/fields_test.go
@@ -217,6 +217,32 @@ func TestEmptyFieldFilter(t *testing.T) {
 	assert.True(t, proto.Equal(ev, expected), "events are equal after filter")
 }
 
+func TestEmptyFieldFilterTopLevelInformation(t *testing.T) {
+	ev := &tetragon.GetEventsResponse{
+		NodeName: "foobarqux",
+		AggregationInfo: &tetragon.AggregationInfo{
+			Count: 1000,
+		},
+		Time: &timestamppb.Timestamp{
+			Seconds: 1000,
+			Nanos:   1000,
+		},
+		Event: &tetragon.GetEventsResponse_ProcessExec{
+			ProcessExec: &tetragon.ProcessExec{
+				Process: &tetragon.Process{},
+				Parent:  &tetragon.Process{},
+			},
+		},
+	}
+
+	filter, err := NewExcludeFieldFilter(nil, nil, false)
+	require.NoError(t, err)
+	ev, _ = filter.Filter(ev)
+	assert.NotEmpty(t, ev.NodeName, "node name must not be empty")
+	assert.NotEmpty(t, ev.Time, "timestamp must not be empty")
+	assert.NotEmpty(t, ev.AggregationInfo, "aggregation info must not be empty")
+}
+
 func TestFieldFilterInvertedEventSet(t *testing.T) {
 	ev := &tetragon.GetEventsResponse{
 		Event: &tetragon.GetEventsResponse_ProcessExec{


### PR DESCRIPTION
We had a regression after some fieldfilter bug fixes and performance optimizations that caused top-level information to be missing from events when field filters are applied. The fix here is to make sure that we are setting non-event fields in the destination struct. Apply the fix and add a unit test to check for future regressions.

```release-note
Fix a regression related to field filters that could cause top-level information to be missing from events.
```