### PR TITLE
bpf: read and copy proc exe at execve for matchBinaries

### DIFF
--- a/bpf/lib/bpf_task.h
+++ b/bpf/lib/bpf_task.h
@@ -10,6 +10,9 @@
 
 /* __d_path_local flags */
 // #define UNRESOLVED_MOUNT_POINTS	   0x01 // (deprecated)
+// this error is returned by __d_path_local in the following cases:
+// - the path walk did not conclude (too many dentry)
+// - the path was too long to fit in the buffer
 #define UNRESOLVED_PATH_COMPONENTS 0x02
 
 #ifdef __LARGE_BPF_PROG

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -270,6 +270,19 @@ struct msg_k8s {
 	char docker_id[DOCKER_ID_LENGTH];
 }; // All fields aligned so no 'packed' attribute.
 
+#define BINARY_PATH_MAX_LEN 256
+
+struct heap_exe {
+	// because of verifier limitations, this has to be 2 * 256 bytes while 256
+	// should be theoretically sufficient, and actually is, in unit tests.
+	char buf[BINARY_PATH_MAX_LEN * 2];
+	// offset points to the start of the path in the above buffer. Use offset to
+	// read the path in the buffer since it's written from the end.
+	char *off;
+	__u32 len;
+	__u32 error;
+}; // All fields aligned so no 'packed' attribute.
+
 struct msg_execve_event {
 	struct msg_common common;
 	struct msg_k8s kube;
@@ -289,9 +302,10 @@ struct msg_execve_event {
 	/* below fields are not part of the event, serve just as
 	 * heap for execve programs
 	 */
+#ifdef __LARGE_BPF_PROG
+	struct heap_exe exe;
+#endif
 }; // All fields aligned so no 'packed' attribute.
-
-#define BINARY_PATH_MAX_LEN 256
 
 // This structure stores the binary path that was recorded on execve.
 // Technically PATH_MAX is 4096 but we limit the length we store since we have


### PR DESCRIPTION
Fix for https://github.com/cilium/tetragon/issues/1741

This PR changes how we read the binary path at `execve` time. We now read `exe` from the `task_struct` instead of relying upon the tracepoint argument that was just the path given to `execve` (thus possibly relative). This was an issue since `matchBinaries` could be avoided using relative links instead of absolute ones at `execve`.

### For a future patch maybe:

In addition to this, we could also use this `exe` value for the binary path of the event. We also previously used the argument of `execve`, being possibly relative and corrected in userspace using `cwd`, but also possibly a symlink. This would thus introduce a user-facing change: tetragon events will now contain the canonical binary path while previously it could have been a symlink.

Without that user might try to "matchBinaries" a symlink file displayed in the Tetragon events and fail to make it work.

Preliminary work would be to make `prepend_name` work with 4096 (or `MAX_PATH`) buffer size.