### PR TITLE
renovate: switch to get Go version from toolchain directive

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,7 @@
     "^make vendor$",
     "^make -C install/kubernetes$",
     "^go mod vendor$",
-    "^install-tool golang \\$\\(grep -oP '\\^go \\\\K\\.\\+' go\\.mod\\)$"
+    "^install-tool golang \\$\\(grep -oP '\\^toolchain go\\\\K\\.\\+' go\\.mod\\)$"
   ],
   // repository configuration
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
@@ -222,7 +222,7 @@
         // We need to trigger a golang install manually here because in some
         // cases it might not be preinstalled, see:
         // https://github.com/renovatebot/renovate/discussions/23485
-        "commands": ["install-tool golang $(grep -oP '^go \\K.+' go.mod)", "make vendor"],
+        "commands": ["install-tool golang $(grep -oP '^toolchain go\\K.+' go.mod)", "make vendor"],
         "fileFilters": ["**/**"],
         "executionMode": "branch"
       },


### PR DESCRIPTION
Since we now use the toolchain as the version we should use because of #2425, renovate need to pick up the toolchain version for its Go install fix.

Trying to fix the issue in https://github.com/cilium/tetragon/pull/2490.
