### PR TITLE
renovate: group all go updates together and fix a rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -213,15 +213,21 @@
       }
     },
     {
-      // main branch is using the new toolchain directive
+      // Grouping go packages updates together
       "groupName": "Go",
       "matchPackageNames": [
         "go",
         "docker.io/library/golang"
       ],
+    },
+    {
+      // main branch is using the new toolchain directive
+      "matchPackageNames": [
+        "go",
+        "docker.io/library/golang"
+      ],
       "matchBaseBranches": [
-        "v1.0",
-        "v1.1",
+        "main",
       ],
       // postUpgradeTasks is only for when the Go module directives are bumped
       "postUpgradeTasks": {
@@ -235,7 +241,6 @@
     },
     {
       // stable branches are using the go directive
-      "groupName": "Go",
       "matchPackageNames": [
         "go",
         "docker.io/library/golang"


### PR DESCRIPTION
Let's group the Go updates together regardless of the branch so that's it's applied to everything. And fix a mistake commited in f03102ca24c1172da539b31548d1ccba556a0d9e putting stables branches instead of main branch in a package rule.
