### PR TITLE
jsonchecker: reset state of the export file

### DIFF
--- a/pkg/jsonchecker/jsonchecker.go
+++ b/pkg/jsonchecker/jsonchecker.go
@@ -175,6 +175,10 @@ func JsonTestCheckExpect(t *testing.T, checker ec.MultiEventChecker, expectCheck
 		return err
 	}
 
+	// NB: some tests will run JsonTestCheckExpect multiple times. Reset any previous
+	// DoneWithExportFile from previous invocations.
+	testutils.KeepExportFile(t)
+
 	// attempt to open the export file
 	t.Logf("jsonTestCheck: opening: %s\n", jsonFname)
 	jsonFile, err := os.Open(jsonFname)

--- a/pkg/testutils/filenames.go
+++ b/pkg/testutils/filenames.go
@@ -111,3 +111,17 @@ func DoneWithExportFile(t testing.TB) error {
 	exportFiles[testName] = ef
 	return nil
 }
+
+// KeepExportFile: marks the export file to be kept
+func KeepExportFile(t testing.TB) error {
+	exportFilesLock.Lock()
+	defer exportFilesLock.Unlock()
+	testName := fixupTestName(t)
+	ef, ok := exportFiles[testName]
+	if !ok {
+		return fmt.Errorf("file for test %s does not exist", testName)
+	}
+	ef.deleteFile = false
+	exportFiles[testName] = ef
+	return nil
+}


### PR DESCRIPTION
Some tests run JsonTestCheckExpect multiple times. Add a KeepExportFile
function to keep the export file and call it at the start of JsonTestCheckExpect.