### PR TITLE
Enabled `tetra` bash autocompletion in the Tetragon image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN curl -L https://github.com/libbpf/bpftool/releases/download/${BPFTOOL_TAG}/b
 # Almost final step runs on target platform (might need emulation) and
 # retrieves (cross-)compiled binaries from builders
 FROM docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d AS base-build
-RUN apk add iproute2
+RUN apk add --no-cache iproute2
 RUN mkdir /var/lib/tetragon/ && \
     mkdir -p /etc/tetragon/tetragon.conf.d/ && \
     mkdir -p /etc/tetragon/tetragon.tp.d/ && \


### PR DESCRIPTION
### Description
Minor UX improvement when troubleshooting inside the Tetragon container image:

```bash
77a8a8762616:/# tetra    # pressing <tab><tab>
bugtool          (Produce a tar archive with debug information)                probe            (Probe for eBPF system features availability)
completion       (Generate the autocompletion script for the specified shell)  stacktrace-tree  (Manage stacktrace trees)
cri              (connect to CRI)                                              status           (Print health status)
getevents        (Print events)                                                tracingpolicy    (Manage tracing policies)
help             (Help about any command)                                      version          (Print version from CLI and server)
loglevel         (Get and dynamically change the log level)
```

### TODOs
- [x] Check if there's a better way to install `bash-completion` in a separate stage and only copying over the relevant files. Why? See outputs of `grype`👇 

Without `bash-completion` installed:
```bash
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                                                 af7eb1d3b2a6
 ✔ Parsed image                                                                                                      sha256:af7eb1d3b2a6396945a08f836e6aaca937027c985cd07e4bf6f3bccb216d50a8
 ✔ Cataloged contents                                                                                                       1bebc98c8d0b81c46ab1f3e5ccda178d7b838a9c291a445f32c650c333291194
   ├── ✔ Packages                        [310 packages]
   ├── ✔ File digests                    [188 files]
   ├── ✔ File metadata                   [188 locations]
   └── ✔ Executables                     [78 executables]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```

With `bash-completion` installed:
```bash
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                                                 dd56dbaea46f
 ✔ Parsed image                                                                                                      sha256:dd56dbaea46f5212cbc49f3f68d023f8084f9c05f894be49828cbebec7da0830
 ✔ Cataloged contents                                                                                                       eb044ca6d3b763ff5a1e187ea2725791a08bb6f183e5b8ad8fecabaa83166846
   ├── ✔ Packages                        [312 packages]
   ├── ✔ File digests                    [696 files]
   ├── ✔ File metadata                   [696 locations]
   └── ✔ Executables                     [78 executables]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```

`188 files` vs. `696 files` and `188 locations` vs. `696 locations`

### Release Note
```release-note
Enabled `tetra` bash autocompletion in the Tetragon image
```
