### PR TITLE
Memory optimizations: remove BTF and kallsyms caches

### DIFF
--- a/pkg/bpf/detect.go
+++ b/pkg/bpf/detect.go
@@ -422,6 +422,10 @@ func HasMissedStatsKprobeMulti() bool {
 }
 
 func LogFeatures() string {
+	// once we have detected all features, flush the BTF spec
+	// we cache all values so calling again a Has* function will
+	// not load the BTF again
+	defer ebtf.FlushKernelSpec()
 	return fmt.Sprintf("override_return: %t, buildid: %t, kprobe_multi: %t, uprobe_multi %t, fmodret: %t, fmodret_syscall: %t, signal: %t, large: %t, link_pin: %t, lsm: %t, missed_stats_kprobe_multi: %t, missed_stats_kprobe: %t",
 		HasOverrideHelper(), HasBuildId(), HasKprobeMulti(), HasUprobeMulti(),
 		HasModifyReturn(), HasModifyReturnSyscall(), HasSignalHelper(), HasProgramLargeSize(),

--- a/pkg/ksyms/ksyms.go
+++ b/pkg/ksyms/ksyms.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/option"
@@ -19,17 +18,8 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
-var (
-	kernelSymbols    *Ksyms
-	setKernelSymbols sync.Once
-)
-
 func KernelSymbols() (*Ksyms, error) {
-	var err error
-	setKernelSymbols.Do(func() {
-		kernelSymbols, err = NewKsyms(option.Config.ProcFS)
-	})
-	return kernelSymbols, err
+	return NewKsyms(option.Config.ProcFS)
 }
 
 type ksym struct {

--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	cachedbtf "github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/logger"
@@ -123,6 +124,9 @@ func (s *Sensor) Load(bpfDir string) error {
 	// Add the *loaded* programs and maps, so they can be unloaded later
 	progsAdd(s.Progs)
 	AllMaps = append(AllMaps, s.Maps...)
+
+	// cleanup the BTF once we have loaded all sensor's program
+	btf.FlushKernelSpec()
 
 	l.WithField("sensor", s.Name).Infof("Loaded BPF maps and events for sensor successfully")
 	s.Loaded = true

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -911,6 +911,11 @@ func doLoadProgram(
 
 	load.Prog = prog
 
+	// in KernelTypes, we use a non-standard BTF which is possibly annotated with symbols
+	// from kernel modules. At this point we don't need that anymore, so we can release
+	// the memory from it.
+	load.KernelTypes = nil
+
 	// Copy the loaded collection before it's destroyed
 	if KeepCollection {
 		return copyLoadedCollection(coll)


### PR DESCRIPTION
Do not cache large objects like the BTF and ksyms. Reload them when needed.

Before:
<img width="2409" alt="Screenshot 2024-09-19 at 11 09 15 AM" src="https://github.com/user-attachments/assets/377f4ba3-06f2-4db2-ac8f-8b89db91c9f0">

After:
<img width="2407" alt="Screenshot 2024-09-19 at 11 31 21 AM" src="https://github.com/user-attachments/assets/76b3d3ac-9117-4a77-83b2-020ba45aced3">
