### PR TITLE
workflows: use defined actions/checkout version in validate-crd.yaml

### DIFF
--- a/.github/workflows/validate-crd.yaml
+++ b/.github/workflows/validate-crd.yaml
@@ -10,7 +10,9 @@ jobs:
   check-version:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Check for CRD changes and version update
         run: |
           crd_changed=0


### PR DESCRIPTION
This is a really small fix just to make renovate able to update that dep.