### PR TITLE
contrib/kind: Make install-tetragon.sh script more portable

### DIFF
--- a/contrib/kind/install-tetragon.sh
+++ b/contrib/kind/install-tetragon.sh
@@ -7,9 +7,9 @@ error() {
 
 set -eu
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-cd "$PROJECT_ROOT"
-source contrib/kind/conf
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_ROOT="$SCRIPT_DIR/../.."
+source "$PROJECT_ROOT/contrib/kind/conf"
 
 if ! command -v helm &>/dev/null; then
     error "helm is not in \$PATH! Bailing out!"
@@ -28,8 +28,8 @@ usage() {
     echo "       --cluster               override cluster name" 1>&2
 }
 
-BASE_VALUES="${TETRAGON_KIND_BASE_VALUES:-contrib/kind/values.yaml}"
-HELM_CHART="${TETRAGON_KIND_HELM_CHART:-install/kubernetes/tetragon}"
+BASE_VALUES="${TETRAGON_KIND_BASE_VALUES:-"$PROJECT_ROOT/contrib/kind/values.yaml"}"
+HELM_CHART="${TETRAGON_KIND_HELM_CHART:-"$PROJECT_ROOT/install/kubernetes/tetragon"}"
 
 FORCE=0
 VALUES=""

--- a/contrib/kind/install-tetragon.sh
+++ b/contrib/kind/install-tetragon.sh
@@ -29,6 +29,7 @@ usage() {
 }
 
 BASE_VALUES="${TETRAGON_KIND_BASE_VALUES:-contrib/kind/values.yaml}"
+HELM_CHART="${TETRAGON_KIND_HELM_CHART:-install/kubernetes/tetragon}"
 
 FORCE=0
 VALUES=""
@@ -85,7 +86,7 @@ if [ -n "$VALUES" ]; then
 fi
 
 echo "Installing Tetragon in cluster..." 1>&2
-helm upgrade --install tetragon install/kubernetes/tetragon \
+helm upgrade --install tetragon "$HELM_CHART" \
   -n "$NAMESPACE" \
   -f "$BASE_VALUES" "${extra_opts[@]}"
 


### PR DESCRIPTION
1. Allow using custom Helm chart in install-tetragon.sh. A custom Helm chart can be passed via TETRAGON_KIND_HELM_CHART envvar. This is useful for testing released charts or custom distributions
2. Make install-tetragon.sh script runnable from anywhere. There were two issues when running script from a location different than the repo root:
   - If running from a different git repo, the project root is detected incorrectly and the script fails to find config
   - If passing a relative path to a values file, the script fails to find it

Ref https://github.com/cilium/tetragon/issues/1849