### PR TITLE
tetragon: Limit max entries of cgroup_rate_map when it's not used

### DIFF
--- a/bpf/process/bpf_rate.h
+++ b/bpf/process/bpf_rate.h
@@ -27,7 +27,7 @@ struct cgroup_rate_options {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_HASH);
-	__uint(max_entries, 32768);
+	__uint(max_entries, 1); /* will be resize by agent when needed */
 	__type(key, struct cgroup_rate_key);
 	__type(value, struct cgroup_rate_value);
 } cgroup_rate_map SEC(".maps");

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -447,6 +447,8 @@ func tetragonExecute() error {
 
 	obs.LogPinnedBpf(observerDir)
 
+	base.ConfigCgroupRate(&option.Config.CgroupRate)
+
 	// load base sensor
 	initialSensor := base.GetInitialSensor()
 	if err := initialSensor.Load(observerDir); err != nil {
@@ -456,7 +458,7 @@ func tetragonExecute() error {
 		initialSensor.Unload()
 	}()
 
-	cgrouprate.NewCgroupRate(ctx, pm, base.CgroupRateMap, &option.Config.CgroupRate)
+	cgrouprate.NewCgroupRate(ctx, pm, base.CgroupRateMapExec, &option.Config.CgroupRate)
 	cgrouprate.Config(base.CgroupRateOptionsMap)
 
 	// now that the base sensor was loaded, we can start the sensor manager

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -440,7 +440,7 @@ func loadExporter(tb testing.TB, ctx context.Context, obs *observer.Observer, op
 		obs.RemoveListener(processManager)
 	})
 
-	cgrouprate.NewCgroupRate(ctx, processManager, base.CgroupRateMap, &option.Config.CgroupRate)
+	cgrouprate.NewCgroupRate(ctx, processManager, base.CgroupRateMapExec, &option.Config.CgroupRate)
 	return nil
 }
 


### PR DESCRIPTION
It's not needed when the feature is disabled.
