### PR TITLE
Fix typo on TracingPolicy Selectors Stack Traces documentation

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -843,7 +843,7 @@ kprobes:
   - call: kfree_skb_reason
     selectors:
     - matchActions:
-      - action: post
+      - action: Post
         stackTrace: true
 ```
 


### PR DESCRIPTION
The yaml file in the Stack Traces section contained a typo that has been fixed.