### PR TITLE
Fix metrics collection in case of duplicate policy names

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -303,7 +303,8 @@ The amount of kernel memory in bytes used by policy's sensors non-shared BPF map
 
 | label | values |
 | ----- | ------ |
-| `policy` | `example-policy` |
+| `policy` | `example-tracingpolicy` |
+| `policy_namespace` | `example-namespace` |
 
 ### `tetragon_tracingpolicy_loaded`
 

--- a/pkg/metrics/policymetrics/policymetrics.go
+++ b/pkg/metrics/policymetrics/policymetrics.go
@@ -35,7 +35,10 @@ var policyState = metrics.MustNewCustomGauge(metrics.NewOpts(
 var policyKernelMemory = metrics.MustNewCustomGauge(metrics.NewOpts(
 	consts.MetricsNamespace, "", "tracingpolicy_kernel_memory_bytes",
 	"The amount of kernel memory in bytes used by policy's sensors non-shared BPF maps (memlock).",
-	nil, nil, []metrics.UnconstrainedLabel{{Name: "policy", ExampleValue: "example-policy"}},
+	nil, nil, []metrics.UnconstrainedLabel{
+		{Name: "policy"},
+		{Name: "policy_namespace"},
+	},
 ))
 
 // This metric collector converts the output of ListTracingPolicies into a few
@@ -70,7 +73,7 @@ func collect(ch chan<- prometheus.Metric) {
 	for _, policy := range list.Policies {
 		state := policy.State
 		counters[state]++
-		ch <- policyKernelMemory.MustMetric(float64(policy.KernelMemoryBytes), policy.Name)
+		ch <- policyKernelMemory.MustMetric(float64(policy.KernelMemoryBytes), policy.Name, policy.Namespace)
 	}
 
 	ch <- policyState.MustMetric(
@@ -95,5 +98,5 @@ func collectForDocs(ch chan<- prometheus.Metric) {
 	for _, state := range stateLabel.Values {
 		ch <- policyState.MustMetric(0, state)
 	}
-	ch <- policyKernelMemory.MustMetric(0, "example-policy")
+	ch <- policyKernelMemory.MustMetric(0, consts.ExamplePolicyLabel, consts.ExampleNamespace)
 }

--- a/pkg/metrics/policymetrics/policymetrics_test.go
+++ b/pkg/metrics/policymetrics/policymetrics_test.go
@@ -23,7 +23,10 @@ func Test_policyStatusCollector_Collect(t *testing.T) {
 	expectedMetrics := func(disabled, enabled, err, load_error int) io.Reader {
 		return strings.NewReader(fmt.Sprintf(`# HELP tetragon_tracingpolicy_kernel_memory_bytes The amount of kernel memory in bytes used by policy's sensors non-shared BPF maps (memlock).
 # TYPE tetragon_tracingpolicy_kernel_memory_bytes gauge
-tetragon_tracingpolicy_kernel_memory_bytes{policy="pizza"} 0
+tetragon_tracingpolicy_kernel_memory_bytes{policy="pizza", policy_namespace=""} 0
+tetragon_tracingpolicy_kernel_memory_bytes{policy="amazing-one", policy_namespace=""} 0
+tetragon_tracingpolicy_kernel_memory_bytes{policy="amazing-one", policy_namespace="default"} 0
+tetragon_tracingpolicy_kernel_memory_bytes{policy="amazing-one", policy_namespace="kube-system"} 0
 # HELP tetragon_tracingpolicy_loaded The number of loaded tracing policy by state.
 # TYPE tetragon_tracingpolicy_loaded gauge
 tetragon_tracingpolicy_loaded{state="disabled"} %d
@@ -39,7 +42,7 @@ tetragon_tracingpolicy_loaded{state="load_error"} %d
 	// manager because in the observer tests we only initialize metrics while the observer
 	// changes for every test (see:
 	// https://github.com/cilium/tetragon/blob/22eb995b19207ac0ced2dd83950ec8e8aedd122d/pkg/observer/observertesthelper/observer_test_helper.go#L272-L276)
-	manager := tus.GetTestSensorManager(context.TODO(), t).Manager
+	manager := tus.GetTestSensorManagerWithDummyPF(context.TODO(), t).Manager
 	observer.SetSensorManager(manager)
 	t.Cleanup(observer.ResetSensorManager)
 
@@ -52,11 +55,32 @@ tetragon_tracingpolicy_loaded{state="load_error"} %d
 		},
 	})
 	assert.NoError(t, err)
-	err = testutil.CollectAndCompare(collector, expectedMetrics(0, 1, 0, 0))
+	// Add three policies with the same name: one clusterwide, two namespaced
+	err = manager.AddTracingPolicy(context.TODO(), &tracingpolicy.GenericTracingPolicy{
+		Metadata: v1.ObjectMeta{
+			Name: "amazing-one",
+		},
+	})
+	assert.NoError(t, err)
+	err = manager.AddTracingPolicy(context.TODO(), &tracingpolicy.GenericTracingPolicyNamespaced{
+		Metadata: v1.ObjectMeta{
+			Name:      "amazing-one",
+			Namespace: "default",
+		},
+	})
+	assert.NoError(t, err)
+	err = manager.AddTracingPolicy(context.TODO(), &tracingpolicy.GenericTracingPolicyNamespaced{
+		Metadata: v1.ObjectMeta{
+			Name:      "amazing-one",
+			Namespace: "kube-system",
+		},
+	})
+	assert.NoError(t, err)
+	err = testutil.CollectAndCompare(collector, expectedMetrics(0, 4, 0, 0))
 	assert.NoError(t, err)
 
 	err = manager.DisableTracingPolicy(context.TODO(), "pizza", "")
 	assert.NoError(t, err)
-	err = testutil.CollectAndCompare(collector, expectedMetrics(1, 0, 0, 0))
+	err = testutil.CollectAndCompare(collector, expectedMetrics(1, 3, 0, 0))
 	assert.NoError(t, err)
 }

--- a/pkg/policyfilter/policyfilter.go
+++ b/pkg/policyfilter/policyfilter.go
@@ -64,18 +64,6 @@ func TestingEnableAndReset(t *testing.T) {
 
 }
 
-// TestingDisableAndReset disable policy filter for tests (see ResetStateOnlyForTesting)
-func TestingDisableAndReset(t *testing.T) {
-	oldEnablePolicyFilterValue := option.Config.EnablePolicyFilter
-	option.Config.EnablePolicyFilter = true
-	resetStateOnlyForTesting()
-	t.Cleanup(func() {
-		option.Config.EnablePolicyFilter = oldEnablePolicyFilterValue
-		resetStateOnlyForTesting()
-	})
-
-}
-
 // State is the policyfilter state interface
 // It handles two things:
 //   - policies being added and removed

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -40,7 +40,14 @@ func StartSensorManager(
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize policy filter state: %w", err)
 	}
+	return StartSensorManagerWithPF(bpfDir, waitChan, pfState)
+}
 
+func StartSensorManagerWithPF(
+	bpfDir string,
+	waitChan chan struct{},
+	pfState policyfilter.State,
+) (*Manager, error) {
 	colMap := newCollectionMap()
 
 	handler, err := newHandler(pfState, colMap, bpfDir)

--- a/pkg/testutils/sensors/policyfilter.go
+++ b/pkg/testutils/sensors/policyfilter.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// nolint:revive // prevent unused-parameter alert
+package sensors
+
+import (
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/tetragon/pkg/labels"
+	"github.com/cilium/tetragon/pkg/policyfilter"
+)
+
+// dummyPF implements policyfilter.State.
+// It's very similar to the disabled state, with the difference that it doesn't
+// return an error on AddPolicy and DelPolicy. It can be used in tests where
+// a namespaced policy must be loaded, but the policyfilter doesn't matter.
+type dummyPF struct{}
+
+func (s *dummyPF) AddPolicy(polID policyfilter.PolicyID, namespace string, podSelector *slimv1.LabelSelector,
+	containerSelector *slimv1.LabelSelector) error {
+	return nil
+}
+
+func (s *dummyPF) DelPolicy(polID policyfilter.PolicyID) error {
+	return nil
+}
+
+func (s *dummyPF) AddPodContainer(podID policyfilter.PodID, namespace, workload, kind string, podLabels labels.Labels,
+	containerID string, cgID policyfilter.CgroupID, containerName string) error {
+	return nil
+}
+
+func (s *dummyPF) UpdatePod(podID policyfilter.PodID, namespace, workload, kind string, podLabels labels.Labels,
+	containerIDs []string, containerNames []string) error {
+	return nil
+}
+
+func (s *dummyPF) DelPodContainer(podID policyfilter.PodID, containerID string) error {
+	return nil
+}
+
+func (s *dummyPF) DelPod(podID policyfilter.PodID) error {
+	return nil
+}
+
+func (s *dummyPF) RegisterPodHandlers(podInformer cache.SharedIndexInformer) {
+}
+
+func (s *dummyPF) Close() error {
+	return nil
+}
+
+func (s *dummyPF) GetNsId(stateID policyfilter.StateID) (*policyfilter.NSID, bool) {
+	return nil, false
+}
+
+func (s *dummyPF) GetIdNs(id policyfilter.NSID) (policyfilter.StateID, bool) {
+	return policyfilter.StateID(0), false
+}


### PR DESCRIPTION
This fixes a metrics collection error that was occurring in case there were
multiple namespaced policies with the same name. The metrics collector is
iterating over all policies and reports tetragon_tracingpolicy_kernel_memory_bytes
metric for each of them. The metric used to be labeled only with the policy
name, so in case there was a second policy with the same name, the collector
reported a duplicate what causes the entire metrics collection job to fail.
Adding a policy_namespace label should prevent duplicates.

There is an underlying assumption that each policy returned by
ListTracingPolicies has a unique (name, namespace) tuple - if it's not the
case, then metrics collection might fail again. Also, I'm not sure if
per-policy memory metrics should be reported for policies in states different
than loaded. Currently they are - I didn't change that behaviour, but it's now
covered by tests.

Fixes: a5301b86f036 ("pkg/metrics: add metrics for policy kernel memory us")