### PR TITLE
Makefile: exclude api tags from version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SUDO ?= sudo
 GO_TEST_TIMEOUT ?= 20m
 E2E_TEST_TIMEOUT ?= 20m
 BUILD_PKG_DIR ?= $(shell pwd)/build/$(TARGET_ARCH)
-VERSION ?= $(shell git describe --tags --always)
+VERSION ?= $(shell git describe --tags --always --exclude 'api/*')
 
 # Do a parallel build with multiple jobs, based on the number of CPUs online
 # in this system: 'make -j8' on a 8-CPU system, etc.


### PR DESCRIPTION
cf0a49dcbb6ddc6ab0617aef9e16a492d7804c5c introduced a tag for the api module. This, however, breaks the release process because the tarball image generation uses the api version and fails. Exclude the api tags from the version.
