### PR TITLE
Replace process cache evictions and misses metrics

### DIFF
--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -53,3 +53,6 @@ tetragon:
   * `tetragon_ringbuf_perf_event_lost_total` -> `tetragon_observer_ringbuf_events_lost_total`
   * `tetragon_ringbuf_queue_received_total` -> `tetragon_observer_ringbuf_queue_events_received_total`
   * `tetragon_ringbuf_queue_lost_total` -> `tetragon_observer_ringbuf_queue_events_lost_total`
+* `tetragon_errors_total{type="process_cache_evicted"}` metric is replaced by `tetragon_process_cache_evicted_total`.
+* `tetragon_errors_total{type=~"process_cache_miss_on_get|process_cache_miss_on_remove"}` metrics are replaced by
+  `tetragon_process_cache_misses_total{operation=~"get|remove"}`.

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -250,6 +250,10 @@ Number of policy filter operations.
 
 The capacity of the process cache. Expected to be constant.
 
+### `tetragon_process_cache_evictions_total`
+
+Number of process cache LRU evictions.
+
 ### `tetragon_process_cache_size`
 
 The size of the process cache

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -254,6 +254,14 @@ The capacity of the process cache. Expected to be constant.
 
 Number of process cache LRU evictions.
 
+### `tetragon_process_cache_misses_total`
+
+Number of process cache misses.
+
+| label | values |
+| ----- | ------ |
+| `operation` | `get, remove` |
+
 ### `tetragon_process_cache_size`
 
 The size of the process cache

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -51,7 +51,7 @@ The total number of Tetragon errors. For internal use only.
 
 | label | values |
 | ----- | ------ |
-| `type ` | `event_finalize_process_info_failed, event_missing_process_info, handler_error, process_cache_evicted, process_cache_miss_on_get, process_cache_miss_on_remove, process_metadata_username_failed, process_metadata_username_ignored_not_in_host_namespaces, process_pid_tid_mismatch` |
+| `type ` | `event_finalize_process_info_failed, event_missing_process_info, handler_error, process_metadata_username_failed, process_metadata_username_ignored_not_in_host_namespaces, process_pid_tid_mismatch` |
 
 ### `tetragon_event_cache_accesses_total`
 

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -15,14 +15,8 @@ import (
 type ErrorType int
 
 const (
-	// Process not found on get() call.
-	ProcessCacheMissOnGet ErrorType = iota
-	// Process evicted from the cache.
-	ProcessCacheEvicted
-	// Process not found on remove() call.
-	ProcessCacheMissOnRemove
 	// Tid and Pid mismatch that could affect BPF and user space caching logic
-	ProcessPidTidMismatch
+	ProcessPidTidMismatch ErrorType = iota
 	// An event is missing process info.
 	EventMissingProcessInfo
 	// An error occurred in an event handler.
@@ -37,9 +31,6 @@ const (
 )
 
 var errorTypeLabelValues = map[ErrorType]string{
-	ProcessCacheMissOnGet:                   "process_cache_miss_on_get",
-	ProcessCacheEvicted:                     "process_cache_evicted",
-	ProcessCacheMissOnRemove:                "process_cache_miss_on_remove",
 	ProcessPidTidMismatch:                   "process_pid_tid_mismatch",
 	EventMissingProcessInfo:                 "event_missing_process_info",
 	HandlerError:                            "handler_error",

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -152,6 +152,7 @@ func (pc *Cache) get(processID string) (*ProcessInternal, error) {
 	if !ok {
 		logger.GetLogger().WithField("id in event", processID).Debug("process not found in cache")
 		errormetrics.ErrorTotalInc(errormetrics.ProcessCacheMissOnGet)
+		processCacheMisses.WithLabelValues("get").Inc()
 		return nil, fmt.Errorf("invalid entry for process ID: %s", processID)
 	}
 	return process, nil
@@ -173,6 +174,7 @@ func (pc *Cache) remove(process *tetragon.Process) bool {
 		processCacheTotal.Dec()
 	} else {
 		errormetrics.ErrorTotalInc(errormetrics.ProcessCacheMissOnRemove)
+		processCacheMisses.WithLabelValues("remove").Inc()
 	}
 	return present
 }

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -133,6 +133,7 @@ func NewCache(
 		processCacheSize,
 		func(_ string, _ *ProcessInternal) {
 			errormetrics.ErrorTotalInc(errormetrics.ProcessCacheEvicted)
+			processCacheEvictions.Inc()
 		},
 	)
 	if err != nil {

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -10,6 +10,13 @@ import (
 )
 
 var (
+	operationLabel = metrics.ConstrainedLabel{
+		Name:   "operation",
+		Values: []string{"get", "remove"},
+	}
+)
+
+var (
 	processCacheTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:   consts.MetricsNamespace,
 		Name:        "process_cache_size",
@@ -26,6 +33,11 @@ var (
 		Name:      "process_cache_evictions_total",
 		Help:      "Number of process cache LRU evictions.",
 	})
+	processCacheMisses = metrics.MustNewCounter(metrics.NewOpts(
+		consts.MetricsNamespace, "", "process_cache_misses_total",
+		"Number of process cache misses.",
+		nil, []metrics.ConstrainedLabel{operationLabel}, nil,
+	), nil)
 )
 
 func newCacheCollector() prometheus.Collector {
@@ -46,6 +58,7 @@ func RegisterMetrics(group metrics.Group) {
 	group.MustRegister(
 		processCacheTotal,
 		processCacheEvictions,
+		processCacheMisses,
 	)
 	group.MustRegister(newCacheCollector())
 }

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -21,6 +21,11 @@ var (
 		"The capacity of the process cache. Expected to be constant.",
 		nil, nil, nil,
 	))
+	processCacheEvictions = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: consts.MetricsNamespace,
+		Name:      "process_cache_evictions_total",
+		Help:      "Number of process cache LRU evictions.",
+	})
 )
 
 func newCacheCollector() prometheus.Collector {
@@ -38,6 +43,9 @@ func newCacheCollector() prometheus.Collector {
 }
 
 func RegisterMetrics(group metrics.Group) {
-	group.MustRegister(processCacheTotal)
+	group.MustRegister(
+		processCacheTotal,
+		processCacheEvictions,
+	)
 	group.MustRegister(newCacheCollector())
 }


### PR DESCRIPTION
Stop reporting tetragon_errors_total metric with "type" label values:
`process_cache_miss_on_get`
`process_cache_evicted`
`process_cache_miss_on_remove`

Evictions and misses are not errors, this is just cache's life, sometimes you
hit, sometimes you miss, and sometimes you gotta evict a process.

They are now reported by more intuitive metrics:
`tetragon_process_cache_evictions_total`
`tetragon_process_cache_misses_total{operation=~"get|remove"}`

Part of #2785