### PR TITLE
tetragon: Make sure lsm programs return bounded value

### DIFF
--- a/bpf/process/bpf_generic_lsm_core.c
+++ b/bpf/process/bpf_generic_lsm_core.c
@@ -79,19 +79,6 @@ static struct generic_maps maps = {
 	.override = (struct bpf_map_def *)&override_tasks,
 };
 
-FUNC_INLINE int try_override(void *ctx)
-{
-	__u64 id = get_current_pid_tgid();
-	__s32 *error;
-
-	error = map_lookup_elem(&override_tasks, &id);
-	if (!error)
-		return 0;
-
-	map_delete_elem(&override_tasks, &id);
-	return (long)*error;
-}
-
 #define MAIN "lsm/generic_lsm_core"
 
 __attribute__((section((MAIN)), used)) int
@@ -172,7 +159,7 @@ generic_lsm_actions(void *ctx)
 
 	// If NoPost action is set, check for Override action here
 	if (!e->lsm.post)
-		return try_override(ctx);
+		return try_override(ctx, (struct bpf_map_def *)&override_tasks);
 
 	return 0;
 }

--- a/bpf/process/bpf_generic_lsm_output.c
+++ b/bpf/process/bpf_generic_lsm_output.c
@@ -50,19 +50,6 @@ struct {
 	__type(value, struct event_config);
 } config_map SEC(".maps");
 
-FUNC_INLINE int try_override(void *ctx)
-{
-	__u64 id = get_current_pid_tgid();
-	__s32 *error;
-
-	error = map_lookup_elem(&override_tasks, &id);
-	if (!error)
-		return 0;
-
-	map_delete_elem(&override_tasks, &id);
-	return (long)*error;
-}
-
 __attribute__((section("lsm/generic_lsm_output"), used)) int
 generic_lsm_output(void *ctx)
 {
@@ -89,5 +76,5 @@ generic_lsm_output(void *ctx)
 #endif
 	if (e->lsm.post)
 		generic_output(ctx, (struct bpf_map_def *)&process_call_heap, MSG_OP_GENERIC_LSM);
-	return try_override(ctx);
+	return try_override(ctx, (struct bpf_map_def *)&override_tasks);
 }


### PR DESCRIPTION
There's recent kernel change forcing LSM bpf programs return value range [-4095, 0]. Making sure we follow that in generic lsm sensor.

[1] 5d99e198be27 bpf, lsm: Add check for BPF LSM return value