### PR TITLE
tetra: avoid panic in the decoder

### DIFF
--- a/pkg/encoder/encoder.go
+++ b/pkg/encoder/encoder.go
@@ -410,7 +410,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 		case "security_file_permission":
 			event := p.Colorer.Blue.Sprintf("❓ %-7s", "security_file_permission")
 			attr := ""
-			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil && kprobe.Args[1] != nil {
+			if len(kprobe.Args) > 1 && kprobe.Args[0] != nil && kprobe.Args[1] != nil {
 				file := kprobe.Args[0].GetFileArg()
 				action := kprobe.Args[1].GetIntArg()
 				if action == 0x02 {
@@ -424,7 +424,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 		case "security_mmap_file":
 			event := p.Colorer.Blue.Sprintf("❓ %-7s", "security_mmap_file")
 			attr := ""
-			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil && kprobe.Args[1] != nil {
+			if len(kprobe.Args) > 1 && kprobe.Args[0] != nil && kprobe.Args[1] != nil {
 				file := kprobe.Args[0].GetFileArg()
 				action := kprobe.Args[1].GetUintArg()
 				eventTag := "mmap-"


### PR DESCRIPTION
We seem to be accessing Args[1] without a proper check. Add the check to avoid the panic.

panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/cilium/tetragon/pkg/encoder.(*CompactEncoder).EventToString(0xc0001e0ec0, 0xc000894240)
        /home/kkourt/src/tetragon/pkg/encoder/encoder.go:413 +0x4438
github.com/cilium/tetragon/pkg/encoder.(*CompactEncoder).Encode(0xc0001e0ec0, {0x1c83480?, 0xc000894240})
        /home/kkourt/src/tetragon/pkg/encoder/encoder.go:110 +0x9f
github.com/cilium/tetragon/cmd/tetra/getevents.getEvents({0x204cd20, 0xc000388840}, {0x205ba68, 0xc0007aec00})
        /home/kkourt/src/tetragon/cmd/tetra/getevents/getevents.go:150 +0x4dd
github.com/cilium/tetragon/cmd/tetra/common.CliRunErr(0x1e4b3c8, 0x1e4b3c0)
        /home/kkourt/src/tetragon/cmd/tetra/common/client.go:95 +0x68a
github.com/cilium/tetragon/cmd/tetra/common.CliRun(...)
        /home/kkourt/src/tetragon/cmd/tetra/common/client.go:99
github.com/cilium/tetragon/cmd/tetra/getevents.New.func2(0xc0002e6a00?, {0x1d275fd?, 0x4?, 0x1d27601?})
        /home/kkourt/src/tetragon/cmd/tetra/getevents/getevents.go:195 +0x108
github.com/spf13/cobra.(*Command).execute(0xc000193b08, {0xc0001e03a0, 0x2, 0x2})
        /home/kkourt/src/tetragon/vendor/github.com/spf13/cobra/command.go:987 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0xc000193808)
        /home/kkourt/src/tetragon/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/kkourt/src/tetragon/vendor/github.com/spf13/cobra/command.go:1039
main.main()
        /home/kkourt/src/tetragon/cmd/tetra/main.go:21 +0x18