### PR TITLE
docs: use different config for development and production 

### DIFF
--- a/docs/config/_default/hugo.toml
+++ b/docs/config/_default/hugo.toml
@@ -9,8 +9,6 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-enableRobotsTXT = true
-
 # Will give values to .Lastmod etc.
 enableGitInfo = true
 

--- a/docs/config/production/hugo.toml
+++ b/docs/config/production/hugo.toml
@@ -1,0 +1,1 @@
+enableRobotsTXT = true

--- a/docs/layouts/partials/hooks/head-end.html
+++ b/docs/layouts/partials/hooks/head-end.html
@@ -1,6 +1,11 @@
+{{/* There are two protections to avoid to ship analytics in development env,
+analytics HTML scripts are included only on production build and we use
+goatcounter.no_onload if the URL is not tetragon.io */}}
+{{ if hugo.IsProduction }}
 <script>
     if (window.location.host !== 'tetragon.io')
         window.goatcounter = {no_onload: true}
 </script>
 <script data-goatcounter="https://tetragon.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,3 +23,14 @@ ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
 
 [build.environment]
 HUGO_VERSION = "0.126.2"
+
+# Hugo has "enableRobotsTXT" to false on the development environment. Here
+# making sure that even the "main" deployment on Netlify (so far available at
+# "https://tetragon.netlify.app/"), includes noindex, nofollow. Only the
+# deployment on GitHub pages should build with the production environment and
+# enable robots.txt.
+[[header]]
+for = "/"
+[headers.values]
+X-Robots-Tag = "noindex, nofollow"
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 [build]
 base = "/docs"
 publish = "public"
-command = "npm ci && hugo"
+command = "npm ci && hugo --environment development"
 # The ignore command is used by Netlify deploy bot to filter if the PR should
 # be previewed or not, and generally if the website should be built or not.
 #


### PR DESCRIPTION
Prevent development deployments of the documentation (preview on Netlify) to appear in search engines.