### PR TITLE
Loading: Check if probe type is registered

### DIFF
--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/sensors/program"
+	"github.com/cilium/tetragon/pkg/sensors/program/cgroup"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 
 	// load rthooks for policy filter
@@ -95,6 +96,13 @@ var (
 	registeredPolicyHandlers = map[string]policyHandler{}
 	// list of registers loaders, see registerProbeType()
 	registeredProbeLoad = map[string]probeLoader{}
+	standardTypes       = map[string]func(string, *program.Program, int) error{
+		"tracepoint":     program.LoadTracepointProgram,
+		"raw_tracepoint": program.LoadRawTracepointProgram,
+		"raw_tp":         program.LoadRawTracepointProgram,
+		"cgrp_socket":    cgroup.LoadCgroupProgram,
+		"kprobe":         program.LoadKprobeProgram,
+	}
 )
 
 // RegisterPolicyHandlerAtInit registers a handler for a tracing policy.


### PR DESCRIPTION
The loadInstance() function loads a BPF program. It checks its type against the list of registered types and calls the appropriate handler if there is a match. Otherwise it tries to match against some known types. If that fails, it attempts to load the program as a kprobe.

If a new probe type is created but isn't registered (due to a typo, bug, or some other error), then the program will silently attempt to load as a kprobe, instead of using the supplied handler.

This commit makes a list of inbuilt probe types, and checks the program type against it (calling the appropriate handler if it is in the list), then checks the program type against the registered probe types (again, calling the appropriate handler if it exists). If both of these fail, it returns an error instead of silently attempting a kprobe load.

This will catch bugs where program types are accidentally specified with an invalid type, or where probes are registered with incorrect names.

```release-note
Add error checking to program loading with respect to probe type.
```