### PR TITLE
tetragon: extra debug info on nsid mappings

### DIFF
--- a/pkg/policyfilter/disabled.go
+++ b/pkg/policyfilter/disabled.go
@@ -59,3 +59,7 @@ func (s *disabled) Close() error {
 func (s *disabled) GetNsId(stateID StateID) (*NSID, bool) {
 	return nil, false
 }
+
+func (s *disabled) GetIdNs(id NSID) (StateID, bool) {
+	return StateID(0), false
+}

--- a/pkg/policyfilter/policyfilter.go
+++ b/pkg/policyfilter/policyfilter.go
@@ -115,6 +115,8 @@ type State interface {
 	// and reporting the state of the system to subsystems and tooling.
 	GetNsId(stateID StateID) (*NSID, bool)
 
+	GetIdNs(id NSID) (StateID, bool)
+
 	// RegisterPodHandlers can be used to register appropriate pod handlers to a pod informer
 	// that for keeping the policy filter state up-to-date.
 	RegisterPodHandlers(podInformer cache.SharedIndexInformer)

--- a/pkg/policyfilter/state.go
+++ b/pkg/policyfilter/state.go
@@ -945,3 +945,10 @@ func (m *state) GetNsId(stateID StateID) (*NSID, bool) {
 	}
 	return nil, false
 }
+
+func (m *state) GetIdNs(id NSID) (StateID, bool) {
+	if stateID, ok := m.nsMap.nsNameMap.Get(id); ok {
+		return stateID, ok
+	}
+	return StateID(0), false
+}


### PR DESCRIPTION
Debugging NSID/Pod mappings is a bit painful if something gets lost in BPF side. Provide a bit more data so we can lookup these entries and their human readable form at any point.

I'm using this to write a debug tool to show bpf maps and correlate with Tetragon data.