### PR TITLE
Perf: Remove extra copies of data from ring buffer

### DIFF
--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -84,9 +84,6 @@ type MsgK8s struct {
 }
 
 type MsgK8sUnix struct {
-	NetNS  uint32
-	Cid    uint32
-	Cgrpid uint64
 	Docker string
 }
 
@@ -115,15 +112,9 @@ type MsgExecveEvent struct {
 }
 
 type MsgExecveEventUnix struct {
-	Common         MsgCommon
-	Kube           MsgK8sUnix
-	Parent         MsgExecveKey
-	ParentFlags    uint64
-	Capabilities   MsgCapabilities
-	Creds          MsgGenericCredMinimal
-	Namespaces     MsgNamespaces
-	CleanupProcess MsgExecveKey
-	Process        MsgProcess
+	Msg     *MsgExecveEvent
+	Kube    MsgK8sUnix
+	Process MsgProcess
 }
 
 type MsgCloneEvent struct {

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -84,25 +84,29 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 	// Create a parent event to hand events off of and convince execCache that parents are known. In order for this to
 	// work we set the Pid == 1 here so that system believes this is the root of the tree.
 	rootEv := tetragonAPI.MsgExecveEventUnix{
-		Common: tetragonAPI.MsgCommon{
-			Op:     5,
-			Flags:  0,
-			Pad_v2: [2]uint8{0, 0},
-			Size:   326,
-			Ktime:  0,
+		Msg: &tetragonAPI.MsgExecveEvent{
+			Common: tetragonAPI.MsgCommon{
+				Op:     5,
+				Flags:  0,
+				Pad_v2: [2]uint8{0, 0},
+				Size:   326,
+				Ktime:  0,
+			},
+			Kube: tetragonAPI.MsgK8s{
+				NetNS:  0,
+				Cid:    0,
+				Cgrpid: 0,
+			},
+			Parent: tetragonAPI.MsgExecveKey{
+				Pid:   0,
+				Pad:   0,
+				Ktime: 0,
+			},
+			ParentFlags: 0,
 		},
 		Kube: tetragonAPI.MsgK8sUnix{
-			NetNS:  0,
-			Cid:    0,
-			Cgrpid: 0,
 			Docker: "",
 		},
-		Parent: tetragonAPI.MsgExecveKey{
-			Pid:   0,
-			Pad:   0,
-			Ktime: 0,
-		},
-		ParentFlags: 0,
 		Process: tetragonAPI.MsgProcess{
 			Size:       78,
 			PID:        1,
@@ -121,25 +125,29 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 	execRootMsg = execRootMsg.Cast(rootEv).(EXEC)
 
 	parentEv := tetragonAPI.MsgExecveEventUnix{
-		Common: tetragonAPI.MsgCommon{
-			Op:     5,
-			Flags:  0,
-			Pad_v2: [2]uint8{0, 0},
-			Size:   326,
-			Ktime:  21034975106173,
+		Msg: &tetragonAPI.MsgExecveEvent{
+			Common: tetragonAPI.MsgCommon{
+				Op:     5,
+				Flags:  0,
+				Pad_v2: [2]uint8{0, 0},
+				Size:   326,
+				Ktime:  21034975106173,
+			},
+			Kube: tetragonAPI.MsgK8s{
+				NetNS:  4026531992,
+				Cid:    0,
+				Cgrpid: 0,
+			},
+			Parent: tetragonAPI.MsgExecveKey{
+				Pid:   1,
+				Pad:   0,
+				Ktime: 0,
+			},
+			ParentFlags: 0,
 		},
 		Kube: tetragonAPI.MsgK8sUnix{
-			NetNS:  4026531992,
-			Cid:    0,
-			Cgrpid: 0,
 			Docker: Docker,
 		},
-		Parent: tetragonAPI.MsgExecveKey{
-			Pid:   1,
-			Pad:   0,
-			Ktime: 0,
-		},
-		ParentFlags: 0,
 		Process: tetragonAPI.MsgProcess{
 			Size:       78,
 			PID:        ParentPid,
@@ -158,25 +166,29 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 	execParentMsg = execParentMsg.Cast(parentEv).(EXEC)
 
 	execEv := tetragonAPI.MsgExecveEventUnix{
-		Common: tetragonAPI.MsgCommon{
-			Op:     5,
-			Flags:  0,
-			Pad_v2: [2]uint8{0, 0},
-			Size:   326,
-			Ktime:  21034975106173,
+		Msg: &tetragonAPI.MsgExecveEvent{
+			Common: tetragonAPI.MsgCommon{
+				Op:     5,
+				Flags:  0,
+				Pad_v2: [2]uint8{0, 0},
+				Size:   326,
+				Ktime:  21034975106173,
+			},
+			Kube: tetragonAPI.MsgK8s{
+				NetNS:  4026531992,
+				Cid:    0,
+				Cgrpid: 0,
+			},
+			Parent: tetragonAPI.MsgExecveKey{
+				Pid:   ParentPid,
+				Pad:   0,
+				Ktime: ParentKtime,
+			},
+			ParentFlags: 0,
 		},
 		Kube: tetragonAPI.MsgK8sUnix{
-			NetNS:  4026531992,
-			Cid:    0,
-			Cgrpid: 0,
 			Docker: Docker,
 		},
-		Parent: tetragonAPI.MsgExecveKey{
-			Pid:   ParentPid,
-			Pad:   0,
-			Ktime: ParentKtime,
-		},
-		ParentFlags: 0,
 		Process: tetragonAPI.MsgProcess{
 			Size:     78,
 			PID:      Pid,

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -167,26 +167,30 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 		nil,
 		&rthooks.Runner{})
 	assert.NoError(t, err)
-	pi := &exec.MsgExecveEventUnix{MsgExecveEventUnix: processapi.MsgExecveEventUnix{
-		Common: processapi.MsgCommon{
-			Ktime: 1234,
+	pi := &exec.MsgExecveEventUnix{
+		Unix: &processapi.MsgExecveEventUnix{
+			Msg: &processapi.MsgExecveEvent{
+				Common: processapi.MsgCommon{
+					Ktime: 1234,
+				},
+				Creds: processapi.MsgGenericCredMinimal{
+					Uid:  1000,
+					Gid:  1000,
+					Euid: 10000,
+					Egid: 10000,
+				},
+				Capabilities: processapi.MsgCapabilities{
+					Permitted:   1,
+					Effective:   1,
+					Inheritable: 1,
+				},
+			},
+			Process: processapi.MsgProcess{
+				PID:        5678,
+				SecureExec: processapi.ExecveSetuid | processapi.ExecveSetgid,
+			},
 		},
-		Creds: processapi.MsgGenericCredMinimal{
-			Uid:  1000,
-			Gid:  1000,
-			Euid: 10000,
-			Egid: 10000,
-		},
-		Capabilities: processapi.MsgCapabilities{
-			Permitted:   1,
-			Effective:   1,
-			Inheritable: 1,
-		},
-		Process: processapi.MsgProcess{
-			PID:        5678,
-			SecureExec: processapi.ExecveSetuid | processapi.ExecveSetgid,
-		},
-	}}
+	}
 
 	assert.Nil(t, exec.GetProcessExec(pi, false).Process.Cap)
 

--- a/pkg/grpc/test/test.go
+++ b/pkg/grpc/test/test.go
@@ -20,7 +20,7 @@ var (
 )
 
 type MsgTestEventUnix struct {
-	testapi.MsgTestEvent
+	Msg *testapi.MsgTestEvent
 }
 
 func (msg *MsgTestEventUnix) Notify() bool {
@@ -37,17 +37,17 @@ func (msg *MsgTestEventUnix) Retry(internal *process.ProcessInternal, ev notify.
 
 func (msg *MsgTestEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 	var res *tetragon.GetEventsResponse
-	switch msg.Common.Op {
+	switch msg.Msg.Common.Op {
 	case ops.MSG_OP_TEST:
 		res = &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_Test{Test: &tetragon.Test{
-				Arg0: msg.Arg0,
-				Arg1: msg.Arg1,
-				Arg2: msg.Arg2,
-				Arg3: msg.Arg3,
+				Arg0: msg.Msg.Arg0,
+				Arg1: msg.Msg.Arg1,
+				Arg2: msg.Msg.Arg2,
+				Arg3: msg.Msg.Arg3,
 			}},
 			NodeName: nodeName,
-			Time:     ktime.ToProto(msg.Common.Ktime),
+			Time:     ktime.ToProto(msg.Msg.Common.Ktime),
 		}
 	default:
 		logger.GetLogger().WithField("message", msg).Warn("HandleTestMessage: Unhandled event")
@@ -57,5 +57,5 @@ func (msg *MsgTestEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 
 func (msg *MsgTestEventUnix) Cast(o interface{}) notify.Message {
 	t := o.(testapi.MsgTestEvent)
-	return &MsgTestEventUnix{MsgTestEvent: t}
+	return &MsgTestEventUnix{Msg: &t}
 }

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -340,16 +340,12 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 }
 
 type MsgGenericTracepointUnix struct {
-	Common     processapi.MsgCommon
-	ProcessKey processapi.MsgExecveKey
-	Id         int64
-	Tid        uint32
+	Msg        *tracingapi.MsgGenericTracepoint
 	Subsys     string
 	Event      string
 	Args       []tracingapi.MsgGenericTracepointArg
 	PolicyName string
 	Message    string
-	Action     uint64
 }
 
 func (msg *MsgGenericTracepointUnix) Notify() bool {
@@ -357,21 +353,21 @@ func (msg *MsgGenericTracepointUnix) Notify() bool {
 }
 
 func (msg *MsgGenericTracepointUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, &msg.Tid, timestamp)
+	return eventcache.HandleGenericInternal(ev, msg.Msg.ProcessKey.Pid, &msg.Msg.Tid, timestamp)
 }
 
 func (msg *MsgGenericTracepointUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev, &msg.Tid)
+	return eventcache.HandleGenericEvent(internal, ev, &msg.Msg.Tid)
 }
 
 func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse {
 	var tetragonParent, tetragonProcess *tetragon.Process
 
-	proc, parent := process.GetParentProcessInternal(msg.ProcessKey.Pid, msg.ProcessKey.Ktime)
+	proc, parent := process.GetParentProcessInternal(msg.Msg.ProcessKey.Pid, msg.Msg.ProcessKey.Ktime)
 	if proc == nil {
 		tetragonProcess = &tetragon.Process{
-			Pid:       &wrapperspb.UInt32Value{Value: msg.ProcessKey.Pid},
-			StartTime: ktime.ToProto(msg.ProcessKey.Ktime),
+			Pid:       &wrapperspb.UInt32Value{Value: msg.Msg.ProcessKey.Pid},
+			StartTime: ktime.ToProto(msg.Msg.ProcessKey.Ktime),
 		}
 	} else {
 		tetragonProcess = proc.UnsafeGetProcess()
@@ -422,7 +418,7 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 		Args:       tetragonArgs,
 		PolicyName: msg.PolicyName,
 		Message:    msg.Message,
-		Action:     kprobeAction(msg.Action),
+		Action:     kprobeAction(msg.Msg.ActionId),
 	}
 
 	if tetragonProcess.Pid == nil {
@@ -433,7 +429,7 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 	if ec := eventcache.Get(); ec != nil &&
 		(ec.Needed(tetragonProcess) ||
 			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
-		ec.Add(nil, tetragonEvent, msg.Common.Ktime, msg.ProcessKey.Ktime, msg)
+		ec.Add(nil, tetragonEvent, msg.Msg.Common.Ktime, msg.Msg.ProcessKey.Ktime, msg)
 		return nil
 	}
 
@@ -446,13 +442,13 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 		// deep copy of all the fields of the thread leader from the cache in
 		// order to safely modify them, to not corrupt gRPC streams.
 		tetragonEvent.Process = proc.GetProcessCopy()
-		process.UpdateEventProcessTid(tetragonEvent.Process, &msg.Tid)
+		process.UpdateEventProcessTid(tetragonEvent.Process, &msg.Msg.Tid)
 	}
 
 	return &tetragon.GetEventsResponse{
 		Event:    &tetragon.GetEventsResponse_ProcessTracepoint{ProcessTracepoint: tetragonEvent},
 		NodeName: nodeName,
-		Time:     ktime.ToProto(msg.Common.Ktime),
+		Time:     ktime.ToProto(msg.Msg.Common.Ktime),
 	}
 }
 

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -72,11 +72,11 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 	var tetragonArgs []*tetragon.KprobeArgument
 	var tetragonReturnArg *tetragon.KprobeArgument
 
-	proc, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
+	proc, parent := process.GetParentProcessInternal(event.Msg.ProcessKey.Pid, event.Msg.ProcessKey.Ktime)
 	if proc == nil {
 		tetragonProcess = &tetragon.Process{
-			Pid:       &wrapperspb.UInt32Value{Value: event.ProcessKey.Pid},
-			StartTime: ktime.ToProto(event.ProcessKey.Ktime),
+			Pid:       &wrapperspb.UInt32Value{Value: event.Msg.ProcessKey.Pid},
+			StartTime: ktime.ToProto(event.Msg.ProcessKey.Ktime),
 		}
 	} else {
 		tetragonProcess = proc.UnsafeGetProcess()
@@ -302,7 +302,7 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 		FunctionName: event.FuncName,
 		Args:         tetragonArgs,
 		Return:       tetragonReturnArg,
-		Action:       kprobeAction(event.Action),
+		Action:       kprobeAction(event.Msg.ActionId),
 		ReturnAction: kprobeAction(event.ReturnAction),
 		StackTrace:   stackTrace,
 		PolicyName:   event.PolicyName,
@@ -317,7 +317,7 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 	if ec := eventcache.Get(); ec != nil &&
 		(ec.Needed(tetragonProcess) ||
 			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
-		ec.Add(nil, tetragonEvent, event.Common.Ktime, event.ProcessKey.Ktime, event)
+		ec.Add(nil, tetragonEvent, event.Msg.Common.Ktime, event.Msg.ProcessKey.Ktime, event)
 		return nil
 	}
 
@@ -330,7 +330,7 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 		// deep copy of all the fields of the thread leader from the cache in
 		// order to safely modify them, to not corrupt gRPC streams.
 		tetragonEvent.Process = proc.GetProcessCopy()
-		process.UpdateEventProcessTid(tetragonEvent.Process, &event.Tid)
+		process.UpdateEventProcessTid(tetragonEvent.Process, &event.Msg.Tid)
 	}
 	if parent != nil {
 		tetragonEvent.Parent = tetragonParent
@@ -469,14 +469,8 @@ func (msg *MsgGenericTracepointUnix) PolicyInfo() tracingpolicy.PolicyInfo {
 }
 
 type MsgGenericKprobeUnix struct {
-	Common       processapi.MsgCommon
-	ProcessKey   processapi.MsgExecveKey
-	Namespaces   processapi.MsgNamespaces
-	Capabilities processapi.MsgCapabilities
-	Id           uint64
-	Action       uint64
+	Msg          *tracingapi.MsgGenericKprobe
 	ReturnAction uint64
-	Tid          uint32
 	FuncName     string
 	Args         []tracingapi.MsgGenericKprobeArg
 	PolicyName   string
@@ -489,11 +483,11 @@ func (msg *MsgGenericKprobeUnix) Notify() bool {
 }
 
 func (msg *MsgGenericKprobeUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, &msg.Tid, timestamp)
+	return eventcache.HandleGenericInternal(ev, msg.Msg.ProcessKey.Pid, &msg.Msg.Tid, timestamp)
 }
 
 func (msg *MsgGenericKprobeUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev, &msg.Tid)
+	return eventcache.HandleGenericEvent(internal, ev, &msg.Msg.Tid)
 }
 
 func (msg *MsgGenericKprobeUnix) HandleMessage() *tetragon.GetEventsResponse {
@@ -504,7 +498,7 @@ func (msg *MsgGenericKprobeUnix) HandleMessage() *tetragon.GetEventsResponse {
 	return &tetragon.GetEventsResponse{
 		Event:    &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: k},
 		NodeName: nodeName,
-		Time:     ktime.ToProto(msg.Common.Ktime),
+		Time:     ktime.ToProto(msg.Msg.Common.Ktime),
 	}
 }
 

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -597,9 +597,7 @@ func (msg *MsgProcessLoaderUnix) Cast(o interface{}) notify.Message {
 }
 
 type MsgGenericUprobeUnix struct {
-	Common     processapi.MsgCommon
-	ProcessKey processapi.MsgExecveKey
-	Tid        uint32
+	Msg        *tracingapi.MsgGenericKprobe
 	Path       string
 	Symbol     string
 	PolicyName string
@@ -618,21 +616,21 @@ func (msg *MsgGenericUprobeUnix) PolicyInfo() tracingpolicy.PolicyInfo {
 }
 
 func (msg *MsgGenericUprobeUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
-	return eventcache.HandleGenericInternal(ev, msg.ProcessKey.Pid, &msg.Tid, timestamp)
+	return eventcache.HandleGenericInternal(ev, msg.Msg.ProcessKey.Pid, &msg.Msg.Tid, timestamp)
 }
 
 func (msg *MsgGenericUprobeUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
-	return eventcache.HandleGenericEvent(internal, ev, &msg.Tid)
+	return eventcache.HandleGenericEvent(internal, ev, &msg.Msg.Tid)
 }
 
 func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {
 	var tetragonParent, tetragonProcess *tetragon.Process
 
-	proc, parent := process.GetParentProcessInternal(event.ProcessKey.Pid, event.ProcessKey.Ktime)
+	proc, parent := process.GetParentProcessInternal(event.Msg.ProcessKey.Pid, event.Msg.ProcessKey.Ktime)
 	if proc == nil {
 		tetragonProcess = &tetragon.Process{
-			Pid:       &wrapperspb.UInt32Value{Value: event.ProcessKey.Pid},
-			StartTime: ktime.ToProto(event.ProcessKey.Ktime),
+			Pid:       &wrapperspb.UInt32Value{Value: event.Msg.ProcessKey.Pid},
+			StartTime: ktime.ToProto(event.Msg.ProcessKey.Ktime),
 		}
 	} else {
 		tetragonProcess = proc.UnsafeGetProcess()
@@ -663,7 +661,7 @@ func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {
 	if ec := eventcache.Get(); ec != nil &&
 		(ec.Needed(tetragonProcess) ||
 			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent))) {
-		ec.Add(nil, tetragonEvent, event.Common.Ktime, event.ProcessKey.Ktime, event)
+		ec.Add(nil, tetragonEvent, event.Msg.Common.Ktime, event.Msg.ProcessKey.Ktime, event)
 		return nil
 	}
 
@@ -676,7 +674,7 @@ func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {
 		// deep copy of all the fields of the thread leader from the cache in
 		// order to safely modify them, to not corrupt gRPC streams.
 		tetragonEvent.Process = proc.GetProcessCopy()
-		process.UpdateEventProcessTid(tetragonEvent.Process, &event.Tid)
+		process.UpdateEventProcessTid(tetragonEvent.Process, &event.Msg.Tid)
 	}
 	return tetragonEvent
 }
@@ -689,7 +687,7 @@ func (msg *MsgGenericUprobeUnix) HandleMessage() *tetragon.GetEventsResponse {
 	return &tetragon.GetEventsResponse{
 		Event:    &tetragon.GetEventsResponse_ProcessUprobe{ProcessUprobe: k},
 		NodeName: nodeName,
-		Time:     ktime.ToProto(msg.Common.Ktime),
+		Time:     ktime.ToProto(msg.Msg.Common.Ktime),
 	}
 }
 

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -273,9 +273,9 @@ func initProcessInternalExec(
 	}
 	execID := GetExecID(&process)
 	protoPod := GetPodInfo(containerID, process.Filename, args, process.NSPID)
-	apiCaps := caps.GetMsgCapabilities(event.Capabilities)
+	apiCaps := caps.GetMsgCapabilities(event.Msg.Capabilities)
 	binary := path.GetBinaryAbsolutePath(process.Filename, cwd)
-	apiNs, err := namespace.GetMsgNamespaces(event.Namespaces)
+	apiNs, err := namespace.GetMsgNamespaces(event.Msg.Namespaces)
 	if err != nil {
 		logger.GetLogger().WithFields(logrus.Fields{
 			"event.name":            "Execve",
@@ -287,7 +287,7 @@ func initProcessInternalExec(
 		}).Warn("ExecveEvent: parsing namespaces failed")
 	}
 
-	creds := &event.Creds
+	creds := &event.Msg.Creds
 	apiCreds := &tetragon.ProcessCredentials{
 		Uid:        &wrapperspb.UInt32Value{Value: creds.Uid},
 		Gid:        &wrapperspb.UInt32Value{Value: creds.Gid},
@@ -437,12 +437,12 @@ func GetParentProcessInternal(pid uint32, ktime uint64) (*ProcessInternal, *Proc
 // AddExecEvent constructs a new ProcessInternal structure from an Execve event, adds it to the cache, and also returns it
 func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 	var proc *ProcessInternal
-	if event.CleanupProcess.Ktime == 0 || event.Process.Flags&api.EventClone != 0 {
+	if event.Msg.CleanupProcess.Ktime == 0 || event.Process.Flags&api.EventClone != 0 {
 		// there is a case where we cannot find this entry in execve_map
 		// in that case we use as parent what Linux knows
-		proc = initProcessInternalExec(event, event.Parent)
+		proc = initProcessInternalExec(event, event.Msg.Parent)
 	} else {
-		proc = initProcessInternalExec(event, event.CleanupProcess)
+		proc = initProcessInternalExec(event, event.Msg.CleanupProcess)
 	}
 
 	procCache.add(proc)

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -442,17 +442,17 @@ func assertCgroupv1Events(ctx context.Context, t *testing.T, selectedController 
 			}
 		}
 		if exec, ok := ev.(*grpcexec.MsgExecveEventUnix); ok {
-			if strings.Contains(exec.Process.Filename, "printf") {
-				args := strings.Split(exec.Process.Args, `\n`)
+			if strings.Contains(exec.Unix.Process.Filename, "printf") {
+				args := strings.Split(exec.Unix.Process.Args, `\n`)
 				argDir := args[0]
 				for i, cgroup := range cgroupHierarchiesMap[selectedController] {
 					// Ensure that argument matches the target cgroup directory of
 					// the hierarchy we want
 					if cgroup.path == argDir {
 						// cgroup path match, let's save the cgrpid of the execve
-						cgroupHierarchiesMap[selectedController][i].execCgrpID = exec.Kube.Cgrpid
+						cgroupHierarchiesMap[selectedController][i].execCgrpID = exec.Unix.Msg.Kube.Cgrpid
 						// save the received docker id of the execve
-						cgroupHierarchiesMap[selectedController][i].actualDocker = exec.Kube.Docker
+						cgroupHierarchiesMap[selectedController][i].actualDocker = exec.Unix.Kube.Docker
 						// we had our match break
 						break
 					}
@@ -505,17 +505,17 @@ func assertCgroupv2Events(ctx context.Context, t *testing.T, cgroupRoot string, 
 			}
 		}
 		if exec, ok := ev.(*grpcexec.MsgExecveEventUnix); ok {
-			if strings.Contains(exec.Process.Filename, "printf") {
-				args := strings.Split(exec.Process.Args, `\n`)
+			if strings.Contains(exec.Unix.Process.Filename, "printf") {
+				args := strings.Split(exec.Unix.Process.Args, `\n`)
 				argDir := args[0]
 				for i, cgroup := range cgroupHierarchy {
 					// Ensure that argument matches the target cgroup directory of
 					// the hierarchy we want
 					if cgroup.path == argDir {
 						// cgroup path match, let's save the cgrpid of the execve
-						cgroupHierarchy[i].execCgrpID = exec.Kube.Cgrpid
+						cgroupHierarchy[i].execCgrpID = exec.Unix.Msg.Kube.Cgrpid
 						// save the received docker id of the execve
-						cgroupHierarchy[i].actualDocker = exec.Kube.Docker
+						cgroupHierarchy[i].actualDocker = exec.Unix.Kube.Docker
 						// we had our match break
 						break
 					}

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -633,7 +633,7 @@ func TestExecPerfring(t *testing.T) {
 	events := perfring.RunTestEvents(t, ctx, ops)
 	for _, ev := range events {
 		if exec, ok := ev.(*grpcexec.MsgExecveEventUnix); ok {
-			if exec.Process.Filename == "/bin/true" {
+			if exec.Unix.Process.Filename == "/bin/true" {
 				return
 			}
 		}

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -187,53 +187,55 @@ func pushExecveEvents(p procs) {
 	}
 
 	m := exec.MsgExecveEventUnix{}
-	m.Common.Op = ops.MSG_OP_EXECVE
-	m.Common.Size = processapi.MsgUnixSize + p.psize + p.size
+	m.Unix = &processapi.MsgExecveEventUnix{}
+	m.Unix.Msg = &processapi.MsgExecveEvent{}
+	m.Unix.Msg.Common.Op = ops.MSG_OP_EXECVE
+	m.Unix.Msg.Common.Size = processapi.MsgUnixSize + p.psize + p.size
 
-	m.Kube.NetNS = 0
-	m.Kube.Cid = 0
-	m.Kube.Cgrpid = 0
+	m.Unix.Msg.Kube.NetNS = 0
+	m.Unix.Msg.Kube.Cid = 0
+	m.Unix.Msg.Kube.Cgrpid = 0
 	if p.pid > 0 {
-		m.Kube.Docker, err = procsDockerId(p.pid)
+		m.Unix.Kube.Docker, err = procsDockerId(p.pid)
 		if err != nil {
 			logger.GetLogger().WithError(err).Warn("Procfs execve event pods/ identifier error")
 		}
 	}
 
-	m.Parent.Pid = p.ppid
-	m.Parent.Ktime = p.pktime
+	m.Unix.Msg.Parent.Pid = p.ppid
+	m.Unix.Msg.Parent.Ktime = p.pktime
 
-	m.Capabilities.Permitted = p.permitted
-	m.Capabilities.Effective = p.effective
-	m.Capabilities.Inheritable = p.inheritable
+	m.Unix.Msg.Capabilities.Permitted = p.permitted
+	m.Unix.Msg.Capabilities.Effective = p.effective
+	m.Unix.Msg.Capabilities.Inheritable = p.inheritable
 
-	m.Namespaces.UtsInum = p.uts_ns
-	m.Namespaces.IpcInum = p.ipc_ns
-	m.Namespaces.MntInum = p.mnt_ns
-	m.Namespaces.PidInum = p.pid_ns
-	m.Namespaces.PidChildInum = p.pid_for_children_ns
-	m.Namespaces.NetInum = p.net_ns
-	m.Namespaces.TimeInum = p.time_ns
-	m.Namespaces.TimeChildInum = p.time_for_children_ns
-	m.Namespaces.CgroupInum = p.cgroup_ns
-	m.Namespaces.UserInum = p.user_ns
+	m.Unix.Msg.Namespaces.UtsInum = p.uts_ns
+	m.Unix.Msg.Namespaces.IpcInum = p.ipc_ns
+	m.Unix.Msg.Namespaces.MntInum = p.mnt_ns
+	m.Unix.Msg.Namespaces.PidInum = p.pid_ns
+	m.Unix.Msg.Namespaces.PidChildInum = p.pid_for_children_ns
+	m.Unix.Msg.Namespaces.NetInum = p.net_ns
+	m.Unix.Msg.Namespaces.TimeInum = p.time_ns
+	m.Unix.Msg.Namespaces.TimeChildInum = p.time_for_children_ns
+	m.Unix.Msg.Namespaces.CgroupInum = p.cgroup_ns
+	m.Unix.Msg.Namespaces.UserInum = p.user_ns
 
-	m.Process.Size = p.size
-	m.Process.PID = p.pid
-	m.Process.TID = p.tid
-	m.Process.NSPID = p.nspid
+	m.Unix.Process.Size = p.size
+	m.Unix.Process.PID = p.pid
+	m.Unix.Process.TID = p.tid
+	m.Unix.Process.NSPID = p.nspid
 	// use euid to be compatible with ps
-	m.Process.UID = p.uids[1]
-	m.Process.AUID = p.auid
-	m.Creds = processapi.MsgGenericCredMinimal{
+	m.Unix.Process.UID = p.uids[1]
+	m.Unix.Process.AUID = p.auid
+	m.Unix.Msg.Creds = processapi.MsgGenericCredMinimal{
 		Uid: p.uids[0], Euid: p.uids[1], Suid: p.uids[2], FSuid: p.uids[3],
 		Gid: p.gids[0], Egid: p.gids[1], Sgid: p.gids[2], FSgid: p.gids[3],
 	}
-	m.Process.Flags = p.flags | flags
-	m.Process.Ktime = p.ktime
-	m.Common.Ktime = p.ktime
-	m.Process.Filename = filename
-	m.Process.Args = args
+	m.Unix.Process.Flags = p.flags | flags
+	m.Unix.Process.Ktime = p.ktime
+	m.Unix.Msg.Common.Ktime = p.ktime
+	m.Unix.Process.Filename = filename
+	m.Unix.Process.Args = args
 
 	observer.AllListeners(&m)
 }

--- a/pkg/sensors/exec/threads_test.go
+++ b/pkg/sensors/exec/threads_test.go
@@ -129,9 +129,9 @@ func TestMatchCloneThreadsIDs(t *testing.T) {
 	for _, ev := range events {
 		switch ev := ev.(type) {
 		case *grpcexec.MsgExecveEventUnix:
-			if ev.Process.Filename == testBin {
-				execPID = ev.Process.PID
-				execTID = ev.Process.TID
+			if ev.Unix.Process.Filename == testBin {
+				execPID = ev.Unix.Process.PID
+				execTID = ev.Unix.Process.TID
 			}
 		case *grpcexec.MsgCloneEventUnix:
 			// We found the exec parent then catch the single per thread

--- a/pkg/sensors/test/test.go
+++ b/pkg/sensors/test/test.go
@@ -43,7 +43,7 @@ func AddTest() {
 
 func msgToTestUnix(m *api.MsgTestEvent) *test.MsgTestEventUnix {
 	return &test.MsgTestEventUnix{
-		MsgTestEvent: *m,
+		Msg: m,
 	}
 }
 

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -1205,14 +1205,8 @@ func handleMsgGenericKprobe(m *api.MsgGenericKprobe, gk *genericKprobe, r *bytes
 	}
 
 	unix := &tracing.MsgGenericKprobeUnix{}
-	unix.Common = m.Common
-	unix.ProcessKey = m.ProcessKey
-	unix.Id = m.FuncId
-	unix.Action = m.ActionId
-	unix.Tid = m.Tid
+	unix.Msg = m
 	unix.FuncName = gk.funcName
-	unix.Namespaces = m.Namespaces
-	unix.Capabilities = m.Capabilities
 	unix.PolicyName = gk.policyName
 	unix.Message = gk.message
 
@@ -1651,7 +1645,7 @@ func retprobeMerge(prev pendingEvent, curr pendingEvent) *tracing.MsgGenericKpro
 			enterEv.Args = append(enterEv.Args, retArg)
 		}
 	}
-	enterEv.ReturnAction = retEv.Action
+	enterEv.ReturnAction = retEv.Msg.ActionId
 	return enterEv
 }
 

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -621,13 +621,9 @@ func handleGenericTracepoint(r *bytes.Reader) ([]observer.Event, error) {
 	}
 
 	unix := &tracing.MsgGenericTracepointUnix{
-		Common:     m.Common,
-		ProcessKey: m.ProcessKey,
-		Id:         m.FuncId,
-		Tid:        m.Tid,
-		Subsys:     "UNKNOWN",
-		Event:      "UNKNOWN",
-		Action:     m.ActionId,
+		Msg:    &m,
+		Subsys: "UNKNOWN",
+		Event:  "UNKNOWN",
 	}
 
 	tp, err := genericTracepointTable.getTracepoint(int(m.FuncId))

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -89,9 +89,7 @@ func handleGenericUprobe(r *bytes.Reader) ([]observer.Event, error) {
 	}
 
 	unix := &tracing.MsgGenericUprobeUnix{}
-	unix.Common = m.Common
-	unix.ProcessKey = m.ProcessKey
-	unix.Tid = m.Tid
+	unix.Msg = &m
 	unix.Path = uprobeEntry.path
 	unix.Symbol = uprobeEntry.symbol
 	unix.PolicyName = uprobeEntry.policyName

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3825,11 +3825,11 @@ func matchBinariesPerfringTest(t *testing.T, operator string, values []string) {
 	tailEventExist := false
 	for _, ev := range events {
 		if kprobe, ok := ev.(*tracing.MsgGenericKprobeUnix); ok {
-			if int(kprobe.ProcessKey.Pid) == tailPID {
+			if int(kprobe.Msg.ProcessKey.Pid) == tailPID {
 				tailEventExist = true
 				continue
 			}
-			if int(kprobe.ProcessKey.Pid) == headPID {
+			if int(kprobe.Msg.ProcessKey.Pid) == headPID {
 				t.Error("kprobe event triggered by /usr/bin/head should be filtered by the matchBinaries selector")
 				break
 			}
@@ -3915,7 +3915,7 @@ func TestKprobeMatchBinariesEarlyExec(t *testing.T) {
 
 	for _, ev := range events {
 		if kprobe, ok := ev.(*tracing.MsgGenericKprobeUnix); ok {
-			if int(kprobe.ProcessKey.Pid) == tailCommand.Process.Pid && kprobe.FuncName == arch.AddSyscallPrefixTestHelper(t, "sys_read") {
+			if int(kprobe.Msg.ProcessKey.Pid) == tailCommand.Process.Pid && kprobe.FuncName == arch.AddSyscallPrefixTestHelper(t, "sys_read") {
 				return
 			}
 		}
@@ -4012,15 +4012,15 @@ func TestKprobeMatchBinariesPrefixMatchArgs(t *testing.T) {
 	tailEventExist := false
 	for _, ev := range events {
 		if kprobe, ok := ev.(*tracing.MsgGenericKprobeUnix); ok {
-			if int(kprobe.ProcessKey.Pid) == tailEtcPID {
+			if int(kprobe.Msg.ProcessKey.Pid) == tailEtcPID {
 				tailEventExist = true
 				continue
 			}
-			if int(kprobe.ProcessKey.Pid) == tailProcPID {
+			if int(kprobe.Msg.ProcessKey.Pid) == tailProcPID {
 				t.Error("kprobe event triggered by \"/usr/bin/tail /proc/uptime\" should be filtered by the matchArgs selector")
 				break
 			}
-			if int(kprobe.ProcessKey.Pid) == headPID {
+			if int(kprobe.Msg.ProcessKey.Pid) == headPID {
 				t.Error("kprobe event triggered by /usr/bin/head should be filtered by the matchBinaries selector")
 				break
 			}

--- a/pkg/sensors/tracing/loader.go
+++ b/pkg/sensors/tracing/loader.go
@@ -167,10 +167,9 @@ func handleLoader(r *bytes.Reader) ([]observer.Event, error) {
 	path := m.Path[:m.PathSize-1]
 
 	msg := &tracing.MsgProcessLoaderUnix{
-		ProcessKey: m.ProcessKey,
-		Ktime:      m.Common.Ktime,
-		Path:       strutils.UTF8FromBPFBytes(path),
-		Buildid:    m.BuildId[:m.BuildIdSize],
+		Msg:     &m,
+		Path:    strutils.UTF8FromBPFBytes(path),
+		Buildid: m.BuildId[:m.BuildIdSize],
 	}
 	return []observer.Event{msg}, nil
 }

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -236,8 +236,8 @@ func TestNamespacedPolicies(t *testing.T) {
 						return &x
 					}
 				} else if execEvent, ok := x.(*grpcexec.MsgExecveEventUnix); ok {
-					if strings.HasSuffix(execEvent.Process.Filename, "lseek-pipe") {
-						t.Logf("exec:%s %s, cgroupid:%d flags:%v", execEvent.Process.Filename, execEvent.Process.Args, execEvent.Kube.Cgrpid, execEvent.Process.Flags)
+					if strings.HasSuffix(execEvent.Unix.Process.Filename, "lseek-pipe") {
+						t.Logf("exec:%s %s, cgroupid:%d flags:%v", execEvent.Unix.Process.Filename, execEvent.Unix.Process.Args, execEvent.Unix.Msg.Kube.Cgrpid, execEvent.Unix.Process.Flags)
 					}
 				}
 				return nil

--- a/pkg/testutils/perfring/perfring.go
+++ b/pkg/testutils/perfring/perfring.go
@@ -33,7 +33,7 @@ func loopEvents(events []observer.Event, eventFn EventFn, complChecker *testsens
 	for _, ev := range events {
 		switch xev := ev.(type) {
 		case *testapi.MsgTestEventUnix:
-			cpu := xev.Arg0
+			cpu := xev.Msg.Arg0
 			complChecker.Update(cpu)
 		}
 


### PR DESCRIPTION
Most sensors send data from kernel to user space via the perf ring buffer. They typically copy it into a struct, and copy it from that struct to another "Unix" struct. This series removes the second copy by replacing the duplicate members in the Unix struct with a pointer to the original struct. This should improve perf.