### PR TITLE
Prevent search engines from indexing deploy preview URLs and force redirect already indexed URLs to the homepage.

### DIFF
--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /deploy-preview-*

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,3 +23,11 @@ ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
 
 [build.environment]
 HUGO_VERSION = "0.126.2"
+
+
+[[redirects]]
+from = "/deploy-preview-*" 
+to = "https://tetragon.io/"
+status = 301
+force = true
+


### PR DESCRIPTION

See Slack conversation reference from Scott Lowe 

This patch prevents the deploy previews from being indexed in search engines and force-redirects existing indexed deploy preview pages to the main Tetragon site.

1. updates the netlify config to include redirect rule

2. create a robots.txt file the prevents indexing deploy preview pages

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->


### Description
Prevent search engines from indexing deploy preview URLs and force redirect already indexed URLs to the homepage.

