### PR TITLE
tetra: LSM events compact print support

### DIFF
--- a/pkg/encoder/encoder.go
+++ b/pkg/encoder/encoder.go
@@ -491,6 +491,14 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 			event := p.Colorer.Blue.Sprintf("⁉️ %-7s", "tracepoint")
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s %s", event, processInfo, tp.Subsys, tp.Event), caps), nil
 		}
+	case *tetragon.GetEventsResponse_ProcessLsm:
+		lsm := response.GetProcessLsm()
+		if lsm.Process == nil {
+			return "", ErrMissingProcessInfo
+		}
+		processInfo, caps := p.Colorer.ProcessInfo(response.NodeName, lsm.Process)
+		event := p.Colorer.Blue.Sprintf("🔒 %-7s", "LSM")
+		return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, lsm.FunctionName), caps), nil
 	}
 
 	return "", ErrUnknownEventType


### PR DESCRIPTION
Adding LSM events compact printing like it is done for kprobes in default case.

It seems that I forgot about `tetra` compact  printing for LSM events.  Maybe we can change ❓ symbol to something else to distinguish LSM hooks and kprobes. 