### PR TITLE
fix: path to og:image

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -76,7 +76,7 @@ copyright = "The Authors of Tetragon"
 # privacy_policy = "https://policies.google.com/privacy"
 
 # First one is picked as the Twitter card image if not set on page.
-images = ["static/default-twitter-card-image.png"]
+images = ["default-twitter-card-image.png"]
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.


### PR DESCRIPTION
This PR fixes the path to `og:image` – open graph meta tags [preview](https://www.opengraph.xyz/url/https%3A%2F%2Fdeploy-preview-2505--tetragon.netlify.app%2F)