### PR TITLE
tetragon: fix deprecated pprof flag compatibility

### DIFF
--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -186,7 +186,9 @@ func ReadAndSetFlags() error {
 	Config.CpuProfile = viper.GetString(KeyCpuProfile)
 	Config.MemProfile = viper.GetString(KeyMemProfile)
 	Config.PprofAddr = viper.GetString(KeyDeprecatedPprofAddr)
-	Config.PprofAddr = viper.GetString(KeyPprofAddr)
+	if viper.IsSet(KeyPprofAddr) {
+		Config.PprofAddr = viper.GetString(KeyPprofAddr)
+	}
 
 	Config.EventQueueSize = viper.GetUint(KeyEventQueueSize)
 


### PR DESCRIPTION
Looks like I wasn't completely concentrated when I wrote fe78328cf7a8, this commit avoids to override the old flag value with an empty string.
