### PR TITLE
backports/v1.0: fieldfilters: fix regression with missing top-level info and add test

### DIFF
--- a/pkg/fieldfilters/fields.go
+++ b/pkg/fieldfilters/fields.go
@@ -5,6 +5,7 @@ package fieldfilters
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -206,14 +207,25 @@ func (f *FieldFilter) Filter(event *tetragon.GetEventsResponse) (*tetragon.GetEv
 
 	src := event.ProtoReflect()
 	dst := src.New()
-	var filterErr error
+	var filterErrs []error
 	src.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
-		if fd.ContainingOneof() == nil || !src.Has(fd) {
+		if !src.Has(fd) {
 			return true
 		}
-		event := src.Get(fd).Message().Interface()
-		dstEvent := dst.Mutable(fd).Message().Interface()
-		filterErr = fieldmask_utils.StructToStruct(f.fields, event, dstEvent)
+
+		if fd.ContainingOneof() != nil && fd.ContainingOneof().Name() == "event" {
+			event := src.Get(fd).Message().Interface()
+			dstEvent := dst.Mutable(fd).Message().Interface()
+			err := fieldmask_utils.StructToStruct(f.fields, event, dstEvent)
+			if err != nil {
+				filterErrs = append(filterErrs, err)
+			}
+			return true
+		}
+
+		// Preserve all information that is not in the Event field
+		dst.Set(fd, v)
+
 		return true
 	})
 
@@ -221,5 +233,5 @@ func (f *FieldFilter) Filter(event *tetragon.GetEventsResponse) (*tetragon.GetEv
 		return nil, fmt.Errorf("invalid event after field filter")
 	}
 
-	return dst.Interface().(*tetragon.GetEventsResponse), filterErr
+	return dst.Interface().(*tetragon.GetEventsResponse), errors.Join(filterErrs...)
 }

--- a/pkg/fieldfilters/fields_test.go
+++ b/pkg/fieldfilters/fields_test.go
@@ -235,6 +235,32 @@ func TestEmptyFieldFilter(t *testing.T) {
 	assert.True(t, proto.Equal(ev, expected), "events are equal after filter")
 }
 
+func TestEmptyFieldFilterTopLevelInformation(t *testing.T) {
+	ev := &tetragon.GetEventsResponse{
+		NodeName: "foobarqux",
+		AggregationInfo: &tetragon.AggregationInfo{
+			Count: 1000,
+		},
+		Time: &timestamppb.Timestamp{
+			Seconds: 1000,
+			Nanos:   1000,
+		},
+		Event: &tetragon.GetEventsResponse_ProcessExec{
+			ProcessExec: &tetragon.ProcessExec{
+				Process: &tetragon.Process{},
+				Parent:  &tetragon.Process{},
+			},
+		},
+	}
+
+	filter, err := NewExcludeFieldFilter(nil, nil, false)
+	require.NoError(t, err)
+	ev, _ = filter.Filter(ev)
+	assert.NotEmpty(t, ev.NodeName, "node name must not be empty")
+	assert.NotEmpty(t, ev.Time, "timestamp must not be empty")
+	assert.NotEmpty(t, ev.AggregationInfo, "aggregation info must not be empty")
+}
+
 func TestFieldFilterInvertedEventSet(t *testing.T) {
 	ev := &tetragon.GetEventsResponse{
 		Event: &tetragon.GetEventsResponse_ProcessExec{


### PR DESCRIPTION
[upstream commit 651fcf1818a5271eef93a0a8e33104b778a22205]

We had a regression after some fieldfilter bug fixes and performance optimizations that caused top-level information to be missing from events when field filters are applied. The fix here is to make sure that we are setting non-event fields in the destination struct. Apply the fix and add a unit test to check for future regressions.

Backport of #1882.

```release-note
Fix a regression related to field filters that could cause top-level information to be missing from events.
```