### PR TITLE
killer sensor: add support for fmod_ret

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -21,7 +21,7 @@ PROCESS = bpf_execve_event.o bpf_execve_event_v53.o bpf_fork.o bpf_exit.o bpf_ge
 	  bpf_multi_kprobe_v61.o bpf_multi_retkprobe_v61.o \
 	  bpf_generic_uprobe_v61.o \
 	  bpf_loader.o \
-	  bpf_killer.o bpf_multi_killer.o
+	  bpf_killer.o bpf_multi_killer.o bpf_fmodret_killer.o
 
 CGROUP = bpf_cgroup_mkdir.o bpf_cgroup_rmdir.o bpf_cgroup_release.o
 BPFTEST = bpf_lseek.o bpf_globals.o
@@ -75,6 +75,30 @@ objs/%.ll: $(ALIGNCHECKERDIR)%.c
 $(DEPSDIR)%.d: $(ALIGNCHECKERDIR)%.c
 	$(CLANG) $(CLANG_FLAGS) -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
 
+
+# Killer programs: bpf_killer, bpf_multi_killer, bpf_fmodret_killer
+
+## bpf_killer: __BPF_OVERRIDE_RETURN, but no __MULTI_KPROBE
+objs/bpf_killer.ll: process/bpf_killer.c
+	$(CLANG) $(CLANG_FLAGS) -D__BPF_OVERRIDE_RETURN -c $< -o $@
+
+$(DEPSDIR)bpf_killer.d: process/bpf_killer.c
+	$(CLANG) $(CLANG_FLAGS) -D__BPF_OVERRIDE_RETURN -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@) $< > $@
+
+## bpf_multi_killer: __BPF_OVERRIDE_RETURN and __MULTI_KPROBE
+objs/bpf_multi_killer.ll: process/bpf_killer.c
+	$(CLANG) $(CLANG_FLAGS) -D__BPF_OVERRIDE_RETURN -D__MULTI_KPROBE -c $< -o $@
+
+$(DEPSDIR)/bpf_multi_killer.d: process/bpf_killer.c
+	$(CLANG) $(CLANG_FLAGS) -D__BPF_OVERRIDE_RETURN -D__MULTI_KPROBE -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@) $< > $@
+
+## bpf_fmodret_killer no bpf_override_return: we need fmod_ret
+objs/bpf_fmodret_killer.ll: process/bpf_killer.c
+	$(CLANG) $(CLANG_FLAGS) -c $< -o $@
+
+$(DEPSDIR)/bpf_fmodret_killer.d: process/bpf_killer.c
+	$(CLANG) $(CLANG_FLAGS) -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@) $< > $@
+
 # PROCESSDIR
 objs/%.ll: $(PROCESSDIR)%.c
 	$(CLANG) $(CLANG_FLAGS) -c $< -o $@
@@ -88,11 +112,6 @@ objs/%_v53.ll:
 $(DEPSDIR)%.d: $(PROCESSDIR)%.c
 	$(CLANG) $(CLANG_FLAGS) -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@
 
-objs/bpf_multi_killer.ll: process/bpf_killer.c
-	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__MULTI_KPROBE -c $< -o $@
-
-$(DEPSDIR)/bpf_multi_killer.d: process/bpf_killer.c
-	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -D__MULTI_KPROBE -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@) $< > $@
 
 $(DEPSDIR)%_v53.d:
 	$(CLANG) $(CLANG_FLAGS) -D__LARGE_BPF_PROG -MM -MP -MT $(patsubst $(DEPSDIR)%.d, $(OBJSDIR)%.ll, $@)   $< > $@

--- a/bpf/lib/bpf_task.h
+++ b/bpf/lib/bpf_task.h
@@ -158,12 +158,13 @@ static inline __attribute__((always_inline)) struct execve_map_value *
 event_find_curr(__u32 *ppid, bool *walked)
 {
 	struct task_struct *task = (struct task_struct *)get_current_task();
-	__u32 pid = get_current_pid_tgid() >> 32;
 	struct execve_map_value *value = 0;
 	int i;
+	__u32 pid;
 
 #pragma unroll
 	for (i = 0; i < 4; i++) {
+		probe_read(&pid, sizeof(pid), _(&task->tgid));
 		value = execve_map_get_noinit(pid);
 		if (value && value->key.ktime != 0)
 			break;
@@ -172,7 +173,6 @@ event_find_curr(__u32 *ppid, bool *walked)
 		probe_read(&task, sizeof(task), _(&task->real_parent));
 		if (!task)
 			break;
-		probe_read(&pid, sizeof(pid), _(&task->tgid));
 	}
 	*ppid = pid;
 	return value;

--- a/bpf/process/bpf_killer.c
+++ b/bpf/process/bpf_killer.c
@@ -2,14 +2,8 @@
 
 char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
 
-#ifdef __MULTI_KPROBE
-#define MAIN "kprobe.multi/killer"
-#else
-#define MAIN "kprobe/killer"
-#endif
-
-__attribute__((section(MAIN), used)) int
-killer(void *ctx)
+static inline __attribute__((always_inline)) int
+do_killer(void *ctx)
 {
 	__u64 id = get_current_pid_tgid();
 	struct killer_data *data;
@@ -18,11 +12,42 @@ killer(void *ctx)
 	if (!data)
 		return 0;
 
-	if (data->error)
-		override_return(ctx, data->error);
 	if (data->signal)
 		send_signal(data->signal);
 
 	map_delete_elem(&killer_data, &id);
+	return data->error;
+}
+
+#if defined(__BPF_OVERRIDE_RETURN)
+
+#ifdef __MULTI_KPROBE
+#define MAIN "kprobe.multi/killer"
+#else
+#define MAIN "kprobe/killer"
+#endif
+
+__attribute__((section(MAIN), used)) int
+multi_kprobe_killer(void *ctx)
+{
+	long ret;
+
+	ret = do_killer(ctx);
+	if (ret)
+		override_return(ctx, ret);
+
 	return 0;
 }
+
+#else /* !__BPF_OVERRIDE_RETURN */
+
+/* Putting security_task_prctl in here to pass contrib/verify/verify.sh test,
+ * in normal run the function is set by tetragon dynamically.
+ */
+__attribute__((section("fmod_ret/security_task_prctl"), used)) long
+fmodret_killer(void *ctx)
+{
+	return do_killer(ctx);
+}
+
+#endif

--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -17,3 +17,4 @@ threads-tester
 bench-reader
 threads-exit
 killer-tester
+killer-tester-32

--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -18,3 +18,4 @@ bench-reader
 threads-exit
 killer-tester
 killer-tester-32
+/getcpu

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -19,7 +19,8 @@ PROGS = sigkill-tester \
 	bench-reader \
 	threads-exit \
 	killer-tester \
-	drop-privileges
+	drop-privileges \
+	getcpu
 
 # For now killer-tester is compiled to 32-bit only on x86_64 as we want
 # to test 32-bit binaries and system calls compatibility layer.
@@ -78,6 +79,9 @@ killer-tester-32: killer-tester.c
 
 lseek-pipe: FORCE
 	go build -o lseek-pipe ./go/lseek-pipe
+
+getcpu: FORCE
+	go build -o getcpu ./go/getcpu
 
 .PHONY: clean
 clean:

--- a/contrib/tester-progs/go/getcpu/getcpu.go
+++ b/contrib/tester-progs/go/getcpu/getcpu.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package main
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	var cpu, node int
+	_, _, err := unix.Syscall(
+		unix.SYS_GETCPU,
+		uintptr(unsafe.Pointer(&cpu)),
+		uintptr(unsafe.Pointer(&node)),
+		0,
+	)
+	os.Exit(int(err))
+}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -553,18 +553,17 @@ func createGenericKprobeSensor(
 	kprobes := spec.KProbes
 	lists := spec.Lists
 
-	options, err := getKprobeOptions(spec.Options)
+	specOpts, err := getSpecOptions(spec.Options)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set options: %s", err)
+		return nil, fmt.Errorf("failed to get spec options: %s", err)
 	}
 
 	// use multi kprobe only if:
 	// - it's not disabled by spec option
 	// - it's not disabled by command line option
 	// - there's support detected
-	if !options.DisableKprobeMulti {
-		useMulti = !option.Config.DisableKprobeMulti &&
-			bpf.HasKprobeMulti()
+	if !specOpts.DisableKprobeMulti {
+		useMulti = !option.Config.DisableKprobeMulti && bpf.HasKprobeMulti()
 	}
 
 	if useMulti {

--- a/pkg/sensors/tracing/killer.go
+++ b/pkg/sensors/tracing/killer.go
@@ -115,7 +115,7 @@ func selectOverrideMethod(specOpts *specOptions) (OverrideMethod, error) {
 		// by default, first try OverrideReturn and if this does not work try fmod_ret
 		if bpf.HasOverrideHelper() {
 			overrideMethod = OverrideMethodReturn
-		} else if bpf.HasModifyReturn() {
+		} else if bpf.HasModifyReturnSyscall() {
 			overrideMethod = OverrideMethodFmodRet
 		} else {
 			return OverrideMethodInvalid, fmt.Errorf("no override helper or mod_ret support: cannot load killer")
@@ -125,7 +125,7 @@ func selectOverrideMethod(specOpts *specOptions) (OverrideMethod, error) {
 			return OverrideMethodInvalid, fmt.Errorf("option override return set, but it is not supported")
 		}
 	case OverrideMethodFmodRet:
-		if !bpf.HasModifyReturn() {
+		if !bpf.HasModifyReturnSyscall() {
 			return OverrideMethodInvalid, fmt.Errorf("option fmod_ret set, but it is not supported")
 		}
 	}

--- a/pkg/sensors/tracing/killer.go
+++ b/pkg/sensors/tracing/killer.go
@@ -20,6 +20,10 @@ import (
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
 
+const (
+	killerDataMapName = "killer_data"
+)
+
 type killerHandler struct {
 	configured   bool
 	syscallsSyms []string
@@ -233,7 +237,7 @@ func (kh *killerHandler) createKillerSensor(
 		return nil, fmt.Errorf("unexpected override method: %d", overrideMethod)
 	}
 
-	killerDataMap := program.MapBuilderPin("killer_data", "killer_data", load)
+	killerDataMap := program.MapBuilderPin(killerDataMapName, killerDataMapName, load)
 	maps = append(maps, killerDataMap)
 
 	return &sensors.Sensor{

--- a/pkg/sensors/tracing/killer.go
+++ b/pkg/sensors/tracing/killer.go
@@ -160,6 +160,10 @@ func createKillerSensor(
 		useMulti = !option.Config.DisableKprobeMulti && bpf.HasKprobeMulti()
 	}
 
+	if !bpf.HasSignalHelper() {
+		return nil, fmt.Errorf("killer sensor requires signal helper which is not available")
+	}
+
 	prog := sensors.PathJoin(name, "killer_kprobe")
 	if bpf.HasOverrideHelper() {
 		attach := fmt.Sprintf("%d syscalls: %s", len(syscallsSyms), syscallsSyms)

--- a/pkg/sensors/tracing/killer_amd64_test.go
+++ b/pkg/sensors/tracing/killer_amd64_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/syscallinfo/i386"
 	"github.com/cilium/tetragon/pkg/testutils"
 
@@ -20,12 +19,7 @@ import (
 )
 
 func TestKillerOverride32(t *testing.T) {
-	if !bpf.HasOverrideHelper() && !bpf.HasModifyReturn() {
-		t.Skip("skipping killer test, neither bpf_override_return nor fmod_ret is available")
-	}
-	if !bpf.HasSignalHelper() {
-		t.Skip("skipping killer test, bpf_send_signal helper not available")
-	}
+	testKillerCheckSkip(t)
 
 	test := testutils.RepoRootPath("contrib/tester-progs/killer-tester-32")
 	yaml := NewKillerSpecBuilder("killer-override").
@@ -54,12 +48,7 @@ func TestKillerOverride32(t *testing.T) {
 }
 
 func TestKillerSignal32(t *testing.T) {
-	if !bpf.HasOverrideHelper() && !bpf.HasModifyReturn() {
-		t.Skip("skipping killer test, bpf_override_return helper not available")
-	}
-	if !bpf.HasSignalHelper() {
-		t.Skip("skipping killer test, bpf_send_signal helper not available")
-	}
+	testKillerCheckSkip(t)
 
 	test := testutils.RepoRootPath("contrib/tester-progs/killer-tester-32")
 	yaml := NewKillerSpecBuilder("killer-signal").
@@ -89,12 +78,7 @@ func TestKillerSignal32(t *testing.T) {
 }
 
 func TestKillerOverrideBothBits(t *testing.T) {
-	if !bpf.HasOverrideHelper() && !bpf.HasModifyReturn() {
-		t.Skip("skipping killer test, bpf_override_return helper not available")
-	}
-	if !bpf.HasSignalHelper() {
-		t.Skip("skipping killer test, bpf_send_signal helper not available")
-	}
+	testKillerCheckSkip(t)
 
 	test32 := testutils.RepoRootPath("contrib/tester-progs/killer-tester-32")
 	test64 := testutils.RepoRootPath("contrib/tester-progs/killer-tester")

--- a/pkg/sensors/tracing/killer_builder.go
+++ b/pkg/sensors/tracing/killer_builder.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"fmt"
+	"log"
+
+	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/option"
+)
+
+type KillerSpecBuilder struct {
+	name           string
+	syscalls       [][]string
+	kill           *uint32
+	override       *int32
+	binaries       []string
+	overrideMethod string
+	multiKprobe    *bool
+}
+
+func NewKillerSpecBuilder(name string) *KillerSpecBuilder {
+	return &KillerSpecBuilder{
+		name: name,
+	}
+}
+
+func (ksb *KillerSpecBuilder) WithSyscallList(calls ...string) *KillerSpecBuilder {
+	ksb.syscalls = append(ksb.syscalls, calls)
+	return ksb
+}
+
+func (ksb *KillerSpecBuilder) WithKill(sig uint32) *KillerSpecBuilder {
+	ksb.kill = &sig
+	return ksb
+}
+
+func (ksb *KillerSpecBuilder) WithMultiKprobe() *KillerSpecBuilder {
+	multi := true
+	ksb.multiKprobe = &multi
+	return ksb
+}
+
+func (ksb *KillerSpecBuilder) WithoutMultiKprobe() *KillerSpecBuilder {
+	multi := false
+	ksb.multiKprobe = &multi
+	return ksb
+}
+
+func (ksb *KillerSpecBuilder) WithOverrideValue(ret int32) *KillerSpecBuilder {
+	ksb.override = &ret
+	return ksb
+}
+
+func (ksb *KillerSpecBuilder) WithMatchBinaries(bins ...string) *KillerSpecBuilder {
+	ksb.binaries = append(ksb.binaries, bins...)
+	return ksb
+}
+
+func (ksb *KillerSpecBuilder) WithOverrideReturn() *KillerSpecBuilder {
+	ksb.overrideMethod = valOverrideReturn
+	return ksb
+}
+
+func (ksb *KillerSpecBuilder) WithFmodRet() *KillerSpecBuilder {
+	ksb.overrideMethod = valFmodRet
+	return ksb
+
+}
+
+func (ksb *KillerSpecBuilder) WithDefaultOverride() *KillerSpecBuilder {
+	ksb.overrideMethod = ""
+	return ksb
+}
+
+func (ksb *KillerSpecBuilder) MustBuild() *v1alpha1.TracingPolicy {
+	spec, err := ksb.Build()
+	if err != nil {
+		log.Fatalf("MustBuild failed with %v", err)
+	}
+	return spec
+}
+
+func (ksb *KillerSpecBuilder) MustYAML() string {
+	tp, err := ksb.Build()
+	if err != nil {
+		log.Fatalf("MustYAML: build failed with %v", err)
+	}
+
+	b, err := yaml.Marshal(tp)
+	if err != nil {
+		log.Fatalf("MustYAML: marshal failed with %v", err)
+	}
+	return string(b)
+}
+
+func (ksb *KillerSpecBuilder) Build() (*v1alpha1.TracingPolicy, error) {
+
+	var listNames []string
+	var lists []v1alpha1.ListSpec
+	var killers []v1alpha1.KillerSpec
+	var matchBinaries []v1alpha1.BinarySelector
+	var options []v1alpha1.OptionSpec
+
+	for i, syscallList := range ksb.syscalls {
+		var name string
+		if len(ksb.syscalls) > 1 {
+			name = fmt.Sprintf("%s-%d", ksb.name, i+1)
+		} else {
+			name = ksb.name
+		}
+		listName := fmt.Sprintf("list:%s", name)
+		listNames = append(listNames, listName)
+		lists = append(lists, v1alpha1.ListSpec{
+			Name:      name,
+			Type:      "syscalls",
+			Values:    syscallList,
+			Pattern:   nil,
+			Validated: false,
+		})
+		killers = append(killers, v1alpha1.KillerSpec{
+			Syscalls: []string{listName},
+		})
+	}
+
+	actions := []v1alpha1.ActionSelector{{Action: "NotifyKiller"}}
+	act := &actions[0]
+	if ksb.kill == nil && ksb.override == nil {
+		return nil, fmt.Errorf("need either override or kill to notify killer")
+	}
+	if ksb.kill != nil {
+		act.ArgSig = *ksb.kill
+	}
+	if ksb.override != nil {
+		act.ArgError = *ksb.override
+	}
+
+	if len(ksb.binaries) > 0 {
+		matchBinaries = []v1alpha1.BinarySelector{{
+			Operator: "In",
+			Values:   ksb.binaries,
+		}}
+	}
+
+	if ksb.overrideMethod != "" {
+		options = append(options, v1alpha1.OptionSpec{
+			Name:  keyOverrideMethod,
+			Value: ksb.overrideMethod,
+		})
+	}
+
+	if ksb.multiKprobe != nil {
+		options = append(options, v1alpha1.OptionSpec{
+			Name:  option.KeyDisableKprobeMulti,
+			Value: fmt.Sprintf("%t", *ksb.multiKprobe),
+		})
+	}
+
+	// NB: We might want to add options for these in the future
+	syscallIDTy := "syscall64"
+	operator := "InMap"
+
+	return &v1alpha1.TracingPolicy{
+		TypeMeta: k8sv1.TypeMeta{
+			Kind:       "TracingPolicy",
+			APIVersion: "cilium.io/v1alpha1",
+		},
+		ObjectMeta: k8sv1.ObjectMeta{
+			Name: ksb.name,
+		},
+		Spec: v1alpha1.TracingPolicySpec{
+			Lists: lists,
+			Tracepoints: []v1alpha1.TracepointSpec{{
+				Subsystem: "raw_syscalls",
+				Event:     "sys_enter",
+				Args: []v1alpha1.KProbeArg{{
+					Index: 4,
+					Type:  syscallIDTy,
+				}},
+				Selectors: []v1alpha1.KProbeSelector{{
+					MatchArgs: []v1alpha1.ArgSelector{{
+						Index:    0,
+						Operator: operator,
+						Values:   listNames,
+					}},
+					MatchActions:  actions,
+					MatchBinaries: matchBinaries,
+				}},
+			}},
+			Killers: killers,
+			Options: options,
+		},
+	}, nil
+}

--- a/pkg/sensors/tracing/killer_test.go
+++ b/pkg/sensors/tracing/killer_test.go
@@ -24,6 +24,15 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func testKillerCheckSkip(t *testing.T) {
+	if !bpf.HasSignalHelper() {
+		t.Skip("skipping killer test, bpf_send_signal helper not available")
+	}
+	if !bpf.HasOverrideHelper() && !bpf.HasModifyReturnSyscall() {
+		t.Skip("skipping test, neither bpf_override_return nor fmod_ret for syscalls is available")
+	}
+}
+
 func testKiller(t *testing.T, configHook string,
 	test string, test2 string,
 	checker *eventchecker.UnorderedEventChecker,
@@ -64,9 +73,7 @@ func testKiller(t *testing.T, configHook string,
 }
 
 func TestKillerOverride(t *testing.T) {
-	if !bpf.HasSignalHelper() {
-		t.Skip("skipping killer test, bpf_send_signal helper not available")
-	}
+	testKillerCheckSkip(t)
 
 	test := testutils.RepoRootPath("contrib/tester-progs/getcpu")
 	builder := func() *KillerSpecBuilder {
@@ -120,12 +127,7 @@ func TestKillerOverride(t *testing.T) {
 }
 
 func TestKillerSignal(t *testing.T) {
-	if !bpf.HasOverrideHelper() && !bpf.HasModifyReturn() {
-		t.Skip("skipping killer test, neither bpf_override_return nor fmod_ret is available")
-	}
-	if !bpf.HasSignalHelper() {
-		t.Skip("skipping killer test, bpf_send_signal helper not available")
-	}
+	testKillerCheckSkip(t)
 
 	test := testutils.RepoRootPath("contrib/tester-progs/killer-tester")
 

--- a/pkg/sensors/tracing/killer_test.go
+++ b/pkg/sensors/tracing/killer_test.go
@@ -63,7 +63,7 @@ func testKiller(t *testing.T, configHook string,
 }
 
 func TestKillerOverride(t *testing.T) {
-	if !bpf.HasOverrideHelper() {
+	if !bpf.HasOverrideHelper() && !bpf.HasModifyReturn() {
 		t.Skip("skipping killer test, bpf_override_return helper not available")
 	}
 	if !bpf.HasSignalHelper() {

--- a/pkg/sensors/tracing/killer_test.go
+++ b/pkg/sensors/tracing/killer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 )
 
 func testKiller(t *testing.T, configHook string,
@@ -67,10 +68,10 @@ func TestKillerOverride(t *testing.T) {
 		t.Skip("skipping killer test, bpf_send_signal helper not available")
 	}
 
-	test := testutils.RepoRootPath("contrib/tester-progs/killer-tester")
+	test := testutils.RepoRootPath("contrib/tester-progs/getcpu")
 	builder := func() *KillerSpecBuilder {
 		return NewKillerSpecBuilder("killer-override").
-			WithSyscallList("sys_prctl").
+			WithSyscallList("sys_getcpu").
 			WithMatchBinaries(test).
 			WithOverrideValue(-17) // EEXIST
 	}
@@ -79,7 +80,7 @@ func TestKillerOverride(t *testing.T) {
 		WithArgs(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(
-				ec.NewKprobeArgumentChecker().WithSizeArg(syscall.SYS_PRCTL),
+				ec.NewKprobeArgumentChecker().WithSizeArg(unix.SYS_GETCPU),
 			)).
 		WithAction(tetragon.KprobeAction_KPROBE_ACTION_NOTIFYKILLER)
 

--- a/pkg/sensors/tracing/options.go
+++ b/pkg/sensors/tracing/options.go
@@ -12,26 +12,26 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 )
 
-type kprobeOptions struct {
+type specOptions struct {
 	DisableKprobeMulti bool
 }
 
 type opt struct {
-	set func(val string, options *kprobeOptions) error
+	set func(val string, options *specOptions) error
 }
 
 // Allowed kprobe options
 var opts = map[string]opt{
 	option.KeyDisableKprobeMulti: opt{
-		set: func(str string, options *kprobeOptions) (err error) {
+		set: func(str string, options *specOptions) (err error) {
 			options.DisableKprobeMulti, err = strconv.ParseBool(str)
 			return err
 		},
 	},
 }
 
-func getKprobeOptions(specs []v1alpha1.OptionSpec) (*kprobeOptions, error) {
-	options := &kprobeOptions{}
+func getSpecOptions(specs []v1alpha1.OptionSpec) (*specOptions, error) {
+	options := &specOptions{}
 
 	for _, spec := range specs {
 		opt, ok := opts[spec.Name]


### PR DESCRIPTION
this PR is a followup to https://github.com/cilium/tetragon/pull/1948.

It adds `fmod_ret` support to the killer sensor and further improves testing.

```release-note
killer sensor: add fmod_ret support
```