### PR TITLE
examples: Remove ".yaml" suffix from privileges-setuid-root

### DIFF
--- a/examples/policylibrary/privileges/privileges-setuid-root.yaml
+++ b/examples/policylibrary/privileges/privileges-setuid-root.yaml
@@ -53,7 +53,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "privileges-setuid-root.yaml"
+  name: "privileges-setuid-root"
 spec:
   kprobes:
   - call: "__sys_setuid"


### PR DESCRIPTION
This is a tiny change in the example policy name, because the ".yaml" suffix looks a bit awkward.