### PR TITLE
Dockerfile: Remove syntax annotation

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7@sha256:dbbd5e059e8a07ff7ea6233b213b36aa516b4c53c645f1817a4dd18b83cbea56
-
 # Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
It doesn't seem helpful, but it's being updated by Renovate, what causes extra PR and CI noise.