### PR TITLE
doc: Removed old matchBinaries limitation

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -168,7 +168,6 @@ The available operators for `matchBinaries` are:
 
 The `values` field has to be a map of `strings`. The default behaviour
 is `followForks: true`, so all the child processes are followed.
-The current limitation is 4 values.
 
 ### Follow children
 


### PR DESCRIPTION
The limitation of only having 4 values for `matchBinaries` doesn't apply anymore.

```release-note
doc: Removed old matchBinaries limitation
```
