### PR TITLE
crd: make followChildren optional

### DIFF
--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -445,6 +445,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -462,7 +463,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1054,6 +1054,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1071,7 +1072,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1694,6 +1694,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1711,7 +1712,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -2271,6 +2271,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -2288,7 +2289,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -445,6 +445,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -462,7 +463,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1054,6 +1054,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1071,7 +1072,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1694,6 +1694,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1711,7 +1712,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -2271,6 +2271,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -2288,7 +2289,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -445,6 +445,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -462,7 +463,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1054,6 +1054,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1071,7 +1072,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1694,6 +1694,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1711,7 +1712,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -2271,6 +2271,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -2288,7 +2289,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -445,6 +445,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -462,7 +463,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1054,6 +1054,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1071,7 +1072,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1694,6 +1694,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1711,7 +1712,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -2271,6 +2271,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -2288,7 +2289,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -96,6 +96,8 @@ type BinarySelector struct {
 	// Value to compare the argument against.
 	Values []string `json:"values"`
 	// In addition to binaries, match children processes of specified binaries.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
 	FollowChildren bool `json:"followChildren"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.2.2"
+const CustomResourceDefinitionSchemaVersion = "1.2.3"

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -445,6 +445,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -462,7 +463,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1054,6 +1054,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1071,7 +1072,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1694,6 +1694,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1711,7 +1712,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -2271,6 +2271,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -2288,7 +2289,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -445,6 +445,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -462,7 +463,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1054,6 +1054,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1071,7 +1072,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -1694,6 +1694,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -1711,7 +1712,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object
@@ -2271,6 +2271,7 @@ spec:
                             items:
                               properties:
                                 followChildren:
+                                  default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
@@ -2288,7 +2289,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - followChildren
                               - operator
                               - values
                               type: object

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -96,6 +96,8 @@ type BinarySelector struct {
 	// Value to compare the argument against.
 	Values []string `json:"values"`
 	// In addition to binaries, match children processes of specified binaries.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
 	FollowChildren bool `json:"followChildren"`
 }
 

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.2.2"
+const CustomResourceDefinitionSchemaVersion = "1.2.3"


### PR DESCRIPTION
55117f55586f26ee9a8fc5eca734456eb55faf54 Introduced a new field (followChildren), but it was not marked as optional which is a breaking change.

Make the field optional and false by default.

fixes: 55117f55586f26ee9a8fc5eca734456eb55faf54

Reported by @lambdanis https://github.com/cilium/tetragon/pull/2720#issuecomment-2278425729
