### PR TITLE
docs: add noindex, nofollow with X-Robots-Tag on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,3 +23,9 @@ ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
 
 [build.environment]
 HUGO_VERSION = "0.126.2"
+
+[[header]]
+for = "/"
+[headers.values]
+X-Robots-Tag = "none"
+


### PR DESCRIPTION
Apparently, search engines started referencing content from deploy preview and the Netlify deploy. Since we use GitHub pages to deploy at the moment, let's ask robots to not index nor follow when building with Netlify.

