### PR TITLE
tetragon: Factor loader tailcall setup

### DIFF
--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -91,7 +91,11 @@ var (
 	sensorTestInit sync.Once
 )
 
-func setupExitProgram() {
+func setupPrograms() {
+	// execve program tail calls details
+	Execve.SetTailCall("tracepoint", ExecveTailCallsMap)
+
+	// exit program function
 	ks, err := ksyms.KernelSymbols()
 	if err == nil {
 		has_acct_process := ks.IsAvailable("acct_process")
@@ -157,7 +161,7 @@ func GetDefaultMaps(cgroupRate bool) []*program.Map {
 // GetInitialSensor returns the base sensor
 func GetInitialSensor() *sensors.Sensor {
 	sensorInit.Do(func() {
-		setupExitProgram()
+		setupPrograms()
 		sensor.Progs = GetDefaultPrograms(option.CgroupRateEnabled())
 		sensor.Maps = GetDefaultMaps(option.CgroupRateEnabled())
 	})
@@ -166,7 +170,7 @@ func GetInitialSensor() *sensors.Sensor {
 
 func GetInitialSensorTest() *sensors.Sensor {
 	sensorTestInit.Do(func() {
-		setupExitProgram()
+		setupPrograms()
 		sensorTest.Progs = GetDefaultPrograms(true)
 		sensorTest.Maps = GetDefaultMaps(true)
 	})

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -559,18 +559,11 @@ func LoadRawTracepointProgram(bpfDir string, load *Program, verbose int) error {
 }
 
 func LoadKprobeProgram(bpfDir string, load *Program, verbose int) error {
-	var tc tailCall
-	for mName, m := range load.PinMap {
-		if mName == "kprobe_calls" || mName == "retkprobe_calls" {
-			tc = tailCall{m, "kprobe"}
-			break
-		}
-	}
 	opts := &LoadOpts{
 		Attach:   KprobeAttach(load, bpfDir),
 		Open:     KprobeOpen(load),
-		TcMap:    tc.m,
-		TcPrefix: tc.prefix,
+		TcMap:    load.TcMap,
+		TcPrefix: load.TcPrefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
 }
@@ -621,18 +614,11 @@ func LoadUprobeProgram(bpfDir string, load *Program, verbose int) error {
 }
 
 func LoadMultiKprobeProgram(bpfDir string, load *Program, verbose int) error {
-	var tc tailCall
-	for mName, m := range load.PinMap {
-		if mName == "kprobe_calls" || mName == "retkprobe_calls" {
-			tc = tailCall{m, "kprobe"}
-			break
-		}
-	}
 	opts := &LoadOpts{
 		Attach:   MultiKprobeAttach(load, bpfDir),
 		Open:     KprobeOpen(load),
-		TcMap:    tc.m,
-		TcPrefix: tc.prefix,
+		TcMap:    load.TcMap,
+		TcPrefix: load.TcPrefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
 }

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -543,17 +543,10 @@ func MultiKprobeAttach(load *Program, bpfDir string) AttachFunc {
 }
 
 func LoadTracepointProgram(bpfDir string, load *Program, verbose int) error {
-	var tc tailCall
-	for mName, m := range load.PinMap {
-		if mName == "tp_calls" || mName == "execve_calls" {
-			tc = tailCall{m, "tracepoint"}
-			break
-		}
-	}
 	opts := &LoadOpts{
 		Attach:   TracepointAttach(load, bpfDir),
-		TcMap:    tc.m,
-		TcPrefix: tc.prefix,
+		TcMap:    load.TcMap,
+		TcPrefix: load.TcPrefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
 }

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -598,17 +598,10 @@ func LoadKprobeProgramAttachMany(bpfDir string, load *Program, syms []string, ve
 }
 
 func LoadUprobeProgram(bpfDir string, load *Program, verbose int) error {
-	var tc tailCall
-	for mName, m := range load.PinMap {
-		if mName == "uprobe_calls" {
-			tc = tailCall{m, "uprobe"}
-			break
-		}
-	}
 	opts := &LoadOpts{
 		Attach:   UprobeAttach(load),
-		TcMap:    tc.m,
-		TcPrefix: tc.prefix,
+		TcMap:    load.TcMap,
+		TcPrefix: load.TcPrefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
 }
@@ -691,17 +684,10 @@ func LoadLSMProgramSimple(bpfDir string, load *Program, verbose int) error {
 }
 
 func LoadMultiUprobeProgram(bpfDir string, load *Program, verbose int) error {
-	var tc tailCall
-	for mName, m := range load.PinMap {
-		if mName == "uprobe_calls" {
-			tc = tailCall{m, "uprobe"}
-			break
-		}
-	}
 	opts := &LoadOpts{
 		Attach:   MultiUprobeAttach(load),
-		TcMap:    tc.m,
-		TcPrefix: tc.prefix,
+		TcMap:    load.TcMap,
+		TcPrefix: load.TcPrefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
 }

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -27,7 +27,7 @@ type AttachFunc func(*ebpf.Collection, *ebpf.CollectionSpec, *ebpf.Program, *ebp
 type OpenFunc func(*ebpf.CollectionSpec) error
 
 type tailCall struct {
-	name   string
+	m      *Map
 	prefix string
 }
 
@@ -35,7 +35,7 @@ type LoadOpts struct {
 	Attach AttachFunc
 	Open   OpenFunc
 
-	TcMap    string
+	TcMap    *Map
 	TcPrefix string
 }
 
@@ -546,13 +546,13 @@ func LoadTracepointProgram(bpfDir string, load *Program, verbose int) error {
 	var tc tailCall
 	for mName, m := range load.PinMap {
 		if mName == "tp_calls" || mName == "execve_calls" {
-			tc = tailCall{m.PinName, "tracepoint"}
+			tc = tailCall{m, "tracepoint"}
 			break
 		}
 	}
 	opts := &LoadOpts{
 		Attach:   TracepointAttach(load, bpfDir),
-		TcMap:    tc.name,
+		TcMap:    tc.m,
 		TcPrefix: tc.prefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
@@ -569,14 +569,14 @@ func LoadKprobeProgram(bpfDir string, load *Program, verbose int) error {
 	var tc tailCall
 	for mName, m := range load.PinMap {
 		if mName == "kprobe_calls" || mName == "retkprobe_calls" {
-			tc = tailCall{m.PinName, "kprobe"}
+			tc = tailCall{m, "kprobe"}
 			break
 		}
 	}
 	opts := &LoadOpts{
 		Attach:   KprobeAttach(load, bpfDir),
 		Open:     KprobeOpen(load),
-		TcMap:    tc.name,
+		TcMap:    tc.m,
 		TcPrefix: tc.prefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
@@ -615,13 +615,13 @@ func LoadUprobeProgram(bpfDir string, load *Program, verbose int) error {
 	var tc tailCall
 	for mName, m := range load.PinMap {
 		if mName == "uprobe_calls" {
-			tc = tailCall{m.PinName, "uprobe"}
+			tc = tailCall{m, "uprobe"}
 			break
 		}
 	}
 	opts := &LoadOpts{
 		Attach:   UprobeAttach(load),
-		TcMap:    tc.name,
+		TcMap:    tc.m,
 		TcPrefix: tc.prefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
@@ -631,14 +631,14 @@ func LoadMultiKprobeProgram(bpfDir string, load *Program, verbose int) error {
 	var tc tailCall
 	for mName, m := range load.PinMap {
 		if mName == "kprobe_calls" || mName == "retkprobe_calls" {
-			tc = tailCall{m.PinName, "kprobe"}
+			tc = tailCall{m, "kprobe"}
 			break
 		}
 	}
 	opts := &LoadOpts{
 		Attach:   MultiKprobeAttach(load, bpfDir),
 		Open:     KprobeOpen(load),
-		TcMap:    tc.name,
+		TcMap:    tc.m,
 		TcPrefix: tc.prefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
@@ -689,16 +689,16 @@ func LoadTracingProgram(bpfDir string, load *Program, verbose int) error {
 
 func LoadLSMProgram(bpfDir string, load *Program, verbose int) error {
 	var tc tailCall
-	for mName, mPath := range load.PinMap {
+	for mName, m := range load.PinMap {
 		if mName == "lsm_calls" {
-			tc = tailCall{mPath.PinName, "lsm"}
+			tc = tailCall{m, "lsm"}
 			break
 		}
 	}
 	opts := &LoadOpts{
 		Attach:   LSMAttach(),
 		Open:     LSMOpen(load),
-		TcMap:    tc.name,
+		TcMap:    tc.m,
 		TcPrefix: tc.prefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
@@ -712,10 +712,16 @@ func LoadLSMProgramSimple(bpfDir string, load *Program, verbose int) error {
 }
 
 func LoadMultiUprobeProgram(bpfDir string, load *Program, verbose int) error {
-	tc := tailCall{fmt.Sprintf("%s-up_calls", load.PinPath), "uprobe"}
+	var tc tailCall
+	for mName, m := range load.PinMap {
+		if mName == "uprobe_calls" {
+			tc = tailCall{m, "uprobe"}
+			break
+		}
+	}
 	opts := &LoadOpts{
 		Attach:   MultiUprobeAttach(load),
-		TcMap:    tc.name,
+		TcMap:    tc.m,
 		TcPrefix: tc.prefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
@@ -764,8 +770,8 @@ func installTailCalls(bpfDir string, spec *ebpf.CollectionSpec, coll *ebpf.Colle
 		secToProgName[prog.SectionName] = name
 	}
 
-	install := func(mapName string, secPrefix string) error {
-		tailCallsMap, err := ebpf.LoadPinnedMap(filepath.Join(bpfDir, mapName), nil)
+	install := func(pinPath string, secPrefix string) error {
+		tailCallsMap, err := ebpf.LoadPinnedMap(filepath.Join(bpfDir, pinPath), nil)
 		if err != nil {
 			return nil
 		}
@@ -777,7 +783,7 @@ func installTailCalls(bpfDir string, spec *ebpf.CollectionSpec, coll *ebpf.Colle
 				if prog, ok := coll.Programs[progName]; ok {
 					err := tailCallsMap.Update(uint32(i), uint32(prog.FD()), ebpf.UpdateAny)
 					if err != nil {
-						return fmt.Errorf("update of tail-call map '%s' failed: %w", mapName, err)
+						return fmt.Errorf("update of tail-call map '%s' failed: %w", pinPath, err)
 					}
 				}
 			}
@@ -785,8 +791,8 @@ func installTailCalls(bpfDir string, spec *ebpf.CollectionSpec, coll *ebpf.Colle
 		return nil
 	}
 
-	if len(loadOpts.TcMap) != 0 {
-		if err := install(loadOpts.TcMap, loadOpts.TcPrefix); err != nil {
+	if loadOpts.TcMap != nil {
+		if err := install(loadOpts.TcMap.PinName, loadOpts.TcPrefix); err != nil {
 			return err
 		}
 	}

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -26,11 +26,6 @@ type AttachFunc func(*ebpf.Collection, *ebpf.CollectionSpec, *ebpf.Program, *ebp
 
 type OpenFunc func(*ebpf.CollectionSpec) error
 
-type tailCall struct {
-	m      *Map
-	prefix string
-}
-
 type LoadOpts struct {
 	Attach AttachFunc
 	Open   OpenFunc
@@ -660,18 +655,11 @@ func LoadTracingProgram(bpfDir string, load *Program, verbose int) error {
 }
 
 func LoadLSMProgram(bpfDir string, load *Program, verbose int) error {
-	var tc tailCall
-	for mName, m := range load.PinMap {
-		if mName == "lsm_calls" {
-			tc = tailCall{m, "lsm"}
-			break
-		}
-	}
 	opts := &LoadOpts{
 		Attach:   LSMAttach(),
 		Open:     LSMOpen(load),
-		TcMap:    tc.m,
-		TcPrefix: tc.prefix,
+		TcMap:    load.TcMap,
+		TcPrefix: load.TcPrefix,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)
 }

--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -116,6 +116,10 @@ type Program struct {
 
 	// Type information used for CO-RE relocations.
 	KernelTypes *btf.Spec
+
+	// Tail call prefix/map
+	TcPrefix string
+	TcMap    *Map
 }
 
 func (p *Program) SetRetProbe(ret bool) *Program {
@@ -130,6 +134,12 @@ func (p *Program) SetLoaderData(d interface{}) *Program {
 
 func (p *Program) SetAttachData(d interface{}) *Program {
 	p.AttachData = d
+	return p
+}
+
+func (p *Program) SetTailCall(prefix string, m *Map) *Program {
+	p.TcPrefix = prefix
+	p.TcMap = m
 	return p
 }
 

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -329,6 +329,8 @@ func createMultiKprobeSensor(sensorPath, policyName string, multiIDs []idtable.E
 	tailCalls := program.MapBuilderPin("kprobe_calls", sensors.PathJoin(pinPath, "kp_calls"), load)
 	maps = append(maps, tailCalls)
 
+	load.SetTailCall("kprobe", tailCalls)
+
 	filterMap := program.MapBuilderPin("filter_map", sensors.PathJoin(pinPath, "filter_map"), load)
 	maps = append(maps, filterMap)
 
@@ -417,6 +419,8 @@ func createMultiKprobeSensor(sensorPath, policyName string, multiIDs []idtable.E
 
 		tailCalls := program.MapBuilderPin("retkprobe_calls", sensors.PathJoin(pinPath, "retprobe-kp_calls"), loadret)
 		maps = append(maps, tailCalls)
+
+		loadret.SetTailCall("kprobe", tailCalls)
 
 		retConfigMap.SetMaxEntries(len(multiRetIDs))
 		retFilterMap.SetMaxEntries(len(multiRetIDs))
@@ -915,6 +919,8 @@ func createKprobeSensorFromEntry(kprobeEntry *genericKprobe, sensorPath string,
 	tailCalls := program.MapBuilderPin("kprobe_calls", sensors.PathJoin(pinPath, "kp_calls"), load)
 	maps = append(maps, tailCalls)
 
+	load.SetTailCall("kprobe", tailCalls)
+
 	filterMap := program.MapBuilderPin("filter_map", sensors.PathJoin(pinPath, "filter_map"), load)
 	maps = append(maps, filterMap)
 
@@ -996,6 +1002,8 @@ func createKprobeSensorFromEntry(kprobeEntry *genericKprobe, sensorPath string,
 
 		tailCalls := program.MapBuilderPin("retkprobe_calls", sensors.PathJoin(pinPath, "retprobe-kp_calls"), loadret)
 		maps = append(maps, tailCalls)
+
+		loadret.SetTailCall("kprobe", tailCalls)
 
 		filterMap := program.MapBuilderPin("filter_map", sensors.PathJoin(pinPath, "retkprobe_filter_map"), loadret)
 		maps = append(maps, filterMap)

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -372,6 +372,8 @@ func createLsmSensorFromEntry(lsmEntry *genericLsm,
 	tailCalls := program.MapBuilderPin("lsm_calls", sensors.PathJoin(pinPath, "lsm_calls"), load)
 	maps = append(maps, tailCalls)
 
+	load.SetTailCall("lsm", tailCalls)
+
 	filterMap := program.MapBuilderPin("filter_map", sensors.PathJoin(pinPath, "filter_map"), load)
 	maps = append(maps, filterMap)
 

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -424,6 +424,9 @@ func createGenericTracepointSensor(
 		tailCalls := program.MapBuilderPin("tp_calls", sensors.PathJoin(pinPath, "tp_calls"), prog0)
 		maps = append(maps, tailCalls)
 
+		// tracepoint tail calls details
+		prog0.SetTailCall("tracepoint", tailCalls)
+
 		filterMap := program.MapBuilderPin("filter_map", sensors.PathJoin(pinPath, "filter_map"), prog0)
 		maps = append(maps, filterMap)
 

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -421,6 +421,8 @@ func createMultiUprobeSensor(sensorPath string, multiIDs []idtable.EntryID) ([]*
 
 	maps = append(maps, configMap, tailCalls, filterMap)
 
+	load.SetTailCall("uprobe", tailCalls)
+
 	filterMap.SetMaxEntries(len(multiIDs))
 	configMap.SetMaxEntries(len(multiIDs))
 	return progs, maps, nil
@@ -475,6 +477,7 @@ func createUprobeSensorFromEntry(uprobeEntry *genericUprobe,
 	filterMap := program.MapBuilderPin("filter_map", sensors.PathJoin(pinPath, "filter_map"), load)
 	selMatchBinariesMap := program.MapBuilderPin("tg_mb_sel_opts", sensors.PathJoin(pinPath, "tg_mb_sel_opts"), load)
 	maps = append(maps, configMap, tailCalls, filterMap, selMatchBinariesMap)
+	load.SetTailCall("uprobe", tailCalls)
 	return progs, maps
 }
 


### PR DESCRIPTION
move tail call setup to the program layer and get rid of the tail call maps name checking