### PR TITLE
policyfilter: do not mark as beta anymore

### DIFF
--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -64,7 +64,7 @@ options:
       usage: Enable PodInfo custom resource
     - name: enable-policy-filter
       default_value: "false"
-      usage: Enable policy filter code (beta)
+      usage: Enable policy filter code
     - name: enable-policy-filter-debug
       default_value: "false"
       usage: Enable policy filter debug messages

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -363,7 +363,7 @@ func AddFlags(flags *pflag.FlagSet) {
 
 	// Provide option to enable policy filtering. Because the code is new,
 	// this is set to false by default.
-	flags.Bool(KeyEnablePolicyFilter, false, "Enable policy filter code (beta)")
+	flags.Bool(KeyEnablePolicyFilter, false, "Enable policy filter code")
 	flags.Bool(KeyEnablePolicyFilterDebug, false, "Enable policy filter debug messages")
 
 	// Provide option to enable the pidSet export filters.


### PR DESCRIPTION
policyfilter is no longer beta, so remove comment from command line help. Note that policyfilter is mostly useful for k8s environments, where it is enabled by default via the corresponding helm option and we keep the default value as false in the agent for non-k8s installations.