### PR TITLE
policyfilter: add a label that allows to filter based on namespaces

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -20,6 +20,10 @@ const (
 	opNotIn
 )
 
+const (
+	K8sPodNamespace = "k8s:io.kubernetes.pod.namespace"
+)
+
 type selectorOp struct {
 	key      string
 	operator operator

--- a/pkg/policyfilter/state.go
+++ b/pkg/policyfilter/state.go
@@ -204,8 +204,18 @@ func (pol *policy) podMatches(podNs string, podLabels labels.Labels) bool {
 	if pol.namespace != "" && podNs != pol.namespace {
 		return false
 	}
+	var podLabels1 labels.Labels
+	if podLabels != nil {
+		podLabels1 = podLabels
+	} else {
+		podLabels1 = make(labels.Labels)
+	}
 
-	return pol.podSelector.Match(podLabels)
+	if _, ok := podLabels1[labels.K8sPodNamespace]; !ok {
+		podLabels1[labels.K8sPodNamespace] = podNs
+	}
+
+	return pol.podSelector.Match(podLabels1)
 }
 
 func (pol *policy) podInfoMatches(pod *podInfo) bool {


### PR DESCRIPTION
Closes #1854 

Allow policy pod-label filters to use a label depicting the namespace of the pod k8s:io.kubernetes.pod.namespace

```release-note
policy pod-label filters: allow for namespace filtering using k8s:io.kubernetes.pod.namespace
```