### PR TITLE
renovate: fix Go postUpgradeTasks for stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,7 @@
     "^make vendor$",
     "^make -C install/kubernetes$",
     "^go mod vendor$",
+    "^install-tool golang \\$\\(grep -oP '\\^go \\\\K\\.\\+' go\\.mod\\)$",
     "^install-tool golang \\$\\(grep -oP '\\^toolchain go\\\\K\\.\\+' go\\.mod\\)$"
   ],
   // repository configuration
@@ -212,10 +213,15 @@
       }
     },
     {
+      // main branch is using the new toolchain directive
       "groupName": "Go",
       "matchPackageNames": [
         "go",
         "docker.io/library/golang"
+      ],
+      "matchBaseBranches": [
+        "v1.0",
+        "v1.1",
       ],
       // postUpgradeTasks is only for when the Go module directives are bumped
       "postUpgradeTasks": {
@@ -223,6 +229,27 @@
         // cases it might not be preinstalled, see:
         // https://github.com/renovatebot/renovate/discussions/23485
         "commands": ["install-tool golang $(grep -oP '^toolchain go\\K.+' go.mod)", "make vendor"],
+        "fileFilters": ["**/**"],
+        "executionMode": "branch"
+      },
+    },
+    {
+      // stable branches are using the go directive
+      "groupName": "Go",
+      "matchPackageNames": [
+        "go",
+        "docker.io/library/golang"
+      ],
+      "matchBaseBranches": [
+        "v1.0",
+        "v1.1",
+      ],
+      // postUpgradeTasks is only for when the Go module directives are bumped
+      "postUpgradeTasks": {
+        // We need to trigger a golang install manually here because in some
+        // cases it might not be preinstalled, see:
+        // https://github.com/renovatebot/renovate/discussions/23485
+        "commands": ["install-tool golang $(grep -oP '^go \\K.+' go.mod)", "make vendor"],
         "fileFilters": ["**/**"],
         "executionMode": "branch"
       },


### PR DESCRIPTION
We recently switched to using the toolchain directive on the main which broke Go updates postUpgradeTasks on stable branches (see #2494 or commit bee5a74c9e233d379ff912f0db5182ac01f828af).