### PR TITLE
Makefile: add native build support for arm64 MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ endif
 ifeq ($(UNAME_M),aarch64)
 	TARGET_ARCH ?= arm64
 endif
+ifeq ($(UNAME_M),arm64)
+	TARGET_ARCH ?= arm64
+endif
 TARGET_ARCH ?= amd64
 
 # Set GOARCH to TARGET_ARCH only if it's not set so that we can still use both


### PR DESCRIPTION
On MacOS `uname -m` returns `arm64` whereas on Linux it returns `aarch64`.

Fixes https://github.com/cilium/tetragon/issues/2257