### PR TITLE
docs: fix invalid site param in hugo.toml

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -116,6 +116,11 @@ github_subdir = "docs"
 # URL of the Star Wars demo app.
 demo_app_url = "https://raw.githubusercontent.com/cilium/cilium/v1.15.0-pre.1/examples/minikube/http-sw-app.yaml"
 
+# The version number for the version of the docs represented in this doc set.
+# Used in the "version-banner" partial to display a version number for the
+# current doc set.
+version = "v1.0.0"
+
 [params.search.algolia]
 appId = "UI18HE156K"
 apiKey = "77f164b3638095772b770596db900fea"
@@ -161,15 +166,6 @@ sidebar_search_disable = false
   [caches.images]
     dir = ":cacheDir/_images"
     maxAge = -1
-
-#######################################
-# Site variables
-#######################################
-
-# The version number for the version of the docs represented in this doc set.
-# Used in the "version-banner" partial to display a version number for the
-# current doc set.
-version = "v1.0.0"
 
 #######################################
 # hugo module configuration


### PR DESCRIPTION
User ioandr pointed out that those variables were not under the [params] section and thus not working in the shortcodes anymore.

Thanks a lot @ioandr! I messed up this.