### PR TITLE
backports:v1.0: clone ns fixes

### DIFF
--- a/bpf/process/bpf_fork.c
+++ b/bpf/process/bpf_fork.c
@@ -47,6 +47,17 @@ BPF_KPROBE(event_wake_up_new_task, struct task_struct *task)
 		curr->binary = parent->binary;
 		curr->pkey = parent->key;
 
+		/* Store the thread leader capabilities so we can check later
+		 * before the execve hook point if they changed or not.
+		 * This needs to be converted later to credentials.
+		 */
+		get_current_subj_caps(&curr->caps, task);
+
+		/* Store the thread leader namespaces so we can check later
+		 * before the execve hook point if they changed or not.
+		 */
+		get_namespaces(&curr->ns, task);
+
 		u64 size = sizeof(struct msg_clone_event);
 		struct msg_clone_event msg = {
 			.common.op = MSG_OP_CLONE,

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/option"
 	proc "github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/reader/caps"
 	"github.com/cilium/tetragon/pkg/reader/namespace"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/base"
@@ -257,9 +258,14 @@ func TestEventExecve(t *testing.T) {
 
 	testNop := testutils.RepoRootPath("contrib/tester-progs/nop")
 
+	myCaps := ec.NewCapabilitiesChecker().FromCapabilities(caps.GetCurrentCapabilities())
+	myNs := ec.NewNamespacesChecker().FromNamespaces(namespace.GetCurrentNamespace())
+
 	procChecker := ec.NewProcessChecker().
 		WithBinary(sm.Full(testNop)).
-		WithArguments(sm.Full("arg1 arg2 arg3"))
+		WithArguments(sm.Full("arg1 arg2 arg3")).
+		WithCap(myCaps).
+		WithNs(myNs)
 
 	execChecker := ec.NewProcessExecChecker("").WithProcess(procChecker)
 	checker := ec.NewUnorderedEventChecker(execChecker)
@@ -873,6 +879,9 @@ func TestExecProcessCredentials(t *testing.T) {
 
 	testNop := testutils.RepoRootPath("contrib/tester-progs/nop")
 
+	myCaps := ec.NewCapabilitiesChecker().FromCapabilities(caps.GetCurrentCapabilities())
+	myNs := ec.NewNamespacesChecker().FromNamespaces(namespace.GetCurrentNamespace())
+
 	if err := exec.Command(testNop).Run(); err != nil {
 		t.Fatalf("Failed to execute test binary: %s\n", err)
 	}
@@ -895,10 +904,14 @@ func TestExecProcessCredentials(t *testing.T) {
 		WithGid(0).WithEgid(gid).WithSgid(gid).WithFsgid(gid)
 
 	procExecChecker := ec.NewProcessChecker().
-		WithBinary(sm.Full(testNop)).WithProcessCredentials(creds).WithBinaryProperties(nil)
+		WithBinary(sm.Full(testNop)).WithProcessCredentials(creds).WithBinaryProperties(nil).
+		WithCap(myCaps).
+		WithNs(myNs)
 
 	procGidExecChecker := ec.NewProcessChecker().
-		WithBinary(sm.Full(testNop)).WithProcessCredentials(gidCreds).WithBinaryProperties(nil)
+		WithBinary(sm.Full(testNop)).WithProcessCredentials(gidCreds).WithBinaryProperties(nil).
+		WithCap(myCaps).
+		WithNs(myNs)
 
 	execChecker := ec.NewProcessExecChecker("exec").WithProcess(procExecChecker)
 	execGidChecker := ec.NewProcessExecChecker("exec").WithProcess(procGidExecChecker)

--- a/pkg/sensors/tracing/kprobe_threads_test.go
+++ b/pkg/sensors/tracing/kprobe_threads_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
+	"github.com/cilium/tetragon/pkg/reader/caps"
+	"github.com/cilium/tetragon/pkg/reader/namespace"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
@@ -90,10 +92,15 @@ spec:
 
 	cti.AssertPidsTids(t)
 
+	myCaps := ec.NewCapabilitiesChecker().FromCapabilities(caps.GetCurrentCapabilities())
+	myNs := ec.NewNamespacesChecker().FromNamespaces(namespace.GetCurrentNamespace())
+
 	parentCheck := ec.NewProcessChecker().
 		WithBinary(sm.Suffix("threads-tester")).
 		WithPid(cti.ParentPid).
-		WithTid(cti.ParentTid)
+		WithTid(cti.ParentTid).
+		WithCap(myCaps).
+		WithNs(myNs)
 
 	execCheck := ec.NewProcessExecChecker("").
 		WithProcess(parentCheck)
@@ -104,7 +111,9 @@ spec:
 	child1Checker := ec.NewProcessChecker().
 		WithBinary(sm.Suffix("threads-tester")).
 		WithPid(cti.Child1Pid).
-		WithTid(cti.Child1Tid)
+		WithTid(cti.Child1Tid).
+		WithCap(myCaps).
+		WithNs(myNs)
 
 	child1KpChecker := ec.NewProcessKprobeChecker("").
 		WithProcess(child1Checker).WithParent(parentCheck)
@@ -112,7 +121,9 @@ spec:
 	thread1Checker := ec.NewProcessChecker().
 		WithBinary(sm.Suffix("threads-tester")).
 		WithPid(cti.Thread1Pid).
-		WithTid(cti.Thread1Tid)
+		WithTid(cti.Thread1Tid).
+		WithCap(myCaps).
+		WithNs(myNs)
 
 	thread1KpChecker := ec.NewProcessKprobeChecker("").
 		WithProcess(thread1Checker).WithParent(parentCheck)


### PR DESCRIPTION
```release-note
store thread leader namespaces at fork and reduce false positives
```
