### PR TITLE
pkg/sensors: reduce stack trace map memory footprint

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -2103,7 +2103,7 @@ update_pid_tid_from_sock(struct msg_generic_kprobe *e, __u64 sockaddr)
 #define PERF_MAX_STACK_DEPTH 127
 struct {
 	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
-	__uint(max_entries, 32768);
+	__uint(max_entries, 1); // Agent is resizing this if the feature is needed during kprobe load
 	__uint(key_size, sizeof(__u32));
 	__uint(value_size, sizeof(__u64) * PERF_MAX_STACK_DEPTH);
 } stack_trace_map SEC(".maps");


### PR DESCRIPTION
We stopped on a stack trace map that has a max_entries of 32768, which is 64 bits pointers * PERF_MAX_STACK_DEPTH (which is fixed at 127 for now), so 127*64/8=1016 bytes per entry + it's key_size of 32 bits (4 bytes) so 1020 bytes per entry. So 1020 * 32768 = 33,423,360 bytes. From bpftool, this map has a total bytes_memlock of 34,079,040 bytes. So for each stack trace map we load, we had 34MB of kernel memory, and it happened to be loaded many times when we were loading any tracing policy.

Since the map is used by the generic program, the loader will allocate the memory needed for the map even if we don't create a reference from the agent side and create an anonymous map. So we end up allocating a small map of max_entries 1 by default and resize it when the tracing policy actually specifies a matchAction containing a kernelStackTrace or userStackTrace to true. This should drastically reduce the memory footprint of this feature when it's unused.

```release-note
Reduce the kernel memory footprint (accounted by the cgroup memory controller) of the stack trace feature when unused.
```
