### PR TITLE
docs: fix contribution-guide docker run

### DIFF
--- a/docs/content/en/docs/contribution-guide/development-setup.md
+++ b/docs/content/en/docs/contribution-guide/development-setup.md
@@ -120,8 +120,7 @@ docker run --name tetragon \
    --rm -it -d --pid=host \
    --cgroupns=host --privileged \
    -v /sys/kernel/btf/vmlinux:/var/lib/tetragon/btf \
-   cilium/tetragon:latest \
-   bash -c "/usr/bin/tetragon"
+   cilium/tetragon:latest
 ```
 
 Run the `tetra` binary to get Tetragon events:


### PR DESCRIPTION
Fixes: #2293 

Current `docker run` doesn't work. ENTRYPOINT is set as `/usr/bin/tetragon` in [Dockerfile](https://github.com/cilium/tetragon/blob/86e210a6f9b818ef6e170f405bb19680ce63a2b5/Dockerfile#L83), so arguments for `docker run` are not needed.

Tetragon's container was created successfully via the new command:
```
$ docker run --name tetragon \
   --rm -it -d --pid=host \
   --cgroupns=host --privileged \
   -v /sys/kernel/btf/vmlinux:/var/lib/tetragon/btf \
   cilium/tetragon:latest
27016a8ee505aed876f9d7426e60d4ca347689ae56acd1f321192deae2b142f9

$ docker ps
CONTAINER ID   IMAGE                    COMMAND                  CREATED         STATUS          PORTS                       NAMES
27016a8ee505   cilium/tetragon:latest   "/usr/bin/tetragon"      3 seconds ago   Up 2 seconds                                tetragon
```