### PR TITLE
[v1.0] Introduce upgrade notes

### DIFF
--- a/contrib/update-upgrade-notes.sh
+++ b/contrib/update-upgrade-notes.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [ -z "$1" ] || [[ ! $1 =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+  echo "USAGE: ./contrib/update-upgrade-notes.sh vX.Y.Z"
+  exit 1
+fi
+
+NOTES_DIR="${NOTES_DIR:-contrib/upgrade-notes}"
+version=$1
+
+# Copy the latest upgrade notes to a version-specific file and create new latest from the template.
+# Skip for pre-releases.
+if [[ ! "$version" == *"-"* ]]; then
+  cp "$NOTES_DIR/latest.md" "$NOTES_DIR/$version.md"
+  cp "$NOTES_DIR/template.md" "$NOTES_DIR/latest.md"
+fi

--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -1,0 +1,26 @@
+## Upgrade notes
+
+Read the upgrade notes carefully before upgrading Tetragon.
+Depending on your setup, changes listed here might require a manual intervention.
+
+* TBD
+
+#### Agent Options
+
+* TBD
+
+#### Helm Values
+
+* TBD
+
+#### TracingPolicy (k8s CRD)
+
+* TBD
+
+#### Events (protobuf API)
+
+* TBD
+
+#### Metrics
+
+* TBD

--- a/contrib/upgrade-notes/template.md
+++ b/contrib/upgrade-notes/template.md
@@ -1,0 +1,26 @@
+## Upgrade notes
+
+Read the upgrade notes carefully before upgrading Tetragon.
+Depending on your setup, changes listed here might require a manual intervention.
+
+* TBD
+
+### Agent Options
+
+* TBD
+
+### Helm Values
+
+* TBD
+
+### TracingPolicy (k8s CRD)
+
+* TBD
+
+### Events (protobuf API)
+
+* TBD
+
+### Metrics
+
+* TBD


### PR DESCRIPTION
Backporting two commits from https://github.com/cilium/tetragon/pull/2487 so that we can have upgrade notes for v1.0.x releases.