### PR TITLE
pkg/sensors: fix for ratelimit_map wrong path pinning

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -353,7 +353,7 @@ func createMultiKprobeSensor(sensorPath, policyName string, multiIDs []idtable.E
 	}
 
 	if kernels.EnableLargeProgs() {
-		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(sensorPath, "ratelimit_map"), load)
+		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(pinPath, "ratelimit_map"), load)
 		if oneKprobeHasRatelimit {
 			ratelimitMap.SetMaxEntries(ratelimitMapMaxEntries)
 		}
@@ -918,7 +918,7 @@ func createKprobeSensorFromEntry(kprobeEntry *genericKprobe, sensorPath string,
 	}
 
 	if kernels.EnableLargeProgs() {
-		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(sensorPath, "ratelimit_map"), load)
+		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(pinPath, "ratelimit_map"), load)
 		if kprobeEntry.hasRatelimit {
 			// similarly as for stacktrace, we expand the max size only if
 			// needed to reduce the memory footprint when unused


### PR DESCRIPTION
Commit 38ab0122a8d69368833457aad6d3d68858c0b561 pinned the ratelimit_map to the fs but used sensorPath instead pinPath since this is a per kprobe map and not a per sensor map.
