### PR TITLE
[backport/v0.10] Fix libbpf submodule checkout in bpftool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN if [ $BUILDARCH != $TARGETARCH ]; \
     else apt-get install -y curl git llvm gcc pkg-config zlib1g-dev libelf-dev libcap-dev; fi
 # v7.1.0
 ENV BPFTOOL_REV "b01941c8f7890489f09713348a7d89567538504b"
-RUN git clone --recurse-submodules https://github.com/libbpf/bpftool.git . && git checkout ${BPFTOOL_REV}
+RUN git clone https://github.com/libbpf/bpftool.git . && git checkout ${BPFTOOL_REV} && git submodule update --init --recursive
 RUN if [ $BUILDARCH != $TARGETARCH ]; \
     then make -C src EXTRA_CFLAGS=--static CC=aarch64-linux-gnu-gcc -j $(nproc) && aarch64-linux-gnu-strip src/bpftool; \
     else make -C src EXTRA_CFLAGS=--static -j $(nproc) && strip src/bpftool; fi


### PR DESCRIPTION
[upstream commit 0235ed57252b9e03c68ea1dbc6ad0b1b6b5e6298]

Now in the Dockerfile we do:
git clone --recurse-submodules https://github.com/libbpf/bpftool.git . && git checkout ${BPFTOOL_REV} which means that we fetch the libbpf submodule version of the main branch of bpftool and then we move to the appropriate commit that we need. After the checkout we also need to fetch the correct version of the submodules. This patch fixes that.
