### PR TITLE
tetragon: Add overhead metrics

### DIFF
--- a/cmd/tetra/debug/debug.go
+++ b/cmd/tetra/debug/debug.go
@@ -16,5 +16,6 @@ func New() *cobra.Command {
 	cmd.AddCommand(NewMapCmd())
 	cmd.AddCommand(NewDumpCommand())
 	cmd.AddCommand(NewProgsCmd())
+	cmd.AddCommand(NewEnableStatsCmd())
 	return &cmd
 }

--- a/cmd/tetra/debug/stats.go
+++ b/cmd/tetra/debug/stats.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package debug
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+)
+
+func NewEnableStatsCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "enable-stats",
+		Short: "Enable BPF stats",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			// We enable BPF stats system wide keep it enabled as long as
+			// the stats descriptor is open - app is running
+			_, err := ebpf.EnableStats(uint32(unix.BPF_STATS_RUN_TIME))
+			if err != nil {
+				return fmt.Errorf("failed to enable stats: %v", err)
+			}
+
+			// BPF stats are enabled..
+
+			for {
+				time.Sleep(time.Hour)
+			}
+		},
+	}
+
+	return &cmd
+}

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -256,6 +256,28 @@ Number of perf events Tetragon ring buffer events queue lost.
 
 Number of perf events Tetragon ring buffer events queue received.
 
+### `tetragon_overhead_program_runs_total`
+
+The total number of times BPF program was executed.
+
+| label | values |
+| ----- | ------ |
+| `attach` | `sys_open` |
+| `policy` | `enforce` |
+| `policy_namespace` | `   ns` |
+| `sensor` | `generic_kprobe` |
+
+### `tetragon_overhead_program_seconds_total`
+
+The total time of BPF program running.
+
+| label | values |
+| ----- | ------ |
+| `attach` | `sys_open` |
+| `policy` | `enforce` |
+| `policy_namespace` | `   ns` |
+| `sensor` | `generic_kprobe` |
+
 ### `tetragon_policyfilter_hook_container_name_missing_total`
 
 The total number of operations when the container name was missing in the OCI hook

--- a/pkg/metrics/labels.go
+++ b/pkg/metrics/labels.go
@@ -11,6 +11,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var (
+	LabelPolicyNamespace = UnconstrainedLabel{Name: "policy_namespace", ExampleValue: "ns"}
+	LabelPolicy          = UnconstrainedLabel{Name: "policy", ExampleValue: "enforce"}
+)
+
 // ConstrainedLabel represents a label with constrained cardinality.
 // Values is a list of all possible values of the label.
 type ConstrainedLabel struct {

--- a/pkg/metrics/overhead/collector.go
+++ b/pkg/metrics/overhead/collector.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package overhead
+
+import (
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func NewBPFCollector() prometheus.Collector {
+	return metrics.NewCustomCollector(
+		metrics.CustomMetrics{
+			time,
+			runs,
+		},
+		collect,
+		collectForDocs,
+	)
+}
+
+func collect(ch chan<- prometheus.Metric) {
+	sm := observer.GetSensorManager()
+	if sm == nil {
+		logger.GetLogger().Debug("failed retrieving the sensor manager: manager is nil")
+		return
+	}
+
+	overheads, err := sm.ListOverheads()
+	if err != nil {
+		logger.GetLogger().WithError(err).Warn("error listing overheads to collect overheads metrics")
+		return
+	}
+
+	for _, ovh := range overheads {
+		ch <- time.MustMetric(float64(ovh.RunTime), ovh.Namespace, ovh.Policy, ovh.Sensor, ovh.Attach)
+		ch <- runs.MustMetric(float64(ovh.RunCnt), ovh.Namespace, ovh.Policy, ovh.Sensor, ovh.Attach)
+	}
+}
+
+func collectForDocs(ch chan<- prometheus.Metric) {
+	ch <- time.MustMetric(0, "ns", "enforce", "generic_kprobe", "sys_open")
+	ch <- runs.MustMetric(0, "ns", "enforce", "generic_kprobe", "sys_open")
+}

--- a/pkg/metrics/overhead/overhead.go
+++ b/pkg/metrics/overhead/overhead.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package overhead
+
+import (
+	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+)
+
+var (
+	time = metrics.MustNewCustomCounter(metrics.NewOpts(
+		consts.MetricsNamespace, "", "overhead_program_seconds_total",
+		"The total time of BPF program running.",
+		nil, nil, []metrics.UnconstrainedLabel{
+			metrics.UnconstrainedLabel{Name: "policy_namespace", ExampleValue: "ns"},
+			metrics.UnconstrainedLabel{Name: "policy", ExampleValue: "enforce"},
+			metrics.UnconstrainedLabel{Name: "sensor", ExampleValue: "generic_kprobe"},
+			metrics.UnconstrainedLabel{Name: "attach", ExampleValue: "sys_open"},
+		},
+	))
+
+	runs = metrics.MustNewCustomCounter(metrics.NewOpts(
+		consts.MetricsNamespace, "", "overhead_program_runs_total",
+		"The total number of times BPF program was executed.",
+		nil, nil, []metrics.UnconstrainedLabel{
+			metrics.UnconstrainedLabel{Name: "policy_namespace", ExampleValue: "ns"},
+			metrics.UnconstrainedLabel{Name: "policy", ExampleValue: "enforce"},
+			metrics.UnconstrainedLabel{Name: "sensor", ExampleValue: "generic_kprobe"},
+			metrics.UnconstrainedLabel{Name: "attach", ExampleValue: "sys_open"},
+		},
+	))
+)

--- a/pkg/metrics/overhead/overhead.go
+++ b/pkg/metrics/overhead/overhead.go
@@ -13,8 +13,8 @@ var (
 		consts.MetricsNamespace, "", "overhead_program_seconds_total",
 		"The total time of BPF program running.",
 		nil, nil, []metrics.UnconstrainedLabel{
-			metrics.UnconstrainedLabel{Name: "policy_namespace", ExampleValue: "ns"},
-			metrics.UnconstrainedLabel{Name: "policy", ExampleValue: "enforce"},
+			metrics.LabelPolicyNamespace,
+			metrics.LabelPolicy,
 			metrics.UnconstrainedLabel{Name: "sensor", ExampleValue: "generic_kprobe"},
 			metrics.UnconstrainedLabel{Name: "attach", ExampleValue: "sys_open"},
 		},
@@ -24,8 +24,8 @@ var (
 		consts.MetricsNamespace, "", "overhead_program_runs_total",
 		"The total number of times BPF program was executed.",
 		nil, nil, []metrics.UnconstrainedLabel{
-			metrics.UnconstrainedLabel{Name: "policy_namespace", ExampleValue: "ns"},
-			metrics.UnconstrainedLabel{Name: "policy", ExampleValue: "enforce"},
+			metrics.LabelPolicyNamespace,
+			metrics.LabelPolicy,
 			metrics.UnconstrainedLabel{Name: "sensor", ExampleValue: "generic_kprobe"},
 			metrics.UnconstrainedLabel{Name: "attach", ExampleValue: "sys_open"},
 		},

--- a/pkg/metrics/policymetrics/policymetrics.go
+++ b/pkg/metrics/policymetrics/policymetrics.go
@@ -36,8 +36,8 @@ var policyKernelMemory = metrics.MustNewCustomGauge(metrics.NewOpts(
 	consts.MetricsNamespace, "", "tracingpolicy_kernel_memory_bytes",
 	"The amount of kernel memory in bytes used by policy's sensors non-shared BPF maps (memlock).",
 	nil, nil, []metrics.UnconstrainedLabel{
-		{Name: "policy"},
-		{Name: "policy_namespace"},
+		metrics.LabelPolicy,
+		metrics.LabelPolicyNamespace,
 	},
 ))
 

--- a/pkg/metricsconfig/healthmetrics.go
+++ b/pkg/metricsconfig/healthmetrics.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/metrics/kprobemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
+	"github.com/cilium/tetragon/pkg/metrics/overhead"
 	"github.com/cilium/tetragon/pkg/metrics/policyfiltermetrics"
 	"github.com/cilium/tetragon/pkg/metrics/policymetrics"
 	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
@@ -96,4 +97,6 @@ func registerHealthMetrics(group metrics.Group) {
 	group.MustRegister(kprobemetrics.NewBPFCollector())
 	// enforcer metrics
 	group.MustRegister(enforcermetrics.NewCollector())
+	// overhead metris
+	group.MustRegister(overhead.NewBPFCollector())
 }

--- a/pkg/sensors/collection.go
+++ b/pkg/sensors/collection.go
@@ -144,6 +144,29 @@ func (c *collection) destroy() {
 	}
 }
 
+func (cm *collectionMap) listOverheads() ([]ProgOverhead, error) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	overheads := []ProgOverhead{}
+
+	for ck, col := range cm.c {
+		for _, s := range col.sensors {
+			ret, ok := s.Overhead()
+			if !ok {
+				continue
+			}
+			for _, ovh := range ret {
+				ovh.Namespace = ck.namespace
+				ovh.Policy = ck.name
+				overheads = append(overheads, ovh)
+			}
+		}
+	}
+
+	return overheads, nil
+}
+
 func (cm *collectionMap) listPolicies() []*tetragon.TracingPolicyStatus {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()

--- a/pkg/sensors/delayed_sensor_test.go
+++ b/pkg/sensors/delayed_sensor_test.go
@@ -31,6 +31,10 @@ type TestDelayedSensor struct {
 	ch     chan struct{}
 }
 
+func (tds TestDelayedSensor) Overhead() ([]ProgOverhead, bool) {
+	return []ProgOverhead{}, false
+}
+
 func (tds TestDelayedSensor) TotalMemlock() int {
 	return 0
 }

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -267,6 +267,10 @@ func (h *Manager) ListTracingPolicies(_ context.Context) (*tetragon.ListTracingP
 	return ret, nil
 }
 
+func (h *Manager) ListOverheads() ([]ProgOverhead, error) {
+	return h.listOverheads()
+}
+
 func (h *Manager) RemoveSensor(ctx context.Context, sensorName string) error {
 	retc := make(chan error)
 	op := &sensorRemove{
@@ -335,6 +339,7 @@ func (h *Manager) LogSensorsAndProbes(ctx context.Context) {
 // policyLister allows read-only access to the collections map
 type policyLister interface {
 	listPolicies() []*tetragon.TracingPolicyStatus
+	listOverheads() ([]ProgOverhead, error)
 }
 
 // Manager handles dynamic sensor management, such as adding / removing sensors


### PR DESCRIPTION
adding overhead metrics for loaded policies

at the moment we don't display base sensor stats, because that needs some code factoring and will come later