### PR TITLE
tetragon: small improvement to testing merge sensors

### DIFF
--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -74,7 +74,7 @@ func findProgram(cache []*prog, name string, typ ebpf.ProgramType, match ProgMat
 	return p
 }
 
-func mergeSensorMaps(t *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []SensorProg) ([]SensorMap, []SensorProg) {
+func mergeSensorMaps(_ *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []SensorProg) ([]SensorMap, []SensorProg) {
 	// we take maps1,progs1 and merge in maps2,progs2
 	mapsReturn := maps1
 	progsReturn := progs1
@@ -84,16 +84,20 @@ func mergeSensorMaps(t *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []Se
 
 	// merge in progs2
 	for _, p2 := range progs2 {
+		skip := false
 		// do maps share the same program
-		for _, p := range progsReturn {
+		for i, p := range progsReturn {
 			if p.Name == p2.Name && p.Type == p2.Type {
-				t.Fatalf("merge fail: program '%s' in both maps", p.Name)
+				skip = true
+				idxList = append(idxList, uint(i))
+				break
 			}
 		}
-
-		progsReturn = append(progsReturn, p2)
-		idxList = append(idxList, idx)
-		idx++
+		if !skip {
+			idxList = append(idxList, idx)
+			progsReturn = append(progsReturn, p2)
+			idx++
+		}
 	}
 
 	// merge in maps2


### PR DESCRIPTION
Adding some more tests discovered that its sometimes useful to explicitely list progs and maps for clarity. But, the testing utilities mark the test Fatal when this happens. Its not really an error to over specify a test so lets just allow it and have the merge logic skip it.

Without this its annoying to define tests for if multiple sensors work together. For example we have sensor tests with SensorX and another with SensorY if you want to test SensorX+SensorY looks good you get a Fatal just because logic doesn't know how to merge the  defintiion of Maps/Progs. Or you have to cut'n'paste it all over again.