### PR TITLE
chore: unloadpolicy after load

### DIFF
--- a/tests/e2e/tests/policyfilter/policyfilter_test.go
+++ b/tests/e2e/tests/policyfilter/policyfilter_test.go
@@ -118,6 +118,14 @@ func TestNamespacedPolicy(t *testing.T) {
 			}
 			return ctx
 		}).
+		Assess("Uninstall policy", func(ctx context.Context, _ *testing.T, c *envconf.Config) context.Context {
+			ctx, err := helpers.UnloadCRDString(policyNamespace, namespacedPolicy, false)(ctx, c)
+			if err != nil {
+				klog.ErrorS(err, "failed to uninstall policy")
+				t.Fail()
+			}
+			return ctx
+		}).
 		Feature()
 
 	runner.TestInParallel(t, runWorkload, runEventChecker)
@@ -238,6 +246,14 @@ func TestPodLabelFilters(t *testing.T) {
 					t.Fail()
 				}
 
+			}
+			return ctx
+		}).
+		Assess("Uninstall policy", func(ctx context.Context, _ *testing.T, c *envconf.Config) context.Context {
+			ctx, err := helpers.UnloadCRDString(podlblNamespace, podlblPolicy, false)(ctx, c)
+			if err != nil {
+				klog.ErrorS(err, "failed to uninstall policy")
+				t.Fail()
 			}
 			return ctx
 		}).

--- a/tests/e2e/tests/skeleton/skeleton_test.go
+++ b/tests/e2e/tests/skeleton/skeleton_test.go
@@ -113,6 +113,14 @@ func TestSkeletonBasic(t *testing.T) {
 				t.Fail()
 			}
 			return ctx
+		}).
+		Assess("Uninstall policy", func(ctx context.Context, _ *testing.T, c *envconf.Config) context.Context {
+			ctx, err := helpers.UnloadCRDString(namespace, curlPod, true)(ctx, c)
+			if err != nil {
+				klog.ErrorS(err, "failed to spawn workload")
+				t.Fail()
+			}
+			return ctx
 		}).Feature()
 
 	// We run our features using testenv.Test() or testenv.TestInParallel(). These take


### PR DESCRIPTION
This pr will unload the policy that was loaded during the test which ultimately closes the issue #1771 