### PR TITLE
Increase maximum number of tries in WaitForTracingPolicy

### DIFF
--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -22,3 +22,4 @@ enforcer-tester-32
 drop-privileges
 change-capabilities
 direct-write-tester
+user-stacktrace

--- a/tests/e2e/helpers/grpc/grpc.go
+++ b/tests/e2e/helpers/grpc/grpc.go
@@ -24,7 +24,7 @@ func WaitForTracingPolicy(ctx context.Context, policyName string) error {
 		return fmt.Errorf("failed to find tetragon grpc forwarded ports")
 	}
 
-	maxTries := 10
+	maxTries := 20
 	for podName, grpcPort := range tetraPorts {
 		addr := fmt.Sprintf("127.0.0.1:%d", grpcPort)
 		// NB(kkourt): maybe it would make sense to cache the grpc connections in the


### PR DESCRIPTION
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.

After merging https://github.com/cilium/tetragon/pull/2506 it seems that there are cases where 10 * 1 sec is not enough when waiting for a tracing policy to load (mainly in e2e tests).

This patch increases that to 20 * 1 sec to avoid timeouts.
