### PR TITLE
[backport v1.0] pkg/sensors: reduce ratelimit map memory footprint

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1808,7 +1808,7 @@ struct ratelimit_value {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
-	__uint(max_entries, 32768);
+	__uint(max_entries, 1); // Agent is resizing this if the feature is needed during kprobe load
 	__type(key, struct ratelimit_key);
 	__type(value, struct ratelimit_value);
 } ratelimit_map SEC(".maps");

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1792,6 +1792,8 @@ do_action_signal(int signal)
  */
 #define KEY_BYTES_PER_ARG 40
 
+#ifdef __LARGE_BPF_PROG
+
 struct ratelimit_key {
 	__u64 func_id;
 	__u64 retprobe_id;
@@ -1829,7 +1831,6 @@ struct {
 	__type(value, __u8[sizeof(struct ratelimit_key) + 128]);
 } ratelimit_ro_heap SEC(".maps");
 
-#ifdef __LARGE_BPF_PROG
 static inline __attribute__((always_inline)) bool
 rate_limit(__u64 ratelimit_interval, struct msg_generic_kprobe *e)
 {

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -319,7 +319,7 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 	}
 
 	if kernels.EnableLargeProgs() {
-		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(sensorPath, "ratelimit_map"), load)
+		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(pinPath, "ratelimit_map"), load)
 		if oneKprobeHasRatelimit {
 			ratelimitMap.SetMaxEntries(ratelimitMapMaxEntries)
 		}
@@ -968,7 +968,7 @@ func addKprobe(funcName string, f *v1alpha1.KProbeSpec, in *addKprobeIn, selMaps
 	}
 
 	if kernels.EnableLargeProgs() {
-		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(in.sensorPath, "ratelimit_map"), load)
+		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(pinPath, "ratelimit_map"), load)
 		if kprobeEntry.hasRatelimit {
 			// similarly as for stacktrace, we expand the max size only if
 			// needed to reduce the memory footprint when unused

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -310,6 +310,11 @@ func createMultiKprobeSensor(sensorPath string, multiIDs, multiRetIDs []idtable.
 		maps = append(maps, socktrack)
 	}
 
+	if kernels.EnableLargeProgs() {
+		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(sensorPath, "ratelimit_map"), load)
+		maps = append(maps, ratelimitMap)
+	}
+
 	filterMap.SetMaxEntries(len(multiIDs))
 	configMap.SetMaxEntries(len(multiIDs))
 
@@ -948,6 +953,11 @@ func addKprobe(funcName string, f *v1alpha1.KProbeSpec, in *addKprobeIn, selMaps
 	if kernels.EnableLargeProgs() {
 		socktrack := program.MapBuilderPin("socktrack_map", sensors.PathJoin(in.sensorPath, "socktrack_map"), load)
 		out.maps = append(out.maps, socktrack)
+	}
+
+	if kernels.EnableLargeProgs() {
+		ratelimitMap := program.MapBuilderPin("ratelimit_map", sensors.PathJoin(in.sensorPath, "ratelimit_map"), load)
+		out.maps = append(out.maps, ratelimitMap)
 	}
 
 	if setRetprobe {

--- a/tests/vmtests/fetch-data.sh
+++ b/tests/vmtests/fetch-data.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 
 OCIORG=quay.io/lvh-images
-ROOTIMG=$OCIORG/root-images
+ROOTIMG=$OCIORG/root-images:20240717.161638@sha256:62a9890111ab39749792fda4f59c8f736fa350ecaedb0667e3eecbbe790d82ed
 KERNIMG=$OCIORG/kernel-images
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
 KERNEL_VERS="$@"


### PR DESCRIPTION
Backport of https://github.com/cilium/tetragon/pull/2551 and https://github.com/cilium/tetragon/pull/2583

```release-note
Reduce the kernel memory footprint (accounted by the cgroup memory controller) of the ratelimit feature when unused (around ~10MB per kprobe).
```