### PR TITLE
vmtests: deduplicating code using LVH library for arm64 support

### DIFF
--- a/cmd/tetragon-vmtests-run/conf.go
+++ b/cmd/tetragon-vmtests-run/conf.go
@@ -4,37 +4,35 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/cilium/little-vm-helper/pkg/runner"
 	"github.com/cilium/tetragon/pkg/vmtests"
 )
 
-// NB: we should use lvh's RunConf to avoid duplicating code
 type RunConf struct {
-	testImage             string
-	baseFname             string
-	kernelFname           string
+	runner.RunConf
+	vmName                string
+	baseImageFilename     string
 	dontRebuildImage      bool
 	useTetragonTesterInit bool
 	testerOut             string
 	qemuPrint             bool
 	justBoot              bool
 	justBuildImage        bool
-	disableKVM            bool
-	enableHVF             bool
 	btfFile               string
 	disableUnifiedCgroups bool
-	portForwards          runner.PortForwards
 	testerConf            vmtests.Conf
 	detailedResults       bool
 	keepAllLogs           bool
-	rootDev               string
 
 	filesystems []QemuFS
 }
 
-func (rc *RunConf) testImageFname() string {
-	imagesDir := filepath.Dir(rc.baseFname)
-	return filepath.Join(imagesDir, rc.testImage)
+func (rc RunConf) testImageFilename() string {
+	if ext := filepath.Ext(rc.vmName); ext == "" {
+		return fmt.Sprintf("%s.qcow2", rc.vmName)
+	}
+	return rc.vmName
 }

--- a/cmd/tetragon-vmtests-run/image.go
+++ b/cmd/tetragon-vmtests-run/image.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/cilium/little-vm-helper/pkg/images"
 	"github.com/cilium/tetragon/pkg/vmtests"
@@ -201,8 +200,7 @@ func buildNetActions(tmpDir string) ([]images.Action, error) {
 
 func buildTestImage(log *logrus.Logger, rcnf *RunConf) error {
 
-	imagesDir, baseImage := filepath.Split(rcnf.baseFname)
-	hostname := strings.TrimSuffix(rcnf.testImage, filepath.Ext(rcnf.testImage))
+	imagesDir, baseImage := filepath.Split(rcnf.baseImageFilename)
 
 	tmpDir, err := os.MkdirTemp("", "tetragon-vmtests-")
 	if err != nil {
@@ -226,7 +224,7 @@ func buildTestImage(log *logrus.Logger, rcnf *RunConf) error {
 	}
 
 	actions := []images.Action{
-		{Op: &images.SetHostnameCommand{Hostname: hostname}},
+		{Op: &images.SetHostnameCommand{Hostname: rcnf.vmName}},
 		{Op: &images.AppendLineCommand{
 			File: "/etc/sysctl.d/local.conf",
 			Line: "kernel.panic_on_rcu_stall=1",
@@ -241,7 +239,7 @@ func buildTestImage(log *logrus.Logger, rcnf *RunConf) error {
 		// TODO: might be useful to modify the images builder so that
 		// we can build this image using qemu-img -b
 		Images: []images.ImgConf{{
-			Name:    rcnf.testImage,
+			Name:    rcnf.testImageFilename(),
 			Parent:  baseImage,
 			Actions: actions,
 		}},

--- a/cmd/tetragon-vmtests-run/qemu.go
+++ b/cmd/tetragon-vmtests-run/qemu.go
@@ -5,80 +5,36 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"strings"
+	"path/filepath"
 
+	"github.com/cilium/little-vm-helper/pkg/runner"
 	"github.com/sirupsen/logrus"
 )
 
-func buildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
-	qemuArgs := []string{
-		// no need for all the default devices
-		"-nodefaults",
-		// no need display (-nographics seems a bit slower)
-		"-display", "none",
-		// don't reboot, just exit
-		"-no-reboot",
-		// cpus, memory
-		"-smp", "2", "-m", "4G",
-	}
-
-	if rcnf.enableHVF {
-		log.Info("HVF enabled")
-		qemuArgs = append(qemuArgs, "-accel", "hvf")
-	} else if !rcnf.disableKVM {
-		// quick-and-dirty kvm detection
-		if f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0755); err == nil {
-			qemuArgs = append(qemuArgs, "-enable-kvm", "-cpu", "kvm64")
-			f.Close()
-		} else {
-			log.Infof("KVM disabled (%v)", err)
-		}
-	}
-
-	var kernelRoot string
-	switch rcnf.rootDev {
-	case "hda":
-		qemuArgs = append(qemuArgs, "-hda", rcnf.testImageFname())
-		kernelRoot = "/dev/sda"
-	case "vda":
-		qemuArgs = append(qemuArgs, "-drive", fmt.Sprintf("file=%s,if=virtio,index=0,media=disk", rcnf.testImageFname()))
-		kernelRoot = "/dev/vda"
-	default:
-		return nil, fmt.Errorf("invalid root device: %s", rcnf.rootDev)
-	}
-
-	if rcnf.kernelFname != "" {
-		appendArgs := []string{
-			fmt.Sprintf("root=%s", kernelRoot),
-			"console=ttyS0",
-			"earlyprintk=ttyS0",
-			"panic=-1",
-		}
+// buildQemuArgs is a wrapper around LVH's runner.BuildQemuArgs and also handles
+// custom configuration from vmtests
+func buildQemuArgs(log *logrus.Logger, rcnf RunConf) ([]string, error) {
+	if rcnf.KernelFname != "" {
 		if rcnf.disableUnifiedCgroups {
-			appendArgs = append(appendArgs, "systemd.unified_cgroup_hierarchy=0")
+			rcnf.KernelAppendArgs = append(rcnf.KernelAppendArgs, "systemd.unified_cgroup_hierarchy=0")
 		}
 		if rcnf.useTetragonTesterInit {
-			appendArgs = append(appendArgs, fmt.Sprintf("init=%s", TetragonTesterBin))
+			rcnf.KernelAppendArgs = append(rcnf.KernelAppendArgs, fmt.Sprintf("init=%s", TetragonTesterBin))
 		}
-		qemuArgs = append(qemuArgs,
-			"-kernel", rcnf.kernelFname,
-			"-append", strings.Join(appendArgs, " "),
-		)
 	}
 
-	// NB: not sure what the best option is here, this is from trial-and-error
-	qemuArgs = append(qemuArgs,
-		"-serial", "mon:stdio",
-		"-device", "virtio-serial-pci",
-	)
+	rcnf.CPU = 2
+	rcnf.Mem = "4G"
+	// the new image is in the base image folder
+	rcnf.Image = filepath.Join(filepath.Dir(rcnf.baseImageFilename), rcnf.testImageFilename())
+
+	qemuArgs, err := runner.BuildQemuArgs(log, &rcnf.RunConf)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, fs := range rcnf.filesystems {
 		qemuArgs = append(qemuArgs, fs.qemuArgs()...)
-	}
-
-	if len(rcnf.portForwards) > 0 {
-		qemuArgs = append(qemuArgs, rcnf.portForwards.QemuArgs()...)
 	}
 
 	return qemuArgs, nil

--- a/tests/vmtests/fetch-data.sh
+++ b/tests/vmtests/fetch-data.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 
 OCIORG=quay.io/lvh-images
-ROOTIMG=$OCIORG/root-images
+ROOTIMG=$OCIORG/root-images:20240415.162748@sha256:2637beacabbb48e2ee89a8f296a123142257ae10616308f81e7210ac85b92789
 KERNIMG=$OCIORG/kernel-images
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
 KERNEL_VERS="$@"


### PR DESCRIPTION
Deduplicate some codes shared between vmtests and LVH:
- inject LVH runner.RunConf into vmtests RunConf and reuse existing LVH configuration fields.
- use LVH runner.BuildQemuArgs along with custom vmtests logic.
- removes the support for HVF, we would need to put it in LVH to get this again but I don't think this is used nowadays.

This is mainly so that we benefit from the arm64 support as LVH was recently updated to support it.