### PR TITLE
fix(install-tetragon.sh) fix 'kind load docker-image' in kind setup

### DIFF
--- a/contrib/kind/install-tetragon.sh
+++ b/contrib/kind/install-tetragon.sh
@@ -72,8 +72,8 @@ if [ $? == 0 ]; then
     if ! command -v kind &>/dev/null; then
         error "kind is not in \$PATH! Bailing out!"
     fi
-    image=$(yq '.tetragon.image.override' "$BASE_VALUES")
-    image_operator=$(yq '.tetragonOperator.image.override' "$BASE_VALUES")
+    image=$(yq -r '.tetragon.image.override' "$BASE_VALUES")
+    image_operator=$(yq -r '.tetragonOperator.image.override' "$BASE_VALUES")
     kind load docker-image "$image" --name "$CLUSTER_NAME"
     kind load docker-image "$image_operator" --name "$CLUSTER_NAME"
 fi


### PR DESCRIPTION
Fixes https://github.com/cilium/tetragon/issues/2731

### Description

When running `make kind-setup`, the tetragon images are not correctly pushed into kind, which leads to an error loopbackof in the cluster. It happens because of a formatting issue in the `./contrib/kind/install-tetragon.sh` with `yq`. Quotes are added and are unnecessary, which lead to this format in bash `"\"cilium/tetragon:latest\""`.

