### PR TITLE
helm: use renovate to update dockerfiles in the Makefile

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -1,7 +1,15 @@
 # Variables
+
+# renovate: datasource=docker
+HELM_IMAGE=docker.io/alpine/helm:3.3.4@sha256:fc745f290a5671dbd0eb3e162b03bb3652b9f5604fdc28bf3e34bca3fd7ad633
+# renovate: datasource=docker
+KUBECONFORM_IMAGE=ghcr.io/yannh/kubeconform:v0.6.4-alpine@sha256:e68a0b638c6e9b76f1b7d58b4ec94340ef3b6601db25b2e40b29e3ac2d68e4bf
+# renovate: datasource=docker
+HELMDOCS_IMAGE=jnorwood/helm-docs:v1.11.0@sha256:66c8f4164dec860fa5c1528239c4aa826a12485305b7b224594b1a73f7e6879a
+
 SCRIPT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 TETRAGON_CHART := $(SCRIPT_DIR)/tetragon
-HELM ?= docker run --rm -v $(TETRAGON_CHART):/apps alpine/helm:3.3.4
+HELM ?= docker run --rm -v $(TETRAGON_CHART):/apps $(HELM_IMAGE)
 
 # Targets
 .PHONY: all lint docs
@@ -12,8 +20,8 @@ deps:
 
 lint:
 	$(HELM) lint . --with-subcharts
-	$(HELM) template tetragon . | docker run --rm -i ghcr.io/yannh/kubeconform:v0.6.4-alpine@sha256:e68a0b638c6e9b76f1b7d58b4ec94340ef3b6601db25b2e40b29e3ac2d68e4bf --strict --schema-location default
+	$(HELM) template tetragon . | docker run --rm -i $(KUBECONFORM_IMAGE) --strict --schema-location default
 
 docs:
-	docker run --rm -v $(TETRAGON_CHART):/helm-docs -u $$(id -u) jnorwood/helm-docs:v1.11.0@sha256:66c8f4164dec860fa5c1528239c4aa826a12485305b7b224594b1a73f7e6879a
+	docker run --rm -v $(TETRAGON_CHART):/helm-docs -u $$(id -u) $(HELMDOCS_IMAGE)
 	$(SCRIPT_DIR)/export-doc.sh $(SCRIPT_DIR)/../../docs/content/en/docs/reference/helm-chart.md


### PR DESCRIPTION
Part of https://github.com/cilium/tetragon/issues/2234.

Update the following dockerfiles:
- docker.io/alpine/helm
- ghcr.io/yannh/kubeconform
- jnorwood/helm-docs