### PR TITLE
[jsonchecker] Remove const from parameters

### DIFF
--- a/pkg/jsonchecker/jsonchecker.go
+++ b/pkg/jsonchecker/jsonchecker.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
+var (
 	Retries    = 13
 	RetryDelay = 3 * time.Second
 )


### PR DESCRIPTION
In https://github.com/cilium/tetragon/commit/62957f104 we changed the Retries and RetryDelay from var to const. This patch reverst that change as we may need to adjust them based on the test needs.