### PR TITLE
tetragon: update bpf func mappings and add dynptr_*, timer*, ring*

### DIFF
--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -227,6 +227,26 @@ static __u64 BPF_FUNC(get_attach_cookie, void *ctx);
 
 static long BPF_FUNC(loop, __u32 nr_loops, void *callback_fn, void *callback_ctx, __u64 flags);
 
+static long BPF_FUNC(ringbuf_output, void *data, uint64_t size, uint64_t flags);
+static void BPF_FUNC(ringbuf_reserve, void *ringbuf, uint64_t size, uint64_t flags);
+static void BPF_FUNC(ringbuf_submit, void *data, uint64_t flags);
+static void BPF_FUNC(ringbuf_discard, void *data, uint64_t flags);
+static long BPF_FUNC(ringbuf_query, void *ringbuf, uint64_t flags);
+
+static long BPF_FUNC(ringbuf_reserve_dynptr, void *ringbuf, uint32_t size, uint64_t flags, struct bpf_dynptr *ptr);
+static void BPF_FUNC(ringbuf_submit_dynptr, struct bpf_dynptr *ptr, uint64_t flags);
+static void BPF_FUNC(ringbuf_discard_dynptr, struct bpf_dynptr *ptr, uint64_t flags);
+
+static long BPF_FUNC(dynptr_from_mem, void *data, uint32_t size, uint64_t flags, struct bpf_dynptr *ptr);
+static long BPF_FUNC(dynptr_read, void *dst, uint32_t len, const struct bpf_dynptr *src, uint32_t offset, uint64_t flags);
+static long BPF_FUNC(dynptr_write, const struct bpf_dynptr *dst, uint32_t offset, void *src, uint32_t len, uint64_t flags);
+static void BPF_FUNC(dynptr_data, const struct bpf_dynptr *ptr, uint32_t offset, uint32_t len);
+
+static long BPF_FUNC(timer_init, struct bpf_timer *timer, void *map, uint64_t flags);
+static long BPF_FUNC(timer_set_callback, struct bpf_timer *timer, void *callback_fun);
+static long BPF_FUNC(timer_start, struct bpf_timer *timer, uint64_t nsecs, uint64_t flags);
+static long BPF_FUNC(timer_cancel, struct bpf_timer *timer);
+
 /** LLVM built-ins, mem*() routines work for constant size */
 
 #ifndef lock_xadd

--- a/bpf/include/vmlinux.h
+++ b/bpf/include/vmlinux.h
@@ -9400,7 +9400,23 @@ enum bpf_func_id {
 	BPF_FUNC_ima_file_hash = 193,
 	BPF_FUNC_kptr_xchg = 194,
 	BPF_FUNC_map_lookup_percpu_elem = 195,
-	__BPF_FUNC_MAX_ID = 136,
+	BPF_FUNC_skc_to_mptcp_sock = 196,
+	BPF_FUNC_dynptr_from_mem = 197,
+	BPF_FUNC_ringbuf_reserve_dynptr = 198,
+	BPF_FUNC_ringbuf_submit_dynptr = 199,
+	BPF_FUNC_ringbuf_discard_dynptr = 200,
+	BPF_FUNC_dynptr_read = 201,
+	BPF_FUNC_dynptr_write = 202,
+	BPF_FUNC_dynptr_data = 203,
+	BPF_FUNC_tcp_raw_gen_syncookie_ipv4 = 204,
+	BPF_FUNC_tcp_raw_gen_syncookie_ipv6 = 205,
+	BPF_FUNC_tcp_raw_check_syncookie_ipv4 = 206,
+	BPF_FUNC_tcp_raw_check_syncookie_ipv6 = 207,
+	BPF_FUNC_ktime_get_tai_ns = 208,
+	BPF_FUNC_user_ringbuf_drain = 209,
+	BPF_FUNC_cgrp_storage_get = 210,
+	BPF_FUNC_cgrp_storage_delete = 211,
+	__BPF_FUNC_MAX_ID = 212,
 };
 
 struct bpf_func_info {
@@ -85138,4 +85154,13 @@ struct amd_hostbridge {
 	u32 slot;
 	u32 device;
 };
+
+struct bpf_timer {
+	u64 __opaque[2];
+} __attribute__((aligned(8)));
+
+struct bpf_dynptr {
+	__u64 __opaque[2];
+} __attribute__((aligned(8)));
+
 #endif


### PR DESCRIPTION
Update our headers to include some of the more recent helpers for dynptr, timers and ringbuf usage.