### PR TITLE
Define health metrics group

### DIFF
--- a/cmd/tetragon-metrics-docs/main.go
+++ b/cmd/tetragon-metrics-docs/main.go
@@ -27,7 +27,7 @@ func main() {
 func initMetrics(target string, reg *prometheus.Registry, _ *slog.Logger) error {
 	switch target {
 	case "health":
-		metricsconfig.InitHealthMetricsForDocs(reg)
+		metricsconfig.EnableHealthMetrics(reg).InitForDocs()
 	case "resources":
 		metricsconfig.InitResourcesMetricsForDocs(reg)
 	case "events":

--- a/pkg/exporter/metrics.go
+++ b/pkg/exporter/metrics.go
@@ -6,6 +6,7 @@ package exporter
 import (
 	"io"
 
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -30,10 +31,10 @@ var (
 	})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(eventsExportedTotal)
-	registry.MustRegister(eventsExportedBytesTotal)
-	registry.MustRegister(eventsExportTimestamp)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(eventsExportedTotal)
+	group.MustRegister(eventsExportedBytesTotal)
+	group.MustRegister(eventsExportTimestamp)
 }
 
 func newExportedBytesCounterWriter(w io.Writer, c prometheus.Counter) io.Writer {

--- a/pkg/grpc/tracing/stats.go
+++ b/pkg/grpc/tracing/stats.go
@@ -4,6 +4,7 @@
 package tracing
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -17,16 +18,15 @@ var (
 	}, []string{"count"})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(LoaderStats)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(LoaderStats)
+}
 
+func InitMetrics() {
 	// Initialize metrics with labels
 	for _, ty := range LoaderTypeStrings {
 		LoaderStats.WithLabelValues(ty).Add(0)
 	}
-
-	// NOTES:
-	// * Rename process_loader_stats metric (to e.g. process_loader_events_total) and count label (to e.g. event)?
 }
 
 type LoaderType int

--- a/pkg/metrics/cgroupratemetrics/cgroupratemetrics.go
+++ b/pkg/metrics/cgroupratemetrics/cgroupratemetrics.go
@@ -4,6 +4,7 @@
 package cgroupratemetrics
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -41,8 +42,8 @@ var (
 	}, []string{"type"})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(CgroupRateTotal)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(CgroupRateTotal)
 }
 
 // Get a new handle on an ErrorTotal metric for an ErrorType

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/tetragon/pkg/api/ops"
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -84,10 +85,12 @@ var (
 	}, []string{"opcode", "error_type"})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(ErrorTotal)
-	registry.MustRegister(HandlerErrors)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(ErrorTotal)
+	group.MustRegister(HandlerErrors)
+}
 
+func InitMetrics() {
 	// Initialize metrics with labels
 	for er := range errorTypeLabelValues {
 		GetErrorTotal(er).Add(0)
@@ -100,13 +103,6 @@ func InitMetrics(registry *prometheus.Registry) {
 	// NB: We initialize only ops.MsgOpUndef here, but unknown_opcode can occur for any opcode
 	// that is not explicitly handled.
 	GetHandlerErrors(ops.MsgOpUndef, HandlePerfUnknownOp).Add(0)
-
-	// NOTES:
-	// * op, msg_op, opcode - standardize on a label (+ add human-readable label)
-	// * error, error_type, type - standardize on a label
-	// * Delete errors_total{type="handler_error"} - it duplicates handler_errors_total
-	// * Consider further splitting errors_total
-	// * Rename handler_errors_total to event_handler_errors_total?
 }
 
 // Get a new handle on an ErrorTotal metric for an ErrorType

--- a/pkg/metrics/eventcachemetrics/eventcachemetrics.go
+++ b/pkg/metrics/eventcachemetrics/eventcachemetrics.go
@@ -5,6 +5,7 @@ package eventcachemetrics
 
 import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -79,14 +80,16 @@ var (
 	}, []string{"event_type"})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(processInfoErrors)
-	registry.MustRegister(podInfoErrors)
-	registry.MustRegister(EventCacheCount)
-	registry.MustRegister(eventCacheErrorsTotal)
-	registry.MustRegister(eventCacheRetriesTotal)
-	registry.MustRegister(parentInfoErrors)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(processInfoErrors)
+	group.MustRegister(podInfoErrors)
+	group.MustRegister(EventCacheCount)
+	group.MustRegister(eventCacheErrorsTotal)
+	group.MustRegister(eventCacheRetriesTotal)
+	group.MustRegister(parentInfoErrors)
+}
 
+func InitMetrics() {
 	// Initialize metrics with labels
 	for en := range cacheEntryTypeLabelValues {
 		EventCacheRetries(en).Add(0)
@@ -101,11 +104,6 @@ func InitMetrics(registry *prometheus.Registry) {
 			}
 		}
 	}
-
-	// NOTES:
-	// * error, error_type, type - standardize on a label
-	// * event, event_type, type - standardize on a label
-	// * Consider merging event cache errors metrics into one with error, event, entry labels
 }
 
 // Get a new handle on a processInfoErrors metric for an eventType

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -53,19 +53,17 @@ var (
 	}, []string{"policy", "hook"})
 )
 
-func InitHealthMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(FlagCount)
-	registry.MustRegister(NotifyOverflowedEvents)
-	// custom collectors are registered independently
+func RegisterHealthMetrics(group metrics.Group) {
+	group.MustRegister(FlagCount)
+	group.MustRegister(NotifyOverflowedEvents)
+	group.MustRegister(NewBPFCollector())
+}
 
+func InitHealthMetrics() {
 	// Initialize metrics with labels
 	for _, v := range exec.FlagStrings {
 		FlagCount.WithLabelValues(v).Add(0)
 	}
-
-	// NOTES:
-	// * op, msg_op, opcode - standardize on a label (+ add human-readable label)
-	// * event, event_type, type - standardize on a label
 }
 
 func InitEventsMetrics(registry *prometheus.Registry) {

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -27,10 +27,10 @@ var (
 		Help:        "The total number of Tetragon events",
 		ConstLabels: nil,
 	}, []string{"type"})
-	MissedEvents = metrics.NewBPFCounter(prometheus.NewDesc(
-		prometheus.BuildFQName(consts.MetricsNamespace, "", "missed_events_total"),
+	MissedEvents = metrics.MustNewCustomCounter(metrics.NewOpts(
+		consts.MetricsNamespace, "", "missed_events_total",
 		"The total number of Tetragon events per type that are failed to sent from the kernel.",
-		[]string{"msg_op"}, nil,
+		nil, []metrics.ConstrainedLabel{metrics.OpCodeLabel}, nil,
 	))
 	FlagCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,

--- a/pkg/metrics/kprobemetrics/kprobemetrics.go
+++ b/pkg/metrics/kprobemetrics/kprobemetrics.go
@@ -4,6 +4,7 @@
 package kprobemetrics
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -45,18 +46,13 @@ var (
 	})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(MergeErrors)
-	registry.MustRegister(MergeOkTotal)
-	registry.MustRegister(MergePushed)
-
-	// NOTES:
-	// * Consider merging ok and errors into one with status label
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(MergeErrors)
+	group.MustRegister(MergeOkTotal)
+	group.MustRegister(MergePushed)
 }
 
-func InitMetricsForDocs(registry *prometheus.Registry) {
-	InitMetrics(registry)
-
+func InitMetricsForDocs() {
 	// Initialize metrics with example labels
 	for _, curr := range mergeErrorTypeLabelValues {
 		for _, prev := range mergeErrorTypeLabelValues {

--- a/pkg/metrics/labels.go
+++ b/pkg/metrics/labels.go
@@ -3,7 +3,12 @@
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"fmt"
+
+	"github.com/cilium/tetragon/pkg/api/ops"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // ConstrainedLabel represents a label with constrained cardinality.
 // Values is a list of all possible values of the label.
@@ -37,4 +42,24 @@ func promContainsLabel(labels prometheus.ConstrainedLabels, label string) bool {
 		}
 	}
 	return false
+}
+
+// TODO: Standardize labels used by different metrics: op, msg_op, opcode.
+// Also, add a human-readable counterpart.
+var OpCodeLabel = ConstrainedLabel{
+	Name: "msg_op",
+	// These are numbers, not human-readable names.
+	Values: getOpcodes(),
+}
+
+func getOpcodes() []string {
+	result := make([]string, len(ops.OpCodeStrings)-2)
+	i := 0
+	for opcode := range ops.OpCodeStrings {
+		if opcode != ops.MsgOpUndef && opcode != ops.MsgOpTest {
+			result[i] = fmt.Sprint(int32(opcode))
+			i++
+		}
+	}
+	return result
 }

--- a/pkg/metrics/mapmetrics/mapmetrics.go
+++ b/pkg/metrics/mapmetrics/mapmetrics.go
@@ -6,27 +6,29 @@ package mapmetrics
 import (
 	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
-	"github.com/prometheus/client_golang/prometheus"
 )
+
+var MapLabel = metrics.ConstrainedLabel{
+	Name: "map",
+	// These are maps which usage we monitor, not maps from which we read
+	// metrics. Metrics are read from separate maps suffixed with "_stats".
+	Values: []string{"execve_map", "tg_execve_joined_info_map"},
+}
 
 var (
-	MapSize = metrics.NewBPFGauge(prometheus.NewDesc(
-		prometheus.BuildFQName(consts.MetricsNamespace, "", "map_entries"),
+	MapSize = metrics.MustNewCustomGauge(metrics.NewOpts(
+		consts.MetricsNamespace, "", "map_entries",
 		"The total number of in-use entries per map.",
-		[]string{"map"}, nil,
+		nil, []metrics.ConstrainedLabel{MapLabel}, nil,
 	))
-	MapCapacity = metrics.NewBPFGauge(prometheus.NewDesc(
-		prometheus.BuildFQName(consts.MetricsNamespace, "", "map_capacity"),
+	MapCapacity = metrics.MustNewCustomGauge(metrics.NewOpts(
+		consts.MetricsNamespace, "", "map_capacity",
 		"Capacity of a BPF map. Expected to be constant.",
-		[]string{"map"}, nil,
+		nil, []metrics.ConstrainedLabel{MapLabel}, nil,
 	))
-	MapErrors = metrics.NewBPFCounter(prometheus.NewDesc(
-		prometheus.BuildFQName(consts.MetricsNamespace, "", "map_errors_total"),
+	MapErrors = metrics.MustNewCustomGauge(metrics.NewOpts(
+		consts.MetricsNamespace, "", "map_errors_total",
 		"The number of errors per map.",
-		[]string{"map"}, nil,
+		nil, []metrics.ConstrainedLabel{MapLabel}, nil,
 	))
 )
-
-func InitMetrics(_ *prometheus.Registry) {
-	// custom collectors are registered independently
-}

--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/tetragon/pkg/api/ops"
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -28,10 +29,12 @@ var (
 	}, []string{"op"})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(MsgOpsCount)
-	registry.MustRegister(LatencyStats)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(MsgOpsCount)
+	group.MustRegister(LatencyStats)
+}
 
+func InitMetrics() {
 	// Initialize all metrics
 	for opcode := range ops.OpCodeStrings {
 		if opcode != ops.MsgOpUndef && opcode != ops.MsgOpTest {
@@ -39,10 +42,6 @@ func InitMetrics(registry *prometheus.Registry) {
 			LatencyStats.WithLabelValues(fmt.Sprint(int32(opcode)))
 		}
 	}
-
-	// NOTES:
-	// * op, msg_op, opcode - standardize on a label (+ add human-readable label)
-	// * Rename handling_latency to handler_latency_microseconds?
 }
 
 // Get a new handle on a msgOpsCount metric for an OpCode

--- a/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
+++ b/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
@@ -4,6 +4,7 @@
 package policyfiltermetrics
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -80,9 +81,11 @@ var (
 	})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(PolicyFilterOpMetrics, PolicyFilterHookContainerNameMissingMetrics)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(PolicyFilterOpMetrics, PolicyFilterHookContainerNameMissingMetrics)
+}
 
+func InitMetrics() {
 	// Initialize metrics with labels
 	for _, subsys := range subsysLabelValues {
 		for _, op := range operationLabelValues {
@@ -93,10 +96,6 @@ func InitMetrics(registry *prometheus.Registry) {
 			}
 		}
 	}
-
-	// NOTES:
-	// * Don't confuse op in policyfilter_metrics_total with ops.OpCode
-	// * Rename policyfilter_metrics_total to get rid of _metrics?
 }
 
 func OpInc(subsys Subsys, op Operation, err string) {

--- a/pkg/metrics/policystatemetrics/policystatemetrics.go
+++ b/pkg/metrics/policystatemetrics/policystatemetrics.go
@@ -10,41 +10,41 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type policyStateCollector struct {
-	descriptor *prometheus.Desc
+var stateLabel = metrics.ConstrainedLabel{
+	Name: "state",
+	Values: []string{
+		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_LOAD_ERROR.String()), "tp_state_"),
+		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_ERROR.String()), "tp_state_"),
+		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_DISABLED.String()), "tp_state_"),
+		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_ENABLED.String()), "tp_state_"),
+	},
 }
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(newPolicyStateCollector())
-}
-
-func InitMetricsForDocs(registry *prometheus.Registry) {
-	registry.MustRegister(newPolicyStateZeroCollector())
-}
+var policyState = metrics.MustNewCustomGauge(metrics.NewOpts(
+	consts.MetricsNamespace, "", "tracingpolicy_loaded",
+	"The number of loaded tracing policy by state.",
+	nil, []metrics.ConstrainedLabel{stateLabel}, nil,
+))
 
 // This metric collector converts the output of ListTracingPolicies into a few
 // gauges metrics on collection. Thus, it needs a sensor manager to query.
-func newPolicyStateCollector() *policyStateCollector {
-	return &policyStateCollector{
-		descriptor: prometheus.NewDesc(
-			prometheus.BuildFQName(consts.MetricsNamespace, "", "tracingpolicy_loaded"),
-			"The number of loaded tracing policy by state.",
-			[]string{"state"}, nil,
-		),
-	}
+func NewPolicyStateCollector() metrics.CollectorWithInit {
+	return metrics.NewCustomCollector(
+		metrics.CustomMetrics{
+			policyState,
+		},
+		collect,
+		collectForDocs,
+	)
 }
 
-func (c *policyStateCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.descriptor
-}
-
-func (c *policyStateCollector) Collect(ch chan<- prometheus.Metric) {
-
+func collect(ch chan<- prometheus.Metric) {
 	sm := observer.GetSensorManager()
 	if sm == nil {
 		logger.GetLogger().Debug("failed retrieving the sensor manager: manager is nil")
@@ -65,72 +65,26 @@ func (c *policyStateCollector) Collect(ch chan<- prometheus.Metric) {
 		counters[state]++
 	}
 
-	ch <- prometheus.MustNewConstMetric(
-		c.descriptor,
-		prometheus.GaugeValue,
+	ch <- policyState.MustMetric(
 		float64(counters[tetragon.TracingPolicyState_TP_STATE_LOAD_ERROR]),
 		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_LOAD_ERROR.String()), "tp_state_"),
 	)
-	ch <- prometheus.MustNewConstMetric(
-		c.descriptor,
-		prometheus.GaugeValue,
+	ch <- policyState.MustMetric(
 		float64(counters[tetragon.TracingPolicyState_TP_STATE_ERROR]),
 		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_ERROR.String()), "tp_state_"),
 	)
-	ch <- prometheus.MustNewConstMetric(
-		c.descriptor,
-		prometheus.GaugeValue,
+	ch <- policyState.MustMetric(
 		float64(counters[tetragon.TracingPolicyState_TP_STATE_DISABLED]),
 		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_DISABLED.String()), "tp_state_"),
 	)
-	ch <- prometheus.MustNewConstMetric(
-		c.descriptor,
-		prometheus.GaugeValue,
+	ch <- policyState.MustMetric(
 		float64(counters[tetragon.TracingPolicyState_TP_STATE_ENABLED]),
 		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_ENABLED.String()), "tp_state_"),
 	)
 }
 
-// policyStateZeroCollector implements prometheus.Collector. It collects "zero"
-// metrics. It's intended to be used when the sensor manager doesn't exist, but
-// we still want Prometheus metrics to be exposed.
-type policyStateZeroCollector struct {
-	policyStateCollector
-}
-
-func newPolicyStateZeroCollector() prometheus.Collector {
-	return &policyStateZeroCollector{
-		policyStateCollector: *newPolicyStateCollector(),
+func collectForDocs(ch chan<- prometheus.Metric) {
+	for _, state := range stateLabel.Values {
+		ch <- policyState.MustMetric(0, state)
 	}
-}
-
-func (c *policyStateZeroCollector) Describe(ch chan<- *prometheus.Desc) {
-	c.policyStateCollector.Describe(ch)
-}
-
-func (c *policyStateZeroCollector) Collect(ch chan<- prometheus.Metric) {
-	ch <- prometheus.MustNewConstMetric(
-		c.descriptor,
-		prometheus.GaugeValue,
-		0,
-		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_LOAD_ERROR.String()), "tp_state_"),
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.descriptor,
-		prometheus.GaugeValue,
-		0,
-		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_ERROR.String()), "tp_state_"),
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.descriptor,
-		prometheus.GaugeValue,
-		0,
-		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_DISABLED.String()), "tp_state_"),
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.descriptor,
-		prometheus.GaugeValue,
-		0,
-		strings.TrimPrefix(strings.ToLower(tetragon.TracingPolicyState_TP_STATE_ENABLED.String()), "tp_state_"),
-	)
 }

--- a/pkg/metrics/policystatemetrics/policystatemetrics_test.go
+++ b/pkg/metrics/policystatemetrics/policystatemetrics_test.go
@@ -40,7 +40,7 @@ tetragon_tracingpolicy_loaded{state="load_error"} %d
 	observer.SetSensorManager(manager)
 	t.Cleanup(observer.ResetSensorManager)
 
-	collector := newPolicyStateCollector()
+	collector := NewPolicyStateCollector()
 	reg.Register(collector)
 
 	err := manager.AddTracingPolicy(context.TODO(), &tracingpolicy.GenericTracingPolicy{

--- a/pkg/metrics/ratelimitmetrics/ratelimitmetrics.go
+++ b/pkg/metrics/ratelimitmetrics/ratelimitmetrics.go
@@ -4,6 +4,7 @@
 package ratelimitmetrics
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -17,6 +18,6 @@ var (
 	})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(RateLimitDropped)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(RateLimitDropped)
 }

--- a/pkg/metrics/ringbufmetrics/ringbufmetrics.go
+++ b/pkg/metrics/ringbufmetrics/ringbufmetrics.go
@@ -4,6 +4,7 @@
 package ringbufmetrics
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -29,8 +30,8 @@ var (
 	})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(PerfEventReceived)
-	registry.MustRegister(PerfEventLost)
-	registry.MustRegister(PerfEventErrors)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(PerfEventReceived)
+	group.MustRegister(PerfEventLost)
+	group.MustRegister(PerfEventErrors)
 }

--- a/pkg/metrics/ringbufqueuemetrics/ringbufqueuemetrics.go
+++ b/pkg/metrics/ringbufqueuemetrics/ringbufqueuemetrics.go
@@ -4,6 +4,7 @@
 package ringbufqueuemetrics
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -23,7 +24,7 @@ var (
 	})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(Received)
-	registry.MustRegister(Lost)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(Received)
+	group.MustRegister(Lost)
 }

--- a/pkg/metrics/watchermetrics/watchermetrics.go
+++ b/pkg/metrics/watchermetrics/watchermetrics.go
@@ -4,6 +4,7 @@
 package watchermetrics
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -45,16 +46,15 @@ var (
 	}, []string{"watcher"})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(WatcherErrors)
-	registry.MustRegister(WatcherEvents)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(WatcherErrors)
+	group.MustRegister(WatcherEvents)
+}
 
+func InitMetrics() {
 	// Initialize metrics with labels
 	GetWatcherEvents(K8sWatcher).Add(0)
 	GetWatcherErrors(K8sWatcher, FailedToGetPodError).Add(0)
-
-	// NOTES:
-	// * error, error_type, type - standardize on a label
 }
 
 // Get a new handle on an WatcherEvents metric for a watcher type

--- a/pkg/metricsconfig/healthmetrics.go
+++ b/pkg/metricsconfig/healthmetrics.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metricsconfig
+
+import (
+	"sync"
+
+	"github.com/cilium/tetragon/pkg/eventcache"
+	"github.com/cilium/tetragon/pkg/exporter"
+	"github.com/cilium/tetragon/pkg/grpc/tracing"
+	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/cgroupratemetrics"
+	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
+	"github.com/cilium/tetragon/pkg/metrics/eventcachemetrics"
+	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/kprobemetrics"
+	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
+	"github.com/cilium/tetragon/pkg/metrics/policyfiltermetrics"
+	"github.com/cilium/tetragon/pkg/metrics/policystatemetrics"
+	"github.com/cilium/tetragon/pkg/metrics/ratelimitmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
+	"github.com/cilium/tetragon/pkg/metrics/ringbufqueuemetrics"
+	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/version"
+	grpcmetrics "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	healthMetrics     metrics.Group
+	healthMetricsOnce sync.Once
+)
+
+func GetHealthGroup() metrics.Group {
+	healthMetricsOnce.Do(func() {
+		healthMetrics = metrics.NewMetricsGroup(true)
+	})
+	return healthMetrics
+}
+
+func EnableHealthMetrics(registry *prometheus.Registry) metrics.Group {
+	healthMetrics := GetHealthGroup()
+	registerHealthMetrics(healthMetrics)
+	registry.MustRegister(healthMetrics)
+	return healthMetrics
+}
+
+// NOTE: Health metrics group is marked as constrained. However, the
+// constraints are only enforced for metrics implementing CollectorWithInit,
+// and custom collectors are responsible for enforcing it on their own. So the
+// group's cardinality isn't really constrained until all metrics are migrated
+// to the new interface.
+func registerHealthMetrics(group metrics.Group) {
+	// build info metrics
+	group.MustRegister(version.NewBuildInfoCollector())
+	// error metrics
+	errormetrics.RegisterMetrics(group)
+	group.ExtendInit(errormetrics.InitMetrics)
+	// event cache metrics
+	eventcachemetrics.RegisterMetrics(group)
+	group.MustRegister(eventcache.NewCacheCollector())
+	group.ExtendInit(eventcachemetrics.InitMetrics)
+	// event metrics
+	eventmetrics.RegisterHealthMetrics(group)
+	group.ExtendInit(eventmetrics.InitHealthMetrics)
+	// map metrics
+	group.MustRegister(observer.NewBPFCollector())
+	// opcode metrics
+	opcodemetrics.RegisterMetrics(group)
+	group.ExtendInit(opcodemetrics.InitMetrics)
+	// policy filter metrics
+	policyfiltermetrics.RegisterMetrics(group)
+	group.ExtendInit(policyfiltermetrics.InitMetrics)
+	// process metrics
+	process.RegisterMetrics(group)
+	// ringbuf metrics
+	ringbufmetrics.RegisterMetrics(group)
+	// ringbuf queue metrics
+	ringbufqueuemetrics.RegisterMetrics(group)
+	// watcher metrics
+	watchermetrics.RegisterMetrics(group)
+	group.ExtendInit(watchermetrics.InitMetrics)
+	// observer metrics
+	observer.RegisterMetrics(group)
+	group.ExtendInit(observer.InitMetrics)
+	// tracing metrics
+	tracing.RegisterMetrics(group)
+	group.ExtendInit(tracing.InitMetrics)
+	// rate limit metrics
+	ratelimitmetrics.RegisterMetrics(group)
+	// exporter metrics
+	exporter.RegisterMetrics(group)
+	// cgrup rate metrics
+	cgroupratemetrics.RegisterMetrics(group)
+	// kprobe metrics
+	kprobemetrics.RegisterMetrics(group)
+	group.ExtendInitForDocs(kprobemetrics.InitMetricsForDocs)
+	// policy state metrics
+	group.MustRegister(policystatemetrics.NewPolicyStateCollector())
+	// gRPC metrics
+	group.MustRegister(grpcmetrics.NewServerMetrics())
+}

--- a/pkg/metricsconfig/initmetrics.go
+++ b/pkg/metricsconfig/initmetrics.go
@@ -4,75 +4,11 @@
 package metricsconfig
 
 import (
-	"github.com/cilium/tetragon/pkg/eventcache"
-	"github.com/cilium/tetragon/pkg/exporter"
-	"github.com/cilium/tetragon/pkg/grpc/tracing"
-	"github.com/cilium/tetragon/pkg/metrics/cgroupratemetrics"
-	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
-	"github.com/cilium/tetragon/pkg/metrics/eventcachemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
-	"github.com/cilium/tetragon/pkg/metrics/kprobemetrics"
-	"github.com/cilium/tetragon/pkg/metrics/mapmetrics"
-	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
-	"github.com/cilium/tetragon/pkg/metrics/policyfiltermetrics"
-	"github.com/cilium/tetragon/pkg/metrics/policystatemetrics"
-	"github.com/cilium/tetragon/pkg/metrics/ratelimitmetrics"
-	"github.com/cilium/tetragon/pkg/metrics/ringbufmetrics"
-	"github.com/cilium/tetragon/pkg/metrics/ringbufqueuemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/syscallmetrics"
-	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
-	"github.com/cilium/tetragon/pkg/observer"
-	"github.com/cilium/tetragon/pkg/process"
-	"github.com/cilium/tetragon/pkg/version"
-	grpcmetrics "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 )
-
-func initHealthMetrics(registry *prometheus.Registry) {
-	version.InitMetrics(registry)
-	errormetrics.InitMetrics(registry)
-	eventcachemetrics.InitMetrics(registry)
-	registry.MustRegister(eventcache.NewCacheCollector())
-	eventmetrics.InitHealthMetrics(registry)
-	mapmetrics.InitMetrics(registry)
-	opcodemetrics.InitMetrics(registry)
-	policyfiltermetrics.InitMetrics(registry)
-	process.InitMetrics(registry)
-	ringbufmetrics.InitMetrics(registry)
-	ringbufqueuemetrics.InitMetrics(registry)
-	watchermetrics.InitMetrics(registry)
-	observer.InitMetrics(registry)
-	tracing.InitMetrics(registry)
-	ratelimitmetrics.InitMetrics(registry)
-	exporter.InitMetrics(registry)
-	cgroupratemetrics.InitMetrics(registry)
-
-	// register common third-party collectors
-	registry.MustRegister(grpcmetrics.NewServerMetrics())
-}
-
-func initAllHealthMetrics(registry *prometheus.Registry) {
-	initHealthMetrics(registry)
-
-	kprobemetrics.InitMetrics(registry)
-	policystatemetrics.InitMetrics(registry)
-
-	// register custom collectors
-	registry.MustRegister(observer.NewBPFCollector())
-	registry.MustRegister(eventmetrics.NewBPFCollector())
-}
-
-func InitHealthMetricsForDocs(registry *prometheus.Registry) {
-	initHealthMetrics(registry)
-
-	kprobemetrics.InitMetricsForDocs(registry)
-	policystatemetrics.InitMetricsForDocs(registry)
-
-	// register custom zero collectors
-	registry.MustRegister(observer.NewBPFZeroCollector())
-	registry.MustRegister(eventmetrics.NewBPFZeroCollector())
-}
 
 func initResourcesMetrics(registry *prometheus.Registry) {
 	// register common third-party collectors
@@ -99,7 +35,8 @@ func InitEventsMetricsForDocs(registry *prometheus.Registry) {
 }
 
 func InitAllMetrics(registry *prometheus.Registry) {
-	initAllHealthMetrics(registry)
+	healthMetrics := EnableHealthMetrics(registry)
+	healthMetrics.Init()
 	initAllResourcesMetrics(registry)
 	initAllEventsMetrics(registry)
 }

--- a/pkg/observer/data_stats.go
+++ b/pkg/observer/data_stats.go
@@ -4,6 +4,7 @@
 package observer
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -42,20 +43,18 @@ var (
 	}, []string{"op"})
 )
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(DataEventStats)
-	registry.MustRegister(DataEventSizeHist)
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(DataEventStats)
+	group.MustRegister(DataEventSizeHist)
+}
 
+func InitMetrics() {
 	// Initialize metrics with labels
 	for _, ev := range DataEventTypeStrings {
 		DataEventStats.WithLabelValues(ev).Add(0)
 	}
 	DataEventSizeHist.WithLabelValues(DataEventOpOk.String())
 	DataEventSizeHist.WithLabelValues(DataEventOpBad.String())
-
-	// NOTES:
-	// * Don't confuse op in data_event_size with ops.OpCode
-	// * Don't confuse event in data_events_total with tetragon.EventType
 }
 
 type DataEventType int

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -4,6 +4,7 @@
 package process
 
 import (
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -45,7 +46,7 @@ func NewCacheCollector() prometheus.Collector {
 	}
 }
 
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(ProcessCacheTotal)
-	registry.MustRegister(NewCacheCollector())
+func RegisterMetrics(group metrics.Group) {
+	group.MustRegister(ProcessCacheTotal)
+	group.MustRegister(NewCacheCollector())
 }

--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -31,7 +31,7 @@ func (b *buildInfoCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- b.self
 }
 
-func newBuildInfoCollector() prometheus.Collector {
+func NewBuildInfoCollector() prometheus.Collector {
 	buildInfo := ReadBuildInfo()
 	c := &buildInfoCollector{
 		prometheus.MustNewConstMetric(
@@ -51,8 +51,4 @@ func newBuildInfoCollector() prometheus.Collector {
 	}
 	c.init(c.self)
 	return c
-}
-
-func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(newBuildInfoCollector())
 }


### PR DESCRIPTION
There are two things happening here:

1. Refactored custom collectors to use new helpers from pkg/metrics (commits 1-3). The main win here is simplifying how custom metrics are included in reference docs - we don't need to define a separate type and register it separately just for generating docs.
2. Defined a health metrics group (last commit). The idea is that in the future this group will have constrained cardinality and will be enabled by default (in contrast to another group with potentially high cardinality "debug" metrics). This commit only refactors the existing metrics initialization code to use the new framework. The health metrics group contains all metrics that were documented in the "health metrics" section, but in the future some of them will likely be moved to another group.

I had this PR already: #2604 stacked on top of #2606, but then I merged the latter, the base branch got deleted, the PR got closed and I can't reopen it, so opening it again.