### PR TITLE
workflows: use GitHub arm64 runners instead of actuated

### DIFF
--- a/.github/workflows/bpf-unit-tests.yml
+++ b/.github/workflows/bpf-unit-tests.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'bpf/**'
+      - '.github/workflows/bpf-unit-tests.yml'
   push:
     branches:
       - main
@@ -14,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, actuated-arm64-4cpu-8gb ]
+        os: [ ubuntu-22.04, ubuntu-22.04-arm64 ]
     steps:
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, actuated-arm64-4cpu-8gb ]
+        os: [ ubuntu-20.04, ubuntu-22.04-arm64 ]
     steps:
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies ARM
       run: |
         sudo apt-get -y install gcc-arm-linux-gnueabihf
-      if: ${{ matrix.os == 'actuated-arm64-4cpu-8gb' }}
+      if: ${{ matrix.os == 'ubuntu-22.04-arm64' }}
 
     - name: Install bpftool
       uses: mtardy/setup-bpftool@adeab4f9332cc28db56064a93911860d0775665b # v1.0.3

--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -76,7 +76,7 @@ jobs:
             match_arch: x86-64
             cross_compile: no
             upload_path: upload/
-          - os: actuated-arm64-4cpu-8gb
+          - os: ubuntu-22.04-arm64
             arch: arm64
             match_arch: arm64
             cross_compile: yes

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -111,9 +111,10 @@ jobs:
           docker pull ${{ needs.prepare.outputs.operatorImage }}
 
     - name: Run e2e Tests
+      env:
+        GHA_OS: ${{matrix.os}}
       run: |
         cd go/src/github.com/cilium/tetragon
-
         make e2e-test E2E_TESTS=${{matrix.package.f}} E2E_BUILD_IMAGES=0 E2E_AGENT=${{ needs.prepare.outputs.agentImage }} E2E_OPERATOR=${{ needs.prepare.outputs.operatorImage }} EXTRA_TESTFLAGS="-cluster-name=${{ env.clusterName }} -args -v=4"
 
     - name: Upload Tetragon Logs

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, actuated-arm64-4cpu-16gb ]
+        os: [ ubuntu-22.04, ubuntu-22.04-arm64 ]
         package: ${{fromJson(needs.prepare.outputs.packages)}}
     steps:
     - name: Checkout Code

--- a/tests/e2e/tests/labels/labels_test.go
+++ b/tests/e2e/tests/labels/labels_test.go
@@ -7,6 +7,7 @@ package labels_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -95,6 +96,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestLabelsDemoApp(t *testing.T) {
+	if os.Getenv("GHA_OS") == "ubuntu-22.04-arm64" {
+		t.Skip("Skipping, see: ://github.com/cilium/tetragon/issues/3060")
+	}
+
 	// Must be called at the beginning of every test
 	runner.SetupExport(t)
 


### PR DESCRIPTION
CNCF stopped funding actuated arm64 runners but GitHub now proposes their own runners part of the GitHub offering.
