### PR TITLE
tetragon: fix the process exit signal when core dumped

### DIFF
--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -23,3 +23,4 @@ drop-privileges
 change-capabilities
 direct-write-tester
 user-stacktrace
+pause

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -24,7 +24,8 @@ PROGS = sigkill-tester \
 	getcpu \
 	direct-write-tester \
 	change-capabilities \
-	user-stacktrace
+	user-stacktrace \
+	pause
 
 
 all: $(PROGS)

--- a/contrib/tester-progs/pause.c
+++ b/contrib/tester-progs/pause.c
@@ -1,0 +1,7 @@
+#include <unistd.h>
+
+int main(int argc, char** argv)
+{
+	pause();
+	return 0;
+}

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -351,6 +351,11 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 	code := event.Info.Code >> 8
 	signal := readerexec.Signal(event.Info.Code & 0xFF)
 
+	if event.Info.Code&0x80 != 0 {
+		// Core dumped
+		signal = readerexec.Signal(event.Info.Code & 0x7F)
+	}
+
 	// Per thread tracking rules PID == TID.
 	//
 	// Exit events should have TID==PID at same time we want to correlate


### PR DESCRIPTION
### Description

The ProcessExit event returns a signal that the process received when it exited. However, core dumped signals (SIGSEGV, SIGILL, etc.) are not returned.

This patch fixes the issue by checking if the process exit code has the core dump bit set (7th bit, 0x80), and returns the correct signal. I used the kernel [code](https://elixir.bootlin.com/linux/v5.19/source/kernel/signal.c#L2076-L2078) as a reference to fix it.

### How to Verify

Launch the `tetra` CLI with the following command:

```bash
tetra getevents --process "run" --output compact
```

Then launch a random program and terminate it using different signals:

```bash
./run &
kill -9 $!
./run &
kill -11 $!
```

**Expected Behavior:**

Before: the signal for core dumped processes is not displayed correctly.

![before](https://github.com/user-attachments/assets/3d621a7a-10c1-4720-951d-02d7db7db706)

After: the correct signal for core dumped processes is displayed.
![after](https://github.com/user-attachments/assets/02b95099-205c-4d0a-889c-4d8c42f4dfee)
