### PR TITLE
Document release notes process & introduce upgrade notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -14,15 +14,22 @@ assignees: ''
 
       export RELEASE=v0.8.1
 
-- [ ] Open a pull request to update the Helm chart and docs version:
+- [ ] Open a pull request to update the Helm chart and docs:
 
       git checkout -b pr/prepare-$RELEASE
+
+      # update Helm chart
       ./contrib/update-helm-chart.sh $RELEASE
       make -C install/kubernetes
       git add install/kubernetes/tetragon/
-      # update hugo version
+
+      # update version in docs (Hugo config)
       sed -i "s/^version =.*/version = \"${RELEASE}\"/" docs/hugo.toml
       git add docs/
+
+      # update upgrade notes
+      ./contrib/update-upgrade-notes.sh $RELEASE
+      git add contrib/upgrade-notes/
 
       git commit -s -m "Prepare for $RELEASE release"
       git push origin HEAD
@@ -70,11 +77,15 @@ gitGraph
 - [ ] When a tag is pushed, a GitHub Action job takes care of creating a new GitHub
       draft release, building artifacts and attaching them to the draft release. Once
       the draft is available in the [releases page]:
-  - [ ] Use the "Auto-generate release notes" button to generate the release notes.
+  - [ ] Use `tgt-notes` from [tetragon-github-tools](https://github.com/isovalent/tetragon-github-tools/)
+        to generate a first version of the release notes based on `release-note/` tags and PR messages.
+  - [ ] Copy upgrade notes from `contrib/upgrade-notes/vX.Y.Z.md` file into the release notes.
+        (Skip if there are no upgrade notes - it's quite likely for patch releases).
+  - [ ] Review the release notes and update them as needed.
   - [ ] Make sure the "Set as a pre-release" and "Set as the latest release" checkboxes are set correctly.
         Every `-pre.N` or `-rc.N` release should be marked as a pre-release, and a stable release with the highest
         version should be marked as latest.
-  - [ ] Review the release notes and click on "Publish Release" at the bottom.
+  - [ ] Click on "Publish Release" at the bottom.
 
 - [ ] Publish Helm chart
    - Follow [cilium/charts RELEASE.md] to publish the Helm chart.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,8 @@ Thanks for contributing! Please ensure your pull request adheres to the followin
 - [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
 - [ ] All code is covered by unit and/or end-to-end tests where feasible.
 - [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
-- [ ] Provide a title or release-note blurb suitable for the release notes.
+- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
+- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
 - [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
 
 <!-- Description of change -->

--- a/contrib/update-upgrade-notes.sh
+++ b/contrib/update-upgrade-notes.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [ -z "$1" ] || [[ ! $1 =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+  echo "USAGE: ./contrib/update-upgrade-notes.sh vX.Y.Z"
+  exit 1
+fi
+
+NOTES_DIR="${NOTES_DIR:-contrib/upgrade-notes}"
+version=$1
+
+# Copy the latest upgrade notes to a version-specific file and create new latest from the template.
+# Skip for pre-releases.
+if [[ ! "$version" == *"-"* ]]; then
+  cp "$NOTES_DIR/latest.md" "$NOTES_DIR/$version.md"
+  cp "$NOTES_DIR/template.md" "$NOTES_DIR/latest.md"
+fi

--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -1,0 +1,26 @@
+## Upgrade notes
+
+Read the upgrade notes carefully before upgrading Tetragon.
+Depending on your setup, changes listed here might require a manual intervention.
+
+* TBD
+
+#### Agent Options
+
+* TBD
+
+#### Helm Values
+
+* TBD
+
+#### TracingPolicy (k8s CRD)
+
+* TBD
+
+#### Events (protobuf API)
+
+* TBD
+
+#### Metrics
+
+* TBD

--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -11,7 +11,21 @@ Depending on your setup, changes listed here might require a manual intervention
 
 #### Helm Values
 
-* TBD
+* Tetragon container now uses the gRPC liveness probe by default. To continue using "tetra status" for liveness probe,
+specify `tetragon.livenessProbe` Helm value. For example:
+```yaml
+tetragon:
+  livenessProbe:
+     timeoutSeconds: 60
+     exec:
+       command:
+       - tetra
+       - status
+       - --server-address
+       - "54321"
+       - --retries
+       - "5"
+```
 
 #### TracingPolicy (k8s CRD)
 

--- a/contrib/upgrade-notes/template.md
+++ b/contrib/upgrade-notes/template.md
@@ -1,0 +1,26 @@
+## Upgrade notes
+
+Read the upgrade notes carefully before upgrading Tetragon.
+Depending on your setup, changes listed here might require a manual intervention.
+
+* TBD
+
+### Agent Options
+
+* TBD
+
+### Helm Values
+
+* TBD
+
+### TracingPolicy (k8s CRD)
+
+* TBD
+
+### Events (protobuf API)
+
+* TBD
+
+### Metrics
+
+* TBD

--- a/contrib/upgrade-notes/v1.1.0.md
+++ b/contrib/upgrade-notes/v1.1.0.md
@@ -1,0 +1,39 @@
+## Upgrade notes
+
+Read the upgrade notes carefully before upgrading Tetragon.
+Depending on your setup, changes listed here might require a manual intervention.
+
+### Agent Options
+
+### Helm Values
+
+* `tetragonOperator.skipCRDCreation` value is deprecated and will be removed. Use `crds.installMethod=none` instead.
+
+### TracingPolicy (k8s CRD)
+
+* The `symbol` field (string) in uprobe spec is replaced with `symbols` (array of strings). If using policies with uprobes, you need to replace the symbol field.
+* Killer is renamed to enforcer. If using policies with killers, you need to replace `killers` with `enforcers` and `action: NotifyKiller` with `action: NotifyEnforcer`.
+* To distinguish different stacktraces, kernel stacktraces are now enabled with `kernelStackTrace` policy field (renamed from `stackTrace`).
+
+### Events (protobuf API)
+
+* Deprecated `pod.labels` field is removed. Use `pod.pod_labels` instead.
+* To distinguish different stacktraces, kernel stacktraces are now posted in `kernel_stack_trace` event field (renamed from `stack_trace`).
+
+### Metrics
+
+* Metrics related to monitoring BPF maps and userspace caches are fixed:
+  * tetragon_map_drops_total is removed (it was duplicating tetragon_errors_total{type="process_cache_evicted"})
+  * tetragon_map_in_use_gauge{map="eventcache"} is removed (event cache is not a BPF map)
+  * tetragon_map_in_use_gauge{map="processLru"} is replaced with tetragon_process_cache_size (process cache is not a BPF map)
+* Metrics with known labels values are initialized to 0 on startup. This helps to ensure stable resources usage and metrics queries. This also involves changes in several metrics labels:
+  * error_type label on tetragon_handler_errors_total metric is either "unknown_opcode" or "event_handler_failed" instead of the Go type of the error
+  * event_type label on tetragon_event_cache*_errors_total metrics is one of the values defined in Tetragon API (tetragon.EventType) instead of the Go type of the event
+  * error label on tetragon_event_cache_errors_total metric is "nil_process_pid"
+  * error label is removed from tetragon_policyfilter_metrics_total metric
+* Metrics for map and cache sizes are improved:
+  * tetragon_map_in_use_gauge metric is renamed to tetragon_map_entries and doesn't have total label anymore
+  * New tetragon_map_capacity metric exposes the BPF maps capacity
+  * New tetragon_event_cache_entries metric measures the event cache size
+  * New tetragon_process_cache_size metric measures the process cache size
+  * New tetragon_process_cache_capacity metric exposes the process cache capacity

--- a/docs/content/en/docs/contribution-guide/release-notes.md
+++ b/docs/content/en/docs/contribution-guide/release-notes.md
@@ -1,0 +1,56 @@
+---
+title: "Release & upgrade notes"
+weight: 7
+description: "Guide on how to write release notes for new contributions."
+---
+
+Tetragon release notes are published on the [GitHub releases page](https://github.com/cilium/tetragon/releases).
+To ensure the release notes are accurate and helpful, contributors should write them alongside development. Then, at
+the time of release, the final notes are compiled and published.
+
+This guide is intended for both Tetragon developers and reviewers. Please follow it when creating or reviewing pull
+requests.
+
+## `release-note` blurb in PR
+
+When you create a pull request, the template will include a `release-note` blurb in the description. Write a short
+description of your change there. Focus on the user perspective - that is, what functionality is available, not how
+it's implemented.
+
+The `release-note` blurb will be compiled into the release notes as a bullet point. If you delete the `release-note`
+blurb from the PR description, then the PR title will be used instead (it's reasonable to do so for example when the
+change has no user impact).
+
+## `release-note/*` label
+
+Each pull request should have exactly one `release-note/*` label. The label will be added by a reviewer, but feel free
+to suggest one when you create a PR.
+
+The following `release-note/*` labels are available:
+
+* `release-note/major` - use it for changes you want to be highlighted in the release. Typically these are new
+  features, but the question to answer is always if it's a highlight of the release, not how big or new the change is.
+* `release-note/minor` - use it for other user-visible changes, for example improving an existing functionality or
+  adding a new config option
+* `release-note/bug` - use it for bug fixes
+* `release-note/misc` - use it for changes that don't have any user impact, for example refactoring or tests
+* `release-note/ci` - use it for CI-only changes (`.github` directory)
+* `release-note/docs` - use it for documentation-only changes (`docs` directory)
+* `release-note/dependency` - use it for PRs that only update dependencies. This label is added automatically to PRs
+  created by Renovate bot and is rarely used by humans.
+
+## Upgrade notes
+
+Upgrade notes highlight changes that require attention when upgrading Tetragon. They instruct users on how to adapt in
+case the change requires a manual intervention.
+
+Examples of changes that should be covered in upgrade notes:
+* renaming/removing config options
+* renaming/removing API fields
+* renaming/removing metrics or metric labels
+* changes with a significant performance impact
+* deprecations
+
+If your change entails an upgrade note, write it in the `contrib/upgrade-notes/latest.md` file (if your change doesn't
+fit nicely in the predefined sections, just add a note at the top). The upgrade notes will be included in the release,
+in addition to the regular release notes.


### PR DESCRIPTION
Documenting changes introduced in 1.1 release was not a trivial task, so here I'm attempting to improve the process around release & upgrade notes. There are two different aspects:
1. I documented the existing practices for `release-note` blurbs and labels in PRs (see `docs/content/en/docs/contribution-guide/release-notes.md`).
2. I want to introduce a practice of writing separate upgrade notes for changes that require attention when upgrading Tetragon. Initially I wanted to introduce a dedicated docs page, similar to the [one from Cilium](https://docs.cilium.io/en/latest/operations/upgrade/#version-specific-notes). However, I think keeping upgrade notes together with the regular release notes is a better solution, as many users at least skim through the release notes and Tetragon upgrade generally should be simple enough to not require a dedicated docs page. So instead I added an upgrade notes template to the `contrib` dir and updated the release process.

The first commit should be backported to the stable branches: v1.0 and v1.1.

Also I'm suggesting to stop using the `release-note/breaking-changes` label (it's not documented here) and highlight any potential breaking changes in the upgrade notes instead (with understanding that breaking changes should be avoided in the first place).

Pinging @cilium/tetragon on this one. All of this makes sense only if Tetragon core developers follow these practices, so please review and comment if you disagree with something.