### PR TITLE
Update Dockerfiles to build clang-18 images

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -43,13 +43,9 @@ SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles: false
-SpacesInAngles: false
 SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
-SpacesInParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
 SpacesInSquareBrackets: false
 TabWidth: 8
 UseTab: Always

--- a/Dockerfile.clang
+++ b/Dockerfile.clang
@@ -1,8 +1,8 @@
-FROM docker.io/library/ubuntu:22.04@sha256:0bced47fffa3361afa981854fcabcd4577cd43cebbb808cea2b1f33a3dd7f508
+FROM docker.io/library/ubuntu:24.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 RUN apt-get update && apt-get install -y --no-install-recommends  \
-    clang-15 libclang-common-15-dev libclang-cpp15    	          \
-    libllvm15 llvm-15-linker-tools libclang1-15                   \
-    llvm-15 llvm-15-runtime llvm-15-linker-tools make             \
+    clang-18 libclang-common-18-dev libclang-cpp18    	          \
+    libllvm18 llvm-18-linker-tools libclang1-18                   \
+    llvm-18 llvm-18-runtime llvm-18-linker-tools make             \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN ln -vsnf /usr/lib/llvm-15/bin/clang /usr/bin/clang
-RUN ln -vsnf /usr/lib/llvm-15/bin/llc /usr/bin/llc
+RUN ln -vsnf /usr/lib/llvm-18/bin/clang /usr/bin/clang
+RUN ln -vsnf /usr/lib/llvm-18/bin/llc /usr/bin/llc

--- a/Dockerfile.clang-format
+++ b/Dockerfile.clang-format
@@ -1,8 +1,8 @@
-FROM docker.io/library/ubuntu:22.04@sha256:0bced47fffa3361afa981854fcabcd4577cd43cebbb808cea2b1f33a3dd7f508
+FROM docker.io/library/ubuntu:24.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 
 RUN apt-get -y update
-RUN apt-get -y install clang-format-14
-RUN ln -s /bin/clang-format-14 /bin/clang-format
+RUN apt-get -y install clang-format-18
+RUN ln -s /bin/clang-format-18 /bin/clang-format
 
 USER 1000
 WORKDIR /tetragon


### PR DESCRIPTION
First half of https://github.com/cilium/tetragon/pull/2777.