### PR TITLE
Tetragon Go Test: Reduce CI time, run test packages in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ clean: cli-clean tarball-clean
 
 .PHONY: test
 test: tester-progs tetragon-bpf
-	$(GO) test -exec "$(SUDO)" -p 1 -parallel 1 $(GOFLAGS) -gcflags=$(GO_BUILD_GCFLAGS) -timeout $(GO_TEST_TIMEOUT) -failfast -cover ./pkg/... ./cmd/... ./operator/... ${EXTRA_TESTFLAGS}
+	$(GO) test -exec "$(SUDO)" $(GOFLAGS) -gcflags=$(GO_BUILD_GCFLAGS) -timeout $(GO_TEST_TIMEOUT) -failfast -cover ./pkg/sensors/tracing/... ./pkg/... ./cmd/... ./operator/... ${EXTRA_TESTFLAGS}
 
 .PHONY: bench
 bench:


### PR DESCRIPTION
Currently, we run tests sequentially, each package by each process. We can increase the parallelism of the test by removing the `-p 1` flag, so that we can run multiple test packages at a time. 
Furthermore, since there is no `t.Parallel()` call in tests, we can now remove `-parallel 1` flags also.

By moving the order of test packages, the [slowest test](https://github.com/cilium/tetragon/actions/runs/8757182496/job/24035287586#step:8:167) to run first, I hope this change can reduce `Tetragon Go Test` from around [~20min](https://github.com/cilium/tetragon/actions/runs/8757182496) to [~15min](https://github.com/Trung-DV/tetragon/actions/runs/8773573293)