### PR TITLE
Revert "chore(deps): update all github action artifacts to v4"

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -168,7 +168,7 @@ jobs:
 
       # Upload artifact digests
       - name: Upload artifact digests
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: image-digest clang
           path: image-digest
@@ -186,7 +186,7 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           path: image-digest/
 

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -215,7 +215,7 @@ jobs:
 
       # Upload artifact digests
       - name: Upload artifact digests
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: image-digest ${{ matrix.name }}
           path: image-digest
@@ -233,7 +233,7 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           path: image-digest/
 

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -147,7 +147,7 @@ jobs:
 
       # Upload artifact digests
       - name: Upload artifact digests
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: image-digest ${{ matrix.name }}
           path: image-digest
@@ -165,7 +165,7 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           path: image-digest/
 
@@ -213,7 +213,7 @@ jobs:
 
       # Cache tarball releases for later
       - name: Save tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz Tarball
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}
           path: release/
@@ -239,13 +239,13 @@ jobs:
         run: make cli-release
 
       - name: Retrieve tetragon-${{ steps.tag.outputs.tag }}-amd64.tar.gz
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: tetragon-${{ steps.tag.outputs.tag }}-amd64
           path: release
 
       - name: Retrieve tetragon-${{ steps.tag.outputs.tag }}-arm64.tar.gz
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: tetragon-${{ steps.tag.outputs.tag }}-arm64
           path: release

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Upload Tetragon logs
       if: failure()
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: tetragon-json
         path: /tmp/tetragon.gotest*
@@ -78,7 +78,7 @@ jobs:
 
     - name: Upload bugtool dumps
       if: failure()
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: tetragon-bugtool
         path: /tmp/tetragon-bugtool*

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Upload Tetragon Logs
       if: failure() || cancelled()
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: tetragon-logs
         path: /tmp/tetragon.e2e.*

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -55,7 +55,7 @@ jobs:
         tar cz --exclude='tetragon/.git' -f /tmp/tetragon.tar ./tetragon
 
     - name: upload build
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
          name: tetragon-build
          path: /tmp/tetragon.tar
@@ -98,7 +98,7 @@ jobs:
         sudo chmod go+rX -R /boot/
 
     - name: download build data
-      uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
          name: tetragon-build
 
@@ -143,7 +143,7 @@ jobs:
 
     - name: Upload test results on failure or cancelation
       if: failure() || cancelled()
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: tetragon-vmtests-${{ matrix.kernel }}-${{ matrix.group }}-results
         path: go/src/github.com/cilium/tetragon/tests/vmtests/vmtests-results-*
@@ -155,8 +155,7 @@ jobs:
     if: success()
     steps:
       # delete the built binaries from the artifacts in case of overall success
-      - uses: geekyeggo/delete-artifact@9d15d164b1dcd538ff1b1a2984bc2c0240986c3b # v4.0.0
+      - uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: tetragon-build
-


### PR DESCRIPTION
Temporary fix for https://github.com/cilium/tetragon/issues/1927.

This partially reverts commit eb4d9a2ba435f785c7f29d5f291eaa8d58ad22e6. Downgrade waiting for actions/download-artifact#249 being resolved.