### PR TITLE
[btf] Cleanup AddModulesToSpec 

### DIFF
--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -133,9 +133,6 @@ options:
       usage: Absolute path of the kubernetes kubeconfig file
     - name: kernel
       usage: Kernel version
-    - name: kmods
-      default_value: '[]'
-      usage: List of kernel modules to load symbols from
     - name: log-format
       default_value: text
       usage: Set log format

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -79,8 +79,6 @@ type config struct {
 
 	EnableMsgHandlingLatency bool
 
-	KMods []string
-
 	EnablePodInfo          bool
 	EnableTracingPolicyCRD bool
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -87,8 +87,6 @@ const (
 
 	KeyEnableMsgHandlingLatency = "enable-msg-handling-latency"
 
-	KeyKmods = "kmods"
-
 	KeyEnablePodInfo          = "enable-pod-info"
 	KeyEnableTracingPolicyCRD = "enable-tracing-policy-crd"
 
@@ -188,8 +186,6 @@ func ReadAndSetFlags() error {
 	Config.EnablePidSetFilter = viper.GetBool(KeyEnablePidSetFilter)
 
 	Config.TracingPolicyDir = viper.GetString(KeyTracingPolicyDir)
-
-	Config.KMods = viper.GetStringSlice(KeyKmods)
 
 	Config.EnablePodInfo = viper.GetBool(KeyEnablePodInfo)
 	Config.EnableTracingPolicyCRD = viper.GetBool(KeyEnableTracingPolicyCRD)
@@ -352,8 +348,6 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Bool(KeyEnablePidSetFilter, false, "Enable pidSet export filters. Not recommended for production use")
 
 	flags.Bool(KeyEnableMsgHandlingLatency, false, "Enable metrics for message handling latency")
-
-	flags.StringSlice(KeyKmods, []string{}, "List of kernel modules to load symbols from")
 
 	flags.String(KeyRBQueueSize, "65535", "Set size of channel between ring buffer and sensor go routines (default 65k, allows K/M/G suffix)")
 

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/ebpf/link"
 	cachedbtf "github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors/unloader"
 	"golang.org/x/sys/unix"
 )
@@ -719,18 +718,12 @@ func doLoadProgram(
 	verbose int,
 ) (*LoadedCollection, error) {
 	var btfSpec *btf.Spec
-	if btfFilePath := cachedbtf.GetCachedBTFFile(); btfFilePath != "/sys/kernel/btf/vmlinux" || len(option.Config.KMods) > 0 {
+	if btfFilePath := cachedbtf.GetCachedBTFFile(); btfFilePath != "/sys/kernel/btf/vmlinux" {
 		// Non-standard path to BTF, open it and provide it as 'KernelTypes'.
 		var err error
 		btfSpec, err = btf.LoadSpec(btfFilePath)
 		if err != nil {
 			return nil, fmt.Errorf("opening BTF file '%s' failed: %w", btfFilePath, err)
-		}
-		if len(option.Config.KMods) > 0 {
-			btfSpec, err = cachedbtf.AddModulesToSpec(btfSpec, option.Config.KMods)
-			if err != nil {
-				return nil, fmt.Errorf("adding modules to spec failed: %w", err)
-			}
 		}
 	}
 
@@ -821,6 +814,9 @@ func doLoadProgram(
 		// as that makes the loading very slow.
 		opts.Programs.LogLevel = 1
 		opts.Programs.LogSize = verifierLogBufferSize
+		if load.KernelTypes != nil {
+			opts.Programs.KernelTypes = load.KernelTypes
+		}
 		// If we hit ENOSPC that means that our log size is not big enough,
 		// so keep trying again with log size * 2 until we succeed or the kernel
 		// complains.

--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/tetragon/pkg/sensors/unloader"
 )
 
@@ -109,6 +110,9 @@ type Program struct {
 	LC *LoadedCollection
 
 	RewriteConstants map[string]interface{}
+
+	// Type information used for CO-RE relocations.
+	KernelTypes *btf.Spec
 }
 
 func (p *Program) SetRetProbe(ret bool) *Program {

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -427,13 +427,6 @@ func preValidateKprobes(name string, kprobes []v1alpha1.KProbeSpec, lists []v1al
 		return err
 	}
 
-	if len(option.Config.KMods) > 0 {
-		btfobj, err = btf.AddModulesToSpec(btfobj, option.Config.KMods)
-		if err != nil {
-			return fmt.Errorf("adding modules to spec failed: %w", err)
-		}
-	}
-
 	// validate lists first
 	err = preValidateLists(lists)
 	if err != nil {


### PR DESCRIPTION
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.

Now (as of 0.14.0) cilium/ebpf handles kmod BTFs natively (https://pkg.go.dev/github.com/cilium/ebpf#ProgramOptions.KernelModuleTypes).

Thus we can remove some duplicate code (i.e. mainly function AddModulesToSpec). This patch does this cleanup.

In Tetragon, we used kmod BTF in 2 places:
1. In order to attach to a function which is now handled automatically by cilium/ebpf.
2. In order to validate if the function name exists in the BTF and to check the argument types. In that case, we need to manually load the spec from the kmod that we care about. This is because cilium/ebpf checks (and loads the appropriate BTF) during the attach phase (i.e. https://github.com/cilium/ebpf/blob/5976561b28aabf23df00f3507cc3b240305b531b/prog.go#L157-L177).

```release-note
Cleanup code related to handling kmod BTFs.
```
