### PR TITLE
api/ops: Remove MsgOp* constants

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -139,7 +139,7 @@ The total number of event handler errors. For internal use only.
 | label | values |
 | ----- | ------ |
 | `error_type` | `event_handler_failed, unknown_opcode` |
-| `opcode` | `0, 11, 13, 14, 15, 23, 24, 25, 26, 5, 7` |
+| `opcode` | `0, 13, 14, 15, 16, 23, 24, 25, 26, 27, 5, 7` |
 
 ### `tetragon_handling_latency`
 
@@ -147,7 +147,7 @@ The latency of handling messages in us.
 
 | label | values |
 | ----- | ------ |
-| `op   ` | `11, 13, 14, 15, 23, 24, 25, 26, 5, 7` |
+| `op   ` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 5, 7` |
 
 ### `tetragon_map_capacity`
 
@@ -179,7 +179,7 @@ The total number of Tetragon events per type that are failed to sent from the ke
 
 | label | values |
 | ----- | ------ |
-| `msg_op` | `11, 13, 14, 15, 23, 24, 25, 26, 5, 7` |
+| `msg_op` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 5, 7` |
 
 ### `tetragon_missed_link_probes_total`
 
@@ -205,7 +205,7 @@ The total number of times we encounter a given message opcode. For internal use 
 
 | label | values |
 | ----- | ------ |
-| `msg_op` | `11, 13, 14, 15, 23, 24, 25, 26, 5, 7` |
+| `msg_op` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 5, 7` |
 
 ### `tetragon_notify_overflowed_events_total`
 

--- a/pkg/api/ops/ops.go
+++ b/pkg/api/ops/ops.go
@@ -9,6 +9,10 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 )
 
+type OpCode int
+
+// OpCodes must be in sync with msg_ops enum in bpf/lib/msg_types.h
+// and should have a human-readable representation in OpCodeStrings.
 const (
 	MSG_OP_UNDEF = 0
 	// MSG_OP_EXECVE event indicates a process was created. The 'PID'
@@ -26,14 +30,10 @@ const (
 	MSG_OP_GENERIC_LSM        = 16
 
 	// MSG_OP_CLONE notifies user-space that a clone() event has occurred.
-	MSG_OP_CLONE = 23
-
-	MSG_OP_DATA = 24
-
-	MSG_OP_CGROUP = 25
-
-	MSG_OP_LOADER = 26
-
+	MSG_OP_CLONE    = 23
+	MSG_OP_DATA     = 24
+	MSG_OP_CGROUP   = 25
+	MSG_OP_LOADER   = 26
 	MSG_OP_THROTTLE = 27
 
 	// just for testing
@@ -65,36 +65,20 @@ const (
 	_CGROUP_STATE_MAX   CgroupState = 4
 )
 
-type OpCode int
-
-const (
-	MsgOpUndef              = iota
-	MsgOpExecve             = 5
-	MsgOpExit               = 7
-	MsgOpKfreeSkb           = 11
-	MsgOpGenericKprobe      = 13
-	MsgOpGeneric_Tracepoint = 14
-	MsgOpGenericUprobe      = 15
-	MsgOpClone              = 23
-	MsgOpData               = 24
-	MsgOpCgroup             = 25
-	MsgOpLoader             = 26
-	MsgOpTest               = 254
-)
-
 var OpCodeStrings = map[OpCode]string{
-	MsgOpUndef:              "Undef",
-	MsgOpExecve:             "Execve",
-	MsgOpExit:               "Exit",
-	MsgOpKfreeSkb:           "KfreeSkb",
-	MsgOpGenericKprobe:      "GenericKprobe",
-	MsgOpGeneric_Tracepoint: "GenericTracepoint",
-	MsgOpGenericUprobe:      "GenericUprobe",
-	MsgOpClone:              "Clone",
-	MsgOpData:               "Data",
-	MsgOpCgroup:             "Cgroup",
-	MsgOpLoader:             "Loader",
-	MsgOpTest:               "Test",
+	MSG_OP_UNDEF:              "Undef",
+	MSG_OP_EXECVE:             "Execve",
+	MSG_OP_EXIT:               "Exit",
+	MSG_OP_GENERIC_KPROBE:     "GenericKprobe",
+	MSG_OP_GENERIC_TRACEPOINT: "GenericTracepoint",
+	MSG_OP_GENERIC_UPROBE:     "GenericUprobe",
+	MSG_OP_GENERIC_LSM:        "GenericLSM",
+	MSG_OP_CLONE:              "Clone",
+	MSG_OP_DATA:               "Data",
+	MSG_OP_CGROUP:             "Cgroup",
+	MSG_OP_LOADER:             "Loader",
+	MSG_OP_THROTTLE:           "Throttle",
+	MSG_OP_TEST:               "Test",
 }
 
 func (op OpCode) String() string {

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -96,13 +96,13 @@ func InitMetrics() {
 		GetErrorTotal(er).Add(0)
 	}
 	for opcode := range ops.OpCodeStrings {
-		if opcode != ops.MsgOpUndef && opcode != ops.MsgOpTest {
+		if opcode != ops.MSG_OP_UNDEF && opcode != ops.MSG_OP_TEST {
 			GetHandlerErrors(opcode, HandlePerfHandlerError).Add(0)
 		}
 	}
-	// NB: We initialize only ops.MsgOpUndef here, but unknown_opcode can occur for any opcode
+	// NB: We initialize only ops.MSG_OP_UNDEF here, but unknown_opcode can occur for any opcode
 	// that is not explicitly handled.
-	GetHandlerErrors(ops.MsgOpUndef, HandlePerfUnknownOp).Add(0)
+	GetHandlerErrors(ops.MSG_OP_UNDEF, HandlePerfUnknownOp).Add(0)
 }
 
 // Get a new handle on an ErrorTotal metric for an ErrorType

--- a/pkg/metrics/labels.go
+++ b/pkg/metrics/labels.go
@@ -56,7 +56,7 @@ func getOpcodes() []string {
 	result := make([]string, len(ops.OpCodeStrings)-2)
 	i := 0
 	for opcode := range ops.OpCodeStrings {
-		if opcode != ops.MsgOpUndef && opcode != ops.MsgOpTest {
+		if opcode != ops.MSG_OP_UNDEF && opcode != ops.MSG_OP_TEST {
 			result[i] = fmt.Sprint(int32(opcode))
 			i++
 		}

--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -37,7 +37,7 @@ func RegisterMetrics(group metrics.Group) {
 func InitMetrics() {
 	// Initialize all metrics
 	for opcode := range ops.OpCodeStrings {
-		if opcode != ops.MsgOpUndef && opcode != ops.MsgOpTest {
+		if opcode != ops.MSG_OP_UNDEF && opcode != ops.MSG_OP_TEST {
 			GetOpTotal(opcode).Add(0)
 			LatencyStats.WithLabelValues(fmt.Sprint(int32(opcode)))
 		}


### PR DESCRIPTION
`MsgOp*` constants were duplicating `MSG_OP_*`. There is no point in maintaining two lists, and `MsgOp*` constants weren't added for some new features. Let's keep `MSG_OP_*` for consistency with other types and bpf.

Also remove `MsgOpKfreeSkb` (not used and not existing in bpf) and update metrics docs with missing opcodes.