### PR TITLE
metrics: Expose more errors in tetragon_bpf_missed_events_total counter

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -15,7 +15,7 @@ Number of Tetragon perf events that are failed to be sent from the kernel.
 
 | label | values |
 | ----- | ------ |
-| `error` | `EBUSY, ENOSPC, unknown` |
+| `error` | `E2BIG, EBUSY, EINVAL, ENOENT, ENOSPC, unknown` |
 | `msg_op` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 5, 7` |
 
 ### `tetragon_build_info`

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -51,7 +51,10 @@ const (
 
 const (
 	SentFailedUnknown = iota
+	SentFailedEnoent
+	SentFailedE2big
 	SentFailedEbusy
+	SentFailedEinval
 	SentFailedEnospc
 	SentFailedMax
 )

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -25,7 +25,10 @@ import (
 var (
 	perfEventErrors = map[int]string{
 		processapi.SentFailedUnknown: "unknown",
+		processapi.SentFailedEnoent:  "ENOENT",
+		processapi.SentFailedE2big:   "E2BIG",
 		processapi.SentFailedEbusy:   "EBUSY",
+		processapi.SentFailedEinval:  "EINVAL",
 		processapi.SentFailedEnospc:  "ENOSPC",
 	}
 	perfEventErrorLabel = metrics.ConstrainedLabel{


### PR DESCRIPTION
When testing I saw a bunch of "unknown" errors. To further investigate, let's split out ENOENT, E2BIG and EINVAL into separate label values. This should be almost all errors returned by perf_event_output, I left out only EOPNOTSUPP.