### PR TITLE
Add LoadLSMProgramSimple

### DIFF
--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -704,6 +704,13 @@ func LoadLSMProgram(bpfDir string, load *Program, verbose int) error {
 	return loadProgram(bpfDir, load, opts, verbose)
 }
 
+func LoadLSMProgramSimple(bpfDir string, load *Program, verbose int) error {
+	opts := &LoadOpts{
+		Attach: LSMAttach(),
+	}
+	return loadProgram(bpfDir, load, opts, verbose)
+}
+
 func LoadMultiUprobeProgram(bpfDir string, load *Program, verbose int) error {
 	tc := tailCall{fmt.Sprintf("%s-up_calls", load.PinPath), "uprobe"}
 	opts := &LoadOpts{


### PR DESCRIPTION
### Description
https://github.com/cilium/tetragon/commit/0b090efc47f89f80336db39b365d54fa25979327 modifies LoadLSMProgram to be gelenic_lsm specific.

This patch adds LoadLSMProgramSimple that is generic enough to be used in other use cases.

```release-note
Add LoadLSMProgramSimple to load LSM programs.
```
