### PR TITLE
syscallinfo: fix typo for oldlstat

### DIFF
--- a/pkg/syscallinfo/syscallnames_amd64.go
+++ b/pkg/syscallinfo/syscallnames_amd64.go
@@ -461,7 +461,7 @@ var syscallNames32 = map[int]string{
 	i386.SYS_SETGROUPS:                    "sys_setgroups",
 	i386.SYS_SELECT:                       "sys_select",
 	i386.SYS_SYMLINK:                      "sys_symlink",
-	i386.SYS_OLDLSTAT:                     "sys_oldstat",
+	i386.SYS_OLDLSTAT:                     "sys_oldlstat",
 	i386.SYS_READLINK:                     "sys_readlink",
 	i386.SYS_USELIB:                       "sys_uselib",
 	i386.SYS_SWAPON:                       "sys_swapon",


### PR DESCRIPTION
There seems to be a typo for SYS_OLDLSTAT. The name should be oldlstat rather than oldstat.

Looking at the i386/linux.go file:
```
$ grep -e 'OLDL\?STAT' ./pkg/syscallinfo/i386/linux.go
        SYS_OLDSTAT                      = 18
        SYS_OLDLSTAT                     = 84
```

Verified the number with:
```
$ cat oldlstat.c
int main(int argc, char **argv)
{
        printf("SYS_oldlstat:%d\n", SYS_oldlstat);
        return 0;
}
$ gcc -Wall -m32 oldlstat.c -o oldlstat
$ ./oldlstat
SYS_oldlstat:84
```

