### PR TITLE
backports:v1.1: clone ns fixes

### DIFF
--- a/bpf/process/bpf_fork.c
+++ b/bpf/process/bpf_fork.c
@@ -22,7 +22,6 @@ BPF_KPROBE(event_wake_up_new_task, struct task_struct *task)
 {
 	struct execve_map_value *curr, *parent;
 	struct msg_clone_event msg;
-	struct msg_capabilities caps;
 	u64 msg_size = sizeof(struct msg_clone_event);
 	u32 tgid = 0;
 
@@ -61,10 +60,12 @@ BPF_KPROBE(event_wake_up_new_task, struct task_struct *task)
 	 * before the execve hook point if they changed or not.
 	 * This needs to be converted later to credentials.
 	 */
-	get_current_subj_caps(&caps, task);
-	curr->caps.permitted = caps.permitted;
-	curr->caps.effective = caps.effective;
-	curr->caps.inheritable = caps.inheritable;
+	get_current_subj_caps(&curr->caps, task);
+
+	/* Store the thread leader namespaces so we can check later
+	 * before the execve hook point if they changed or not.
+	 */
+	get_namespaces(&curr->ns, task);
 
 	/* Setup the msg_clone_event and sent to the user. */
 	msg.common.op = MSG_OP_CLONE;

--- a/pkg/sensors/tracing/kprobe_threads_test.go
+++ b/pkg/sensors/tracing/kprobe_threads_test.go
@@ -19,6 +19,7 @@ import (
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/reader/caps"
+	"github.com/cilium/tetragon/pkg/reader/namespace"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
@@ -92,12 +93,14 @@ spec:
 	cti.AssertPidsTids(t)
 
 	myCaps := ec.NewCapabilitiesChecker().FromCapabilities(caps.GetCurrentCapabilities())
+	myNs := ec.NewNamespacesChecker().FromNamespaces(namespace.GetCurrentNamespace())
 
 	parentCheck := ec.NewProcessChecker().
 		WithBinary(sm.Suffix("threads-tester")).
 		WithPid(cti.ParentPid).
 		WithTid(cti.ParentTid).
-		WithCap(myCaps)
+		WithCap(myCaps).
+		WithNs(myNs)
 
 	execCheck := ec.NewProcessExecChecker("").
 		WithProcess(parentCheck)
@@ -109,7 +112,8 @@ spec:
 		WithBinary(sm.Suffix("threads-tester")).
 		WithPid(cti.Child1Pid).
 		WithTid(cti.Child1Tid).
-		WithCap(myCaps)
+		WithCap(myCaps).
+		WithNs(myNs)
 
 	child1KpChecker := ec.NewProcessKprobeChecker("").
 		WithProcess(child1Checker).WithParent(parentCheck)
@@ -118,7 +122,8 @@ spec:
 		WithBinary(sm.Suffix("threads-tester")).
 		WithPid(cti.Thread1Pid).
 		WithTid(cti.Thread1Tid).
-		WithCap(myCaps)
+		WithCap(myCaps).
+		WithNs(myNs)
 
 	thread1KpChecker := ec.NewProcessKprobeChecker("").
 		WithProcess(thread1Checker).WithParent(parentCheck)


### PR DESCRIPTION
```release-note
store thread leader namespaces at fork and reduce false positives
```
