### PR TITLE
enforcer: fix multiple prog issue with fmod_ret

### DIFF
--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -26,6 +26,13 @@ func MapBuilder(name string, ld *Program) *Map {
 	return &Map{name, name, ld, Idle(), nil}
 }
 
+func MapBuilderPinManyProgs(name, pin string, lds ...*Program) *Map {
+	for _, ld := range lds {
+		ld.PinMap[name] = pin
+	}
+	return &Map{name, pin, lds[0], Idle(), nil}
+}
+
 func MapBuilderPin(name, pin string, ld *Program) *Map {
 	ld.PinMap[name] = pin
 	return &Map{name, pin, ld, Idle(), nil}

--- a/pkg/sensors/tracing/enforcer.go
+++ b/pkg/sensors/tracing/enforcer.go
@@ -50,9 +50,9 @@ func init() {
 	sensors.RegisterPolicyHandlerAtInit("enforcer", gEnforcerPolicy)
 }
 
-func enforcerMap(policyName string, load *program.Program) *program.Map {
-	return program.MapBuilderPin(enforcerDataMapName,
-		fmt.Sprintf("%s_%s", enforcerDataMapName, policyName), load)
+func enforcerMap(policyName string, load ...*program.Program) *program.Map {
+	return program.MapBuilderPinManyProgs(enforcerDataMapName,
+		fmt.Sprintf("%s_%s", enforcerDataMapName, policyName), load...)
 }
 
 func (kp *enforcerPolicy) enforcerGet(name string) (*enforcerHandler, bool) {
@@ -315,7 +315,7 @@ func (kp *enforcerPolicy) createEnforcerSensor(
 		return nil, fmt.Errorf("unexpected override method: %d", overrideMethod)
 	}
 
-	enforcerDataMap := enforcerMap(policyName, load)
+	enforcerDataMap := enforcerMap(policyName, progs...)
 	maps = append(maps, enforcerDataMap)
 
 	if ok := kp.enforcerAdd(name, kh); !ok {


### PR DESCRIPTION
When using fmod_ret, we need to load multiple programs -- one for each attach point we want to enforce.

In the current implementation, each program would use its own map which means that the enforcer notification worked only for a single program.

This patch fixes the code so that all programs use the same map. It also adds a test.

```release-note
enforcer: fix issue when using multiple calls with fmod_ret
```
