### PR TITLE
Fix tetragon build

### DIFF
--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	cachedbtf "github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors/unloader"
 	"golang.org/x/sys/unix"
 )


### PR DESCRIPTION
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.

https://github.com/cilium/tetragon/commit/f44ce8cbb43d0ea3df532360a78328b863be85cf removed "github.com/cilium/tetragon/pkg/option" import from pkg/sensors/program/loader.go. This is merged without a rebase to latest master.

https://github.com/cilium/tetragon/commit/81a3e14f74cb1bcc02cfe5c503aa169d7e3b72dc adds a new dependancy on "github.com/cilium/tetragon/pkg/option" so removing that in the first commit breaks the build.

This patch fixes that.

```release-note
Fix a build issue in tetragon binary.
```
