### PR TITLE
Set node_name to hostname if NODE_NAME envvar is not found 

### DIFF
--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -221,7 +221,7 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 }
 
 func Test_getNodeNameForExport(t *testing.T) {
-	assert.Equal(t, "", node.GetNodeNameForExport())
+	assert.NotEqual(t, "", node.GetNodeNameForExport()) // we should get the hostname here
 	assert.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
 	assert.Equal(t, "from-node-name", node.GetNodeNameForExport())
 	assert.NoError(t, os.Setenv("HUBBLE_NODE_NAME", "from-hubble-node-name"))

--- a/pkg/reader/node/node.go
+++ b/pkg/reader/node/node.go
@@ -3,7 +3,11 @@
 
 package node
 
-import "os"
+import (
+	"os"
+
+	"github.com/cilium/tetragon/pkg/logger"
+)
 
 // getNodeNameForExport returns node name string for JSON export. It uses NODE_NAME
 // env variable by default, which is also used by k8s watcher to watch for local pods:
@@ -12,9 +16,16 @@ import "os"
 //
 // Set HUBBLE_NODE_NAME to override the node_name field for JSON export.
 func GetNodeNameForExport() string {
+	var err error
 	nodeName := os.Getenv("HUBBLE_NODE_NAME")
-	if nodeName != "" {
-		return nodeName
+	if nodeName == "" {
+		nodeName = os.Getenv("NODE_NAME")
 	}
-	return os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		nodeName, err = os.Hostname()
+		if err != nil {
+			logger.GetLogger().WithError(err).Warn("failed to retrieve hostname")
+		}
+	}
+	return nodeName
 }


### PR DESCRIPTION
This enables node_name field in the standalone (non-k8s) mode.

```release-note
Set events node_name field to the hostname in the standalone (non-k8s) mode.
```