### PR TITLE
tetra: fix `--policy-names` to apply all event types

### DIFF
--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -127,5 +127,17 @@ func GetPolicyName(event *v1.Event) string {
 	if !ok {
 		return ""
 	}
-	return helpers.ResponseGetProcessKprobe(response).GetPolicyName()
+
+	switch ev := (response.Event).(type) {
+	case *tetragon.GetEventsResponse_ProcessKprobe:
+		return ev.ProcessKprobe.GetPolicyName()
+	case *tetragon.GetEventsResponse_ProcessTracepoint:
+		return ev.ProcessTracepoint.GetPolicyName()
+	case *tetragon.GetEventsResponse_ProcessUprobe:
+		return ev.ProcessUprobe.GetPolicyName()
+	case *tetragon.GetEventsResponse_ProcessLsm:
+		return ev.ProcessLsm.GetPolicyName()
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
### Description

In #1867, the `--policy-names` flag was added to filter events based on the tracing policy. However, the filter was only appled to `kprobe` events.

This patch extends the filter to support all events types: `kprobe`, `tracepoint`, `uprobe` and `lsm`.
