### PR TITLE
tracing: allow only one of kprobes/tracepoints/lsm

### DIFF
--- a/pkg/sensors/tracing/policyhandler.go
+++ b/pkg/sensors/tracing/policyhandler.go
@@ -27,8 +27,19 @@ func (h policyHandler) PolicyHandler(
 
 	policyName := policy.TpName()
 	spec := policy.TpSpec()
-	if len(spec.KProbes) > 0 && len(spec.Tracepoints) > 0 {
-		return nil, errors.New("tracing policies with both kprobes and tracepoints are not currently supported")
+
+	sections := 0
+	if len(spec.KProbes) > 0 {
+		sections++
+	}
+	if len(spec.Tracepoints) > 0 {
+		sections++
+	}
+	if len(spec.LsmHooks) > 0 {
+		sections++
+	}
+	if sections > 1 {
+		return nil, errors.New("tracing policies with multiple sections of kprobes, tracepoints, or lsm hooks are currently not supported")
 	}
 
 	handler := eventhandler.GetCustomEventhandler(policy)


### PR DESCRIPTION
For historic reasons, the tracing sensor has three different aspects: kprobes, tracepoints, and (recently) lsm hooks.

Also for historic reasons, we did not allow tracepoints and kprobes in the same policy.

With the addition of the LSM sensor
(8eb13e8abf2caddae083f09979adf5cebdc32e11), if a policy includes an lsm section together with either a kprobe section or a tracepoint section, the lsm section will be ignored.

This patch rejects policies that have more than one section of kprobes, tracepoints, and lsm hooks in the policy.

A better solution would be to decouple the tracing sensor, and create one sensor for kprobes, one for tracepoints, and one for lsm sensors. See: https://github.com/cilium/tetragon/issues/2706

CC: @anfedotoff 
