### PR TITLE
k8s: Fix CRDs Go code generation

### DIFF
--- a/pkg/k8s/Makefile
+++ b/pkg/k8s/Makefile
@@ -21,10 +21,10 @@ generate:
 .PHONY: __do_generate
 __do_generate:
 	./tools/controller-gen crd paths=./apis/... output:dir=apis/cilium.io/client/crds/v1alpha1
-	chmod +x vendor/k8s.io/code-generator/kube_codegen.sh
-	# Do two invocations of kube_codegen.sh, one with --plural-exceptions, one without
+	chmod +x vendor/k8s.io/code-generator/generate-internal-groups.sh
+	# Do two invocations of generate-groups.sh, one with --plural-exceptions, one without
 	export GOPATH=$$(go env GOPATH); \
-	  bash vendor/k8s.io/code-generator/kube_codegen.sh deepcopy,defaulter \
+	  bash vendor/k8s.io/code-generator/generate-groups.sh deepcopy,defaulter \
 	  github.com/cilium/tetragon/pkg/k8s/client \
 	  github.com/cilium/tetragon/pkg/k8s/apis \
 	  cilium.io:v1alpha1 \
@@ -32,7 +32,7 @@ __do_generate:
 	  -o . \
 	  --trim-path-prefix github.com/cilium/tetragon/pkg/k8s \
 	  ; \
-	  bash vendor/k8s.io/code-generator/kube_codegen.sh lister,informer,client \
+	  bash vendor/k8s.io/code-generator/generate-groups.sh lister,informer,client \
 	  github.com/cilium/tetragon/pkg/k8s/client \
 	  github.com/cilium/tetragon/pkg/k8s/apis \
 	  cilium.io:v1alpha1 \

--- a/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
@@ -231,6 +231,11 @@ func (in *KProbeSpec) DeepCopyInto(out *KProbeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -480,6 +485,11 @@ func (in *TracepointSpec) DeepCopyInto(out *TracepointSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -642,6 +652,11 @@ func (in *TracingPolicySpec) DeepCopyInto(out *TracingPolicySpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ContainerSelector != nil {
+		in, out := &in.ContainerSelector, &out.ContainerSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Lists != nil {
 		in, out := &in.Lists, &out.Lists
 		*out = make([]ListSpec, len(*in))
@@ -692,6 +707,11 @@ func (in *UProbeSpec) DeepCopyInto(out *UProbeSpec) {
 	if in.Args != nil {
 		in, out := &in.Args, &out.Args
 		*out = make([]KProbeArg, len(*in))
+		copy(*out, *in)
+	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
 	return

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
@@ -231,6 +231,11 @@ func (in *KProbeSpec) DeepCopyInto(out *KProbeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -480,6 +485,11 @@ func (in *TracepointSpec) DeepCopyInto(out *TracepointSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -642,6 +652,11 @@ func (in *TracingPolicySpec) DeepCopyInto(out *TracingPolicySpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ContainerSelector != nil {
+		in, out := &in.ContainerSelector, &out.ContainerSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Lists != nil {
 		in, out := &in.Lists, &out.Lists
 		*out = make([]ListSpec, len(*in))
@@ -692,6 +707,11 @@ func (in *UProbeSpec) DeepCopyInto(out *UProbeSpec) {
 	if in.Args != nil {
 		in, out := &in.Args, &out.Args
 		*out = make([]KProbeArg, len(*in))
+		copy(*out, *in)
+	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
 	return


### PR DESCRIPTION
Commit a9c509f1f7c738bbeb1565f83eb9da70941a22ba replaced execution of deprecated scripts with
k8s.io/code-generator/kube_codegen.sh. However, kube_codegen.sh doesn't generate
code on its own, but rather defines helper functions. To migrate to
kube_codegen.sh we'll need to call these functions from another script.
Additionally, it'll change with version 1.30 of k8s libraries - that's why I
opted to simply revert the change for now. When k8s libraries are updated to
1.30, the code generation scripts should be updated too.