### PR TITLE
v1.2 backports

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -410,7 +410,10 @@ func tetragonExecute() error {
 		}
 
 		k8sClient := kubernetes.NewForConfigOrDie(config)
-		k8sWatcher = watcher.NewK8sWatcher(k8sClient, 60*time.Second)
+		k8sWatcher, err = watcher.NewK8sWatcher(k8sClient, 60*time.Second)
+		if err != nil {
+			return err
+		}
 	} else {
 		log.Info("Disabling Kubernetes API")
 		k8sWatcher = watcher.NewFakeK8sWatcher(nil)

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -81,6 +81,8 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.enableProcessCred | bool | `false` | Enable Capabilities visibility in exec and kprobe events. |
 | tetragon.enableProcessNs | bool | `false` | Enable Namespaces visibility in exec and kprobe events. |
 | tetragon.enabled | bool | `true` |  |
+| tetragon.eventCacheRetries | int | `15` | Configure the number of retries in tetragon's event cache. |
+| tetragon.eventCacheRetryDelay | int | `2` | Configure the delay (in seconds) between retires in tetragon's event cache. |
 | tetragon.exportAllowList | string | `"{\"event_set\":[\"PROCESS_EXEC\", \"PROCESS_EXIT\", \"PROCESS_KPROBE\", \"PROCESS_UPROBE\", \"PROCESS_TRACEPOINT\", \"PROCESS_LSM\"]}"` | Allowlist for JSON export. For example, to export only process_connect events from the default namespace:  exportAllowList: |   {"namespace":["default"],"event_set":["PROCESS_EXEC"]} |
 | tetragon.exportDenyList | string | `"{\"health_check\":true}\n{\"namespace\":[\"\", \"cilium\", \"kube-system\"]}"` | Denylist for JSON export. For example, to exclude exec events that look similar to Kubernetes health checks and all the events from kube-system namespace and the host:  exportDenyList: |   {"health_check":true}   {"namespace":["kube-system",""]}  |
 | tetragon.exportFileCompress | bool | `false` | Compress rotated JSON export files. |

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -275,6 +275,10 @@ The number of loaded tracing policy by state.
 | ----- | ------ |
 | `state` | `disabled, enabled, error, load_error` |
 
+### `tetragon_watcher_delete_pod_cache_hits`
+
+The total hits for pod information in the deleted pod cache.
+
 ### `tetragon_watcher_errors_total`
 
 The total number of errors for a given watcher type.

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -76,6 +76,12 @@ options:
       default_value: "true"
       usage: |
         Enable TracingPolicy and TracingPolicyNamespaced custom resources
+    - name: event-cache-retries
+      default_value: "15"
+      usage: Number of retries for event cache
+    - name: event-cache-retry-delay
+      default_value: "2"
+      usage: Delay in seconds between event cache retries
     - name: event-queue-size
       default_value: "10000"
       usage: Set the size of the internal event queue.

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -63,6 +63,8 @@ Helm chart for Tetragon
 | tetragon.enableProcessCred | bool | `false` | Enable Capabilities visibility in exec and kprobe events. |
 | tetragon.enableProcessNs | bool | `false` | Enable Namespaces visibility in exec and kprobe events. |
 | tetragon.enabled | bool | `true` |  |
+| tetragon.eventCacheRetries | int | `15` | Configure the number of retries in tetragon's event cache. |
+| tetragon.eventCacheRetryDelay | int | `2` | Configure the delay (in seconds) between retires in tetragon's event cache. |
 | tetragon.exportAllowList | string | `"{\"event_set\":[\"PROCESS_EXEC\", \"PROCESS_EXIT\", \"PROCESS_KPROBE\", \"PROCESS_UPROBE\", \"PROCESS_TRACEPOINT\", \"PROCESS_LSM\"]}"` | Allowlist for JSON export. For example, to export only process_connect events from the default namespace:  exportAllowList: |   {"namespace":["default"],"event_set":["PROCESS_EXEC"]} |
 | tetragon.exportDenyList | string | `"{\"health_check\":true}\n{\"namespace\":[\"\", \"cilium\", \"kube-system\"]}"` | Denylist for JSON export. For example, to exclude exec events that look similar to Kubernetes health checks and all the events from kube-system namespace and the host:  exportDenyList: |   {"health_check":true}   {"namespace":["kube-system",""]}  |
 | tetragon.exportFileCompress | bool | `false` | Compress rotated JSON export files. |

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -70,4 +70,6 @@ data:
 {{- if .Values.tetragon.pprof.enabled }}
   pprof-address: {{ .Values.tetragon.pprof.address }}:{{ .Values.tetragon.pprof.port }}
 {{- end }}
+  event-cache-retries: {{ .Values.tetragon.eventCacheRetries | quote }}
+  event-cache-retry-delay: {{ .Values.tetragon.eventCacheRetryDelay | quote }}
   {{- include "configmap.extra" . | nindent 2 }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -222,6 +222,10 @@ tetragon:
     extraVolumeMounts: []
     # -- resources for the the oci-hook-setup init container
     resources: {}
+  # -- Configure the number of retries in tetragon's event cache.
+  eventCacheRetries: 15
+  # -- Configure the delay (in seconds) between retires in tetragon's event cache.
+  eventCacheRetryDelay: 2
 # Tetragon Operator settings
 tetragonOperator:
   # -- Enables the Tetragon Operator.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -45,6 +45,10 @@ const (
 
 	// Pid file where to write tetragon main PID
 	DefaultPidFile = DefaultRunDir + "tetragon.pid"
+
+	// defaults for the event cache
+	DefaultEventCacheNumRetries = 15
+	DefaultEventCacheRetryDelay = 2
 )
 
 var (

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -415,7 +415,7 @@ func GrpcExecOutOfOrder[EXEC notify.Message, EXIT notify.Message](t *testing.T) 
 		AllEvents = append(AllEvents, e)
 	}
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 	CheckExecEvents(t, AllEvents, parentPid, currentPid)
 }
 
@@ -474,7 +474,7 @@ func GrpcExecMisingParent[EXEC notify.Message, EXIT notify.Message](t *testing.T
 		AllEvents = append(AllEvents, e)
 	}
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 
 	assert.Equal(t, len(AllEvents), 1)
 	execEv := AllEvents[0].GetProcessExec()
@@ -503,7 +503,7 @@ func GrpcMissingExec[EXEC notify.Message, EXIT notify.Message](t *testing.T) {
 		AllEvents = append(AllEvents, e)
 	}
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 
 	assert.Equal(t, len(AllEvents), 1)
 	ev := AllEvents[0]
@@ -659,7 +659,7 @@ func GrpcExecCloneOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT not
 		AllEvents = append(AllEvents, e)
 	}
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 
 	CheckCloneEvents(t, AllEvents, currentPid, clonePid)
 }
@@ -793,8 +793,8 @@ func GrpcExecPodInfoInOrder[EXEC notify.Message, EXIT notify.Message](t *testing
 		AllEvents = append(AllEvents, e)
 	}
 
-	fakeWatcher.AddPod(dummyPod)                                                  // setup some dummy pod to return
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	fakeWatcher.AddPod(dummyPod)                                                                      // setup some dummy pod to return
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 	CheckPodEvents(t, AllEvents)
 }
 
@@ -838,7 +838,7 @@ func GrpcExecPodInfoOutOfOrder[EXEC notify.Message, EXIT notify.Message](t *test
 	}
 
 	fakeWatcher.AddPod(dummyPod)
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 	CheckPodEvents(t, AllEvents)
 }
 
@@ -886,7 +886,7 @@ func GrpcExecPodInfoInOrderAfter[EXEC notify.Message, EXIT notify.Message](t *te
 		AllEvents = append(AllEvents, e)
 	}
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 	CheckPodEvents(t, AllEvents)
 }
 
@@ -933,7 +933,7 @@ func GrpcExecPodInfoOutOfOrderAfter[EXEC notify.Message, EXIT notify.Message](t 
 		AllEvents = append(AllEvents, e)
 	}
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 	CheckPodEvents(t, AllEvents)
 }
 
@@ -983,7 +983,7 @@ func GrpcExecPodInfoDelayedOutOfOrder[EXEC notify.Message, EXIT notify.Message](
 
 	fakeWatcher.AddPod(dummyPod) // setup some dummy pod to return
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 
 	CheckPodEvents(t, AllEvents)
 }
@@ -1032,7 +1032,7 @@ func GrpcExecPodInfoDelayedInOrder[EXEC notify.Message, EXIT notify.Message](t *
 
 	fakeWatcher.AddPod(dummyPod) // setup some dummy pod to return
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 
 	CheckPodEvents(t, AllEvents)
 }
@@ -1079,7 +1079,7 @@ func GrpcDelayedExecK8sOutOfOrder[EXEC notify.Message, EXIT notify.Message](t *t
 		AllEvents = append(AllEvents, e)
 	}
 
-	time.Sleep(time.Millisecond * ((eventcache.CacheStrikes + 4) * CacheTimerMs)) // wait for cache to do it's work
+	time.Sleep(time.Millisecond * time.Duration((option.Config.EventCacheNumRetries+4)*CacheTimerMs)) // wait for cache to do it's work
 
 	CheckPodEvents(t, AllEvents)
 }

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	CacheTimerMs = 100
+	CacheTimerMs = 1
 )
 
 var (

--- a/pkg/jsonchecker/jsonchecker.go
+++ b/pkg/jsonchecker/jsonchecker.go
@@ -15,15 +15,14 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/api/v1/tetragon/codegen/helpers"
-	"github.com/cilium/tetragon/pkg/eventcache"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/sirupsen/logrus"
 )
 
-var (
+const (
 	Retries    = 13
-	RetryDelay = eventcache.EventRetryTimer + (1 * time.Second)
+	RetryDelay = 3 * time.Second
 )
 
 // DebugError is an error that will create a debug output message

--- a/pkg/jsonchecker/jsonchecker.go
+++ b/pkg/jsonchecker/jsonchecker.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
+var (
 	Retries    = 13
 	RetryDelay = 3 * time.Second
 )

--- a/pkg/metrics/watchermetrics/watchermetrics.go
+++ b/pkg/metrics/watchermetrics/watchermetrics.go
@@ -44,17 +44,26 @@ var (
 		Help:        "The total number of events for a given watcher type.",
 		ConstLabels: nil,
 	}, []string{"watcher"})
+
+	WatcherDeletedPodCacheHits = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   consts.MetricsNamespace,
+		Name:        "watcher_delete_pod_cache_hits",
+		Help:        "The total hits for pod information in the deleted pod cache.",
+		ConstLabels: nil,
+	})
 )
 
 func RegisterMetrics(group metrics.Group) {
 	group.MustRegister(WatcherErrors)
 	group.MustRegister(WatcherEvents)
+	group.MustRegister(WatcherDeletedPodCacheHits)
 }
 
 func InitMetrics() {
 	// Initialize metrics with labels
 	GetWatcherEvents(K8sWatcher).Add(0)
 	GetWatcherErrors(K8sWatcher, FailedToGetPodError).Add(0)
+	GetWatcherDeletedPodCacheHits().Add(0)
 }
 
 // Get a new handle on an WatcherEvents metric for a watcher type
@@ -65,4 +74,8 @@ func GetWatcherEvents(watcherType Watcher) prometheus.Counter {
 // Get a new handle on an WatcherEvents metric for a watcher type
 func GetWatcherErrors(watcherType Watcher, watcherError ErrorType) prometheus.Counter {
 	return WatcherErrors.WithLabelValues(watcherType.String(), string(watcherError))
+}
+
+func GetWatcherDeletedPodCacheHits() prometheus.Counter {
+	return WatcherDeletedPodCacheHits
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/spf13/viper"
@@ -100,6 +101,9 @@ type config struct {
 
 	EnableCgIDmap      bool
 	EnableCgIDmapDebug bool
+
+	EventCacheNumRetries int
+	EventCacheRetryDelay int
 }
 
 var (
@@ -117,6 +121,11 @@ var (
 
 		// Enable all metrics labels by default
 		MetricsLabelFilter: DefaultLabelFilter(),
+
+		// set default valus for the event cache
+		// mainly used in the case of testing
+		EventCacheNumRetries: defaults.DefaultEventCacheNumRetries,
+		EventCacheRetryDelay: defaults.DefaultEventCacheRetryDelay,
 	}
 )
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -112,6 +112,9 @@ const (
 
 	KeyEnableCgIDmap      = "enable-cgidmap"
 	KeyEnableCgIDmapDebug = "enable-cgidmap-debug"
+
+	KeyEventCacheRetries    = "event-cache-retries"
+	KeyEventCacheRetryDelay = "event-cache-retry-delay"
 )
 
 type UsernameMetadaCode int
@@ -238,6 +241,10 @@ func ReadAndSetFlags() error {
 
 	Config.EnableCgIDmap = viper.GetBool(KeyEnableCgIDmap)
 	Config.EnableCgIDmapDebug = viper.GetBool(KeyEnableCgIDmapDebug)
+
+	Config.EventCacheNumRetries = viper.GetInt(KeyEventCacheRetries)
+	Config.EventCacheRetryDelay = viper.GetInt(KeyEventCacheRetryDelay)
+
 	return nil
 }
 
@@ -401,4 +408,7 @@ func AddFlags(flags *pflag.FlagSet) {
 
 	flags.Bool(KeyEnableCgIDmap, false, "enable pod resolution via cgroup ids")
 	flags.Bool(KeyEnableCgIDmapDebug, false, "enable cgidmap debugging info")
+
+	flags.Int(KeyEventCacheRetries, defaults.DefaultEventCacheNumRetries, "Number of retries for event cache")
+	flags.Int(KeyEventCacheRetryDelay, defaults.DefaultEventCacheRetryDelay, "Delay in seconds between event cache retries")
 }

--- a/pkg/process/podinfo_test.go
+++ b/pkg/process/podinfo_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/watcher"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	v1 "k8s.io/api/core/v1"
@@ -49,7 +50,8 @@ func TestK8sWatcher_GetPodInfo(t *testing.T) {
 	}
 
 	k8sClient := fake.NewSimpleClientset(&pod)
-	watcher := watcher.NewK8sWatcher(k8sClient, time.Hour)
+	watcher, err := watcher.NewK8sWatcher(k8sClient, time.Hour)
+	require.NoError(t, err)
 	watcher.Start()
 	pid := uint32(1)
 	podInfo := getPodInfo(watcher, "abcd1234", "curl", "cilium.io", 1)

--- a/pkg/watcher/deleted_pod_cache.go
+++ b/pkg/watcher/deleted_pod_cache.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package watcher
+
+import (
+	"github.com/cilium/tetragon/pkg/logger"
+	lru "github.com/hashicorp/golang-lru/v2"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type deletedPodCacheEntry struct {
+	pod        *v1.Pod
+	contStatus *v1.ContainerStatus
+}
+
+type deletedPodCache struct {
+	*lru.Cache[string, deletedPodCacheEntry]
+}
+
+func newDeletedPodCache() (*deletedPodCache, error) {
+	c, err := lru.New[string, deletedPodCacheEntry](128)
+	if err != nil {
+		return nil, err
+	}
+	return &deletedPodCache{c}, nil
+}
+
+func (c *deletedPodCache) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) {
+			var pod *corev1.Pod
+			switch concreteObj := obj.(type) {
+			case *corev1.Pod:
+				pod = concreteObj
+			case cache.DeletedFinalStateUnknown:
+				// Handle the case when the watcher missed the deletion event
+				// (e.g. due to a lost apiserver connection).
+				deletedObj, ok := concreteObj.Obj.(*corev1.Pod)
+				if !ok {
+					return
+				}
+				pod = deletedObj
+			default:
+				return
+			}
+
+			run := func(s []v1.ContainerStatus) {
+				for i := range s {
+					contStatus := &s[i]
+					contID := contStatus.ContainerID
+					if contID == "" {
+						continue
+					}
+
+					key, err := containerIDKey(contID)
+					if err != nil {
+						logger.GetLogger().Warn("failed to crate container key for id '%s': %w", contID, err)
+						continue
+					}
+
+					c.Add(key, deletedPodCacheEntry{
+						pod:        pod,
+						contStatus: contStatus,
+					})
+				}
+			}
+
+			run(pod.Status.InitContainerStatuses)
+			run(pod.Status.ContainerStatuses)
+			run(pod.Status.EphemeralContainerStatuses)
+		},
+	}
+}
+
+func (c *deletedPodCache) findContainer(containerID string) (*corev1.Pod, *corev1.ContainerStatus, bool) {
+	v, ok := c.Get(containerID)
+	if !ok {
+		return nil, nil, false
+	}
+
+	return v.pod, v.contStatus, true
+}

--- a/pkg/watcher/deleted_pod_cache.go
+++ b/pkg/watcher/deleted_pod_cache.go
@@ -5,6 +5,7 @@ package watcher
 
 import (
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
 	lru "github.com/hashicorp/golang-lru/v2"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -81,5 +82,6 @@ func (c *deletedPodCache) findContainer(containerID string) (*corev1.Pod, *corev
 		return nil, nil, false
 	}
 
+	watchermetrics.GetWatcherDeletedPodCacheHits().Inc()
 	return v.pod, v.contStatus, true
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -225,7 +225,7 @@ func (watcher *K8sWatcher) FindContainer(containerID string) (*corev1.Pod, *core
 	// If we can't find any pod indexed then fall back to the entire pod list.
 	// If we find more than 1 pods indexed also fall back to the entire pod list.
 	if len(objs) != 1 {
-		return findContainer(containerID, podInformer.GetStore().List())
+		objs = podInformer.GetStore().List()
 	}
 	return findContainer(containerID, objs)
 }

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+type tlog struct {
+	*testing.T
+	Logger *logrus.Logger
+}
+
+func (tl tlog) Write(p []byte) (n int, err error) {
+	tl.Log(string(p))
+	return len(p), nil
+}
+
+// This test tests that we can still do pod association when a pod is removed from the k8s cache
+// (effectively, this tests the deleted pod cache feature).
+func TestFastK8s(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// NB: using testutils.CaptureLog causes import cycle
+	log := logger.GetLogger().(*logrus.Logger)
+	lc := &tlog{T: t, Logger: log}
+	log.SetOutput(lc)
+
+	// example taken from https://github.com/kubernetes/client-go/blob/04ef61f72b7bc5ae6efef4e4dc0001746637fdb3/examples/fake-client/main_test.go
+	watcherStarted := make(chan struct{})
+	// Create the fake client.
+	client := k8sfake.NewSimpleClientset()
+
+	// create test state
+	ts := testState{
+		client: client,
+	}
+
+	// A catch-all watch reactor that allows us to inject the watcherStarted channel.
+	client.PrependWatchReactor("*", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := client.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		close(watcherStarted)
+		return true, watch, nil
+	})
+
+	// We will create an informer that writes added pods to a channel.
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := informerFactory.Core().V1().Pods().Informer()
+	podInformer.AddEventHandler(ts.eventHandler())
+
+	watcher, err := newK8sWatcher(informerFactory)
+	require.Nil(t, err)
+	watcher.Start()
+
+	// This is not required in tests, but it serves as a proof-of-concept by
+	// ensuring that the informer goroutine have warmed up and called List before
+	// we send any events to it.
+	cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced)
+
+	// The fake client doesn't support resource version. Any writes to the client
+	// after the informer's initial LIST and before the informer establishing the
+	// watcher will be missed by the informer. Therefore we wait until the watcher
+	// starts.
+	// Note that the fake client isn't designed to work with informer. It
+	// doesn't support resource version. It's encouraged to use a real client
+	// in an integration/E2E test if you need to test complex behavior with
+	// informer/controllers.
+	<-watcherStarted
+
+	namespace := "ns1"
+	t.Log("adding pod")
+	ts.createPod(t, namespace, "mypod", "mycontainer")
+
+	ts.waitForCallbacks(t)
+	pod, _, found := watcher.FindContainer(contIDFromName("mycontainer"))
+	require.True(t, found, "added pod should be found")
+	require.Equal(t, pod.Name, "mypod")
+
+	t.Log("deleting pod")
+	ts.deletePod(t, namespace, "mypod")
+
+	ts.waitForCallbacks(t)
+	pod, _, found = watcher.FindContainer(contIDFromName("mycontainer"))
+	require.True(t, found, "deleted pod should be found")
+	require.Equal(t, pod.Name, "mypod")
+}
+
+type testContainer struct {
+	name string
+	id   string
+}
+
+type testPod struct {
+	name       string
+	id         uuid.UUID
+	namespace  string
+	containers []testContainer
+}
+
+func (tp *testPod) Pod() *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tp.name,
+			UID:       k8stypes.UID(tp.id.String()),
+			Namespace: tp.namespace,
+		},
+		Spec:   v1.PodSpec{},
+		Status: v1.PodStatus{},
+	}
+
+	for _, cont := range tp.containers {
+		pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+			Name: cont.name,
+		})
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, v1.ContainerStatus{
+			Name:        cont.name,
+			ContainerID: cont.id,
+			State: v1.ContainerState{
+				Running: &v1.ContainerStateRunning{},
+			},
+		})
+	}
+
+	return pod
+}
+
+type testState struct {
+	// number of pod adds/deletes
+	nrAdds, nrDels atomic.Uint64
+	// number of callbacks being called for pods adds/deletes
+	cbAdds, cbDels atomic.Uint64
+
+	client *fake.Clientset
+}
+
+func contIDFromName(s string) string {
+	return fmt.Sprintf("cont-id-%s", s)
+}
+
+func (ts *testState) createPod(t *testing.T, namespace string, name string, containerNames ...string) {
+	podID := uuid.New()
+	testPod := testPod{
+		name:      name,
+		id:        podID,
+		namespace: namespace,
+	}
+
+	for _, contName := range containerNames {
+		testPod.containers = append(testPod.containers, testContainer{
+			name: contName,
+			id:   "docker://" + contIDFromName(contName),
+		})
+	}
+
+	pod := testPod.Pod()
+	_, err := ts.client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	require.Nil(t, err, "failed to create pod")
+	ts.nrAdds.Add(1)
+}
+
+func (ts *testState) deletePod(t *testing.T, namespace string, name string) {
+	err := ts.client.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	require.Nil(t, err, "failed to delete pod")
+	ts.nrDels.Add(1)
+}
+
+func (ts *testState) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(_ interface{}) {
+			ts.cbAdds.Add(1)
+		},
+		DeleteFunc: func(_ interface{}) {
+			ts.cbDels.Add(1)
+		},
+	}
+}
+
+func (ts *testState) callbacksDone() bool {
+	return (ts.cbAdds.Load() == ts.nrAdds.Load()) &&
+		(ts.cbDels.Load() == ts.nrDels.Load())
+}
+
+func (ts *testState) waitForCallbacks(t *testing.T) {
+	dt := 1 * time.Millisecond
+	for i := 0; i < 6; i++ {
+		time.Sleep(dt)
+		if ts.callbacksDone() {
+			return
+		}
+		dt = 5 * dt
+	}
+
+	t.Fatalf("waitForCallbacks: timeout (%s)", dt)
+}


### PR DESCRIPTION
Backported PRs

  * https://github.com/cilium/tetragon/pull/2928
       * [Make EventCache configurable](https://github.com/cilium/tetragon/commit/62957f1042c56acac1e335d104b577c83d61f0e9)
       * [Reduce the delay in GRPC gotests](https://github.com/cilium/tetragon/commit/aab03febf6abbb9bb22eb480d7b9e8185ab05108)
       * [Export EventCache tunables in the Helm Chart](https://github.com/cilium/tetragon/commit/451f921b9947fa652afc641a8801bad769ded5c5)
  * https://github.com/cilium/tetragon/pull/2930
       * [watcher: refactor watcher](https://github.com/cilium/tetragon/commit/5c838d5fbb30e55d8bf5467831507b22808d69b7)
       * [watcher: add a containerIDKey function](https://github.com/cilium/tetragon/commit/ebd7e4338585765ee487dc6a64a1aba0cc8f4469)
       * [watcher: change FindContainer function](https://github.com/cilium/tetragon/commit/2c3ea83c27493d9205f5d969bbbd7be67954fb94)
       * [watcher: add test for "fast" k8s API server](https://github.com/cilium/tetragon/commit/7043d06fc5d79be8a9147e6fa98387739a0b41ba)
       * [watcher: add a deleted pod cache](https://github.com/cilium/tetragon/commit/27df62be718d81871de062aec3bbb410ce30e601)
       * [watcher: add metrics for deleted pod cache](https://github.com/cilium/tetragon/commit/3cefc44c8c04242e7899a0d9716189745e96e7b5)
  * https://github.com/cilium/tetragon/pull/2948
       * [bpf: allow all operations for syscall64 type](https://github.com/cilium/tetragon/commit/b90d9086c416aa48765ac524ffcb50ddc5d7aeee)
  * https://github.com/cilium/tetragon/pull/2936
       * [[jsonchecker] Remove const from parameters](https://github.com/cilium/tetragon/commit/c35738cf1034e72b896678368432c92e071925b1)



```release-note
tetragon: make eventCache number of retries and delays tunable.
tetragon: pod association: add a cache for deleted pods
```