### PR TITLE
helm: Remove deprecated tetragonOperator.skipCRDCreation value

### DIFF
--- a/contrib/upgrade-notes/v1.2.0.md
+++ b/contrib/upgrade-notes/v1.2.0.md
@@ -26,7 +26,7 @@ tetragon:
        - --retries
        - "5"
 ```
-* Deprecated `tetragon.skipCRDCreation` Helm value is removed. Use `crds.installMethod=none` instead.
+* Deprecated `tetragonOperator.skipCRDCreation` Helm value is removed. Use `crds.installMethod=none` instead.
 
 * `tetragon.ociHookSetup` Helm value is deprecated. Use `tetragon.rthooks` instead.
 

--- a/install/kubernetes/tetragon/templates/operator_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/operator_configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- include "tetragon-operator.labels" . | nindent 4 }}
 data:
   {{- if eq .Values.crds.installMethod "operator" }}
-  skip-crd-creation: {{ .Values.tetragonOperator.skipCRDCreation | quote }}
+  skip-crd-creation: "false"
   {{- else }}
   skip-crd-creation: "true"
   {{- end }}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
In this PR https://github.com/cilium/tetragon/pull/2498, the `tetragon.skipCRDCreation` key was removed from the `values.yaml` file; however, there is still a reference to it in the operator config map.
From what I understand, the operator expects a boolean value, and in case the installation method is `operator`, it should be set to `false`.

The patch makes the following changes:
1. Remove deprecated `tetragon.skipCRDCreation` from the operator config map and set `false` as the static value in `skip-crd-creation`.
2. Rename `tetragon.skipCRDCreation` to `tetragonOperator.skipCRDCreation` in the upgrade notes for Tetragon `1.2.0`.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Remove deprecated `tetragonOperator.skipCRDCreation` from the operator config map and set "false" when `.Values.crds.installMethod` is `operator`
```
