### PR TITLE
doc: use tag variable for docker-based commands

### DIFF
--- a/docs/content/en/docs/getting-started/enforcement.md
+++ b/docs/content/en/docs/getting-started/enforcement.md
@@ -153,7 +153,7 @@ docker run --name tetragon --rm --pull always \
   --pid=host --cgroupns=host --privileged               \
   -v ${PWD}/file_monitoring_enforce.yaml:/etc/tetragon/tetragon.tp.d/file_monitoring_enforce.yaml \
   -v /sys/kernel/btf/vmlinux:/var/lib/tetragon/btf      \
-  quay.io/cilium/tetragon:latest
+  quay.io/cilium/tetragon:{{< latest-version >}}
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/docs/content/en/docs/getting-started/file-events.md
+++ b/docs/content/en/docs/getting-started/file-events.md
@@ -43,7 +43,7 @@ docker run -d --name tetragon --rm --pull always \
   --pid=host --cgroupns=host --privileged \
   -v ${PWD}/file_monitoring.yaml:/etc/tetragon/tetragon.tp.d/file_monitoring.yaml \
   -v /sys/kernel/btf/vmlinux:/var/lib/tetragon/btf \
-  quay.io/cilium/tetragon:latest
+  quay.io/cilium/tetragon:{{< latest-version >}}
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/docs/content/en/docs/getting-started/install-docker.md
+++ b/docs/content/en/docs/getting-started/install-docker.md
@@ -26,7 +26,7 @@ using the released container images.
 docker run -d --name tetragon --rm --pull always \
     --pid=host --cgroupns=host --privileged             \
     -v /sys/kernel/btf/vmlinux:/var/lib/tetragon/btf    \
-    quay.io/cilium/tetragon:latest
+    quay.io/cilium/tetragon:{{< latest-version >}}
 ```
 
 This will start Tetragon in a privileged container running in the background.

--- a/docs/content/en/docs/getting-started/network.md
+++ b/docs/content/en/docs/getting-started/network.md
@@ -133,7 +133,7 @@ docker run -d --name tetragon --rm --pull always \
   --pid=host --cgroupns=host --privileged               \
   -v ${PWD}/network_egress_cluster_subst.yaml:/etc/tetragon/tetragon.tp.d/network_egress_cluster_subst.yaml \
   -v /sys/kernel/btf/vmlinux:/var/lib/tetragon/btf      \
-  quay.io/cilium/tetragon:latest
+  quay.io/cilium/tetragon:{{< latest-version >}}
 ```
 
 Once Tetragon is running, use `docker exec` to run the `tetra getevents` command


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

Users attempting to run docker-based commands from production images, eg. on the [Quick Local Docker Install](https://tetragon.io/docs/getting-started/install-docker/) page, will not have a local `:latest` copy, and will not be able to proceed through the getting started guide. This ensures that the latest tag available on quay.io is rendered in the docs
