### PR TITLE
bpf: fix incorrect inline asm output operands sections 

### DIFF
--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -132,8 +132,8 @@ BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 	 * 0x1000 should be maximum argument length, so masking
 	 * with 0x1fff is safe and verifier will be happy.
 	 */
-	asm volatile("%[size] &= 0x1fff;\n" ::[size] "+r"(size)
-		     :);
+	asm volatile("%[size] &= 0x1fff;\n"
+		     : [size] "+r"(size));
 
 	switch (do_copy) {
 	case char_buf:

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -168,40 +168,40 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	msg->a0 = ({
 		unsigned long ctx_off = config->t_arg0_ctx_off;
 		int ty = config->arg0;
-		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
-			     :);
+		asm volatile("%[ctx_off] &= 0xffff;\n"
+			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a1 = ({
 		unsigned long ctx_off = config->t_arg1_ctx_off;
 		int ty = config->arg1;
-		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
-			     :);
+		asm volatile("%[ctx_off] &= 0xffff;\n"
+			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a2 = ({
 		unsigned long ctx_off = config->t_arg2_ctx_off;
 		int ty = config->arg2;
-		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
-			     :);
+		asm volatile("%[ctx_off] &= 0xffff;\n"
+			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a3 = ({
 		unsigned long ctx_off = config->t_arg3_ctx_off;
 		int ty = config->arg3;
-		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
-			     :);
+		asm volatile("%[ctx_off] &= 0xffff;\n"
+			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a4 = ({
 		unsigned long ctx_off = config->t_arg4_ctx_off;
 		int ty = config->arg4;
-		asm volatile("%[ctx_off] &= 0xffff;\n" ::[ctx_off] "+r"(ctx_off)
-			     :);
+		asm volatile("%[ctx_off] &= 0xffff;\n"
+			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -139,8 +139,8 @@ prepend_name(char *buf, char **bufptr, int *buflen, const char *name, u32 namele
 	// This ensures that namelen is < 256, which is aligned with kernel's max dentry name length
 	// that is 255 (https://elixir.bootlin.com/linux/v5.10/source/include/uapi/linux/limits.h#L12).
 	// Needed to bound that for probe_read call.
-	asm volatile("%[namelen] &= 0xff;\n" ::[namelen] "+r"(namelen)
-		     :);
+	asm volatile("%[namelen] &= 0xff;\n"
+		     : [namelen] "+r"(namelen));
 	probe_read(buf + buffer_offset + write_slash, namelen * sizeof(char), name);
 
 	*bufptr = buf + buffer_offset;
@@ -382,10 +382,10 @@ getcwd(struct msg_process *curr, __u32 offset, __u32 proc_pid)
 	if (!buffer)
 		return 0;
 
-	asm volatile("%[offset] &= 0x3ff;\n" ::[offset] "+r"(offset)
-		     :);
-	asm volatile("%[size] &= 0xff;\n" ::[size] "+r"(size)
-		     :);
+	asm volatile("%[offset] &= 0x3ff;\n"
+		     : [offset] "+r"(offset));
+	asm volatile("%[size] &= 0xff;\n"
+		     : [size] "+r"(size));
 	probe_read((char *)curr + offset, size, buffer);
 
 	// Unfortunate special case for '/' where nothing was added we need

--- a/bpf/process/data_event.h
+++ b/bpf/process/data_event.h
@@ -84,9 +84,7 @@ __do_str(void *ctx, struct msg_data *msg, unsigned long arg, bool *done)
 	asm volatile("%[max] &= 0x7fff;\n"
 		     "if %[max] < 32736 goto +1\n;"
 		     "%[max] = 32736;\n"
-		     :
-		     : [max] "+r"(max)
-		     :);
+		     : [max] "+r"(max));
 
 	ret = probe_read_str(&msg->arg[0], max, (char *)arg);
 	if (ret < 0)
@@ -101,9 +99,7 @@ __do_str(void *ctx, struct msg_data *msg, unsigned long arg, bool *done)
 	size = ret + offsetof(struct msg_data, arg);
 	/* Code movement from clang forces us to inline bounds checks here */
 	asm volatile("%[size] &= 0x7fff;\n"
-		     :
-		     : [size] "+r"(size)
-		     :);
+		     : [size] "+r"(size));
 	msg->common.size = size;
 	perf_event_output_metric(ctx, MSG_OP_DATA, &tcpmon_map, BPF_F_CURRENT_CPU, msg, size);
 	return ret;

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -94,8 +94,8 @@ generic_process_event(void *ctx, struct bpf_map_def *heap_map,
 		int am;
 
 		am = (&config->arg0m)[index];
-		asm volatile("%[am] &= 0xffff;\n" ::[am] "+r"(am)
-			     :);
+		asm volatile("%[am] &= 0xffff;\n"
+			     : [am] "+r"(am));
 
 		errv = read_call_arg(ctx, e, index, ty, total, a, am, data_heap);
 		if (errv > 0)

--- a/bpf/process/pfilter.h
+++ b/bpf/process/pfilter.h
@@ -135,8 +135,8 @@ process_filter_pid(struct selector_filter *sf, __u32 *f,
 	else {
 		__u64 o = (__u64)off;
 		o = o / 4;
-		asm volatile("%[o] &= 0x3ff;\n" ::[o] "+r"(o)
-			     :);
+		asm volatile("%[o] &= 0x3ff;\n"
+			     : [o] "+r"(o));
 		sel = f[o];
 	}
 	return __process_filter_pid(sf->ty, sf->flags, sel, pid, enter);
@@ -157,8 +157,8 @@ process_filter_namespace(struct selector_filter *sf, __u32 *f,
 	else {
 		__u64 o = (__u64)off;
 		o = o / 4;
-		asm volatile("%[o] &= 0x3ff;\n" ::[o] "+r"(o)
-			     :);
+		asm volatile("%[o] &= 0x3ff;\n"
+			     : [o] "+r"(o));
 		sel = f[o];
 	}
 

--- a/bpf/process/pfilter.h
+++ b/bpf/process/pfilter.h
@@ -587,8 +587,8 @@ generic_process_filter(struct bpf_map_def *heap, struct bpf_map_def *fmap)
 		pass = selector_process_filter(f, curr, enter, msg);
 		if (pass) {
 			/* Verify lost that msg is not null here so recheck */
-			asm volatile("%[curr] &= 0x1f;\n" ::[curr] "r+"(curr)
-				     :);
+			asm volatile("%[curr] &= 0x1f;\n"
+				     : [curr] "+r"(curr));
 			sel->active[curr] = true;
 			sel->active[SELECTORS_ACTIVE] = true;
 			sel->pass |= true;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -261,8 +261,9 @@ return_stack_error(char *args, int orig, int err)
 	asm volatile("%[orig] &= 0xfff;\n"
 		     "r1 = *(u64 *)%[args];\n"
 		     "r1 += %[orig];\n"
-		     "*(u32 *)(r1 + 0) = %[err];\n" ::[orig] "r+"(orig),
-		     [args] "m+"(args), [err] "r+"(err)
+		     "*(u32 *)(r1 + 0) = %[err];\n"
+		     : [orig] "+r"(orig), [args] "+m"(args), [err] "+r"(err)
+		     :
 		     : "r1");
 	return sizeof(int);
 }

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -246,8 +246,8 @@ FUNC_INLINE int return_error(int *s, int err)
 FUNC_INLINE char *
 args_off(struct msg_generic_kprobe *e, unsigned long off)
 {
-	asm volatile("%[off] &= 0x3fff;\n" ::[off] "+r"(off)
-		     :);
+	asm volatile("%[off] &= 0x3fff;\n"
+		     : [off] "+r"(off));
 	return e->args + off;
 }
 
@@ -285,8 +285,8 @@ parse_iovec_array(long off, unsigned long arg, int i, unsigned long max,
 		size = max;
 	if (size > 4094)
 		return char_buf_toolarge;
-	asm volatile("%[size] &= 0xfff;\n" ::[size] "+r"(size)
-		     :);
+	asm volatile("%[size] &= 0xfff;\n"
+		     : [size] "+r"(size));
 	err = probe_read(args_off(e, off), size, (char *)iov.iov_base);
 	if (err < 0)
 		return char_buf_pagefault;
@@ -346,8 +346,8 @@ FUNC_INLINE long copy_path(char *args, const struct path *arg)
 	if (!buffer)
 		return 0;
 
-	asm volatile("%[size] &= 0xff;\n" ::[size] "+r"(size)
-		     :);
+	asm volatile("%[size] &= 0xff;\n"
+		     : [size] "+r"(size));
 	probe_read(curr, size, buffer);
 	*s = size;
 	size += 4;
@@ -583,8 +583,8 @@ __copy_char_buf(void *ctx, long off, unsigned long arg, unsigned long bytes,
 
 	/* Bound bytes <4095 to ensure bytes does not read past end of buffer */
 	rd_bytes = bytes < 0x1000 ? bytes : 0xfff;
-	asm volatile("%[rd_bytes] &= 0xfff;\n" ::[rd_bytes] "+r"(rd_bytes)
-		     :);
+	asm volatile("%[rd_bytes] &= 0xfff;\n"
+		     : [rd_bytes] "+r"(rd_bytes));
 	err = probe_read(&s[2], rd_bytes, (char *)arg);
 	if (err < 0)
 		return return_error(s, char_buf_pagefault);
@@ -1667,8 +1667,8 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
 		bool set32bit = false;
 
 		argsoff = filters->argoff[i];
-		asm volatile("%[argsoff] &= 0x3ff;\n" ::[argsoff] "+r"(argsoff)
-			     :);
+		asm volatile("%[argsoff] &= 0x3ff;\n"
+			     : [argsoff] "+r"(argsoff));
 
 		if (argsoff <= 0)
 			return pass ? seloff : 0;
@@ -1680,11 +1680,11 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
 		if (index > 5)
 			return 0;
 
-		asm volatile("%[index] &= 0x7;\n" ::[index] "+r"(index)
-			     :);
+		asm volatile("%[index] &= 0x7;\n"
+			     : [index] "+r"(index));
 		argoff = e->argsoff[index];
-		asm volatile("%[argoff] &= 0x7ff;\n" ::[argoff] "+r"(argoff)
-			     :);
+		asm volatile("%[argoff] &= 0x7ff;\n"
+			     : [argoff] "+r"(argoff));
 		args = &e->args[argoff];
 
 		switch (filter->type) {
@@ -2383,9 +2383,7 @@ generic_output(void *ctx, struct bpf_map_def *heap, u8 op)
 	asm volatile("%[total] &= 0x7fff;\n"
 		     "if %[total] < 9000 goto +1\n;"
 		     "%[total] = 9000;\n"
-		     :
-		     : [total] "+r"(total)
-		     :);
+		     : [total] "+r"(total));
 	perf_event_output_metric(ctx, op, &tcpmon_map, BPF_F_CURRENT_CPU, e, total);
 	return 0;
 }

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -374,7 +374,7 @@ FUNC_INLINE long copy_path(char *args, const struct path *arg)
 		"r2 = *(u16 *)%[mode];\n"
 		"*(u16 *)(r1 + 4) = r2;\n"
 		:
-		: [pid] "m"(args), [flags] "m"(flags), [offset] "+m"(size), [mode] "m"(i_mode)
+		: [pid] "m"(args), [flags] "m"(flags), [offset] "m"(size), [mode] "m"(i_mode)
 		: "r0", "r1", "r2", "r7", "memory"
 		: a);
 a:


### PR DESCRIPTION
In some places, certainly because of copy-paste we use the inputs operands instead of the output operands section.

I also spotted some incorrect constraints, `r+` instead of `+r` for example.