### PR TITLE
vmtests: use ubuntu-latest

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -89,7 +89,7 @@ jobs:
       cancel-in-progress: true
     needs: build
     name: Test kernel ${{ matrix.kernel }} / test group ${{ matrix.group }}
-    runs-on: ubuntu-latest-4cores-16gb
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
     - name: Install VM test dependencies


### PR DESCRIPTION
vmtests needed nested virtualization, so they were using ubuntu-latest-4cores-16gb machines. Now, ubuntu-latest also supports nested virtualization so switch vmtest to ubnutu-latest.


