### PR TITLE
renovate: run make vendor on any Go update

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -208,7 +208,7 @@
         "gomodUpdateImportPaths",
       ],
       postUpgradeTasks: {
-        "commands": ["/tmp/install-buildx", "make protogen", "make crds", "make metrics-docs"],
+        "commands": ["/tmp/install-buildx", "make protogen", "make crds", "make metrics-docs", "make vendor"],
         "fileFilters": ["**/**"],
         "executionMode": "branch"
       }


### PR DESCRIPTION
This should fix the situation in https://github.com/cilium/tetragon/pull/2884 or https://github.com/cilium/tetragon/pull/2900.