### PR TITLE
pkg/sensors/tracing: fix LSM open tests

### DIFF
--- a/pkg/sensors/tracing/enforcer_test.go
+++ b/pkg/sensors/tracing/enforcer_test.go
@@ -296,7 +296,7 @@ func testSecurity(t *testing.T, tracingPolicy, tempFile string) {
 	}
 }
 
-func enforcerSecurityTempFile(t *testing.T) string {
+func directWriteTempFile(t *testing.T) string {
 	// We can't use t.TempDir as it writes into /tmp by default.
 	// The direct-write-tester.c program opens and writes using the O_DIRECT
 	// flag that is unsupported and return EINVAL on tmpfs, while it works on a
@@ -341,7 +341,7 @@ func TestEnforcerSecuritySigKill(t *testing.T) {
 		t.Skip("Older kernels do not support matchArgs for more than one arguments")
 	}
 
-	tempFile := enforcerSecurityTempFile(t)
+	tempFile := directWriteTempFile(t)
 
 	tracingPolicy := `
 apiVersion: cilium.io/v1alpha1
@@ -428,7 +428,7 @@ func TestEnforcerSecurityNotifyEnforcer(t *testing.T) {
 		t.Skip("Older kernels do not support matchArgs for more than one arguments")
 	}
 
-	tempFile := enforcerSecurityTempFile(t)
+	tempFile := directWriteTempFile(t)
 
 	tracingPolicy := `
 apiVersion: cilium.io/v1alpha1

--- a/pkg/sensors/tracing/lsm_test.go
+++ b/pkg/sensors/tracing/lsm_test.go
@@ -111,7 +111,7 @@ func TestLSMOpenFile(t *testing.T) {
 	defer cancel()
 
 	testBin := testutils.RepoRootPath("contrib/tester-progs/direct-write-tester")
-	tempFile := t.TempDir() + "/test"
+	tempFile := directWriteTempFile(t)
 
 	configHook := `
 apiVersion: cilium.io/v1alpha1


### PR DESCRIPTION
Very similar to 1e9b9c7bb933d7a83e4bce663addc33ab3f58c4b.

It was merged just before that fix and was not yet rebased with the new base image so it escaped the test failure.

cc @anfedotoff 