### PR TITLE
tetra: add a probe command to probe BPF features 

### DIFF
--- a/cmd/tetra/commands_linux.go
+++ b/cmd/tetra/commands_linux.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/tetragon/cmd/tetra/bugtool"
 	"github.com/cilium/tetragon/cmd/tetra/dump"
 	"github.com/cilium/tetragon/cmd/tetra/policyfilter"
+	"github.com/cilium/tetragon/cmd/tetra/probe"
 	"github.com/cilium/tetragon/cmd/tetra/tracingpolicy"
 	"github.com/spf13/cobra"
 )
@@ -17,4 +18,5 @@ func addCommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(tracingpolicy.New())
 	rootCmd.AddCommand(dump.New())
 	rootCmd.AddCommand(policyfilter.New())
+	rootCmd.AddCommand(probe.New())
 }

--- a/cmd/tetra/probe/probe.go
+++ b/cmd/tetra/probe/probe.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package probe
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/spf13/cobra"
+)
+
+func checkCapSysAdmin() (bool, error) {
+	caps := unix.CapUserData{}
+	err := unix.Capget(&unix.CapUserHeader{Version: unix.LINUX_CAPABILITY_VERSION_3}, &caps)
+	if err != nil {
+		return false, fmt.Errorf("error getting capabilities: %w", err)
+	}
+	return caps.Effective&(1<<unix.CAP_SYS_ADMIN) != 0, nil
+}
+
+func New() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "probe",
+		Short: "Probe for eBPF system features availability",
+		Long:  "Probe detects whether the eBPF system features required by Tetragon are\navailable on the running kernel.\n",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			// Also checking against CAP_BPF and CAP_PERFMON requires more work
+			// since they are stored beyond the 32 bits set. Checking
+			// CAP_SYS_ADMIN should produce sufficient warning most of the time.
+			if ok, err := checkCapSysAdmin(); err == nil && !ok {
+				cmd.PrintErrln("warning: for accurate results, you may need to run as root and/or with sufficient capabilities.")
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Println(strings.ReplaceAll(bpf.LogFeatures(), ", ", "\n"))
+		},
+	}
+	return &cmd
+}

--- a/cmd/tetra/probe/probe_test.go
+++ b/cmd/tetra/probe/probe_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package probe
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ProbeCommand(t *testing.T) {
+	cmd := New()
+	cmdOutput := &bytes.Buffer{}
+	cmd.SetOut(cmdOutput)
+	cmd.SetErr(io.Discard)
+
+	cmd.Execute()
+
+	t.Run("ContainsTrueFalse", func(t *testing.T) {
+		assert.True(t, strings.Contains(cmdOutput.String(), "false") || strings.Contains(cmdOutput.String(), "true"))
+	})
+
+	t.Run("EnoughFeatureLines", func(t *testing.T) {
+		assert.GreaterOrEqual(t, strings.Count(cmdOutput.String(), "\n"), 7)
+	})
+}

--- a/pkg/bpf/detect.go
+++ b/pkg/bpf/detect.go
@@ -127,7 +127,7 @@ func detectModifyReturnSyscall() bool {
 	if err != nil {
 		return false
 	}
-	logger.GetLogger().Infof("probing detectModifyReturnSyscall using %s", sysGetcpu)
+	logger.GetLogger().Debugf("probing detectModifyReturnSyscall using %s", sysGetcpu)
 	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
 		Name: "probe_sys_fmod_ret",
 		Type: ebpf.Tracing,


### PR DESCRIPTION
This can typically be run in the context of Kubernetes with the following command:
```shell
kubectl run bpf-probe --image=quay.io/cilium/tetragon --privileged --restart=Never -it --rm --command -- tetra probe
```