### PR TITLE
tetragon: Add debug interface to track cgroups to workload/ns mappings

### DIFF
--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -11,6 +11,8 @@
 #include "bpf_helpers.h"
 #include "bpf_rate.h"
 
+#include "policy_filter.h"
+
 char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
 
 struct {

--- a/bpf/process/policy_filter.h
+++ b/bpf/process/policy_filter.h
@@ -6,7 +6,15 @@
 
 #include "bpf_tracing.h"
 
-#define POLICY_FILTER_MAX_POLICIES 128
+#define POLICY_FILTER_MAX_POLICIES   128
+#define POLICY_FILTER_MAX_NAMESPACES 1024
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, POLICY_FILTER_MAX_NAMESPACES);
+	__uint(key_size, sizeof(u64));
+	__uint(value_size, sizeof(u64));
+} tg_cgroup_namespace_map SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);

--- a/cmd/tetra/dump/dump.go
+++ b/cmd/tetra/dump/dump.go
@@ -128,3 +128,28 @@ func PolicyfilterState(fname string) {
 		fmt.Printf("%d: %s\n", polId, strings.Join(ids, ","))
 	}
 }
+
+func NamespaceState(fname string) error {
+	m, err := ebpf.LoadPinnedMap(fname, &ebpf.LoadPinOptions{
+		ReadOnly: true,
+	})
+	if err != nil {
+		logger.GetLogger().WithError(err).WithField("file", fname).Warn("Could not open process tree map")
+		return err
+	}
+
+	defer m.Close()
+
+	var (
+		key uint64
+		val uint64
+	)
+
+	fmt.Printf("cgroupId: stableId\n")
+	iter := m.Iterate()
+	for iter.Next(&key, &val) {
+		fmt.Printf("%d: %d\n", key, val)
+	}
+
+	return nil
+}

--- a/cmd/tetra/policyfilter/policyfilter.go
+++ b/cmd/tetra/policyfilter/policyfilter.go
@@ -28,8 +28,25 @@ func New() *cobra.Command {
 		dumpCmd(),
 		addCommand(),
 		cgroupGetIDCommand(),
+		dumpDebugCmd(),
 	)
 
+	return ret
+}
+
+func dumpDebugCmd() *cobra.Command {
+	mapFname := filepath.Join(defaults.DefaultMapRoot, defaults.DefaultMapPrefix, policyfilter.CgrpNsMapName)
+	ret := &cobra.Command{
+		Use:   "dumpcgrp",
+		Short: "dump cgroup ID to namespace state",
+		Args:  cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			dump.NamespaceState(mapFname)
+		},
+	}
+
+	flags := ret.Flags()
+	flags.StringVar(&mapFname, "map-fname", mapFname, "policyfilter map filename")
 	return ret
 }
 

--- a/pkg/policyfilter/disabled.go
+++ b/pkg/policyfilter/disabled.go
@@ -31,12 +31,12 @@ func (s *disabled) DelPolicy(polID PolicyID) error {
 	return fmt.Errorf("policyfilter is disabled")
 }
 
-func (s *disabled) AddPodContainer(podID PodID, namespace string, podLabels labels.Labels,
+func (s *disabled) AddPodContainer(podID PodID, namespace, workload, kind string, podLabels labels.Labels,
 	containerID string, cgID CgroupID, containerName string) error {
 	return nil
 }
 
-func (s *disabled) UpdatePod(podID PodID, namespace string, podLabels labels.Labels,
+func (s *disabled) UpdatePod(podID PodID, namespace, workload, kind string, podLabels labels.Labels,
 	containerIDs []string, containerNames []string) error {
 	return nil
 }
@@ -54,4 +54,8 @@ func (s *disabled) RegisterPodHandlers(podInformer cache.SharedIndexInformer) {
 
 func (s *disabled) Close() error {
 	return nil
+}
+
+func (s *disabled) GetNsId(stateID StateID) (*NSID, bool) {
+	return nil, false
 }

--- a/pkg/policyfilter/namespace.go
+++ b/pkg/policyfilter/namespace.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package policyfilter
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/sensors/exec/config"
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+const (
+	CgrpNsMapName      = "tg_cgroup_namespace_map"
+	namespaceCacheSize = 1024
+)
+
+type NSID struct {
+	Namespace string
+	Workload  string
+	Kind      string
+}
+
+// NamespaceMap is a simple wrapper for ebpf.Map so that we can write methods for it
+type NamespaceMap struct {
+	cgroupIdMap *ebpf.Map
+	nsIdMap     *lru.Cache[StateID, NSID]
+	nsNameMap   *lru.Cache[NSID, StateID]
+	id          StateID
+}
+
+// newNamespaceMap returns a new namespace mapping. The namespace map consists of
+// two pieces. First a cgroup to ID map. The ID is useful for BPF so we can avoid
+// strings in BPF side. Then a stable ID to namespace mapping.
+func newNamespaceMap() (*NamespaceMap, error) {
+	idCache, err := lru.New[StateID, NSID](namespaceCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("create namespace ID cache failed")
+	}
+	nameCache, err := lru.New[NSID, StateID](namespaceCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("create namespace name cache failed")
+	}
+
+	objName := config.ExecObj()
+	objPath := path.Join(option.Config.HubbleLib, objName)
+	spec, err := ebpf.LoadCollectionSpec(objPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading spec for %s failed: %w", objPath, err)
+	}
+	nsMapSpec, ok := spec.Maps[CgrpNsMapName]
+	if !ok {
+		return nil, fmt.Errorf("%s not found in %s", CgrpNsMapName, objPath)
+	}
+
+	ret, err := ebpf.NewMap(nsMapSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	mapDir := bpf.MapPrefixPath()
+	pinPath := filepath.Join(mapDir, CgrpNsMapName)
+	os.Remove(pinPath)
+	os.Mkdir(mapDir, os.ModeDir)
+	err = ret.Pin(pinPath)
+	if err != nil {
+		ret.Close()
+		return nil, fmt.Errorf("failed to pin Namespace map in %s: %w", pinPath, err)
+	}
+
+	return &NamespaceMap{
+		cgroupIdMap: ret,
+		nsIdMap:     idCache,
+		nsNameMap:   nameCache,
+		id:          1,
+	}, err
+}

--- a/pkg/policyfilter/policyfilter.go
+++ b/pkg/policyfilter/policyfilter.go
@@ -98,18 +98,22 @@ type State interface {
 	// AddPodContainer informs policyfilter about a new container and its cgroup id in a pod.
 	// The pod might or might not have been encountered before.
 	// This method is intended to update policyfilter state from container hooks
-	AddPodContainer(podID PodID, namespace string, podLabels labels.Labels,
+	AddPodContainer(podID PodID, namespace, workload, kind string, podLabels labels.Labels,
 		containerID string, cgID CgroupID, containerName string) error
 
 	// UpdatePod updates the pod state for a pod, where containerIDs contains all the container ids for the given pod.
 	// This method is intended to be used from k8s watchers (where no cgroup information is available)
-	UpdatePod(podID PodID, namespace string, podLabels labels.Labels,
+	UpdatePod(podID PodID, namespace, workload, kind string, podLabels labels.Labels,
 		containerIDs []string, containerNames []string) error
 
 	// DelPodContainer informs policyfilter that a container was deleted from a pod
 	DelPodContainer(podID PodID, containerID string) error
 	// DelPod informs policyfilter that a pod has been deleted
 	DelPod(podID PodID) error
+
+	// Report opaque cgroup ID to nsId mapping. This method is intended to allow inspecting
+	// and reporting the state of the system to subsystems and tooling.
+	GetNsId(stateID StateID) (*NSID, bool)
 
 	// RegisterPodHandlers can be used to register appropriate pod handlers to a pod informer
 	// that for keeping the policy filter state up-to-date.

--- a/pkg/policyfilter/state_test.go
+++ b/pkg/policyfilter/state_test.go
@@ -26,27 +26,27 @@ func TestState(t *testing.T) {
 
 	pod1 := PodID(uuid.New())
 	cgidi1 := CgroupID(2001)
-	err = s.AddPodContainer(pod1, "ns2", nil, "cont1", cgidi1, "main1")
+	err = s.AddPodContainer(pod1, "ns2", "wl2", "kind2", nil, "cont1", cgidi1, "main1")
 	require.NoError(t, err)
 	cgidi2 := CgroupID(2002)
-	err = s.AddPodContainer(pod1, "ns2", nil, "cont2", cgidi2, "main2")
+	err = s.AddPodContainer(pod1, "ns2", "wl2", "kind2", nil, "cont2", cgidi2, "main2")
 	require.NoError(t, err)
 
 	pod2 := PodID(uuid.New())
 	cgidi3 := CgroupID(1001)
-	err = s.AddPodContainer(pod2, "ns1", nil, "cont3", cgidi3, "main3")
+	err = s.AddPodContainer(pod2, "ns1", "wl1", "kind1", nil, "cont3", cgidi3, "main3")
 	require.NoError(t, err)
 
 	cgidi4 := CgroupID(3001)
 	pod3 := PodID(uuid.New())
-	err = s.AddPodContainer(pod3, "ns3", nil, "cont4", cgidi4, "main4")
+	err = s.AddPodContainer(pod3, "ns3", "wl3", "kind3", nil, "cont4", cgidi4, "main4")
 	require.NoError(t, err)
 	pod4 := PodID(uuid.New())
 	cgidi5 := CgroupID(3002)
-	err = s.AddPodContainer(pod4, "ns3", nil, "cont5", cgidi5, "main5")
+	err = s.AddPodContainer(pod4, "ns3", "wl3", "kind3", nil, "cont5", cgidi5, "main5")
 	require.NoError(t, err)
 	cgidi6 := CgroupID(3003)
-	err = s.AddPodContainer(pod4, "ns3", nil, "cont6", cgidi6, "main6")
+	err = s.AddPodContainer(pod4, "ns3", "wl3", "kind3", nil, "cont6", cgidi6, "main6")
 	require.NoError(t, err)
 
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -7,11 +7,11 @@ import (
 	"log"
 	"sync"
 
-	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/ksyms"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/exec/config"
 	"github.com/cilium/tetragon/pkg/sensors/program"
 )
 
@@ -21,7 +21,7 @@ const (
 
 var (
 	Execve = program.Builder(
-		ExecObj(),
+		config.ExecObj(),
 		"sched/sched_process_exec",
 		"tracepoint/sys_execve",
 		"event_execve",
@@ -171,18 +171,6 @@ func GetInitialSensorTest() *sensors.Sensor {
 		sensorTest.Maps = GetDefaultMaps(true)
 	})
 	return &sensorTest
-}
-
-// ExecObj returns the exec object based on the kernel version
-func ExecObj() string {
-	if kernels.EnableV61Progs() {
-		return "bpf_execve_event_v61.o"
-	} else if kernels.MinKernelVersion("5.11") {
-		return "bpf_execve_event_v511.o"
-	} else if kernels.EnableLargeProgs() {
-		return "bpf_execve_event_v53.o"
-	}
-	return "bpf_execve_event.o"
 }
 
 func ConfigCgroupRate(opts *option.CgroupRate) {

--- a/pkg/sensors/config/confmap/confmap.go
+++ b/pkg/sensors/config/confmap/confmap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors/base"
+	"github.com/cilium/tetragon/pkg/sensors/exec/config"
 	"github.com/cilium/tetragon/pkg/sensors/program"
 	"github.com/sirupsen/logrus"
 )
@@ -42,7 +43,7 @@ var (
 
 // confmapSpec returns the spec for the configuration map
 func confmapSpec() (*ebpf.MapSpec, error) {
-	objName := base.ExecObj()
+	objName := config.ExecObj()
 	objPath := path.Join(option.Config.HubbleLib, objName)
 	spec, err := ebpf.LoadCollectionSpec(objPath)
 	if err != nil {

--- a/pkg/sensors/exec/config/config.go
+++ b/pkg/sensors/exec/config/config.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package config
+
+import "github.com/cilium/tetragon/pkg/kernels"
+
+// ExecObj returns the exec object based on the kernel version
+func ExecObj() string {
+	if kernels.EnableV61Progs() {
+		return "bpf_execve_event_v61.o"
+	} else if kernels.MinKernelVersion("5.11") {
+		return "bpf_execve_event_v511.o"
+	} else if kernels.EnableLargeProgs() {
+		return "bpf_execve_event_v53.o"
+	}
+	return "bpf_execve_event.o"
+}

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -269,10 +269,10 @@ func TestNamespacedPolicies(t *testing.T) {
 	podId1 := uuid.New()
 	podId2 := uuid.New()
 	require.NoError(t, err)
-	err = pfState.AddPodContainer(policyfilter.PodID(podId1), "ns1", nil,
+	err = pfState.AddPodContainer(policyfilter.PodID(podId1), "ns1", "wl1", "kind1", nil,
 		"pod1-container1", cgID1, "container-name1")
 	require.NoError(t, err)
-	err = pfState.AddPodContainer(policyfilter.PodID(podId2), "ns2", nil,
+	err = pfState.AddPodContainer(policyfilter.PodID(podId2), "ns2", "wl2", "kind2", nil,
 		"pod1-container2", cgID2, "container-name2")
 	require.NoError(t, err)
 


### PR DESCRIPTION
Debugging BPF and some kernel functions I want to understand cgroup to namespace mappings at event side. This patch maintains a stable mapping between cgroups and human readable namespaces. The end goal is to filter out noisy namespaces from execs which will be follow up series. This is minimally useful as is.

To support this just extend the use of namespace filters from kprobe and tracepoints into a more general space where we can hook selectors.
