### PR TITLE
metrics: Expose go_sched_latencies_seconds

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -400,6 +400,10 @@ Number of bytes obtained from system for stack allocator.
 
 Number of bytes obtained from system.
 
+### `go_sched_latencies_seconds`
+
+Distribution of the time goroutines have spent in the scheduler in a runnable state before actually running. Bucket counts increase monotonically.
+
 ### `go_threads`
 
 Number of OS threads created.

--- a/pkg/metricsconfig/initmetrics.go
+++ b/pkg/metricsconfig/initmetrics.go
@@ -4,6 +4,8 @@
 package metricsconfig
 
 import (
+	"regexp"
+
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/metrics/syscallmetrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,7 +14,10 @@ import (
 
 func initResourcesMetrics(registry *prometheus.Registry) {
 	// register common third-party collectors
-	registry.MustRegister(collectors.NewGoCollector())
+	registry.MustRegister(collectors.NewGoCollector(
+		collectors.WithGoCollectorRuntimeMetrics(
+			collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile(`^/sched/latencies:seconds`)},
+		)))
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 }
 


### PR DESCRIPTION
It's a useful metric. From https://pkg.go.dev/runtime/metrics:

/sched/latencies:seconds
  Distribution of the time goroutines have spent in the scheduler
  in a runnable state before actually running. Bucket counts
  increase monotonically.