### PR TITLE
e2e: check policy state

### DIFF
--- a/tests/e2e/helpers/grpc/grpc.go
+++ b/tests/e2e/helpers/grpc/grpc.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/tests/e2e/state"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -65,7 +66,14 @@ func ensureTracingPolicy(ctx context.Context, policyName string, client tetragon
 
 	for _, pol := range res.GetPolicies() {
 		if pol.GetName() == policyName {
-			return nil
+			if pol.State == tetragon.TracingPolicyState_TP_STATE_ENABLED && pol.Error == "" {
+				return nil
+			}
+			return fmt.Errorf("policy %s exists but is in state:%s (error:%s)",
+				policyName,
+				tetragon.TracingPolicyState_name[int32(pol.State)],
+				pol.Error,
+			)
 		}
 	}
 


### PR DESCRIPTION
When we check whether a policy is there, having it appear in the list is not enough. We need to check that its state is enabled and that there are no errors.