### PR TITLE
gitattributes: add to the list of generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
+# helm chart
 /install/kubernetes/tetragon/README.md linguist-generated
+
+# api
+/api/v1/README.md linguist-generated
+
+# docs
 /docs/content/en/docs/reference/helm-chart.md linguist-generated
+/docs/content/en/docs/reference/grpc-api.md linguist-generated
+/docs/data/tetragon_flags.yaml linguist-generated


### PR DESCRIPTION
This is quality of life improvement for GitHub, when marked like this, those files appear as redacted with the "Load diff" option to make review easier.