### PR TITLE
metrics: Remove pod from the queue after deleting metrics

### DIFF
--- a/pkg/metrics/metricwithpod.go
+++ b/pkg/metrics/metricwithpod.go
@@ -128,5 +128,6 @@ func StartPodDeleteHandler() {
 			return
 		}
 		DeleteMetricsForPod(pod.(*corev1.Pod))
+		queue.Done(pod)
 	}
 }


### PR DESCRIPTION
This is done to prevent a memory leak in environments with a high pod churn or very long-running Tetragon agents.

Credits to Tam Mach for fixing a similar issue in cilium/cilium#31714.