### PR TITLE
[backport/v1.1][bugfix] Fix clone event caching due to missing pod info

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -481,7 +481,7 @@ func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 }
 
 // AddCloneEvent adds a new process into the cache from a CloneEvent
-func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
+func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) (*ProcessInternal, error) {
 	parentExecId := GetProcessID(event.Parent.Pid, event.Parent.Ktime)
 	parent, err := Get(parentExecId)
 	if err != nil {
@@ -490,17 +490,17 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 			"event.parent.pid":     event.Parent.Pid,
 			"event.parent.exec_id": parentExecId,
 		}).WithError(err).Debug("CloneEvent: parent process not found in cache")
-		return err
+		return nil, err
 	}
 
 	proc, err := initProcessInternalClone(event, parent, parentExecId)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	parent.RefInc()
 	procCache.add(proc)
-	return nil
+	return proc, nil
 }
 
 func Get(execId string) (*ProcessInternal, error) {


### PR DESCRIPTION
[upstream commit 20bba351bd5dd0476315bfb8334189cc351ba1b2]

The eventcache API provides 2 handlers.

These are:
RetryInternal -> called to setup process information Retry -> called to setup pod information

In the case of clone events, we used to have en empty implementation on the Retry handler. This results in an issue with missing pod information which is described in detail here: https://github.com/cilium/tetragon/issues/2902

This patch provides the proper Retry implementation to handle also those cases.

FIXES: https://github.com/cilium/tetragon/issues/2902