### PR TITLE
Remove --enable-process-ancestors flag

### DIFF
--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -68,9 +68,6 @@ options:
     - name: enable-policy-filter-debug
       default_value: "false"
       usage: Enable policy filter debug messages
-    - name: enable-process-ancestors
-      default_value: "true"
-      usage: Include ancestors in process exec events
     - name: enable-process-cred
       default_value: "false"
       usage: Enable process_cred events

--- a/examples/configuration/tetragon.yaml
+++ b/examples/configuration/tetragon.yaml
@@ -16,7 +16,6 @@ debug: false
 disable-kprobe-multi: false
 enable-export-aggregation: false
 enable-k8s-api: false
-enable-process-ancestors: true
 enable-process-cred: false
 enable-process-ns: false
 event-queue-size: 10000

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -33,9 +33,8 @@ const (
 	KeyLogLevel  = "log-level"
 	KeyLogFormat = "log-format"
 
-	KeyEnableK8sAPI           = "enable-k8s-api"
-	KeyK8sKubeConfigPath      = "k8s-kubeconfig-path"
-	KeyEnableProcessAncestors = "enable-process-ancestors"
+	KeyEnableK8sAPI      = "enable-k8s-api"
+	KeyK8sKubeConfigPath = "k8s-kubeconfig-path"
 
 	KeyMetricsServer      = "metrics-server"
 	KeyMetricsLabelFilter = "metrics-label-filter"
@@ -310,7 +309,6 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.String(KeyLogFormat, "text", "Set log format")
 	flags.Bool(KeyEnableK8sAPI, false, "Access Kubernetes API to associate Tetragon events with Kubernetes pods")
 	flags.String(KeyK8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
-	flags.Bool(KeyEnableProcessAncestors, true, "Include ancestors in process exec events")
 	flags.String(KeyMetricsServer, "", "Metrics server address (e.g. ':2112'). Disabled by default")
 	flags.String(KeyMetricsLabelFilter, "namespace,workload,pod,binary", "Comma-separated list of enabled metrics labels. Unknown labels will be ignored.")
 	flags.String(KeyServerAddress, "localhost:54321", "gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock'). An empty address disables the gRPC server")


### PR DESCRIPTION
Tetragon does not use this flag, so let's just remove it instead of deprecating it first.