### PR TITLE
tetragon:trivial: create run dir early to avoid errors

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -173,6 +173,9 @@ func tetragonExecute() error {
 	log.WithField("version", version.Version).Info("Starting tetragon")
 	log.WithField("config", viper.AllSettings()).Info("config settings")
 
+	// Create run dir early
+	os.MkdirAll(defaults.DefaultRunDir, 0755)
+
 	// When an instance terminates or restarts it may cleanup bpf programs,
 	// having a check here to see if another instance is already running, can
 	// help debug errors.
@@ -333,7 +336,6 @@ func tetragonExecute() error {
 	 * events no state should be lost/missed.
 	 */
 	obs.RemovePrograms()
-	os.Mkdir(defaults.DefaultRunDir, os.ModeDir)
 
 	if err := btf.InitCachedBTF(option.Config.HubbleLib, option.Config.BTF); err != nil {
 		return err


### PR DESCRIPTION
Create the /run/tetragon runtime directory of Tetragon early, as we have
code that tries to lookup for that directory early and could report
errors. One example is when we are looking for pidfile of tetragon.

On host install we always keep the cgroup2 mount inside /run/tetragon
which pins the runtime directory on the host forever. We do not have
strict unmount logic as there is no harm in keeping another mirror
of cgroup2 inside /run/tetragon, so on Tetragon restarts the runtime
will always be there. But on first ever start the directory won't be
there and errors will be reported.

Fix this by having the mkdir as early as possible before anything else.