### PR TITLE
docs: remove cncf label on homepage

### DIFF
--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -8,12 +8,6 @@ linkTitle = "Tetragon - eBPF-based Security Observability and Runtime Enforcemen
     <div class="hero">
         <div class="container">
             <div class="hero__intro">
-                <span class="hero__label">
-                    <img src="/svgs/logos/cncf-logo.svg" width="26" height="26" loading="eager" alt="" />
-                    <span>
-                        We are a proud <b>CNCF project</b>
-                    </span>
-                </span>
                 <h1 class="title title--xl">
                     eBPF-based Security Observability and Runtime Enforcement
                 </h1>


### PR DESCRIPTION
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.

<!-- Description of change -->
Removes the  CNCF label on the homepage for reasons we've discussed. 