### PR TITLE
README: remove the link to the tutorials in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ and generates events enriched with Linux and Kubernetes metadata:
 See further resources:
 - [Conference Talks, Books, Blog Posts, and Labs](https://tetragon.io/docs/resources/)
 - [Frequently Asked Question](https://tetragon.io/docs/faq/)
-- [Step by steps tutorials](https://tetragon.io/docs/tutorials/)
 - [References](https://tetragon.io/docs/reference/)
 
 ## Join the community


### PR DESCRIPTION
This section was removed by #2097.