### PR TITLE
TracingPolicyStatus: only add error if err not nil

### DIFF
--- a/pkg/sensors/handler.go
+++ b/pkg/sensors/handler.go
@@ -162,7 +162,10 @@ func (h *handler) listTracingPolicies(op *tracingPolicyList) error {
 			Name:     name,
 			Enabled:  col.enabled,
 			FilterId: col.policyfilterID,
-			Error:    fmt.Sprint(col.err),
+		}
+
+		if col.err != nil {
+			pol.Error = col.err.Error()
 		}
 
 		pol.Namespace = ""


### PR DESCRIPTION
This commit fixes the issue where the error
message was added to the status even if the
error was nil.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/).
- [x] All code is covered by unit and/or end-to-end tests tests where feasible.
- [x] All commits contain a well written commit message including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository. 
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
