### PR TITLE
renovate: update Go version properly for v1.1

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -295,7 +295,7 @@
       ]
     },
     {
-      // update go version until next minor for stable branches
+      // update go patch for 1.21 for stable branches
       "enabled": true,
       "matchPackageNames": [
         "go",
@@ -304,6 +304,17 @@
       "allowedVersions": "/^1\\.21\\.[0-9]+-?(alpine)?$/",
       "matchBaseBranches": [
         "v1.0",
+      ]
+    },
+    {
+      // update go patch for 1.22 for stable branches
+      "enabled": true,
+      "matchPackageNames": [
+        "go",
+        "docker.io/library/golang"
+      ],
+      "allowedVersions": "/^1\\.22\\.[0-9]+-?(alpine)?$/",
+      "matchBaseBranches": [
         "v1.1",
       ]
     },


### PR DESCRIPTION
Stable branch v1.1 was put in the rule to update <1.21 while it was already using 1.22. This fix should allow proper patch updates on v1.1 for the go version.