### PR TITLE
killer sensor: improve testing

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -119,6 +119,7 @@ jobs:
                 --kernel ${kimage} \
                 --kernel-ver  ${{ matrix.kernel }} \
                 --base tests/vmtests/test-data/images/base.qcow2 \
+                --enable-detailed-results \
                 --testsfile ./tests/vmtests/test-group-${{ matrix.group }}
 
     - name: test kernel ${{ matrix.kernel }} with btf file
@@ -134,6 +135,7 @@ jobs:
                 --kernel-ver  ${{ matrix.kernel }} \
                 --btf-file ${btf} \
                 --base tests/vmtests/test-data/images/base.qcow2 \
+                --enable-detailed-results \
                 --testsfile ./tests/vmtests/test-group-${{ matrix.group }}
 
     - name: Chmod test results on failure or cancelation

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -66,17 +66,17 @@ jobs:
         matrix:
            kernel:
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - 'bpf-next-20231215.012940'
+              - 'bpf-next-20240108.012952'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '6.1-20231128.100518'
+              - '6.1-20231220.153727'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '5.15-20231128.100518'
+              - '5.15-20231220.153727'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '5.10-20231128.100518'
+              - '5.10-20231220.153727'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '5.4-20231128.100518'
+              - '5.4-20231220.153727'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '4.19-20231128.100518'
+              - '4.19-20231220.153727'
            group:
               - 0
     concurrency:

--- a/cmd/tetragon-vmtests-run/conf.go
+++ b/cmd/tetragon-vmtests-run/conf.go
@@ -27,6 +27,8 @@ type RunConf struct {
 	disableUnifiedCgroups bool
 	portForwards          runner.PortForwards
 	testerConf            vmtests.Conf
+	detailedResults       bool
+	keepAllLogs           bool
 
 	filesystems []QemuFS
 }

--- a/cmd/tetragon-vmtests-run/main.go
+++ b/cmd/tetragon-vmtests-run/main.go
@@ -125,6 +125,11 @@ func main() {
 				return errors.New("failed")
 			}
 
+			if results.nrSkipedTests == results.nrTests {
+				fmt.Printf("All %d tests were skipped 🤔 (took: %s, skipped:%d)\n", results.nrTests, dur, results.nrSkipedTests)
+				return nil
+			}
+
 			fmt.Printf("All %d tests succeeded! 🎉🚢🍕 (took: %s, skipped:%d)\n", results.nrTests, dur, results.nrSkipedTests)
 			return nil
 		},

--- a/cmd/tetragon-vmtests-run/main.go
+++ b/cmd/tetragon-vmtests-run/main.go
@@ -35,6 +35,12 @@ func main() {
 				return fmt.Errorf("error parseing ports: %w", err)
 			}
 
+			// Keep all logs if user asked for it, or if user asked for detailed results
+			// since we need the log files to generate them.
+			if rcnf.keepAllLogs || rcnf.detailedResults {
+				rcnf.testerConf.KeepAllLogs = true
+			}
+
 			// Hardcoded (for now):
 			// mount cwd as cwd in the VM (this helps with contrib/test-progs paths)
 			// set output to be <cwd>/tester-tetragon.out.
@@ -150,10 +156,11 @@ func main() {
 	cmd.Flags().StringVar(&rcnf.testerConf.TestsFile, "testsfile", "", "list of tests to run")
 	cmd.Flags().StringVar(&rcnf.btfFile, "btf-file", "", "BTF file to use.")
 	cmd.Flags().BoolVar(&rcnf.testerConf.FailFast, "fail-fast", false, "Exit as soon as an error is encountered.")
-	cmd.Flags().BoolVar(&rcnf.testerConf.KeepAllLogs, "keep-all-logs", false, "Normally, logs are kept only for failed tests. This switch keeps all logs.")
+	cmd.Flags().BoolVar(&rcnf.keepAllLogs, "keep-all-logs", false, "Normally, logs are kept only for failed tests. This switch keeps all logs.")
 	cmd.Flags().BoolVar(&rcnf.disableUnifiedCgroups, "disable-unified-cgroups", false, "boot with systemd.unified_cgroup_hierarchy=0.")
 	cmd.Flags().StringArrayVarP(&ports, "port", "p", nil, "Forward a port (hostport[:vmport[:tcp|udp]])")
 	cmd.Flags().StringVar(&rcnf.testerConf.KernelVer, "kernel-ver", "", "kenel version")
+	cmd.Flags().BoolVar(&rcnf.detailedResults, "enable-detailed-results", false, "produce detailed results")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/tetragon-vmtests-run/run_tests.go
+++ b/cmd/tetragon-vmtests-run/run_tests.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 
 type runTestsResults struct {
 	nrTests, nrFailedTests, nrSkipedTests int
+	totalDuration                         time.Duration
 }
 
 func runTests(
@@ -66,28 +68,153 @@ func runTests(
 		results = append(results, result)
 	}
 
-	var totalDuration time.Duration
-	errCnt := 0
-	skipCnt := 0
+	var out runTestsResults
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
-	for _, r := range results {
-		totalDuration += r.Duration
-		ok := "✅"
-		if r.Error {
-			ok = "❌"
-			errCnt++
-		} else if r.Skip {
-			ok = "⏭️"
-			skipCnt++
+	for _, res := range results {
+		// NB: res.Skip means that the test was never executed, so we cannot print detailed
+		// results.
+		if rcnf.detailedResults && res.Outfile != "" && !res.Skip {
+			updateResultsDetailed(w, &res, &out)
+		} else {
+			updateResultsSimple(w, &res, &out)
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t(%s)\n", ok, r.Name, r.Duration.Round(time.Millisecond), totalDuration.Round(time.Millisecond))
 	}
 	w.Flush()
 
-	return &runTestsResults{
-		nrTests:       len(results),
-		nrFailedTests: errCnt,
-		nrSkipedTests: skipCnt,
-	}, nil
+	return &out, nil
+}
+
+func updateResultsSimple(w io.Writer, res *vmtests.Result, out *runTestsResults) {
+	out.nrTests++
+	out.totalDuration += res.Duration
+	ok := "✅"
+	if res.Error {
+		ok = "❌"
+		out.nrFailedTests++
+	} else if res.Skip {
+		// "⏭️"
+		// ok = "\u23E9"
+		out.nrSkipedTests++
+	}
+	fmt.Fprintf(w, "%s\t%s\t%s\t(%s)\n", ok, res.Name, res.Duration.Round(time.Millisecond), out.totalDuration.Round(time.Millisecond))
+}
+
+// see: https://pkg.go.dev/cmd/test2json
+type TestEvent struct {
+	Time    time.Time // encodes as an RFC3339-format string
+	Action  string
+	Package string
+	Test    string
+	Elapsed float64 // seconds
+	Output  string
+}
+
+func updateResultsDetailed(w io.Writer, res *vmtests.Result, out *runTestsResults) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	f, err := os.Open(res.Outfile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error openning %s: %v", res.Outfile, res)
+		updateResultsSimple(w, res, out)
+		return
+	}
+	defer f.Close()
+
+	prog := "go"
+	// NB: we need -t to enable timestamps and get the Elapsed field
+	args := []string{"tool", "test2json", "-t"}
+	cmd := exec.CommandContext(ctx, prog, args...)
+	cmd.Stdin = f
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error executing test2json: %v", res)
+		updateResultsSimple(w, res, out)
+		return
+	}
+	buff := bytes.NewBuffer(output)
+	scanner := bufio.NewScanner(buff)
+
+	var totalDuration time.Duration
+
+	type detail struct {
+		name string
+		icon string
+		dur  time.Duration
+	}
+	var details []detail
+
+	nrTests := 0
+	nrSkippedTests := 0
+	nrFailedTests := 0
+	for scanner.Scan() {
+		var tevent TestEvent
+		line := scanner.Bytes()
+		err := json.Unmarshal(line, &tevent)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing: '%s': %v, bailing out", line, err)
+			updateResultsSimple(w, res, out)
+			return
+		}
+		if tevent.Test == "" {
+			continue
+		}
+
+		var icon string
+		switch tevent.Action {
+		case "skip":
+			nrSkippedTests++
+			// "⚡"
+			icon = "\u26a1"
+		case "pass":
+			icon = "✅"
+		case "fail":
+			nrFailedTests++
+			icon = "❌"
+		default:
+			continue
+		}
+
+		nrTests++
+		dur := time.Duration(float64(time.Second) * tevent.Elapsed)
+		details = append(details, detail{name: tevent.Test, icon: icon, dur: dur})
+
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "Scanner failed: %v, bailing out", err)
+		updateResultsSimple(w, res, out)
+		return
+	}
+
+	out.totalDuration += res.Duration
+	out.nrTests += nrTests
+	out.nrSkipedTests += nrSkippedTests
+	out.nrFailedTests += nrFailedTests
+
+	icon := "✅"
+	if res.Error {
+		icon = "❌"
+	} else if nrSkippedTests == nrTests {
+		// "⚡"
+		icon = "\u26a1"
+	} else if nrFailedTests > 0 {
+		// NB(kkourt): res.Error should not be false
+		icon = "⁉️"
+	}
+
+	fmt.Fprintf(w, "%s\t%s\t(total:%d failed:%d skipped:%d)\t%s\t%s\n", icon, res.Name, nrTests, nrFailedTests, nrSkippedTests, res.Duration, out.totalDuration)
+	if len(details) > 1 {
+		for i, detail := range details {
+			totalDuration += detail.dur
+			if i == len(details)-1 {
+				fmt.Fprintf(w, "└─%s\t%s\t%s\t(%s)\n", detail.icon, detail.name, detail.dur.Round(time.Millisecond), totalDuration)
+			} else {
+				fmt.Fprintf(w, "├─%s\t%s\t%s\t(%s)\n", detail.icon, detail.name, detail.dur.Round(time.Millisecond), totalDuration)
+			}
+		}
+	}
+
 }

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -68,8 +68,9 @@ uprobe-test-2: uprobe-test-1
 	cp uprobe-test-1 uprobe-test-2
 
 # -m32 is an x86_64 flag.
+# NB(kkourt) we compile this as static to avoid the need for ia32 libs in VMs
 killer-tester-32: killer-tester.c
-	$(GCC) -Wall -m32 $< -o $@
+	$(GCC) -Wall -m32 -static $< -o $@
 
 lseek-pipe: FORCE
 	go build -o lseek-pipe ./go/lseek-pipe

--- a/pkg/vmtests/vmtests.go
+++ b/pkg/vmtests/vmtests.go
@@ -122,7 +122,7 @@ func Run(cnf *Conf) error {
 		if testFile[0] != '/' {
 			testFile = filepath.Join(cnf.TetragonDir, testFile)
 		}
-		tests, err = LoadTestsFromFile(testFile)
+		tests, err = LoadTestsFromFile(testDir, testFile)
 		if err != nil {
 			return err
 		}

--- a/pkg/vmtests/vmtests.go
+++ b/pkg/vmtests/vmtests.go
@@ -160,8 +160,10 @@ func Run(cnf *Conf) error {
 		prog := filepath.Join(testDir, name)
 		progArgs := []string{"-test.v"}
 		if test.Test != "" {
-			t := test.Test
-			name = fmt.Sprintf("%s.%s", name, t)
+			name = fmt.Sprintf("%s.%s", name, test.Test)
+			// It is possible that a test is a substring of another. Use a strict
+			// pattern so that we execute only the specified test.
+			t := fmt.Sprintf("^%s$", test.Test)
 			progArgs = append(progArgs, "-test.run", t)
 		}
 


### PR DESCRIPTION
This PR aims address the fact that our killer sensor tests were always skipped and we never noticed.

The reason was that our CI kernels were not configured with `CONFIG_BPF_KPROBE_OVERRIDE`. This was fixed in https://github.com/cilium/little-vm-helper-images/pull/286.

Adding the new kernel images  (https://github.com/cilium/tetragon/pull/1907) lead to some test failures that are meant to be addressed in this PR. This was because our CI did not have a ia32 libc: this is addressed by compiling the ia32 program statically


The only way to note that the tests were skipped using` t.Skip()` was to execute them manually and check the logs. This is not ideal, so  this PR adds support to the vmtests for providing detailed results that show what tests are actually skipped and what tests are not.

We introduce a new symbol for the tests that are skipped using `t.Skip()`: ⚡

Parsing the detailed results allows us to also report sub-tests (i.e., tests executed with t.Run()).

Here's an output example:

```
✅      pkg.sensors.tracing.Test_Kprobe_DisableEnablePolicy                                     (total:3 failed:0 skipped:0)    2.680496982s    1m33.952671893s
├─✅    Test_Kprobe_DisableEnablePolicy/sensor                                                  1.05s                           (1.05s)
├─✅    Test_Kprobe_DisableEnablePolicy/tracing-policy                                          1.09s                           (2.14s)
└─✅    Test_Kprobe_DisableEnablePolicy                                                         2.56s                           (4.7s)
⚡      pkg.sensors.tracing.TestKillerOverride32                                                (total:1 failed:0 skipped:1)    130.759191ms    1m34.083431084s
⚡      pkg.sensors.tracing.TestKillerSignal32                                                  (total:1 failed:0 skipped:1)    132.393451ms    1m34.215824535s
⚡      pkg.sensors.tracing.TestKillerOverrideBothBits                                          (total:1 failed:0 skipped:1)    119.455061ms    1m34.335279596s
⚡      pkg.sensors.tracing.TestKillerOverride                                                  (total:1 failed:0 skipped:1)    121.255148ms    1m34.456534744s
⚡      pkg.sensors.tracing.TestKillerSignal                                                    (total:1 failed:0 skipped:1)    136.665421ms    1m34.593200165s
✅      pkg.sensors.tracing.TestKillerMulti                                                     (total:1 failed:0 skipped:0)    132.761861ms    1m34.
```

Note that above is just an example. Killer tests are no longer skipped in kernels other than 4.19:
```
✅	pkg.sensors.tracing.TestKillerOverride32						(total:1 failed:0 skipped:0)	5.387274581s	2m32.342462607s
✅	pkg.sensors.tracing.TestKillerSignal32							(total:1 failed:0 skipped:0)	5.502833907s	2m37.845296514s
✅	pkg.sensors.tracing.TestKillerOverrideBothBits						(total:1 failed:0 skipped:0)	5.436053879s	2m43.281350393s
✅	pkg.sensors.tracing.TestKillerOverride32						(total:1 failed:0 skipped:0)	5.477340976s	2m48.758691369s
✅	pkg.sensors.tracing.TestKillerOverrideBothBits						(total:1 failed:0 skipped:0)	5.398464379s	2m54.157155748s
✅	pkg.sensors.tracing.TestKillerOverride							(total:1 failed:0 skipped:0)	2.410312467s	2m56.567468215s
✅	pkg.sensors.tracing.TestKillerSignal32							(total:1 failed:0 skipped:0)	5.409613867s	3m1.977082082s
✅	pkg.sensors.tracing.TestKillerSignal							(total:1 failed:0 skipped:0)	2.470995213s	3m4.448077295s
✅	pkg.sensors.tracing.TestKillerMulti							(total:1 failed:0 skipped:0)	498.18272ms	3m4.946260015s
```

A subsequent PR (https://github.com/cilium/tetragon/pull/1953) will add:
 * support for `fmod_ret` for kernels that do not provide `CONFIG_BPF_KPROBE_OVERRIDE`.
 * the ability to test all different combinations in our kernels. For example, we should test both killer sensors with `fmod_ret` and `bpf_override_return` in our CI kernels where `CONFIG_BPF_KPROBE_OVERRIDE` is set.
 * a check in the killer sensor on whether the bpf_send_signal is supported
