### PR TITLE
helm: Add tetragon.livenessProbe value

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -90,6 +90,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.image.override | string | `nil` |  |
 | tetragon.image.repository | string | `"quay.io/cilium/tetragon"` |  |
 | tetragon.image.tag | string | `"v1.0.3"` |  |
+| tetragon.livenessProbe | object | `{}` | Overrides the default livenessProbe for the tetragon container. |
 | tetragon.processCacheSize | int | `65536` |  |
 | tetragon.prometheus.address | string | `""` | The address at which to expose metrics. Set it to "" to expose on all available interfaces. |
 | tetragon.prometheus.enabled | bool | `true` | Whether to enable exposing Tetragon metrics. |

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -73,6 +73,7 @@ Helm chart for Tetragon
 | tetragon.image.override | string | `nil` |  |
 | tetragon.image.repository | string | `"quay.io/cilium/tetragon"` |  |
 | tetragon.image.tag | string | `"v1.0.3"` |  |
+| tetragon.livenessProbe | object | `{}` | Overrides the default livenessProbe for the tetragon container. |
 | tetragon.processCacheSize | int | `65536` |  |
 | tetragon.prometheus.address | string | `""` | The address at which to expose metrics. Set it to "" to expose on all available interfaces. |
 | tetragon.prometheus.enabled | bool | `true` | Whether to enable exposing Tetragon metrics. |

--- a/install/kubernetes/templates/_container_tetragon.tpl
+++ b/install/kubernetes/templates/_container_tetragon.tpl
@@ -66,7 +66,10 @@
   resources:
     {{- toYaml . | nindent 4 }}
 {{- end }}
-{{- if .Values.tetragon.grpc.enabled }}
+{{- if .Values.tetragon.livenessProbe }}
+  livenessProbe:
+  {{- toYaml .Values.tetragon.livenessProbe | nindent 4 }}
+{{- else if .Values.tetragon.grpc.enabled }}
   livenessProbe:
      timeoutSeconds: 60
      exec:

--- a/install/kubernetes/values.yaml
+++ b/install/kubernetes/values.yaml
@@ -59,6 +59,11 @@ tetragon:
   extraVolumeMounts: []
   securityContext:
     privileged: true
+  # -- Overrides the default livenessProbe for the tetragon container.
+  livenessProbe: {}
+  #  grpc:
+  #    port: 54321
+
   # Tetragon puts processes in an LRU cache. The cache is used to find ancestors for subsequently exec'ed
   # processes.
   processCacheSize: 65536


### PR DESCRIPTION
[ upstream commit 1871fe85f1fd5bf62846a861b9f995265cb214c9 ]

Add tetragon.livenessProbe Helm value that overrides the default liveness probe for the tetragon container. For example, to use grpc probe, you can specify tetragon.livenessProbe Helm value like this:

    tetragon:
      livenessProbe:
        grpc:
          port: 54321