### PR TITLE
Use HTTP liveness probe instead of tetra status

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -82,7 +82,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.image.override | string | `nil` |  |
 | tetragon.image.repository | string | `"quay.io/cilium/tetragon"` |  |
 | tetragon.image.tag | string | `"v1.1.0"` |  |
-| tetragon.livenessProbe | object | `{}` | Overrides the default livenessProbe for the tetragon container. |
+| tetragon.livenessProbe | object | `{"httpGet":{"path":"/liveness","port":6789},"timeoutSeconds":60}` | Overrides the default livenessProbe for the tetragon container. |
 | tetragon.ociHookSetup | object | `{"enabled":false,"extraVolumeMounts":[],"failAllowNamespaces":"","installDir":"/opt/tetragon","interface":"oci-hooks","resources":{},"securityContext":{"privileged":true}}` | Configure tetragon's init container for setting up tetragon-oci-hook on the host |
 | tetragon.ociHookSetup.enabled | bool | `false` | enable  init container to setup tetragon-oci-hook |
 | tetragon.ociHookSetup.extraVolumeMounts | list | `[]` | Extra volume mounts to add to the oci-hook-setup init container |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -64,7 +64,7 @@ Helm chart for Tetragon
 | tetragon.image.override | string | `nil` |  |
 | tetragon.image.repository | string | `"quay.io/cilium/tetragon"` |  |
 | tetragon.image.tag | string | `"v1.1.0"` |  |
-| tetragon.livenessProbe | object | `{}` | Overrides the default livenessProbe for the tetragon container. |
+| tetragon.livenessProbe | object | `{"httpGet":{"path":"/liveness","port":6789},"timeoutSeconds":60}` | Overrides the default livenessProbe for the tetragon container. |
 | tetragon.ociHookSetup | object | `{"enabled":false,"extraVolumeMounts":[],"failAllowNamespaces":"","installDir":"/opt/tetragon","interface":"oci-hooks","resources":{},"securityContext":{"privileged":true}}` | Configure tetragon's init container for setting up tetragon-oci-hook on the host |
 | tetragon.ociHookSetup.enabled | bool | `false` | enable  init container to setup tetragon-oci-hook |
 | tetragon.ociHookSetup.extraVolumeMounts | list | `[]` | Extra volume mounts to add to the oci-hook-setup init container |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -64,9 +64,11 @@ tetragon:
   securityContext:
     privileged: true
   # -- Overrides the default livenessProbe for the tetragon container.
-  livenessProbe: {}
-  #  grpc:
-  #    port: 54321
+  livenessProbe:
+    timeoutSeconds: 60
+    httpGet:
+      path: "/liveness"
+      port: 6789
 
   # Tetragon puts processes in an LRU cache. The cache is used to find ancestors
   # for subsequently exec'ed processes.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/).
- [x] All code is covered by unit and/or end-to-end tests tests where feasible.
- [x] All commits contain a well written commit message including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository. 
- [x] Thanks for contributing!

Now, we use tetra status command to report the status of tetragon agent. This comes with some overheads as tetra binary has a lot of additional functionality and it seems like an overkill to use that for status reporting.

On the other hand, k8s supports liveness probes by using an HTTP endpoint (i.e. https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes). This patch first creates a new HTTP endpoint to report agent status and then change helm to make use of that.

```release-note
Use HTTP liveness probe instead of tetra status.
```
