### PR TITLE
chore: rename TracingPolicy function

### DIFF
--- a/tests/e2e/helpers/grpc/grpc.go
+++ b/tests/e2e/helpers/grpc/grpc.go
@@ -41,7 +41,7 @@ func WaitForTracingPolicy(ctx context.Context, policyName string) error {
 		client := tetragon.NewFineGuidanceSensorsClient(conn)
 
 		for i := 0; i < maxTries; i++ {
-			err = waitForTracingPolicy(ctx, policyName, client)
+			err = ensureTracingPolicy(ctx, policyName, client)
 			if err == nil {
 				break
 			}
@@ -57,7 +57,7 @@ func WaitForTracingPolicy(ctx context.Context, policyName string) error {
 	return nil
 }
 
-func waitForTracingPolicy(ctx context.Context, policyName string, client tetragon.FineGuidanceSensorsClient) error {
+func ensureTracingPolicy(ctx context.Context, policyName string, client tetragon.FineGuidanceSensorsClient) error {
 	res, err := client.ListTracingPolicies(ctx, &tetragon.ListTracingPoliciesRequest{})
 	if err != nil {
 		return err


### PR DESCRIPTION
renaming ```waitForTracingPolicy``` to ```ensureTracingPolicy``` because that is what it does and the waiting part is done by ```WaitForTracingPolicy``` so we could import ```ensureTracingPolicy``` to other packages in future without confusions

```release-note
Rename a function in e2e test helpers.
```