### PR TITLE
version: add version string to metrics

### DIFF
--- a/cmd/tetragon-metrics-docs/metricsmd/metricsmd.go
+++ b/cmd/tetragon-metrics-docs/metricsmd/metricsmd.go
@@ -45,6 +45,10 @@ func New(targets map[string]string, init initMetricsFunc) *cobra.Command {
 					Label:  "time",
 					Values: []string{"2022-05-13T15:54:45Z"},
 				},
+				{
+					Label:  "version",
+					Values: []string{"v1.2.0"},
+				},
 			},
 		},
 	}

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -28,6 +28,7 @@ Build information about tetragon
 | `go_version` | `go1.22.0` |
 | `modified` | `false` |
 | `time ` | `2022-05-13T15:54:45Z` |
+| `version` | `v1.2.0` |
 
 ### `tetragon_data_cache_capacity`
 

--- a/pkg/version/metrics.go
+++ b/pkg/version/metrics.go
@@ -40,6 +40,7 @@ func NewBuildInfoCollector() prometheus.Collector {
 				"Build information about tetragon",
 				nil,
 				prometheus.Labels{
+					"version":    Version,
 					"go_version": buildInfo.GoVersion,
 					"commit":     buildInfo.Commit,
 					"time":       buildInfo.Time,


### PR DESCRIPTION
Before this patch:
tetragon_build_info{commit="61b575c72b22aa8bb6d7ed8af2d3dbfee43f6307",go_version="go1.23.1",modified="true",time="2024-10-23T06:20:18Z"} 1

After:
tetragon_build_info{commit="61b575c72b22aa8bb6d7ed8af2d3dbfee43f6307",go_version="go1.23.1",modified="true",time="2024-10-23T06:20:18Z",version="v1.3.0-pre.0-216-g61b575c72"} 1

```release-note
metrics: add version to build information
```
