### PR TITLE
ci: only check docs on PR to main

### DIFF
--- a/.github/workflows/build-deploy-docs.yaml
+++ b/.github/workflows/build-deploy-docs.yaml
@@ -11,6 +11,8 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/build-deploy-docs.yaml'
+    branches: 
+      - 'main'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/check-links-pr.yaml
+++ b/.github/workflows/check-links-pr.yaml
@@ -6,6 +6,8 @@ on:
       - 'README.md'
       - 'docs/content/**.md'
       - '.github/workflows/check-links-pr.yaml'
+    branches: 
+      - 'main'
 
 jobs:
   links-checker:


### PR DESCRIPTION
It doesn't make sense to run the links checker on old release branches, since we only deploy docs from main.