### PR TITLE
Improve local k8s developer experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,6 +304,9 @@ image-clang:
 	$(QUIET)@echo "Push like this when ready:"
 	$(QUIET)@echo "${CONTAINER_ENGINE} push cilium/clang:$(DOCKER_IMAGE_TAG)"
 
+.PHONY: images
+images: image image-operator
+
 .PHONY: tarball tarball-release tarball-clean
 # Share same build environment as docker image
 tarball: tarball-clean image
@@ -401,3 +404,14 @@ version:
 .PHONY: docs
 docs:
 	$(MAKE) -C docs
+
+.PHONY: kind
+kind:
+	./contrib/localdev/bootstrap-kind-cluster.sh
+
+.PHONY: kind-install-tetragon 
+kind-install-tetragon:
+	./contrib/localdev/install-tetragon.sh --image cilium/tetragon:latest --operator cilium/tetragon-operator:latest
+
+.PHONY: kind-setup
+kind-setup: images kind kind-install-tetragon

--- a/docs/content/en/docs/contribution-guide/development-setup.md
+++ b/docs/content/en/docs/contribution-guide/development-setup.md
@@ -112,19 +112,11 @@ make tarball
 
 ### Running Tetragon in kind
 
-The scripts in contrib/localdev will help you run Tetragon locally in a kind
-cluster. First, ensure that docker, kind, kubectl, and helm are installed on
-your system. Then, run the following commands:
+This command will setup tetragon, kind cluster and install tetragon in it. Ensure docker, kind, kubectl, and helm are installed.
 
 ```shell
-# Build Tetragon agent and operator images
-make LOCAL_CLANG=0 image image-operator
-
-# Bootstrap the cluster
-contrib/localdev/bootstrap-kind-cluster.sh
-
-# Install Tetragon
-contrib/localdev/install-tetragon.sh --image cilium/tetragon:latest --operator cilium/tetragon-operator:latest
+# Setup tetragon on kind
+make kind-setup
 ```
 
 Verify that Tetragon is installed by running:
@@ -145,20 +137,6 @@ make
 If you are getting an error, you can try to run `sudo launchctl load
 /Library/LaunchDaemons/org.virtualbox.startup.plist` (from [a Stackoverflow
 answer](https://stackoverflow.com/questions/18149546/macos-vagrant-up-failed-dev-vboxnetctl-no-such-file-or-directory)).
-
-### Local Development in Minikube
-
-You can also run the tetragon agent directly (instead of in a pod). Here we
-describe how this can be done in minikube:
-
-```shell
-minikube start --driver=kvm2
-minikube mount $HOME:$HOME # so that we can use .kube/config
-./tetragon-operator --kube-config ~/.kube/config
-make STATIC=1 tetragon
-minikube ssh --  'sudo mkdir -p /var/run/cilium/tetragon'
-minikube ssh sudo "sh -c 'NODE_NAME=minikube /home/kkourt/src/tetragon/tetragon --bpf-lib /home/kkourt/src/tetragon/bpf/objs --server-address unix:///var/run/cilium/tetragon/tetragon.sock --enable-k8s-api --k8s-kubeconfig-path /home/kkourt/.kube/config'"
-```
 
 ### What's next
 


### PR DESCRIPTION
Compile all commands listed for kind setup into one make command via ```make kind-setup``` and updated docs accordingly and removes minikube setup as there is neglible chances that someone will use it over kind and we have to make our docs clean

Closes #1849 