### PR TITLE
[v1.1] backport: bpf: use CORE for execve hook

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -62,15 +62,4 @@ static inline __attribute__((always_inline)) size_t generic_kprobe_common_size()
 	return offsetof(struct msg_generic_kprobe, args);
 }
 
-/* tracepoint args */
-struct sched_execve_args {
-	unsigned short common_type;
-	unsigned char common_flags;
-	unsigned char common_preempt_count;
-	int common_pid;
-	int filename;
-	int pid;
-	int old_pid;
-};
-
 #endif // _GENERIC__

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -176,10 +176,10 @@ read_exe(struct task_struct *task, struct heap_exe *exe)
 #endif
 
 __attribute__((section("tracepoint/sys_execve"), used)) int
-event_execve(struct sched_execve_args *ctx)
+event_execve(struct trace_event_raw_sched_process_exec *ctx)
 {
 	struct task_struct *task = (struct task_struct *)get_current_task();
-	char *filename = (char *)ctx + (ctx->filename & 0xFFFF);
+	char *filename = (char *)ctx + (_(ctx->__data_loc_filename) & 0xFFFF);
 	struct msg_execve_event *event;
 	struct execve_map_value *parent;
 	struct msg_process *p;
@@ -241,7 +241,7 @@ event_execve(struct sched_execve_args *ctx)
  * has already been collected, then send it to the perf buffer.
  */
 __attribute__((section("tracepoint/0"), used)) int
-execve_send(struct sched_execve_args *ctx)
+execve_send(void *ctx)
 {
 	struct msg_execve_event *event;
 	struct execve_map_value *curr;


### PR DESCRIPTION
[ upstream commit 8100230e93aa5d86b9a8ca863e1d1e165d06ce53 ]

Users reported an issue on RHEL 9 with binary names being wrong.

Looking at the sched/sched_process_exec tracepoint we hook into:

  $ cat /sys/kernel/debug/tracing/events/sched/sched_process_exec/format
  name: sched_process_exec
  ID: 310
  format:
          field:unsigned short common_type;       offset:0;       size:2; signed:0;
          field:unsigned char common_flags;       offset:2;       size:1; signed:0;
          field:unsigned char common_preempt_count;       offset:3;       size:1; signed:0;
          field:int common_pid;   offset:4;       size:4; signed:1;
          field:unsigned char common_preempt_lazy_count;  offset:8;       size:1; signed:0;

          field:__data_loc char[] filename;       offset:12;      size:4; signed:1;
          field:pid_t pid;        offset:16;      size:4; signed:1;
          field:pid_t old_pid;    offset:20;      size:4; signed:1;

There is an additional argument: common_preempt_lazy_count, which means that the struct we use (sched_execve_args) is no longer valid.

This patch removes the above struct, and instead, uses CORE and the trace_event_raw_sched_process_exec struct.

Reproduced and patch tested locally on a Rocky Linux 5.3 with a 5.14.0-362.24.1.el9_3.0.1.x86_64  kernel.