### PR TITLE
helm: Add tetragon.livenessProbe value

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -82,6 +82,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.image.override | string | `nil` |  |
 | tetragon.image.repository | string | `"quay.io/cilium/tetragon"` |  |
 | tetragon.image.tag | string | `"v1.1.0"` |  |
+| tetragon.livenessProbe | object | `{}` | Overrides the default livenessProbe for the tetragon container. |
 | tetragon.ociHookSetup | object | `{"enabled":false,"extraVolumeMounts":[],"installDir":"/opt/tetragon","interface":"oci-hooks","resources":{},"securityContext":{"privileged":true}}` | Configure tetragon's init container for setting up tetragon-oci-hook on the host |
 | tetragon.ociHookSetup.enabled | bool | `false` | enable  init container to setup tetragon-oci-hook |
 | tetragon.ociHookSetup.extraVolumeMounts | list | `[]` | Extra volume mounts to add to the oci-hook-setup init container |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -64,6 +64,7 @@ Helm chart for Tetragon
 | tetragon.image.override | string | `nil` |  |
 | tetragon.image.repository | string | `"quay.io/cilium/tetragon"` |  |
 | tetragon.image.tag | string | `"v1.1.0"` |  |
+| tetragon.livenessProbe | object | `{}` | Overrides the default livenessProbe for the tetragon container. |
 | tetragon.ociHookSetup | object | `{"enabled":false,"extraVolumeMounts":[],"installDir":"/opt/tetragon","interface":"oci-hooks","resources":{},"securityContext":{"privileged":true}}` | Configure tetragon's init container for setting up tetragon-oci-hook on the host |
 | tetragon.ociHookSetup.enabled | bool | `false` | enable  init container to setup tetragon-oci-hook |
 | tetragon.ociHookSetup.extraVolumeMounts | list | `[]` | Extra volume mounts to add to the oci-hook-setup init container |

--- a/install/kubernetes/tetragon/templates/_container_tetragon.tpl
+++ b/install/kubernetes/tetragon/templates/_container_tetragon.tpl
@@ -64,7 +64,10 @@
   resources:
     {{- toYaml . | nindent 4 }}
 {{- end }}
-{{- if .Values.tetragon.grpc.enabled }}
+{{- if .Values.tetragon.livenessProbe }}
+  livenessProbe:
+  {{- toYaml .Values.tetragon.livenessProbe | nindent 4 }}
+{{- else if .Values.tetragon.grpc.enabled }}
   livenessProbe:
      timeoutSeconds: 60
      exec:

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -63,6 +63,11 @@ tetragon:
   extraVolumeMounts: []
   securityContext:
     privileged: true
+  # -- Overrides the default livenessProbe for the tetragon container.
+  livenessProbe: {}
+  #  grpc:
+  #    port: 54321
+
   # Tetragon puts processes in an LRU cache. The cache is used to find ancestors
   # for subsequently exec'ed processes.
   processCacheSize: 65536


### PR DESCRIPTION
[ upstream commit 1871fe85f1fd5bf62846a861b9f995265cb214c9 ]

Add tetragon.livenessProbe Helm value that overrides the default liveness probe for the tetragon container. For example, to use grpc probe, you can specify tetragon.livenessProbe Helm value like this:

    tetragon:
      livenessProbe:
        grpc:
          port: 54321