### PR TITLE
backports/1.0: exporter: fix hang when exporter fails to start

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -134,14 +134,23 @@ func (s *Server) GetEventsWG(request *tetragon.GetEventsRequest, server tetragon
 	}).Debug("Received a GetEvents request")
 	allowList, err := filters.BuildFilterList(s.ctx, request.AllowList, filters.Filters)
 	if err != nil {
+		if readyWG != nil {
+			readyWG.Done()
+		}
 		return err
 	}
 	denyList, err := filters.BuildFilterList(s.ctx, request.DenyList, filters.Filters)
 	if err != nil {
+		if readyWG != nil {
+			readyWG.Done()
+		}
 		return err
 	}
 	aggregator, err := aggregator.NewAggregator(server, request.AggregationOptions)
 	if err != nil {
+		if readyWG != nil {
+			readyWG.Done()
+		}
 		return err
 	}
 	if aggregator != nil {


### PR DESCRIPTION
[upstream commit: 44bd44c]

The Exporter.Start() implementation uses a WaitGroup to wait until the exporter is ready after launching it in a goroutine. Unfortunately, this WaitGroup never gets set to Done when we encounter an error while starting the exporter. This ultimately causes the Tetragon process to hang indefinitely. Fix the issue by simply calling readyWG.Done() when we encounter an error here.

```release-note
Fix a hang when the exporter fails to start.
```