### PR TITLE
tetragon: Unpin map only if you are owner

### DIFF
--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -223,7 +223,7 @@ func (m *Map) Unload() error {
 	}
 	log.Info("map was unloaded")
 	if m.MapHandle != nil {
-		if !option.Config.KeepSensorsOnExit {
+		if m.IsOwner() && !option.Config.KeepSensorsOnExit {
 			m.MapHandle.Unpin()
 			if m.Type == MapTypeGlobal {
 				DeleteGlobMap(m.Name)


### PR DESCRIPTION
John reported issue where user maps unpinned exisintg maps on unloading,
which is wrong, we just need to close the ebpf handle.

Reported-by: John Fastabend <john.fastabend@gmail.com>
Signed-off-by: Jiri Olsa <jolsa@kernel.org>
