### PR TITLE
feat: add banner to community meetings and move tetragon slides

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -1,4 +1,5 @@
 @import "button";
+@import "community-banner";
 @import "home";
 @import "header";
 @import "footer";

--- a/docs/assets/scss/community-banner.scss
+++ b/docs/assets/scss/community-banner.scss
@@ -1,0 +1,47 @@
+.td-community-banner {
+  font-size: 14px;
+  text-align: center;
+
+  a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 9px 14px;
+    color: #253737;
+    background-color: #E2F7F7;
+    border-bottom: 1px solid #42D7D74F;
+
+
+    &:hover,
+    &:focus-visible {
+      background-color: #B0EDED80;
+    }
+
+    @media screen and (max-width: 767px) {}
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+}
+
+.td-community-banner__text {
+  max-width: calc(100% - 18px);
+  text-wrap: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.td-community-banner__main-text {
+  margin-left: 14px;
+  margin-right: 4px;
+  padding-left: 14px;
+  font-weight: 700;
+  letter-spacing: -0.28px;
+  border-left: 1px solid #253737A6;
+
+  a:hover &,
+  a:focus-visible & {
+    color: #5C6D70;
+  }
+}

--- a/docs/assets/scss/header.scss
+++ b/docs/assets/scss/header.scss
@@ -1,3 +1,9 @@
+.td-home header {
+  position: sticky;
+  top: 0;
+  z-index: 32;
+}
+
 .td-navbar {
   height: 64px;
   padding: 20px 0;
@@ -5,6 +11,7 @@
   border-bottom: 1px solid #E5E7E7;
 
   .td-home & {
+    position: static;
     font-family: "Manrope", sans-serif;
     background-color: #f7fdfd;
     border-bottom-color: #f7fdfd;

--- a/docs/assets/scss/home.scss
+++ b/docs/assets/scss/home.scss
@@ -15,9 +15,6 @@
 @import "home/presentation";
 
 .home {
-  // dirty hack that should be changed if we change the size of the navbar
-  margin-top: 64px;
-
   margin-left: auto;
   margin-right: auto;
   max-width: 1216px;
@@ -63,4 +60,3 @@
     list-style: none;
   }
 }
-

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -241,53 +241,6 @@ linkTitle = "Tetragon - eBPF-based Security Observability and Runtime Enforcemen
         </ul>
     </div>
 
-    <div class="presentation">
-        <ul class="presentation__list">
-            <li class="presentation__item presentation__banner">
-                <div class="presentation__banner-inner">
-                    <h2 class="presentation__title">What is a Tracing Policy?</h2>
-                    <p class="presentation__banner-description">Tracing Policies define what situations Tetragon
-                        should react to...</p>
-                    <ul class="presentation__banner-list">
-                        <li class="presentation__banner-item">
-                            <span class="presentation__banner-number">1</span>
-                            <span class="presentation__banner-decor"></span>
-                        </li>
-                        <li class="presentation__banner-item">
-                            <span class="presentation__banner-number">2</span>
-                            <span class="presentation__banner-decor presentation__banner-decor--wide"></span>
-                        </li>
-                        <li class="presentation__banner-item">
-                            <span class="presentation__banner-number">3</span>
-                            <span class="presentation__banner-decor"></span>
-                        </li>
-                    </ul>
-                    <img class="presentation__banner-img" src="/images/home/jedi-bee-teacher.png" width="242" height="186"
-                        alt="Jedi-Bee techer" />
-                </div>
-            </li>
-
-            <li class="presentation__item">
-                <h2 class="title">Showcase Tetragon: Slides for Speakers</h2>
-                <p class="presentation__description">We've created a slide deck for talks, presentations, and demos on
-                    Tetragon. Feel free to use it as-is or customize it to fit your specific needs.</p>
-                <a class="button button--text"
-                    href="https://docs.google.com/presentation/d/1jNJ0pPkHjvv4QN_K01FGbNLaWD5gqgbwxCNAehn4PBQ/edit#slide=id.p"
-                    target="_blank">
-                    See presentation
-                    <svg width="13" height="12" viewBox="0 0 13 12" fill="none" xmlns="http://www.w3.org/2000/svg"
-                        aria-hidden="true">
-                        <path
-                            d="M1 5.12939C0.585787 5.12939 0.25 5.46518 0.25 5.87939C0.25 6.29361 0.585787 6.62939 1 6.62939V5.12939ZM12 5.12939L1 5.12939V6.62939L12 6.62939V5.12939Z"
-                            fill="currentColor" />
-                        <path d="M7.11108 1L12 5.7735L7.11108 10.7444" stroke="currentColor" stroke-width="1.5"
-                            stroke-linecap="round" stroke-linejoin="round" />
-                    </svg>
-                </a>
-            </li>
-        </ul>
-    </div>
-
     <div class="tabs">
         <h2 class="title tabs__title">How to Install Tetragon?</h2>
         <ul class="tabs__list">
@@ -670,6 +623,53 @@ linkTitle = "Tetragon - eBPF-based Security Observability and Runtime Enforcemen
                   </svg>
                 </span>
                     </div>
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    <div class="presentation">
+        <ul class="presentation__list">
+            <li class="presentation__item presentation__banner">
+                <div class="presentation__banner-inner">
+                    <h2 class="presentation__title">What is a Tracing Policy?</h2>
+                    <p class="presentation__banner-description">Tracing Policies define what situations Tetragon
+                        should react to...</p>
+                    <ul class="presentation__banner-list">
+                        <li class="presentation__banner-item">
+                            <span class="presentation__banner-number">1</span>
+                            <span class="presentation__banner-decor"></span>
+                        </li>
+                        <li class="presentation__banner-item">
+                            <span class="presentation__banner-number">2</span>
+                            <span class="presentation__banner-decor presentation__banner-decor--wide"></span>
+                        </li>
+                        <li class="presentation__banner-item">
+                            <span class="presentation__banner-number">3</span>
+                            <span class="presentation__banner-decor"></span>
+                        </li>
+                    </ul>
+                    <img class="presentation__banner-img" src="/images/home/jedi-bee-teacher.png" width="242"
+                        height="186" alt="Jedi-Bee techer" />
+                </div>
+            </li>
+
+            <li class="presentation__item">
+                <h2 class="title">Showcase Tetragon: Slides for Speakers</h2>
+                <p class="presentation__description">We've created a slide deck for talks, presentations, and demos on
+                    Tetragon. Feel free to use it as-is or customize it to fit your specific needs.</p>
+                <a class="button button--text"
+                    href="https://docs.google.com/presentation/d/1jNJ0pPkHjvv4QN_K01FGbNLaWD5gqgbwxCNAehn4PBQ/edit#slide=id.p"
+                    target="_blank">
+                    See presentation
+                    <svg width="13" height="12" viewBox="0 0 13 12" fill="none" xmlns="http://www.w3.org/2000/svg"
+                        aria-hidden="true">
+                        <path
+                            d="M1 5.12939C0.585787 5.12939 0.25 5.46518 0.25 5.87939C0.25 6.29361 0.585787 6.62939 1 6.62939V5.12939ZM12 5.12939L1 5.12939V6.62939L12 6.62939V5.12939Z"
+                            fill="currentColor" />
+                        <path d="M7.11108 1L12 5.7735L7.11108 10.7444" stroke="currentColor" stroke-width="1.5"
+                            stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
                 </a>
             </li>
         </ul>

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+<head>
+    {{ partial "head.html" . }}
+</head>
+<body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    {{ partial "community-banner.html" . }}
+    <header>
+        {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-default td-outer">
+        <main role="main" class="td-main">
+            {{ block "main" . }}{{ end }}
+        </main>
+        {{ partial "footer.html" . }}
+    </div>
+    {{ partialCached "scripts.html" . }}
+</body>
+</html>

--- a/docs/layouts/partials/community-banner.html
+++ b/docs/layouts/partials/community-banner.html
@@ -1,0 +1,18 @@
+<div class="td-community-banner">
+    <a class="td-community-banner__link" href="https://isogo.to/tetragon-meeting-notes" target="_blank"
+        rel="noopener noreferrer">
+        <span class="td-community-banner__text">
+            Join us at the monthly Tetragon Community Meeting!
+            <span class="td-community-banner__main-text">
+                Learn more
+            </span>
+        </span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 15 14" fill="none">
+            <path
+                d="M2.5 6.62891C2.08579 6.62891 1.75 6.96469 1.75 7.37891C1.75 7.79312 2.08579 8.12891 2.5 8.12891V6.62891ZM13.5 6.62891L2.5 6.62891V8.12891L13.5 8.12891V6.62891Z"
+                fill="currentColor" />
+            <path d="M8.61133 2.5L13.5002 7.2735L8.61133 12.2444" stroke="currentColor" stroke-width="1.5"
+                stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+    </a>
+</div>


### PR DESCRIPTION
### Description

Add banner before header and move slider section after community links at the homepage

<img width="988" alt="image" src="https://github.com/user-attachments/assets/42e96d78-c6ba-42dc-85ee-6890f4863160">

<img width="628" alt="image" src="https://github.com/user-attachments/assets/f7571922-af98-4928-a381-6fca0e6aa12e">
