### PR TITLE
renovate: add v1.1 in stable branches in config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -282,6 +282,7 @@
       "matchPackagePatterns": ["*"],
       "matchBaseBranches": [
         "v1.0",
+        "v1.1",
       ]
     },
     {
@@ -290,6 +291,7 @@
       "matchPackageNames": ["docker.io/library/alpine"],
       "matchBaseBranches": [
         "v1.0",
+        "v1.1",
       ]
     },
     {
@@ -301,7 +303,8 @@
       ],
       "allowedVersions": "/^1\\.21\\.[0-9]+-?(alpine)?$/",
       "matchBaseBranches": [
-        "v1.0"
+        "v1.0",
+        "v1.1",
       ]
     },
     // ignore deps section
@@ -324,10 +327,6 @@
       "matchUpdateTypes": [
         "patch"
       ],
-      matchBaseBranches: [
-        "main",
-        "v1.0"
-      ]
     },
     {
       // do not allow any updates for major.minor for LVH, they will be done by maintainers


### PR DESCRIPTION
Some entries were missing from the v1.1 renovate config update (d7304ec722de2dae3fa558b213aeb95cdd06450b) and some unnecessary updates were showing up from renovate.

This should reduce by a lot the number of PRs created by renovate on v1.1.

Should we update the release checklist to make this more explicit?