### PR TITLE
bpf: fix missed linux_binprm_type in selector_arg_offset function

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1686,6 +1686,9 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
 			args += 4;
 		case file_ty:
 		case path_ty:
+#ifdef __LARGE_BPF_PROG
+		case linux_binprm_type:
+#endif
 			pass &= filter_file_buf(filter, (struct string_buf *)args);
 			break;
 		case string_type:

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5989,6 +5989,9 @@ spec:
 }
 
 func TestLinuxBinprmExtractPath(t *testing.T) {
+	if !kernels.EnableLargeProgs() {
+		t.Skip("Older kernels do not support matchArgs with linux_binprm")
+	}
 	testutils.CaptureLog(t, logger.GetLogger().(*logrus.Logger))
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()


### PR DESCRIPTION
It's seems to me, that `case linux_binprm_type:` in [selector_arg_offset](https://github.com/cilium/tetragon/blob/main/bpf/process/types/basic.h#L1617) function is missing. [security_bprm_check.yaml](https://github.com/cilium/tetragon/blob/main/examples/tracingpolicy/security_bprm_check.yaml) from examples doesn't work.