### PR TITLE
kprobemetrics: Fix collecting missed metrics

### DIFF
--- a/pkg/metrics/kprobemetrics/collector.go
+++ b/pkg/metrics/kprobemetrics/collector.go
@@ -73,8 +73,8 @@ type missedKey struct {
 func collect(ch chan<- prometheus.Metric) {
 	allPrograms := sensors.AllPrograms()
 
-	mapProg := make(map[*missedKey]uint64)
-	mapLink := make(map[*missedKey]uint64)
+	mapProg := make(map[missedKey]uint64)
+	mapLink := make(map[missedKey]uint64)
 
 	// Group all the metrics together so we avoid of duplicate
 	// metric values due to missing policy name.
@@ -88,7 +88,7 @@ func collect(ch chan<- prometheus.Metric) {
 			continue
 		}
 
-		key := &missedKey{load.Policy, load.Attach}
+		key := missedKey{load.Policy, load.Attach}
 
 		if okLink {
 			mapLink[key] = mapLink[key] + valLink


### PR DESCRIPTION
When collecting metrics from kernel, Tetragon needs to aggregate them in userspace maps to avoid duplicate labelsets, which cause metrics server errors. This was done incorrectly, using a pointer to missedKey struct as the aggregation key. Use missedKey struct directly.
