### PR TITLE
bpf: bump prepend_name underlying buffer size 4096

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -67,7 +67,7 @@ jobs:
         matrix:
            kernel:
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - 'rhel8-20240620.102250'
+              - 'rhel8.9-20240806.173325'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
               - 'bpf-next-20240624.013140'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images

--- a/Makefile
+++ b/Makefile
@@ -264,8 +264,10 @@ test: tester-progs tetragon-bpf ## Run Go tests.
 tester-progs: ## Compile helper programs for unit testing.
 	$(MAKE) -C $(TESTER_PROGS_DIR)
 
+## bpf-test: ## run BPF tests.
+## bpf-test BPFGOTESTFLAGS="-v": ## run BPF tests with verbose.
 .PHONY: bpf-test
-bpf-test: ## Run BPF tests.
+bpf-test:
 	$(MAKE) -C ./bpf run-test
 
 .PHONY: verify

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -273,12 +273,7 @@ struct msg_k8s {
 #define BINARY_PATH_MAX_LEN 256
 
 struct heap_exe {
-	// because of verifier limitations, this has to be 2 * 256 bytes while 256
-	// should be theoretically sufficient, and actually is, in unit tests.
-	char buf[BINARY_PATH_MAX_LEN * 2];
-	// offset points to the start of the path in the above buffer. Use offset to
-	// read the path in the buffer since it's written from the end.
-	char *off;
+	char buf[BINARY_PATH_MAX_LEN];
 	__u32 len;
 	__u32 error;
 }; // All fields aligned so no 'packed' attribute.

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -12,14 +12,14 @@
 #define ENAMETOOLONG 36 /* File name too long */
 
 #define MATCH_BINARIES_PATH_MAX_LENGTH 256
-#define MAX_BUF_LEN		       256
+#define MAX_BUF_LEN		       4096
 
 struct buffer_heap_map_value {
-	// Buffer is twice the needed size because of the verifier. In prepend_name
-	// unit tests, the verifier figures out that 255 is enough and that the
-	// buffer_offset will not overflow, but in the real use-case it looks like
-	// it's forgetting about that.
-	unsigned char buf[MAX_BUF_LEN * 2];
+	// Buffer need a bit more space here  because of the verifier. In
+	// prepend_name unit tests, the verifier figures out that MAX_BUF_LEN is
+	// enough and that the buffer_offset will not overflow, but in the real
+	// use-case it looks like it's forgetting about that.
+	unsigned char buf[MAX_BUF_LEN + 256];
 };
 
 struct {
@@ -119,15 +119,13 @@ prepend_name(char *buf, char **bufptr, int *buflen, const char *name, u32 namele
 
 	*buflen -= (namelen + write_slash);
 
-	// This will not happen as buffer_offset cannot be above 256 and namelen is
-	// bound to 255. Needed to make the verifier happy in older kernels.
 	if (namelen + write_slash > buffer_offset)
 		return -ENAMETOOLONG;
 
 	buffer_offset -= (namelen + write_slash);
 
 	// This will never happen. buffer_offset is the diff of the initial buffer pointer
-	// with the current buffer pointer. This will be at max 256 bytes (similar to the initial
+	// with the current buffer pointer. This will be at max 4096 bytes (similar to the initial
 	// size).
 	// Needed to bound that for probe_read call.
 	if (buffer_offset >= MAX_BUF_LEN)

--- a/bpf/tests/prepend_name_test.c
+++ b/bpf/tests/prepend_name_test.c
@@ -13,7 +13,7 @@
 
 char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
 
-#define TEST_MAX_BUF_LEN 256
+#define TEST_MAX_BUF_LEN 4096
 #define NAME_MAX	 255
 
 struct test_prepend_name_state_map_value {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3886,6 +3886,55 @@ func TestKprobeMatchBinaries(t *testing.T) {
 	})
 }
 
+func TestKprobeMatchBinariesPrefixLargePath(t *testing.T) {
+	if !kernels.EnableLargeProgs() {
+		t.Skip()
+	}
+
+	// create a large temporary directory path
+	tmpDir := t.TempDir()
+	targetBinLargePath := tmpDir
+	// add (255 + 1) * 15 = 3840 chars to the path
+	// max is 4096 and we want to leave some space for the tmpdir + others
+	for range 15 {
+		targetBinLargePath += "/" + strings.Repeat("a", unix.NAME_MAX)
+	}
+	err := os.MkdirAll(targetBinLargePath, 0755)
+	require.NoError(t, err)
+
+	// copy the binary into it
+	targetBinLargePath += "/true"
+	fileExec, err := exec.LookPath("true")
+	require.NoError(t, err)
+	err = exec.Command("cp", fileExec, targetBinLargePath).Run()
+	require.NoError(t, err)
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	createCrdFile(t, getMatchBinariesCrd("Prefix", []string{tmpDir}))
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	if err := exec.Command(targetBinLargePath).Run(); err != nil {
+		t.Fatalf("failed to run true: %s", err)
+	}
+
+	checker := ec.NewUnorderedEventChecker(ec.NewProcessKprobeChecker("").
+		WithProcess(ec.NewProcessChecker().WithBinary(sm.Full(targetBinLargePath))).
+		WithFunctionName(sm.Full("fd_install")))
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
 // matchBinariesPerfringTest checks that the matchBinaries do correctly
 // filter the events i.e. it checks that no other events appear.
 func matchBinariesPerfringTest(t *testing.T, operator string, values []string) {


### PR DESCRIPTION
Fixes #2758
### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

The matchBinaries Prefix operator fails to match a path longer than 256 chars because of the way we read the binary path. We use the exe of the process and walk the dentry from end to beginning. Thus if the path is too long, the buffer contains an incorrect start.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Fix a bug related to the matchBinaries Prefix operator by increasing the buffer size used by our dentry walk. Now the matchBinaries Prefix operator can correctly trigger a match on any path above 255 chars.
```
