### PR TITLE
[v1.1] Fix tetragon_process_cache_size metric

### DIFF
--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var ProcessCacheTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+var processCacheTotal = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace:   consts.MetricsNamespace,
 	Name:        "process_cache_size",
 	Help:        "The size of the process cache",
@@ -46,6 +46,6 @@ func NewCacheCollector() prometheus.Collector {
 }
 
 func InitMetrics(registry *prometheus.Registry) {
-	registry.MustRegister(ProcessCacheTotal)
+	registry.MustRegister(processCacheTotal)
 	registry.MustRegister(NewCacheCollector())
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -87,9 +87,8 @@ func InitCache(w watcher.K8sResourceWatcher, size int) error {
 }
 
 func FreeCache() {
-	procCache.Purge()
+	procCache.purge()
 	procCache = nil
-	ProcessCacheTotal.Set(0)
 }
 
 // GetProcessCopy() duplicates tetragon.Process and returns it
@@ -478,7 +477,6 @@ func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 	}
 
 	procCache.add(proc)
-	ProcessCacheTotal.Inc()
 	return proc
 }
 
@@ -502,7 +500,6 @@ func AddCloneEvent(event *tetragonAPI.MsgCloneEvent) error {
 
 	parent.RefInc()
 	procCache.add(proc)
-	ProcessCacheTotal.Inc()
 	return nil
 }
 


### PR DESCRIPTION
[ upstream commit: 9e35cbab946bf8c2d7d001dcf5a3b39b74768e8a ]

tetragon_process_cache_size metric was increased on every add() and never decreased. This is incorrect - fix it, so that it's increased on add() only if there was no LRU eviction and it's decreased on remove().