### PR TITLE
crd: Added shortnames and catagory for Tetragon CRDs

### DIFF
--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_podinfo.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_podinfo.yaml
@@ -11,6 +11,8 @@ spec:
     kind: PodInfo
     listKind: PodInfoList
     plural: podinfo
+    shortNames:
+    - tgpi
     singular: podinfo
   scope: Namespaced
   versions:

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -11,6 +11,8 @@ spec:
     kind: TracingPolicy
     listKind: TracingPolicyList
     plural: tracingpolicies
+    shortNames:
+    - tgtp
     singular: tracingpolicy
   scope: Cluster
   versions:

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - tetragon
     kind: TracingPolicy
     listKind: TracingPolicyList
     plural: tracingpolicies

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - tetragon
     kind: TracingPolicyNamespaced
     listKind: TracingPolicyNamespacedList
     plural: tracingpoliciesnamespaced

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -11,6 +11,8 @@ spec:
     kind: TracingPolicyNamespaced
     listKind: TracingPolicyNamespacedList
     plural: tracingpoliciesnamespaced
+    shortNames:
+    - tgtpn
     singular: tracingpolicynamespaced
   scope: Namespaced
   versions:

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_podinfo.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_podinfo.yaml
@@ -11,6 +11,8 @@ spec:
     kind: PodInfo
     listKind: PodInfoList
     plural: podinfo
+    shortNames:
+    - tgpi
     singular: podinfo
   scope: Namespaced
   versions:

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -11,6 +11,8 @@ spec:
     kind: TracingPolicy
     listKind: TracingPolicyList
     plural: tracingpolicies
+    shortNames:
+    - tgtp
     singular: tracingpolicy
   scope: Cluster
   versions:

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - tetragon
     kind: TracingPolicy
     listKind: TracingPolicyList
     plural: tracingpolicies

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - tetragon
     kind: TracingPolicyNamespaced
     listKind: TracingPolicyNamespacedList
     plural: tracingpoliciesnamespaced

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -11,6 +11,8 @@ spec:
     kind: TracingPolicyNamespaced
     listKind: TracingPolicyNamespacedList
     plural: tracingpoliciesnamespaced
+    shortNames:
+    - tgtpn
     singular: tracingpolicynamespaced
   scope: Namespaced
   versions:

--- a/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -37,7 +37,7 @@ const (
 // +genclient:noStatus
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="tracingpolicy",path="tracingpolicies",scope="Cluster",shortName={tgtp}
+// +kubebuilder:resource:categories={tetragon},singular="tracingpolicy",path="tracingpolicies",scope="Cluster",shortName={tgtp}
 type TracingPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -48,7 +48,7 @@ type TracingPolicy struct {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="tracingpolicynamespaced",path="tracingpoliciesnamespaced",scope="Namespaced",shortName={tgtpn}
+// +kubebuilder:resource:categories={tetragon},singular="tracingpolicynamespaced",path="tracingpoliciesnamespaced",scope="Namespaced",shortName={tgtpn}
 type TracingPolicyNamespaced struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -37,7 +37,7 @@ const (
 // +genclient:noStatus
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="tracingpolicy",path="tracingpolicies",scope="Cluster",shortName={}
+// +kubebuilder:resource:singular="tracingpolicy",path="tracingpolicies",scope="Cluster",shortName={tgtp}
 type TracingPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -48,7 +48,7 @@ type TracingPolicy struct {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="tracingpolicynamespaced",path="tracingpoliciesnamespaced",scope="Namespaced",shortName={}
+// +kubebuilder:resource:singular="tracingpolicynamespaced",path="tracingpoliciesnamespaced",scope="Namespaced",shortName={tgtpn}
 type TracingPolicyNamespaced struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -384,7 +384,7 @@ type WorkloadObjectMeta struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="podinfo",path="podinfo",scope="Namespaced",shortName={}
+// +kubebuilder:resource:singular="podinfo",path="podinfo",scope="Namespaced",shortName={tgpi}
 
 // PodInfo is the Scheme for the Podinfo API
 type PodInfo struct {

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.3.5"
+const CustomResourceDefinitionSchemaVersion = "1.3.6"

--- a/pkg/k8s/crdutils/register.go
+++ b/pkg/k8s/crdutils/register.go
@@ -194,6 +194,7 @@ func constructV1CRD(
 				Plural:     template.Spec.Names.Plural,
 				ShortNames: template.Spec.Names.ShortNames,
 				Singular:   template.Spec.Names.Singular,
+				Categories: template.Spec.Names.Categories,
 			},
 			Scope:    template.Spec.Scope,
 			Versions: template.Spec.Versions,

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_podinfo.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_podinfo.yaml
@@ -11,6 +11,8 @@ spec:
     kind: PodInfo
     listKind: PodInfoList
     plural: podinfo
+    shortNames:
+    - tgpi
     singular: podinfo
   scope: Namespaced
   versions:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -11,6 +11,8 @@ spec:
     kind: TracingPolicy
     listKind: TracingPolicyList
     plural: tracingpolicies
+    shortNames:
+    - tgtp
     singular: tracingpolicy
   scope: Cluster
   versions:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - tetragon
     kind: TracingPolicy
     listKind: TracingPolicyList
     plural: tracingpolicies

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - tetragon
     kind: TracingPolicyNamespaced
     listKind: TracingPolicyNamespacedList
     plural: tracingpoliciesnamespaced

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -11,6 +11,8 @@ spec:
     kind: TracingPolicyNamespaced
     listKind: TracingPolicyNamespacedList
     plural: tracingpoliciesnamespaced
+    shortNames:
+    - tgtpn
     singular: tracingpolicynamespaced
   scope: Namespaced
   versions:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -37,7 +37,7 @@ const (
 // +genclient:noStatus
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="tracingpolicy",path="tracingpolicies",scope="Cluster",shortName={tgtp}
+// +kubebuilder:resource:categories={tetragon},singular="tracingpolicy",path="tracingpolicies",scope="Cluster",shortName={tgtp}
 type TracingPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -48,7 +48,7 @@ type TracingPolicy struct {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="tracingpolicynamespaced",path="tracingpoliciesnamespaced",scope="Namespaced",shortName={tgtpn}
+// +kubebuilder:resource:categories={tetragon},singular="tracingpolicynamespaced",path="tracingpoliciesnamespaced",scope="Namespaced",shortName={tgtpn}
 type TracingPolicyNamespaced struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -37,7 +37,7 @@ const (
 // +genclient:noStatus
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="tracingpolicy",path="tracingpolicies",scope="Cluster",shortName={}
+// +kubebuilder:resource:singular="tracingpolicy",path="tracingpolicies",scope="Cluster",shortName={tgtp}
 type TracingPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -48,7 +48,7 @@ type TracingPolicy struct {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="tracingpolicynamespaced",path="tracingpoliciesnamespaced",scope="Namespaced",shortName={}
+// +kubebuilder:resource:singular="tracingpolicynamespaced",path="tracingpoliciesnamespaced",scope="Namespaced",shortName={tgtpn}
 type TracingPolicyNamespaced struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -384,7 +384,7 @@ type WorkloadObjectMeta struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="podinfo",path="podinfo",scope="Namespaced",shortName={}
+// +kubebuilder:resource:singular="podinfo",path="podinfo",scope="Namespaced",shortName={tgpi}
 
 // PodInfo is the Scheme for the Podinfo API
 type PodInfo struct {

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.3.5"
+const CustomResourceDefinitionSchemaVersion = "1.3.6"

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/crdutils/register.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/crdutils/register.go
@@ -194,6 +194,7 @@ func constructV1CRD(
 				Plural:     template.Spec.Names.Plural,
 				ShortNames: template.Spec.Names.ShortNames,
 				Singular:   template.Spec.Names.Singular,
+				Categories: template.Spec.Names.Categories,
 			},
 			Scope:    template.Spec.Scope,
 			Versions: template.Spec.Versions,


### PR DESCRIPTION
Let's slightly improve the Tetragon UX for lazy people like I am 😄.

- `podinfo` -> `tgpi`
- `tracingpolicy` -> `tgtp`
- `tracingpoliciesnamespaced` -> `tgtpn`

Furthermore, it's now possible to interact with user-relevant CRs (all besides `PodInfo`) at the same time via the `tetragon` category.

BTW, Cilium does the same for every Cilium CRD.

```release-note
crd: Added shortnames and catagory for Tetragon CRDs
```
