### PR TITLE
ProcessCache: Remove stale entries

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -275,6 +275,10 @@ Number of process cache misses.
 | ----- | ------ |
 | `operation` | `get, remove` |
 
+### `tetragon_process_cache_removed_stale_total`
+
+Number of process cache stale entries removed.
+
 ### `tetragon_process_cache_size`
 
 The size of the process cache

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -180,6 +180,9 @@ options:
     - name: process-cache-size
       default_value: "65536"
       usage: Size of the process cache
+    - name: process-cache-stale-interval
+      default_value: 1h0m0s
+      usage: Interval between stale process cache checks
     - name: procfs
       default_value: /proc/
       usage: Location of procfs to consume existing PIDs

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -3,6 +3,8 @@
 
 package defaults
 
+import "time"
+
 const (
 	// DefaultMapRoot is the default path where BPFFS should be mounted
 	DefaultMapRoot = "/sys/fs/bpf"
@@ -49,6 +51,9 @@ const (
 	// defaults for the event cache
 	DefaultEventCacheNumRetries = 15
 	DefaultEventCacheRetryDelay = 2
+
+	// defaults for process cache
+	DefaultProcessCacheStaleInterval = time.Duration(60 * time.Minute)
 )
 
 var (

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -406,7 +406,7 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 		ec.Add(nil, tetragonEvent, event.Common.Ktime, event.ProcessKey.Ktime, event)
 		return nil
 	}
-	if parent != nil {
+	if proc != nil && !proc.HasCustomRefCnt() && parent != nil {
 		parent.RefDec("parent")
 	}
 	if proc != nil {
@@ -427,10 +427,14 @@ func (msg *MsgExitEventUnix) Notify() bool {
 func (msg *MsgExitEventUnix) RetryInternal(ev notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
 	internal, parent := process.GetParentProcessInternal(msg.ProcessKey.Pid, timestamp)
 	var err error
+	hasCustomRefCnt := false
+	if internal != nil && internal.HasCustomRefCnt() {
+		hasCustomRefCnt = true
+	}
 
 	if parent != nil {
 		ev.SetParent(parent.UnsafeGetProcess())
-		if !msg.RefCntDone[ParentRefCnt] {
+		if !hasCustomRefCnt && !msg.RefCntDone[ParentRefCnt] {
 			parent.RefDec("parent")
 			msg.RefCntDone[ParentRefCnt] = true
 		}
@@ -494,9 +498,13 @@ func (msg *MsgProcessCleanupEventUnix) Notify() bool {
 func (msg *MsgProcessCleanupEventUnix) RetryInternal(_ notify.Event, timestamp uint64) (*process.ProcessInternal, error) {
 	internal, parent := process.GetParentProcessInternal(msg.PID, timestamp)
 	var err error
+	hasCustomRefCnt := false
+	if internal != nil && internal.HasCustomRefCnt() {
+		hasCustomRefCnt = true
+	}
 
 	if parent != nil {
-		if !msg.RefCntDone[ParentRefCnt] {
+		if !hasCustomRefCnt && !msg.RefCntDone[ParentRefCnt] {
 			parent.RefDec("parent")
 			msg.RefCntDone[ParentRefCnt] = true
 		}
@@ -528,7 +536,9 @@ func (msg *MsgProcessCleanupEventUnix) Retry(_ *process.ProcessInternal, _ notif
 func (msg *MsgProcessCleanupEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 	msg.RefCntDone = [2]bool{false, false}
 	if process, parent := process.GetParentProcessInternal(msg.PID, msg.Ktime); process != nil && parent != nil {
-		parent.RefDec("parent")
+		if !process.HasCustomRefCnt() {
+			parent.RefDec("parent")
+		}
 		process.RefDec("process")
 	} else {
 		if ec := eventcache.Get(); ec != nil {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -104,6 +104,8 @@ type config struct {
 
 	EventCacheNumRetries int
 	EventCacheRetryDelay int
+
+	ProcessCacheStaleInterval time.Duration
 }
 
 var (
@@ -122,10 +124,13 @@ var (
 		// Enable all metrics labels by default
 		MetricsLabelFilter: DefaultLabelFilter(),
 
-		// set default valus for the event cache
+		// set default values for the event cache
 		// mainly used in the case of testing
 		EventCacheNumRetries: defaults.DefaultEventCacheNumRetries,
 		EventCacheRetryDelay: defaults.DefaultEventCacheRetryDelay,
+
+		// set default values for the process cache
+		ProcessCacheStaleInterval: defaults.DefaultProcessCacheStaleInterval,
 	}
 )
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -115,6 +115,8 @@ const (
 
 	KeyEventCacheRetries    = "event-cache-retries"
 	KeyEventCacheRetryDelay = "event-cache-retry-delay"
+
+	KeyProcessCacheStaleInterval = "process-cache-stale-interval"
 )
 
 type UsernameMetadaCode int
@@ -244,6 +246,8 @@ func ReadAndSetFlags() error {
 
 	Config.EventCacheNumRetries = viper.GetInt(KeyEventCacheRetries)
 	Config.EventCacheRetryDelay = viper.GetInt(KeyEventCacheRetryDelay)
+
+	Config.ProcessCacheStaleInterval = viper.GetDuration(KeyProcessCacheStaleInterval)
 
 	return nil
 }
@@ -411,4 +415,6 @@ func AddFlags(flags *pflag.FlagSet) {
 
 	flags.Int(KeyEventCacheRetries, defaults.DefaultEventCacheNumRetries, "Number of retries for event cache")
 	flags.Int(KeyEventCacheRetryDelay, defaults.DefaultEventCacheRetryDelay, "Delay in seconds between event cache retries")
+
+	flags.Duration(KeyProcessCacheStaleInterval, defaults.DefaultProcessCacheStaleInterval, "Interval between stale process cache checks")
 }

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -4,24 +4,22 @@
 package process
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-func TestProcessCache(t *testing.T) {
-	// add a process to the cache.
-	cache, err := NewCache(10)
-	require.NoError(t, err)
-	pid := wrapperspb.UInt32Value{Value: 1234}
-	execID := "process1"
+func createFakeProcess(pid uint32, execID string) *ProcessInternal {
 	proc := ProcessInternal{
 		process: &tetragon.Process{
 			ExecId: execID,
-			Pid:    &pid,
+			Pid:    &wrapperspb.UInt32Value{Value: pid},
 		},
 		capabilities: &tetragon.Capabilities{
 			Permitted: []tetragon.CapabilitiesType{
@@ -29,18 +27,159 @@ func TestProcessCache(t *testing.T) {
 				tetragon.CapabilitiesType_CAP_AUDIT_WRITE,
 			},
 		},
+		refcntOps: make(map[string]int32),
 	}
-	cache.add(&proc)
+	return &proc
+}
+
+func addFakeProcess(pc *Cache, pid uint32, execID string) {
+	proc := createFakeProcess(pid, execID)
+	pc.add(proc)
+}
+
+func TestProcessCacheAddAndRemove(t *testing.T) {
+	// add a process to the cache.
+	execId := "process1"
+	cache, err := NewCache(10)
+	require.NoError(t, err)
+	addFakeProcess(cache, 1234, execId)
 	assert.Equal(t, cache.len(), 1)
 
-	result, err := cache.get(proc.process.ExecId)
+	result, err := cache.get(execId)
 	assert.NoError(t, err)
-	assert.Equal(t, proc.process.ExecId, result.process.ExecId)
-	assert.Equal(t, proc.capabilities, result.capabilities)
+	assert.Equal(t, execId, result.process.ExecId)
+	assert.Equal(t, result.capabilities,
+		&tetragon.Capabilities{
+			Permitted: []tetragon.CapabilitiesType{
+				tetragon.CapabilitiesType_CAP_AUDIT_READ,
+				tetragon.CapabilitiesType_CAP_AUDIT_WRITE,
+			},
+		})
 
 	// remove the entry from cache.
-	assert.True(t, cache.remove(proc.process))
+	assert.True(t, cache.remove(result.process))
 	assert.Equal(t, cache.len(), 0)
-	_, err = cache.get(proc.process.ExecId)
+	_, err = cache.get(execId)
 	assert.Error(t, err)
+}
+
+func TestProcessCacheProcessOrChildExit(t *testing.T) {
+	assert.True(t, processOrChildExit("process--"))
+	assert.True(t, processOrChildExit("parent--"))
+	assert.False(t, processOrChildExit("process++"))
+	assert.False(t, processOrChildExit("parent++"))
+	assert.False(t, processOrChildExit("process-x--"))
+}
+
+func TestProcessCacheProcessAndChildrenHaveExited(t *testing.T) {
+	p := createFakeProcess(123, "myProc")
+	// empty (invalid) process should be counted as exited (this situation shouldn't occur)
+	assert.True(t, processAndChildrenHaveExited(p))
+	p.refcntOps["process++"] = 1
+	// active process has not exited
+	assert.False(t, processAndChildrenHaveExited(p))
+	p.refcntOps["process--"] = 1
+	// completed process has exited
+	assert.True(t, processAndChildrenHaveExited(p))
+	// set the process as active again
+	p.refcntOps["process--"] = 0
+	p.refcntOps["parent++"] = 1
+	// active process with child has not exited
+	assert.False(t, processAndChildrenHaveExited(p))
+	p.refcntOps["parent--"] = 1
+	// active process with exited child has not exited
+	assert.False(t, processAndChildrenHaveExited(p))
+	p.refcntOps["process--"] = 1
+	// completed process with exited child has exited
+	assert.True(t, processAndChildrenHaveExited(p))
+}
+
+func TestProcessCacheRemoveStale(t *testing.T) {
+	// add some processes to the cache.
+	execId := []string{"process1", "process2", "process3", "process4", "process5", "process6", "process7"}
+	var p []*ProcessInternal
+	cache, err := NewCache(10)
+	require.NoError(t, err)
+
+	p = append(p, createFakeProcess(1234, execId[0]))
+	p[0].refcntOps["process++"] = 1 // process started (but not exited)
+	cache.add(p[0])
+	assert.Equal(t, cache.len(), 1)
+
+	p = append(p, createFakeProcess(1235, execId[1]))
+	p[1].refcntOps["process++"] = 1                   // process started
+	p[1].refcntOps["process--"] = 1                   // process exited
+	p[1].exitTime = time.Now().Add(-20 * time.Minute) // exitTime is 20 minutes ago (stale)
+	cache.add(p[1])
+	assert.Equal(t, cache.len(), 2)
+
+	p = append(p, createFakeProcess(1236, execId[2]))
+	p[2].refcntOps["process++"] = 1                  // process started
+	p[2].refcntOps["process--"] = 1                  // process exited
+	p[2].exitTime = time.Now().Add(-2 * time.Minute) // exitTime is 2 minutes ago (not stale)
+	cache.add(p[2])
+	assert.Equal(t, cache.len(), 3)
+
+	p = append(p, createFakeProcess(1237, execId[3]))
+	p[3].refcntOps["process++"] = 1                   // process started
+	p[3].refcntOps["process--"] = 1                   // process exited
+	p[3].refcntOps["parent++"] = 1                    // child started
+	p[3].exitTime = time.Now().Add(-20 * time.Minute) // exitTime is 20 minutes ago (but process is not stale)
+	cache.add(p[3])
+	assert.Equal(t, cache.len(), 4)
+
+	p = append(p, createFakeProcess(1238, execId[4]))
+	p[4].refcntOps["process++"] = 1                  // process started
+	p[4].refcntOps["process--"] = 1                  // process exited
+	p[4].refcntOps["parent++"] = 1                   // child started
+	p[4].exitTime = time.Now().Add(-2 * time.Minute) // exitTime is 2 minutes ago (not stale)
+	cache.add(p[4])
+	assert.Equal(t, cache.len(), 5)
+
+	p = append(p, createFakeProcess(1239, execId[5]))
+	p[5].refcntOps["process++"] = 1                   // process started
+	p[5].refcntOps["process--"] = 1                   // process exited
+	p[5].refcntOps["parent++"] = 1                    // child started
+	p[5].refcntOps["parent--"] = 1                    // child exited
+	p[5].exitTime = time.Now().Add(-20 * time.Minute) // exitTime is 20 minutes ago (stale)
+	cache.add(p[5])
+	assert.Equal(t, cache.len(), 6)
+
+	p = append(p, createFakeProcess(1240, execId[6]))
+	p[6].refcntOps["process++"] = 1                  // process started
+	p[6].refcntOps["process--"] = 1                  // process exited
+	p[6].refcntOps["parent++"] = 1                   // child started
+	p[6].refcntOps["parent--"] = 1                   // child exited
+	p[6].exitTime = time.Now().Add(-2 * time.Minute) // exitTime is 2 minutes ago (not stale)
+	cache.add(p[6])
+	assert.Equal(t, cache.len(), 7)
+
+	// confirm entries are in cache
+	for i := 0; i < 7; i++ {
+		result, err := cache.get(execId[i])
+		assert.NoError(t, err)
+		assert.Equal(t, execId[i], result.process.ExecId)
+	}
+
+	// remove stale entries from cache.
+	cache.cleanStaleEntries()
+
+	// two entries should have been removed
+	assert.Equal(t, cache.len(), 5)
+	assert.NoError(t, testutil.CollectAndCompare(processCacheRemovedStale, strings.NewReader(`# HELP tetragon_process_cache_removed_stale_total Number of process cache stale entries removed.
+# TYPE tetragon_process_cache_removed_stale_total counter
+tetragon_process_cache_removed_stale_total 2
+`)))
+
+	// confirm entries are in cache
+	for i := 0; i < 7; i++ {
+		result, err := cache.get(execId[i])
+		switch i {
+		case 0, 2, 3, 4, 6:
+			assert.NoError(t, err)
+			assert.Equal(t, execId[i], result.process.ExecId)
+		case 1, 5:
+			assert.Error(t, err)
+		}
+	}
 }

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -38,6 +38,11 @@ var (
 		"Number of process cache misses.",
 		nil, []metrics.ConstrainedLabel{operationLabel}, nil,
 	), nil)
+	processCacheRemovedStale = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: consts.MetricsNamespace,
+		Name:      "process_cache_removed_stale_total",
+		Help:      "Number of process cache stale entries removed.",
+	})
 )
 
 func newCacheCollector() prometheus.Collector {
@@ -59,6 +64,7 @@ func RegisterMetrics(group metrics.Group) {
 		processCacheTotal,
 		processCacheEvictions,
 		processCacheMisses,
+		processCacheRemovedStale,
 	)
 	group.MustRegister(newCacheCollector())
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cilium/tetragon/pkg/cgidmap"
 	"github.com/cilium/tetragon/pkg/fieldfilters"
@@ -62,6 +63,8 @@ type ProcessInternal struct {
 	// protects the refcntOps map
 	refcntOpsLock sync.Mutex
 	cgID          uint64
+	// the time the process and all children exited
+	exitTime time.Time
 }
 
 var (


### PR DESCRIPTION
Add stale entry removal functionality to the process cache. This won't affect normal operations, but in the event that a custom ref count has been placed on an entry and not removed (for whatever reason, maybe logic error, maybe missed event, etc), remove entries where the process and all its children have exited at least 10 minutes ago. Record a metric when entries are removed.
