### PR TITLE
cves: add runc CVE-2024-21626 detection

### DIFF
--- a/examples/tracingpolicy/cves/cve-2024-21626-runc.yaml
+++ b/examples/tracingpolicy/cves/cve-2024-21626-runc.yaml
@@ -1,0 +1,134 @@
+# https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21626
+#
+# runc is a CLI tool for spawning and running containers on Linux according
+# to the OCI specification. According to runc Security Advisory:
+# https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv
+#
+# runc 1.1.11 and earlier, due to an internal file descriptor leak, an
+# attacker could cause a newly-spawned container process to have a working
+# directory in the host filesystem namespace, allowing access to the host
+# filesystem and container escapes.
+#
+#
+# Attack 1: process.cwd "mis-configuration"
+#
+# The CVSS score for this attack is CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N (8.2, high severity).
+#
+# In runc 1.1.11 and earlier, several file descriptors were inadvertently leaked
+# internally within runc into runc init, including a handle to the host filesystem.
+# If the container was configured to have process.cwd set to /proc/self/fd/7/
+# (the actual fd can change depending on file opening order in runc), the resulting
+# pid1 process will have a working directory in the host mount namespace and thus
+# the spawned process can access the entire host filesystem.
+#
+# This Tracing Policy protects against this attack 1 and kills the process.
+#
+#
+# Attack 2: runc exec container breakout
+#
+# The CVSS score for this attack is CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:N (7.2, high severity).
+#
+# (This is a modification of attack 1, constructed to allow for a process inside a
+#  container to break out.)
+#
+# The same fd leak and lack of verification of the working directory in attack 1
+# also apply to runc exec. If a malicious process inside the container knows that
+# some administrative process will call "runc exec --cwd" with a special
+# given path, in most cases they can replace that path with a symlink to
+# /proc/self/fd/7/. Once the container process has executed the container binary,
+# PR_SET_DUMPABLE protections no longer apply and the attacker can open
+# /proc/$exec_pid/cwd to get access to the host filesystem.
+#
+# Use this Tracing Policy to protect against this attack 2 and kill the process.
+#
+#
+# Attacks 3a and 3b: process.args host binary overwrite attack
+#
+# (These are modifications of attacks 1 and 2, constructed to overwrite a host
+#  binary by using execve to bring a magic-link reference into the container.)
+#
+# Attack 3a is attack 1 but adapted to overwrite a host binary, where a malicious
+# image is set up to execute /proc/self/fd/7/../../../bin/bash and run a shell
+# script that overwrites /proc/self/exe, overwriting the host copy of /bin/bash.
+# The CVSS score for this attack is CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H (8.6, high severity).
+#
+# Attack 3b is attack 2 but adapted to overwrite a host binary, where the malicious
+# container process overwrites all of the possible runc exec target binaries inside
+# the container (such as /bin/bash) such that a host target binary is executed and
+# then the container process opens /proc/$pid/exe to get access to the host binary
+# and overwrite it.
+# The CVSS score for this attack is CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H (8.2, high severity).
+#
+# This Tracing Policy does not protect against Attacks 3a and 3b.
+#
+#
+# This cve-2024-21626-runc Tetragon Tracing Policy can be used to detect usage of
+# magic symlinks /proc/* that are passed to runc in order to change current working
+# directory. The detection is performed at the system call layer.
+#
+# Further, this Tracing Policy checks at kernel layer if the current working
+# directory of current container process is being set to '/sys/fs/cgroup' which is
+# one of the leaked file descriptors in runc that was fixed in:
+# https://github.com/opencontainers/runc/commit/506552a88bd3455e80a9b3829568e94ec0160309
+#
+# While this Tracing Policy is able to block '/sys/fs/cgroup' file descriptors leaks and
+# block CVE-2024-21626 exploits that change the working directory, it is not intended as
+# a complete prevention of all possible file descriptors leaks and exploits for runc.
+# If there are more leaks from the host filesystem, then adding those resolved host
+# filesystem paths to the 'set_fs_pwd' kprobe section, under the 'matchArgs' to detect
+# usage of such leaks will certainly block all of them.
+#
+
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "cve-2024-21626-runc"
+  annotations:
+    url: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21626"
+    description: "Prevents exploitation of runc CVE-2024-21626"
+    author: "Tetragon.io Team"
+spec:
+  kprobes:
+  - call: "sys_chdir"
+    syscall: true
+    message: "Possible exploit of runc cve-2024-21626 vulnerability"
+    args:
+      - index: 0
+        type: "string"
+    selectors:
+    - matchBinaries:
+      - operator: "In"
+        values:
+        # Add your runc paths here
+        - "/usr/bin/runc"
+        - "/usr/sbin/runc"
+        - "/usr/local/sbin/runc"
+      matchArgs:
+      - index: 0
+        operator: "Prefix"
+        values:
+        - "/proc/self/fd/"
+      matchActions:
+        - action: Sigkill
+  - call: "set_fs_pwd"
+    syscall: false
+    message: "Possible exploit of runc cve-2024-21626 vulnerability"
+    args:
+      - index: 1
+        type: "path"
+    selectors:
+    - matchBinaries:
+      - operator: "In"
+        values:
+        # Add your runc paths here
+        - "/usr/bin/runc"
+        - "/usr/sbin/runc"
+        - "/usr/local/sbin/runc"
+      matchArgs:
+      - index: 1
+        operator: "Prefix"
+        values:
+        # Add any leaked path here
+        - "/sys/fs/cgroup"
+      matchActions:
+        - action: Sigkill


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-21626

runc is a CLI tool for spawning and running containers on Linux according to the OCI specification. According to runc Security Advisory: https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv

runc 1.1.11 and earlier, due to an internal file descriptor leak, an attacker could cause a newly-spawned container process to have a working directory in the host filesystem namespace, allowing access to the host filesystem and container escapes.

Attack 1: process.cwd "mis-configuration"

The CVSS score for this attack is CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N (8.2, high severity).

In runc 1.1.11 and earlier, several file descriptors were inadvertently leaked internally within runc into runc init, including a handle to the host filesystem. If the container was configured to have process.cwd set to /proc/self/fd/7/ (the actual fd can change depending on file opening order in runc), the resulting pid1 process will have a working directory in the host mount namespace and thus the spawned process can access the entire host filesystem.

To reproduce: tested on up to date ubuntu, downgrade to runc 1.1.11:

   sudo apt install containerd.io=1.6.27-1

1. Start container and access host file system:

   docker run -ti --rm --workdir=/proc/self/fd/7 ubuntu ls ../../../etc/passwd

This Tracing Policy protects against this attack 1 and kills the process.

Attack 2: runc exec container breakout

The CVSS score for this attack is CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:N (7.2, high severity).

(This is a modification of attack 1, constructed to allow for a process inside a
 container to break out.)

The same fd leak and lack of verification of the working directory in attack 1 also apply to runc exec. If a malicious process inside the container knows that some administrative process will call "runc exec --cwd" with a special given path, in most cases they can replace that path with a symlink to /proc/self/fd/7/. Once the container process has executed the container binary, PR_SET_DUMPABLE protections no longer apply and the attacker can open /proc/$exec_pid/cwd to get access to the host filesystem.

To reproduce: tested on up to date ubuntu, downgrade to runc 1.1.11:

   sudo apt install containerd.io=1.6.27-1

   1. Start container:

      docker run -ti --rm --name ubuntu ubuntu bash

   2. Then inside the container create the evil symlink to point to the host filesystem

      ln -s /proc/self/fd/7 /hostfilesystem1 ln -s /proc/self/fd/8 /hostfilesystem2

   3. Now if an administrator exec into the container with workdir set to the evil symlink:

      docker exec -it --workdir=/hostfilesystem1 ubuntu bash

      or

      docker exec -it --workdir=/hostfilesystem2 ubuntu bash

   4. Then inside original container 1, using the $pid of the new exec'ed bash of 3, accessing the host filesystem is possible with this:

      ls /proc/48/cwd/../../../etc/passwd

Use this Tracing Policy to protect against this attack 2 and kill the process.

Attacks 3a and 3b: process.args host binary overwrite attack

(These are modifications of attacks 1 and 2, constructed to overwrite a host
 binary by using execve to bring a magic-link reference into the container.)

Attack 3a is attack 1 but adapted to overwrite a host binary, where a malicious image is set up to execute /proc/self/fd/7/../../../bin/bash and run a shell script that overwrites /proc/self/exe, overwriting the host copy of /bin/bash. The CVSS score for this attack is CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H (8.6, high severity).

Attack 3b is attack 2 but adapted to overwrite a host binary, where the malicious container process overwrites all of the possible runc exec target binaries inside the container (such as /bin/bash) such that a host target binary is executed and then the container process opens /proc/$pid/exe to get access to the host binary and overwrite it.
The CVSS score for this attack is CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H (8.2, high severity).

This Tracing Policy does not protect against Attacks 3a and 3b.

This cve-2024-21626-runc Tetragon Tracing Policy can be used to detect usage of magic symlinks /proc/* that are passed to runc in order to change current working directory. The detection is performed at the system call layer.

Further, this Tracing Policy checks at kernel layer if the current working directory of current container process is being set to '/sys/fs/cgroup' which is one of the leaked file descriptors in runc that was fixed in: https://github.com/opencontainers/runc/commit/506552a88bd3455e80a9b3829568e94ec0160309

While this Tracing Policy is able to block '/sys/fs/cgroup' file descriptors leaks and block CVE-2024-21626 exploits that change the working directory, it is not intended as a complete prevention of all possible file descriptors leaks and exploits for runc. If there are more leaks from the host filesystem, then adding those resolved host filesystem paths to the 'set_fs_pwd' kprobe section, under the 'matchArgs' to detect usage of such host filesystem paths will certainly block all leaks.