### PR TITLE
pkg/sensors: reduce memory footprint of unused `override_tasks` maps

### DIFF
--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -34,7 +34,7 @@ struct {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 32768);
+	__uint(max_entries, 1); // will be resized by agent when needed
 	__type(key, __u64);
 	__type(value, __s32);
 } override_tasks SEC(".maps");

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -555,6 +555,8 @@ type hasMaps struct {
 	enforcer   bool
 }
 
+// hasMapsSetup setups the has maps for the per policy maps. The per kprobe maps
+// are setup later in createSingleKprobeSensor or createMultiKprobeSensor.
 func hasMapsSetup(spec *v1alpha1.TracingPolicySpec) hasMaps {
 	has := hasMaps{}
 	for _, kprobe := range spec.KProbes {

--- a/pkg/sensors/tracing/kprobe_maxentries_test.go
+++ b/pkg/sensors/tracing/kprobe_maxentries_test.go
@@ -78,6 +78,7 @@ func TestMaxEntries(t *testing.T) {
 			{"enforcer_data", 1},
 			{"stack_trace_map", 1},
 			{"ratelimit_map", 1},
+			{"override_tasks", 1},
 		}, `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -96,6 +97,7 @@ spec:
 			{"enforcer_data", 1},
 			{"stack_trace_map", 1},
 			{"ratelimit_map", 1},
+			{"override_tasks", 1},
 		}, `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -129,6 +131,7 @@ spec:
 			{"enforcer_data", 1},
 			{"stack_trace_map", stackTraceMapMaxEntries},
 			{"ratelimit_map", 1},
+			{"override_tasks", 1},
 		}, `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -152,6 +155,7 @@ spec:
 			{"enforcer_data", 1},
 			{"stack_trace_map", 1},
 			{"ratelimit_map", ratelimitMapMaxEntries},
+			{"override_tasks", 1},
 		}, `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -189,6 +193,7 @@ spec:
 			{"enforcer_data", enforcerMapMaxEntries},
 			{"stack_trace_map", 1},
 			{"ratelimit_map", 1},
+			{"override_tasks", 1},
 		}, `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -223,6 +228,41 @@ spec:
       - action: "NotifyEnforcer"
         argError: -1
         argSig: 9
+`)
+	})
+
+	t.Run("override_tasks", func(t *testing.T) {
+		if !bpf.HasOverrideHelper() {
+			t.Skip("skipping test, neither bpf_override_return nor fmod_ret for syscalls is available")
+		}
+
+		run(t, []testMap{
+			{"fdinstall_map", 1},
+			{"enforcer_data", 1},
+			{"stack_trace_map", 1},
+			{"ratelimit_map", 1},
+			{"override_tasks", overrideMapMaxEntries},
+		}, `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "override-example"
+spec:
+  kprobes:
+  - call: "sys_symlinkat"
+    syscall: true
+    args:
+    - index: 0
+      type: "string"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "/etc/passwd"
+      matchActions:
+      - action: Override
+        argError: -1
 `)
 	})
 }


### PR DESCRIPTION
Some of the plumbing was already present. We now pin the map correctly.

```release-note
Reduce the kernel memory footprint (accounted by the cgroup v2 memory controller) of the override feature when unused (around ~3MB per kprobe).
```
