### PR TITLE
feat: validate crd versions

### DIFF
--- a/.github/workflows/validate-crd.yaml
+++ b/.github/workflows/validate-crd.yaml
@@ -1,0 +1,45 @@
+name: Check CRD version update
+
+on:
+  pull_request:
+    paths:
+      - 'pkg/k8s/apis/cilium.io/client/crds/v1alpha1/*.yaml'
+      - 'pkg/k8s/apis/cilium.io/v1alpha1/version.go'
+
+jobs:
+  check-version:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for CRD changes and version update
+        run: |
+          crd_changed=0
+          version_changed=0
+
+          # Check for CRD changes
+          crd_changes=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} -- pkg/k8s/apis/cilium.io/client/crds/v1alpha1/*.yaml)
+          if [ -n "$crd_changes" ]; then
+            crd_changed=1
+          fi
+
+          # Check for version variable changes
+
+          old_version=$(git show ${{ github.event.pull_request.base.sha }}:pkg/k8s/apis/cilium.io/v1alpha1/version.go | sed -n 's/^const CustomResourceDefinitionSchemaVersion = "\(.*\)".*/\1/p')
+          new_version=$(sed -n 's/^const CustomResourceDefinitionSchemaVersion = "\(.*\)".*/\1/p' pkg/k8s/apis/cilium.io/v1alpha1/version.go)
+
+          echo "old_version=$old_version"
+          echo "new_version=$new_version"
+
+          if [ "$old_version" != "$new_version" ]; then
+            version_changed=1
+          fi
+
+          if [ "$crd_changed" -eq 1 ] && [ "$version_changed" -eq 0 ]; then
+            echo "Changes to the files pkg/k8s/apis/cilium.io/client/crds/v1alpha1/*.yaml requires CustomResourceDefinitionSchemaVersion to be updated in pkg/k8s/apis/cilium.io/v1alpha1/version.go"
+            exit 1
+          fi
+
+          if [ "$crd_changed" -eq 0 ] && [ "$version_changed" -eq 1 ]; then
+            echo "CustomResourceDefinitionSchemaVersion in pkg/k8s/apis/cilium.io/v1alpha1/version.go to be updated only in case of modifying the files pkg/k8s/apis/cilium.io/client/crds/v1alpha1/*.yaml"
+            exit 1
+          fi


### PR DESCRIPTION
### Issue

This pr Closes #1412  

### Description
 If there is a change in the crd yaml files and if ```CustomResourceDefinitionSchemaVersion``` value is not updated accordingly in ```pkg/k8s/apis/cilium.io/v1alpha1/version.go``` or vice-versa . The CI will fail

How to test locally ?

follow this https://github.com/cilium/tetragon/pull/1919#pullrequestreview-1811074405 



for the event.json thing set it as 

```{
  "pull_request": {
    "head": {
      "ref": "test-dev-2"
    },
    "base": {
      "ref": "test-dev",
      "sha":"58acf63b51238a93cb2d13cba90a80d6662d45bd"
    }
  }
        }
```

you can replace the sha field by the latest commit on your base branch

here I added CustomResourceDefinitionSchemaVersion to ```pkg/k8s/apis/cilium.io/v1alpha1/version.go``` in both branches

and changed yaml files ```pkg/k8s/apis/cilium.io/v1alpha1/version.go``` and  CustomResourceDefinitionSchemaVersion in HEAD branch (test-dev-2) 

change the branch

```git checkout test-dev-2``` (the branch that makes the pr request because we have HEAD in the yaml)

then you should see the success output as I saw

```
[Check CRD version update/check-version] ⭐ Run Main actions/checkout@v3
[Check CRD version update/check-version]   🐳  docker cp src=/home/sadath/go/src/tetragon/. dst=/home/sadath/go/src/tetragon
[Check CRD version update/check-version]   ✅  Success - Main actions/checkout@v3
[Check CRD version update/check-version] ⭐ Run Main Check for CRD changes and version update
[Check CRD version update/check-version]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
| old_version=0.10.1
| new_version=0.10.4
| crd_changed=1
| version_changed=1
[Check CRD version update/check-version]   ✅  Success - Main Check for CRD changes and version update
[Check CRD version update/check-version] Cleaning up container for job check-version
[Check CRD version update/check-version] 🏁  Job succeeded
```

if you changed crd yaml files but not version you will see the failure output something as I see here 

```
[Check CRD version update/check-version]   ✅  Success - Main Install git
[Check CRD version update/check-version] ⭐ Run Main actions/checkout@v3
[Check CRD version update/check-version]   🐳  docker cp src=/home/sadath/go/src/tetragon/. dst=/home/sadath/go/src/tetragon
[Check CRD version update/check-version]   ✅  Success - Main actions/checkout@v3
[Check CRD version update/check-version] ⭐ Run Main Check for CRD changes and version update
[Check CRD version update/check-version]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
| old_version=0.10.1
| new_version=0.10.1
| CRD changed but version not updated
[Check CRD version update/check-version]   ❌  Failure - Main Check for CRD changes and version update
[Check CRD version update/check-version] exitcode '1': failure
[Check CRD version update/check-version] 🏁  Job failed
Error: Job 'check-version' failed
```
And for vice-versa 
```
[Check CRD version update/check-version] ⭐ Run Main actions/checkout@v3
[Check CRD version update/check-version]   🐳  docker cp src=/home/sadath/go/src/tetragon/. dst=/home/sadath/go/src/tetragon
[Check CRD version update/check-version]   ✅  Success - Main actions/checkout@v3
[Check CRD version update/check-version] ⭐ Run Main Check for CRD changes and version update
[Check CRD version update/check-version]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
| old_version=0.10.1
| new_version=0.10.7
| Version updated but CRD not changed
[Check CRD version update/check-version]   ❌  Failure - Main Check for CRD changes and version update
[Check CRD version update/check-version] exitcode '1': failure
[Check CRD version update/check-version] 🏁  Job failed
Error: Job 'check-version' failed
```


