### PR TITLE
workflows: add apt-get update before installs

### DIFF
--- a/.github/workflows/bpf-unit-tests.yml
+++ b/.github/workflows/bpf-unit-tests.yml
@@ -26,7 +26,9 @@ jobs:
         go-version: '1.21.5'
 
     - name: Install LLVM
-      run: sudo apt-get -y install clang llvm
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install clang llvm
 
     - name: Run BPF unit test
       run: make bpf-test BPFGOTESTFLAGS="-v"

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -30,11 +30,13 @@ jobs:
 
     - name: Install dependencies x86
       run: |
+        sudo apt-get update
         sudo apt-get -y install libc6-dev-i386
       if: ${{ matrix.os == 'ubuntu-20.04' }}
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get -y install libelf-dev netcat-traditional libcap-dev gcc
 
         sudo sed -i '/secure_path/d' /etc/sudoers

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -31,7 +31,8 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        sudo apt install libelf-dev netcat-traditional libcap-dev gcc libc6-dev-i386
+        sudo apt-get update
+        sudo apt-get install -y libelf-dev netcat-traditional libcap-dev gcc libc6-dev-i386
         echo `which clang`
         echo `which llc`
         echo `clang --version`
@@ -89,9 +90,9 @@ jobs:
     steps:
     - name: Install VM test dependencies
       run: |
-        sudo apt-get -qy update
+        sudo apt-get update
         sudo apt-cache search qemu
-        sudo apt-get -qy install mmdebstrap libguestfs-tools qemu-utils qemu-system-x86 cpu-checker qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager
+        sudo apt-get install -y mmdebstrap libguestfs-tools qemu-utils qemu-system-x86 cpu-checker qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager
 
     - name: Make kernel accessible
       run: |


### PR DESCRIPTION
Some workflows started to fail because the cache was invalid: some package was updated and it was still trying to install the previous one, then missing.

See [an example of workflow failing because of this](https://github.com/cilium/tetragon/actions/runs/7495570080/job/20405920129).