### PR TITLE
helm: Don't give operator permissions to create CRDs if not needed

### DIFF
--- a/install/kubernetes/tetragon/templates/operator_clusterrole.yaml
+++ b/install/kubernetes/tetragon/templates/operator_clusterrole.yaml
@@ -26,12 +26,14 @@ rules:
       - patch
       - update
       - watch
+  {{- if eq .Values.crds.installMethod "operator" }}
   - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
     verbs:
       - create
+  {{- end }}
   - apiGroups:
       - apiextensions.k8s.io
     resources:


### PR DESCRIPTION
Don't give operator permissions to create CRDs if not needed 
Result of the change :

![image](https://github.com/cilium/tetragon/assets/85927700/fae3bc02-2028-4ba1-979c-c882d31a4fbb)
Reproduce the result:
create a local values.yaml file with CRD creation disabled:

```
tetragonOperator:
  skipCRDCreation: true
```

and then run
and install Tetragon with using local Helm chart and your values.yaml file:

`./contrib/localdev/install-tetragon.sh --values values.yaml
`Then, check the operator ClusterRole using kubectl:

`kubectl get clusterrole tetragon-operator -oyaml`

Fixes: #2226