### PR TITLE
tetragon: fix redaction filters log message

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -113,7 +113,7 @@ func setRedactionFilters() error {
 	var err error
 	redactionFilters := viper.GetString(option.KeyRedactionFilters)
 	fieldfilters.RedactionFilters, err = fieldfilters.ParseRedactionFilterList(redactionFilters)
-	if err != nil {
+	if err == nil {
 		log.WithFields(logrus.Fields{"redactionFilters": redactionFilters}).Info("Configured redaction filters")
 	} else {
 		log.WithError(err).Error("Error configuring redaction filters")


### PR DESCRIPTION
Fix redaction filters log message to no longer log that an error occurred on success.