### PR TITLE
pkg/metrics: fix a typo in `policyfilter_metrics_total`

### DIFF
--- a/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
+++ b/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
@@ -15,7 +15,7 @@ import (
 var (
 	PolicyFilterOpMetrics = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
-		Name:        "policyflter_metrics_total",
+		Name:        "policyfilter_metrics_total",
 		Help:        "Policy filter metrics. For internal use only.",
 		ConstLabels: nil,
 	}, []string{"subsys", "op", "error_type"})


### PR DESCRIPTION
This is a breaking change but this metric is for internal use only so it should not be too bad.