### PR TITLE
[backport v1.1] pkg/sensors: reduce memory footprint of unused `override_tasks` maps

### DIFF
--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -33,7 +33,7 @@ struct {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 32768);
+	__uint(max_entries, 1); // will be resized by agent when needed
 	__type(key, __u64);
 	__type(value, __s32);
 } override_tasks SEC(".maps");

--- a/pkg/sensors/tracing/kprobe_maxentries_test.go
+++ b/pkg/sensors/tracing/kprobe_maxentries_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/sensors"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
@@ -72,6 +73,7 @@ func TestMaxEntries(t *testing.T) {
 			{"fdinstall_map", 1},
 			{"stack_trace_map", 1},
 			{"ratelimit_map", 1},
+			{"override_tasks", 1},
 		}, `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -89,6 +91,7 @@ spec:
 			{"fdinstall_map", fdInstallMapMaxEntries},
 			{"stack_trace_map", 1},
 			{"ratelimit_map", 1},
+			{"override_tasks", 1},
 		}, `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -121,6 +124,7 @@ spec:
 			{"fdinstall_map", 1},
 			{"stack_trace_map", stackTraceMapMaxEntries},
 			{"ratelimit_map", 1},
+			{"override_tasks", 1},
 		}, `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -143,6 +147,7 @@ spec:
 			{"fdinstall_map", 1},
 			{"stack_trace_map", 1},
 			{"ratelimit_map", ratelimitMapMaxEntries},
+			{"override_tasks", 1},
 		}, `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -164,6 +169,40 @@ spec:
         matchActions:
         - action: Post
           rateLimit: "1m"
+`)
+	})
+
+	t.Run("override_tasks", func(t *testing.T) {
+		if !bpf.HasOverrideHelper() {
+			t.Skip("skipping test, neither bpf_override_return nor fmod_ret for syscalls is available")
+		}
+
+		run(t, []testMap{
+			{"fdinstall_map", 1},
+			{"stack_trace_map", 1},
+			{"ratelimit_map", 1},
+			{"override_tasks", overrideMapMaxEntries},
+		}, `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "override-example"
+spec:
+  kprobes:
+  - call: "sys_symlinkat"
+    syscall: true
+    args:
+    - index: 0
+      type: "string"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "/etc/passwd"
+      matchActions:
+      - action: Override
+        argError: -1
 `)
 	})
 }

--- a/pkg/sensors/tracing/kprobe_maxentries_test.go
+++ b/pkg/sensors/tracing/kprobe_maxentries_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
+	"github.com/cilium/tetragon/pkg/sensors"
+	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+	"github.com/stretchr/testify/assert"
+)
+
+type testMap struct {
+	name    string
+	entries int
+}
+
+func runConfig(t *testing.T, config string, fn func(string, int)) {
+	var err error
+
+	err = os.WriteFile(testConfigFile, []byte(config), 0644)
+	if err != nil {
+		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
+	}
+
+	sens, err := observertesthelper.GetDefaultSensorsWithFile(t, testConfigFile,
+		tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+
+	for _, sensor := range sens {
+		for _, load := range sensor.Progs {
+			c := load.LC
+			for _, p := range c.Programs {
+				for _, id := range p.MapIDs {
+					m, err := ebpf.NewMapFromID(id)
+					if err != nil {
+						t.Fatalf("can't open map id %d: %s\n", id, err)
+					}
+					info, err := m.Info()
+					if err != nil {
+						t.Fatalf("can't get map info: %s\n", err)
+					}
+					fn(info.Name, int(info.MaxEntries))
+				}
+			}
+		}
+	}
+
+	sensors.UnloadSensors(sens)
+}
+
+func run(t *testing.T, maps []testMap, config string) {
+	runConfig(t, config, func(name string, entries int) {
+		for _, m := range maps {
+			if name == m.name {
+				t.Logf("checking '%s' expected entries: %d\n", m.name, m.entries)
+				assert.Equal(t, m.entries, entries)
+			}
+		}
+	})
+}
+
+func TestMaxEntries(t *testing.T) {
+	t.Run("noresize", func(t *testing.T) {
+		run(t, []testMap{
+			{"fdinstall_map", 1},
+			{"stack_trace_map", 1},
+			{"ratelimit_map", 1},
+		}, `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "1"
+spec:
+  kprobes:
+  - call: "sys_read"
+    syscall: true
+`)
+	})
+
+	t.Run("fdinstall_map", func(t *testing.T) {
+		run(t, []testMap{
+			{"fdinstall_map", fdInstallMapMaxEntries},
+			{"stack_trace_map", 1},
+			{"ratelimit_map", 1},
+		}, `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "syswritefollowfdpsswd"
+spec:
+  kprobes:
+  - call: "fd_install"
+    syscall: false
+    args:
+    - index: 0
+      type: int
+    - index: 1
+      type: "file"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Equal"
+        values:
+        - "/tmp/test"
+      matchActions:
+      - action: FollowFD
+        argFd: 0
+        argName: 1
+`)
+	})
+
+	t.Run("stack_trace_map", func(t *testing.T) {
+		run(t, []testMap{
+			{"fdinstall_map", 1},
+			{"stack_trace_map", stackTraceMapMaxEntries},
+			{"ratelimit_map", 1},
+		}, `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "stack-traces-example"
+spec:
+  kprobes:
+    - call: fd_install
+      syscall: false
+      selectors:
+        - matchActions:
+          - action: Post
+            kernelStackTrace: true
+            userStackTrace: true
+`)
+	})
+
+	t.Run("ratelimit_map", func(t *testing.T) {
+		run(t, []testMap{
+			{"fdinstall_map", 1},
+			{"stack_trace_map", 1},
+			{"ratelimit_map", ratelimitMapMaxEntries},
+		}, `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "process-creds-changed"
+spec:
+  kprobes:
+  - call: "commit_creds"
+    syscall: false
+    args:
+    - index: 0  # The new credentials to apply
+      type: "cred"
+    selectors:
+      - matchNamespaces:
+        - namespace: Pid
+          operator: NotIn
+          values:
+          - "host_ns"
+        matchActions:
+        - action: Post
+          rateLimit: "1m"
+`)
+	})
+}


### PR DESCRIPTION
```release-note
Reduce the kernel memory footprint (accounted by the cgroup v2 memory controller) of the override feature when unused (around ~3MB per kprobe).
```
