### PR TITLE
tetragon: improve how we handle cgroupv1 and cgroupv2

### DIFF
--- a/bpf/lib/bpf_cgroup.h
+++ b/bpf/lib/bpf_cgroup.h
@@ -361,7 +361,7 @@ FUNC_INLINE __u64 tg_get_current_cgroup_id(void)
 	if (conf) {
 		/* Select which cgroup version */
 		cgrpfs_magic = conf->cgrp_fs_magic;
-		subsys_idx = conf->tg_cgrp_subsys_idx;
+		subsys_idx = conf->tg_cgrpv1_subsys_idx;
 	}
 
 	/*

--- a/bpf/lib/environ_conf.h
+++ b/bpf/lib/environ_conf.h
@@ -21,7 +21,7 @@ struct tetragon_conf {
 	__u32 pid; /* Tetragon pid for debugging purpose */
 	__u32 nspid; /* Tetragon pid in namespace for debugging purpose */
 	__u32 tg_cgrp_hierarchy; /* Tetragon tracked hierarchy ID */
-	__u32 tg_cgrp_subsys_idx; /* Tetragon tracked cgroup subsystem state index at compile time */
+	__u32 tg_cgrpv1_subsys_idx; /* Tetragon tracked cgroupv1 subsystem state index at compile time */
 	__u32 tg_cgrp_level; /* Tetragon cgroup level */
 	__u64 tg_cgrpid; /* Tetragon current cgroup ID to avoid filtering blocking itself */
 	__u64 cgrp_fs_magic; /* Cgroupv1 or Cgroupv2 */

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -578,7 +578,7 @@ __event_get_cgroup_info(struct task_struct *task, struct msg_k8s *kube)
 	if (conf) {
 		/* Select which cgroup version */
 		cgrpfs_magic = conf->cgrp_fs_magic;
-		subsys_idx = conf->tg_cgrp_subsys_idx;
+		subsys_idx = conf->tg_cgrpv1_subsys_idx;
 	}
 
 	cgrp = get_task_cgroup(task, cgrpfs_magic, subsys_idx, &flags);

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -581,7 +581,7 @@ __event_get_cgroup_info(struct task_struct *task, struct msg_k8s *kube)
 		subsys_idx = conf->tg_cgrp_subsys_idx;
 	}
 
-	cgrp = get_task_cgroup(task, subsys_idx, &flags);
+	cgrp = get_task_cgroup(task, cgrpfs_magic, subsys_idx, &flags);
 	if (!cgrp)
 		return 0;
 

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -215,7 +215,7 @@ func parseCgroupv1SubSysIds(filePath string) error {
 				/* We care only for the controllers that we want */
 				if idx >= CGROUP_SUBSYS_COUNT {
 					/* Maybe some cgroups are not upstream? */
-					return fmt.Errorf("Cgroup default subsystem '%s' is indexed at idx=%d higher than CGROUP_SUBSYS_COUNT=%d",
+					return fmt.Errorf("Cgroupv1 default subsystem '%s' is indexed at idx=%d higher than CGROUP_SUBSYS_COUNT=%d",
 						fields[0], idx, CGROUP_SUBSYS_COUNT)
 				}
 
@@ -229,7 +229,7 @@ func parseCgroupv1SubSysIds(filePath string) error {
 					logger.GetLogger().WithFields(logrus.Fields{
 						"cgroup.fs":              cgroupFSPath,
 						"cgroup.controller.name": controller.Name,
-					}).WithError(err).Warnf("parsing controller line from '%s' failed", filePath)
+					}).WithError(err).Warnf("Cgroupv1 parsing controller line from '%s' failed", filePath)
 				}
 			}
 		}
@@ -239,14 +239,14 @@ func parseCgroupv1SubSysIds(filePath string) error {
 	logger.GetLogger().WithFields(logrus.Fields{
 		"cgroup.fs":          cgroupFSPath,
 		"cgroup.controllers": fmt.Sprintf("[%s]", strings.Join(allcontrollers, " ")),
-	}).Debugf("Cgroup available controllers")
+	}).Debugf("Cgroupv1 available controllers")
 
 	// Could not find 'memory', 'pids' nor 'cpuset' controllers, are they compiled in?
 	if !fixed {
-		err = fmt.Errorf("detect cgroup controllers IDs from '%s' failed", filePath)
+		err = fmt.Errorf("detect cgroupv1 controllers IDs from '%s' failed", filePath)
 		logger.GetLogger().WithFields(logrus.Fields{
 			"cgroup.fs": cgroupFSPath,
-		}).WithError(err).Warnf("Cgroup controllers 'memory', 'pids' and 'cpuset' are missing")
+		}).WithError(err).Warnf("Cgroupv1 controllers 'memory', 'pids' and 'cpuset' are missing")
 		return err
 	}
 
@@ -258,11 +258,11 @@ func parseCgroupv1SubSysIds(filePath string) error {
 				"cgroup.controller.name":        controller.Name,
 				"cgroup.controller.hierarchyID": controller.Id,
 				"cgroup.controller.index":       controller.Idx,
-			}).Infof("Supported cgroup controller '%s' is active on the system", controller.Name)
+			}).Infof("Cgroupv1 supported controller '%s' is active on the system", controller.Name)
 		} else {
 			// Warn with error
 			err = fmt.Errorf("controller '%s' is not active", controller.Name)
-			logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warnf("Supported cgroup controller '%s' is not active", controller.Name)
+			logger.GetLogger().WithField("cgroup.fs", cgroupFSPath).WithError(err).Warnf("Cgroupv1 supported controller is missing")
 		}
 	}
 

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -351,8 +351,8 @@ func setCgrpv1SubsystemIdx(controller *CgroupController) {
 }
 
 // GetCgrpHierarchyID() returns the ID of the Cgroup hierarchy
-// that is used to track processes. This is used for Cgroupv1 as for
-// Cgroupv2 we run in the default hierarchy.
+// that is used to track processes. This is used mostly for
+// Cgroupv1 as for Cgroupv2 we run in the default hierarchy.
 func GetCgrpHierarchyID() uint32 {
 	return cgrpHierarchy
 }
@@ -807,7 +807,7 @@ func CgroupIDFromPID(pid uint32) (uint64, error) {
 	case CGROUP_LEGACY, CGROUP_HYBRID:
 		pathFunc = func(line string) (bool, string) {
 			// TODO: test the cgroup v1 implementation
-			v1Prefix := fmt.Sprintf("%d:%s:", GetCgrpv1SubsystemIdx(), GetCgrpControllerName())
+			v1Prefix := fmt.Sprintf("%d:%s:", GetCgrpHierarchyID(), GetCgrpControllerName())
 			if !strings.HasPrefix(line, v1Prefix) {
 				return false, ""
 			}

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -131,7 +131,7 @@ misc	10	1	1
 	err := os.WriteFile(file, []byte(d.data), 0644)
 	require.NoError(t, err)
 
-	err = parseCgroupSubSysIds(file)
+	err = parseCgroupv1SubSysIds(file)
 	require.NoError(t, err)
 	for _, c := range CgroupControllers {
 		if strings.Contains(d.used, c.Name) {
@@ -142,6 +142,25 @@ misc	10	1	1
 			require.Zero(t, c.Id)
 		}
 	}
+}
+
+func TestCheckCgroupv2Controllers(t *testing.T) {
+	testDir := t.TempDir()
+	empty_controllers := ""
+
+	file := filepath.Join(testDir, "cgroup.controllers")
+	err := os.WriteFile(file, []byte(empty_controllers), 0644)
+	require.NoError(t, err)
+
+	err = checkCgroupv2Controllers(testDir)
+	require.Error(t, err)
+
+	controllers := "cpuset cpu io memory hugetlb pids rdma misc"
+	err = os.WriteFile(file, []byte(controllers), 0644)
+	require.NoError(t, err)
+
+	err = checkCgroupv2Controllers(testDir)
+	require.NoError(t, err)
 }
 
 // Test cgroup mode detection on an invalid directory
@@ -248,7 +267,7 @@ func TestDetectCgroupFSMagic(t *testing.T) {
 // - We properly discover compiled-in cgroup controllers
 // - Their hierarchy IDs
 // - Their css index
-func TestDiscoverSubSysIdsDefault(t *testing.T) {
+func TestDiscoverCgroupv1SubSysIdsDefault(t *testing.T) {
 	fs, err := DetectCgroupFSMagic()
 	assert.NoError(t, err)
 	assert.NotEqual(t, CGROUP_UNDEF, fs)
@@ -263,26 +282,28 @@ func TestDiscoverSubSysIdsDefault(t *testing.T) {
 	if err == nil {
 		accessFs = true
 	}
+
+	/* Let's skip now as we are interested only in Cgroupv1 for asserting controllers index */
+	if cgroupMode == CGROUP_UNIFIED {
+		return
+	}
+
 	for _, controller := range CgroupControllers {
 		if accessFs {
-			if cgroupMode == CGROUP_UNIFIED {
-				assert.EqualValues(t, 0, controller.Id, "Cgroupv2 Controller '%s' hierarchy ID should be O as it is Unified Cgroup", controller.Name)
-			} else {
-				assert.NotEqualValues(t, 0, controller.Id, "Cgroupv1 Controller '%s' hierarchy ID should not be zero", controller.Name)
-			}
+			assert.NotEqualValues(t, 0, controller.Id, "Cgroupv1 Controller '%s' hierarchy ID should not be zero", controller.Name)
 		}
 
 		if controller.Active {
 			fixed = true
 
-			// If those controllers are active let's check their css index
+			// If those controllers are active and we are in cgroupv1 let's check their css index
 			if controller.Name == "memory" || controller.Name == "pids" {
 				assert.NotEqualValues(t, 0, controller.Idx, "Cgroup Controller '%s' css index should not be zero", controller.Name)
 			}
 		}
 	}
 
-	assert.Equalf(t, true, fixed, "TestDiscoverSubSysIdsDefault() could not detect and fix compiled Cgroup controllers")
+	assert.Equalf(t, true, fixed, "TestDiscoverSubSysIdsDefault() could not detect active cgroup controllers")
 }
 
 func TestGetCgroupIdFromPath(t *testing.T) {

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -102,6 +102,26 @@ func TestCgroupNameFromCStr(t *testing.T) {
 	}
 }
 
+// Ensure that Cgroupv1 controllers discovery fails if no 'cpuset' and no 'memory'
+func TestParseCgroupSubSysIdsWithoutMemoryCpuset(t *testing.T) {
+	testDir := t.TempDir()
+	invalid_cgroupv1_controllers :=
+		`
+#subsys_name	hierarchy	num_cgroups	enabled
+cpu	6	78	1
+cpuacct	6	78	1
+blkio	4	78	1
+perf_event	8	2	1
+`
+
+	file := filepath.Join(testDir, "testfile")
+	err := os.WriteFile(file, []byte(invalid_cgroupv1_controllers), 0644)
+	require.NoError(t, err)
+
+	err = parseCgroupv1SubSysIds(file)
+	require.Error(t, err)
+}
+
 func TestParseCgroupSubSysIds(t *testing.T) {
 
 	testDir := t.TempDir()

--- a/pkg/sensors/config/confmap/confmap.go
+++ b/pkg/sensors/config/confmap/confmap.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/tetragon/pkg/sensors/exec/config"
 	"github.com/cilium/tetragon/pkg/sensors/program"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -27,14 +28,14 @@ type TetragonConfKey struct {
 }
 
 type TetragonConfValue struct {
-	LogLevel        uint32 `align:"loglevel"`           // Tetragon log level
-	PID             uint32 `align:"pid"`                // Tetragon PID for debugging purpose
-	NSPID           uint32 `align:"nspid"`              // Tetragon PID in namespace for debugging purpose
-	TgCgrpHierarchy uint32 `align:"tg_cgrp_hierarchy"`  // Tetragon Cgroup tracking hierarchy ID
-	TgCgrpSubsysIdx uint32 `align:"tg_cgrp_subsys_idx"` // Tracking Cgroup css idx at compile time
-	TgCgrpLevel     uint32 `align:"tg_cgrp_level"`      // Tetragon cgroup level
-	TgCgrpId        uint64 `align:"tg_cgrpid"`          // Tetragon cgroup ID
-	CgrpFsMagic     uint64 `align:"cgrp_fs_magic"`      // Cgroupv1 or cgroupv2
+	LogLevel          uint32 `align:"loglevel"`             // Tetragon log level
+	PID               uint32 `align:"pid"`                  // Tetragon PID for debugging purpose
+	NSPID             uint32 `align:"nspid"`                // Tetragon PID in namespace for debugging purpose
+	TgCgrpHierarchy   uint32 `align:"tg_cgrp_hierarchy"`    // Tetragon Cgroup tracking hierarchy ID
+	TgCgrpv1SubsysIdx uint32 `align:"tg_cgrpv1_subsys_idx"` // Tracking Cgroupv1 css idx at compile time
+	TgCgrpLevel       uint32 `align:"tg_cgrp_level"`        // Tetragon cgroup level
+	TgCgrpId          uint64 `align:"tg_cgrpid"`            // Tetragon cgroup ID
+	CgrpFsMagic       uint64 `align:"cgrp_fs_magic"`        // Cgroupv1 or cgroupv2
 }
 
 var (
@@ -108,11 +109,11 @@ func UpdateTgRuntimeConf(mapDir string, nspid int) error {
 	}
 
 	v := &TetragonConfValue{
-		LogLevel:        uint32(logger.GetLogLevel()),
-		TgCgrpHierarchy: cgroups.GetCgrpHierarchyID(),
-		TgCgrpSubsysIdx: cgroups.GetCgrpSubsystemIdx(),
-		NSPID:           uint32(nspid),
-		CgrpFsMagic:     cgroupFsMagic,
+		LogLevel:          uint32(logger.GetLogLevel()),
+		TgCgrpHierarchy:   cgroups.GetCgrpHierarchyID(),
+		TgCgrpv1SubsysIdx: cgroups.GetCgrpv1SubsystemIdx(),
+		NSPID:             uint32(nspid),
+		CgrpFsMagic:       cgroupFsMagic,
 	}
 
 	if err := UpdateConfMap(mapDir, v); err != nil {
@@ -120,16 +121,27 @@ func UpdateTgRuntimeConf(mapDir string, nspid int) error {
 		return err
 	}
 
-	log.WithFields(logrus.Fields{
-		"confmap-update":                configMapName,
-		"deployment.mode":               mode.String(),
-		"log.level":                     logrus.Level(v.LogLevel).String(),
-		"cgroup.fs.magic":               cgroups.CgroupFsMagicStr(v.CgrpFsMagic),
-		"cgroup.controller.name":        cgroups.GetCgrpControllerName(),
-		"cgroup.controller.hierarchyID": v.TgCgrpHierarchy,
-		"cgroup.controller.index":       v.TgCgrpSubsysIdx,
-		"NSPID":                         nspid,
-	}).Info("Updated TetragonConf map successfully")
+	if v.CgrpFsMagic == unix.CGROUP2_SUPER_MAGIC {
+		log.WithFields(logrus.Fields{
+			"confmap-update":     configMapName,
+			"deployment.mode":    mode.String(),
+			"log.level":          logrus.Level(v.LogLevel).String(),
+			"cgroup.fs.magic":    cgroups.CgroupFsMagicStr(v.CgrpFsMagic),
+			"cgroup.hierarchyID": v.TgCgrpHierarchy,
+			"NSPID":              nspid,
+		}).Info("Updated TetragonConf map successfully")
+	} else {
+		log.WithFields(logrus.Fields{
+			"confmap-update":                configMapName,
+			"deployment.mode":               mode.String(),
+			"log.level":                     logrus.Level(v.LogLevel).String(),
+			"cgroup.fs.magic":               cgroups.CgroupFsMagicStr(v.CgrpFsMagic),
+			"cgroup.controller.name":        cgroups.GetCgrpControllerName(),
+			"cgroup.controller.hierarchyID": v.TgCgrpHierarchy,
+			"cgroup.controller.index":       v.TgCgrpv1SubsysIdx,
+			"NSPID":                         nspid,
+		}).Info("Updated TetragonConf map successfully")
+	}
 
 	return nil
 }

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -129,7 +129,7 @@ func logTetragonConfig(t *testing.T, mapDir string) error {
 	}
 
 	t.Logf("Test %s tetragon configuration: cgroup.magic=%s  logLevel=%d  cgroup.hierarchyID=%d  cgroup.subsysIdx=%d  cgroup.trackinglevel=%d  cgroup.ID=%d",
-		t.Name(), cgroups.CgroupFsMagicStr(conf.CgrpFsMagic), conf.LogLevel, conf.TgCgrpHierarchy, conf.TgCgrpSubsysIdx, conf.TgCgrpLevel, conf.TgCgrpId)
+		t.Name(), cgroups.CgroupFsMagicStr(conf.CgrpFsMagic), conf.LogLevel, conf.TgCgrpHierarchy, conf.TgCgrpv1SubsysIdx, conf.TgCgrpLevel, conf.TgCgrpId)
 
 	return nil
 }
@@ -581,7 +581,7 @@ func setupTgRuntimeConf(t *testing.T, trackingCgrpLevel, logLevel, hierarchyId, 
 	}
 
 	if subSysIdx != invalidValue {
-		val.TgCgrpSubsysIdx = subSysIdx
+		val.TgCgrpv1SubsysIdx = subSysIdx
 	}
 
 	mapDir := bpf.MapPrefixPath()
@@ -635,7 +635,7 @@ func TestTgRuntimeConf(t *testing.T) {
 	assert.EqualValues(t, ret, val)
 
 	assert.Equal(t, ret.TgCgrpHierarchy, cgroups.GetCgrpHierarchyID())
-	assert.Equal(t, ret.TgCgrpSubsysIdx, cgroups.GetCgrpSubsystemIdx())
+	assert.Equal(t, ret.TgCgrpv1SubsysIdx, cgroups.GetCgrpv1SubsystemIdx())
 	assert.Equal(t, ret.LogLevel, uint32(logger.GetLogLevel()))
 }
 
@@ -1323,7 +1323,7 @@ func TestCgroupv1ExecK8sHierarchyInHybridMemory(t *testing.T) {
 	testCgroupv1K8sHierarchyInHybrid(t, true, "memory")
 }
 
-// This test will use the piDisableSensorsds cgroup controller if available
+// This test will use the pids cgroup controller if available
 func TestCgroupv1ExecK8sHierarchyInHybridPids(t *testing.T) {
 	testCgroupv1K8sHierarchyInHybrid(t, true, "pids")
 }

--- a/pkg/testutils/confmap.go
+++ b/pkg/testutils/confmap.go
@@ -33,11 +33,11 @@ func GetTgRuntimeConf() (*confmap.TetragonConfValue, error) {
 	}
 
 	return &confmap.TetragonConfValue{
-		LogLevel:        uint32(logger.GetLogLevel()),
-		TgCgrpHierarchy: cgroups.GetCgrpHierarchyID(),
-		TgCgrpSubsysIdx: cgroups.GetCgrpSubsystemIdx(),
-		NSPID:           uint32(nspid),
-		CgrpFsMagic:     cgroupFsMagic,
+		LogLevel:          uint32(logger.GetLogLevel()),
+		TgCgrpHierarchy:   cgroups.GetCgrpHierarchyID(),
+		TgCgrpv1SubsysIdx: cgroups.GetCgrpv1SubsystemIdx(),
+		NSPID:             uint32(nspid),
+		CgrpFsMagic:       cgroupFsMagic,
 	}, nil
 }
 


### PR DESCRIPTION
kernel v6.11 introduced new CONFIG_MEMCG_V1 and CONFIG_CPUSETS_V1 [1]
that changed how userspace detects the compiled cgroup controllers,
if the new CONFIG_MEMCG_V1=n then memory and same for cpuset controller
will not be exported in /proc/cgroups.

In Cgroupv2 we automatically handle this with these changes. If your distribution
runs in Cgroupv1 then these changes also handle it assuming you have
both CONFIG_MEMCG=y and CONFIG_MEMCG_V1=y are set.  

[1] "af000ce85293b8e60" "cgroup: Do not report unavailable v1 controllers in /proc/cgroups"

Kernel v6.11 introduced a new CONFIG_MEMCG_V1 for legacy cgroup v1 memory controller which may affect Tetragon cgroup environment detection, process and container/pod association. Improve Tetragon so we handle the new configuration and allow process container association to properly work if the distribution boots in default unified hierarchy Cgroupv2.
If the distribution boots in Hybrid Cgroupv1 mode then ensure the appropriate controllers are exported otherwise report an error and print the kernel config that are needed, probably: CONFIG_MEMCG=y, CONFIG_MEMCG_V1=y, CONFIG_CPUSETS=y and CONFIG_CPUSETS_V1=y all must be set to have proper process and container/pod association. 


```release-note:
cgroups: fix kernel  config issue introduced in 6.11. For cgroup v1, setting CONFIG_MEMCG=y, CONFIG_MEMCG_V1=y, CONFIG_CPUSETS=y and CONFIG_CPUSETS_V1=y is required for Tetragon to work.
```
