### PR TITLE
tracingpolicy: comment message field for older versions support

### DIFF
--- a/examples/policylibrary/cves/cve-2024-3094-xz-ssh.yaml
+++ b/examples/policylibrary/cves/cve-2024-3094-xz-ssh.yaml
@@ -42,7 +42,7 @@ spec:
   - call: "security_mmap_file"
     syscall: false
     return: true
-    message: "OpenSSH daemon using vulnerable XZ libraries CVE-2024-3094"
+    # message: "OpenSSH daemon using vulnerable XZ libraries CVE-2024-3094"
     # tags: [ "cve", "cve.2024.3094" ]
     args:
     - index: 0
@@ -67,7 +67,5 @@ spec:
         - "liblzma.so.5.6.0"
         - "liblzma.so.5.6.1"
       matchActions:
-      # Change action to 'Sigkill' or 'Override' with 'argError: -1' to block
-      # the ssh session.
         - action: Post
           rateLimit: "1m"


### PR DESCRIPTION
Remove the new "message" field so users can run it on old versions