### PR TITLE
CI: Changed lint Helm CI trigger

### DIFF
--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -7,10 +7,12 @@ on:
     paths:
     - 'install/kubernetes/**'
     - 'pkg/k8s/apis/cilium.io/client/crds/v1alpha1/*.yaml'
+    - '.github/workflows/lint-helm.yaml'
   pull_request:
     paths:
     - 'install/kubernetes/**'
     - 'pkg/k8s/apis/cilium.io/client/crds/v1alpha1/*.yaml'
+    - '.github/workflows/lint-helm.yaml'
 
 jobs:
   generated-files:


### PR DESCRIPTION
### Description
The 'lint Helm' GitHub workflow should also be triggered when its definition changes. Required for a follow up improvement of it.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
CI: Changed lint Helm CI trigger
```
