### PR TITLE
cmd/tetra: remove tp_state_ prefix in state in tp list

### DIFF
--- a/cmd/tetra/tracingpolicy/tracingpolicy.go
+++ b/cmd/tetra/tracingpolicy/tracingpolicy.go
@@ -179,7 +179,7 @@ func New() *cobra.Command {
 					fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\t%s\t\n",
 						pol.Id,
 						pol.Name,
-						strings.ToLower(pol.State.String()),
+						strings.TrimPrefix(strings.ToLower(pol.State.String()), "tp_state_"),
 						pol.FilterId,
 						namespace,
 						sensors,


### PR DESCRIPTION
Protobuf requires every enum values to be unique and thus good practice is to start them with their enum type name as prefix. But this information can be removed when outputing the state in human format.