### PR TITLE
tetragon: Use cilium/ebpf detection

### DIFF
--- a/pkg/bpf/detect.go
+++ b/pkg/bpf/detect.go
@@ -24,7 +24,6 @@ type Feature struct {
 }
 
 var (
-	signalHelper     Feature
 	kprobeMulti      Feature
 	buildid          Feature
 	modifyReturn     Feature
@@ -35,29 +34,8 @@ func HasOverrideHelper() bool {
 	return features.HaveProgramHelper(ebpf.Kprobe, asm.FnOverrideReturn) == nil
 }
 
-func detectSignalHelper() bool {
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type: ebpf.Kprobe,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R2, 2, asm.DWord),
-			asm.Instruction{OpCode: asm.OpCode(asm.JumpClass).SetJumpOp(asm.Call), Constant: 109},
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-		License: "GPL",
-	})
-	if err != nil {
-		return false
-	}
-	prog.Close()
-	return true
-}
-
 func HasSignalHelper() bool {
-	signalHelper.init.Do(func() {
-		signalHelper.detected = detectSignalHelper()
-	})
-	return signalHelper.detected
+	return features.HaveProgramHelper(ebpf.Kprobe, asm.FnSendSignal) == nil
 }
 
 func detectKprobeMulti() bool {

--- a/pkg/bpf/detect.go
+++ b/pkg/bpf/detect.go
@@ -24,10 +24,9 @@ type Feature struct {
 }
 
 var (
-	kprobeMulti      Feature
-	buildid          Feature
-	modifyReturn     Feature
-	largeProgramSize Feature
+	kprobeMulti  Feature
+	buildid      Feature
+	modifyReturn Feature
 )
 
 func HasOverrideHelper() bool {
@@ -127,32 +126,8 @@ func HasModifyReturn() bool {
 	return modifyReturn.detected
 }
 
-func detectLargeProgramSize() bool {
-	insns := asm.Instructions{}
-
-	for i := 0; i < 4096; i++ {
-		insns = append(insns, asm.Mov.Imm(asm.R0, 1))
-	}
-	insns = append(insns, asm.Return())
-
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:         ebpf.Kprobe,
-		Instructions: insns,
-		AttachType:   ebpf.AttachModifyReturn,
-		License:      "MIT",
-	})
-	if err != nil {
-		return false
-	}
-	prog.Close()
-	return true
-}
-
 func HasProgramLargeSize() bool {
-	largeProgramSize.init.Do(func() {
-		largeProgramSize.detected = detectLargeProgramSize()
-	})
-	return largeProgramSize.detected
+	return features.HaveLargeInstructions() == nil
 }
 
 func LogFeatures() string {


### PR DESCRIPTION
We can outsource some of our detection code to ebpf/cilium,
some we need to keep so far, because there's no support for that yet.