### PR TITLE
docs: Fix cosign instructions

### DIFF
--- a/docs/content/en/docs/installation/verify.md
+++ b/docs/content/en/docs/installation/verify.md
@@ -20,13 +20,13 @@ Since version 0.8.4, all Tetragon container images are signed using cosign.
 Let's verify a Tetragon image's signature using the `cosign verify` command:
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository cilium/tetragon --certificate-oidc-issuer https://token.actions.githubusercontent.com <Image URL> | jq
+cosign verify --certificate-github-workflow-repository cilium/tetragon --certificate-oidc-issuer https://token.actions.githubusercontent.com <Image URL> | jq
 ```
 
 {{< note >}}
-`COSIGN_EXPERIMENTAL=1` is used to allow verification of images signed in
-KEYLESS mode. To learn more about keyless signing, please refer to [Keyless
-Signatures](https://github.com/sigstore/cosign/blob/main/KEYLESS.md#keyless-signatures).
+If you are using cosign < v2.0.0, you must set `COSIGN_EXPERIMENTAL=1`
+environment variable to allow verification of images signed in KEYLESS mode.
+To learn more about keyless signing, please refer to [Sigstore documentation](https://docs.sigstore.dev/signing/overview/).
 {{< /note >}}
 
 ## Verify the SBOM signature


### PR DESCRIPTION
Cosign documentation was migrated to https://docs.sigstore.dev/ in sigstore/cosign#822 and the markdown files were removed in sigstore/cosign#3587. Tetragon documentation was linking to one of this files. Now it's linking to https://docs.sigstore.dev/.

While here, remove `COSIGN_EXPERIMENTAL=1` from the cosign command for verifying keyless-signed images. It's not required since cosign v2.0.0 (see https://blog.sigstore.dev/cosign-2-0-released/).

Fixes #2209