### PR TITLE
pkg/sensors: fix memory use of unloaded sensors

### DIFF
--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -206,6 +206,11 @@ func (p *Program) Unload() error {
 	}
 	p.unloader = nil
 	p.unloaderOverride = nil
+	// The above unloader can succeed while not removing a pin to the program
+	// because of option.Config.KeepSensorsOnExit, and thus the maps remain.
+	if !p.Prog.IsPinned() {
+		p.LoadedMapsInfo = nil
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #3013 

Sensors that are disabled are not loaded and should not use memory, thus we clear the LoadedMapsInfo on unloading programs.
