### PR TITLE
Added metrics for LRU data cache

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -29,6 +29,26 @@ Build information about tetragon
 | `modified` | `false` |
 | `time ` | `2022-05-13T15:54:45Z` |
 
+### `tetragon_data_cache_capacity`
+
+The capacity of the data cache.
+
+### `tetragon_data_cache_evictions_total`
+
+Number of data cache LRU evictions.
+
+### `tetragon_data_cache_misses_total`
+
+Number of data cache misses.
+
+| label | values |
+| ----- | ------ |
+| `operation` | `get, remove` |
+
+### `tetragon_data_cache_size`
+
+The size of the data cache
+
 ### `tetragon_data_event_size`
 
 The size of received data events.

--- a/pkg/observer/cache.go
+++ b/pkg/observer/cache.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package observer
+
+import (
+	"fmt"
+
+	"github.com/cilium/tetragon/pkg/api/dataapi"
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+type cache struct {
+	cache *lru.Cache[dataapi.DataEventId, []byte]
+	size  int
+}
+
+// newCache constructs a cache of fixed size with the callback function that increments
+// data_cache_evictions_total counter every time the cache is evicted.
+func newCache(dataCacheSize int) (*cache, error) {
+	lruCache, err := lru.NewWithEvict(
+		dataCacheSize,
+		func(_ dataapi.DataEventId, _ []byte) {
+			dataCacheEvictions.Inc()
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	cache := &cache{
+		cache: lruCache,
+		size:  dataCacheSize,
+	}
+	return cache, nil
+}
+
+func (c *cache) get(dataEventId dataapi.DataEventId) ([]byte, error) {
+	data, ok := c.cache.Get(dataEventId)
+	if !ok {
+		dataCacheMisses.WithLabelValues("get").Inc()
+		return nil, fmt.Errorf("data event with id : %v not found", dataEventId)
+	}
+	return data, nil
+}
+
+func (c *cache) add(id dataapi.DataEventId, msgData []byte) bool {
+	evicted := c.cache.Add(id, msgData)
+	if !evicted {
+		dataCacheTotal.Inc()
+	}
+	return evicted
+}
+
+func (c *cache) remove(desc dataapi.DataEventDesc) bool {
+	present := c.cache.Remove(desc.Id)
+	if present {
+		dataCacheTotal.Dec()
+	} else {
+		dataCacheMisses.WithLabelValues("remove").Inc()
+	}
+	return present
+}

--- a/pkg/observer/data.go
+++ b/pkg/observer/data.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/tetragon/pkg/api/dataapi"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/logger"
-	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 func init() {
@@ -20,29 +19,28 @@ func init() {
 }
 
 var (
-	dataMap *lru.Cache[dataapi.DataEventId, []byte]
+	dataCache *cache
 )
 
 func InitDataCache(size int) error {
 	var err error
-
-	dataMap, err = lru.New[dataapi.DataEventId, []byte](size)
+	dataCache, err = newCache(size)
 	return err
 }
 
 func DataAdd(id dataapi.DataEventId, msgData []byte) error {
 	size := len(msgData)
-	data, ok := dataMap.Get(id)
-	if !ok {
-		dataMap.Add(id, msgData)
+	data, err := dataCache.get(id)
+	if err != nil {
+		dataCache.add(id, msgData)
 		DataEventMetricInc(DataEventAdded)
 	} else {
 		data = append(data, msgData...)
-		dataMap.Add(id, data)
+		dataCache.add(id, data)
 		DataEventMetricInc(DataEventAppended)
+		logger.GetLogger().WithFields(nil).Tracef("Data message received id %v, size %v, total %v", id, size, len(data))
 	}
 
-	logger.GetLogger().WithFields(nil).Tracef("Data message received id %v, size %v, total %v", id, size, len(data))
 	return nil
 }
 
@@ -60,13 +58,13 @@ func add(r *bytes.Reader, m *dataapi.MsgData) error {
 }
 
 func DataGet(desc dataapi.DataEventDesc) ([]byte, error) {
-	data, ok := dataMap.Get(desc.Id)
-	if !ok {
+	data, err := dataCache.get(desc.Id)
+	if err != nil {
 		DataEventMetricInc(DataEventNotMatched)
-		return nil, fmt.Errorf("failed to find data for id: %v", desc.Id)
+		return nil, err
 	}
 
-	dataMap.Remove(desc.Id)
+	dataCache.remove(desc)
 
 	// make sure we did not loose anything on the way through ring buffer
 	if len(data) != int(desc.Size-desc.Leftover) {
@@ -88,12 +86,12 @@ func HandleData(r *bytes.Reader) ([]Event, error) {
 	m := dataapi.MsgData{}
 	err := binary.Read(r, binary.LittleEndian, &m)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read data msg")
+		return nil, fmt.Errorf("failed to read data msg")
 	}
 
 	err = add(r, &m)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to add data msg")
+		return nil, fmt.Errorf("failed to add data msg")
 	}
 
 	// we don't send the event further
@@ -101,5 +99,5 @@ func HandleData(r *bytes.Reader) ([]Event, error) {
 }
 
 func DataPurge() {
-	dataMap.Purge()
+	dataCache.cache.Purge()
 }


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes #679 

### Description
This PR adds additional metrics around LRU data cache such as size, capacity, evictions and cache miss in order to have a same set of metrics collection across the board.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```
Add metrics for LRU data cache
```
