### PR TITLE
policyfiletr K8s test fix

### DIFF
--- a/pkg/policyfilter/k8s_test.go
+++ b/pkg/policyfilter/k8s_test.go
@@ -114,16 +114,16 @@ func (ts *testState) eventHandler(m *state) cache.ResourceEventHandler {
 	h := m.getPodEventHandlers()
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			ts.cbAdds.Add(1)
 			h.OnAdd(obj, false)
+			ts.cbAdds.Add(1)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			ts.cbUpds.Add(1)
 			h.OnUpdate(oldObj, newObj)
+			ts.cbUpds.Add(1)
 		},
 		DeleteFunc: func(obj interface{}) {
-			ts.cbDels.Add(1)
 			h.OnDelete(obj)
+			ts.cbDels.Add(1)
 		},
 	}
 }

--- a/pkg/policyfilter/state.go
+++ b/pkg/policyfilter/state.go
@@ -531,7 +531,7 @@ func (m *state) addCgroupIDs(cinfo []containerInfo, pod *podInfo) error {
 			}
 			continue
 		}
-		logger.GetLogger().WithField("cgrp", c).WithField("pod", pod).WithField("id", nsmap.id).Warn("update cgroupid map")
+		logger.GetLogger().WithField("cgrp", c).WithField("pod", pod).WithField("id", nsmap.id).Debug("update cgroupid map")
 
 		// If this is a new namespace we create a new map entry and bind it to a stable id.
 		if err := nsmap.cgroupIdMap.Update(&c.cgID, nsmap.id, ebpf.UpdateAny); err != nil {

--- a/tests/vmtests/README.md
+++ b/tests/vmtests/README.md
@@ -21,7 +21,7 @@ make: Leaving directory '/home/kkourt/src/tetragon/tests/vmtests'
 
 Download rootfs images and kernels in `tests/vmtests/test-data`
 ```
-$ ./tests/vmtests/fetch-data.sh 4.19 5.4 bpf-next
+$ ./tests/vmtests/fetch-data.sh 4.19-main 5.4-main bpf-next-main
 ...
 $ ls tests/vmtests/test-data/images tests/vmtests/test-data/kernels
 tests/vmtests/test-data/images:


### PR DESCRIPTION
I've noticed a flake in the pkg.policyfilter.TestK8s

The test uses a fake k8s clientset, applies changes (e.g., adding or
removing pods), and then checks whether the policyfilter bpf map has the
expected contents.

We need to check the state after the pod informer callbacks have be
called. To do so, we maintain an operation count. We check that all
operations have been completed and then compare the contents of the
policyfilter map.

We seem to be increasing the counter first and then calling the
callback, however, which means that there is a small race where the
counts match but the bpf map contents have not been updated.

This patch increases the counters after the callback returns.

This seems to fix the issue in my local machine.

Also, two more minor updates.

Fixes: https://github.com/cilium/tetragon/issues/2470