### PR TITLE
Dockerfile: bump bpftool revision to 7.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ RUN apt-get update
 RUN if [ $BUILDARCH != $TARGETARCH ]; \
     then apt-get install -y curl git llvm gcc pkg-config zlib1g-dev libelf-dev libelf-dev:arm64 libcap-dev:arm64 crossbuild-essential-$TARGETARCH; \
     else apt-get install -y curl git llvm gcc pkg-config zlib1g-dev libelf-dev libcap-dev; fi
-# v7.1.0
-ENV BPFTOOL_REV "b01941c8f7890489f09713348a7d89567538504b"
+# v7.3.0
+ENV BPFTOOL_REV "687e7f06f2ee104ed6515ec3a9816af77bfa7a17"
 RUN git clone --recurse-submodules https://github.com/libbpf/bpftool.git . && git checkout ${BPFTOOL_REV}
 RUN if [ $BUILDARCH != $TARGETARCH ]; \
     then make -C src EXTRA_CFLAGS=--static CC=aarch64-linux-gnu-gcc -j $(nproc) && aarch64-linux-gnu-strip src/bpftool; \


### PR DESCRIPTION
This should fix #1606.

Previous version failed to build on old kernels, see issue libbpf/bpftool#17 for more information.