### PR TITLE
Fix tetragon_process_cache_size metric

### DIFF
--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var ProcessCacheTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+var processCacheTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace:   consts.MetricsNamespace,
 	Name:        "process_cache_size",
 	Help:        "The size of the process cache",
@@ -47,6 +47,6 @@ func NewCacheCollector() prometheus.Collector {
 }
 
 func RegisterMetrics(group metrics.Group) {
-	group.MustRegister(ProcessCacheTotal)
+	group.MustRegister(processCacheTotal)
 	group.MustRegister(NewCacheCollector())
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -80,9 +80,8 @@ func InitCache(w watcher.K8sResourceWatcher, size int) error {
 }
 
 func FreeCache() {
-	procCache.Purge()
+	procCache.purge()
 	procCache = nil
-	ProcessCacheTotal.Set(0)
 }
 
 // GetProcessCopy() duplicates tetragon.Process and returns it
@@ -471,7 +470,6 @@ func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 	}
 
 	procCache.add(proc)
-	ProcessCacheTotal.Inc()
 	return proc
 }
 
@@ -495,7 +493,6 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 
 	parent.RefInc()
 	procCache.add(proc)
-	ProcessCacheTotal.Inc()
 	return nil
 }
 


### PR DESCRIPTION
tetragon_process_cache_size metric was increased on every add() and never decreased. This is incorrect - fix it, so that it's increased on add() only if there was no LRU eviction and it's decreased on remove().