### PR TITLE
fork_test: remove pid export filter

### DIFF
--- a/pkg/sensors/exec/fork_test.go
+++ b/pkg/sensors/exec/fork_test.go
@@ -38,7 +38,7 @@ func TestFork(t *testing.T) {
 	defer testPipes.Close()
 
 	t.Logf("starting observer")
-	obs, err := observertesthelper.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	obs, err := observertesthelper.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib)
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}


### PR DESCRIPTION
As described in issue 2691, TestFork has been flaky. The way this test works is that a child is forked, which then forks a second chlid, which exits and we are looking for the exit event of the second child.

My best guess on why the flake happens is that the pid filtering filters out the second exit event. This can happen, for example, if the pid cache of the pid filter has not yet seen an event with a known parent.

So if the exit event of the second child comes before the exit event of the first chilid, then the first child's pid will not be in the cache when we get the second child exit and the event will be filtered out.

Based on the above reasoning, this commit removes the pid filter for the test.

Fixes: #2691 
