### PR TITLE
Makefile: Do not use $(MAKE) when calling make with `docker run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ tetragon-bpf-local:
 
 tetragon-bpf-container:
 	$(CONTAINER_ENGINE) rm tetragon-clang || true
-	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon:Z -u $$(id -u) -e BPF_TARGET_ARCH=$(BPF_TARGET_ARCH) --name tetragon-clang $(CLANG_IMAGE) $(MAKE) -C /tetragon/bpf -j$(JOBS) $(__BPF_DEBUG_FLAGS)
+	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon:Z -u $$(id -u) -e BPF_TARGET_ARCH=$(BPF_TARGET_ARCH) --name tetragon-clang $(CLANG_IMAGE) make -C /tetragon/bpf -j$(JOBS) $(__BPF_DEBUG_FLAGS)
 	$(CONTAINER_ENGINE) rm tetragon-clang
 
 .PHONY: bpf-test


### PR DESCRIPTION
Using `$(MAKE)` will expand to the absolute path of `make` on the host, which can fail in docker if that path does not exist in the image.

Instead, just call `docker run ... make` without the $(MAKE) variable.