### PR TITLE
killer: assorted fixes

### DIFF
--- a/bpf/process/bpf_killer.c
+++ b/bpf/process/bpf_killer.c
@@ -23,12 +23,14 @@ do_killer(void *ctx)
 
 #ifdef __MULTI_KPROBE
 #define MAIN "kprobe.multi/killer"
+#define FUNC kprobe_multi_killer
 #else
 #define MAIN "kprobe/killer"
+#define FUNC kprobe_killer
 #endif
 
 __attribute__((section(MAIN), used)) int
-multi_kprobe_killer(void *ctx)
+FUNC(void *ctx)
 {
 	long ret;
 

--- a/contrib/tester-progs/killer-tester.c
+++ b/contrib/tester-progs/killer-tester.c
@@ -1,9 +1,18 @@
 #include <stdio.h>
 #include <sys/prctl.h>
 #include <errno.h>
+#include <stdlib.h>
+#include <limits.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
-	prctl(0xffff, 0, 0, 0, 0);
+	long long num = 0xffff;
+
+	if (argc == 2) {
+		num = strtoll(argv[1], NULL, 16);
+		if (num == LONG_MIN)
+			return -EINVAL;
+	}
+	prctl(num, 0, 0, 0, 0);
 	return errno;
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -248,7 +248,7 @@ func filterMaps(load *program.Program, pinPath string, kprobeEntry *genericKprob
 	return maps
 }
 
-func createMultiKprobeSensor(sensorPath string, multiIDs []idtable.EntryID) ([]*program.Program, []*program.Map, error) {
+func createMultiKprobeSensor(sensorPath, policyName string, multiIDs []idtable.EntryID) ([]*program.Program, []*program.Map, error) {
 	var multiRetIDs []idtable.EntryID
 	var progs []*program.Program
 	var maps []*program.Map
@@ -318,7 +318,7 @@ func createMultiKprobeSensor(sensorPath string, multiIDs []idtable.EntryID) ([]*
 		maps = append(maps, socktrack)
 	}
 
-	killerDataMap := program.MapBuilderPin(killerDataMapName, killerDataMapName, load)
+	killerDataMap := killerMap(policyName, load)
 	maps = append(maps, killerDataMap)
 
 	filterMap.SetMaxEntries(len(multiIDs))
@@ -564,7 +564,7 @@ func createGenericKprobeSensor(
 	}
 
 	if useMulti {
-		progs, maps, err = createMultiKprobeSensor(in.sensorPath, ids)
+		progs, maps, err = createMultiKprobeSensor(in.sensorPath, in.policyName, ids)
 	} else {
 		progs, maps, err = createSingleKprobeSensor(in.sensorPath, ids)
 	}
@@ -868,7 +868,7 @@ func createKprobeSensorFromEntry(kprobeEntry *genericKprobe, sensorPath string,
 		maps = append(maps, socktrack)
 	}
 
-	killerDataMap := program.MapBuilderPin(killerDataMapName, killerDataMapName, load)
+	killerDataMap := killerMap(kprobeEntry.policyName, load)
 	maps = append(maps, killerDataMap)
 
 	if kprobeEntry.loadArgs.retprobe {

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -472,7 +472,7 @@ func createGenericTracepointSensor(
 		}
 		maps = append(maps, matchBinariesPaths)
 
-		killerDataMap := program.MapBuilderPin("killer_data", "killer_data", prog0)
+		killerDataMap := killerMap(policyName, prog0)
 		maps = append(maps, killerDataMap)
 
 		selMatchBinariesMap := program.MapBuilderPin("tg_mb_sel_opts", sensors.PathJoin(pinPath, "tg_mb_sel_opts"), prog0)


### PR DESCRIPTION
Forcing fmod_ret method for secrity_* functions.
Allow multiple killer sensors.