### PR TITLE
CI: Improved K8s Kubeconformance validation

### DIFF
--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -2,8 +2,8 @@ name: Lint helm chart
 on:
   push:
     branches:
-      - main
-      - v*
+    - main
+    - v*
     paths:
     - 'install/kubernetes/**'
     - 'pkg/k8s/apis/cilium.io/client/crds/v1alpha1/*.yaml'
@@ -14,12 +14,65 @@ on:
     - 'pkg/k8s/apis/cilium.io/client/crds/v1alpha1/*.yaml'
     - '.github/workflows/lint-helm.yaml'
 
+env:
+  MIN_K8S_VERSION: "1.23.0"
+  # renovate: datasource=python-version
+  PYTHON_VERSION: "3.12"
+
 jobs:
   generated-files:
     runs-on: ubuntu-latest
     steps:
+      # Get source
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-      - name: Run install/kubernetes
+
+      # Check / install dependencies
+      - name: Check if vendored openapi2jsonschema.py script is up to date
+        run: |
+          make -C install/kubernetes openapi2jsonschema.py
+          test -z "$(git status --porcelain)"
+          if [ $? != 0 ]; then
+            git status --porcelain
+            echo "Vendored openapi2jsonschema.py script is out of date."
+            echo "Please run 'make -C install/kubernetes openapi2jsonschema.py' and submit your changes."; exit 1
+          fi
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install pipenv
+        id: install-pipenv
+        shell: bash
+        run: |
+          python -m pip install --upgrade --no-cache-dir pip
+          python -m pip install --no-cache-dir pipenv
+      - name: Cache Pipfile
+        id: cache-pipfile
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
+      - name: Sync Pipfile
+        id: sync-pipfile
+        shell: bash
+        working-directory: install/kubernetes
+        run: |
+          pipenv sync --dev --python ${{ env.PYTHON_VERSION }}
+      - name: Check if vendored CRD JSON schemas are up to date
+        run: |
+          make -C install/kubernetes generate-jsonschemas
+          test -z "$(git status --porcelain)"
+          if [ $? != 0 ]; then
+            git status --porcelain
+            echo "Vendored CRD JSON schemas are out of date."
+            echo "Please run 'make -C install/kubernetes generate-jsonschemas' and submit your changes."; exit 1
+          fi
+      - name: Install Helm CLI # Required for the Helm chart templating
+        uses: azure/setup-helm@v4.2.0
+
+      # Validate Helm chart
+      - name: Generate Helm chart
         run: |
           make -C install/kubernetes
       - name: Validate generated files
@@ -29,3 +82,46 @@ jobs:
             git status --porcelain
             echo "Please run 'make -C install/kubernetes' and submit your changes."; exit 1
           fi
+
+      # (Re-)run Kubeconform checks explicitly once again to catch specific errors in that regard (to get the STDOUT/STDERR)
+      - name: Run Kubeconform with minimum supported K8s version
+        id: kubeconform_min_k8s_version
+        uses: mathiasvr/command-output@v2.0.0
+        with:
+          shell: bash
+          run: |
+            make -C install/kubernetes kubeconform K8S_VERSION=${{ env.MIN_K8S_VERSION }}
+      - name: Run Kubeconform with latest K8s version
+        id: kubeconform_latest_k8s_version
+        uses: mathiasvr/command-output@v2.0.0
+        with:
+          shell: bash
+          run: |
+            make -C install/kubernetes kubeconform
+
+      # Post Kubeconform issues as comment on the GH PR, if there are any
+      - name: Comment Kubeconform Output
+        if: failure() && (steps.kubeconform_min_k8s_version.outcome != 'success' || steps.kubeconform_latest_k8s_version.outcome != 'success')
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          hide_and_recreate: true
+          skip_unchanged: true
+          message: |
+            ## Kubeconform with minimum supported K8s version ${{ env.MIN_K8S_VERSION }}
+            STDOUT:
+            ```
+            ${{ steps.kubeconform_min_k8s_version.outputs.stdout }}
+            ```
+            STDERR:
+            ```
+            ${{ steps.kubeconform_min_k8s_version.outputs.stderr }}
+            ```
+            ## Kubeconform with latest K8s version
+            STDOUT:
+            ```
+            ${{ steps.kubeconform_latest_k8s_version.outputs.stdout }}
+            ```
+            STDERR:
+            ```
+            ${{ steps.kubeconform_latest_k8s_version.outputs.stderr }}
+            ```

--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -13,6 +13,7 @@ on:
     - 'install/kubernetes/**'
     - 'pkg/k8s/apis/cilium.io/client/crds/v1alpha1/*.yaml'
     - '.github/workflows/lint-helm.yaml'
+  workflow_call:
 
 env:
   MIN_K8S_VERSION: "1.23.0"

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -12,19 +12,20 @@ KUBECONFORM_VERSION := v0.6.7
 PYTHON := python3
 PIPENV := pipenv
 K8S_VERSION := master
+HELM_VALUES_OVERRIDE := "helm_lint_values_override.yaml"
 
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 TETRAGON_CHART := tetragon
 CRDS := $(REPO_ROOT)/pkg/k8s/apis/cilium.io/client/crds/v1alpha1
 JSON_SCHEMAS := $(REPO_ROOT)/install/kubernetes/schemas
 
-HELM ?= docker run --rm -v $(CURDIR)/$(TETRAGON_CHART):/apps $(HELM_IMAGE)
+HELM ?= docker run --rm -v $(CURDIR)/$(TETRAGON_CHART):/apps -v $(CURDIR)/$(HELM_VALUES_OVERRIDE):/$(HELM_VALUES_OVERRIDE) $(HELM_IMAGE)
 
 .PHONY: all
 all: deps $(TETRAGON_CHART)/crds-yaml lint docs openapi2jsonschema.py generate-jsonschemas kubeconform
 
 .PHONY: deps
-deps: 
+deps:
 	$(HELM) dependency update .
 
 .PHONY: lint
@@ -66,9 +67,8 @@ kubeconform:
 	@echo "## Testing Helm chart: \"$(TETRAGON_CHART)\""
 	$(HELM) template $(TETRAGON_CHART) . \
 	-f values.yaml \
-	--set crds.installMethod=helm \
-	--set tracingPolicies.default.enabled=true |\
-		docker run --rm -i -v $(JSON_SCHEMAS):/schemas $(KUBECONFORM_IMAGE) \
+	-f /$(HELM_VALUES_OVERRIDE) \
+	| docker run --rm -i -v $(JSON_SCHEMAS):/schemas $(KUBECONFORM_IMAGE) \
 		-summary \
 		-verbose \
 		-schema-location default \

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -7,15 +7,21 @@ HELM_IMAGE=docker.io/alpine/helm:3.15.3@sha256:ba0dcbbcf31f780bd8cdeeabc44bc6939
 KUBECONFORM_IMAGE=ghcr.io/yannh/kubeconform:v0.6.7-alpine@sha256:824e0c248809e4b2da2a768b16b107cf17ada88a89ec6aa6050e566ba93ebbc6
 # renovate: datasource=docker
 HELMDOCS_IMAGE=docker.io/jnorwood/helm-docs:v1.14.2@sha256:7e562b49ab6b1dbc50c3da8f2dd6ffa8a5c6bba327b1c6335cc15ce29267979c
+# renovate: datasource=github-releases depName=yannh/kubeconform
+KUBECONFORM_VERSION := v0.6.7
+PYTHON := python3
+PIPENV := pipenv
+K8S_VERSION := master
 
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 TETRAGON_CHART := tetragon
 CRDS := $(REPO_ROOT)/pkg/k8s/apis/cilium.io/client/crds/v1alpha1
+JSON_SCHEMAS := $(REPO_ROOT)/install/kubernetes/schemas
 
 HELM ?= docker run --rm -v $(CURDIR)/$(TETRAGON_CHART):/apps $(HELM_IMAGE)
 
 .PHONY: all
-all: deps $(TETRAGON_CHART)/crds-yaml lint docs
+all: deps $(TETRAGON_CHART)/crds-yaml lint docs openapi2jsonschema.py generate-jsonschemas kubeconform
 
 .PHONY: deps
 deps: 
@@ -24,7 +30,6 @@ deps:
 .PHONY: lint
 lint:
 	$(HELM) lint . --with-subcharts
-	$(HELM) template tetragon . | docker run --rm -i $(KUBECONFORM_IMAGE) --strict --schema-location default
 
 .PHONY: docs
 docs:
@@ -40,3 +45,35 @@ docs:
 .PHONY: $(TETRAGON_CHART)/crds-yaml
 $(TETRAGON_CHART)/crds-yaml: $(CRDS)
 	cp -rf $(CRDS)/. $(TETRAGON_CHART)/crds-yaml
+
+# openapi2jsonschema.py script generating JSON schema from the CRD YAML spec.
+.PHONY: openapi2jsonschema.py
+openapi2jsonschema.py:
+	curl -sSfLO https://raw.githubusercontent.com/yannh/kubeconform/$(KUBECONFORM_VERSION)/scripts/$@
+
+# To validate (using openapi2jsonschema.py) default Ruleset policies included in the Helm chart, we need to pass the
+# JSON schema of the TracingPolicy CRD. This target generates such schema. It requires pipenv to be pre-installed.
+.PHONY: generate-jsonschemas
+generate-jsonschemas: $(CRDS)
+	mkdir -p $(JSON_SCHEMAS)/
+	pipenv install
+	FILENAME_FORMAT='{kind}-{fullgroup}' $(PIPENV) run $(PYTHON) openapi2jsonschema.py $(CRDS)/*
+	mv $(REPO_ROOT)/install/kubernetes/*-cilium.io.json $(JSON_SCHEMAS)/
+	pipenv --rm
+
+.PHONY: kubeconform
+kubeconform:
+	@echo "## Testing Helm chart: \"$(TETRAGON_CHART)\""
+	$(HELM) template $(TETRAGON_CHART) . \
+	-f values.yaml \
+	--set crds.installMethod=helm \
+	--set tracingPolicies.default.enabled=true |\
+		docker run --rm -i -v $(JSON_SCHEMAS):/schemas $(KUBECONFORM_IMAGE) \
+		-summary \
+		-verbose \
+		-schema-location default \
+		-schema-location '/schemas/{{ .ResourceKind }}-{{ .Group }}.json' \
+		-skip CustomResourceDefinition \
+		-strict \
+		-kubernetes-version $(K8S_VERSION)
+	@echo ""

--- a/install/kubernetes/Pipfile
+++ b/install/kubernetes/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pyyaml = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.12"

--- a/install/kubernetes/Pipfile.lock
+++ b/install/kubernetes/Pipfile.lock
@@ -1,0 +1,81 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "27a55b76dc774eff1af052a9de8b0c6b059a44578b80abeb18dbe190986011e0"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.12"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "pyyaml": {
+            "hashes": [
+                "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff",
+                "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48",
+                "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086",
+                "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e",
+                "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133",
+                "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5",
+                "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484",
+                "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee",
+                "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5",
+                "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68",
+                "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a",
+                "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf",
+                "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99",
+                "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8",
+                "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85",
+                "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19",
+                "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc",
+                "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a",
+                "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1",
+                "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317",
+                "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c",
+                "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631",
+                "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d",
+                "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652",
+                "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5",
+                "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e",
+                "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b",
+                "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8",
+                "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476",
+                "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706",
+                "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563",
+                "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237",
+                "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b",
+                "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083",
+                "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180",
+                "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425",
+                "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e",
+                "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f",
+                "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725",
+                "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183",
+                "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab",
+                "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774",
+                "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725",
+                "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
+                "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5",
+                "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d",
+                "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290",
+                "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44",
+                "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed",
+                "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4",
+                "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba",
+                "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12",
+                "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==6.0.2"
+        }
+    },
+    "develop": {}
+}

--- a/install/kubernetes/helm_lint_values_override.yaml
+++ b/install/kubernetes/helm_lint_values_override.yaml
@@ -1,0 +1,2 @@
+crds:
+  installMethod: helm

--- a/install/kubernetes/openapi2jsonschema.py
+++ b/install/kubernetes/openapi2jsonschema.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+# Derived from https://github.com/instrumenta/openapi2jsonschema
+import yaml
+import json
+import sys
+import os
+import urllib.request
+if 'DISABLE_SSL_CERT_VALIDATION' in os.environ:
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
+
+def test_additional_properties():
+    for test in iter([{
+        "input": {"something": {"properties": {}}},
+        "expect": {'something': {'properties': {}, "additionalProperties": False}}
+    },{
+        "input": {"something": {"somethingelse": {}}},
+        "expect": {'something': {'somethingelse': {}}}
+    }]):
+        assert additional_properties(test["input"]) == test["expect"]
+
+def additional_properties(data, skip=False):
+    "This recreates the behaviour of kubectl at https://github.com/kubernetes/kubernetes/blob/225b9119d6a8f03fcbe3cc3d590c261965d928d0/pkg/kubectl/validation/schema.go#L312"
+    if isinstance(data, dict):
+        if "properties" in data and not skip:
+            if "additionalProperties" not in data:
+                data["additionalProperties"] = False
+        for _, v in data.items():
+            additional_properties(v)
+    return data
+
+def test_replace_int_or_string():
+    for test in iter([{
+        "input": {"something": {"format": "int-or-string"}},
+        "expect": {'something': {'oneOf': [{'type': 'string'}, {'type': 'integer'}]}}
+    },{
+        "input": {"something": {"format": "string"}},
+        "expect": {"something": {"format": "string"}},
+    }]):
+        assert replace_int_or_string(test["input"]) == test["expect"]
+
+def replace_int_or_string(data):
+    new = {}
+    try:
+        for k, v in iter(data.items()):
+            new_v = v
+            if isinstance(v, dict):
+                if "format" in v and v["format"] == "int-or-string":
+                    new_v = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+                else:
+                    new_v = replace_int_or_string(v)
+            elif isinstance(v, list):
+                new_v = list()
+                for x in v:
+                    new_v.append(replace_int_or_string(x))
+            else:
+                new_v = v
+            new[k] = new_v
+        return new
+    except AttributeError:
+        return data
+
+def allow_null_optional_fields(data, parent=None, grand_parent=None, key=None):
+    new = {}
+    try:
+        for k, v in iter(data.items()):
+            new_v = v
+            if isinstance(v, dict):
+                new_v = allow_null_optional_fields(v, data, parent, k)
+            elif isinstance(v, list):
+                new_v = list()
+                for x in v:
+                    new_v.append(allow_null_optional_fields(x, v, parent, k))
+            elif isinstance(v, str):
+                is_non_null_type = k == "type" and v != "null"
+                has_required_fields = grand_parent and "required" in grand_parent
+                if is_non_null_type and not has_required_fields:
+                    new_v = [v, "null"]
+            new[k] = new_v
+        return new
+    except AttributeError:
+        return data
+
+
+def append_no_duplicates(obj, key, value):
+    """
+    Given a dictionary, lookup the given key, if it doesn't exist create a new array.
+    Then check if the given value already exists in the array, if it doesn't add it.
+    """
+    if key not in obj:
+        obj[key] = []
+    if value not in obj[key]:
+        obj[key].append(value)
+
+
+def write_schema_file(schema, filename):
+    schemaJSON = ""
+
+    schema = additional_properties(schema, skip=not os.getenv("DENY_ROOT_ADDITIONAL_PROPERTIES"))
+    schema = replace_int_or_string(schema)
+    schemaJSON = json.dumps(schema, indent=2)
+
+    # Dealing with user input here..
+    filename = os.path.basename(filename)
+    f = open(filename, "w")
+    print(schemaJSON, file=f)
+    f.close()
+    print("JSON schema written to {filename}".format(filename=filename))
+
+
+def construct_value(load, node):
+    # Handle nodes that start with '='
+    # See https://github.com/yaml/pyyaml/issues/89
+    if not isinstance(node, yaml.ScalarNode):
+        raise yaml.constructor.ConstructorError(
+            "while constructing a value",
+            node.start_mark,
+            "expected a scalar, but found %s" % node.id, node.start_mark
+        )
+    yield str(node.value)
+
+
+if __name__ == "__main__":
+  if len(sys.argv) < 2:
+      print('Missing FILE parameter.\nUsage: %s [FILE]' % sys.argv[0])
+      exit(1)
+
+  for crdFile in sys.argv[1:]:
+      if crdFile.startswith("http"):
+        f = urllib.request.urlopen(crdFile)
+      else:
+        f = open(crdFile)
+      with f:
+          defs = []
+          yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:value', construct_value)
+          for y in yaml.load_all(f, Loader=yaml.SafeLoader):
+              if y is None:
+                  continue
+              if "items" in y:
+                  defs.extend(y["items"])
+              if "kind" not in y:
+                  continue
+              if y["kind"] != "CustomResourceDefinition":
+                  continue
+              else:
+                  defs.append(y)
+
+          for y in defs:
+              filename_format = os.getenv("FILENAME_FORMAT", "{kind}_{version}")
+              filename = ""
+              if "spec" in y and "versions" in y["spec"] and y["spec"]["versions"]:
+                  for version in y["spec"]["versions"]:
+                      if "schema" in version and "openAPIV3Schema" in version["schema"]:
+                          filename = filename_format.format(
+                              kind=y["spec"]["names"]["kind"],
+                              group=y["spec"]["group"].split(".")[0],
+                              fullgroup=y["spec"]["group"],
+                              version=version["name"],
+                          ).lower() + ".json"
+
+                          schema = version["schema"]["openAPIV3Schema"]
+                          write_schema_file(schema, filename)
+                      elif "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:
+                          filename = filename_format.format(
+                              kind=y["spec"]["names"]["kind"],
+                              group=y["spec"]["group"].split(".")[0],
+                              fullgroup=y["spec"]["group"],
+                              version=version["name"],
+                          ).lower() + ".json"
+
+                          schema = y["spec"]["validation"]["openAPIV3Schema"]
+                          write_schema_file(schema, filename)
+              elif "spec" in y and "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:
+                  filename = filename_format.format(
+                      kind=y["spec"]["names"]["kind"],
+                      group=y["spec"]["group"].split(".")[0],
+                      fullgroup=y["spec"]["group"],
+                      version=y["spec"]["version"],
+                  ).lower() + ".json"
+
+                  schema = y["spec"]["validation"]["openAPIV3Schema"]
+                  write_schema_file(schema, filename)
+
+  exit(0)

--- a/install/kubernetes/schemas/podinfo-cilium.io.json
+++ b/install/kubernetes/schemas/podinfo-cilium.io.json
@@ -1,0 +1,81 @@
+{
+  "description": "PodInfo is the Scheme for the Podinfo API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "hostNetwork": {
+          "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "podIP": {
+          "description": "IP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.",
+          "type": "string"
+        },
+        "podIPs": {
+          "description": "List of Ip addresses allocated to the pod. 0th entry must be same as PodIP.",
+          "items": {
+            "properties": {
+              "IP": {
+                "description": "IP is an IP address (IPv4 or IPv6) assigned to the pod",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "workloadObject": {
+      "description": "Workload that created this pod.",
+      "properties": {
+        "name": {
+          "description": "Name of the object.",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of this object.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "workloadType": {
+      "description": "Workload type (e.g. \"Deployment\", \"Daemonset\") that created this pod.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/install/kubernetes/schemas/tracingpolicy-cilium.io.json
+++ b/install/kubernetes/schemas/tracingpolicy-cilium.io.json
@@ -1,0 +1,2933 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Tracing policy specification.",
+      "properties": {
+        "containerSelector": {
+          "description": "ContainerSelector selects containers that this policy applies to. A map of container fields will be constructed in the same way as a map of labels. The name of the field represents the label \"key\", and the value of the field - label \"value\". Currently, only the \"name\" field is supported.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "enum": [
+                      "In",
+                      "NotIn",
+                      "Exists",
+                      "DoesNotExist"
+                    ],
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "description": "MatchLabelsValue represents the value from the MatchLabels {key,value} pair.",
+                "maxLength": 63,
+                "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "enforcers": {
+          "description": "A killer spec.",
+          "items": {
+            "properties": {
+              "calls": {
+                "description": "Calls where enforcer is executed in",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "calls"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "kprobes": {
+          "description": "A list of kprobe specs.",
+          "items": {
+            "properties": {
+              "args": {
+                "description": "A list of function arguments to include in the trace output.",
+                "items": {
+                  "properties": {
+                    "index": {
+                      "description": "Position of the argument.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "label": {
+                      "description": "Label to output in the JSON",
+                      "type": "string"
+                    },
+                    "maxData": {
+                      "default": false,
+                      "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                      "type": "boolean"
+                    },
+                    "returnCopy": {
+                      "default": false,
+                      "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                      "type": "boolean"
+                    },
+                    "sizeArgIndex": {
+                      "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "default": "auto",
+                      "description": "Argument type.",
+                      "enum": [
+                        "auto",
+                        "int",
+                        "int8",
+                        "uint8",
+                        "int16",
+                        "uint16",
+                        "uint32",
+                        "int32",
+                        "uint64",
+                        "int64",
+                        "char_buf",
+                        "char_iovec",
+                        "size_t",
+                        "skb",
+                        "sock",
+                        "string",
+                        "fd",
+                        "file",
+                        "filename",
+                        "path",
+                        "nop",
+                        "bpf_attr",
+                        "perf_event",
+                        "bpf_map",
+                        "user_namespace",
+                        "capability",
+                        "kiocb",
+                        "iov_iter",
+                        "cred",
+                        "load_info",
+                        "module",
+                        "syscall64",
+                        "kernel_cap_t",
+                        "cap_inheritable",
+                        "cap_permitted",
+                        "cap_effective",
+                        "linux_binprm",
+                        "data_loc",
+                        "net_device"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "call": {
+                "description": "Name of the function to apply the kprobe spec to.",
+                "type": "string"
+              },
+              "message": {
+                "description": "A short message of 256 characters max that will be included in the event output to inform users what is going on.",
+                "type": "string"
+              },
+              "return": {
+                "default": false,
+                "description": "Indicates whether to collect return value of the traced function.",
+                "type": "boolean"
+              },
+              "returnArg": {
+                "description": "A return argument to include in the trace output.",
+                "properties": {
+                  "index": {
+                    "description": "Position of the argument.",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "label": {
+                    "description": "Label to output in the JSON",
+                    "type": "string"
+                  },
+                  "maxData": {
+                    "default": false,
+                    "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                    "type": "boolean"
+                  },
+                  "returnCopy": {
+                    "default": false,
+                    "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                    "type": "boolean"
+                  },
+                  "sizeArgIndex": {
+                    "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": {
+                    "default": "auto",
+                    "description": "Argument type.",
+                    "enum": [
+                      "auto",
+                      "int",
+                      "int8",
+                      "uint8",
+                      "int16",
+                      "uint16",
+                      "uint32",
+                      "int32",
+                      "uint64",
+                      "int64",
+                      "char_buf",
+                      "char_iovec",
+                      "size_t",
+                      "skb",
+                      "sock",
+                      "string",
+                      "fd",
+                      "file",
+                      "filename",
+                      "path",
+                      "nop",
+                      "bpf_attr",
+                      "perf_event",
+                      "bpf_map",
+                      "user_namespace",
+                      "capability",
+                      "kiocb",
+                      "iov_iter",
+                      "cred",
+                      "load_info",
+                      "module",
+                      "syscall64",
+                      "kernel_cap_t",
+                      "cap_inheritable",
+                      "cap_permitted",
+                      "cap_effective",
+                      "linux_binprm",
+                      "data_loc",
+                      "net_device"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "index",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "returnArgAction": {
+                "description": "An action to perform on the return argument. Available actions are: Post;TrackSock;UntrackSock",
+                "type": "string"
+              },
+              "selectors": {
+                "description": "Selectors to apply before producing trace output. Selectors are ORed.",
+                "items": {
+                  "description": "KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.",
+                  "properties": {
+                    "matchActions": {
+                      "description": "A list of actions to execute when this selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchBinaries": {
+                      "description": "A list of binary exec name filters.",
+                      "items": {
+                        "properties": {
+                          "followChildren": {
+                            "default": false,
+                            "description": "In addition to binaries, match children processes of specified binaries.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "In",
+                              "NotIn",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilities": {
+                      "description": "A list of capabilities and IDs",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilityChanges": {
+                      "description": "IDs for capabilities changes",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaceChanges": {
+                      "description": "IDs for namespace changes",
+                      "items": {
+                        "properties": {
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace types (e.g., Mnt, Pid) to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaces": {
+                      "description": "A list of namespaces and IDs",
+                      "items": {
+                        "properties": {
+                          "namespace": {
+                            "description": "Namespace selector name.",
+                            "enum": [
+                              "Uts",
+                              "Ipc",
+                              "Mnt",
+                              "Pid",
+                              "PidForChildren",
+                              "Net",
+                              "Time",
+                              "TimeForChildren",
+                              "Cgroup",
+                              "User"
+                            ],
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace IDs (or host_ns for host namespace) of namespaces to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "namespace",
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchPIDs": {
+                      "description": "A list of process ID filters. MatchPIDs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "followForks": {
+                            "default": false,
+                            "description": "Matches any descendant processes of the matching PIDs.",
+                            "type": "boolean"
+                          },
+                          "isNamespacePID": {
+                            "default": false,
+                            "description": "Indicates whether PIDs are namespace PIDs.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "PID selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Process IDs to match.",
+                            "items": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnActions": {
+                      "description": "A list of actions to execute when MatchReturnArgs selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "syscall": {
+                "default": true,
+                "description": "Indicates whether the traced function is a syscall.",
+                "type": "boolean"
+              },
+              "tags": {
+                "description": "Tags to categorize the event, will be include in the event output. Maximum of 16 Tags are supported.",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 16,
+                "type": "array"
+              }
+            },
+            "required": [
+              "call"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lists": {
+          "description": "A list of list specs.",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Name of the list",
+                "type": "string"
+              },
+              "pattern": {
+                "description": "Pattern for 'generated' lists.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Indicates the type of the list values.",
+                "enum": [
+                  "syscalls",
+                  "generated_syscalls",
+                  "generated_ftrace"
+                ],
+                "type": "string"
+              },
+              "validated": {
+                "description": "List was validated",
+                "type": "boolean"
+              },
+              "values": {
+                "description": "Values of the list",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "loader": {
+          "description": "Enable loader events",
+          "type": "boolean"
+        },
+        "lsmhooks": {
+          "description": "A list of uprobe specs.",
+          "items": {
+            "properties": {
+              "args": {
+                "description": "A list of function arguments to include in the trace output.",
+                "items": {
+                  "properties": {
+                    "index": {
+                      "description": "Position of the argument.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "label": {
+                      "description": "Label to output in the JSON",
+                      "type": "string"
+                    },
+                    "maxData": {
+                      "default": false,
+                      "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                      "type": "boolean"
+                    },
+                    "returnCopy": {
+                      "default": false,
+                      "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                      "type": "boolean"
+                    },
+                    "sizeArgIndex": {
+                      "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "default": "auto",
+                      "description": "Argument type.",
+                      "enum": [
+                        "auto",
+                        "int",
+                        "int8",
+                        "uint8",
+                        "int16",
+                        "uint16",
+                        "uint32",
+                        "int32",
+                        "uint64",
+                        "int64",
+                        "char_buf",
+                        "char_iovec",
+                        "size_t",
+                        "skb",
+                        "sock",
+                        "string",
+                        "fd",
+                        "file",
+                        "filename",
+                        "path",
+                        "nop",
+                        "bpf_attr",
+                        "perf_event",
+                        "bpf_map",
+                        "user_namespace",
+                        "capability",
+                        "kiocb",
+                        "iov_iter",
+                        "cred",
+                        "load_info",
+                        "module",
+                        "syscall64",
+                        "kernel_cap_t",
+                        "cap_inheritable",
+                        "cap_permitted",
+                        "cap_effective",
+                        "linux_binprm",
+                        "data_loc",
+                        "net_device"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "hook": {
+                "description": "Name of the function to apply the kprobe spec to.",
+                "type": "string"
+              },
+              "message": {
+                "description": "A short message of 256 characters max that will be included in the event output to inform users what is going on.",
+                "type": "string"
+              },
+              "selectors": {
+                "description": "Selectors to apply before producing trace output. Selectors are ORed.",
+                "items": {
+                  "description": "KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.",
+                  "properties": {
+                    "matchActions": {
+                      "description": "A list of actions to execute when this selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchBinaries": {
+                      "description": "A list of binary exec name filters.",
+                      "items": {
+                        "properties": {
+                          "followChildren": {
+                            "default": false,
+                            "description": "In addition to binaries, match children processes of specified binaries.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "In",
+                              "NotIn",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilities": {
+                      "description": "A list of capabilities and IDs",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilityChanges": {
+                      "description": "IDs for capabilities changes",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaceChanges": {
+                      "description": "IDs for namespace changes",
+                      "items": {
+                        "properties": {
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace types (e.g., Mnt, Pid) to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaces": {
+                      "description": "A list of namespaces and IDs",
+                      "items": {
+                        "properties": {
+                          "namespace": {
+                            "description": "Namespace selector name.",
+                            "enum": [
+                              "Uts",
+                              "Ipc",
+                              "Mnt",
+                              "Pid",
+                              "PidForChildren",
+                              "Net",
+                              "Time",
+                              "TimeForChildren",
+                              "Cgroup",
+                              "User"
+                            ],
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace IDs (or host_ns for host namespace) of namespaces to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "namespace",
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchPIDs": {
+                      "description": "A list of process ID filters. MatchPIDs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "followForks": {
+                            "default": false,
+                            "description": "Matches any descendant processes of the matching PIDs.",
+                            "type": "boolean"
+                          },
+                          "isNamespacePID": {
+                            "default": false,
+                            "description": "Indicates whether PIDs are namespace PIDs.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "PID selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Process IDs to match.",
+                            "items": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnActions": {
+                      "description": "A list of actions to execute when MatchReturnArgs selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "tags": {
+                "description": "Tags to categorize the event, will be include in the event output. Maximum of 16 Tags are supported.",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 16,
+                "type": "array"
+              }
+            },
+            "required": [
+              "hook"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "options": {
+          "description": "A list of overloaded options",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Name of the option",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value of the option",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "podSelector": {
+          "description": "PodSelector selects pods that this policy applies to",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "enum": [
+                      "In",
+                      "NotIn",
+                      "Exists",
+                      "DoesNotExist"
+                    ],
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "description": "MatchLabelsValue represents the value from the MatchLabels {key,value} pair.",
+                "maxLength": 63,
+                "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tracepoints": {
+          "description": "A list of tracepoint specs.",
+          "items": {
+            "properties": {
+              "args": {
+                "description": "A list of function arguments to include in the trace output.",
+                "items": {
+                  "properties": {
+                    "index": {
+                      "description": "Position of the argument.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "label": {
+                      "description": "Label to output in the JSON",
+                      "type": "string"
+                    },
+                    "maxData": {
+                      "default": false,
+                      "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                      "type": "boolean"
+                    },
+                    "returnCopy": {
+                      "default": false,
+                      "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                      "type": "boolean"
+                    },
+                    "sizeArgIndex": {
+                      "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "default": "auto",
+                      "description": "Argument type.",
+                      "enum": [
+                        "auto",
+                        "int",
+                        "int8",
+                        "uint8",
+                        "int16",
+                        "uint16",
+                        "uint32",
+                        "int32",
+                        "uint64",
+                        "int64",
+                        "char_buf",
+                        "char_iovec",
+                        "size_t",
+                        "skb",
+                        "sock",
+                        "string",
+                        "fd",
+                        "file",
+                        "filename",
+                        "path",
+                        "nop",
+                        "bpf_attr",
+                        "perf_event",
+                        "bpf_map",
+                        "user_namespace",
+                        "capability",
+                        "kiocb",
+                        "iov_iter",
+                        "cred",
+                        "load_info",
+                        "module",
+                        "syscall64",
+                        "kernel_cap_t",
+                        "cap_inheritable",
+                        "cap_permitted",
+                        "cap_effective",
+                        "linux_binprm",
+                        "data_loc",
+                        "net_device"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "event": {
+                "description": "Tracepoint event",
+                "type": "string"
+              },
+              "message": {
+                "description": "A short message of 256 characters max that will be included in the event output to inform users what is going on.",
+                "type": "string"
+              },
+              "selectors": {
+                "description": "Selectors to apply before producing trace output. Selectors are ORed.",
+                "items": {
+                  "description": "KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.",
+                  "properties": {
+                    "matchActions": {
+                      "description": "A list of actions to execute when this selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchBinaries": {
+                      "description": "A list of binary exec name filters.",
+                      "items": {
+                        "properties": {
+                          "followChildren": {
+                            "default": false,
+                            "description": "In addition to binaries, match children processes of specified binaries.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "In",
+                              "NotIn",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilities": {
+                      "description": "A list of capabilities and IDs",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilityChanges": {
+                      "description": "IDs for capabilities changes",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaceChanges": {
+                      "description": "IDs for namespace changes",
+                      "items": {
+                        "properties": {
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace types (e.g., Mnt, Pid) to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaces": {
+                      "description": "A list of namespaces and IDs",
+                      "items": {
+                        "properties": {
+                          "namespace": {
+                            "description": "Namespace selector name.",
+                            "enum": [
+                              "Uts",
+                              "Ipc",
+                              "Mnt",
+                              "Pid",
+                              "PidForChildren",
+                              "Net",
+                              "Time",
+                              "TimeForChildren",
+                              "Cgroup",
+                              "User"
+                            ],
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace IDs (or host_ns for host namespace) of namespaces to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "namespace",
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchPIDs": {
+                      "description": "A list of process ID filters. MatchPIDs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "followForks": {
+                            "default": false,
+                            "description": "Matches any descendant processes of the matching PIDs.",
+                            "type": "boolean"
+                          },
+                          "isNamespacePID": {
+                            "default": false,
+                            "description": "Indicates whether PIDs are namespace PIDs.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "PID selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Process IDs to match.",
+                            "items": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnActions": {
+                      "description": "A list of actions to execute when MatchReturnArgs selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "subsystem": {
+                "description": "Tracepoint subsystem",
+                "type": "string"
+              },
+              "tags": {
+                "description": "Tags to categorize the event, will be include in the event output. Maximum of 16 Tags are supported.",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 16,
+                "type": "array"
+              }
+            },
+            "required": [
+              "event",
+              "subsystem"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "uprobes": {
+          "description": "A list of uprobe specs.",
+          "items": {
+            "properties": {
+              "args": {
+                "description": "A list of function arguments to include in the trace output.",
+                "items": {
+                  "properties": {
+                    "index": {
+                      "description": "Position of the argument.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "label": {
+                      "description": "Label to output in the JSON",
+                      "type": "string"
+                    },
+                    "maxData": {
+                      "default": false,
+                      "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                      "type": "boolean"
+                    },
+                    "returnCopy": {
+                      "default": false,
+                      "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                      "type": "boolean"
+                    },
+                    "sizeArgIndex": {
+                      "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "default": "auto",
+                      "description": "Argument type.",
+                      "enum": [
+                        "auto",
+                        "int",
+                        "int8",
+                        "uint8",
+                        "int16",
+                        "uint16",
+                        "uint32",
+                        "int32",
+                        "uint64",
+                        "int64",
+                        "char_buf",
+                        "char_iovec",
+                        "size_t",
+                        "skb",
+                        "sock",
+                        "string",
+                        "fd",
+                        "file",
+                        "filename",
+                        "path",
+                        "nop",
+                        "bpf_attr",
+                        "perf_event",
+                        "bpf_map",
+                        "user_namespace",
+                        "capability",
+                        "kiocb",
+                        "iov_iter",
+                        "cred",
+                        "load_info",
+                        "module",
+                        "syscall64",
+                        "kernel_cap_t",
+                        "cap_inheritable",
+                        "cap_permitted",
+                        "cap_effective",
+                        "linux_binprm",
+                        "data_loc",
+                        "net_device"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "message": {
+                "description": "A short message of 256 characters max that will be included in the event output to inform users what is going on.",
+                "type": "string"
+              },
+              "path": {
+                "description": "Name of the traced binary",
+                "type": "string"
+              },
+              "selectors": {
+                "description": "Selectors to apply before producing trace output. Selectors are ORed.",
+                "items": {
+                  "description": "KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.",
+                  "properties": {
+                    "matchActions": {
+                      "description": "A list of actions to execute when this selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchBinaries": {
+                      "description": "A list of binary exec name filters.",
+                      "items": {
+                        "properties": {
+                          "followChildren": {
+                            "default": false,
+                            "description": "In addition to binaries, match children processes of specified binaries.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "In",
+                              "NotIn",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilities": {
+                      "description": "A list of capabilities and IDs",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilityChanges": {
+                      "description": "IDs for capabilities changes",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaceChanges": {
+                      "description": "IDs for namespace changes",
+                      "items": {
+                        "properties": {
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace types (e.g., Mnt, Pid) to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaces": {
+                      "description": "A list of namespaces and IDs",
+                      "items": {
+                        "properties": {
+                          "namespace": {
+                            "description": "Namespace selector name.",
+                            "enum": [
+                              "Uts",
+                              "Ipc",
+                              "Mnt",
+                              "Pid",
+                              "PidForChildren",
+                              "Net",
+                              "Time",
+                              "TimeForChildren",
+                              "Cgroup",
+                              "User"
+                            ],
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace IDs (or host_ns for host namespace) of namespaces to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "namespace",
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchPIDs": {
+                      "description": "A list of process ID filters. MatchPIDs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "followForks": {
+                            "default": false,
+                            "description": "Matches any descendant processes of the matching PIDs.",
+                            "type": "boolean"
+                          },
+                          "isNamespacePID": {
+                            "default": false,
+                            "description": "Indicates whether PIDs are namespace PIDs.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "PID selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Process IDs to match.",
+                            "items": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnActions": {
+                      "description": "A list of actions to execute when MatchReturnArgs selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "symbols": {
+                "description": "List of the traced symbols",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "tags": {
+                "description": "Tags to categorize the event, will be include in the event output. Maximum of 16 Tags are supported.",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 16,
+                "type": "array"
+              }
+            },
+            "required": [
+              "path",
+              "symbols"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object"
+}

--- a/install/kubernetes/schemas/tracingpolicynamespaced-cilium.io.json
+++ b/install/kubernetes/schemas/tracingpolicynamespaced-cilium.io.json
@@ -1,0 +1,2933 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Tracing policy specification.",
+      "properties": {
+        "containerSelector": {
+          "description": "ContainerSelector selects containers that this policy applies to. A map of container fields will be constructed in the same way as a map of labels. The name of the field represents the label \"key\", and the value of the field - label \"value\". Currently, only the \"name\" field is supported.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "enum": [
+                      "In",
+                      "NotIn",
+                      "Exists",
+                      "DoesNotExist"
+                    ],
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "description": "MatchLabelsValue represents the value from the MatchLabels {key,value} pair.",
+                "maxLength": 63,
+                "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "enforcers": {
+          "description": "A killer spec.",
+          "items": {
+            "properties": {
+              "calls": {
+                "description": "Calls where enforcer is executed in",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "calls"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "kprobes": {
+          "description": "A list of kprobe specs.",
+          "items": {
+            "properties": {
+              "args": {
+                "description": "A list of function arguments to include in the trace output.",
+                "items": {
+                  "properties": {
+                    "index": {
+                      "description": "Position of the argument.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "label": {
+                      "description": "Label to output in the JSON",
+                      "type": "string"
+                    },
+                    "maxData": {
+                      "default": false,
+                      "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                      "type": "boolean"
+                    },
+                    "returnCopy": {
+                      "default": false,
+                      "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                      "type": "boolean"
+                    },
+                    "sizeArgIndex": {
+                      "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "default": "auto",
+                      "description": "Argument type.",
+                      "enum": [
+                        "auto",
+                        "int",
+                        "int8",
+                        "uint8",
+                        "int16",
+                        "uint16",
+                        "uint32",
+                        "int32",
+                        "uint64",
+                        "int64",
+                        "char_buf",
+                        "char_iovec",
+                        "size_t",
+                        "skb",
+                        "sock",
+                        "string",
+                        "fd",
+                        "file",
+                        "filename",
+                        "path",
+                        "nop",
+                        "bpf_attr",
+                        "perf_event",
+                        "bpf_map",
+                        "user_namespace",
+                        "capability",
+                        "kiocb",
+                        "iov_iter",
+                        "cred",
+                        "load_info",
+                        "module",
+                        "syscall64",
+                        "kernel_cap_t",
+                        "cap_inheritable",
+                        "cap_permitted",
+                        "cap_effective",
+                        "linux_binprm",
+                        "data_loc",
+                        "net_device"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "call": {
+                "description": "Name of the function to apply the kprobe spec to.",
+                "type": "string"
+              },
+              "message": {
+                "description": "A short message of 256 characters max that will be included in the event output to inform users what is going on.",
+                "type": "string"
+              },
+              "return": {
+                "default": false,
+                "description": "Indicates whether to collect return value of the traced function.",
+                "type": "boolean"
+              },
+              "returnArg": {
+                "description": "A return argument to include in the trace output.",
+                "properties": {
+                  "index": {
+                    "description": "Position of the argument.",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "label": {
+                    "description": "Label to output in the JSON",
+                    "type": "string"
+                  },
+                  "maxData": {
+                    "default": false,
+                    "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                    "type": "boolean"
+                  },
+                  "returnCopy": {
+                    "default": false,
+                    "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                    "type": "boolean"
+                  },
+                  "sizeArgIndex": {
+                    "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "type": {
+                    "default": "auto",
+                    "description": "Argument type.",
+                    "enum": [
+                      "auto",
+                      "int",
+                      "int8",
+                      "uint8",
+                      "int16",
+                      "uint16",
+                      "uint32",
+                      "int32",
+                      "uint64",
+                      "int64",
+                      "char_buf",
+                      "char_iovec",
+                      "size_t",
+                      "skb",
+                      "sock",
+                      "string",
+                      "fd",
+                      "file",
+                      "filename",
+                      "path",
+                      "nop",
+                      "bpf_attr",
+                      "perf_event",
+                      "bpf_map",
+                      "user_namespace",
+                      "capability",
+                      "kiocb",
+                      "iov_iter",
+                      "cred",
+                      "load_info",
+                      "module",
+                      "syscall64",
+                      "kernel_cap_t",
+                      "cap_inheritable",
+                      "cap_permitted",
+                      "cap_effective",
+                      "linux_binprm",
+                      "data_loc",
+                      "net_device"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "index",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "returnArgAction": {
+                "description": "An action to perform on the return argument. Available actions are: Post;TrackSock;UntrackSock",
+                "type": "string"
+              },
+              "selectors": {
+                "description": "Selectors to apply before producing trace output. Selectors are ORed.",
+                "items": {
+                  "description": "KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.",
+                  "properties": {
+                    "matchActions": {
+                      "description": "A list of actions to execute when this selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchBinaries": {
+                      "description": "A list of binary exec name filters.",
+                      "items": {
+                        "properties": {
+                          "followChildren": {
+                            "default": false,
+                            "description": "In addition to binaries, match children processes of specified binaries.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "In",
+                              "NotIn",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilities": {
+                      "description": "A list of capabilities and IDs",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilityChanges": {
+                      "description": "IDs for capabilities changes",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaceChanges": {
+                      "description": "IDs for namespace changes",
+                      "items": {
+                        "properties": {
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace types (e.g., Mnt, Pid) to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaces": {
+                      "description": "A list of namespaces and IDs",
+                      "items": {
+                        "properties": {
+                          "namespace": {
+                            "description": "Namespace selector name.",
+                            "enum": [
+                              "Uts",
+                              "Ipc",
+                              "Mnt",
+                              "Pid",
+                              "PidForChildren",
+                              "Net",
+                              "Time",
+                              "TimeForChildren",
+                              "Cgroup",
+                              "User"
+                            ],
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace IDs (or host_ns for host namespace) of namespaces to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "namespace",
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchPIDs": {
+                      "description": "A list of process ID filters. MatchPIDs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "followForks": {
+                            "default": false,
+                            "description": "Matches any descendant processes of the matching PIDs.",
+                            "type": "boolean"
+                          },
+                          "isNamespacePID": {
+                            "default": false,
+                            "description": "Indicates whether PIDs are namespace PIDs.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "PID selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Process IDs to match.",
+                            "items": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnActions": {
+                      "description": "A list of actions to execute when MatchReturnArgs selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "syscall": {
+                "default": true,
+                "description": "Indicates whether the traced function is a syscall.",
+                "type": "boolean"
+              },
+              "tags": {
+                "description": "Tags to categorize the event, will be include in the event output. Maximum of 16 Tags are supported.",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 16,
+                "type": "array"
+              }
+            },
+            "required": [
+              "call"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lists": {
+          "description": "A list of list specs.",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Name of the list",
+                "type": "string"
+              },
+              "pattern": {
+                "description": "Pattern for 'generated' lists.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Indicates the type of the list values.",
+                "enum": [
+                  "syscalls",
+                  "generated_syscalls",
+                  "generated_ftrace"
+                ],
+                "type": "string"
+              },
+              "validated": {
+                "description": "List was validated",
+                "type": "boolean"
+              },
+              "values": {
+                "description": "Values of the list",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "loader": {
+          "description": "Enable loader events",
+          "type": "boolean"
+        },
+        "lsmhooks": {
+          "description": "A list of uprobe specs.",
+          "items": {
+            "properties": {
+              "args": {
+                "description": "A list of function arguments to include in the trace output.",
+                "items": {
+                  "properties": {
+                    "index": {
+                      "description": "Position of the argument.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "label": {
+                      "description": "Label to output in the JSON",
+                      "type": "string"
+                    },
+                    "maxData": {
+                      "default": false,
+                      "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                      "type": "boolean"
+                    },
+                    "returnCopy": {
+                      "default": false,
+                      "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                      "type": "boolean"
+                    },
+                    "sizeArgIndex": {
+                      "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "default": "auto",
+                      "description": "Argument type.",
+                      "enum": [
+                        "auto",
+                        "int",
+                        "int8",
+                        "uint8",
+                        "int16",
+                        "uint16",
+                        "uint32",
+                        "int32",
+                        "uint64",
+                        "int64",
+                        "char_buf",
+                        "char_iovec",
+                        "size_t",
+                        "skb",
+                        "sock",
+                        "string",
+                        "fd",
+                        "file",
+                        "filename",
+                        "path",
+                        "nop",
+                        "bpf_attr",
+                        "perf_event",
+                        "bpf_map",
+                        "user_namespace",
+                        "capability",
+                        "kiocb",
+                        "iov_iter",
+                        "cred",
+                        "load_info",
+                        "module",
+                        "syscall64",
+                        "kernel_cap_t",
+                        "cap_inheritable",
+                        "cap_permitted",
+                        "cap_effective",
+                        "linux_binprm",
+                        "data_loc",
+                        "net_device"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "hook": {
+                "description": "Name of the function to apply the kprobe spec to.",
+                "type": "string"
+              },
+              "message": {
+                "description": "A short message of 256 characters max that will be included in the event output to inform users what is going on.",
+                "type": "string"
+              },
+              "selectors": {
+                "description": "Selectors to apply before producing trace output. Selectors are ORed.",
+                "items": {
+                  "description": "KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.",
+                  "properties": {
+                    "matchActions": {
+                      "description": "A list of actions to execute when this selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchBinaries": {
+                      "description": "A list of binary exec name filters.",
+                      "items": {
+                        "properties": {
+                          "followChildren": {
+                            "default": false,
+                            "description": "In addition to binaries, match children processes of specified binaries.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "In",
+                              "NotIn",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilities": {
+                      "description": "A list of capabilities and IDs",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilityChanges": {
+                      "description": "IDs for capabilities changes",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaceChanges": {
+                      "description": "IDs for namespace changes",
+                      "items": {
+                        "properties": {
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace types (e.g., Mnt, Pid) to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaces": {
+                      "description": "A list of namespaces and IDs",
+                      "items": {
+                        "properties": {
+                          "namespace": {
+                            "description": "Namespace selector name.",
+                            "enum": [
+                              "Uts",
+                              "Ipc",
+                              "Mnt",
+                              "Pid",
+                              "PidForChildren",
+                              "Net",
+                              "Time",
+                              "TimeForChildren",
+                              "Cgroup",
+                              "User"
+                            ],
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace IDs (or host_ns for host namespace) of namespaces to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "namespace",
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchPIDs": {
+                      "description": "A list of process ID filters. MatchPIDs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "followForks": {
+                            "default": false,
+                            "description": "Matches any descendant processes of the matching PIDs.",
+                            "type": "boolean"
+                          },
+                          "isNamespacePID": {
+                            "default": false,
+                            "description": "Indicates whether PIDs are namespace PIDs.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "PID selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Process IDs to match.",
+                            "items": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnActions": {
+                      "description": "A list of actions to execute when MatchReturnArgs selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "tags": {
+                "description": "Tags to categorize the event, will be include in the event output. Maximum of 16 Tags are supported.",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 16,
+                "type": "array"
+              }
+            },
+            "required": [
+              "hook"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "options": {
+          "description": "A list of overloaded options",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Name of the option",
+                "type": "string"
+              },
+              "value": {
+                "description": "Value of the option",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "podSelector": {
+          "description": "PodSelector selects pods that this policy applies to",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "enum": [
+                      "In",
+                      "NotIn",
+                      "Exists",
+                      "DoesNotExist"
+                    ],
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "description": "MatchLabelsValue represents the value from the MatchLabels {key,value} pair.",
+                "maxLength": 63,
+                "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "tracepoints": {
+          "description": "A list of tracepoint specs.",
+          "items": {
+            "properties": {
+              "args": {
+                "description": "A list of function arguments to include in the trace output.",
+                "items": {
+                  "properties": {
+                    "index": {
+                      "description": "Position of the argument.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "label": {
+                      "description": "Label to output in the JSON",
+                      "type": "string"
+                    },
+                    "maxData": {
+                      "default": false,
+                      "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                      "type": "boolean"
+                    },
+                    "returnCopy": {
+                      "default": false,
+                      "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                      "type": "boolean"
+                    },
+                    "sizeArgIndex": {
+                      "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "default": "auto",
+                      "description": "Argument type.",
+                      "enum": [
+                        "auto",
+                        "int",
+                        "int8",
+                        "uint8",
+                        "int16",
+                        "uint16",
+                        "uint32",
+                        "int32",
+                        "uint64",
+                        "int64",
+                        "char_buf",
+                        "char_iovec",
+                        "size_t",
+                        "skb",
+                        "sock",
+                        "string",
+                        "fd",
+                        "file",
+                        "filename",
+                        "path",
+                        "nop",
+                        "bpf_attr",
+                        "perf_event",
+                        "bpf_map",
+                        "user_namespace",
+                        "capability",
+                        "kiocb",
+                        "iov_iter",
+                        "cred",
+                        "load_info",
+                        "module",
+                        "syscall64",
+                        "kernel_cap_t",
+                        "cap_inheritable",
+                        "cap_permitted",
+                        "cap_effective",
+                        "linux_binprm",
+                        "data_loc",
+                        "net_device"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "event": {
+                "description": "Tracepoint event",
+                "type": "string"
+              },
+              "message": {
+                "description": "A short message of 256 characters max that will be included in the event output to inform users what is going on.",
+                "type": "string"
+              },
+              "selectors": {
+                "description": "Selectors to apply before producing trace output. Selectors are ORed.",
+                "items": {
+                  "description": "KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.",
+                  "properties": {
+                    "matchActions": {
+                      "description": "A list of actions to execute when this selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchBinaries": {
+                      "description": "A list of binary exec name filters.",
+                      "items": {
+                        "properties": {
+                          "followChildren": {
+                            "default": false,
+                            "description": "In addition to binaries, match children processes of specified binaries.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "In",
+                              "NotIn",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilities": {
+                      "description": "A list of capabilities and IDs",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilityChanges": {
+                      "description": "IDs for capabilities changes",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaceChanges": {
+                      "description": "IDs for namespace changes",
+                      "items": {
+                        "properties": {
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace types (e.g., Mnt, Pid) to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaces": {
+                      "description": "A list of namespaces and IDs",
+                      "items": {
+                        "properties": {
+                          "namespace": {
+                            "description": "Namespace selector name.",
+                            "enum": [
+                              "Uts",
+                              "Ipc",
+                              "Mnt",
+                              "Pid",
+                              "PidForChildren",
+                              "Net",
+                              "Time",
+                              "TimeForChildren",
+                              "Cgroup",
+                              "User"
+                            ],
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace IDs (or host_ns for host namespace) of namespaces to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "namespace",
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchPIDs": {
+                      "description": "A list of process ID filters. MatchPIDs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "followForks": {
+                            "default": false,
+                            "description": "Matches any descendant processes of the matching PIDs.",
+                            "type": "boolean"
+                          },
+                          "isNamespacePID": {
+                            "default": false,
+                            "description": "Indicates whether PIDs are namespace PIDs.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "PID selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Process IDs to match.",
+                            "items": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnActions": {
+                      "description": "A list of actions to execute when MatchReturnArgs selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "subsystem": {
+                "description": "Tracepoint subsystem",
+                "type": "string"
+              },
+              "tags": {
+                "description": "Tags to categorize the event, will be include in the event output. Maximum of 16 Tags are supported.",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 16,
+                "type": "array"
+              }
+            },
+            "required": [
+              "event",
+              "subsystem"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "uprobes": {
+          "description": "A list of uprobe specs.",
+          "items": {
+            "properties": {
+              "args": {
+                "description": "A list of function arguments to include in the trace output.",
+                "items": {
+                  "properties": {
+                    "index": {
+                      "description": "Position of the argument.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "label": {
+                      "description": "Label to output in the JSON",
+                      "type": "string"
+                    },
+                    "maxData": {
+                      "default": false,
+                      "description": "Read maximum possible data (currently 327360). This field is only used for char_buff data. When this value is false (default), the bpf program will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon supports fetching up to 327360 bytes if this flag is turned on",
+                      "type": "boolean"
+                    },
+                    "returnCopy": {
+                      "default": false,
+                      "description": "This field is used only for char_buf and char_iovec types. It indicates that this argument should be read later (when the kretprobe for the symbol is triggered) because it might not be populated when the kprobe is triggered at the entrance of the function. For example, a buffer supplied to read(2) won't have content until kretprobe is triggered.",
+                      "type": "boolean"
+                    },
+                    "sizeArgIndex": {
+                      "description": "Specifies the position of the corresponding size argument for this argument. This field is used only for char_buf and char_iovec types.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": {
+                      "default": "auto",
+                      "description": "Argument type.",
+                      "enum": [
+                        "auto",
+                        "int",
+                        "int8",
+                        "uint8",
+                        "int16",
+                        "uint16",
+                        "uint32",
+                        "int32",
+                        "uint64",
+                        "int64",
+                        "char_buf",
+                        "char_iovec",
+                        "size_t",
+                        "skb",
+                        "sock",
+                        "string",
+                        "fd",
+                        "file",
+                        "filename",
+                        "path",
+                        "nop",
+                        "bpf_attr",
+                        "perf_event",
+                        "bpf_map",
+                        "user_namespace",
+                        "capability",
+                        "kiocb",
+                        "iov_iter",
+                        "cred",
+                        "load_info",
+                        "module",
+                        "syscall64",
+                        "kernel_cap_t",
+                        "cap_inheritable",
+                        "cap_permitted",
+                        "cap_effective",
+                        "linux_binprm",
+                        "data_loc",
+                        "net_device"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "message": {
+                "description": "A short message of 256 characters max that will be included in the event output to inform users what is going on.",
+                "type": "string"
+              },
+              "path": {
+                "description": "Name of the traced binary",
+                "type": "string"
+              },
+              "selectors": {
+                "description": "Selectors to apply before producing trace output. Selectors are ORed.",
+                "items": {
+                  "description": "KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The results of MatchPIDs and MatchArgs are ANDed.",
+                  "properties": {
+                    "matchActions": {
+                      "description": "A list of actions to execute when this selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchBinaries": {
+                      "description": "A list of binary exec name filters.",
+                      "items": {
+                        "properties": {
+                          "followChildren": {
+                            "default": false,
+                            "description": "In addition to binaries, match children processes of specified binaries.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "In",
+                              "NotIn",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilities": {
+                      "description": "A list of capabilities and IDs",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchCapabilityChanges": {
+                      "description": "IDs for capabilities changes",
+                      "items": {
+                        "properties": {
+                          "isNamespaceCapability": {
+                            "default": false,
+                            "description": "Indicates whether these caps are namespace caps.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "type": {
+                            "default": "Effective",
+                            "description": "Type of capabilities",
+                            "enum": [
+                              "Effective",
+                              "Inheritable",
+                              "Permitted"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Capabilities to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaceChanges": {
+                      "description": "IDs for namespace changes",
+                      "items": {
+                        "properties": {
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace types (e.g., Mnt, Pid) to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchNamespaces": {
+                      "description": "A list of namespaces and IDs",
+                      "items": {
+                        "properties": {
+                          "namespace": {
+                            "description": "Namespace selector name.",
+                            "enum": [
+                              "Uts",
+                              "Ipc",
+                              "Mnt",
+                              "Pid",
+                              "PidForChildren",
+                              "Net",
+                              "Time",
+                              "TimeForChildren",
+                              "Cgroup",
+                              "User"
+                            ],
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Namespace selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Namespace IDs (or host_ns for host namespace) of namespaces to match.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "namespace",
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchPIDs": {
+                      "description": "A list of process ID filters. MatchPIDs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "followForks": {
+                            "default": false,
+                            "description": "Matches any descendant processes of the matching PIDs.",
+                            "type": "boolean"
+                          },
+                          "isNamespacePID": {
+                            "default": false,
+                            "description": "Indicates whether PIDs are namespace PIDs.",
+                            "type": "boolean"
+                          },
+                          "operator": {
+                            "description": "PID selector operator.",
+                            "enum": [
+                              "In",
+                              "NotIn"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Process IDs to match.",
+                            "items": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "operator",
+                          "values"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnActions": {
+                      "description": "A list of actions to execute when MatchReturnArgs selector matches",
+                      "items": {
+                        "properties": {
+                          "action": {
+                            "description": "Action to execute.",
+                            "enum": [
+                              "Post",
+                              "FollowFD",
+                              "UnfollowFD",
+                              "Sigkill",
+                              "CopyFD",
+                              "Override",
+                              "GetUrl",
+                              "DnsLookup",
+                              "NoPost",
+                              "Signal",
+                              "TrackSock",
+                              "UntrackSock",
+                              "NotifyEnforcer"
+                            ],
+                            "type": "string"
+                          },
+                          "argError": {
+                            "description": "error value for override action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFd": {
+                            "description": "An arg index for the fd for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argFqdn": {
+                            "description": "A FQDN to lookup for the dnsLookup action",
+                            "type": "string"
+                          },
+                          "argName": {
+                            "description": "An arg index for the filename for fdInstall action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSig": {
+                            "description": "A signal number for signal action",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argSock": {
+                            "description": "An arg index for the sock for trackSock and untrackSock actions",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "argUrl": {
+                            "description": "A URL for the getUrl action",
+                            "type": "string"
+                          },
+                          "kernelStackTrace": {
+                            "description": "Enable kernel stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          },
+                          "rateLimit": {
+                            "description": "A time period within which repeated messages will not be posted. Can be specified in seconds (default or with 's' suffix), minutes ('m' suffix) or hours ('h' suffix). Only valid with the post action.",
+                            "type": "string"
+                          },
+                          "rateLimitScope": {
+                            "description": "The scope of the provided rate limit argument. Can be \"thread\" (default), \"process\" (all threads for the same process), or \"global\". If \"thread\" is selected then rate limiting applies per thread; if \"process\" is selected then rate limiting applies per process; if \"global\" is selected then rate limiting applies regardless of which process or thread caused the action. Only valid with the post action and with a rateLimit specified.",
+                            "type": "string"
+                          },
+                          "userStackTrace": {
+                            "description": "Enable user stack trace export. Only valid with the post action.",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchReturnArgs": {
+                      "description": "A list of argument filters. MatchArgs are ANDed.",
+                      "items": {
+                        "properties": {
+                          "index": {
+                            "description": "Position of the argument to apply fhe filter to.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "operator": {
+                            "description": "Filter operation.",
+                            "enum": [
+                              "Equal",
+                              "NotEqual",
+                              "Prefix",
+                              "NotPrefix",
+                              "Postfix",
+                              "NotPostfix",
+                              "GreaterThan",
+                              "LessThan",
+                              "GT",
+                              "LT",
+                              "Mask",
+                              "SPort",
+                              "NotSPort",
+                              "SPortPriv",
+                              "NotSportPriv",
+                              "DPort",
+                              "NotDPort",
+                              "DPortPriv",
+                              "NotDPortPriv",
+                              "SAddr",
+                              "NotSAddr",
+                              "DAddr",
+                              "NotDAddr",
+                              "Protocol",
+                              "Family",
+                              "State",
+                              "InMap",
+                              "NotInMap"
+                            ],
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "Value to compare the argument against.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "index",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "symbols": {
+                "description": "List of the traced symbols",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "tags": {
+                "description": "Tags to categorize the event, will be include in the event output. Maximum of 16 Tags are supported.",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 16,
+                "type": "array"
+              }
+            },
+            "required": [
+              "path",
+              "symbols"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
### Description
- Improved Helm chart validation by using Kubeconformance with enabled CR validation.
- Added JSON schemas for the Tetragon CRDs as we might need them in the future to validate CRs from the Helm chart (TPs, etc.).

Follow up PR of https://github.com/cilium/tetragon/pull/2804

### Changelog

```release-note
CI: Improved K8s Kubeconformance validation
```
