### PR TITLE
Actions: add rateLimitScope

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -825,6 +825,11 @@ matchActions:
   rateLimit: 5m
 ```
 
+By default, the rate limiting is applied per thread, meaning that only repeated
+actions by the same thread will be rate limited. This can be expanded to all
+threads for a process by specifying a rateLimitScope with value "process"; or
+can be expanded to all processes by specifying the same with the value "global".
+
 #### Stack traces
 
 `Post` takes the `stackTrace` parameter, when turned to `true` (by default to

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -285,6 +285,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -581,6 +592,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
@@ -908,6 +930,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -1204,6 +1237,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
@@ -1355,6 +1399,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -1651,6 +1706,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -285,6 +285,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -581,6 +592,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
@@ -908,6 +930,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -1204,6 +1237,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
@@ -1355,6 +1399,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -1651,6 +1706,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -221,6 +221,14 @@ type ActionSelector struct {
 	// or hours ('h' suffix). Only valid with the post action.
 	RateLimit string `json:"rateLimit"`
 	// +kubebuilder:validation:Optional
+	// The scope of the provided rate limit argument. Can be "thread" (default),
+	// "process" (all threads for the same process), or "global". If "thread" is
+	// selected then rate limiting applies per thread; if "process" is selected
+	// then rate limiting applies per process; if "global" is selected then rate
+	// limiting applies regardless of which process or thread caused the action.
+	// Only valid with the post action and with a rateLimit specified.
+	RateLimitScope string `json:"rateLimitScope"`
+	// +kubebuilder:validation:Optional
 	// Enable stack trace export. Only valid with the post action.
 	StackTrace bool `json:"stackTrace"`
 }

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.1.2"
+const CustomResourceDefinitionSchemaVersion = "1.1.3"

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -477,6 +477,7 @@ func TestParseMatchAction(t *testing.T) {
 	expected1 := []byte{
 		0x00, 0x00, 0x00, 0x00, // Action = "post"
 		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
+		0x00, 0x00, 0x00, 0x00, // DontRepeatForScope = 0
 		0x00, 0x00, 0x00, 0x00, // StackTrace = 0
 	}
 	if err := ParseMatchAction(k, act1, &actionArgTable); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
@@ -488,9 +489,10 @@ func TestParseMatchAction(t *testing.T) {
 	expected2 := []byte{
 		0x00, 0x00, 0x00, 0x00, // Action = "post"
 		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
+		0x00, 0x00, 0x00, 0x00, // DontRepeatForScope = 0
 		0x00, 0x00, 0x00, 0x00, // StackTrace = 0
 	}
-	length := []byte{28, 0x00, 0x00, 0x00}
+	length := []byte{36, 0x00, 0x00, 0x00}
 	expected := append(length, expected1[:]...)
 	expected = append(expected, expected2[:]...)
 
@@ -593,11 +595,11 @@ func TestInitKernelSelectors(t *testing.T) {
 	}
 
 	expected_selsize_small := []byte{
-		0xf8, 0x00, 0x00, 0x00, // size = pids + args + actions + namespaces + capabilities  + 4
+		0xfc, 0x00, 0x00, 0x00, // size = pids + args + actions + namespaces + capabilities  + 4
 	}
 
 	expected_selsize_large := []byte{
-		0x2c, 0x01, 0x00, 0x00, // size = pids + args + actions + namespaces + namespacesChanges + capabilities + capabilityChanges + 4
+		0x30, 0x01, 0x00, 0x00, // size = pids + args + actions + namespaces + namespacesChanges + capabilities + capabilityChanges + 4
 	}
 
 	expected_filters := []byte{
@@ -682,14 +684,14 @@ func TestInitKernelSelectors(t *testing.T) {
 
 	expected_last_large := []byte{
 		// arg header
-		88, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 4
+		88, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 24
 		24, 0x00, 0x00, 0x00, // arg[0] offset
 		64, 0x00, 0x00, 0x00, // arg[1] offset
 		0x00, 0x00, 0x00, 0x00, // arg[2] offset
 		0x00, 0x00, 0x00, 0x00, // arg[3] offset
 		0x00, 0x00, 0x00, 0x00, // arg[4] offset
 
-		//arg1 size = 26
+		//arg1 size = 40
 		0x01, 0x00, 0x00, 0x00, // Index == 1
 		0x03, 0x00, 0x00, 0x00, // operator == equal
 		32, 0x00, 0x00, 0x00, // length == 32
@@ -710,9 +712,10 @@ func TestInitKernelSelectors(t *testing.T) {
 		0x02, 0x00, 0x00, 0x00, // value 2
 
 		// actions header
-		28, 0x00, 0x00, 0x00, // size = (3 * sizeof(uint32) * number of actions) + args
+		32, 0x00, 0x00, 0x00, // size = (4 * sizeof(uint32) * number of actions) + args
 		0x00, 0x00, 0x00, 0x00, // post to userspace
 		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
+		0x00, 0x00, 0x00, 0x00, // DontRepeatForScope = 0
 		0x00, 0x00, 0x00, 0x00, // StackTrace = 0
 		0x01, 0x00, 0x00, 0x00, // fdinstall
 		0x00, 0x00, 0x00, 0x00, // arg index of fd
@@ -721,14 +724,14 @@ func TestInitKernelSelectors(t *testing.T) {
 
 	expected_last_small := []byte{
 		// arg header
-		64, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 4
+		64, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 32
 		24, 0x00, 0x00, 0x00, // arg[0] offset
 		0x00, 0x00, 0x00, 0x00, // arg[1] offset
 		0x00, 0x00, 0x00, 0x00, // arg[2] offset
 		0x00, 0x00, 0x00, 0x00, // arg[3] offset
 		0x00, 0x00, 0x00, 0x00, // arg[4] offset
 
-		//arg1 size = 26
+		//arg1 size = 40
 		0x01, 0x00, 0x00, 0x00, // Index == 1
 		0x03, 0x00, 0x00, 0x00, // operator == equal
 		32, 0x00, 0x00, 0x00, // length == 32
@@ -741,9 +744,10 @@ func TestInitKernelSelectors(t *testing.T) {
 		0xff, 0xff, 0xff, 0xff, // map ID for strings 121-144
 
 		// actions header
-		28, 0x00, 0x00, 0x00, // size = (3 * sizeof(uint32) * number of actions) + args + 4
+		32, 0x00, 0x00, 0x00, // size = (4 * sizeof(uint32) * number of actions) + args + 4
 		0x00, 0x00, 0x00, 0x00, // post to userspace
 		0x00, 0x00, 0x00, 0x00, // DontRepeatFor = 0
+		0x00, 0x00, 0x00, 0x00, // DontRepeatForScope = 0
 		0x00, 0x00, 0x00, 0x00, // StackTrace = 0
 		0x01, 0x00, 0x00, 0x00, // fdinstall
 		0x00, 0x00, 0x00, 0x00, // arg index of fd
@@ -925,16 +929,17 @@ func TestReturnSelectorArgIntActionFollowfd(t *testing.T) {
 
 	expU32Push(1)  // off: 0       number of selectors
 	expU32Push(4)  // off: 4       relative ofset of selector (4 + 4 = 8)
-	expU32Push(56) // off: 8       selector: length
+	expU32Push(60) // off: 8       selector: length
 	expU32Push(24) // off: 12      selector: matchReturnArgs length
 	expU32Push(0)  // off: 16      selector: matchReturnArgs arg offset[0]
 	expU32Push(0)  // off: 20      selector: matchReturnArgs arg offset[1]
 	expU32Push(0)  // off: 24      selector: matchReturnArgs arg offset[2]
 	expU32Push(0)  // off: 28      selector: matchReturnArgs arg offset[3]
 	expU32Push(0)  // off: 32      selector: matchReturnArgs arg offset[4]
-	expU32Push(28) // off: 36      selector: matchReturnActions length
+	expU32Push(32) // off: 36      selector: matchReturnActions length
 	expU32Push(0)  // off: 40      selector: selectors.ActionTypePost
 	expU32Push(0)  // off: 44      selector: rateLimit
+	expU32Push(0)  // off: 44      selector: rateLimitScope
 	expU32Push(0)  // off: 48      selector: stackTrace
 	expU32Push(1)  // off: 52      selector: selectors.ActionTypeFollowFd
 	expU32Push(7)  // off: 56      selector: action.ArgFd

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -285,6 +285,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -581,6 +592,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
@@ -908,6 +930,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -1204,6 +1237,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
@@ -1355,6 +1399,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -1651,6 +1706,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -285,6 +285,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -581,6 +592,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
@@ -908,6 +930,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -1204,6 +1237,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
@@ -1355,6 +1399,17 @@ spec:
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
                                   type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
+                                  type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid
                                     with the post action.
@@ -1651,6 +1706,17 @@ spec:
                                     in seconds (default or with 's' suffix), minutes
                                     ('m' suffix) or hours ('h' suffix). Only valid
                                     with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: The scope of the provided rate limit
+                                    argument. Can be "thread" (default), "process"
+                                    (all threads for the same process), or "global".
+                                    If "thread" is selected then rate limiting applies
+                                    per thread; if "process" is selected then rate
+                                    limiting applies per process; if "global" is selected
+                                    then rate limiting applies regardless of which
+                                    process or thread caused the action. Only valid
+                                    with the post action and with a rateLimit specified.
                                   type: string
                                 stackTrace:
                                   description: Enable stack trace export. Only valid

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -221,6 +221,14 @@ type ActionSelector struct {
 	// or hours ('h' suffix). Only valid with the post action.
 	RateLimit string `json:"rateLimit"`
 	// +kubebuilder:validation:Optional
+	// The scope of the provided rate limit argument. Can be "thread" (default),
+	// "process" (all threads for the same process), or "global". If "thread" is
+	// selected then rate limiting applies per thread; if "process" is selected
+	// then rate limiting applies per process; if "global" is selected then rate
+	// limiting applies regardless of which process or thread caused the action.
+	// Only valid with the post action and with a rateLimit specified.
+	RateLimitScope string `json:"rateLimitScope"`
+	// +kubebuilder:validation:Optional
 	// Enable stack trace export. Only valid with the post action.
 	StackTrace bool `json:"stackTrace"`
 }

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.1.2"
+const CustomResourceDefinitionSchemaVersion = "1.1.3"


### PR DESCRIPTION
Post actions can have a rateLimit argument that specifies how often identical events from the same hook and thread are generated. There is a use case to rate limit per process or generally.

This commit introduces the rateLimitScope argument, to be used with rateLimit, to specify whether the rate limiting should be limited to the same thread, the same process, or globally, using values "thread" (default), "process", or "global".

```release-note
Add rateLimitScope to control what rateLimit applies to.
```
