### PR TITLE
Tracepoint tests: Fix comm signedness and length check

### DIFF
--- a/pkg/tracepoint/tracepoint_test.go
+++ b/pkg/tracepoint/tracepoint_test.go
@@ -5,10 +5,7 @@ package tracepoint
 
 import (
 	"reflect"
-	"runtime"
 	"testing"
-
-	"github.com/cilium/tetragon/pkg/kernels"
 )
 
 func TestTracepointLoadFormat(t *testing.T) {
@@ -23,80 +20,98 @@ func TestTracepointLoadFormat(t *testing.T) {
 		t.FailNow()
 	}
 
-	// the standard does not specify if char is signed or not
-	// historically, it's signed on amd64 and unsigned on arm64
-	isCharSigned := true
-	if runtime.GOARCH == "arm64" {
-		isCharSigned = false
-	}
+	// The standard does not specify if char is signed or not.
+	// Historically, it's signed on amd64 and unsigned on arm64.
+	// We can't rely on the architecture to determine this as
+	// some 6.x kernels on x86_64 have an unsigned char. Also
+	// the comm length is sometimes specified as 16 and other
+	// times as TASK_COMM_LEN.
+	// Let's test all combinations as any working one is a test
+	// pass.
 
-	var commField FieldFormat
-	if kernels.MinKernelVersion("5.17.0") {
-		commField = FieldFormat{
-			FieldStr: "char comm[TASK_COMM_LEN]",
-			Offset:   12,
-			Size:     16,
-			IsSigned: isCharSigned,
-		}
-	} else {
-		commField = FieldFormat{
+	commField := [4]FieldFormat{
+		{
 			FieldStr: "char comm[16]",
 			Offset:   12,
 			Size:     16,
-			IsSigned: isCharSigned,
+			IsSigned: true,
+		},
+		{
+			FieldStr: "char comm[16]",
+			Offset:   12,
+			Size:     16,
+			IsSigned: false,
+		},
+		{
+			FieldStr: "char comm[TASK_COMM_LEN]",
+			Offset:   12,
+			Size:     16,
+			IsSigned: true,
+		},
+		{
+			FieldStr: "char comm[TASK_COMM_LEN]",
+			Offset:   12,
+			Size:     16,
+			IsSigned: false,
+		},
+	}
+
+	for loop := 0; loop < 4; loop++ {
+		fields := []FieldFormat{
+			FieldFormat{
+				FieldStr: "unsigned short common_type",
+				Offset:   0,
+				Size:     2,
+				IsSigned: false,
+			},
+			FieldFormat{
+				FieldStr: "unsigned char common_flags",
+				Offset:   2,
+				Size:     1,
+				IsSigned: false,
+			},
+			FieldFormat{
+				FieldStr: "unsigned char common_preempt_count",
+				Offset:   3,
+				Size:     1,
+				IsSigned: false,
+			},
+			FieldFormat{
+				FieldStr: "int common_pid",
+				Offset:   4,
+				Size:     4,
+				IsSigned: true,
+			},
+			FieldFormat{
+				FieldStr: "pid_t pid",
+				Offset:   8,
+				Size:     4,
+				IsSigned: true,
+			},
+			commField[loop],
+			FieldFormat{
+				FieldStr: "unsigned long clone_flags",
+				Offset:   32,
+				Size:     8,
+				IsSigned: false,
+			},
+			FieldFormat{
+				FieldStr: "short oom_score_adj",
+				Offset:   40,
+				Size:     2,
+				IsSigned: true,
+			},
 		}
-	}
 
-	fields := []FieldFormat{
-		FieldFormat{
-			FieldStr: "unsigned short common_type",
-			Offset:   0,
-			Size:     2,
-			IsSigned: false,
-		},
-		FieldFormat{
-			FieldStr: "unsigned char common_flags",
-			Offset:   2,
-			Size:     1,
-			IsSigned: false,
-		},
-		FieldFormat{
-			FieldStr: "unsigned char common_preempt_count",
-			Offset:   3,
-			Size:     1,
-			IsSigned: false,
-		},
-		FieldFormat{
-			FieldStr: "int common_pid",
-			Offset:   4,
-			Size:     4,
-			IsSigned: true,
-		},
-		FieldFormat{
-			FieldStr: "pid_t pid",
-			Offset:   8,
-			Size:     4,
-			IsSigned: true,
-		},
-		commField,
-		FieldFormat{
-			FieldStr: "unsigned long clone_flags",
-			Offset:   32,
-			Size:     8,
-			IsSigned: false,
-		},
-		FieldFormat{
-			FieldStr: "short oom_score_adj",
-			Offset:   40,
-			Size:     2,
-			IsSigned: true,
-		},
-	}
-
-	// NB: ID does not seem to be the same across systems, so we check only fields
-	if !reflect.DeepEqual(&fields, &gt.Format.Fields) {
-		t.Logf("Unexpected result:\nexpected:%v\ngot     :%v\n", &fields, &gt.Format.Fields)
-		t.Fail()
+		// NB: ID does not seem to be the same across systems, so we check only fields
+		if reflect.DeepEqual(&fields, &gt.Format.Fields) {
+			break
+		} else if loop == 3 {
+			t.Logf("Unexpected result:\nexpected (something like):\n%v\ngot:\n%v\n", &fields, &gt.Format.Fields)
+			t.Logf("The comm field could have signed equal to 0 or 1.\n")
+			t.Logf("The comm field length could be 16 or TASK_COMM_LEN.\n")
+			t.Fail()
+		}
 	}
 }
 


### PR DESCRIPTION
The TestTracepointLoadFormat test in pkg/tracepoint checks that the tracepoint format we can read matches what we expect. Unfortunately, in some cases the format of the comm field is unpredictable (within a few options).

This commit changes the test to allow the different formats we have observed.