### PR TITLE
Documentation improvements

### DIFF
--- a/docs/content/en/docs/concepts/events.md
+++ b/docs/content/en/docs/concepts/events.md
@@ -110,8 +110,8 @@ section. All events in Tetragon contain a `process_exec` block to identify the p
 event. For execution events this is the primary block. For [Tracing Policy]({{< ref "/docs/concepts/tracing-policy" >}}) events the
 hook that generated the event will attach further data to this. The `process_exec` event provides
 a cluster wide unique id the `process_exec.exec_id` for this process along with the metadata expected
-in a Kubernetes cluster  `process_exec.process.pod`. The binary and args being executed are part of 
-the event here `process_exec.process.binary` and `process_exec.process.args`. Finarlly a `node_name`
+in a Kubernetes cluster  `process_exec.process.pod`. The binary and args being executed are part of
+the event here `process_exec.process.binary` and `process_exec.process.args`. Finally, a `node_name`
 and `time` provide the location and time for the event and will be present in all event types.
 
 A default deployment writes the JSON log to `/var/run/cilium/tetragon/tetragon.log` where it can

--- a/docs/content/en/docs/getting-started/file-events.md
+++ b/docs/content/en/docs/getting-started/file-events.md
@@ -67,8 +67,8 @@ This will generate a read event (Docker events will omit Kubernetes metadata),
 💥 exit    default/xwing /bin/cat /etc/shadow 0
 ```
 
-Attempts to write in sensitive directories will similar create an event. For
-example attempting to write in `/etc`.
+Attempts to write in sensitive directories will similarly create write events.
+For example, attempting to write in `/etc`.
 
 {{< tabpane lang=shell >}}
 {{< tab Kubernetes >}}

--- a/docs/content/en/docs/getting-started/install-k8s.md
+++ b/docs/content/en/docs/getting-started/install-k8s.md
@@ -73,7 +73,7 @@ nodes:
         containerPath: /procHost
 EOF
 kind create cluster --config kind-config.yaml
-EXTRA_HELM_FLAGS="--set tetragon.hostProcPath=/procHost" # flags for helm install
+EXTRA_HELM_FLAGS=(--set tetragon.hostProcPath=/procHost) # flags for helm install
 ```
 {{% /tab %}}
 
@@ -86,7 +86,7 @@ To install and deploy Tetragon, run the following commands:
 ```shell
 helm repo add cilium https://helm.cilium.io
 helm repo update
-helm install tetragon ${EXTRA_HELM_FLAGS} cilium/tetragon -n kube-system
+helm install tetragon ${EXTRA_HELM_FLAGS[@]} cilium/tetragon -n kube-system
 kubectl rollout status -n kube-system ds/tetragon -w
 ```
 

--- a/docs/content/en/docs/getting-started/install-k8s.md
+++ b/docs/content/en/docs/getting-started/install-k8s.md
@@ -96,18 +96,16 @@ parameters.
 
 ### Deploy demo application
 
-To explore Tetragon its helpful to have a sample workload. Here we use the Cilium
-HTTP application, but any workload would work equally well.
-
-To use our [demo
-application](https://docs.cilium.io/en/v1.11/gettingstarted/http/#deploy-the-demo-application)
+To explore Tetragon it is helpful to have a sample workload. Here we use Cilium's
+[demo application](https://docs.cilium.io/en/stable/gettingstarted/demo/),
+but any workload would work equally well:
 
 ```shell
 kubectl create -f {{< demo-app-url >}}
 ```
 
 Before going forward, verify that all pods are up and running - it might take
-several seconds for some pods until they satisfy all the dependencies:
+several seconds for some pods to satisfy all the dependencies:
 
 ```shell
 kubectl get pods

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -113,6 +113,9 @@ github_project_repo = "https://github.com/cilium/tetragon"
 # Specify a value here if your content directory is not in your repo's root directory
 github_subdir = "docs"
 
+# URL of the Star Wars demo app.
+demo_app_url = "https://raw.githubusercontent.com/cilium/cilium/v1.15.0-pre.1/examples/minikube/http-sw-app.yaml"
+
 [params.search.algolia]
 appId = "UI18HE156K"
 apiKey = "77f164b3638095772b770596db900fea"
@@ -167,9 +170,6 @@ sidebar_search_disable = false
 # Used in the "version-banner" partial to display a version number for the
 # current doc set.
 version = "v1.0.0"
-
-# URL of the Star Wars demo app.
-demo_app_url = "https://raw.githubusercontent.com/cilium/cilium/v1.15.0-pre.1/examples/minikube/http-sw-app.yaml"
 
 #######################################
 # hugo module configuration


### PR DESCRIPTION
This PR provides the following fixes for Tetragon's docs:

1. Ensure that the URL with the manifest of the Cilium SW demo application is rendered in `kubectl` commands
2. Ensure that the K8s installation guide works for both `zsh` and `bash` shells

Signed-off-by: Ioannis Androulidakis <androulidakis.ioannis@gmail.com>