### PR TITLE
helm: Template CRDs directly to get standard k8s labels

### DIFF
--- a/docs/content/en/docs/contribution-guide/making-changes.md
+++ b/docs/content/en/docs/contribution-guide/making-changes.md
@@ -75,7 +75,7 @@ these files (`pkg/k8s/`), you need to run code generation:
 
 ```shell
 make crds
-make -C install/kubernetes tetragon/crds-yaml
+make -C install/kubernetes tetragon/templates/crds
 ```
 
 ## Making changes to Helm chart

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -15,7 +15,7 @@ CRDS := $(REPO_ROOT)/pkg/k8s/apis/cilium.io/client/crds/v1alpha1
 HELM ?= docker run --rm -v ./$(TETRAGON_CHART):/apps $(HELM_IMAGE)
 
 .PHONY: all
-all: deps $(TETRAGON_CHART)/crds-yaml lint docs
+all: deps $(TETRAGON_CHART)/templates/crds lint docs
 
 .PHONY: deps
 deps: 
@@ -32,11 +32,16 @@ docs:
 	./export-doc.sh $(REPO_ROOT)/docs/content/en/docs/reference/helm-chart.md
 
 # NB: Helm has an "official" way to install CRDs which requires simply putting
-# them in the crds directory. This method doesn't prevents accidental deletion
+# them in the top-level crds directory. This method prevents accidental deletion
 # of custom resources, because it doesn't delete CRDs when the chart is
 # uninstalled. However, it doesn't support CRD upgrades, which is why we opt to
-# install CRDs alongside other resources. This means we can't put them in the
-# crds directory, so we name in crds-yaml instead.
-.PHONY: $(TETRAGON_CHART)/crds-yaml
-$(TETRAGON_CHART)/crds-yaml: $(CRDS)
-	cp -rf $(CRDS)/. $(TETRAGON_CHART)/crds-yaml
+# install CRDs alongside other resources.
+.PHONY: $(TETRAGON_CHART)/templates/crds
+$(TETRAGON_CHART)/templates/crds: $(CRDS)
+	mkdir -p $@
+	for file in $(CRDS)/*.yaml; do \
+		template_file="$@/$$(basename $$file)"; \
+		echo "{{- if eq .Values.crds.installMethod \"helm\" }}" > "$$template_file"; \
+		cat "$$file" >> "$$template_file"; \
+		echo "{{- end }}" >> "$$template_file"; \
+	done

--- a/install/kubernetes/tetragon/templates/crds.yaml
+++ b/install/kubernetes/tetragon/templates/crds.yaml
@@ -1,6 +1,0 @@
-{{- if eq .Values.crds.installMethod "helm" }}
-{{- range $path, $_ := .Files.Glob "crds-yaml/*.yaml" }}
----
-{{ $.Files.Get $path }}
-{{- end }}
-{{- end }}

--- a/install/kubernetes/tetragon/templates/crds/cilium.io_podinfo.yaml
+++ b/install/kubernetes/tetragon/templates/crds/cilium.io_podinfo.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.crds.installMethod "helm" }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -93,3 +94,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/install/kubernetes/tetragon/templates/crds/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/templates/crds/cilium.io_tracingpolicies.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.crds.installMethod "helm" }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5,15 +6,15 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
-  name: tracingpoliciesnamespaced.cilium.io
+  name: tracingpolicies.cilium.io
 spec:
   group: cilium.io
   names:
-    kind: TracingPolicyNamespaced
-    listKind: TracingPolicyNamespacedList
-    plural: tracingpoliciesnamespaced
-    singular: tracingpolicynamespaced
-  scope: Namespaced
+    kind: TracingPolicy
+    listKind: TracingPolicyList
+    plural: tracingpolicies
+    singular: tracingpolicy
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:
@@ -2027,3 +2028,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/install/kubernetes/tetragon/templates/crds/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/templates/crds/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.crds.installMethod "helm" }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5,15 +6,15 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
-  name: tracingpolicies.cilium.io
+  name: tracingpoliciesnamespaced.cilium.io
 spec:
   group: cilium.io
   names:
-    kind: TracingPolicy
-    listKind: TracingPolicyList
-    plural: tracingpolicies
-    singular: tracingpolicy
-  scope: Cluster
+    kind: TracingPolicyNamespaced
+    listKind: TracingPolicyNamespacedList
+    plural: tracingpoliciesnamespaced
+    singular: tracingpolicynamespaced
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
@@ -2027,3 +2028,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}


### PR DESCRIPTION
So far CRDs were included in the Helm chart like this:
1. Copy into crds-yaml directory
2. Concatenate in a template using .Files.Get

With such approach, Helm doesn't add standard k8s "app.kubernetes.io/*" labels (e.g. version, managed-by) to CRDs like it does for other resources. Having these labels is useful from the operational perspective, so this commit changes how CRDs are included in the Helm chart. It now works like this:
1. Copy inside the templates directory
2. Wrap each CRD in an if block to check if it should be included
