### PR TITLE
ci: Add rhel8 kernel in vmtests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -252,9 +252,10 @@
       ],
       // LVH uses custom versioning for its images, need to match those kinds of tags:
       // - bpf-next-20230914.012459
+      // - rhel8-20240304.134252
       // - 5.15-20230912.232842
       // - 5.19-20230912.232842@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
-      "versioning": "regex:^((?<compatibility>[a-z-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
+      "versioning": "regex:^((?<compatibility>[a-z0-9-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
       "groupName": "all lvh-images main",

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -67,19 +67,21 @@ jobs:
         matrix:
            kernel:
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - 'bpf-next-20240228.012524'
+              - 'rhel8-20240304.163057'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '6.6-20240221.111541'
+              - 'bpf-next-20240304.163057'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '6.1-20240221.111541'
+              - '6.6-20240304.163057'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '5.15-20240221.111541'
+              - '6.1-20240304.163057'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '5.10-20240221.111541'
+              - '5.15-20240304.163057'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '5.4-20240221.111541'
+              - '5.10-20240304.163057'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - '4.19-20240221.111541'
+              - '5.4-20240304.163057'
+              # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
+              - '4.19-20240304.163057'
            group:
               - 0
     concurrency:

--- a/cmd/tetragon-vmtests-run/conf.go
+++ b/cmd/tetragon-vmtests-run/conf.go
@@ -29,6 +29,7 @@ type RunConf struct {
 	testerConf            vmtests.Conf
 	detailedResults       bool
 	keepAllLogs           bool
+	rootDev               string
 
 	filesystems []QemuFS
 }

--- a/cmd/tetragon-vmtests-run/main.go
+++ b/cmd/tetragon-vmtests-run/main.go
@@ -161,6 +161,7 @@ func main() {
 	cmd.Flags().StringArrayVarP(&ports, "port", "p", nil, "Forward a port (hostport[:vmport[:tcp|udp]])")
 	cmd.Flags().StringVar(&rcnf.testerConf.KernelVer, "kernel-ver", "", "kenel version")
 	cmd.Flags().BoolVar(&rcnf.detailedResults, "enable-detailed-results", false, "produce detailed results")
+	cmd.Flags().StringVar(&rcnf.rootDev, "root-dev", "vda", "type of root device (hda or vda)")
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/tetragon-vmtests-run/qemu.go
+++ b/cmd/tetragon-vmtests-run/qemu.go
@@ -36,13 +36,21 @@ func buildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
 		}
 	}
 
-	qemuArgs = append(qemuArgs,
-		"-hda", rcnf.testImageFname(),
-	)
+	var kernelRoot string
+	switch rcnf.rootDev {
+	case "hda":
+		qemuArgs = append(qemuArgs, "-hda", rcnf.testImageFname())
+		kernelRoot = "/dev/sda"
+	case "vda":
+		qemuArgs = append(qemuArgs, "-drive", fmt.Sprintf("file=%s,if=virtio,index=0,media=disk", rcnf.testImageFname()))
+		kernelRoot = "/dev/vda"
+	default:
+		return nil, fmt.Errorf("invalid root device: %s", rcnf.rootDev)
+	}
 
 	if rcnf.kernelFname != "" {
 		appendArgs := []string{
-			"root=/dev/sda",
+			fmt.Sprintf("root=%s", kernelRoot),
 			"console=ttyS0",
 			"earlyprintk=ttyS0",
 			"panic=-1",


### PR DESCRIPTION
Also, fix renovate to pick up the next rhel8 images.

```release-notes
Add rhel8 kernel in vmtests.
```