### PR TITLE
CVE: detect and mitigate cups foomatic-rip CVE-2024-47176 2024-47177

### DIFF
--- a/examples/tracingpolicy/cves/cve-cups-CVE-2024-47176-2024-47177.yaml
+++ b/examples/tracingpolicy/cves/cve-cups-CVE-2024-47176-2024-47177.yaml
@@ -1,0 +1,96 @@
+# https://www.cve.org/CVERecord?id=CVE-2024-47177
+# https://github.com/OpenPrinting/cups-browsed/security/advisories/GHSA-rj88-6mr5-rcw8
+# https://www.evilsocket.net/2024/09/26/Attacking-UNIX-systems-via-CUPS-Part-I/
+#
+# In Summary there are four vulnerabilities:
+#
+# "CUPS is a standards-based, open-source printing system, and `cups-browsed` contains
+#  network printing functionality including, but not limited to, auto-discovering print
+#  services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it
+#  to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP
+#  request to an attacker controlled URL. When combined with other vulnerabilities,
+#  such as CVE-2024-47076, CVE-2024-47175, and CVE-2024-47177, an attacker can execute
+#  arbitrary commands remotely on the target machine without authentication when a
+#  malicious printer is printed to."
+#
+# The final CVE-2024-47177 is with a score CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H (9.0 Critical)
+#
+# Detection:
+#
+# - Running default Tetragon with enable process credentials for user IDs details:
+#   https://tetragon.io/docs/installation/configuration/#enable-process-credentials
+#
+#   Query Tetragon JSON logs assuming they are in "/var/log/tetragon/tetragon.log":
+#
+#   jq 'select(.process_exec != null) | select(.process_exec.parent.binary | contains("foomatic-rip"))' \
+#         /var/log/tetragon/tetragon.log
+#
+#   Example output:
+#     {
+#       "process_exec": {
+#         "process": {
+#         "exec_id": "cm9yb25vYToyOTk4MDQ1MzgwOTcxNjoxMTI4OTA=",
+#         "pid": 112890,
+#         "uid": 7,
+#         "cwd": "/",
+#         "binary": "/bin/sh",
+#         "arguments": "-e -c \"touch /tmp/cups_exploit #\"",
+#         "process_credentials": {
+#           "uid": 7,
+#           "gid": 7,
+#           "euid": 7,
+#           "egid": 7,
+#         }
+#       },
+#       "parent": {
+#         "exec_id": "cm9yb25vYToyOTk4MDQ1MjMzNDEzOToxMTI4ODg=",
+#         "pid": 112888,
+#         "uid": 7,
+#         "cwd": "/",
+#         "binary": "/usr/lib/cups/filter/foomatic-rip"
+#         ...
+#
+#
+# Metigation:
+#
+#  * Disable BrowerRemoteProtocol in /etc/cups/cups-browsed.conf
+#    https://ubuntu.com/blog/cups-remote-code-execution-vulnerability-fix-available
+#
+#  * Update this Tracing Policy to kill execution of commands by foomatic-rip binary, however
+#    foomatic-rip is part of Foomatic, a comprehensive database of printers, printer drivers,
+#    and driver descriptions. It is a universal print filter which is used as a CUPS filter
+#    to translate PostScript and PDF from standard input or a file to the printer's native
+#    language. The translation is done with an external renderer, usually Ghostscript gs
+#    tool.
+#
+#    According to the CUPS developers:
+#    "...we can certainly recommend that people not use Foomatic, but there are likely hundreds
+#     of older printer models (before 2010) that are only supported through Foomatic."
+#
+
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "cve-cups-2024-47176-2024-47177"
+  annotations:
+    url: "https://www.cve.org/CVERecord?id=CVE-2024-47177"
+    description: "Detects and Prevents exploitation of cups CVE-2024-47177"
+    author: "Tetragon.io Team"
+spec:
+  kprobes:
+  - call: "security_bprm_check"
+    syscall: false
+    args:
+    - index: 0
+      type: "linux_binprm"
+    message: "Foomatic-rip print filter/RIP wrapper executing a command"
+    tags: [ "cve.2024-47176", "cve.2024-47177", "severity.critical" ]
+    selectors:
+    - matchBinaries:
+      - operator: "In"
+        values:
+        # Add your foomatic-rip paths here
+        - "/usr/lib/cups/filter/foomatic-rip"
+        - "/lib/cups/filter/foomatic-rip"
+      #matchActions:  # Uncomment this to kill all execution from foomatic-rip
+      #- action: Sigkill


### PR DESCRIPTION
https://www.cve.org/CVERecord?id=CVE-2024-47177
https://github.com/OpenPrinting/cups-browsed/security/advisories/GHSA-rj88-6mr5-rcw8 https://www.evilsocket.net/2024/09/26/Attacking-UNIX-systems-via-CUPS-Part-I/

In Summary there are four vulnerabilities:

"CUPS is a standards-based, open-source printing system, and `cups-browsed` contains network printing functionality including, but not limited to, auto-discovering print services and shared printers. `cups-browsed` binds to `INADDR_ANY:631`, causing it to trust any packet from any source, and can cause the `Get-Printer-Attributes` IPP request to an attacker controlled URL. When combined with other vulnerabilities, such as CVE-2024-47076, CVE-2024-47175, and CVE-2024-47177, an attacker can execute arbitrary commands remotely on the target machine without authentication when a malicious printer is printed to."

The commands are executed through foomatic-rip binary, to detect such executions run the following filter on tetragon JSON events:

  jq 'select(.process_exec != null) | \
     select(.process_exec.parent.binary | contains("foomatic-rip"))' \
     /var/log/tetragon/tetragon.log

This policy can detect and block foomatic-rip binary from executing commands, however according to CUPS developers:
"...we can certainly recommend that people not use Foomatic, but there are likely
 hundreds of older printer models (before 2010) that are only supported through
 Foomatic."

```release-note
CVE: detect and mitigate cups foomatic-rip CVE-2024-47176 2024-47177
```
