### PR TITLE
Git-ignore drop-privileges along with other binaries

### DIFF
--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -19,3 +19,4 @@ threads-exit
 killer-tester
 killer-tester-32
 /getcpu
+drop-privileges


### PR DESCRIPTION
As agreed in PR #2031. W/o corresponding issue, because change is minor.