### PR TITLE
rthooks: Fix rootDir in createRuntime hook

### DIFF
--- a/contrib/tetragon-rthooks/cmd/oci-hook/main.go
+++ b/contrib/tetragon-rthooks/cmd/oci-hook/main.go
@@ -259,6 +259,14 @@ func createContainerHook(log *slog.Logger) (error, map[string]string) {
 		return errors.New("unable to determine either RootDir or cgroupPath, bailing out"), nil
 	}
 
+	// We expect the rootDir to be the root directory of the container.
+	// In "containerd (createContainer)" and "cri-o" we are already in the
+	// container root directory. In "containerd (createRuntime)" we need to
+	// append the rootDir the root path from the spec.
+	if configName == "config.json" {
+		rootDir = path.Join(rootDir, spec.Root.Path)
+	}
+
 	createContainer := &tetragon.CreateContainer{
 		CgroupsPath:   cgroupPath,
 		RootDir:       rootDir,


### PR DESCRIPTION
When using the createContainer hook in containerd or cri-o the rootDir points to the root directory of the container that is created.

In the case where we use the createRuntime hook in containerd the roodDir points to the location of the config.json file which is not the same as the container root directory. In order to fix that, we need to append the Root.Path from the spec.