### PR TITLE
Makefile: fix a missing 'vendor' target in oci-hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ install:
 vendor:
 	$(MAKE) -C ./api vendor
 	$(MAKE) -C ./pkg/k8s vendor
-	$(MAKE) -C ./contrib/rthooks/tetragon-oci-hook
+	$(MAKE) -C ./contrib/rthooks/tetragon-oci-hook vendor
 	$(GO) mod tidy
 	$(GO) mod vendor
 	$(GO) mod verify


### PR DESCRIPTION
It seems that it's a mistake from https://github.com/cilium/tetragon/commit/606aa9a67e77120e7968737ab51541da92692623#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R201. I was trying to rebase https://github.com/cilium/tetragon/pull/2175 and discovered the issue.