### PR TITLE
pkg/sensors: reduce memory footprint of unused fdinstall maps and various fixes

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1777,7 +1777,7 @@ struct fdinstall_value {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
-	__uint(max_entries, 32000);
+	__uint(max_entries, 1); // will be resized by agent when needed
 	__type(key, struct fdinstall_key);
 	__type(value, struct fdinstall_value);
 } fdinstall_map SEC(".maps");

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -646,6 +646,10 @@ func addKprobe(funcName string, f *v1alpha1.KProbeSpec, in *addKprobeIn) (id idt
 		return idtable.UninitializedEntryID, err
 	}
 
+	if f == nil {
+		return errFn(errors.New("error adding kprobe, the kprobe spec is nil"))
+	}
+
 	config := &api.EventConfig{}
 	config.PolicyID = uint32(in.policyID)
 	if len(f.ReturnArgAction) > 0 {

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -409,6 +409,9 @@ func createGenericTracepointSensor(
 		progs = append(progs, prog0)
 
 		fdinstall := program.MapBuilderPin("fdinstall_map", sensors.PathJoin(pinPath, "fdinstall_map"), prog0)
+		if selectorsHaveFDInstall(tp.Spec.Selectors) {
+			fdinstall.SetMaxEntries(fdInstallMapMaxEntries)
+		}
 		maps = append(maps, fdinstall)
 
 		tailCalls := program.MapBuilderPin("tp_calls", sensors.PathJoin(pinPath, "tp_calls"), prog0)

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -312,6 +312,10 @@ func createGenericTracepoint(
 	policyName string,
 	customHandler eventhandler.Handler,
 ) (*genericTracepoint, error) {
+	if conf == nil {
+		return nil, errors.New("failed creating generic tracepoint, conf is nil")
+	}
+
 	tp := tracepoint.Tracepoint{
 		Subsys: conf.Subsystem,
 		Event:  conf.Event,


### PR DESCRIPTION
~~The code is not great but it fixes the issue, maybe we can do it more elegantly idk~~

```release-note
Reduce the kernel memory footprint (accounted by the cgroup memory controller) of the ratelimit feature when unused (around ~11MB per kprobe).
```
