### PR TITLE
TestLabelsDemoApp: Replace isovalent/jobs-app by Opentelemetry demo app

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -40,7 +40,7 @@ jobs:
   run-e2e-test:
     needs: list-e2e-pkg
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 20
     name: ${{matrix.os}} / ${{ matrix.package.s }}
     strategy:
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ e2e-test: image image-operator
 else
 e2e-test:
 endif
-	$(GO) test -p 1 -parallel 1 $(GOFLAGS) -gcflags=$(GO_BUILD_GCFLAGS) -timeout $(E2E_TEST_TIMEOUT) -failfast -cover $(E2E_TESTS) ${EXTRA_TESTFLAGS} -fail-fast -tetragon.helm.set tetragon.image.override="$(E2E_AGENT)" -tetragon.helm.set tetragonOperator.image.override="$(E2E_OPERATOR)" -tetragon.helm.url="" -tetragon.helm.chart="$(realpath ./install/kubernetes/tetragon)" $(E2E_BTF_FLAGS)
+	$(GO) list $(E2E_TESTS) | xargs -Ipkg $(GO) test $(GOFLAGS) -gcflags=$(GO_BUILD_GCFLAGS) -timeout $(E2E_TEST_TIMEOUT) -failfast -cover pkg ${EXTRA_TESTFLAGS} -fail-fast -tetragon.helm.set tetragon.image.override="$(E2E_AGENT)" -tetragon.helm.set tetragonOperator.image.override="$(E2E_OPERATOR)" -tetragon.helm.url="" -tetragon.helm.chart="$(realpath ./install/kubernetes/tetragon)" $(E2E_BTF_FLAGS)
 
 TEST_COMPILE ?= ./...
 .PHONY: test-compile

--- a/api/vendor/github.com/cilium/tetragon/pkg/matchers/stringmatcher/stringmatcher.go
+++ b/api/vendor/github.com/cilium/tetragon/pkg/matchers/stringmatcher/stringmatcher.go
@@ -4,12 +4,12 @@
 package stringmatcher
 
 import (
-	json "encoding/json"
-	fmt "fmt"
-	regexp "regexp"
-	strings "strings"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
 
-	yaml "sigs.k8s.io/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 // Operator is en enum over types of StringMatcher

--- a/pkg/matchers/stringmatcher/stringmatcher.go
+++ b/pkg/matchers/stringmatcher/stringmatcher.go
@@ -4,12 +4,12 @@
 package stringmatcher
 
 import (
-	json "encoding/json"
-	fmt "fmt"
-	regexp "regexp"
-	strings "strings"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
 
-	yaml "sigs.k8s.io/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 // Operator is en enum over types of StringMatcher

--- a/tests/e2e/tests/labels/labels_test.go
+++ b/tests/e2e/tests/labels/labels_test.go
@@ -32,7 +32,7 @@ const (
 func installDemoApp(labelsChecker *checker.RPCChecker) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		manager := helm.New(c.KubeconfigFile())
-		if err := manager.RunRepo(helm.WithArgs("add", "isovalent", "https://helm.isovalent.com")); err != nil {
+		if err := manager.RunRepo(helm.WithArgs("add", "open-telemetry", "https://open-telemetry.github.io/opentelemetry-helm-charts")); err != nil {
 			t.Fatalf("failed to add helm repo: %s", err)
 		}
 
@@ -42,15 +42,17 @@ func installDemoApp(labelsChecker *checker.RPCChecker) features.Func {
 
 		for i := 0; i < demoAppRetry; i++ {
 			if err := manager.RunInstall(
-				helm.WithName("jobs-app"),
-				helm.WithChart("isovalent/jobs-app"),
-				helm.WithVersion("v0.7.1"),
+				helm.WithName("otel-demo"),
+				helm.WithChart("open-telemetry/opentelemetry-demo"),
+				helm.WithVersion("0.30.3"),
 				helm.WithNamespace(namespace),
-				helm.WithArgs("--create-namespace", "--wait"),
+				helm.WithArgs("--create-namespace"),
+				helm.WithWait(),
 			); err != nil {
 				labelsChecker.ResetTimeout()
 				t.Logf("failed to install demo app. run with `-args -v=4` for more context from helm: %s", err)
 			} else {
+				t.Log("demo app install successfully")
 				return ctx
 			}
 		}
@@ -64,7 +66,7 @@ func uninstallDemoApp() features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		manager := helm.New(c.KubeconfigFile())
 		if err := manager.RunUninstall(
-			helm.WithName("jobs-app"),
+			helm.WithName("otel-demo"),
 			helm.WithNamespace(namespace),
 		); err != nil {
 			t.Fatalf("failed to uninstall demo app. run with `-args -v=4` for more context from helm: %s", err)
@@ -120,63 +122,163 @@ func TestLabelsDemoApp(t *testing.T) {
 
 func labelsEventChecker() *checker.RPCChecker {
 	labelsEventChecker := ec.NewUnorderedEventChecker(
-		ec.NewProcessExecChecker("coreapi").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
-			"app":               *sm.Full("coreapi"),
-			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
+		ec.NewProcessExecChecker("otel-demo-grafana").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/instance": *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":     *sm.Full("grafana"),
+			"pod-template-hash":          *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker("crawler").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
-			"app":               *sm.Full("crawler"),
-			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
+		ec.NewProcessExecChecker("otel-demo-jaeger").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("all-in-one"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("jaeger"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker("elasticsearch").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
-			"app":                                *sm.Full("elasticsearch-master"),
-			"chart":                              *sm.Full("elasticsearch"),
-			"controller-revision-hash":           *sm.Regex("elasticsearch-master-[a-f0-9]+"),
-			"release":                            *sm.Full("jobs-app"),
-			"statefulset.kubernetes.io/pod-name": *sm.Prefix("elasticsearch-master"),
+		ec.NewProcessExecChecker("otel-demo-otelcol").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/instance": *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":     *sm.Full("otelcol"),
+			"component":                  *sm.Full("standalone-collector"),
+			"pod-template-hash":          *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker("jobposting").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
-			"app":               *sm.Full("jobposting"),
-			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
+		ec.NewProcessExecChecker("otel-demo-prometheus").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component":  *sm.Full("server"),
+			"app.kubernetes.io/instance":   *sm.Full("otel-demo"),
+			"app.kubernetes.io/managed-by": *sm.Full("Helm"),
+			"app.kubernetes.io/name":       *sm.Full("prometheus"),
+			"app.kubernetes.io/part-of":    *sm.Full("prometheus"),
+			"pod-template-hash":            *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker("kafka").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
-			"app.kubernetes.io/instance":         *sm.Full("jobs-app"),
-			"app.kubernetes.io/managed-by":       *sm.Full("strimzi-cluster-operator"),
-			"app.kubernetes.io/name":             *sm.Full("kafka"),
-			"app.kubernetes.io/part-of":          *sm.Full("strimzi-jobs-app"),
-			"statefulset.kubernetes.io/pod-name": *sm.Prefix("jobs-app-kafka"),
-			"strimzi.io/controller":              *sm.Full("strimzipodset"),
-			"strimzi.io/controller-name":         *sm.Full("jobs-app-kafka"),
-			"strimzi.io/cluster":                 *sm.Full("jobs-app"),
-			"strimzi.io/kind":                    *sm.Full("Kafka"),
-			"strimzi.io/name":                    *sm.Full("jobs-app-kafka"),
-			"strimzi.io/pod-name":                *sm.Prefix("jobs-app-kafka"),
+		ec.NewProcessExecChecker("otel-demo-accountingservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("accountingservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-accountingservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-accountingservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker("zookeeper").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
-			"app.kubernetes.io/instance":         *sm.Full("jobs-app"),
-			"app.kubernetes.io/managed-by":       *sm.Full("strimzi-cluster-operator"),
-			"app.kubernetes.io/name":             *sm.Full("zookeeper"),
-			"app.kubernetes.io/part-of":          *sm.Full("strimzi-jobs-app"),
-			"statefulset.kubernetes.io/pod-name": *sm.Prefix("jobs-app-zookeeper"),
-			"strimzi.io/cluster":                 *sm.Full("jobs-app"),
-			"strimzi.io/controller":              *sm.Full("strimzipodset"),
-			"strimzi.io/controller-name":         *sm.Full("jobs-app-zookeeper"),
-			"strimzi.io/kind":                    *sm.Full("Kafka"),
-			"strimzi.io/name":                    *sm.Full("jobs-app-zookeeper"),
-			"strimzi.io/pod-name":                *sm.Prefix("jobs-app-zookeeper"),
+		ec.NewProcessExecChecker("otel-demo-adservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("adservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-adservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-adservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker("loader").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
-			"app":               *sm.Full("loader"),
-			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
+		ec.NewProcessExecChecker("otel-demo-cartservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("cartservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-cartservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-cartservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+")}))),
+		ec.NewProcessExecChecker("otel-demo-checkoutservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("checkoutservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-checkoutservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-checkoutservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker("recruiter").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
-			"app":               *sm.Full("recruiter"),
-			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
+		ec.NewProcessExecChecker("otel-demo-currencyservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("currencyservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-currencyservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-currencyservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
 		}))),
-		ec.NewProcessExecChecker("cluster-operator").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
-			"name":              *sm.Full("strimzi-cluster-operator"),
-			"pod-template-hash": *sm.Regex("[a-f0-9]+"),
-			"strimzi.io/kind":   *sm.Full("cluster-operator"),
+		ec.NewProcessExecChecker("otel-demo-emailservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("emailservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-emailservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-emailservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-flagd").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("flagd"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-flagd"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-flagd"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-frauddetectionservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("frauddetectionservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-frauddetectionservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-frauddetectionservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-frontend").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("frontend"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-frontend"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-frontend"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-frontendproxy").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("frontendproxy"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-frontendproxy"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-frontendproxy"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-kafka").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("kafka"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-kafka"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-kafka"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-loadgenerator").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("loadgenerator"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-loadgenerator"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-loadgenerator"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-paymentservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("paymentservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-paymentservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-paymentservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-productcatalogservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("productcatalogservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-productcatalogservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-productcatalogservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+")}))),
+		ec.NewProcessExecChecker("otel-demo-quoteservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("quoteservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-quoteservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-quoteservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-recommendationservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("recommendationservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-recommendationservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-recommendationservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-redis").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("redis"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-redis"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-redis"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-shippingservice").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component": *sm.Full("shippingservice"),
+			"app.kubernetes.io/instance":  *sm.Full("otel-demo"),
+			"app.kubernetes.io/name":      *sm.Full("otel-demo-shippingservice"),
+			"opentelemetry.io/name":       *sm.Full("otel-demo-shippingservice"),
+			"pod-template-hash":           *sm.Regex("[a-f0-9]+"),
+		}))),
+		ec.NewProcessExecChecker("otel-demo-opensearch").WithProcess(ec.NewProcessChecker().WithPod(ec.NewPodChecker().WithPodLabels(map[string]sm.StringMatcher{
+			"app.kubernetes.io/component":        *sm.Full("otel-demo-opensearch"),
+			"app.kubernetes.io/instance":         *sm.Full("otel-demo"),
+			"app.kubernetes.io/managed-by":       *sm.Full("Helm"),
+			"app.kubernetes.io/name":             *sm.Full("opensearch"),
+			"controller-revision-hash":           *sm.Prefix("otel-demo-opensearch"),
+			"helm.sh/chart":                      *sm.Prefix("opensearch"),
+			"statefulset.kubernetes.io/pod-name": *sm.Prefix("otel-demo-opensearch"),
 		}))),
 	)
 


### PR DESCRIPTION
Migrate e2e labels test from `isovalent/jobs-app` to Opentelemetry demo app
- Update the labels checker
- remove `-p 1 -parallel 1` flags when running tests

Fixes: #1976, #2176