### PR TITLE
docs: updates resources section with newer content

### DIFF
--- a/docs/content/en/docs/resources/_index.md
+++ b/docs/content/en/docs/resources/_index.md
@@ -8,6 +8,7 @@ description: "Additional resources to learn about Tetragon"
 
 | Title | Authors | Conference | Date |
 | ----- | ------- | ---------- | ---- |
+| [eBPF-based, Kubernetes-native: observability & security with Tetragon](https://www.youtube.com/watch?v=xqKp6GfMuic)                                                     | Anna Kapuścińska    | TechSpot                                         | 2024 |
 | [Past, Present, Future of Tetragon- First Production Use Cases, Lessons Learnt, Where Are We Heading? ](https://youtu.be/2BIe4VmSYyQ)                        | John Fastabend & Natália Réka Ivánkó | KubeCon EU                                        | 2023 |
 | [eBPF and Kubernetes — Better Together! Observability and Security with Tetragon](https://youtu.be/oU7dPKoVfm4)                                              | Anna Kapuścińska & James Laverack    | Kubernetes Community Days UK                      | 2023 |
 | [The Next Log4jshell?! Preparing for CVEs with eBPF!](https://youtu.be/u8HKg5pENj4)                                                                          | John Fastabend & Natália Réka Ivánkó | KubeCon EU                                        | 2023 |
@@ -37,5 +38,12 @@ description: "Additional resources to learn about Tetragon"
 
 ### Hands-on lab
 
-[Security Observability with eBPF and Tetragon](https://isovalent.com/labs/) - Natália Réka Ivánkó, Roland Wolters, Raphaël Pinson
+[Getting Started with Tetragon](https://isovalent.com/labs/tetragon-getting-started/) - Natália Réka Ivánkó, Roland Wolters, Raphaël Pinson
 
+[Exploring Tetragon - A Security Observability Tool for Kubernetes, Docker, and Linux](https://labs.iximiuz.com/tutorials/introduction-to-tetragon) - Ivan Velichko
+
+### Video Tutorials
+
+[eBPF for Runtime Enforcement | Tetragon Introduction and Overview](https://www.youtube.com/watch?v=MObLmvBeu00) - Rawkode Academy
+
+[Restrict Access to Secure Files with Tetragon | eBPF Runtime Enforcement](https://www.youtube.com/watch?v=SiQm6N3ucyc) - Rawkode Academy


### PR DESCRIPTION
More talks, blogs, labs and tutorials.

This patch updates the resources section of the docs by adding:

1. updated content around talks, blogs and video tutorials.

Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.

<!-- Description of change -->

Fixes: #issue-number

```release-note
updates docs resources section with newer content
```
