### PR TITLE
identifies tetragon pod managing a pod

### DIFF
--- a/contrib/k8s-get-tetragon-pod.sh
+++ b/contrib/k8s-get-tetragon-pod.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of Cilium
+
+set -o errexit
+set -o pipefail
+
+# Given a pod name and namespace, get the corresponding tetragon pod name.
+
+K8S_NAMESPACE="${K8S_NAMESPACE:-kube-system}"
+
+if [[ $# -ne 2  ]]
+then
+	echo "Usage: $(basename "$0") <pod> <namespace>" >&2
+	exit 1
+fi
+TARGET_POD_NAME="$1"
+TARGET_POD_NAMESPACE="$2"
+
+# Get the target pod's node.
+target_pod_node="$(kubectl get pod "${TARGET_POD_NAME}" -n "${TARGET_POD_NAMESPACE}" --no-headers -o custom-columns=:.spec.nodeName)"
+if [[ -z "${target_pod_node}" ]]
+then
+	echo "pod ${TARGET_POD_NAMESPACE}/${TARGET_POD_NAME} has no node assigned" >&2
+	exit 1
+fi
+
+# Get the Cilium pod running on the target pod's node (using exact node matching).
+kubectl get pods -n "${K8S_NAMESPACE}" -l app.kubernetes.io/name=tetragon --no-headers -o custom-columns=:.metadata.name,:.spec.nodeName | awk -v node="${target_pod_node}" '$2==node {print $1}'


### PR DESCRIPTION
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.

<!-- Description of change -->

This is slightly modified script of https://raw.githubusercontent.com/cilium/cilium/main/contrib/k8s/k8s-get-cilium-pod.sh . This script helps user to identify tetragon pod running on the same node as a pod. 

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
