### PR TITLE
vmtests: install dhclient

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -96,7 +96,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-cache search qemu
-        sudo apt-get install -y mmdebstrap libguestfs-tools qemu-utils qemu-system-x86 cpu-checker qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager
+        sudo apt-get install -y mmdebstrap libguestfs-tools qemu-utils qemu-system-x86 cpu-checker qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager isc-dhcp-client
 
     - name: Make kernel accessible
       run: |


### PR DESCRIPTION
All tests are failing with:
 time="2024-10-15T15:35:54Z" level=warning msg="stderr> virt-customize: error: libguestfs error: passt exited with status 1\n"
time="2024-10-15T15:35:54Z" level=warning msg="stderr> \n" time="2024-10-15T15:35:54Z" level=warning msg="stderr> If reporting bugs, run virt-customize with debugging enabled and include the complete output:\n" time="2024-10-15T15:35:54Z" level=warning msg="stderr> \n"
time="2024-10-15T15:35:54Z" level=warning msg="stderr>   virt-customize -v -x [...]\n"
time="2024-10-15T15:35:54Z" level=error msg="error executing command" error="exit status 1" image=tetragon.qcow2
time="2024-10-15T15:35:54Z" level=warning msg="image file 'tests/vmtests/test-data/images/tetragon.qcow2' not deleted so that it can be inspected"
time="2024-10-15T15:35:54Z" level=warning msg="image build failed" image=tetragon.qcow2 queue= result="{Error:exit status 1 CachedImageUsed:false CachedImageDeleted:}"
Error: images errors:tetragon.qcow2: exit status 1

A potential culprit is missing dhclient (see
https://github.com/cilium/little-vm-helper-images/pull/604).
