### PR TITLE
Tracepoints: Add support for data_loc params and sock and skb types

### DIFF
--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -68,12 +68,14 @@ static inline __attribute__((always_inline)) unsigned long get_ctx_ul(void *src,
 	case s64_ty:
 	case u64_ty: {
 		u64 ret;
+
 		probe_read(&ret, sizeof(u64), src);
 		return ret;
 	}
 
 	case size_type: {
 		size_t ret;
+
 		probe_read(&ret, sizeof(size_t), src);
 		return (unsigned long)ret;
 	}
@@ -81,6 +83,7 @@ static inline __attribute__((always_inline)) unsigned long get_ctx_ul(void *src,
 	case nop_s32_ty:
 	case s32_ty: {
 		s32 ret;
+
 		probe_read(&ret, sizeof(u32), src);
 		return ret;
 	}
@@ -88,6 +91,7 @@ static inline __attribute__((always_inline)) unsigned long get_ctx_ul(void *src,
 	case nop_u32_ty:
 	case u32_ty: {
 		u32 ret;
+
 		probe_read(&ret, sizeof(u32), src);
 		return ret;
 	}
@@ -97,6 +101,13 @@ static inline __attribute__((always_inline)) unsigned long get_ctx_ul(void *src,
 		char *buff;
 		probe_read(&buff, sizeof(char *), src);
 		return (unsigned long)buff;
+	}
+
+	case data_loc_type: {
+		u32 ret;
+
+		probe_read(&ret, sizeof(ret), src);
+		return ret;
 	}
 
 	case const_buf_type: {

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -114,6 +114,20 @@ static inline __attribute__((always_inline)) unsigned long get_ctx_ul(void *src,
 		return (unsigned long)src;
 	}
 
+	case skb_type: {
+		struct sk_buff *skb;
+
+		probe_read(&skb, sizeof(struct sk_buff *), src);
+		return (unsigned long)skb;
+	}
+
+	case sock_type: {
+		struct sock *sk;
+
+		probe_read(&sk, sizeof(struct sock *), src);
+		return (unsigned long)sk;
+	}
+
 	default:
 	case nop_ty:
 		return 0;

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -3,6 +3,8 @@
 
 package generictypes
 
+import "fmt"
+
 const (
 	GenericIntType    = 1
 	GenericCharBuffer = 2
@@ -57,85 +59,108 @@ const (
 	GenericInvalidType = -2
 )
 
+var GenericStringToType = map[string]int{
+	"string":          GenericStringType,
+	"int":             GenericIntType,
+	"uint64":          GenericU64Type,
+	"unsigned long":   GenericU64Type,
+	"ulong":           GenericU64Type,
+	"uint32":          GenericU32Type,
+	"sint64":          GenericS64Type,
+	"int64":           GenericS64Type,
+	"long":            GenericS64Type,
+	"sint32":          GenericS32Type,
+	"int32":           GenericS32Type,
+	"skb":             GenericSkbType,
+	"sock":            GenericSockType,
+	"size_t":          GenericSizeType,
+	"char_buf":        GenericCharBuffer,
+	"char_iovec":      GenericCharIovec,
+	"filename":        GenericFilenameType,
+	"file":            GenericFileType,
+	"path":            GenericPathType,
+	"fd":              GenericFdType,
+	"cred":            GenericCredType,
+	"const_buf":       GenericConstBuffer,
+	"nop":             GenericNopType,
+	"bpf_attr":        GenericBpfAttr,
+	"perf_event":      GenericPerfEvent,
+	"bpf_map":         GenericBpfMap,
+	"user_namespace":  GenericUserNamespace,
+	"capability":      GenericCapability,
+	"kiocb":           GenericKiocb,
+	"iov_iter":        GenericIovIter,
+	"load_info":       GenericLoadModule,
+	"module":          GenericKernelModule,
+	"syscall64":       GenericSyscall64,
+	"sint16":          GenericS16Type,
+	"int16":           GenericS16Type,
+	"uint16":          GenericU16Type,
+	"sint8":           GenericS8Type,
+	"int8":            GenericS8Type,
+	"uint8":           GenericU8Type,
+	"kernel_cap_t":    GenericKernelCap,
+	"cap_inheritable": GenericCapInheritable,
+	"cap_permitted":   GenericCapPermitted,
+	"cap_effective":   GenericCapEffective,
+	"linux_binprm":    GenericLinuxBinprmType,
+	"data_loc":        GenericDataLoc,
+}
+
+var GenericTypeToStringTable = map[int]string{
+	GenericStringType:      "string",
+	GenericIntType:         "int",
+	GenericU64Type:         "uint64",
+	GenericU32Type:         "uint32",
+	GenericS64Type:         "int64",
+	GenericS32Type:         "int32",
+	GenericSkbType:         "skb",
+	GenericSockType:        "sock",
+	GenericSizeType:        "size_t",
+	GenericCharBuffer:      "char_buf",
+	GenericCharIovec:       "char_iovec",
+	GenericFilenameType:    "filename",
+	GenericFileType:        "file",
+	GenericPathType:        "path",
+	GenericFdType:          "fd",
+	GenericCredType:        "cred",
+	GenericConstBuffer:     "const_buf",
+	GenericNopType:         "nop",
+	GenericBpfAttr:         "bpf_attr",
+	GenericPerfEvent:       "perf_event",
+	GenericBpfMap:          "bpf_map",
+	GenericUserNamespace:   "user_namespace",
+	GenericCapability:      "capability",
+	GenericKiocb:           "kiocb",
+	GenericIovIter:         "iov_iter",
+	GenericLoadModule:      "load_info",
+	GenericKernelModule:    "module",
+	GenericSyscall64:       "syscall64",
+	GenericS16Type:         "int16",
+	GenericU16Type:         "uint16",
+	GenericS8Type:          "int8",
+	GenericU8Type:          "uint8",
+	GenericKernelCap:       "kernel_cap_t",
+	GenericCapInheritable:  "cap_inheritable",
+	GenericCapPermitted:    "cap_permitted",
+	GenericCapEffective:    "cap_effective",
+	GenericLinuxBinprmType: "linux_binprm",
+	GenericDataLoc:         "data_loc",
+	GenericInvalidType:     "",
+}
+
 func GenericTypeFromString(arg string) int {
-	switch arg {
-	case "string":
-		return GenericStringType
-	case "int":
-		return GenericIntType
-	case "uint64", "unsigned long", "ulong":
-		return GenericU64Type
-	case "uint32":
-		return GenericU32Type
-	case "sint64", "int64", "long":
-		return GenericS64Type
-	case "sint32", "int32":
-		return GenericS32Type
-	case "skb":
-		return GenericSkbType
-	case "sock":
-		return GenericSockType
-	case "size_t":
-		return GenericSizeType
-	case "char_buf":
-		return GenericCharBuffer
-	case "char_iovec":
-		return GenericCharIovec
-	case "filename":
-		return GenericFilenameType
-	case "file":
-		return GenericFileType
-	case "path":
-		return GenericPathType
-	case "fd":
-		return GenericFdType
-	case "cred":
-		return GenericCredType
-	case "const_buf":
-		return GenericConstBuffer
-	case "nop":
-		return GenericNopType
-	case "bpf_attr":
-		return GenericBpfAttr
-	case "perf_event":
-		return GenericPerfEvent
-	case "bpf_map":
-		return GenericBpfMap
-	case "user_namespace":
-		return GenericUserNamespace
-	case "capability":
-		return GenericCapability
-	case "kiocb":
-		return GenericKiocb
-	case "iov_iter":
-		return GenericIovIter
-	case "load_info":
-		return GenericLoadModule
-	case "module":
-		return GenericKernelModule
-	case "syscall64":
-		return GenericSyscall64
-	case "sint16", "int16":
-		return GenericS16Type
-	case "uint16":
-		return GenericU16Type
-	case "sint8", "int8":
-		return GenericS8Type
-	case "uint8":
-		return GenericU8Type
-	case "kernel_cap_t":
-		return GenericKernelCap
-	case "cap_inheritable":
-		return GenericCapInheritable
-	case "cap_permitted":
-		return GenericCapPermitted
-	case "cap_effective":
-		return GenericCapEffective
-	case "linux_binprm":
-		return GenericLinuxBinprmType
-	case "data_loc":
-		return GenericDataLoc
-	default:
-		return GenericInvalidType
+	ty, ok := GenericStringToType[arg]
+	if !ok {
+		ty = GenericInvalidType
 	}
+	return ty
+}
+
+func GenericTypeToString(ty int) (string, error) {
+	arg, ok := GenericTypeToStringTable[ty]
+	if !ok {
+		return "", fmt.Errorf("invalid argument type")
+	}
+	return arg, nil
 }

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -51,6 +51,8 @@ const (
 
 	GenericLinuxBinprmType = 37
 
+	GenericDataLoc = 38
+
 	GenericNopType     = -1
 	GenericInvalidType = -2
 )
@@ -131,6 +133,8 @@ func GenericTypeFromString(arg string) int {
 		return GenericCapEffective
 	case "linux_binprm":
 		return GenericLinuxBinprmType
+	case "data_loc":
+		return GenericDataLoc
 	default:
 		return GenericInvalidType
 	}

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -131,6 +131,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index
@@ -227,6 +228,7 @@ spec:
                           - cap_permitted
                           - cap_effective
                           - linux_binprm
+                          - data_loc
                           type: string
                       required:
                       - index
@@ -876,6 +878,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index
@@ -1431,6 +1434,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -131,6 +131,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index
@@ -227,6 +228,7 @@ spec:
                           - cap_permitted
                           - cap_effective
                           - linux_binprm
+                          - data_loc
                           type: string
                       required:
                       - index
@@ -876,6 +878,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index
@@ -1431,6 +1434,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -55,7 +55,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=auto;int;int8;uint8;int16;uint16;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm
+	// +kubebuilder:validation:Enum=auto;int;int8;uint8;int16;uint16;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc
 	// +kubebuilder:default=auto
 	// Argument type.
 	Type string `json:"type"`

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.1.6"
+const CustomResourceDefinitionSchemaVersion = "1.1.7"

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -178,6 +178,8 @@ const (
 	argTypeSyscall64 = 28
 
 	argTypeLinuxBinprm = 29
+
+	argTypeDataLoc = 38
 )
 
 var argTypeTable = map[string]uint32{
@@ -199,6 +201,7 @@ var argTypeTable = map[string]uint32{
 	"fqdn":         argTypeFqdn,
 	"syscall64":    argTypeSyscall64,
 	"linux_binprm": argTypeLinuxBinprm,
+	"data_loc":     argTypeDataLoc,
 }
 
 var argTypeStringTable = map[uint32]string{
@@ -220,6 +223,7 @@ var argTypeStringTable = map[uint32]string{
 	argTypeFqdn:        "fqdn",
 	argTypeSyscall64:   "syscall64",
 	argTypeLinuxBinprm: "linux_binprm",
+	argTypeDataLoc:     "data_loc",
 }
 
 const (
@@ -849,7 +853,7 @@ func ParseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 		}
 	case SelectorOpEQ, SelectorOpNEQ:
 		switch ty {
-		case argTypeFd, argTypeFile, argTypePath, argTypeString, argTypeCharBuf, argTypeLinuxBinprm:
+		case argTypeFd, argTypeFile, argTypePath, argTypeString, argTypeCharBuf, argTypeLinuxBinprm, argTypeDataLoc:
 			err := writeMatchStrings(k, arg.Values, ty)
 			if err != nil {
 				return fmt.Errorf("writeMatchStrings error: %w", err)

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	gt "github.com/cilium/tetragon/pkg/generictypes"
 	"github.com/cilium/tetragon/pkg/idtable"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/kernels"
@@ -556,34 +557,34 @@ func TestMultipleSelectorsExample(t *testing.T) {
 	}
 
 	// value               absolute offset    explanation
-	expU32Push(2)               // off: 0       number of selectors
-	expU32Push(8)               // off: 4       relative ofset of 1st selector (4 + 8 = 12)
-	expU32Push(100)             // off: 8       relative ofset of 2nd selector (8 + 124 = 132)
-	expU32Push(96)              // off: 12      selector1: length (76 + 12 = 96)
-	expU32Push(24)              // off: 16      selector1: MatchPIDs: len
-	expU32Push(SelectorOpNotIn) // off: 20      selector1: MatchPIDs[0]: op
-	expU32Push(0)               // off: 24      selector1: MatchPIDs[0]: flags
-	expU32Push(2)               // off: 28      selector1: MatchPIDs[0]: number of values
-	expU32Push(33)              // off: 32      selector1: MatchPIDs[0]: val1
-	expU32Push(44)              // off: 36      selector1: MatchPIDs[0]: val2
-	expU32Push(4)               // off: 40      selector1: MatchNamespaces: len
-	expU32Push(4)               // off: 44      selector1: MatchCapabilities: len
-	expU32Push(4)               // off: 48      selector1: MatchNamespaceChanges: len
-	expU32Push(4)               // off: 52      selector1: MatchCapabilityChanges: len
-	expU32Push(48)              // off: 80      selector1: matchArgs: len
-	expU32Push(24)              // off: 84      selector1: matchArgs[0]: offset
-	expU32Push(0)               // off: 88      selector1: matchArgs[1]: offset
-	expU32Push(0)               // off: 92      selector1: matchArgs[2]: offset
-	expU32Push(0)               // off: 96      selector1: matchArgs[3]: offset
-	expU32Push(0)               // off: 100     selector1: matchArgs[4]: offset
-	expU32Push(1)               // off: 104     selector1: matchArgs: arg0: index
-	expU32Push(SelectorOpEQ)    // off: 108     selector1: matchArgs: arg0: operator
-	expU32Push(16)              // off: 112     selector1: matchArgs: arg0: len of vals
-	expU32Push(argTypeInt)      // off: 116     selector1: matchArgs: arg0: type
-	expU32Push(10)              // off: 120     selector1: matchArgs: arg0: val0: 10
-	expU32Push(20)              // off: 124     selector1: matchArgs: arg0: val1: 20
-	expU32Push(4)               // off: 128     selector1: matchActions: length
-	expU32Push(96)              // off: 132     selector2: length
+	expU32Push(2)                 // off: 0       number of selectors
+	expU32Push(8)                 // off: 4       relative ofset of 1st selector (4 + 8 = 12)
+	expU32Push(100)               // off: 8       relative ofset of 2nd selector (8 + 124 = 132)
+	expU32Push(96)                // off: 12      selector1: length (76 + 12 = 96)
+	expU32Push(24)                // off: 16      selector1: MatchPIDs: len
+	expU32Push(SelectorOpNotIn)   // off: 20      selector1: MatchPIDs[0]: op
+	expU32Push(0)                 // off: 24      selector1: MatchPIDs[0]: flags
+	expU32Push(2)                 // off: 28      selector1: MatchPIDs[0]: number of values
+	expU32Push(33)                // off: 32      selector1: MatchPIDs[0]: val1
+	expU32Push(44)                // off: 36      selector1: MatchPIDs[0]: val2
+	expU32Push(4)                 // off: 40      selector1: MatchNamespaces: len
+	expU32Push(4)                 // off: 44      selector1: MatchCapabilities: len
+	expU32Push(4)                 // off: 48      selector1: MatchNamespaceChanges: len
+	expU32Push(4)                 // off: 52      selector1: MatchCapabilityChanges: len
+	expU32Push(48)                // off: 80      selector1: matchArgs: len
+	expU32Push(24)                // off: 84      selector1: matchArgs[0]: offset
+	expU32Push(0)                 // off: 88      selector1: matchArgs[1]: offset
+	expU32Push(0)                 // off: 92      selector1: matchArgs[2]: offset
+	expU32Push(0)                 // off: 96      selector1: matchArgs[3]: offset
+	expU32Push(0)                 // off: 100     selector1: matchArgs[4]: offset
+	expU32Push(1)                 // off: 104     selector1: matchArgs: arg0: index
+	expU32Push(SelectorOpEQ)      // off: 108     selector1: matchArgs: arg0: operator
+	expU32Push(16)                // off: 112     selector1: matchArgs: arg0: len of vals
+	expU32Push(gt.GenericIntType) // off: 116     selector1: matchArgs: arg0: type
+	expU32Push(10)                // off: 120     selector1: matchArgs: arg0: val0: 10
+	expU32Push(20)                // off: 124     selector1: matchArgs: arg0: val1: 20
+	expU32Push(4)                 // off: 128     selector1: matchActions: length
+	expU32Push(96)                // off: 132     selector2: length
 	// ... everything else should be the same as selector1 ...
 
 	if bytes.Equal(expected[:expectedLen], b[:expectedLen]) == false {
@@ -892,22 +893,22 @@ func TestReturnSelectorArgInt(t *testing.T) {
 		expectedLen += 4
 	}
 
-	expU32Push(1)            // off: 0       number of selectors
-	expU32Push(4)            // off: 4       relative ofset of selector (4 + 4 = 8)
-	expU32Push(56)           // off: 8       selector: length
-	expU32Push(48)           // off: 12      selector: matchReturnArgs length
-	expU32Push(24)           // off: 16      selector: matchReturnArgs arg offset[0]
-	expU32Push(0)            // off: 20      selector: matchReturnArgs arg offset[1]
-	expU32Push(0)            // off: 24      selector: matchReturnArgs arg offset[2]
-	expU32Push(0)            // off: 28      selector: matchReturnArgs arg offset[3]
-	expU32Push(0)            // off: 32      selector: matchReturnArgs arg offset[4]
-	expU32Push(0)            // off: 36      selector: matchReturnArgs[0].Index
-	expU32Push(SelectorOpEQ) // off: 40      selector: matchReturnArgs[0].Operator
-	expU32Push(16)           // off: 44      selector: length (4 + 3*4) = 16
-	expU32Push(argTypeInt)   // off: 48      selector: matchReturnArgs[0].Type
-	expU32Push(10)           // off: 52      selector: matchReturnArgs[0].Values[0]
-	expU32Push(20)           // off: 56      selector: matchReturnArgs[0].Values[1]
-	expU32Push(4)            // off: 60      selector: MatchActions length
+	expU32Push(1)                 // off: 0       number of selectors
+	expU32Push(4)                 // off: 4       relative ofset of selector (4 + 4 = 8)
+	expU32Push(56)                // off: 8       selector: length
+	expU32Push(48)                // off: 12      selector: matchReturnArgs length
+	expU32Push(24)                // off: 16      selector: matchReturnArgs arg offset[0]
+	expU32Push(0)                 // off: 20      selector: matchReturnArgs arg offset[1]
+	expU32Push(0)                 // off: 24      selector: matchReturnArgs arg offset[2]
+	expU32Push(0)                 // off: 28      selector: matchReturnArgs arg offset[3]
+	expU32Push(0)                 // off: 32      selector: matchReturnArgs arg offset[4]
+	expU32Push(0)                 // off: 36      selector: matchReturnArgs[0].Index
+	expU32Push(SelectorOpEQ)      // off: 40      selector: matchReturnArgs[0].Operator
+	expU32Push(16)                // off: 44      selector: length (4 + 3*4) = 16
+	expU32Push(gt.GenericIntType) // off: 48      selector: matchReturnArgs[0].Type
+	expU32Push(10)                // off: 52      selector: matchReturnArgs[0].Values[0]
+	expU32Push(20)                // off: 56      selector: matchReturnArgs[0].Values[1]
+	expU32Push(4)                 // off: 60      selector: MatchActions length
 
 	if bytes.Equal(expected[:expectedLen], b[:expectedLen]) == false {
 		t.Errorf("\ngot: %v\nexp: %v\n", b[:expectedLen], expected[:expectedLen])

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -745,7 +745,7 @@ func handleMsgGenericTracepoint(
 					logger.GetLogger().Warnf("failed to read array argument: unexpected base type: %w", intTy.Base)
 				}
 			}
-		case gt.GenericStringType:
+		case gt.GenericStringType, gt.GenericDataLoc:
 			if arg, err := parseString(r); err != nil {
 				logger.GetLogger().WithError(err).Warn("error parsing arg type string")
 			} else {

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -505,7 +505,10 @@ func (tp *genericTracepoint) InitKernelSelectors(lists []v1alpha1.ListSpec) erro
 		if err != nil {
 			return fmt.Errorf("output argument %v unsupported: %w", tpArg, err)
 		}
-		selType := selectors.ArgTypeToString(uint32(ty))
+		selType, err := gt.GenericTypeToString(ty)
+		if err != nil {
+			return fmt.Errorf("output argument %v type not found: %w", tpArg, err)
+		}
 
 		// NB: this a selector argument, meant to be passed to InitKernelSelectors.
 		// The only fields needed for the latter are Index and Type

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -131,6 +131,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index
@@ -227,6 +228,7 @@ spec:
                           - cap_permitted
                           - cap_effective
                           - linux_binprm
+                          - data_loc
                           type: string
                       required:
                       - index
@@ -876,6 +878,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index
@@ -1431,6 +1434,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -131,6 +131,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index
@@ -227,6 +228,7 @@ spec:
                           - cap_permitted
                           - cap_effective
                           - linux_binprm
+                          - data_loc
                           type: string
                       required:
                       - index
@@ -876,6 +878,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index
@@ -1431,6 +1434,7 @@ spec:
                             - cap_permitted
                             - cap_effective
                             - linux_binprm
+                            - data_loc
                             type: string
                         required:
                         - index

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -55,7 +55,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=auto;int;int8;uint8;int16;uint16;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm
+	// +kubebuilder:validation:Enum=auto;int;int8;uint8;int16;uint16;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc
 	// +kubebuilder:default=auto
 	// Argument type.
 	Type string `json:"type"`

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.1.6"
+const CustomResourceDefinitionSchemaVersion = "1.1.7"


### PR DESCRIPTION
Tracepoint strings are typically presented as data_loc char buffers. This series provides support for these when they hold strings. The second commit in this series standardises on a global set of types that we support. The third commit adds support for sock and skb types.

```release-note
Add support for data_loc char buffers.
```
