### PR TITLE
release_template: also tag API module

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -32,6 +32,7 @@ assignees: ''
       git checkout main
       git pull origin main
       git tag -a $RELEASE -m "$RELEASE release" -s
+      git tag -a api/$RELEASE -m "api/$RELEASE release" -s
       git push origin $RELEASE
 
 - If release is `X.Y.0`:


### PR DESCRIPTION
Releasing multiple modules from the same repo, requires tags for each. Add a tag for the api/ modules in the release process.