### PR TITLE
pkg/sensors: fix binprm matchArgs test

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1686,6 +1686,9 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
 			args += 4;
 		case file_ty:
 		case path_ty:
+#ifdef __LARGE_BPF_PROG
+		case linux_binprm_type:
+#endif
 			pass &= filter_file_buf(filter, (struct string_buf *)args);
 			break;
 		case string_type:


### PR DESCRIPTION
Based on https://github.com/cilium/tetragon/pull/2623 work. Given this comment https://github.com/cilium/tetragon/pull/2623#issuecomment-2203882956.
cc @anfedotoff @dwindsor.

Running the test with the first commit only should fail as expected:
```shell
go test -exec sudo ./pkg/sensors/tracing --run TestLinuxBinprmExtractPath
```

With @anfedotoff patch, the test should now be green.