### PR TITLE
metrics: Return a copy of LabelFilter in WithEnabledLabels(nil)

### DIFF
--- a/pkg/metrics/labelfilter.go
+++ b/pkg/metrics/labelfilter.go
@@ -3,10 +3,22 @@
 
 package metrics
 
+import (
+	"maps"
+)
+
 type LabelFilter map[string]bool
 
+// WithEnabledLabels returns a new LabelFilter with only the labels in enabledLabels enabled.
+// If enabledLabels is nil, a copy of the original LabelFilter is returned.
+// If enabledLabels is empty, all labels are disabled.
+// If enabledLabels contains labels that are not in the original LabelFilter, they are ignored.
 func (f LabelFilter) WithEnabledLabels(enabledLabels []string) LabelFilter {
-	labelFilter := make(LabelFilter)
+	labelFilter := maps.Clone(f)
+	if enabledLabels == nil {
+		return labelFilter
+	}
+
 	// disable all configurable labels
 	for l := range f {
 		labelFilter[l] = false

--- a/pkg/metrics/labels.go
+++ b/pkg/metrics/labels.go
@@ -9,18 +9,18 @@ type FilteredLabels interface {
 }
 
 type ProcessLabels struct {
-	namespace string
-	workload  string
-	pod       string
-	binary    string
+	Namespace string
+	Workload  string
+	Pod       string
+	Binary    string
 }
 
 func NewProcessLabels(namespace, workload, pod, binary string) *ProcessLabels {
 	return &ProcessLabels{
-		namespace: namespace,
-		workload:  workload,
-		pod:       pod,
-		binary:    binary,
+		Namespace: namespace,
+		Workload:  workload,
+		Pod:       pod,
+		Binary:    binary,
 	}
 }
 
@@ -29,5 +29,5 @@ func (l ProcessLabels) Keys() []string {
 }
 
 func (l ProcessLabels) Values() []string {
-	return []string{l.namespace, l.workload, l.pod, l.binary}
+	return []string{l.Namespace, l.Workload, l.Pod, l.Binary}
 }


### PR DESCRIPTION
LabelFilter.WithEnabledLabels behaved in the same way when passed nil or an empty slice - it disabled all labels. However, it's convenient to have a "no-op" option and just return a copy of the original filter. Let's do that when the passed slice is nil.

This change doesn't affect users. Currently the method is always called with a non-nil slice.

While here, I documented LabelFilter.WithEnabledLabels with edge cases. I also sneaked one convenience change - export fields in ProcessLabels struct.