### PR TITLE
allow to disable the gRPC server

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -767,6 +767,10 @@ func startExporter(ctx context.Context, server *server.Server) error {
 }
 
 func Serve(ctx context.Context, listenAddr string, srv *server.Server) error {
+	// we use an empty listen address to effectively disable the gRPC server
+	if len(listenAddr) == 0 {
+		return nil
+	}
 	grpcServer := grpc.NewServer()
 	tetragon.RegisterFineGuidanceSensorsServer(grpcServer, srv)
 	proto, addr, err := server.SplitListenAddr(listenAddr)

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -185,7 +185,7 @@ options:
     - name: server-address
       default_value: localhost:54321
       usage: |
-        gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock'
+        gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock'). An empty address disables the gRPC server
     - name: tracing-policy
       usage: Tracing policy file to load at startup
     - name: tracing-policy-dir

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -44,6 +44,7 @@ data:
 {{- if .Values.tetragon.grpc.enabled }}
   server-address: {{ .Values.tetragon.grpc.address }}
 {{- else }}
+  server-address: ""
 {{- end }}
 {{- if .Values.tetragon.healthGrpc.enabled }}
   health-server-address: :{{ .Values.tetragon.healthGrpc.port }}

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -296,7 +296,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Bool(KeyEnableProcessAncestors, true, "Include ancestors in process exec events")
 	flags.String(KeyMetricsServer, "", "Metrics server address (e.g. ':2112'). Disabled by default")
 	flags.String(KeyMetricsLabelFilter, "namespace,workload,pod,binary", "Comma-separated list of enabled metrics labels. Unknown labels will be ignored.")
-	flags.String(KeyServerAddress, "localhost:54321", "gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock'")
+	flags.String(KeyServerAddress, "localhost:54321", "gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock'). An empty address disables the gRPC server")
 	flags.String(KeyGopsAddr, "", "gops server address (e.g. 'localhost:8118'). Disabled by default")
 	flags.Bool(KeyEnableProcessCred, false, "Enable process_cred events")
 	flags.Bool(KeyEnableProcessNs, false, "Enable namespace information in process_exec and process_kprobe events")


### PR DESCRIPTION
Currently, there is no way to disable the gRPC server. this commit checks if the provided address is empty and, if so, does not start the server. It also updates the helm configmap template so that if gRPC is disabled, then an empty address is passed to the agent.

```release-note
Allow disabling gRPC either by selecting 'enabled:false' in the helm chart or by passing an empty address to the agent
```

Fixes: https://github.com/cilium/tetragon/issues/2477
