### PR TITLE
verify.sh: Handle when bpf_verride_return is unavailable

### DIFF
--- a/contrib/verify/verify.sh
+++ b/contrib/verify/verify.sh
@@ -8,6 +8,7 @@ shopt -s nullglob
 RED="\033[31m"
 BLUEUNDER="\033[34;4m"
 GREEN="\033[32m"
+YELLOW="\033[33m"
 NOCOLOR="\033[0m"
 TETRAGONDIR=/var/lib/tetragon
 DEBUG=0
@@ -81,6 +82,14 @@ for obj in "$TETRAGONDIR"/*.o; do
 	# Generic LSM BPF needs more complex userspace logic to load, so ignore it
 	if [[ "$B" == bpf_generic_lsm* ]]; then
 		continue
+	fi
+
+	# Check if bpf_override_return is available
+	if [[ "$B" == bpf_generic_kprobe* || "$B" == bpf_enforcer* ]]; then
+		if ! bpftool feature probe | grep -q "bpf_override_return"; then
+			echo -e "${YELLOW}bpf_override_return not available, skipping $B ...${NOCOLOR}\n"
+			continue
+		fi
 	fi
 
 	echo -e -n "Verifying $BLUEUNDER$obj$NOCOLOR... "


### PR DESCRIPTION
While taking a look at tetragon, I tried running verify.sh and
observed bpf_enforce and bpf_generic_kprobe* all fail because
bpf_override_return is not available. I also observed that this seems
be handled conditionally in tetragon via the
pkg.bpf.HasOverrideHelper() function.

This change updates verify.sh to check for bpf_override_return before
trying to load these programs. If it's not present, it will be skipped
cleanly since it's not expected to work.

A cleaner solution is to reuse the same check from the Go code.
Rewriting this script in Go is tracked in issue #229.

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
