### PR TITLE
helm: Add tetragon_pod label to metrics via ServiceMonitor

### DIFF
--- a/install/kubernetes/tetragon/templates/servicemonitor.yaml
+++ b/install/kubernetes/tetragon/templates/servicemonitor.yaml
@@ -22,6 +22,10 @@ spec:
           sourceLabels:
             - __meta_kubernetes_pod_node_name
           targetLabel: node
+        - replacement: ${1}
+          sourceLabels:
+            - __meta_kubernetes_pod_name
+          targetLabel: tetragon_pod
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
Prometheus Operator by default adds "pod" label, representing the metrics exporter pod, to all scraped metrics. However, Tetragon exposes events metrics with "pod" label, which represents the process that generated events, not Tetragon pod. This label is not overridden if using the default ServiceMonitor (with "honorLabels: true") - that's good. However, it still can be useful to know which Tetragon pod exported the metric. Let's add "tetragon_pod" label to metrics scraped via default ServiceMonitor.
