### PR TITLE
Fix linter warnings in Dockerfiles

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM quay.io/cilium/clang:aeaada5cf60efe8d0e772d032fe3cc2bc613739c@sha256:b440ae7b3591a80ffef8120b2ac99e802bbd31dee10f5f15a48566832ae0866f as bpf-builder
+FROM quay.io/cilium/clang:aeaada5cf60efe8d0e772d032fe3cc2bc613739c@sha256:b440ae7b3591a80ffef8120b2ac99e802bbd31dee10f5f15a48566832ae0866f AS bpf-builder
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN apt-get update
 RUN apt-get install -y linux-libc-dev

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -8,7 +8,7 @@ ARG ALPINE_IMAGE=docker.io/library/alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as builder
+FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} AS builder
 
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
@@ -25,10 +25,10 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/tetragon --moun
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-FROM --platform=${BUILDPLATFORM} ${ALPINE_IMAGE} as certs
+FROM --platform=${BUILDPLATFORM} ${ALPINE_IMAGE} AS certs
 RUN apk --update add ca-certificates
 
-FROM ${BASE_IMAGE} as release
+FROM ${BASE_IMAGE} AS release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/Dockerfile.rthooks
+++ b/Dockerfile.rthooks
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=docker.io/library/alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b8
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as builder
+FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} AS builder
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
@@ -21,7 +21,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/tetragon \
     && mv ./contrib/tetragon-rthooks/tetragon-oci-hook-setup /out/${TARGETOS}/${TARGETARCH}/usr/bin \
     && mv ./contrib/tetragon-rthooks/tetragon-nri-hook       /out/${TARGETOS}/${TARGETARCH}/usr/bin
 
-FROM ${BASE_IMAGE} as image
+FROM ${BASE_IMAGE} AS image
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.

--- a/Dockerfile.tarball
+++ b/Dockerfile.tarball
@@ -1,6 +1,6 @@
-FROM cilium/tetragon:latest as tetragon-release
+FROM cilium/tetragon:latest AS tetragon-release
 
-FROM scratch as linux-tarball-1
+FROM scratch AS linux-tarball-1
 
 # Copy install script
 COPY install/linux-tarball/install.sh /
@@ -27,7 +27,7 @@ COPY --from=tetragon-release /usr/bin/gops /usr/local/lib/tetragon/
 COPY --from=tetragon-release /var/lib/tetragon /usr/local/lib/tetragon/bpf
 
 # We need one layer
-FROM scratch as linux-tarball-2
+FROM scratch AS linux-tarball-2
 
 ARG TETRAGON_VERSION
 ARG TARGET_ARCH

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM quay.io/cilium/clang:aeaada5cf60efe8d0e772d032fe3cc2bc613739c@sha256:b440ae7b3591a80ffef8120b2ac99e802bbd31dee10f5f15a48566832ae0866f as bpf-builder
+FROM quay.io/cilium/clang:aeaada5cf60efe8d0e772d032fe3cc2bc613739c@sha256:b440ae7b3591a80ffef8120b2ac99e802bbd31dee10f5f15a48566832ae0866f AS bpf-builder
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN apt-get update
 RUN apt-get install -y linux-libc-dev


### PR DESCRIPTION
Silly changes to fix linter warnings:
```
FromAsCasing: 'as' and 'FROM' keywords' casing do not match
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
```
