### PR TITLE
helm: Set rthooks.podSecurityContext to empty by default

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -46,7 +46,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | podLabelsOverride | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` |  |
-| rthooks | object | `{"annotations":{},"enabled":false,"extraHookArgs":{},"extraLabels":{},"extraVolumeMounts":[],"failAllowNamespaces":"","image":{"override":null,"repository":"quay.io/cilium/tetragon-rthooks","tag":"v0.3"},"installDir":"/opt/tetragon","interface":"","nriHook":{"nriSocket":"/var/run/nri/nri.sock"},"ociHooks":{"hooksPath":"/usr/share/containers/oci/hooks.d"},"podAnnotations":{},"podSecurityContext":{"privileged":true},"priorityClassName":"","resources":{},"serviceAccount":{"name":""}}` | Method for installing Tetagon rthooks (tetragon-rthooks) daemonset The tetragon-rthooks daemonset is responsible for installing run-time hooks on the host. See: https://tetragon.io/docs/concepts/runtime-hooks |
+| rthooks | object | `{"annotations":{},"enabled":false,"extraHookArgs":{},"extraLabels":{},"extraVolumeMounts":[],"failAllowNamespaces":"","image":{"override":null,"repository":"quay.io/cilium/tetragon-rthooks","tag":"v0.3"},"installDir":"/opt/tetragon","interface":"","nriHook":{"nriSocket":"/var/run/nri/nri.sock"},"ociHooks":{"hooksPath":"/usr/share/containers/oci/hooks.d"},"podAnnotations":{},"podSecurityContext":{},"priorityClassName":"","resources":{},"serviceAccount":{"name":""}}` | Method for installing Tetagon rthooks (tetragon-rthooks) daemonset The tetragon-rthooks daemonset is responsible for installing run-time hooks on the host. See: https://tetragon.io/docs/concepts/runtime-hooks |
 | rthooks.annotations | object | `{}` | Annotations for the Tetragon rthooks daemonset |
 | rthooks.enabled | bool | `false` | Enable the Tetragon rthooks daemonset |
 | rthooks.extraHookArgs | object | `{}` | extra args to pass to tetragon-oci-hook |
@@ -61,7 +61,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | rthooks.ociHooks | object | `{"hooksPath":"/usr/share/containers/oci/hooks.d"}` | configuration for "oci-hooks" interface |
 | rthooks.ociHooks.hooksPath | string | `"/usr/share/containers/oci/hooks.d"` | directory to install .json file for running the hook |
 | rthooks.podAnnotations | object | `{}` | Pod annotations for the Tetrargon rthooks pod |
-| rthooks.podSecurityContext | object | `{"privileged":true}` | security context for the Tetrargon rthooks pod |
+| rthooks.podSecurityContext | object | `{}` | security context for the Tetrargon rthooks pod |
 | rthooks.priorityClassName | string | `""` | priorityClassName for the Tetrargon rthooks pod |
 | rthooks.resources | object | `{}` | resources for the the oci-hook-setup init container |
 | rthooks.serviceAccount | object | `{"name":""}` | rthooks service account. |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -28,7 +28,7 @@ Helm chart for Tetragon
 | podLabelsOverride | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` |  |
-| rthooks | object | `{"annotations":{},"enabled":false,"extraHookArgs":{},"extraLabels":{},"extraVolumeMounts":[],"failAllowNamespaces":"","image":{"override":null,"repository":"quay.io/cilium/tetragon-rthooks","tag":"v0.3"},"installDir":"/opt/tetragon","interface":"","nriHook":{"nriSocket":"/var/run/nri/nri.sock"},"ociHooks":{"hooksPath":"/usr/share/containers/oci/hooks.d"},"podAnnotations":{},"podSecurityContext":{"privileged":true},"priorityClassName":"","resources":{},"serviceAccount":{"name":""}}` | Method for installing Tetagon rthooks (tetragon-rthooks) daemonset The tetragon-rthooks daemonset is responsible for installing run-time hooks on the host. See: https://tetragon.io/docs/concepts/runtime-hooks |
+| rthooks | object | `{"annotations":{},"enabled":false,"extraHookArgs":{},"extraLabels":{},"extraVolumeMounts":[],"failAllowNamespaces":"","image":{"override":null,"repository":"quay.io/cilium/tetragon-rthooks","tag":"v0.3"},"installDir":"/opt/tetragon","interface":"","nriHook":{"nriSocket":"/var/run/nri/nri.sock"},"ociHooks":{"hooksPath":"/usr/share/containers/oci/hooks.d"},"podAnnotations":{},"podSecurityContext":{},"priorityClassName":"","resources":{},"serviceAccount":{"name":""}}` | Method for installing Tetagon rthooks (tetragon-rthooks) daemonset The tetragon-rthooks daemonset is responsible for installing run-time hooks on the host. See: https://tetragon.io/docs/concepts/runtime-hooks |
 | rthooks.annotations | object | `{}` | Annotations for the Tetragon rthooks daemonset |
 | rthooks.enabled | bool | `false` | Enable the Tetragon rthooks daemonset |
 | rthooks.extraHookArgs | object | `{}` | extra args to pass to tetragon-oci-hook |
@@ -43,7 +43,7 @@ Helm chart for Tetragon
 | rthooks.ociHooks | object | `{"hooksPath":"/usr/share/containers/oci/hooks.d"}` | configuration for "oci-hooks" interface |
 | rthooks.ociHooks.hooksPath | string | `"/usr/share/containers/oci/hooks.d"` | directory to install .json file for running the hook |
 | rthooks.podAnnotations | object | `{}` | Pod annotations for the Tetrargon rthooks pod |
-| rthooks.podSecurityContext | object | `{"privileged":true}` | security context for the Tetrargon rthooks pod |
+| rthooks.podSecurityContext | object | `{}` | security context for the Tetrargon rthooks pod |
 | rthooks.priorityClassName | string | `""` | priorityClassName for the Tetrargon rthooks pod |
 | rthooks.resources | object | `{}` | resources for the the oci-hook-setup init container |
 | rthooks.serviceAccount | object | `{"name":""}` | rthooks service account. |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -368,8 +368,7 @@ rthooks:
   # -- priorityClassName for the Tetrargon rthooks pod
   priorityClassName: ""
   # -- security context for the Tetrargon rthooks pod
-  podSecurityContext:
-    privileged: true
+  podSecurityContext: {}
   # -- installDir is the host location where the tetragon-oci-hook binary will be installed
   installDir: "/opt/tetragon"
   # -- Comma-separated list of namespaces to allow Pod creation for, in case tetragon-oci-hook fails to reach Tetragon agent.


### PR DESCRIPTION
[ upstream commit 255835998a8295f2500afc03d978f5a59b07dc85 ]

Set rthooks.podSecurityContext to empty by default to be consistent with the security context setting of Tetragon pods. Also note that "privileged" setting only applies to container security context [^1][^2].

[^1]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podsecuritycontext-v1-core
[^2]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#securitycontext-v1-core