### PR TITLE
process:bpf: report euid as the process.uid

### DIFF
--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -795,7 +795,7 @@ https://github.com/opencontainers/runtime-spec/blob/main/config.md#createcontain
 | ----- | ---- | ----- | ----------- |
 | exec_id | [string](#string) |  | Exec ID uniquely identifies the process over time across all the nodes in the cluster. |
 | pid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | Process identifier from host PID namespace. |
-| uid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | User identifier associated with the process. |
+| uid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective User identifier used for permission checks. This field maps to the &#39;ProcessCredentials.euid&#39; field. Run with the `--enable-process-cred` flag to enable &#39;ProcessCredentials&#39; and get all the User and Group identifiers. |
 | cwd | [string](#string) |  | Current working directory of the process. |
 | binary | [string](#string) |  | Absolute path of the executed binary. |
 | arguments | [string](#string) |  | Arguments passed to the binary at execution. |
@@ -809,7 +809,7 @@ https://github.com/opencontainers/runtime-spec/blob/main/config.md#createcontain
 | cap | [Capabilities](#tetragon-Capabilities) |  | Set of capabilities that define the permissions the process can execute with. |
 | ns | [Namespaces](#tetragon-Namespaces) |  | Linux namespaces of the process, disabled by default, can be enabled by the `--enable-process-ns` flag. |
 | tid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | Thread ID, note that for the thread group leader, tid is equal to pid. |
-| process_credentials | [ProcessCredentials](#tetragon-ProcessCredentials) |  | Process credentials |
+| process_credentials | [ProcessCredentials](#tetragon-ProcessCredentials) |  | Process credentials, disabled by default, can be enabled by the `--enable-process-cred` flag. |
 | binary_properties | [BinaryProperties](#tetragon-BinaryProperties) |  | Executed binary properties. This field is only available on ProcessExec events. |
 | user | [UserRecord](#tetragon-UserRecord) |  | UserRecord contains user information about the event.
 
@@ -828,14 +828,14 @@ UserRecord is only supported when i) Tetragon is running as a systemd service or
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| uid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The real user ID |
-| gid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The real group ID |
-| euid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective user ID |
-| egid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective group ID |
-| suid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The saved user ID |
-| sgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The saved group ID |
-| fsuid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | the filesystem user ID |
-| fsgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The filesystem group ID |
+| uid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The real user ID of the process&#39; owner. |
+| gid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The real group ID of the process&#39; owner. |
+| euid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective user ID used for permission checks. |
+| egid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective group ID used for permission checks. |
+| suid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The saved user ID. |
+| sgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The saved group ID. |
+| fsuid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | the filesystem user ID used for filesystem access checks. Usually equals the euid. |
+| fsgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The filesystem group ID used for filesystem access checks. Usually equals the egid. |
 | securebits | [SecureBitsType](#tetragon-SecureBitsType) | repeated | Secure management flags |
 | caps | [Capabilities](#tetragon-Capabilities) |  | Set of capabilities that define the permissions the process can execute with. |
 | user_ns | [UserNamespace](#tetragon-UserNamespace) |  | User namespace where the UIDs, GIDs and capabilities are relative to. |

--- a/api/v1/tetragon/tetragon.pb.go
+++ b/api/v1/tetragon/tetragon.pb.go
@@ -885,21 +885,21 @@ type ProcessCredentials struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The real user ID
+	// The real user ID of the process' owner.
 	Uid *wrapperspb.UInt32Value `protobuf:"bytes,1,opt,name=uid,proto3" json:"uid,omitempty"`
-	// The real group ID
+	// The real group ID of the process' owner.
 	Gid *wrapperspb.UInt32Value `protobuf:"bytes,2,opt,name=gid,proto3" json:"gid,omitempty"`
-	// The effective user ID
+	// The effective user ID used for permission checks.
 	Euid *wrapperspb.UInt32Value `protobuf:"bytes,3,opt,name=euid,proto3" json:"euid,omitempty"`
-	// The effective group ID
+	// The effective group ID used for permission checks.
 	Egid *wrapperspb.UInt32Value `protobuf:"bytes,4,opt,name=egid,proto3" json:"egid,omitempty"`
-	// The saved user ID
+	// The saved user ID.
 	Suid *wrapperspb.UInt32Value `protobuf:"bytes,5,opt,name=suid,proto3" json:"suid,omitempty"`
-	// The saved group ID
+	// The saved group ID.
 	Sgid *wrapperspb.UInt32Value `protobuf:"bytes,6,opt,name=sgid,proto3" json:"sgid,omitempty"`
-	// the filesystem user ID
+	// the filesystem user ID used for filesystem access checks. Usually equals the euid.
 	Fsuid *wrapperspb.UInt32Value `protobuf:"bytes,7,opt,name=fsuid,proto3" json:"fsuid,omitempty"`
-	// The filesystem group ID
+	// The filesystem group ID used for filesystem access checks. Usually equals the egid.
 	Fsgid *wrapperspb.UInt32Value `protobuf:"bytes,8,opt,name=fsgid,proto3" json:"fsgid,omitempty"`
 	// Secure management flags
 	Securebits []SecureBitsType `protobuf:"varint,9,rep,packed,name=securebits,proto3,enum=tetragon.SecureBitsType" json:"securebits,omitempty"`
@@ -1271,7 +1271,9 @@ type Process struct {
 	ExecId string `protobuf:"bytes,1,opt,name=exec_id,json=execId,proto3" json:"exec_id,omitempty"`
 	// Process identifier from host PID namespace.
 	Pid *wrapperspb.UInt32Value `protobuf:"bytes,2,opt,name=pid,proto3" json:"pid,omitempty"`
-	// User identifier associated with the process.
+	// The effective User identifier used for permission checks. This field maps to the
+	// 'ProcessCredentials.euid' field. Run with the `--enable-process-cred` flag to
+	// enable 'ProcessCredentials' and get all the User and Group identifiers.
 	Uid *wrapperspb.UInt32Value `protobuf:"bytes,3,opt,name=uid,proto3" json:"uid,omitempty"`
 	// Current working directory of the process.
 	Cwd string `protobuf:"bytes,4,opt,name=cwd,proto3" json:"cwd,omitempty"`
@@ -1355,7 +1357,8 @@ type Process struct {
 	Ns *Namespaces `protobuf:"bytes,15,opt,name=ns,proto3" json:"ns,omitempty"`
 	// Thread ID, note that for the thread group leader, tid is equal to pid.
 	Tid *wrapperspb.UInt32Value `protobuf:"bytes,16,opt,name=tid,proto3" json:"tid,omitempty"`
-	// Process credentials
+	// Process credentials, disabled by default, can be enabled by the
+	// `--enable-process-cred` flag.
 	ProcessCredentials *ProcessCredentials `protobuf:"bytes,17,opt,name=process_credentials,json=processCredentials,proto3" json:"process_credentials,omitempty"`
 	// Executed binary properties. This field is only available on ProcessExec events.
 	BinaryProperties *BinaryProperties `protobuf:"bytes,18,opt,name=binary_properties,json=binaryProperties,proto3" json:"binary_properties,omitempty"`

--- a/api/v1/tetragon/tetragon.proto
+++ b/api/v1/tetragon/tetragon.proto
@@ -112,21 +112,21 @@ message UserNamespace {
 }
 
 message ProcessCredentials {
-	// The real user ID
+	// The real user ID of the process' owner.
 	google.protobuf.UInt32Value uid = 1;
-	// The real group ID
+	// The real group ID of the process' owner.
 	google.protobuf.UInt32Value gid = 2;
-	// The effective user ID
+	// The effective user ID used for permission checks.
 	google.protobuf.UInt32Value euid = 3;
-	// The effective group ID
+	// The effective group ID used for permission checks.
 	google.protobuf.UInt32Value egid = 4;
-	// The saved user ID
+	// The saved user ID.
 	google.protobuf.UInt32Value suid = 5;
-	// The saved group ID
+	// The saved group ID.
 	google.protobuf.UInt32Value sgid = 6;
-	// the filesystem user ID
+	// the filesystem user ID used for filesystem access checks. Usually equals the euid.
 	google.protobuf.UInt32Value fsuid = 7;
-	// The filesystem group ID
+	// The filesystem group ID used for filesystem access checks. Usually equals the egid.
 	google.protobuf.UInt32Value fsgid = 8;
 	// Secure management flags
 	repeated SecureBitsType securebits = 9;
@@ -178,7 +178,9 @@ message Process {
     string exec_id = 1;
     // Process identifier from host PID namespace.
     google.protobuf.UInt32Value pid = 2;
-    // User identifier associated with the process.
+    // The effective User identifier used for permission checks. This field maps to the
+    // 'ProcessCredentials.euid' field. Run with the `--enable-process-cred` flag to
+    // enable 'ProcessCredentials' and get all the User and Group identifiers.
     google.protobuf.UInt32Value uid = 3;
     // Current working directory of the process.
     string cwd = 4;
@@ -262,7 +264,8 @@ message Process {
     Namespaces ns = 15;
     // Thread ID, note that for the thread group leader, tid is equal to pid.
     google.protobuf.UInt32Value tid = 16;
-    // Process credentials
+    // Process credentials, disabled by default, can be enabled by the
+    // `--enable-process-cred` flag.
     ProcessCredentials process_credentials = 17;
     // Executed binary properties. This field is only available on ProcessExec events.
     BinaryProperties binary_properties = 18;

--- a/contrib/rthooks/tetragon-oci-hook/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
+++ b/contrib/rthooks/tetragon-oci-hook/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
@@ -885,21 +885,21 @@ type ProcessCredentials struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The real user ID
+	// The real user ID of the process' owner.
 	Uid *wrapperspb.UInt32Value `protobuf:"bytes,1,opt,name=uid,proto3" json:"uid,omitempty"`
-	// The real group ID
+	// The real group ID of the process' owner.
 	Gid *wrapperspb.UInt32Value `protobuf:"bytes,2,opt,name=gid,proto3" json:"gid,omitempty"`
-	// The effective user ID
+	// The effective user ID used for permission checks.
 	Euid *wrapperspb.UInt32Value `protobuf:"bytes,3,opt,name=euid,proto3" json:"euid,omitempty"`
-	// The effective group ID
+	// The effective group ID used for permission checks.
 	Egid *wrapperspb.UInt32Value `protobuf:"bytes,4,opt,name=egid,proto3" json:"egid,omitempty"`
-	// The saved user ID
+	// The saved user ID.
 	Suid *wrapperspb.UInt32Value `protobuf:"bytes,5,opt,name=suid,proto3" json:"suid,omitempty"`
-	// The saved group ID
+	// The saved group ID.
 	Sgid *wrapperspb.UInt32Value `protobuf:"bytes,6,opt,name=sgid,proto3" json:"sgid,omitempty"`
-	// the filesystem user ID
+	// the filesystem user ID used for filesystem access checks. Usually equals the euid.
 	Fsuid *wrapperspb.UInt32Value `protobuf:"bytes,7,opt,name=fsuid,proto3" json:"fsuid,omitempty"`
-	// The filesystem group ID
+	// The filesystem group ID used for filesystem access checks. Usually equals the egid.
 	Fsgid *wrapperspb.UInt32Value `protobuf:"bytes,8,opt,name=fsgid,proto3" json:"fsgid,omitempty"`
 	// Secure management flags
 	Securebits []SecureBitsType `protobuf:"varint,9,rep,packed,name=securebits,proto3,enum=tetragon.SecureBitsType" json:"securebits,omitempty"`
@@ -1271,7 +1271,9 @@ type Process struct {
 	ExecId string `protobuf:"bytes,1,opt,name=exec_id,json=execId,proto3" json:"exec_id,omitempty"`
 	// Process identifier from host PID namespace.
 	Pid *wrapperspb.UInt32Value `protobuf:"bytes,2,opt,name=pid,proto3" json:"pid,omitempty"`
-	// User identifier associated with the process.
+	// The effective User identifier used for permission checks. This field maps to the
+	// 'ProcessCredentials.euid' field. Run with the `--enable-process-cred` flag to
+	// enable 'ProcessCredentials' and get all the User and Group identifiers.
 	Uid *wrapperspb.UInt32Value `protobuf:"bytes,3,opt,name=uid,proto3" json:"uid,omitempty"`
 	// Current working directory of the process.
 	Cwd string `protobuf:"bytes,4,opt,name=cwd,proto3" json:"cwd,omitempty"`
@@ -1355,7 +1357,8 @@ type Process struct {
 	Ns *Namespaces `protobuf:"bytes,15,opt,name=ns,proto3" json:"ns,omitempty"`
 	// Thread ID, note that for the thread group leader, tid is equal to pid.
 	Tid *wrapperspb.UInt32Value `protobuf:"bytes,16,opt,name=tid,proto3" json:"tid,omitempty"`
-	// Process credentials
+	// Process credentials, disabled by default, can be enabled by the
+	// `--enable-process-cred` flag.
 	ProcessCredentials *ProcessCredentials `protobuf:"bytes,17,opt,name=process_credentials,json=processCredentials,proto3" json:"process_credentials,omitempty"`
 	// Executed binary properties. This field is only available on ProcessExec events.
 	BinaryProperties *BinaryProperties `protobuf:"bytes,18,opt,name=binary_properties,json=binaryProperties,proto3" json:"binary_properties,omitempty"`

--- a/contrib/rthooks/tetragon-oci-hook/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
+++ b/contrib/rthooks/tetragon-oci-hook/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
@@ -112,21 +112,21 @@ message UserNamespace {
 }
 
 message ProcessCredentials {
-	// The real user ID
+	// The real user ID of the process' owner.
 	google.protobuf.UInt32Value uid = 1;
-	// The real group ID
+	// The real group ID of the process' owner.
 	google.protobuf.UInt32Value gid = 2;
-	// The effective user ID
+	// The effective user ID used for permission checks.
 	google.protobuf.UInt32Value euid = 3;
-	// The effective group ID
+	// The effective group ID used for permission checks.
 	google.protobuf.UInt32Value egid = 4;
-	// The saved user ID
+	// The saved user ID.
 	google.protobuf.UInt32Value suid = 5;
-	// The saved group ID
+	// The saved group ID.
 	google.protobuf.UInt32Value sgid = 6;
-	// the filesystem user ID
+	// the filesystem user ID used for filesystem access checks. Usually equals the euid.
 	google.protobuf.UInt32Value fsuid = 7;
-	// The filesystem group ID
+	// The filesystem group ID used for filesystem access checks. Usually equals the egid.
 	google.protobuf.UInt32Value fsgid = 8;
 	// Secure management flags
 	repeated SecureBitsType securebits = 9;
@@ -178,7 +178,9 @@ message Process {
     string exec_id = 1;
     // Process identifier from host PID namespace.
     google.protobuf.UInt32Value pid = 2;
-    // User identifier associated with the process.
+    // The effective User identifier used for permission checks. This field maps to the
+    // 'ProcessCredentials.euid' field. Run with the `--enable-process-cred` flag to
+    // enable 'ProcessCredentials' and get all the User and Group identifiers.
     google.protobuf.UInt32Value uid = 3;
     // Current working directory of the process.
     string cwd = 4;
@@ -262,7 +264,8 @@ message Process {
     Namespaces ns = 15;
     // Thread ID, note that for the thread group leader, tid is equal to pid.
     google.protobuf.UInt32Value tid = 16;
-    // Process credentials
+    // Process credentials, disabled by default, can be enabled by the
+    // `--enable-process-cred` flag.
     ProcessCredentials process_credentials = 17;
     // Executed binary properties. This field is only available on ProcessExec events.
     BinaryProperties binary_properties = 18;

--- a/docs/content/en/docs/reference/grpc-api.md
+++ b/docs/content/en/docs/reference/grpc-api.md
@@ -459,7 +459,7 @@ https://github.com/opencontainers/runtime-spec/blob/main/config.md#createcontain
 | ----- | ---- | ----- | ----------- |
 | exec_id | [string](#string) |  | Exec ID uniquely identifies the process over time across all the nodes in the cluster. |
 | pid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | Process identifier from host PID namespace. |
-| uid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | User identifier associated with the process. |
+| uid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective User identifier used for permission checks. This field maps to the &#39;ProcessCredentials.euid&#39; field. Run with the `--enable-process-cred` flag to enable &#39;ProcessCredentials&#39; and get all the User and Group identifiers. |
 | cwd | [string](#string) |  | Current working directory of the process. |
 | binary | [string](#string) |  | Absolute path of the executed binary. |
 | arguments | [string](#string) |  | Arguments passed to the binary at execution. |
@@ -473,7 +473,7 @@ https://github.com/opencontainers/runtime-spec/blob/main/config.md#createcontain
 | cap | [Capabilities](#tetragon-Capabilities) |  | Set of capabilities that define the permissions the process can execute with. |
 | ns | [Namespaces](#tetragon-Namespaces) |  | Linux namespaces of the process, disabled by default, can be enabled by the `--enable-process-ns` flag. |
 | tid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | Thread ID, note that for the thread group leader, tid is equal to pid. |
-| process_credentials | [ProcessCredentials](#tetragon-ProcessCredentials) |  | Process credentials |
+| process_credentials | [ProcessCredentials](#tetragon-ProcessCredentials) |  | Process credentials, disabled by default, can be enabled by the `--enable-process-cred` flag. |
 | binary_properties | [BinaryProperties](#tetragon-BinaryProperties) |  | Executed binary properties. This field is only available on ProcessExec events. |
 | user | [UserRecord](#tetragon-UserRecord) |  | UserRecord contains user information about the event.
 
@@ -485,14 +485,14 @@ UserRecord is only supported when i) Tetragon is running as a systemd service or
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| uid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The real user ID |
-| gid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The real group ID |
-| euid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective user ID |
-| egid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective group ID |
-| suid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The saved user ID |
-| sgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The saved group ID |
-| fsuid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | the filesystem user ID |
-| fsgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The filesystem group ID |
+| uid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The real user ID of the process&#39; owner. |
+| gid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The real group ID of the process&#39; owner. |
+| euid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective user ID used for permission checks. |
+| egid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The effective group ID used for permission checks. |
+| suid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The saved user ID. |
+| sgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The saved group ID. |
+| fsuid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | the filesystem user ID used for filesystem access checks. Usually equals the euid. |
+| fsgid | [google.protobuf.UInt32Value](#google-protobuf-UInt32Value) |  | The filesystem group ID used for filesystem access checks. Usually equals the egid. |
 | securebits | [SecureBitsType](#tetragon-SecureBitsType) | repeated | Secure management flags |
 | caps | [Capabilities](#tetragon-Capabilities) |  | Set of capabilities that define the permissions the process can execute with. |
 | user_ns | [UserNamespace](#tetragon-UserNamespace) |  | User namespace where the UIDs, GIDs and capabilities are relative to. |

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -1148,10 +1148,10 @@ func TestExecProcessCredentialsSetgidChanges(t *testing.T) {
 	setgidNonRootCreds := ec.NewProcessCredentialsChecker().
 		WithUid(0).WithEuid(uint32(gid)).WithSuid(uint32(gid)).WithFsuid(uint32(gid)).
 		WithGid(0).WithEgid(uint32(gid)).WithSgid(uint32(gid)).WithFsgid(uint32(gid))
-	procExecSetgidNoRootChecker := ec.NewProcessChecker().WithUid(uint32(0)).
+	procExecSetgidNoRootChecker := ec.NewProcessChecker().WithUid(uint32(gid)).
 		WithBinary(sm.Full(testSuid)).WithProcessCredentials(setgidNonRootCreds).WithBinaryProperties(bpSetgidNoRoot)
 	execSetgidNoRootChecker := ec.NewProcessExecChecker("exec").WithProcess(procExecSetgidNoRootChecker)
-	procExitSetgidNoRootChecker := ec.NewProcessChecker().WithUid(uint32(0)).
+	procExitSetgidNoRootChecker := ec.NewProcessChecker().WithUid(uint32(gid)).
 		WithBinary(sm.Full(testSuid)).WithProcessCredentials(setgidNonRootCreds).WithBinaryProperties(nil)
 	exitSetgidNoRootChecker := ec.NewProcessExitChecker("exit").WithProcess(procExitSetgidNoRootChecker)
 
@@ -1222,10 +1222,10 @@ func TestExecProcessCredentialsSetuidChanges(t *testing.T) {
 	setuidNonRootCreds := ec.NewProcessCredentialsChecker().
 		WithUid(0).WithEuid(uint32(gid)).WithSuid(uint32(gid)).WithFsuid(uint32(gid)).
 		WithGid(0).WithEgid(uint32(gid)).WithSgid(uint32(gid)).WithFsgid(uint32(gid))
-	procExecSetuidNoRootChecker := ec.NewProcessChecker().WithUid(uint32(0)).
+	procExecSetuidNoRootChecker := ec.NewProcessChecker().WithUid(uint32(gid)).
 		WithBinary(sm.Full(testSuid)).WithProcessCredentials(setuidNonRootCreds).WithBinaryProperties(bpSetuidNoRoot)
 	execSetuidNoRootChecker := ec.NewProcessExecChecker("exec").WithProcess(procExecSetuidNoRootChecker)
-	procExitSetuidNoRootChecker := ec.NewProcessChecker().WithUid(uint32(0)).
+	procExitSetuidNoRootChecker := ec.NewProcessChecker().WithUid(uint32(gid)).
 		WithBinary(sm.Full(testSuid)).WithProcessCredentials(setuidNonRootCreds).WithBinaryProperties(nil)
 	exitSetuidNoRootChecker := ec.NewProcessExitChecker("exit").WithProcess(procExitSetuidNoRootChecker)
 
@@ -1240,10 +1240,10 @@ func TestExecProcessCredentialsSetuidChanges(t *testing.T) {
 	setuidRootCreds := ec.NewProcessCredentialsChecker().
 		WithUid(uint32(gid)).WithEuid(0).WithSuid(0).WithFsuid(0).
 		WithGid(uint32(gid)).WithEgid(uint32(gid)).WithSgid(uint32(gid)).WithFsgid(uint32(gid))
-	procExecSetuidRootChecker := ec.NewProcessChecker().WithUid(uint32(gid)).
+	procExecSetuidRootChecker := ec.NewProcessChecker().WithUid(uint32(0)).
 		WithBinary(sm.Full(testSu)).WithProcessCredentials(setuidRootCreds).WithBinaryProperties(bpSetuidRoot)
 	execSetuidRootChecker := ec.NewProcessExecChecker("exec").WithProcess(procExecSetuidRootChecker)
-	procExitSetuidRootChecker := ec.NewProcessChecker().WithUid(uint32(gid)).
+	procExitSetuidRootChecker := ec.NewProcessChecker().WithUid(uint32(0)).
 		WithBinary(sm.Full(testSu)).WithProcessCredentials(setuidRootCreds).WithBinaryProperties(nil)
 	exitSetuidRootChecker := ec.NewProcessExitChecker("exit").WithProcess(procExitSetuidRootChecker)
 

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.pb.go
@@ -885,21 +885,21 @@ type ProcessCredentials struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The real user ID
+	// The real user ID of the process' owner.
 	Uid *wrapperspb.UInt32Value `protobuf:"bytes,1,opt,name=uid,proto3" json:"uid,omitempty"`
-	// The real group ID
+	// The real group ID of the process' owner.
 	Gid *wrapperspb.UInt32Value `protobuf:"bytes,2,opt,name=gid,proto3" json:"gid,omitempty"`
-	// The effective user ID
+	// The effective user ID used for permission checks.
 	Euid *wrapperspb.UInt32Value `protobuf:"bytes,3,opt,name=euid,proto3" json:"euid,omitempty"`
-	// The effective group ID
+	// The effective group ID used for permission checks.
 	Egid *wrapperspb.UInt32Value `protobuf:"bytes,4,opt,name=egid,proto3" json:"egid,omitempty"`
-	// The saved user ID
+	// The saved user ID.
 	Suid *wrapperspb.UInt32Value `protobuf:"bytes,5,opt,name=suid,proto3" json:"suid,omitempty"`
-	// The saved group ID
+	// The saved group ID.
 	Sgid *wrapperspb.UInt32Value `protobuf:"bytes,6,opt,name=sgid,proto3" json:"sgid,omitempty"`
-	// the filesystem user ID
+	// the filesystem user ID used for filesystem access checks. Usually equals the euid.
 	Fsuid *wrapperspb.UInt32Value `protobuf:"bytes,7,opt,name=fsuid,proto3" json:"fsuid,omitempty"`
-	// The filesystem group ID
+	// The filesystem group ID used for filesystem access checks. Usually equals the egid.
 	Fsgid *wrapperspb.UInt32Value `protobuf:"bytes,8,opt,name=fsgid,proto3" json:"fsgid,omitempty"`
 	// Secure management flags
 	Securebits []SecureBitsType `protobuf:"varint,9,rep,packed,name=securebits,proto3,enum=tetragon.SecureBitsType" json:"securebits,omitempty"`
@@ -1271,7 +1271,9 @@ type Process struct {
 	ExecId string `protobuf:"bytes,1,opt,name=exec_id,json=execId,proto3" json:"exec_id,omitempty"`
 	// Process identifier from host PID namespace.
 	Pid *wrapperspb.UInt32Value `protobuf:"bytes,2,opt,name=pid,proto3" json:"pid,omitempty"`
-	// User identifier associated with the process.
+	// The effective User identifier used for permission checks. This field maps to the
+	// 'ProcessCredentials.euid' field. Run with the `--enable-process-cred` flag to
+	// enable 'ProcessCredentials' and get all the User and Group identifiers.
 	Uid *wrapperspb.UInt32Value `protobuf:"bytes,3,opt,name=uid,proto3" json:"uid,omitempty"`
 	// Current working directory of the process.
 	Cwd string `protobuf:"bytes,4,opt,name=cwd,proto3" json:"cwd,omitempty"`
@@ -1355,7 +1357,8 @@ type Process struct {
 	Ns *Namespaces `protobuf:"bytes,15,opt,name=ns,proto3" json:"ns,omitempty"`
 	// Thread ID, note that for the thread group leader, tid is equal to pid.
 	Tid *wrapperspb.UInt32Value `protobuf:"bytes,16,opt,name=tid,proto3" json:"tid,omitempty"`
-	// Process credentials
+	// Process credentials, disabled by default, can be enabled by the
+	// `--enable-process-cred` flag.
 	ProcessCredentials *ProcessCredentials `protobuf:"bytes,17,opt,name=process_credentials,json=processCredentials,proto3" json:"process_credentials,omitempty"`
 	// Executed binary properties. This field is only available on ProcessExec events.
 	BinaryProperties *BinaryProperties `protobuf:"bytes,18,opt,name=binary_properties,json=binaryProperties,proto3" json:"binary_properties,omitempty"`

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/tetragon.proto
@@ -112,21 +112,21 @@ message UserNamespace {
 }
 
 message ProcessCredentials {
-	// The real user ID
+	// The real user ID of the process' owner.
 	google.protobuf.UInt32Value uid = 1;
-	// The real group ID
+	// The real group ID of the process' owner.
 	google.protobuf.UInt32Value gid = 2;
-	// The effective user ID
+	// The effective user ID used for permission checks.
 	google.protobuf.UInt32Value euid = 3;
-	// The effective group ID
+	// The effective group ID used for permission checks.
 	google.protobuf.UInt32Value egid = 4;
-	// The saved user ID
+	// The saved user ID.
 	google.protobuf.UInt32Value suid = 5;
-	// The saved group ID
+	// The saved group ID.
 	google.protobuf.UInt32Value sgid = 6;
-	// the filesystem user ID
+	// the filesystem user ID used for filesystem access checks. Usually equals the euid.
 	google.protobuf.UInt32Value fsuid = 7;
-	// The filesystem group ID
+	// The filesystem group ID used for filesystem access checks. Usually equals the egid.
 	google.protobuf.UInt32Value fsgid = 8;
 	// Secure management flags
 	repeated SecureBitsType securebits = 9;
@@ -178,7 +178,9 @@ message Process {
     string exec_id = 1;
     // Process identifier from host PID namespace.
     google.protobuf.UInt32Value pid = 2;
-    // User identifier associated with the process.
+    // The effective User identifier used for permission checks. This field maps to the
+    // 'ProcessCredentials.euid' field. Run with the `--enable-process-cred` flag to
+    // enable 'ProcessCredentials' and get all the User and Group identifiers.
     google.protobuf.UInt32Value uid = 3;
     // Current working directory of the process.
     string cwd = 4;
@@ -262,7 +264,8 @@ message Process {
     Namespaces ns = 15;
     // Thread ID, note that for the thread group leader, tid is equal to pid.
     google.protobuf.UInt32Value tid = 16;
-    // Process credentials
+    // Process credentials, disabled by default, can be enabled by the
+    // `--enable-process-cred` flag.
     ProcessCredentials process_credentials = 17;
     // Executed binary properties. This field is only available on ProcessExec events.
     BinaryProperties binary_properties = 18;


### PR DESCRIPTION
Instead of reporting the real uid of the task that is the owner of the task, let's report the effective uid that is used to calculate the privileges of the current task when acting upon other objects. This allows to be compatible with 'ps' too.

See commits for further details.
