### PR TITLE
policyfiltermetrics: Refactor and rename metrics

### DIFF
--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -44,4 +44,5 @@ tetragon:
 
 #### Metrics
 
-* TBD
+* `tetragon_policyfilter_metrics_total` metric is renamed to `tetragon_policyfilter_operations_total`, and its `op`
+  label is renamed to `operation`.

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -215,14 +215,14 @@ The total number of events dropped because listener buffer was full
 
 The total number of operations when the container name was missing in the OCI hook
 
-### `tetragon_policyfilter_metrics_total`
+### `tetragon_policyfilter_operations_total`
 
-Policy filter metrics. For internal use only.
+Number of policy filter operations.
 
 | label | values |
 | ----- | ------ |
 | `error` | `generic-error, pod-namespace-conflict` |
-| `op   ` | `add, add-container, delete, update` |
+| `operation` | `add, add-container, delete, update` |
 | `subsys` | `pod-handlers, rthooks` |
 
 ### `tetragon_process_cache_capacity`

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20240524165444-4d4ba1473f21
 	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
+	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.22.0
 	golang.org/x/time v0.6.0
@@ -177,7 +178,6 @@ require (
 	go.uber.org/dig v1.17.1 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect

--- a/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
+++ b/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
@@ -4,6 +4,8 @@
 package policyfiltermetrics
 
 import (
+	"golang.org/x/exp/maps"
+
 	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/prometheus/client_golang/prometheus"
@@ -64,15 +66,29 @@ func (s OperationErr) String() string {
 }
 
 var (
-	PolicyFilterOpMetrics = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:   consts.MetricsNamespace,
-		Name:        "policyfilter_metrics_total",
-		Help:        "Policy filter metrics. For internal use only.",
-		ConstLabels: nil,
-	}, []string{"subsys", "op", "error"})
+	subsysLabel = metrics.ConstrainedLabel{
+		Name:   "subsys",
+		Values: maps.Values(subsysLabelValues),
+	}
+
+	operationLabel = metrics.ConstrainedLabel{
+		Name:   "op",
+		Values: maps.Values(operationLabelValues),
+	}
+
+	errorLabel = metrics.ConstrainedLabel{
+		Name:   "error",
+		Values: maps.Values(operationErrLabels),
+	}
 )
 
 var (
+	PolicyFilterOpMetrics = metrics.MustNewCounter(metrics.NewOpts(
+		consts.MetricsNamespace, "", "policyfilter_metrics_total",
+		"Policy filter metrics. For internal use only.",
+		nil, []metrics.ConstrainedLabel{subsysLabel, operationLabel, errorLabel}, nil,
+	), nil)
+
 	PolicyFilterHookContainerNameMissingMetrics = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace:   consts.MetricsNamespace,
 		Name:        "policyfilter_hook_container_name_missing_total",
@@ -83,19 +99,6 @@ var (
 
 func RegisterMetrics(group metrics.Group) {
 	group.MustRegister(PolicyFilterOpMetrics, PolicyFilterHookContainerNameMissingMetrics)
-}
-
-func InitMetrics() {
-	// Initialize metrics with labels
-	for _, subsys := range subsysLabelValues {
-		for _, op := range operationLabelValues {
-			for _, err := range operationErrLabels {
-				PolicyFilterOpMetrics.WithLabelValues(
-					subsys, op, err,
-				).Add(0)
-			}
-		}
-	}
 }
 
 func OpInc(subsys Subsys, op Operation, err string) {

--- a/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
+++ b/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
@@ -72,7 +72,7 @@ var (
 	}
 
 	operationLabel = metrics.ConstrainedLabel{
-		Name:   "op",
+		Name:   "operation",
 		Values: maps.Values(operationLabelValues),
 	}
 
@@ -84,8 +84,8 @@ var (
 
 var (
 	PolicyFilterOpMetrics = metrics.MustNewCounter(metrics.NewOpts(
-		consts.MetricsNamespace, "", "policyfilter_metrics_total",
-		"Policy filter metrics. For internal use only.",
+		consts.MetricsNamespace, "", "policyfilter_operations_total",
+		"Number of policy filter operations.",
 		nil, []metrics.ConstrainedLabel{subsysLabel, operationLabel, errorLabel}, nil,
 	), nil)
 

--- a/pkg/metricsconfig/healthmetrics.go
+++ b/pkg/metricsconfig/healthmetrics.go
@@ -73,7 +73,6 @@ func registerHealthMetrics(group metrics.Group) {
 	group.ExtendInit(opcodemetrics.InitMetrics)
 	// policy filter metrics
 	policyfiltermetrics.RegisterMetrics(group)
-	group.ExtendInit(policyfiltermetrics.InitMetrics)
 	// process metrics
 	process.RegisterMetrics(group)
 	// ringbuf metrics


### PR DESCRIPTION
### Description

See commits.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
`tetragon_policyfilter_metrics_total` metric is renamed to `tetragon_policyfilter_operations_total`, and its `op` label is renamed to `operation`.
```
