### PR TITLE
tetragon: Harden loader sensor

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -69,6 +69,8 @@ jobs:
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
               - 'bpf-next-20240126.012639'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
+              - '6.6-20240123.120815'
+              # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
               - '6.1-20240125.104921'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
               - '5.15-20240125.104921'


### PR DESCRIPTION
Making the loader sensor to send data for non excutable mmaps as well
to increase the chance that we might be able to read build id for the
binary at least from one of them.
    
As we can't sleep at the current loader probed function, we depend on
the page with build id being swapped-in, which might not be always the
case. By allowing to send build id data for mmap non executable mmap
events we increase the chance of getting the build id data for binary.
