### PR TITLE
Remove --expose-kernel-addresses and --pprof-addr flags

### DIFF
--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -123,9 +123,6 @@ options:
       default_value: "-1"
       usage: |
         Rate limit (per minute) for event export. Set to -1 to disable
-    - name: expose-kernel-addresses
-      default_value: "false"
-      usage: Expose real kernel addresses in events stack traces
     - name: expose-stack-addresses
       default_value: "false"
       usage: Expose real linear addresses in events stack traces
@@ -179,7 +176,6 @@ options:
     - name: netns-dir
       default_value: /var/run/docker/netns/
       usage: Network namespace dir
-    - name: pprof-addr
     - name: pprof-address
       usage: |
         Serves runtime profile data via HTTP (e.g. 'localhost:6060'). Disabled by default

--- a/examples/configuration/tetragon.yaml
+++ b/examples/configuration/tetragon.yaml
@@ -39,7 +39,7 @@ log-level: info
 metrics-server:
 metrics-label-filter:
 netns-dir: /var/run/docker/netns/
-pprof-addr:
+pprof-address:
 process-cache-size: 65536
 procfs: /proc/
 rb-size: 0

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -46,10 +46,9 @@ const (
 	KeyTracingPolicy      = "tracing-policy"
 	KeyTracingPolicyDir   = "tracing-policy-dir"
 
-	KeyCpuProfile          = "cpuprofile"
-	KeyMemProfile          = "memprofile"
-	KeyPprofAddr           = "pprof-address"
-	KeyDeprecatedPprofAddr = "pprof-addr"
+	KeyCpuProfile = "cpuprofile"
+	KeyMemProfile = "memprofile"
+	KeyPprofAddr  = "pprof-address"
 
 	KeyExportFilename             = "export-filename"
 	KeyExportFileMaxSizeMB        = "export-file-max-size-mb"
@@ -92,8 +91,7 @@ const (
 	KeyEnablePodInfo          = "enable-pod-info"
 	KeyEnableTracingPolicyCRD = "enable-tracing-policy-crd"
 
-	KeyExposeStackAddresses  = "expose-stack-addresses"
-	KeyExposeKernelAddresses = "expose-kernel-addresses"
+	KeyExposeStackAddresses = "expose-stack-addresses"
 
 	KeyGenerateDocs = "generate-docs"
 
@@ -192,10 +190,7 @@ func ReadAndSetFlags() error {
 
 	Config.CpuProfile = viper.GetString(KeyCpuProfile)
 	Config.MemProfile = viper.GetString(KeyMemProfile)
-	Config.PprofAddr = viper.GetString(KeyDeprecatedPprofAddr)
-	if viper.IsSet(KeyPprofAddr) {
-		Config.PprofAddr = viper.GetString(KeyPprofAddr)
-	}
+	Config.PprofAddr = viper.GetString(KeyPprofAddr)
 
 	Config.EventQueueSize = viper.GetUint(KeyEventQueueSize)
 
@@ -222,15 +217,7 @@ func ReadAndSetFlags() error {
 		return fmt.Errorf("unknown option for %s: %q", KeyUsernameMetadata, o)
 	}
 
-	// manually handle the deprecation of --expose-kernel-addresses
-	if viper.IsSet(KeyExposeKernelAddresses) {
-		log.Warnf("Flag --%s has been deprecated, please use --%s instead", KeyExposeKernelAddresses, KeyExposeStackAddresses)
-		Config.ExposeStackAddresses = viper.GetBool(KeyExposeKernelAddresses)
-	}
-	// if both --expose-kernel-addresses and --expose-stack-addresses are set, the latter takes priority
-	if viper.IsSet(KeyExposeStackAddresses) {
-		Config.ExposeStackAddresses = viper.GetBool(KeyExposeStackAddresses)
-	}
+	Config.ExposeStackAddresses = viper.GetBool(KeyExposeStackAddresses)
 
 	Config.CgroupRate = ParseCgroupRate(viper.GetString(KeyCgroupRate))
 	Config.HealthServerAddress = viper.GetString(KeyHealthServerAddress)
@@ -345,8 +332,6 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.MarkHidden(KeyMemProfile)
 
 	flags.String(KeyPprofAddr, "", "Serves runtime profile data via HTTP (e.g. 'localhost:6060'). Disabled by default")
-	flags.String(KeyDeprecatedPprofAddr, "", "")
-	flags.MarkDeprecated(KeyDeprecatedPprofAddr, "please use --pprof-address")
 
 	// JSON export aggregation options.
 	flags.Bool(KeyEnableExportAggregation, false, "Enable JSON export aggregation")
@@ -393,9 +378,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Bool(KeyEnablePodInfo, false, "Enable PodInfo custom resource")
 	flags.Bool(KeyEnableTracingPolicyCRD, true, "Enable TracingPolicy and TracingPolicyNamespaced custom resources")
 
-	flags.Bool(KeyExposeKernelAddresses, false, "Expose real kernel addresses in events stack traces")
 	flags.Bool(KeyExposeStackAddresses, false, "Expose real linear addresses in events stack traces")
-	flags.MarkHidden(KeyExposeKernelAddresses)
 
 	flags.Bool(KeyGenerateDocs, false, "Generate documentation in YAML format to stdout")
 


### PR DESCRIPTION
- The --expose-kernel-addresses flag got deprecated in v1.1 [^1].
- The --pprof-addr flag got deprecated in v1.2 [^2].

[^1]: https://github.com/cilium/tetragon/commit/0d53eccaacf332a444c5073e88a58b8e77176fe9
[^2]: https://github.com/cilium/tetragon/commit/fe78328cf7a8c436a0335e734e609eb1d230750e