### PR TITLE
Export the Notifier interface

### DIFF
--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -44,7 +44,7 @@ func NewProcessManager(
 	pm.Server = server.NewServer(ctx, wg, pm, manager, hookRunner)
 
 	// Exec cache is always needed to ensure events have an associated Process{}
-	eventcache.New(pm.Server)
+	eventcache.New(pm)
 
 	logger.GetLogger().WithFields(logrus.Fields{
 		"enableK8s":         option.Config.EnableK8s,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,7 +32,7 @@ type Listener interface {
 	Notify(res *tetragon.GetEventsResponse)
 }
 
-type notifier interface {
+type Notifier interface {
 	AddListener(listener Listener)
 	RemoveListener(listener Listener)
 	NotifyListener(original interface{}, processed *tetragon.GetEventsResponse)
@@ -64,7 +64,7 @@ type hookRunner interface {
 type Server struct {
 	ctx          context.Context
 	ctxCleanupWG *sync.WaitGroup
-	notifier     notifier
+	notifier     Notifier
 	observer     observer
 	hookRunner   hookRunner
 }
@@ -73,7 +73,7 @@ type getEventsListener struct {
 	events chan *tetragon.GetEventsResponse
 }
 
-func NewServer(ctx context.Context, cleanupWg *sync.WaitGroup, notifier notifier, observer observer, hookRunner hookRunner) *Server {
+func NewServer(ctx context.Context, cleanupWg *sync.WaitGroup, notifier Notifier, observer observer, hookRunner hookRunner) *Server {
 	return &Server{
 		ctx:          ctx,
 		ctxCleanupWG: cleanupWg,
@@ -100,10 +100,6 @@ func (l *getEventsListener) Notify(res *tetragon.GetEventsResponse) {
 		// events channel is full: drop the event so that we do not block everything
 		eventmetrics.NotifyOverflowedEvents.Inc()
 	}
-}
-
-func (s *Server) NotifyListeners(original interface{}, processed *tetragon.GetEventsResponse) {
-	s.notifier.NotifyListener(original, processed)
 }
 
 // removeNotifierAndDrain removes the events listener while draining


### PR DESCRIPTION
Export the Notifier interface, and pass it to eventcache instead of passing the entire Server struct. Remove Server.NotifyListeners() method, which is simply a wrapper that calls NotifyListener() on the underlying Notifier.