### PR TITLE
[backport v1.0] pkg/sensors: reduce memory footprint of unused fdinstall maps

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1677,7 +1677,7 @@ struct fdinstall_value {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
-	__uint(max_entries, 32000);
+	__uint(max_entries, 1); // will be resized by agent when needed
 	__type(key, struct fdinstall_key);
 	__type(value, struct fdinstall_value);
 } fdinstall_map SEC(".maps");

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -655,6 +655,10 @@ func addKprobe(funcName string, f *v1alpha1.KProbeSpec, in *addKprobeIn, selMaps
 
 	loadProgName, loadProgRetName := kernels.GenericKprobeObjs()
 
+	if f == nil {
+		return nil, errors.New("error ading kprobe, the kprobe spec is nil")
+	}
+
 	config := &api.EventConfig{}
 	config.PolicyID = uint32(in.policyID)
 	if len(f.ReturnArgAction) > 0 {

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -400,6 +400,9 @@ func createGenericTracepointSensor(
 		progs = append(progs, prog0)
 
 		fdinstall := program.MapBuilderPin("fdinstall_map", sensors.PathJoin(pinPath, "fdinstall_map"), prog0)
+		if selectorsHaveFDInstall(tp.Spec.Selectors) {
+			fdinstall.SetMaxEntries(fdInstallMapMaxEntries)
+		}
 		maps = append(maps, fdinstall)
 
 		tailCalls := program.MapBuilderPin("tp_calls", sensors.PathJoin(pinPath, "tp_calls"), prog0)

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -319,6 +319,10 @@ func createGenericTracepoint(
 	policyName string,
 	customHandler eventhandler.Handler,
 ) (*genericTracepoint, error) {
+	if conf == nil {
+		return nil, errors.New("failed creating generic tracepoint, conf is nil")
+	}
+
 	tp := tracepoint.Tracepoint{
 		Subsys: conf.Subsystem,
 		Event:  conf.Event,


### PR DESCRIPTION
```release-note
Reduce the kernel memory footprint (accounted by the cgroup memory controller) of the fdinstall feature when unused (around ~11MB per kprobe).
```
