### PR TITLE
docs: fix assertions about tracingpolicy args field 

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -214,11 +214,9 @@ running in all the bash shells.
 
 ## Arguments
 
-Kprobes and tracepoints may use the optional `args` field. It is a list of
-arguments to include in the trace output. Tetragon's BPF code requires
-information about the types of arguments to properly read, print and
-filter on its arguments. This information needs to be provided by the user under the
-`args` section. For the [available
+Kprobes and tracepoints may use the optional `args` field. Tetragon's BPF code requires
+information about the types of arguments to properly read, print and filters on its arguments.
+ This information can be provided by the user under the `args` section. For the [available
 types](https://github.com/cilium/tetragon/blob/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml#L64-L88),
 check the [`TracingPolicy`
 CRD](https://github.com/cilium/tetragon/blob/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml).

--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -214,7 +214,7 @@ running in all the bash shells.
 
 ## Arguments
 
-Kprobes, uprobes and tracepoints all share a needed arguments fields called `args`. It is a list of
+Kprobes and tracepoints may use the optional `args` field. It is a list of
 arguments to include in the trace output. Tetragon's BPF code requires
 information about the types of arguments to properly read, print and
 filter on its arguments. This information needs to be provided by the user under the


### PR DESCRIPTION
The docs about the _tracing policies_ `args` field make wrong assertions about its use.
The `args` field is not mandatory and it is currently not supported on `uprobes`.