### PR TITLE
tetragon: run Tetragon without access to CRD

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -97,7 +97,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.prometheus.serviceMonitor.scrapeInterval | string | `"10s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
-| tetragonOperator | object | `{"affinity":{},"annotations":{},"extraLabels":{},"extraPodLabels":{},"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.0.2"},"nodeSelector":{},"podAnnotations":{},"podInfo":{"enabled":false},"podSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}},"priorityClassName":"","prometheus":{"address":"","enabled":true,"port":2113,"serviceMonitor":{"enabled":false,"labelsOverride":{},"scrapeInterval":"10s"}},"resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"skipCRDCreation":false,"strategy":{},"tolerations":[{"operator":"Exists"}]}` | Tetragon Operator settings |
+| tetragonOperator | object | `{"affinity":{},"annotations":{},"extraLabels":{},"extraPodLabels":{},"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.0.2"},"nodeSelector":{},"podAnnotations":{},"podInfo":{"enabled":false},"podSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}},"priorityClassName":"","prometheus":{"address":"","enabled":true,"port":2113,"serviceMonitor":{"enabled":false,"labelsOverride":{},"scrapeInterval":"10s"}},"resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"skipCRDCreation":false,"strategy":{},"tolerations":[{"operator":"Exists"}],"tracingPolicy":{"enabled":true}}` | Tetragon Operator settings |
 | tetragonOperator.annotations | object | `{}` | Annotations for the Tetragon Operator Deployment. |
 | tetragonOperator.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment. |
 | tetragonOperator.extraPodLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment Pods. |
@@ -119,5 +119,6 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragonOperator.securityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pods. |
 | tetragonOperator.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | tetragon-operator service account. |
 | tetragonOperator.strategy | object | `{}` | resources for the Tetragon Operator Deployment update strategy |
+| tetragonOperator.tracingPolicy.enabled | bool | `true` | Enables the TracingPolicy and TracingPolicyNamespaced CRD creation. |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -55,6 +55,10 @@ options:
       default_value: "false"
       usage: |
         Enable namespace information in process_exec and process_kprobe events
+    - name: enable-tracing-policy-crd
+      default_value: "true"
+      usage: |
+        Enable TracingPolicy and TracingPolicyNamespaced custom resources
     - name: event-queue-size
       default_value: "10000"
       usage: Set the size of the internal event queue.

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -79,7 +79,7 @@ Helm chart for Tetragon
 | tetragon.prometheus.serviceMonitor.scrapeInterval | string | `"10s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
-| tetragonOperator | object | `{"affinity":{},"annotations":{},"extraLabels":{},"extraPodLabels":{},"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.0.2"},"nodeSelector":{},"podAnnotations":{},"podInfo":{"enabled":false},"podSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}},"priorityClassName":"","prometheus":{"address":"","enabled":true,"port":2113,"serviceMonitor":{"enabled":false,"labelsOverride":{},"scrapeInterval":"10s"}},"resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"skipCRDCreation":false,"strategy":{},"tolerations":[{"operator":"Exists"}]}` | Tetragon Operator settings |
+| tetragonOperator | object | `{"affinity":{},"annotations":{},"extraLabels":{},"extraPodLabels":{},"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.0.2"},"nodeSelector":{},"podAnnotations":{},"podInfo":{"enabled":false},"podSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}},"priorityClassName":"","prometheus":{"address":"","enabled":true,"port":2113,"serviceMonitor":{"enabled":false,"labelsOverride":{},"scrapeInterval":"10s"}},"resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":true,"name":""},"skipCRDCreation":false,"strategy":{},"tolerations":[{"operator":"Exists"}],"tracingPolicy":{"enabled":true}}` | Tetragon Operator settings |
 | tetragonOperator.annotations | object | `{}` | Annotations for the Tetragon Operator Deployment. |
 | tetragonOperator.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment. |
 | tetragonOperator.extraPodLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment Pods. |
@@ -101,6 +101,7 @@ Helm chart for Tetragon
 | tetragonOperator.securityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pods. |
 | tetragonOperator.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | tetragon-operator service account. |
 | tetragonOperator.strategy | object | `{}` | resources for the Tetragon Operator Deployment update strategy |
+| tetragonOperator.tracingPolicy.enabled | bool | `true` | Enables the TracingPolicy and TracingPolicyNamespaced CRD creation. |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |
 

--- a/install/kubernetes/tetragon/templates/operator_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/operator_configmap.yaml
@@ -8,3 +8,4 @@ metadata:
 data:
   skip-crd-creation: {{ .Values.tetragonOperator.skipCRDCreation | quote }}
   skip-pod-info-crd: {{ not .Values.tetragonOperator.podInfo.enabled | quote }}
+  skip-tracing-policy-crd: {{ not .Values.tetragonOperator.tracingPolicy.enabled | quote }}

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -56,4 +56,5 @@ data:
   enable-msg-handling-latency: "true"
 {{- end }}
   enable-pod-info: {{ .Values.tetragonOperator.podInfo.enabled | quote }}
+  enable-tracing-policy-crd: {{ .Values.tetragonOperator.tracingPolicy.enabled | quote }}
   {{- include "configmap.extra" . | nindent 2 }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -232,6 +232,9 @@ tetragonOperator:
     # -- Enables the PodInfo CRD and the controller that reconciles PodInfo
     # custom resources.
     enabled: false
+  tracingPolicy:
+    # -- Enables the TracingPolicy and TracingPolicyNamespaced CRD creation.
+    enabled: true
   # -- Enables the Tetragon Operator metrics.
   prometheus:
     enabled: true

--- a/operator/cmd/common/common.go
+++ b/operator/cmd/common/common.go
@@ -21,6 +21,7 @@ func AddCommonFlags(cmd *cobra.Command) {
 	flags.String(operatorOption.KubeCfgPath, "", "Kubeconfig filepath to connect to k8s")
 	flags.String(operatorOption.ConfigDir, "", "Directory in which tetragon-operator-config configmap is mounted")
 	flags.Bool(operatorOption.SkipPodInfoCRD, false, "When true, PodInfo Custom Resource Definition (CRD) will not be created")
+	flags.Bool(operatorOption.SkipTracingPolicyCRD, false, "When true, TracingPolicy and TracingPolicyNamespaced Custom Resource Definition (CRD) will not be created")
 }
 
 func Initialize(cmd *cobra.Command) {

--- a/operator/crd/crd.go
+++ b/operator/crd/crd.go
@@ -58,7 +58,12 @@ func RegisterCRDs() {
 
 	crds := []crdutils.CRD{}
 	for _, crd := range client.AllCRDs {
-		if option.Config.SkipPodInfoCRD && crd.CRDName == client.PodInfoCRD.CRDName {
+		switch {
+		case option.Config.SkipPodInfoCRD && crd.CRDName == client.PodInfoCRD.CRDName:
+			continue
+		case option.Config.SkipTracingPolicyCRD && crd.CRDName == client.TracingPolicyCRD.CRDName:
+			continue
+		case option.Config.SkipTracingPolicyCRD && crd.CRDName == client.TracingPolicyNamespacedCRD.CRDName:
 			continue
 		}
 		crds = append(crds, crd)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -26,6 +26,10 @@ const (
 	// SkipPodInfoCRD specifies whether the tetragonPod CustomResourceDefinition will be
 	// disabled
 	SkipPodInfoCRD = "skip-pod-info-crd"
+
+	// SkipTracingPolicyCRD specifies whether the tracing-policies CustomResourceDefinition will be
+	// disabled
+	SkipTracingPolicyCRD = "skip-tracing-policy-crd"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -42,6 +46,10 @@ type OperatorConfig struct {
 
 	// SkipPodInfoCRD disables creation of the TetragonPod CustomResourceDefinition only.
 	SkipPodInfoCRD bool
+
+	// SkipTracingPolicyCRD disables creation of the TracingPolicy and
+	// TracingPolicyNamespaced CustomResourceDefinition only.
+	SkipTracingPolicyCRD bool
 }
 
 // Config represents the operator configuration.
@@ -53,4 +61,5 @@ func ConfigPopulate() {
 	Config.KubeCfgPath = viper.GetString(KubeCfgPath)
 	Config.ConfigDir = viper.GetString(ConfigDir)
 	Config.SkipPodInfoCRD = viper.GetBool(SkipPodInfoCRD)
+	Config.SkipTracingPolicyCRD = viper.GetBool(SkipTracingPolicyCRD)
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -83,7 +83,8 @@ type config struct {
 
 	KMods []string
 
-	EnablePodInfo bool
+	EnablePodInfo          bool
+	EnableTracingPolicyCRD bool
 
 	ExposeKernelAddresses bool
 }

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -86,7 +86,8 @@ const (
 
 	KeyKmods = "kmods"
 
-	KeyEnablePodInfo = "enable-pod-info"
+	KeyEnablePodInfo          = "enable-pod-info"
+	KeyEnableTracingPolicyCRD = "enable-tracing-policy-crd"
 
 	KeyExposeKernelAddresses = "expose-kernel-addresses"
 
@@ -165,6 +166,7 @@ func ReadAndSetFlags() error {
 	Config.KMods = viper.GetStringSlice(KeyKmods)
 
 	Config.EnablePodInfo = viper.GetBool(KeyEnablePodInfo)
+	Config.EnableTracingPolicyCRD = viper.GetBool(KeyEnableTracingPolicyCRD)
 
 	Config.TracingPolicy = viper.GetString(KeyTracingPolicy)
 
@@ -271,6 +273,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.String(KeyRBQueueSize, "65535", "Set size of channel between ring buffer and sensor go routines (default 65k, allows K/M/G suffix)")
 
 	flags.Bool(KeyEnablePodInfo, false, "Enable PodInfo custom resource")
+	flags.Bool(KeyEnableTracingPolicyCRD, true, "Enable TracingPolicy and TracingPolicyNamespaced custom resources")
 
 	flags.Bool(KeyExposeKernelAddresses, false, "Expose real kernel addresses in events stack traces")
 


### PR DESCRIPTION
Fixes #1880

## Tetragon
- new flag `enable-tracing-policy-crd` was added and enabled by default

## Tetragon operator
- new flag `skip-tracing-policy-crd` was added and disabled by default

## Helm chart
- two flags above were added into configmaps and values file
