### PR TITLE
docs: update demo app url

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -114,7 +114,7 @@ github_project_repo = "https://github.com/cilium/tetragon"
 github_subdir = "docs"
 
 # URL of the Star Wars demo app.
-demo_app_url = "https://raw.githubusercontent.com/cilium/cilium/v1.15.0-pre.1/examples/minikube/http-sw-app.yaml"
+demo_app_url = "https://raw.githubusercontent.com/cilium/cilium/v1.15.3/examples/minikube/http-sw-app.yaml"
 
 # The version number for the version of the docs represented in this doc set.
 # Used in the "version-banner" partial to display a version number for the


### PR DESCRIPTION
Fixes: #2309

Current demo app url doesn't work in an ARM environment. It needs to be updated by following cilium repository's update: https://github.com/cilium/cilium/pull/31373. 

The new url worked in my ARM environment.
```
$ uname -a
Linux lima-tetragon-dev 5.15.0-101-generic #111-Ubuntu SMP Wed Mar 6 18:01:01 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux

$ k create -f https://raw.githubusercontent.com/cilium/cilium/v1.15.3/examples/minikube/http-sw-app.yaml
service/deathstar created
deployment.apps/deathstar created
pod/tiefighter created
pod/xwing created

$ k get po
NAME                        READY   STATUS    RESTARTS   AGE
deathstar-b4b8ccfb5-kwz85   1/1     Running   0          12s
deathstar-b4b8ccfb5-z7pdj   1/1     Running   0          12s
tiefighter                  1/1     Running   0          12s
xwing                       1/1     Running   0          12s

```

