### PR TITLE
tetragon: Factor uprobe sensor setup

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -2375,7 +2375,7 @@ filter_read_arg(void *ctx, struct bpf_map_def *heap,
 	}
 
 	tail_call(ctx, tailcalls, TAIL_CALL_SEND);
-	return 1;
+	return 0;
 }
 
 static inline __attribute__((always_inline)) long
@@ -2417,7 +2417,7 @@ generic_actions(void *ctx, struct bpf_map_def *heap,
 	postit = do_actions(ctx, e, actions, override_tasks);
 	if (postit)
 		tail_call(ctx, tailcalls, TAIL_CALL_SEND);
-	return 1;
+	return 0;
 }
 
 static inline __attribute__((always_inline)) long
@@ -2468,7 +2468,7 @@ generic_output(void *ctx, struct bpf_map_def *heap, u8 op)
 		     : [total] "+r"(total)
 		     :);
 	perf_event_output_metric(ctx, op, &tcpmon_map, BPF_F_CURRENT_CPU, e, total);
-	return 1;
+	return 0;
 }
 
 /**


### PR DESCRIPTION
after talking to ebpf/cilium maintainers, new release might still take a while,
so pushing at least the generic refactoring change from https://github.com/cilium/tetragon/pull/1914 so it won't get old 

Separating  uprobe sensor setup into addUprobe function, that creates and sets up uprobeEntry object and createSingleUprobeSensor that creates the actual sensor progs/maps arrays.

This way we can easily add multi uprobe sensor create function in following changes.