### PR TITLE
tetragon: Group missed metrics for policy and attach point

### DIFF
--- a/pkg/metrics/kprobemetrics/collector.go
+++ b/pkg/metrics/kprobemetrics/collector.go
@@ -24,56 +24,86 @@ func NewBPFCollector() prometheus.Collector {
 	)
 }
 
-func collectLink(ch chan<- prometheus.Metric, load *program.Program) {
+func collectLink(load *program.Program) (uint64, bool) {
 	if load.Link == nil {
-		return
+		return 0, false
 	}
 
 	info, err := load.Link.Info()
 	if err != nil {
-		return
+		return 0, false
 	}
-
-	missed := uint64(0)
 
 	switch info.Type {
 	case link.PerfEventType:
 		if !bpf.HasMissedStatsPerfEvent() {
-			return
+			return 0, false
 		}
 		pevent := info.PerfEvent()
 		switch pevent.Type {
 		case unix.BPF_PERF_EVENT_KPROBE, unix.BPF_PERF_EVENT_KRETPROBE:
 			kprobe := pevent.Kprobe()
-			missed, _ = kprobe.Missed()
+			return kprobe.Missed()
 		}
 	case link.KprobeMultiType:
 		if !bpf.HasMissedStatsKprobeMulti() {
-			return
+			return 0, false
 		}
 		kmulti := info.KprobeMulti()
-		missed, _ = kmulti.Missed()
-	default:
+		return kmulti.Missed()
 	}
 
-	ch <- MissedLink.MustMetric(float64(missed), load.Policy, load.Attach)
+	return 0, false
 }
 
-func collectProg(ch chan<- prometheus.Metric, load *program.Program) {
+func collectProg(load *program.Program) (uint64, bool) {
 	info, err := load.Prog.Info()
 	if err != nil {
-		return
+		return 0, false
 	}
 
-	missed, _ := info.RecursionMisses()
-	ch <- MissedProg.MustMetric(float64(missed), load.Policy, load.Attach)
+	return info.RecursionMisses()
+}
+
+type missedKey struct {
+	policy string
+	attach string
 }
 
 func collect(ch chan<- prometheus.Metric) {
 	allPrograms := sensors.AllPrograms()
-	for _, prog := range allPrograms {
-		collectLink(ch, prog)
-		collectProg(ch, prog)
+
+	mapProg := make(map[*missedKey]uint64)
+	mapLink := make(map[*missedKey]uint64)
+
+	// Group all the metrics together so we avoid of duplicate
+	// metric values due to missing policy name.
+
+	for _, load := range allPrograms {
+		valLink, okLink := collectLink(load)
+		valProg, okProg := collectProg(load)
+
+		// Store metrics only when we retrieved them successfully.
+		if !okLink && !okProg {
+			continue
+		}
+
+		key := &missedKey{load.Policy, load.Attach}
+
+		if okLink {
+			mapLink[key] = mapLink[key] + valLink
+		}
+		if okProg {
+			mapProg[key] = mapProg[key] + valProg
+		}
+	}
+
+	for key, val := range mapProg {
+		ch <- MissedProg.MustMetric(float64(val), key.policy, key.attach)
+	}
+
+	for key, val := range mapLink {
+		ch <- MissedLink.MustMetric(float64(val), key.policy, key.attach)
 	}
 }
 


### PR DESCRIPTION
    Some of the sensors do not set policy for program and it could
    cause a problem with duplicate metrics values with empty policy.
    
    Making the missed metrics groups by policy and attach point
    values. Also storing only metrics that we managed to received
    correctly (instead of storing them with zero values).
