### PR TITLE
workflows: bump bom version for race condition fix

### DIFF
--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -127,7 +127,7 @@ jobs:
         shell: bash
         env:
           # renovate: datasource=github-releases depName=kubernetes-sigs/bom
-          BOM_VERSION: v0.5.1
+          BOM_VERSION: f0ff48f9a202abfddf656056bbeeb8efe29920ab
         run: |
           go install sigs.k8s.io/bom/cmd/bom@${{ env.BOM_VERSION }}
 

--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -100,7 +100,7 @@ jobs:
         shell: bash
         env:
           # renovate: datasource=github-releases depName=kubernetes-sigs/bom
-          BOM_VERSION: v0.5.1
+          BOM_VERSION: f0ff48f9a202abfddf656056bbeeb8efe29920ab
         run: |
           go install sigs.k8s.io/bom/cmd/bom@${{ env.BOM_VERSION }}
 

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -98,7 +98,7 @@ jobs:
         shell: bash
         env:
           # renovate: datasource=github-releases depName=kubernetes-sigs/bom
-          BOM_VERSION: v0.5.1
+          BOM_VERSION: f0ff48f9a202abfddf656056bbeeb8efe29920ab
         run: |
           go install sigs.k8s.io/bom/cmd/bom@${{ env.BOM_VERSION }}
 


### PR DESCRIPTION
Fixes https://github.com/cilium/tetragon/issues/1894.

We experienced #1894, which made me create kubernetes-sigs/bom#385 only to fix the race condition and realize that it was already patched but no release existed.