### PR TITLE
operator: disable metrics server by default

### DIFF
--- a/operator/cmd/serve/serve.go
+++ b/operator/cmd/serve/serve.go
@@ -90,7 +90,7 @@ func New() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&metricsAddr, "metrics-bind-address", ":2113", "The address the metric endpoint binds to.")
+	cmd.Flags().StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to.")
 	cmd.Flags().StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	cmd.Flags().BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+


### PR DESCRIPTION
Fixes: #1778

Disable the operator's metrics server by default. If the `metrics-bind-address` flag is set, it will be enabled. 
Regarding Helm, `metrics-bind-address` is set as 2113 by default when  `tetragonOperator.prometheus.enabled = true`.
