### PR TITLE
tetragon: Remove superfluous MapDir

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -259,7 +259,6 @@ func tetragonExecute() error {
 	// Get observer bpf maps and programs directory
 	observerDir := getObserverDir()
 	option.Config.BpfDir = observerDir
-	option.Config.MapDir = observerDir
 
 	// Check if option to remove old BPF and maps is enabled.
 	if option.Config.ReleasePinned {
@@ -353,7 +352,7 @@ func tetragonExecute() error {
 	}
 
 	// Probe runtime configuration and do not fail on errors
-	obs.UpdateRuntimeConf(option.Config.MapDir)
+	obs.UpdateRuntimeConf(option.Config.BpfDir)
 
 	var k8sWatcher watcher.K8sResourceWatcher
 	if option.Config.EnableK8s {

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -427,7 +427,7 @@ func tetragonExecute() error {
 
 	// load base sensor
 	base := base.GetInitialSensor()
-	if err := base.Load(observerDir, observerDir); err != nil {
+	if err := base.Load(observerDir); err != nil {
 		return err
 	}
 	defer func() {

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -126,11 +126,11 @@ func runTetragon(ctx context.Context, configFile string, args *Arguments, summar
 
 	baseSensors := base.GetInitialSensor()
 
-	if err := baseSensors.Load(option.Config.BpfDir, option.Config.MapDir); err != nil {
+	if err := baseSensors.Load(option.Config.BpfDir); err != nil {
 		log.Fatalf("Load base error: %s\n", err)
 	}
 
-	if err := benchSensors.Load(option.Config.BpfDir, option.Config.MapDir); err != nil {
+	if err := benchSensors.Load(option.Config.BpfDir); err != nil {
 		log.Fatalf("Load sensors error: %s\n", err)
 	}
 

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -86,7 +86,6 @@ func runTetragon(ctx context.Context, configFile string, args *Arguments, summar
 	option.Config.RBSize = args.RBSize
 
 	option.Config.BpfDir = bpf.MapPrefixPath()
-	option.Config.MapDir = bpf.MapPrefixPath()
 	obs := observer.NewObserver(configFile)
 
 	if err := obs.InitSensorManager(nil); err != nil {

--- a/pkg/metrics/eventmetrics/collector.go
+++ b/pkg/metrics/eventmetrics/collector.go
@@ -25,7 +25,7 @@ func (c *bpfCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *bpfCollector) Collect(ch chan<- prometheus.Metric) {
-	mapHandle, err := ebpf.LoadPinnedMap(filepath.Join(option.Config.MapDir, "tg_stats_map"), nil)
+	mapHandle, err := ebpf.LoadPinnedMap(filepath.Join(option.Config.BpfDir, "tg_stats_map"), nil)
 	if err != nil {
 		return
 	}

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -330,9 +330,9 @@ type Observer struct {
 // On errors we also print a warning that advanced Cgroups tracking will be
 // disabled which might affect process association with kubernetes pods and
 // containers.
-func (k *Observer) UpdateRuntimeConf(mapDir string) error {
+func (k *Observer) UpdateRuntimeConf(bpfDir string) error {
 	pid := os.Getpid()
-	err := confmap.UpdateTgRuntimeConf(mapDir, pid)
+	err := confmap.UpdateTgRuntimeConf(bpfDir, pid)
 	if err != nil {
 		k.log.WithField("observer", "confmap-update").WithError(err).Warn("Update TetragonConf map failed, advanced Cgroups tracking will be disabled")
 		k.log.WithField("observer", "confmap-update").Warn("Continuing without advanced Cgroups tracking. Process association with Pods and Containers might be limited")
@@ -354,7 +354,7 @@ func (k *Observer) Start(ctx context.Context) error {
 
 // InitSensorManager starts the sensor controller
 func (k *Observer) InitSensorManager(waitChan chan struct{}) error {
-	mgr, err := sensors.StartSensorManager(option.Config.BpfDir, option.Config.MapDir, waitChan)
+	mgr, err := sensors.StartSensorManager(option.Config.BpfDir, waitChan)
 	if err != nil {
 		return err
 	}
@@ -412,7 +412,7 @@ func (k *Observer) PrintStats() {
 }
 
 func (k *Observer) RemovePrograms() {
-	RemovePrograms(option.Config.BpfDir, option.Config.MapDir)
+	RemovePrograms(option.Config.BpfDir)
 }
 
 func RemoveSensors(ctx context.Context) {

--- a/pkg/observer/observer_stats.go
+++ b/pkg/observer/observer_stats.go
@@ -45,7 +45,7 @@ func (c *bpfCollector) Collect(ch chan<- prometheus.Metric) {
 			continue
 		}
 		processedMaps[name] = true
-		pin := filepath.Join(option.Config.MapDir, name)
+		pin := filepath.Join(option.Config.BpfDir, name)
 		// Skip map names that end up with _stats.
 		// This will result in _stats_stats suffixes that we don't care about
 		if strings.HasSuffix(pin, statsSuffix) {

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -207,7 +207,6 @@ func newDefaultTestOptions(opts ...TestOption) *TestOptions {
 
 func newDefaultObserver(oo *testObserverOptions) *observer.Observer {
 	option.Config.BpfDir = bpf.MapPrefixPath()
-	option.Config.MapDir = bpf.MapPrefixPath()
 	return observer.NewObserver(oo.config)
 }
 
@@ -312,7 +311,6 @@ func GetDefaultSensorsWithFile(tb testing.TB, file, lib string, opts ...TestOpti
 	opts = append(opts, WithLib(lib))
 
 	option.Config.BpfDir = bpf.MapPrefixPath()
-	option.Config.MapDir = bpf.MapPrefixPath()
 
 	testutils.CaptureLog(tb, logger.GetLogger().(*logrus.Logger))
 

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -434,7 +434,7 @@ func loadExporter(tb testing.TB, ctx context.Context, obs *observer.Observer, op
 func loadObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor,
 	tp tracingpolicy.TracingPolicy) error {
 
-	if err := base.Load(option.Config.BpfDir, option.Config.MapDir); err != nil {
+	if err := base.Load(option.Config.BpfDir); err != nil {
 		tb.Fatalf("Load base error: %s\n", err)
 	}
 
@@ -452,11 +452,11 @@ func loadObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor,
 }
 
 func loadSensor(tb testing.TB, base *sensors.Sensor, sens *sensors.Sensor) error {
-	if err := base.Load(option.Config.BpfDir, option.Config.MapDir); err != nil {
+	if err := base.Load(option.Config.BpfDir); err != nil {
 		tb.Fatalf("Load base error: %s\n", err)
 	}
 
-	if err := sens.Load(option.Config.BpfDir, option.Config.MapDir); err != nil {
+	if err := sens.Load(option.Config.BpfDir); err != nil {
 		tb.Fatalf("LoadConfig error: %s\n", err)
 	}
 	return nil

--- a/pkg/observer/program.go
+++ b/pkg/observer/program.go
@@ -9,8 +9,7 @@ import (
 	"github.com/cilium/tetragon/pkg/sensors"
 )
 
-func RemovePrograms(bpfDir, mapDir string) {
+func RemovePrograms(bpfDir string) {
 	sensors.UnloadAll()
 	os.Remove(bpfDir)
-	os.Remove(mapDir)
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -35,7 +35,6 @@ type config struct {
 
 	GopsAddr string
 
-	MapDir string
 	BpfDir string
 
 	LogOpts map[string]string

--- a/pkg/sensors/collection.go
+++ b/pkg/sensors/collection.go
@@ -35,7 +35,7 @@ func (c *collection) info() string {
 
 // load will attempt to load a collection of sensors. If loading one of the sensors fails, it
 // will attempt to unload the already loaded sensors.
-func (c *collection) load(bpfDir, mapDir string) error {
+func (c *collection) load(bpfDir string) error {
 
 	var err error
 	for _, sensor := range c.sensors {
@@ -44,7 +44,7 @@ func (c *collection) load(bpfDir, mapDir string) error {
 			// because that would complicate things.
 			continue
 		}
-		if err = sensor.Load(bpfDir, mapDir); err != nil {
+		if err = sensor.Load(bpfDir); err != nil {
 			err = fmt.Errorf("sensor %s from collection %s failed to load: %s", sensor.Name, c.name, err)
 			break
 		}

--- a/pkg/sensors/collection.go
+++ b/pkg/sensors/collection.go
@@ -44,11 +44,6 @@ func (c *collection) load(bpfDir, mapDir string) error {
 			// because that would complicate things.
 			continue
 		}
-		if err = sensor.FindPrograms(); err != nil {
-			err = fmt.Errorf("sensor %s programs from collection %s could not be found: %s", sensor.Name, c.name, err)
-			break
-		}
-
 		if err = sensor.Load(bpfDir, mapDir); err != nil {
 			err = fmt.Errorf("sensor %s from collection %s failed to load: %s", sensor.Name, c.name, err)
 			break

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -227,7 +227,7 @@ func handleCgroupEvent(r *bytes.Reader) ([]observer.Event, error) {
 type execProbe struct{}
 
 func (e *execProbe) LoadProbe(args sensors.LoadProbeArgs) error {
-	err := program.LoadTracepointProgram(args.BPFDir, args.MapDir, args.Load, args.Verbose)
+	err := program.LoadTracepointProgram(args.BPFDir, args.Load, args.Verbose)
 	if err == nil {
 		err = procevents.GetRunningProcs()
 	}

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -512,7 +512,7 @@ func TestLoadInitialSensor(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 
 	t.Logf("Loading sensor %v\n", sensor.Name)
-	if err := sensor.Load(bpf.MapPrefixPath(), bpf.MapPrefixPath()); err != nil {
+	if err := sensor.Load(bpf.MapPrefixPath()); err != nil {
 		t.Fatalf("sensor.Load failed: %v\n", err)
 	}
 

--- a/pkg/sensors/handler.go
+++ b/pkg/sensors/handler.go
@@ -15,8 +15,8 @@ import (
 
 type handler struct {
 	// map of sensor collections: name -> collection
-	collections    map[string]collection
-	bpfDir, mapDir string
+	collections map[string]collection
+	bpfDir      string
 
 	nextPolicyID uint64
 	pfState      policyfilter.State
@@ -24,11 +24,10 @@ type handler struct {
 
 func newHandler(
 	pfState policyfilter.State,
-	bpfDir, mapDir string) (*handler, error) {
+	bpfDir string) (*handler, error) {
 	return &handler{
 		collections: map[string]collection{},
 		bpfDir:      bpfDir,
-		mapDir:      mapDir,
 		pfState:     pfState,
 		// NB: we are using policy ids for filtering, so we start with
 		// the first valid id. This is because value 0 is reserved to
@@ -120,7 +119,7 @@ func (h *handler) addTracingPolicy(op *tracingPolicyAdd) error {
 		tracingpolicyID: uint64(tpID),
 		policyfilterID:  uint64(filterID),
 	}
-	if err := col.load(h.bpfDir, h.mapDir); err != nil {
+	if err := col.load(h.bpfDir); err != nil {
 		return err
 	}
 	col.enabled = true
@@ -212,7 +211,7 @@ func (h *handler) enableTracingPolicy(op *tracingPolicyEnable) error {
 		return fmt.Errorf("tracing policy %s is already enabled", op.name)
 	}
 
-	if err := col.load(h.bpfDir, h.mapDir); err != nil {
+	if err := col.load(h.bpfDir); err != nil {
 		return err
 	}
 
@@ -267,7 +266,7 @@ func (h *handler) enableSensor(op *sensorEnable) error {
 		return fmt.Errorf("sensor %s does not exist", op.name)
 	}
 
-	return col.load(h.bpfDir, h.mapDir)
+	return col.load(h.bpfDir)
 }
 
 func (h *handler) disableSensor(op *sensorDisable) error {

--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -335,11 +335,11 @@ func loadInstance(bpfDir, mapDir string, load *program.Program, version, verbose
 
 	switch load.Type {
 	case "tracepoint":
-		return program.LoadTracepointProgram(bpfDir, mapDir, load, verbose)
+		return program.LoadTracepointProgram(bpfDir, load, verbose)
 	case "raw_tracepoint", "raw_tp":
-		return program.LoadRawTracepointProgram(bpfDir, mapDir, load, verbose)
+		return program.LoadRawTracepointProgram(bpfDir, load, verbose)
 	case "cgrp_socket":
-		return cgroup.LoadCgroupProgram(bpfDir, mapDir, load, verbose)
+		return cgroup.LoadCgroupProgram(bpfDir, load, verbose)
 	}
 
 	if probe != nil {
@@ -353,7 +353,7 @@ func loadInstance(bpfDir, mapDir string, load *program.Program, version, verbose
 		})
 	}
 
-	return program.LoadKprobeProgram(bpfDir, mapDir, load, verbose)
+	return program.LoadKprobeProgram(bpfDir, load, verbose)
 }
 
 func observerMinReqs() (bool, error) {

--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -346,7 +346,6 @@ func loadInstance(bpfDir, mapDir string, load *program.Program, version, verbose
 		// Registered probes need extra setup
 		return probe.LoadProbe(LoadProbeArgs{
 			BPFDir:  bpfDir,
-			MapDir:  mapDir,
 			Load:    load,
 			Version: version,
 			Verbose: verbose,

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -41,7 +41,7 @@ func StartSensorManager(
 		return nil, fmt.Errorf("failed to initialize policy filter state: %w", err)
 	}
 
-	handler, err := newHandler(pfState, bpfDir, mapDir)
+	handler, err := newHandler(pfState, bpfDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -33,7 +33,7 @@ type SensorStatus struct {
 // something is received. The intention of this is to allow the main function
 // to first load the base sensor before the sensor manager starts loading other sensors.
 func StartSensorManager(
-	bpfDir, mapDir string,
+	bpfDir string,
 	waitChan chan struct{},
 ) (*Manager, error) {
 	pfState, err := policyfilter.GetState()

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -40,7 +40,7 @@ func TestAddPolicy(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("", "", nil)
+	mgr, err := StartSensorManager("", nil)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
@@ -68,7 +68,7 @@ func TestAddPolicies(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("", "", nil)
+	mgr, err := StartSensorManager("", nil)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
@@ -99,7 +99,7 @@ func TestAddPolicySpecError(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("", "", nil)
+	mgr, err := StartSensorManager("", nil)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
@@ -131,7 +131,7 @@ func TestAddPolicyLoadError(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("", "", nil)
+	mgr, err := StartSensorManager("", nil)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -151,7 +151,7 @@ func TestPolicyFilterDisabled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	handler, err := newHandler(policyfilter.DisabledState(), "", "")
+	handler, err := newHandler(policyfilter.DisabledState(), "")
 	assert.NoError(t, err)
 	mgr, err := startSensorManager(handler, nil)
 	assert.NoError(t, err)

--- a/pkg/sensors/program/cgroup/cgroup.go
+++ b/pkg/sensors/program/cgroup/cgroup.go
@@ -35,5 +35,5 @@ func LoadCgroupProgram(
 		}
 		fgsCgroupFD = fd
 	}
-	return program.LoadProgram(bpfDir, []string{mapDir}, load, program.RawAttach(fgsCgroupFD), verbose)
+	return program.LoadProgram(bpfDir, load, program.RawAttach(fgsCgroupFD), verbose)
 }

--- a/pkg/sensors/program/cgroup/cgroup.go
+++ b/pkg/sensors/program/cgroup/cgroup.go
@@ -19,14 +19,14 @@ var (
 )
 
 func LoadSockOpt(
-	bpfDir, mapDir string,
+	bpfDir string,
 	load *program.Program, verbose int,
 ) error {
-	return LoadCgroupProgram(bpfDir, mapDir, load, verbose)
+	return LoadCgroupProgram(bpfDir, load, verbose)
 }
 
 func LoadCgroupProgram(
-	bpfDir, mapDir string,
+	bpfDir string,
 	load *program.Program, verbose int) error {
 	if fgsCgroupFD < 0 {
 		fd, err := unix.Open(fgsCgroupPath, unix.O_RDONLY, 0)

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -430,7 +430,7 @@ func MultiKprobeAttach(load *Program, bpfDir string) AttachFunc {
 	}
 }
 
-func LoadTracepointProgram(bpfDir, mapDir string, load *Program, verbose int) error {
+func LoadTracepointProgram(bpfDir string, load *Program, verbose int) error {
 	var ci *customInstall
 	for mName, mPath := range load.PinMap {
 		if mName == "tp_calls" || mName == "execve_calls" {
@@ -445,14 +445,14 @@ func LoadTracepointProgram(bpfDir, mapDir string, load *Program, verbose int) er
 	return loadProgram(bpfDir, load, opts, verbose)
 }
 
-func LoadRawTracepointProgram(bpfDir, mapDir string, load *Program, verbose int) error {
+func LoadRawTracepointProgram(bpfDir string, load *Program, verbose int) error {
 	opts := &loadOpts{
 		attach: RawTracepointAttach(load),
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
 }
 
-func LoadKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
+func LoadKprobeProgram(bpfDir string, load *Program, verbose int) error {
 	var ci *customInstall
 	for mName, mPath := range load.PinMap {
 		if mName == "kprobe_calls" || mName == "retkprobe_calls" {
@@ -490,14 +490,14 @@ func KprobeAttachMany(load *Program, syms []string) AttachFunc {
 	}
 }
 
-func LoadKprobeProgramAttachMany(bpfDir, mapDir string, load *Program, syms []string, verbose int) error {
+func LoadKprobeProgramAttachMany(bpfDir string, load *Program, syms []string, verbose int) error {
 	opts := &loadOpts{
 		attach: KprobeAttachMany(load, syms),
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
 }
 
-func LoadUprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
+func LoadUprobeProgram(bpfDir string, load *Program, verbose int) error {
 	var ci *customInstall
 	for mName, mPath := range load.PinMap {
 		if mName == "uprobe_calls" {
@@ -512,7 +512,7 @@ func LoadUprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error 
 	return loadProgram(bpfDir, load, opts, verbose)
 }
 
-func LoadMultiKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) error {
+func LoadMultiKprobeProgram(bpfDir string, load *Program, verbose int) error {
 	var ci *customInstall
 	for mName, mPath := range load.PinMap {
 		if mName == "kprobe_calls" || mName == "retkprobe_calls" {
@@ -528,7 +528,7 @@ func LoadMultiKprobeProgram(bpfDir, mapDir string, load *Program, verbose int) e
 	return loadProgram(bpfDir, load, opts, verbose)
 }
 
-func LoadFmodRetProgram(bpfDir, mapDir string, load *Program, progName string, verbose int) error {
+func LoadFmodRetProgram(bpfDir string, load *Program, progName string, verbose int) error {
 	opts := &loadOpts{
 		attach: func(
 			_ *ebpf.Collection,
@@ -564,14 +564,14 @@ func LoadFmodRetProgram(bpfDir, mapDir string, load *Program, progName string, v
 	return loadProgram(bpfDir, load, opts, verbose)
 }
 
-func LoadTracingProgram(bpfDir, mapDir string, load *Program, verbose int) error {
+func LoadTracingProgram(bpfDir string, load *Program, verbose int) error {
 	opts := &loadOpts{
 		attach: TracingAttach(),
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
 }
 
-func LoadLSMProgram(bpfDir, mapDir string, load *Program, verbose int) error {
+func LoadLSMProgram(bpfDir string, load *Program, verbose int) error {
 	opts := &loadOpts{
 		attach: LSMAttach(),
 	}

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -119,7 +119,7 @@ func RegisterProbeType(probeType string, s probeLoader) {
 
 // LoadProbeArgs are the args to the LoadProbe function.
 type LoadProbeArgs struct {
-	BPFDir, MapDir   string
+	BPFDir           string
 	Load             *program.Program
 	Version, Verbose int
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -933,7 +933,7 @@ func getMapLoad(load *program.Program, kprobeEntry *genericKprobe, index uint32)
 	return selectorsMaploads(state, kprobeEntry.pinPathPrefix, index)
 }
 
-func loadSingleKprobeSensor(id idtable.EntryID, bpfDir, mapDir string, load *program.Program, verbose int) error {
+func loadSingleKprobeSensor(id idtable.EntryID, bpfDir string, load *program.Program, verbose int) error {
 	gk, err := genericKprobeTableGet(id)
 	if err != nil {
 		return err
@@ -961,7 +961,7 @@ func loadSingleKprobeSensor(id idtable.EntryID, bpfDir, mapDir string, load *pro
 	return err
 }
 
-func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir, mapDir string, load *program.Program, verbose int) error {
+func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir string, load *program.Program, verbose int) error {
 	bin_buf := make([]bytes.Buffer, len(ids))
 
 	data := &program.MultiKprobeAttachData{}
@@ -1005,12 +1005,12 @@ func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir, mapDir string, load *p
 	return nil
 }
 
-func loadGenericKprobeSensor(bpfDir, mapDir string, load *program.Program, verbose int) error {
+func loadGenericKprobeSensor(bpfDir string, load *program.Program, verbose int) error {
 	if id, ok := load.LoaderData.(idtable.EntryID); ok {
-		return loadSingleKprobeSensor(id, bpfDir, mapDir, load, verbose)
+		return loadSingleKprobeSensor(id, bpfDir, load, verbose)
 	}
 	if ids, ok := load.LoaderData.([]idtable.EntryID); ok {
-		return loadMultiKprobeSensor(ids, bpfDir, mapDir, load, verbose)
+		return loadMultiKprobeSensor(ids, bpfDir, load, verbose)
 	}
 	return fmt.Errorf("invalid loadData type: expecting idtable.EntryID/[] and got: %T (%v)",
 		load.LoaderData, load.LoaderData)
@@ -1234,5 +1234,5 @@ func retprobeMerge(prev pendingEvent, curr pendingEvent) *tracing.MsgGenericKpro
 }
 
 func (k *observerKprobeSensor) LoadProbe(args sensors.LoadProbeArgs) error {
-	return loadGenericKprobeSensor(args.BPFDir, args.MapDir, args.Load, args.Verbose)
+	return loadGenericKprobeSensor(args.BPFDir, args.Load, args.Verbose)
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -952,7 +952,7 @@ func loadSingleKprobeSensor(id idtable.EntryID, bpfDir, mapDir string, load *pro
 	}
 	load.MapLoad = append(load.MapLoad, config)
 
-	if err := program.LoadKprobeProgram(bpfDir, mapDir, load, verbose); err == nil {
+	if err := program.LoadKprobeProgram(bpfDir, load, verbose); err == nil {
 		logger.GetLogger().Infof("Loaded generic kprobe program: %s -> %s", load.Name, load.Attach)
 	} else {
 		return err
@@ -996,7 +996,7 @@ func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir, mapDir string, load *p
 	load.OverrideFmodRet = false
 	load.SetAttachData(data)
 
-	if err := program.LoadMultiKprobeProgram(bpfDir, mapDir, load, verbose); err == nil {
+	if err := program.LoadMultiKprobeProgram(bpfDir, load, verbose); err == nil {
 		logger.GetLogger().Infof("Loaded generic kprobe sensor: %s -> %s", load.Name, load.Attach)
 	} else {
 		return err

--- a/pkg/sensors/tracing/generickprobe_test.go
+++ b/pkg/sensors/tracing/generickprobe_test.go
@@ -123,7 +123,7 @@ func Test_Kprobe_DisableEnablePolicy(t *testing.T) {
 
 	tus.LoadSensor(t, base.GetInitialSensor())
 	path := bpf.MapPrefixPath()
-	mgr, err := sensors.StartSensorManager(path, path, nil)
+	mgr, err := sensors.StartSensorManager(path, nil)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -598,7 +598,7 @@ func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, v
 	}
 	load.MapLoad = append(load.MapLoad, cfg)
 
-	if err := program.LoadTracepointProgram(bpfDir, mapDir, load, verbose); err == nil {
+	if err := program.LoadTracepointProgram(bpfDir, load, verbose); err == nil {
 		logger.GetLogger().Infof("Loaded generic tracepoint program: %s -> %s", load.Name, load.Attach)
 	} else {
 		return err

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -567,7 +567,7 @@ func (tp *genericTracepoint) EventConfig() (api.EventConfig, error) {
 	return config, nil
 }
 
-func LoadGenericTracepointSensor(bpfDir, mapDir string, load *program.Program, verbose int) error {
+func LoadGenericTracepointSensor(bpfDir string, load *program.Program, verbose int) error {
 
 	tracepointLog = logger.GetLogger()
 
@@ -760,5 +760,5 @@ func handleMsgGenericTracepoint(
 }
 
 func (t *observerTracepointSensor) LoadProbe(args sensors.LoadProbeArgs) error {
-	return LoadGenericTracepointSensor(args.BPFDir, args.MapDir, args.Load, args.Verbose)
+	return LoadGenericTracepointSensor(args.BPFDir, args.Load, args.Verbose)
 }

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -147,7 +147,7 @@ func (k *observerUprobeSensor) LoadProbe(args sensors.LoadProbeArgs) error {
 
 	sensors.AllPrograms = append(sensors.AllPrograms, load)
 
-	if err := program.LoadUprobeProgram(args.BPFDir, args.MapDir, args.Load, args.Verbose); err != nil {
+	if err := program.LoadUprobeProgram(args.BPFDir, args.Load, args.Verbose); err != nil {
 		return err
 	}
 

--- a/pkg/sensors/tracing/killer.go
+++ b/pkg/sensors/tracing/killer.go
@@ -107,7 +107,7 @@ func (kp *killerPolicy) loadSingleKillerSensor(
 	kh *killerHandler,
 	bpfDir, mapDir string, load *program.Program, verbose int,
 ) error {
-	if err := program.LoadKprobeProgramAttachMany(bpfDir, mapDir, load, kh.syscallsSyms, verbose); err == nil {
+	if err := program.LoadKprobeProgramAttachMany(bpfDir, load, kh.syscallsSyms, verbose); err == nil {
 		logger.GetLogger().Infof("Loaded killer sensor: %s", load.Attach)
 	} else {
 		return err
@@ -125,7 +125,7 @@ func (kp *killerPolicy) loadMultiKillerSensor(
 
 	load.SetAttachData(data)
 
-	if err := program.LoadMultiKprobeProgram(bpfDir, mapDir, load, verbose); err != nil {
+	if err := program.LoadMultiKprobeProgram(bpfDir, load, verbose); err != nil {
 		return err
 	}
 
@@ -151,7 +151,7 @@ func (kp *killerPolicy) LoadProbe(args sensors.LoadProbeArgs) error {
 	}
 
 	if strings.HasPrefix(args.Load.Label, "fmod_ret/") {
-		return program.LoadFmodRetProgram(args.BPFDir, args.MapDir, args.Load, "fmodret_killer", args.Verbose)
+		return program.LoadFmodRetProgram(args.BPFDir, args.Load, "fmodret_killer", args.Verbose)
 	}
 
 	return fmt.Errorf("killer loader: unknown label: %s", args.Load.Label)

--- a/pkg/sensors/tracing/killer.go
+++ b/pkg/sensors/tracing/killer.go
@@ -105,7 +105,7 @@ func (kp *killerPolicy) PolicyHandler(
 
 func (kp *killerPolicy) loadSingleKillerSensor(
 	kh *killerHandler,
-	bpfDir, mapDir string, load *program.Program, verbose int,
+	bpfDir string, load *program.Program, verbose int,
 ) error {
 	if err := program.LoadKprobeProgramAttachMany(bpfDir, load, kh.syscallsSyms, verbose); err == nil {
 		logger.GetLogger().Infof("Loaded killer sensor: %s", load.Attach)
@@ -117,7 +117,7 @@ func (kp *killerPolicy) loadSingleKillerSensor(
 
 func (kp *killerPolicy) loadMultiKillerSensor(
 	kh *killerHandler,
-	bpfDir, mapDir string, load *program.Program, verbose int,
+	bpfDir string, load *program.Program, verbose int,
 ) error {
 	data := &program.MultiKprobeAttachData{}
 
@@ -144,10 +144,10 @@ func (kp *killerPolicy) LoadProbe(args sensors.LoadProbeArgs) error {
 		return fmt.Errorf("failed to get killer handler for '%s'", name)
 	}
 	if args.Load.Label == "kprobe.multi/killer" {
-		return kp.loadMultiKillerSensor(kh, args.BPFDir, args.MapDir, args.Load, args.Verbose)
+		return kp.loadMultiKillerSensor(kh, args.BPFDir, args.Load, args.Verbose)
 	}
 	if args.Load.Label == "kprobe/killer" {
-		return kp.loadSingleKillerSensor(kh, args.BPFDir, args.MapDir, args.Load, args.Verbose)
+		return kp.loadSingleKillerSensor(kh, args.BPFDir, args.Load, args.Verbose)
 	}
 
 	if strings.HasPrefix(args.Load.Label, "fmod_ret/") {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -113,7 +113,7 @@ spec:
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
 	initialSensor := base.GetInitialSensor()
-	initialSensor.Load(bpf.MapPrefixPath(), bpf.MapPrefixPath())
+	initialSensor.Load(bpf.MapPrefixPath())
 }
 
 // NB: This is similar to TestKprobeObjectWriteRead, but it's a bit easier to
@@ -4175,7 +4175,7 @@ spec:
 	if err != nil {
 		return err
 	}
-	err = sens.Load(option.Config.BpfDir, option.Config.MapDir)
+	err = sens.Load(option.Config.BpfDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/sensors/tracing/loader.go
+++ b/pkg/sensors/tracing/loader.go
@@ -180,7 +180,7 @@ func (k *loaderSensor) LoadProbe(args sensors.LoadProbeArgs) error {
 		if err := createLoaderEvents(); err != nil {
 			return err
 		}
-		return program.LoadKprobeProgram(args.BPFDir, args.MapDir, args.Load, args.Verbose)
+		return program.LoadKprobeProgram(args.BPFDir, args.Load, args.Verbose)
 	}
 	return nil
 }

--- a/pkg/testutils/sensors/sensors.go
+++ b/pkg/testutils/sensors/sensors.go
@@ -18,8 +18,8 @@ func LoadSensor(t *testing.T, sensor *sensors.Sensor) {
 	if err := sensor.FindPrograms(); err != nil {
 		t.Fatalf("ObserverFindProgs error: %s", err)
 	}
-	mapDir := bpf.MapPrefixPath()
-	if err := sensor.Load(mapDir, mapDir); err != nil {
+	bpfDir := bpf.MapPrefixPath()
+	if err := sensor.Load(bpfDir); err != nil {
 		t.Fatalf("observerLoadSensor error: %s", err)
 	}
 

--- a/pkg/testutils/sensors/sensors.go
+++ b/pkg/testutils/sensors/sensors.go
@@ -47,7 +47,7 @@ func GetTestSensorManager(ctx context.Context, t *testing.T) *TestSensorManager 
 	}
 
 	path := bpf.MapPrefixPath()
-	mgr, err := sensors.StartSensorManager(path, path, nil)
+	mgr, err := sensors.StartSensorManager(path, nil)
 	if err != nil {
 		t.Fatalf("startSensorController failed: %s", err)
 	}


### PR DESCRIPTION
Removing MapDir as preparation for loader refactoring,
it's not used, BpfDir is enough.

Fixes: https://github.com/cilium/tetragon/issues/527