### PR TITLE
tetragon: Move enforcer-tester to .gitignore

### DIFF
--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -16,8 +16,8 @@ lseek-pipe
 threads-tester
 bench-reader
 threads-exit
-killer-tester
-killer-tester-32
+enforcer-tester
+enforcer-tester-32
 /getcpu
 drop-privileges
 change-capabilities


### PR DESCRIPTION
Rename leftover.