### PR TITLE
Makefile: Reduce the amount of vendoring calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,9 +355,11 @@ codegen: | protogen
 protogen: protoc-gen-go-tetragon ## Generate code based on .proto files.
 	# Need to call vendor twice here, once before and once after codegen the reason
 	# being we need to grab changes first plus pull in whatever gets generated here.
-	$(MAKE) vendor
+	$(MAKE) -C api vendor
 	$(MAKE) -C api
-	$(MAKE) vendor
+	$(GO) mod tidy
+	$(GO) mod vendor
+	$(GO) mod verify
 
 .PHONY: protoc-gen-go-tetragon
 protoc-gen-go-tetragon:
@@ -368,15 +370,18 @@ generate: | crds
 crds: ## Generate kubebuilder files.
 	# Need to call vendor twice here, once before and once after generate, the reason
 	# being we need to grab changes first plus pull in whatever gets generated here.
-	$(MAKE) vendor
-	$(MAKE) -C pkg/k8s/
-	$(MAKE) vendor
+	$(MAKE) -C pkg/k8s vendor
+	$(MAKE) -C pkg/k8s
+	$(MAKE) -C pkg/k8s vendor
+	$(GO) mod tidy
+	$(GO) mod vendor
+	$(GO) mod verify
 
 .PHONY: vendor
 vendor: ## Tidy and vendor Go modules.
-	$(MAKE) -C ./api vendor
-	$(MAKE) -C ./pkg/k8s vendor
-	$(MAKE) -C ./contrib/tetragon-rthooks vendor
+	$(MAKE) -C api vendor
+	$(MAKE) -C pkg/k8s vendor
+	$(MAKE) -C contrib/tetragon-rthooks vendor
 	$(GO) mod tidy
 	$(GO) mod vendor
 	$(GO) mod verify


### PR DESCRIPTION
When generating Go code for proto API or k8s CRDs, we don't need to run vendoring for all modules before and after. It should be enough if we run vendoring only for the relevant module (api or pkg/k8s) before, and only for the main module after.
