### PR TITLE
validation: improve error message when failing to load a TracingPolicy

### DIFF
--- a/pkg/tracingpolicy/generictracingpolicy.go
+++ b/pkg/tracingpolicy/generictracingpolicy.go
@@ -272,11 +272,11 @@ func FromYAML(data string) (TracingPolicy, error) {
 
 	validationResult, err := ValidateCRD(policy)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validation failed %q: %w", policy.GetMetadata().Name, err)
 	}
 
 	if len(validationResult.Errors) > 0 {
-		return nil, fmt.Errorf("validation failed: %w", validationResult.AsError())
+		return nil, fmt.Errorf("validation failed: %q: %w", policy.GetMetadata().Name, validationResult.AsError())
 	}
 
 	return policy, nil
@@ -287,7 +287,11 @@ func FromFile(path string) (TracingPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
-	return FromYAML(string(policy))
+	tp, err := FromYAML(string(policy))
+	if err != nil {
+		return nil, fmt.Errorf("failed loading tracing policy file %q: %w", path, err)
+	}
+	return tp, nil
 }
 
 type GenericTracingPolicyNamespaced struct {


### PR DESCRIPTION
Callers of `tracingpolicy.FromFile()` no longer receive highly specific errors, but a generic error, which can also be presented to end users. Callers of `tracingpolicy.FromJSON()` still receive the specific errors, and any generic error wraps a specific one.

The implementation is along the lines suggested by @mtardy in #2022. (Thanks for that input.) Please indicate if my use of `Panicf()` in `pkg/tracingpolicy/generictracingpolicy_test.go` is unwelcome.

BTW, it seems to me that `drop-privileges` should be added to `contrib/tester-progs/.gitignore`. I could create another PR for that, if applicable (plus an issue, if necessary for the trivial change).

Fixes #2022

Signed-off-by: Christian Hörtnagl <christian2@univie.ac.at>