### PR TITLE
proc: set auid to -1 for generated kernel pid 0

### DIFF
--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -107,7 +107,7 @@ func procKernel() procs {
 		pid:         kernelPid,
 		tid:         kernelPid,
 		nspid:       0,
-		auid:        0,
+		auid:        proc.InvalidUid,
 		flags:       api.EventProcFS,
 		ktime:       1,
 		exe:         kernelArgs,


### PR DESCRIPTION
Less confusion by unsetting auid of generated kernel pid 0.