### PR TITLE
doc: Add instructions to remove previous applied network policy.

### DIFF
--- a/docs/content/en/docs/getting-started/enforcement.md
+++ b/docs/content/en/docs/getting-started/enforcement.md
@@ -57,7 +57,12 @@ export SERVICECIDR=$(kubectl describe pod -n kube-system kube-apiserver-kind-con
 {{< /tab >}}
 {{< /tabpane >}}
 
-Then we can apply the egress cluster enforcement policy
+If you have previously applied the network policy in the last section, first remove it:
+```shell
+envsubst < network_egress_cluster.yaml | kubectl delete -f -
+```
+
+Then we can apply the egress cluster enforcement policy:
 
 ```shell
 wget https://raw.githubusercontent.com/cilium/tetragon/main/examples/quickstart/network_egress_cluster_enforce.yaml


### PR DESCRIPTION
Fixes: https://github.com/cilium/tetragon/issues/2724

### Description
The enforcement example for networking allows connections if the previous policy is left applied.
