### PR TITLE
bpf: remove unused const PossibleCPUSysfsPath

### DIFF
--- a/pkg/bpf/perf_linux.go
+++ b/pkg/bpf/perf_linux.go
@@ -12,10 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	PossibleCPUSysfsPath = "/sys/devices/system/cpu/possible"
-)
-
 type PerfEventConfig struct {
 	NumCpus      int
 	NumPages     int


### PR DESCRIPTION
It's unused since switching to use cilium/ebpf functionality to get the number of possible CPUs in commit 582da32e11bd ("tetragon: Implement bpf.GetNumPossibleCPUs through cilium/ebpf library").