### PR TITLE
Update Getting Started guide

### DIFF
--- a/docs/content/en/docs/getting-started/network.md
+++ b/docs/content/en/docs/getting-started/network.md
@@ -4,21 +4,25 @@ weight: 5
 description: "Network access traces with Tetragon"
 ---
 
-This adds a network policy on top of execution and file tracing already
-deployed in the quick start. In this case we monitor all network traffic
-outside the Kubernetes pod CIDR and service CIDR.
+In addition to file access monitoring, Tetragon's tracing policies also support
+monitoring network access. In this section, you will see how to monitor network
+traffic to "external" destinations (destinations that are outside the
+Kubernetes cluster or external to the Docker host where Tetragon is running).
+These instructions assume you already have Tetragon running in either
+Kubernetes or Docker, and that you have deployed the Cilium demo application.
 
-## Kubernetes Cluster Network Access Monitoring
+## Monitoring Kubernetes network access
 
-First we must find the pod CIDR and service CIDR in use. The pod
-IP CIDR can be found relatively easily in many cases.
+First, you'll need to find the pod CIDR and service CIDR in use. In many cases
+the pod CIDR is relatively easy to find.
 
 ```shell
 export PODCIDR=`kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}'`
 ```
 
-The services CIDR can then be fetched depending on environment. We
-require environment variables ZONE and NAME from install steps.
+You can fetch the service CIDR from the cluster in some environments. When
+working with managed Kubernetes offerings (AKS, EKS, or GKE) you will need the
+environment variables used when you created the cluster.
 
 {{< tabpane lang=shell >}}
 
@@ -30,30 +34,48 @@ export SERVICECIDR=$(gcloud container clusters describe ${NAME} --zone ${ZONE} |
 export SERVICECIDR=$(kubectl describe pod -n kube-system kube-apiserver-kind-control-plane | awk -F= '/--service-cluster-ip-range/ {print $2; }')
 {{< /tab >}}
 
+{{< tab EKS >}}
+export SERVICECIDR=$(aws eks describe-cluster --name ${NAME} | jq -r '.cluster.kubernetesNetworkConfig.serviceIpv4Cidr')
+{{< /tab >}}
+
+{{< tab AKS >}}
+export SERVICECIDR=$(az aks show --name ${NAME} --resource-group ${AZURE_RESOURCE_GROUP} | jq -r '.networkProfile.serviceCidr)
+{{< /tab >}}
 {{< /tabpane >}}
 
-First we apply a policy that includes the `podCIDR` and `serviceIP` list as
-filters to avoid filter out cluster local traffic. To apply the policy:
+Once you have this information, you can customize a policy to exclude network
+traffic to the networks stored in the `PODCIDR` and `SERVICECIDR` environment
+variables. Use `envsubst` to do this, and then apply the policy to your
+Kubernetes cluster with `kubectl apply`:
 
 ```shell
 wget https://raw.githubusercontent.com/cilium/tetragon/main/examples/quickstart/network_egress_cluster.yaml
 envsubst < network_egress_cluster.yaml | kubectl apply -f -
 ```
 
-With the file applied we can attach tetra to observe events again:
+Once the tracing policy is applied, you can attach `tetra` to observe events
+again:
 
-```shell
- kubectl exec -ti -n kube-system ds/tetragon -c tetragon -- tetra getevents -o compact --pods xwing --processes curl
-```
+{{< tabpane lang=shell >}}
 
-Then execute a curl command in the xwing pod to curl one of our favorite
+{{< tab "Kubernetes (single node)" >}}
+kubectl exec -ti -n kube-system ds/tetragon -c tetragon -- tetra getevents -o compact --pods xwing --processes curl
+{{< /tab >}}
+
+{{< tab "Kubernetes (multiple nodes" >}}
+POD=$(kubectl -n kubesystem get pods -l 'app.kubernetes.io/name=tetragon' -o name --field-selector spec.nodeName=$(kubectl get pod xwing -o jsonpath='{.spec.nodeName}'))
+kubectl exec -ti -n kube-system $POD -c tetragon -- tetra getevents -o compact --pods xwing --processes curl
+{{< /tab >}}
+{{< /tabpane >}}
+
+Then execute a `curl` command in the "xwing" Pod to access one of our favorite
 sites.
 
 ```shell
  kubectl exec -ti xwing -- bash -c 'curl https://ebpf.io/applications/#tetragon'
 ```
 
-A connect will be observed in the tetra shell:
+You will observe a `connect` event being reported in the output of the `tetra getevents` command:
 
 ```
 🚀 process default/xwing /usr/bin/curl https://ebpf.io/applications/#tetragon
@@ -61,9 +83,9 @@ A connect will be observed in the tetra shell:
 💥 exit    default/xwing /usr/bin/curl https://ebpf.io/applications/#tetragon 60
 ```
 
-We can confirm in-kernel BPF filters are not producing events for in cluster
-traffic by issuing a curl to one of our services and noting there is no connect
-event.
+You can confirm in-kernel BPF filters are not producing events for in-cluster
+traffic by issuing a `curl` to one of our services and noting there is no
+`connect` event.
 
 ```shell
 kubectl exec -ti xwing -- bash -c 'curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing'
@@ -83,63 +105,69 @@ And as expected no new events:
 💥 exit    default/xwing /usr/bin/curl https://ebpf.io/applications/#tetragon 60
 ```
 
-## Docker/Baremetal Network Access Monitoring
+## Monitoring Docker or bare metal network access
 
-This example also works easily for local docker users as well except it is not as
-obvious to the quickstart authors what IP address CIDR will be useful. The policy
-by default will filter all local IPs `127.0.0.1` from the event log. So we can
-demo that here.
+This example also works easily for local Docker users. However, since Docker
+does not have pod CIDR or service CIDR constructs, you will construct a tracing
+policy that filters `127.0.0.1` from the Tetragon event log.
 
-Set env variables to local loopback IP.
+First, set the necessary environment variables to the loopback IP address.
+
 ```shell
 export PODCIDR="127.0.0.1/32"
 export SERVICECIDR="127.0.0.1/32"
 ```
 
-To create the policy,
+Next, customize the policy using `envsubst`.
+
 ```shell
 wget https://raw.githubusercontent.com/cilium/tetragon/main/examples/quickstart/network_egress_cluster.yaml
 envsubst < network_egress_cluster.yaml > network_egress_cluster_subst.yaml
 ```
 
-Start Tetragon with the new policy:
+Finally, start Tetragon with the new policy.
+
 ```shell
-docker stop tetragon-container
-docker run --name tetragon-container --rm --pull always \
+docker stop tetragon
+docker run -d --name tetragon --rm --pull always \
   --pid=host --cgroupns=host --privileged               \
   -v ${PWD}/network_egress_cluster_subst.yaml:/etc/tetragon/tetragon.tp.d/network_egress_cluster_subst.yaml \
   -v /sys/kernel/btf/vmlinux:/var/lib/tetragon/btf      \
-  quay.io/cilium/tetragon-ci:latest
+  quay.io/cilium/tetragon:latest
 ```
 
-Attach to the tetragon output
+Once Tetragon is running, use `docker exec` to run the `tetra getevents` command
+and log the output to your terminal.
+
 ```shell
-docker exec tetragon-container tetra getevents -o compact
+docker exec -ti tetragon tetra getevents -o compact
 ```
 
-Now remote TCP connections will be logged and local IPs filters. Executing a curl
-to generate a remote TCP connect.
+Now remote TCP connections will be logged, but connections to the localhost
+address are filtered out by Tetragon. You can see this by executing a `curl`
+command to generate a remote TCP connect.
+
 ```shell
 curl https://ebpf.io/applications/#tetragon
 ```
 
-Produces the following output:
+This produces the following output:
+
 ```
 🚀 process  /usr/bin/curl https://ebpf.io/applications/#tetragon
 🔌 connect  /usr/bin/curl tcp 192.168.1.190:36124 -> 104.198.14.52:443
 💥 exit     /usr/bin/curl https://ebpf.io/applications/#tetragon 0
 ```
 
-# Whats Next
+## What's next
 
-So far we have installed Tetragon and shown a couple policies to monitor
-sensitive files and provide network auditing for connections outside our own
-cluster and node. Both these cases highlight the value of in kernel filtering.
-Another benefit of in-kernel filtering is we can add
+So far you have installed Tetragon and used a couple policies to monitor
+sensitive files and provide network auditing for connections outside your own
+cluster and node. Both these cases highlight the value of in-kernel filtering.
+Another benefit of in-kernel filtering is you can add
 [enforcement]({{< ref "/docs/getting-started/enforcement" >}}) to the policies
-to not only alert, but block the operation in kernel and/or kill the
-application attempting the operation.
+to not only alert via a log entry, but to block the operation in kernel and/or
+kill the application attempting the operation.
 
 To learn more about policies and events Tetragon can implement review the
 [Concepts]({{< ref "/docs/concepts" >}}) section.
-

--- a/examples/quickstart/network_egress_cluster_enforce.yaml
+++ b/examples/quickstart/network_egress_cluster_enforce.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicyNamespaced
 metadata:
-  name: "monitor-network-activity-outside-cluster-cidr-range"
+  name: "enforce-network-activity-outside-cluster-cidr-range"
 spec:
   kprobes:
   - call: "tcp_connect"


### PR DESCRIPTION
### Description
This PR updates the Getting Started guide for consistency throughout all sections.

Here is the full changeset:

`execution.md`:
Remove language specifier for fenced codeblock.

`file-events.md`:
Add instructions for single-node and multi-node K8s clusters. Clean up Docker instructions.
Ensure consistent header levels.
Minor fixes in spelling and grammar.

`network.md`:
Add EKS, AKS instructions for getting service CIDR. Add instructions for single-node and multi-node K8s clusters. Ensure consistent header levels.
Minor fixes in spelling and grammar.

`enforcement.md`:
Reorganize content to improve flow.
Add EKS, AKS instructions for getting service CIDR. Add instructions for single-node and multi-node K8s clusters. Ensure consistent header levels.
Minor fixes in spelling and grammar.

No release notes/changelog entries necessary.
