### PR TITLE
Postfix operator for matchBinaries selector

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -7,6 +7,7 @@
 #include "bpf_event.h"
 #include "bpf_helpers.h"
 #include "bpf_cred.h"
+#include "../process/string_maps.h"
 
 /* Applying 'packed' attribute to structs causes clang to write to the
  * members byte-by-byte, as offsets may not be aligned. This is bad for
@@ -274,6 +275,7 @@ struct msg_k8s {
 
 struct heap_exe {
 	char buf[BINARY_PATH_MAX_LEN];
+	char end[STRING_POSTFIX_MAX_LENGTH];
 	__u32 len;
 	__u32 error;
 }; // All fields aligned so no 'packed' attribute.
@@ -311,10 +313,16 @@ typedef __u64 mbset_t;
 struct binary {
 	// length of the path stored in path, this should be < BINARY_PATH_MAX_LEN
 	// but can contain negative value in case of copy error.
-	// While s16 would be sufficient, 64 bits are handy for alignment.
-	__s64 path_length;
+	// While s16 would be sufficient, 32 bits are handy for alignment.
+	__s32 path_length;
+	// if end_r contains reversed path postfix
+	__u32 reversed;
 	// BINARY_PATH_MAX_LEN first bytes of the path
 	char path[BINARY_PATH_MAX_LEN];
+	// STRING_POSTFIX_MAX_LENGTH last bytes of the path
+	char end[STRING_POSTFIX_MAX_LENGTH];
+	// STRING_POSTFIX_MAX_LENGTH reversed last bytes of the path
+	char end_r[STRING_POSTFIX_MAX_LENGTH];
 	// matchBinary bitset for binary
 	mbset_t mb_bitset;
 }; // All fields aligned so no 'packed' attribute

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -158,9 +158,17 @@ calls and kernel functions that are coming from `cat` or `tail`.
     - "/usr/bin/tail"
 ```
 
-Currently, only the `In` operator type is supported and the `values` field has
-to be a map of `strings`. The default behaviour is `followForks: true`, so all
-the child processes are followed. The current limitation is 4 values.
+The available operators for `matchBinaries` are:
+- `In`
+- `NotIn`
+- `Prefix`
+- `NotPrefix`
+- `Postfix`
+- `NotPostfix`
+
+The `values` field has to be a map of `strings`. The default behaviour
+is `followForks: true`, so all the child processes are followed.
+The current limitation is 4 values.
 
 **Further examples**
 

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -456,6 +456,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1065,6 +1067,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1705,6 +1709,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -2282,6 +2288,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -456,6 +456,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1065,6 +1067,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1705,6 +1709,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -2282,6 +2288,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -45,6 +45,8 @@ const (
 	MSG_COMMON_FLAG_USER_STACKTRACE   = 0x4
 
 	BINARY_PATH_MAX_LEN = 256
+
+	STRING_POSTFIX_MAX_LENGTH = 128
 )
 
 type MsgExec struct {
@@ -139,8 +141,11 @@ type MsgCapabilities struct {
 }
 
 type Binary struct {
-	PathLength int64
+	PathLength int32
+	Reversed   uint32
 	Path       [BINARY_PATH_MAX_LEN]byte
+	End        [STRING_POSTFIX_MAX_LENGTH]byte
+	End_r      [STRING_POSTFIX_MAX_LENGTH]byte
 	MBSet      uint64
 }
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -456,6 +456,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1065,6 +1067,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1705,6 +1709,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -2282,6 +2288,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -456,6 +456,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1065,6 +1067,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1705,6 +1709,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -2282,6 +2288,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -90,7 +90,7 @@ type KProbeArg struct {
 }
 
 type BinarySelector struct {
-	// +kubebuilder:validation:Enum=In;NotIn;Prefix;NotPrefix
+	// +kubebuilder:validation:Enum=In;NotIn;Prefix;NotPrefix;Postfix;NotPostfix
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.2.3"
+const CustomResourceDefinitionSchemaVersion = "1.2.4"

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -350,7 +350,7 @@ func writeExecveMap(procs []procs) {
 		v.Namespaces.CgroupInum = p.cgroup_ns
 		v.Namespaces.UserInum = p.user_ns
 		pathLength := copy(v.Binary.Path[:], p.exe)
-		v.Binary.PathLength = int64(pathLength)
+		v.Binary.PathLength = int32(pathLength)
 
 		err := m.Put(k, v)
 		if err != nil {

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -456,6 +456,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1065,6 +1067,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1705,6 +1709,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -2282,6 +2288,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -456,6 +456,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1065,6 +1067,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -1705,6 +1709,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.
@@ -2282,6 +2288,8 @@ spec:
                                   - NotIn
                                   - Prefix
                                   - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
                                   type: string
                                 values:
                                   description: Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -90,7 +90,7 @@ type KProbeArg struct {
 }
 
 type BinarySelector struct {
-	// +kubebuilder:validation:Enum=In;NotIn;Prefix;NotPrefix
+	// +kubebuilder:validation:Enum=In;NotIn;Prefix;NotPrefix;Postfix;NotPostfix
 	// Filter operation.
 	Operator string `json:"operator"`
 	// Value to compare the argument against.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.2.3"
+const CustomResourceDefinitionSchemaVersion = "1.2.4"


### PR DESCRIPTION
Details can be found in #2679.

- [x] BPF selector part
- [x] Tetragon selector part 
- [x]  Postfix operator test for matchBinaries selector
- [x] Update docs

```release-note
Add the Postfix and NotPostfix operators to the matchBinaries selector.
```