### PR TITLE
helm, doc: Added debug Helm flag for the agent

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -55,6 +55,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.argsOverride | list | `[]` |  |
 | tetragon.btf | string | `""` |  |
 | tetragon.commandOverride | list | `[]` |  |
+| tetragon.debug | bool | `false` | If you want to run Tetragon in debug mode change this value to true |
 | tetragon.enableK8sAPI | bool | `true` |  |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |
 | tetragon.enablePolicyFilter | bool | `true` | Enable policy filter. This is required for K8s namespace and pod-label filtering. |

--- a/docs/content/en/docs/troubleshooting/_index.md
+++ b/docs/content/en/docs/troubleshooting/_index.md
@@ -91,6 +91,15 @@ level is controlled by the log-level option at startup:
 * Enable debug level with `--log-level=debug`
 * Enable trace level with `--log-level=trace`
 
+### Change log level on Kubernetes
+
+{{< warning >}}
+The Tetragon DaemonSet will be restarted automatically after changing the debug Helm value!
+{{< /warning >}}
+
+It is possible to change the log level of the Tetragon (DaemonSet) instances by
+setting `tetragon.debug` to `true`.
+
 ### Change log level dynamically
 
 It is possible to change the log level dynamically by sending the corresponding

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -37,6 +37,7 @@ Helm chart for Tetragon
 | tetragon.argsOverride | list | `[]` |  |
 | tetragon.btf | string | `""` |  |
 | tetragon.commandOverride | list | `[]` |  |
+| tetragon.debug | bool | `false` | If you want to run Tetragon in debug mode change this value to true |
 | tetragon.enableK8sAPI | bool | `true` |  |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |
 | tetragon.enablePolicyFilter | bool | `true` | Enable policy filter. This is required for K8s namespace and pod-label filtering. |

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -10,6 +10,7 @@ data:
   btf: {{ .Values.tetragon.btf }}
 {{- end }}
   procfs: /procRoot
+  debug: {{ .Values.tetragon.debug | quote }}
   enable-process-cred: {{ .Values.tetragon.enableProcessCred | quote }}
   enable-process-ns: {{ .Values.tetragon.enableProcessNs | quote }}
   process-cache-size: {{ .Values.tetragon.processCacheSize | quote }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -71,6 +71,8 @@ tetragon:
   # Tetragon puts processes in an LRU cache. The cache is used to find ancestors
   # for subsequently exec'ed processes.
   processCacheSize: 65536
+  # -- If you want to run Tetragon in debug mode change this value to true
+  debug: false
   # JSON export filename. Set it to an empty string to disable JSON export altogether.
   exportFilename: tetragon.log
   # JSON export file permissions as a string. Set it to "600" to restrict access to owner.


### PR DESCRIPTION
Added a `debug` Helm flag for the Tetragon agent. Implemented via ConfigMap flag. The Tetragon DaemonSet will be restarted automatically after changing the debug value.

```release-note
helm, doc: Added debug Helm flag for the agent
```
