### PR TITLE
observer: remove unused field

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -274,7 +274,7 @@ func tetragonExecute() error {
 	}
 
 	// Get observer from configFile
-	obs := observer.NewObserver(option.Config.TracingPolicy)
+	obs := observer.NewObserver()
 	defer func() {
 		obs.PrintStats()
 	}()

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -86,7 +86,7 @@ func runTetragon(ctx context.Context, configFile string, args *Arguments, summar
 	option.Config.RBSize = args.RBSize
 
 	option.Config.BpfDir = bpf.MapPrefixPath()
-	obs := observer.NewObserver(configFile)
+	obs := observer.NewObserver()
 
 	if err := obs.InitSensorManager(nil); err != nil {
 		logger.GetLogger().Fatalf("InitSensorManager failed: %v", err)

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -309,9 +309,6 @@ type Observer struct {
 	filterDrop uint64
 	/* Filters */
 	log logrus.FieldLogger
-
-	/* YAML Configuration File */
-	configFile string
 }
 
 // UpdateRuntimeConf() Gathers information about Tetragon runtime environment and
@@ -357,11 +354,10 @@ func (k *Observer) InitSensorManager(waitChan chan struct{}) error {
 	return SetSensorManager(mgr)
 }
 
-func NewObserver(configFile string) *Observer {
+func NewObserver() *Observer {
 	o := &Observer{
-		listeners:  make(map[Listener]struct{}),
-		log:        logger.GetLogger(),
-		configFile: configFile,
+		listeners: make(map[Listener]struct{}),
+		log:       logger.GetLogger(),
 	}
 	observerList = append(observerList, o)
 	return o

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -206,9 +206,9 @@ func newDefaultTestOptions(opts ...TestOption) *TestOptions {
 	return options
 }
 
-func newDefaultObserver(oo *testObserverOptions) *observer.Observer {
+func newDefaultObserver() *observer.Observer {
 	option.Config.BpfDir = bpf.MapPrefixPath()
-	return observer.NewObserver(oo.config)
+	return observer.NewObserver()
 }
 
 func getDefaultObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor, opts ...TestOption) (*observer.Observer, error) {
@@ -225,7 +225,7 @@ func getDefaultObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor
 		option.Config.ProcFS = procfs
 	}
 
-	obs := newDefaultObserver(&o.observer)
+	obs := newDefaultObserver()
 	if testing.Verbose() {
 		option.Config.Verbosity = 1
 	}


### PR DESCRIPTION
Remove an unused field in the observer. It used to be the tracing policy file, which we now handle differently.