### PR TITLE
[grpc/exec] Do not refinc on a nil parent

### DIFF
--- a/pkg/grpc/exec/kthread_init.go
+++ b/pkg/grpc/exec/kthread_init.go
@@ -23,6 +23,7 @@ func (msg *MsgKThreadInitUnix) HandleMessage() *tetragon.GetEventsResponse {
 	parent, err := process.Get(proc.UnsafeGetProcess().ParentExecId)
 	if err != nil {
 		logger.GetLogger().Warnf("Failed to find parent for kernel thread %d", msg.Unix.Msg.Parent.Pid)
+		return nil
 	}
 	parent.RefInc()
 	return nil


### PR DESCRIPTION
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.

When handling kthreads and we cannot find the parent, we print a warning, but we also call refinc on a nil parent which results in a panic in some cases.

This patch fixes that by avoiding the call of refinc in the case where we cannot find a kthread's parent.

Fixes: https://github.com/cilium/tetragon/issues/2614

```release-note
Do not increase the reference count when we cannot find a parent in kthreads.
```
