### PR TITLE
exporter: return err when exporter fails to start

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -706,8 +706,7 @@ func startExporter(ctx context.Context, server *server.Server) error {
 	log.WithFields(logrus.Fields{"fieldFilters": fieldFilters}).Debug("Configured field filters")
 	log.WithFields(logrus.Fields{"logger": writer, "request": &req}).Info("Starting JSON exporter")
 	exporter := exporter.NewExporter(ctx, &req, server, encoder, writer, rateLimiter)
-	exporter.Start()
-	return nil
+	return exporter.Start()
 }
 
 func Serve(ctx context.Context, listenAddr string, srv *server.Server) error {

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -257,7 +257,9 @@ func startBenchmarkExporter(ctx context.Context, obs *observer.Observer, summary
 
 	req := tetragon.GetEventsRequest{AllowList: nil, DenyList: nil, AggregationOptions: nil}
 	exporter := exporter.NewExporter(ctx, &req, processManager.Server, &timingEncoder, writer, nil)
-	exporter.Start()
+	if err := exporter.Start(); err != nil {
+		return err
+	}
 	obs.AddListener(processManager)
 	return nil
 }

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -91,7 +91,7 @@ func TestExporter_Send(t *testing.T) {
 	encoder := encoder.NewProtojsonEncoder(results)
 	request := tetragon.GetEventsRequest{DenyList: []*tetragon.Filter{{BinaryRegex: []string{"b"}}}}
 	exporter := NewExporter(ctx, &request, grpcServer, encoder, results, nil)
-	exporter.Start()
+	assert.NoError(t, exporter.Start(), "exporter must start without errors")
 	eventNotifier.NotifyListener(nil, &tetragon.GetEventsResponse{
 		Event: &tetragon.GetEventsResponse_ProcessExec{
 			ProcessExec: &tetragon.ProcessExec{Process: &tetragon.Process{Binary: "a"}},
@@ -202,7 +202,7 @@ func Test_rateLimitExport(t *testing.T) {
 				results,
 				ratelimit.NewRateLimiter(ctx, 50*time.Millisecond, tt.rateLimit, encoder),
 			)
-			exporter.Start()
+			assert.NoError(t, exporter.Start(), "exporter must start without errors")
 			for i := 0; i < tt.totalEvents; i++ {
 				eventNotifier.NotifyListener(nil, &tetragon.GetEventsResponse{
 					Event: &tetragon.GetEventsResponse_ProcessExec{

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -423,7 +423,9 @@ func loadExporter(tb testing.TB, ctx context.Context, obs *observer.Observer, op
 	req := tetragon.GetEventsRequest{AllowList: opts.allowList, DenyList: opts.denyList}
 	exporter := exporter.NewExporter(ctx, &req, processManager.Server, encoder, outF, nil)
 	logger.GetLogger().Info("Starting JSON exporter")
-	exporter.Start()
+	if err := exporter.Start(); err != nil {
+		return err
+	}
 	obs.AddListener(processManager)
 	tb.Cleanup(func() {
 		obs.RemoveListener(processManager)


### PR DESCRIPTION
In general, when Tetragon encounters an error in its initial configuration, we expect the agent to fail to start and return an appriate error explaining the configuration issue. This is the case for many aspects of initialization, except for the exporter which currently just logs an error message. This is perplexing behaviour because users who want to configure an exporter generally consume Tetragon events that way, so it makes no sense to simply refuse to export events and merrily hum along. Fix this issue by returning an appropriate error when the exporter fails to start so we can bubble it up.

```release-note
Fail with an error when the event exporter fails to start.
```