### PR TITLE
feat(k8s|helmchart): Added tracing policies as an option inside the tetragon helmchart

### DIFF
--- a/install/kubernetes/tetragon/templates/tracingpolicy.yaml
+++ b/install/kubernetes/tetragon/templates/tracingpolicy.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.tracingPolicies }}
+{{- range $index, $policy := .Values.tracingPolicies }}
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "{{ $policy.name }}"
+spec:
+  kprobes:
+  {{- range $hookIndex, $hook := $policy.hooks }}
+  - call: "{{ $hook.call }}"
+    syscall: {{ $hook.syscall }}
+    args:
+    {{- range $argIndex, $arg := $hook.args }}
+    - index: {{ $arg.index }}
+      type: "{{ $arg.type }}"
+    {{- end }}
+    {{- if $hook.selectors }}
+    selectors:
+    {{- range $selectorIndex, $selector := $hook.selectors }}
+    - matchArgs:
+      {{- range $matchArgIndex, $matchArg := $selector.matchArgs }}
+        - index: {{ $matchArg.index }}
+          operator: "{{ $matchArg.operator }}"
+          values:
+          {{- range $valueIndex, $value := $matchArg.values }}
+            - "{{ $value }}"
+          {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+
+  {{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
feat: Added tracing policies as an option inside the tetragon helmchart

This PR is adding:

1. The capability of setting up tracing policies in the helmchart if needed. This update is working and properly running in a production environment of the company i am working on, cant share specific details.


Signed-off-by: Carlos Hernández-Bueno Regojo <carloshdez.bueno@gmail.com>