### PR TITLE
docs: link checker config for docs contributor guide

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -7,5 +7,7 @@ exclude = [
   # see https://github.blog/2013-01-31-relative-links-in-markup-files/
   'docs/assets/icons/logo.*\.svg', 
   # the virtualbox website sends 500 regularly
-  'virtualbox.org'
+  'virtualbox.org',
+  # this is for the documentation contributor guide
+  '^http://localhost:1313/docs$'
 ]


### PR DESCRIPTION
Fixes #1995.

Broken link detector was trigger no the http://localhost:1313/docs link in the guide, which needs being excluded. On the other side we need to exclude only this explicit link since localhost:1313 base is used during local CI links checking.