### PR TITLE
tetragon: Add map ownership

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -31,7 +31,7 @@ PROCESS = bpf_execve_event.o bpf_execve_event_v53.o bpf_fork.o bpf_exit.o bpf_ge
 	  bpf_loader.o \
 	  bpf_cgroup.o \
 	  bpf_enforcer.o bpf_multi_enforcer.o bpf_fmodret_enforcer.o \
-	  bpf_map_test_p1.o bpf_map_test_p2.o
+	  bpf_map_test_p1.o bpf_map_test_p2.o bpf_map_test_p3.o
 
 CGROUP = bpf_cgroup_mkdir.o bpf_cgroup_rmdir.o bpf_cgroup_release.o
 BPFTEST = bpf_lseek.o

--- a/bpf/process/bpf_map_test_p3.c
+++ b/bpf/process/bpf_map_test_p3.c
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "vmlinux.h"
+#include "api.h"
+#include "bpf_tracing.h"
+#include "bpf_helpers.h"
+#include "compiler.h"
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, unsigned long);
+} m1 SEC(".maps");
+
+__attribute__((section("kprobe/wake_up_new_task"), used)) int
+BPF_KPROBE(p2)
+{
+	map_lookup_elem(&m1, &(unsigned long){ 0 });
+	return 0;
+}

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -284,10 +284,22 @@ func GetDefaultObserverWithFile(tb testing.TB, ctx context.Context, file, lib st
 	return GetDefaultObserverWithWatchers(tb, ctx, b, opts...)
 }
 
+func GetDefaultSensorsWithBase(tb testing.TB, b *sensors.Sensor, file, lib string, opts ...TestOption) ([]*sensors.Sensor, error) {
+	opts = append(opts, WithConfig(file))
+	opts = append(opts, WithLib(lib))
+
+	return getDefaultSensors(tb, b, opts...)
+}
+
 func GetDefaultSensorsWithFile(tb testing.TB, file, lib string, opts ...TestOption) ([]*sensors.Sensor, error) {
 	opts = append(opts, WithConfig(file))
 	opts = append(opts, WithLib(lib))
 
+	b := base.GetInitialSensor()
+	return getDefaultSensors(tb, b, opts...)
+}
+
+func getDefaultSensors(tb testing.TB, initialSensor *sensors.Sensor, opts ...TestOption) ([]*sensors.Sensor, error) {
 	option.Config.BpfDir = bpf.MapPrefixPath()
 
 	testutils.CaptureLog(tb, logger.GetLogger().(*logrus.Logger))
@@ -327,13 +339,11 @@ func GetDefaultSensorsWithFile(tb testing.TB, file, lib string, opts ...TestOpti
 		}
 	}
 
-	base := base.GetInitialSensor()
-
-	if err = loadSensors(tb, base, sens); err != nil {
+	if err = loadSensors(tb, initialSensor, sens); err != nil {
 		return nil, err
 	}
 
-	sens = append(sens, base)
+	sens = append(sens, initialSensor)
 	ret := make([]*sensors.Sensor, 0, len(sens))
 	for _, si := range sens {
 		if s, ok := si.(*sensors.Sensor); ok {

--- a/pkg/sensors/config/confmap/confmap.go
+++ b/pkg/sensors/config/confmap/confmap.go
@@ -164,7 +164,7 @@ func UpdateConfMap(mapDir string, v *TetragonConfValue) error {
 		return err
 	}
 
-	m, err := program.LoadOrCreatePinnedMap(mapPath, mapSpec)
+	m, err := program.LoadOrCreatePinnedMap(mapPath, mapSpec, configMap.IsOwner())
 	if err != nil {
 		return err
 	}

--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -47,6 +47,17 @@
 //      - map is local for program, not shared at all
 //
 //  NOTE Please do not share MapTypeProgram maps, it brings confusion.
+//
+//  Each map declares the ownership of the map. The map can be either
+//  owner of the map (via MapBuilder* helpers) or as an user (MapUser*
+//  helpers.
+//
+//  Map owner object owns the pinned map and when loading it sets (and
+//  potentially overwrite) the map's spec and its max entries value.
+//
+//  Map user object object is just using the pinned map and follows its
+//  setup and will fail if the pinned map differs in spec or configured
+//  max entries value.
 
 package program
 
@@ -136,6 +147,22 @@ func MapBuilderType(name string, ty MapType, lds ...*Program) *Map {
 
 func MapBuilderOpts(name string, opts MapOpts, lds ...*Program) *Map {
 	return mapBuilder(name, opts.Type, opts.Owner, lds...)
+}
+
+func MapUser(name string, lds ...*Program) *Map {
+	return mapBuilder(name, MapTypeGlobal, false, lds...)
+}
+
+func MapUserProgram(name string, lds ...*Program) *Map {
+	return mapBuilder(name, MapTypeProgram, false, lds...)
+}
+
+func MapUserSensor(name string, lds ...*Program) *Map {
+	return mapBuilder(name, MapTypeSensor, false, lds...)
+}
+
+func MapUserPolicy(name string, lds ...*Program) *Map {
+	return mapBuilder(name, MapTypePolicy, false, lds...)
 }
 
 func PolicyMapPath(mapDir, policy, name string) string {

--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -133,7 +133,7 @@ func PolicyMapPath(mapDir, policy, name string) string {
 }
 
 func (m *Map) Unload() error {
-	log := logger.GetLogger().WithField("map", m.Name).WithField("pin", m.Name)
+	log := logger.GetLogger().WithField("map", m.Name).WithField("pin", m.PinPath)
 	if !m.PinState.IsLoaded() {
 		log.WithField("count", m.PinState.count).Debug("Refusing to unload map as it is not loaded")
 		return nil


### PR DESCRIPTION
Adding the concept of owning map and splitting Map object to owners and others.

The idea is that the 'owned' Map object takes care of creating/overwriting the pin,
while the 'other' Map object is just a user, that can read/update map but can't create it.

I'm not really happy with the 'other' naming, so any ideas are welcome ;-)