### PR TITLE
workflows: fix usage of untrusted input in check links

### DIFF
--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Getting image tag
         id: tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ ${{ github.event.pull_request.head.sha }} != "" ]; then
             echo "tag=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
@@ -66,7 +68,7 @@ jobs:
             if [ ${{ github.ref_name }} == "main" ]; then
                   echo "name=latest" | tee -a $GITHUB_OUTPUT
             else
-                  echo "name=${{ github.ref_name }}" | tee -a $GITHUB_OUTPUT
+                  echo "name=$REF_NAME" | tee -a $GITHUB_OUTPUT
             fi
           fi
 

--- a/.github/workflows/check-links-cron.yaml
+++ b/.github/workflows/check-links-cron.yaml
@@ -13,6 +13,8 @@ jobs:
     env:
       ISSUE_NAME: 'Documentation: broken links automatic report'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -21,9 +23,7 @@ jobs:
 
       - name: Links Checker
         id: lychee
-        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # v1.10.0
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede # v2.0.2
         with:
           args: --config .github/lychee.toml --base https://tetragon.io docs/content README.md
 

--- a/.github/workflows/check-links-pr.yaml
+++ b/.github/workflows/check-links-pr.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   links-checker:
     runs-on: ubuntu-latest
+    permissions: {} # lychee uses the GITHUB_TOKEN for authentication only
     env:
       PATCH_FILE: "additions.patch"
     steps:
@@ -28,10 +29,10 @@ jobs:
 
       - name: Retrieve additions and replace GitHub main links with local branch
         shell: bash
+        env:
+          REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          REPO=${{ github.event.pull_request.head.repo.full_name }}
-          BRANCH=${{ github.event.pull_request.head.ref }}
-
           git diff -U0 origin/${{ github.base_ref }} -- docs/content README.md | { grep ^\+[^+] || true; } > $PATCH_FILE
 
           sed -i "s#/cilium/tetragon/tree/main#/$REPO/tree/$BRANCH#g" $PATCH_FILE
@@ -57,9 +58,7 @@ jobs:
 
       - name: Check new links
         id: lychee
-        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # v1.10.0
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede # v2.0.2
         with:
           args: --config .github/lychee.toml --base http://localhost:1313 $PATCH_FILE
-          fail: true
+          failIfEmpty: false # this can happen as we are checking diffs


### PR DESCRIPTION
A user could create a branch with a particular name that would trigger a command injection because we use this input directly in the shell scripts generation. See more details in
https://securitylab.github.com/resources/github-actions-untrusted-input/.

This also updates the lychee action that no longer need an explicit GITHUB_TOKEN env variable lycheeverse/lychee-action#195 and reduce the permissions needed by the token in both check links workflows.

Reported-by: Piergiorgio Ladisa <piergiorgio.ladisa@hotmail.it>
