### PR TITLE
tetragon-metrics-docs: Move New function to a separate package

### DIFF
--- a/cmd/tetragon-metrics-docs/main.go
+++ b/cmd/tetragon-metrics-docs/main.go
@@ -7,14 +7,11 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/isovalent/metricstool/pkg/metricsmd"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/cobra"
 
+	"github.com/cilium/tetragon/cmd/tetragon-metrics-docs/metricsmd"
 	"github.com/cilium/tetragon/pkg/metricsconfig"
 )
-
-type initMetricsFunc func(string, *prometheus.Registry, *slog.Logger) error
 
 func main() {
 	targets := map[string]string{
@@ -22,59 +19,9 @@ func main() {
 		"resources": "Tetragon Resources",
 		"events":    "Tetragon Events",
 	}
-	if err := New(targets, initMetrics).Execute(); err != nil {
+	if err := metricsmd.New(targets, initMetrics).Execute(); err != nil {
 		os.Exit(1)
 	}
-}
-
-func New(targets map[string]string, init initMetricsFunc) *cobra.Command {
-	overrides := []metricsmd.LabelOverrides{
-		// Theses metrics takes VCS info into account supplied at build
-		// time, which changes every build, so override those.
-		{
-			Metric: "go_info",
-			Overrides: []metricsmd.LabelValues{
-				{
-					Label:  "version",
-					Values: []string{"go1.22.0"},
-				},
-			},
-		},
-		{
-			Metric: "tetragon_build_info",
-			Overrides: []metricsmd.LabelValues{
-				{
-					Label:  "commit",
-					Values: []string{"931b70f2c9878ba985ba6b589827bea17da6ec33"},
-				},
-				{
-					Label:  "go_version",
-					Values: []string{"go1.22.0"},
-				},
-				{
-					Label:  "modified",
-					Values: []string{"false"},
-				},
-				{
-					Label:  "time",
-					Values: []string{"2022-05-13T15:54:45Z"},
-				},
-			},
-		},
-	}
-
-	config := &metricsmd.Config{
-		Targets:        targets,
-		LabelOverrides: overrides,
-		InitMetrics:    init,
-		HeadingLevel:   1,
-	}
-
-	cmd, err := metricsmd.NewCmd(nil, nil, config)
-	if err != nil {
-		slog.Error("failed to create metrics-docs command", "error", err)
-	}
-	return cmd
 }
 
 func initMetrics(target string, reg *prometheus.Registry, _ *slog.Logger) error {

--- a/cmd/tetragon-metrics-docs/metricsmd/metricsmd.go
+++ b/cmd/tetragon-metrics-docs/metricsmd/metricsmd.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metricsmd
+
+import (
+	"log/slog"
+
+	"github.com/isovalent/metricstool/pkg/metricsmd"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+)
+
+type initMetricsFunc func(string, *prometheus.Registry, *slog.Logger) error
+
+func New(targets map[string]string, init initMetricsFunc) *cobra.Command {
+	overrides := []metricsmd.LabelOverrides{
+		// Theses metrics takes VCS info into account supplied at build
+		// time, which changes every build, so override those.
+		{
+			Metric: "go_info",
+			Overrides: []metricsmd.LabelValues{
+				{
+					Label:  "version",
+					Values: []string{"go1.22.0"},
+				},
+			},
+		},
+		{
+			Metric: "tetragon_build_info",
+			Overrides: []metricsmd.LabelValues{
+				{
+					Label:  "commit",
+					Values: []string{"931b70f2c9878ba985ba6b589827bea17da6ec33"},
+				},
+				{
+					Label:  "go_version",
+					Values: []string{"go1.22.0"},
+				},
+				{
+					Label:  "modified",
+					Values: []string{"false"},
+				},
+				{
+					Label:  "time",
+					Values: []string{"2022-05-13T15:54:45Z"},
+				},
+			},
+		},
+	}
+
+	config := &metricsmd.Config{
+		Targets:        targets,
+		LabelOverrides: overrides,
+		InitMetrics:    init,
+		HeadingLevel:   1,
+	}
+
+	cmd, err := metricsmd.NewCmd(nil, nil, config)
+	if err != nil {
+		slog.Error("failed to create metrics-docs command", "error", err)
+	}
+	return cmd
+}


### PR DESCRIPTION
Introduce metricsmd package containing New function from cmd/tetragon-metrics-docs. This is done so that this function can be imported and reused by different commands.