### PR TITLE
helm: Added dedicated flag for persistent enforcement

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -75,6 +75,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.commandOverride | list | `[]` | Override the command. For advanced users only. |
 | tetragon.debug | bool | `false` | If you want to run Tetragon in debug mode change this value to true |
 | tetragon.enableK8sAPI | bool | `true` | Access Kubernetes API to associate Tetragon events with Kubernetes pods. |
+| tetragon.enableKeepSensorsOnExit | bool | `false` | Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone. |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |
 | tetragon.enablePolicyFilter | bool | `true` | Enable policy filter. This is required for K8s namespace and pod-label filtering. |
 | tetragon.enablePolicyFilterDebug | bool | `false` | Enable policy filter debug messages. |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -57,6 +57,7 @@ Helm chart for Tetragon
 | tetragon.commandOverride | list | `[]` | Override the command. For advanced users only. |
 | tetragon.debug | bool | `false` | If you want to run Tetragon in debug mode change this value to true |
 | tetragon.enableK8sAPI | bool | `true` | Access Kubernetes API to associate Tetragon events with Kubernetes pods. |
+| tetragon.enableKeepSensorsOnExit | bool | `false` | Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone. |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |
 | tetragon.enablePolicyFilter | bool | `true` | Enable policy filter. This is required for K8s namespace and pod-label filtering. |
 | tetragon.enablePolicyFilterDebug | bool | `false` | Enable policy filter debug messages. |

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -72,3 +72,7 @@ data:
   event-cache-retries: {{ .Values.tetragon.eventCacheRetries | quote }}
   event-cache-retry-delay: {{ .Values.tetragon.eventCacheRetryDelay | quote }}
   {{- include "configmap.extra" . | nindent 2 }}
+{{- if .Values.tetragon.enableKeepSensorsOnExit }}
+  keep-sensors-on-exit: "true"
+  release-pinned-bpf: "false"
+{{- end }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -228,6 +228,8 @@ tetragon:
   eventCacheRetries: 15
   # -- Configure the delay (in seconds) between retires in tetragon's event cache.
   eventCacheRetryDelay: 2
+  # -- Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone.
+  enableKeepSensorsOnExit: false
 # Tetragon Operator settings
 tetragonOperator:
   # -- Enables the Tetragon Operator.


### PR DESCRIPTION
I added `tetragon.enableKeepSensorsOnExit` to enable persistent enforcement of the sensors even when the Tetragon process is gone/exited. Let's make this flag (`--keep-sensors-on-exit`) a proper Helm value instead of having users specify it via extraArgs. We _should_ also set `--release-pinned-bpf=false` in case `--keep-sensors-on-exit` gets enabled. See https://github.com/cilium/tetragon/commit/64d620e4278ca59fc8666d60daf40b63600943fa.

https://tetragon.io/docs/concepts/enforcement/persistent-enforcement/

```release-note
helm: Added dedicated persistent enforcement flag
```
