### PR TITLE
[v1.2] helm: Remove deprecated tetragon.skipCRDCreation value

### DIFF
--- a/contrib/upgrade-notes/v1.2.0.md
+++ b/contrib/upgrade-notes/v1.2.0.md
@@ -26,7 +26,7 @@ tetragon:
        - --retries
        - "5"
 ```
-* Deprecated `tetragon.skipCRDCreation` Helm value is removed. Use `crds.installMethod=none` instead.
+* Deprecated `tetragonOperator.skipCRDCreation` Helm value is removed. Use `crds.installMethod=none` instead.
 
 * `tetragon.ociHookSetup` Helm value is deprecated. Use `tetragon.rthooks` instead.
 

--- a/install/kubernetes/tetragon/templates/operator_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/operator_configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- include "tetragon-operator.labels" . | nindent 4 }}
 data:
   {{- if eq .Values.crds.installMethod "operator" }}
-  skip-crd-creation: {{ .Values.tetragonOperator.skipCRDCreation | quote }}
+  skip-crd-creation: "false"
   {{- else }}
   skip-crd-creation: "true"
   {{- end }}


### PR DESCRIPTION
Backport of #2907

(I also updated the published release notes, this was a silly mistake).