### PR TITLE
backports/v0.10: Set node_name to hostname if NODE_NAME envvar is not found

### DIFF
--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -192,7 +192,7 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 }
 
 func Test_getNodeNameForExport(t *testing.T) {
-	assert.Equal(t, "", node.GetNodeNameForExport())
+	assert.NotEqual(t, "", node.GetNodeNameForExport()) // we should get the hostname here
 	assert.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
 	assert.Equal(t, "from-node-name", node.GetNodeNameForExport())
 	assert.NoError(t, os.Setenv("HUBBLE_NODE_NAME", "from-hubble-node-name"))

--- a/pkg/reader/node/node.go
+++ b/pkg/reader/node/node.go
@@ -2,7 +2,11 @@
 // Copyright Authors of Tetragon
 package node
 
-import "os"
+import (
+	"os"
+
+	"github.com/cilium/tetragon/pkg/logger"
+)
 
 // getNodeNameForExport returns node name string for JSON export. It uses NODE_NAME
 // env variable by default, which is also used by k8s watcher to watch for local pods:
@@ -11,9 +15,16 @@ import "os"
 //
 // Set HUBBLE_NODE_NAME to override the node_name field for JSON export.
 func GetNodeNameForExport() string {
+	var err error
 	nodeName := os.Getenv("HUBBLE_NODE_NAME")
-	if nodeName != "" {
-		return nodeName
+	if nodeName == "" {
+		nodeName = os.Getenv("NODE_NAME")
 	}
-	return os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		nodeName, err = os.Hostname()
+		if err != nil {
+			logger.GetLogger().WithError(err).Warn("failed to retrieve hostname")
+		}
+	}
+	return nodeName
 }


### PR DESCRIPTION
upstream commit: b2540c98022a6cf229f7a450478ebc37f8bb92e1

This enables node_name field in the standalone (non-k8s) mode.