### PR TITLE
tetragon: only close maps from map owner

### DIFF
--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -217,6 +217,10 @@ func (m *Map) Unload() error {
 		log.WithField("count", m.PinState.count).Debug("Refusing to unload map as it is not loaded")
 		return nil
 	}
+	if !m.IsOwner() {
+		log.Debug("Not map owner, not unpinning and closing map yet")
+		return nil
+	}
 	if count := m.PinState.RefDec(); count > 0 {
 		log.WithField("count", count).Debug("Reference exists, not unloading map yet")
 		return nil


### PR DESCRIPTION
To make the map API consistent only close the map if its from the map owner. Otherwise sharing maps could be unpinned and closed from sensor collections that do not own the map breaking the owner.