### PR TITLE
Switch to Go 1.23+ stdlib `maps`/`slices` packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - gosimple
     - makezero
     - dupword
+    - gomodguard
 
 linters-settings:
   goheader:
@@ -35,6 +36,19 @@ linters-settings:
       Copyright Authors of {{ PROJECT }}
   dupword:
     keywords: ["the", "and", "a", "for", "to", "as", "in", "of", "with", "by", "on", "at", "from"]
+  gomodguard:
+    blocked:
+      modules:
+        - golang.org/x/exp/maps:
+            recommendations:
+              - iter
+              - maps
+              - slices
+            reason: "Go 1.23+ supports iterating over maps and slices, see https://go.dev/doc/go1.23#iterators"
+        - golang.org/x/exp/slices:
+            recommendations:
+              - slices
+            reason: "Go 1.21+ provides many common operations for slices using generic functions, see https://go.dev/doc/go1.21#slices"
 
 issues:
   max-issues-per-linter: 0

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/vishvananda/netlink v1.3.1-0.20241022031324-976bd8de7d81
 	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
-	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.26.0
 	golang.org/x/time v0.7.0
@@ -152,6 +151,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.31.0 // indirect
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
+	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect

--- a/pkg/eventcache/metrics.go
+++ b/pkg/eventcache/metrics.go
@@ -4,7 +4,8 @@
 package eventcache
 
 import (
-	"golang.org/x/exp/maps"
+	"maps"
+	"slices"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/metrics"
@@ -51,11 +52,11 @@ func (e CacheError) String() string {
 var (
 	entryTypeLabel = metrics.ConstrainedLabel{
 		Name:   "entry_type",
-		Values: maps.Values(cacheEntryTypeLabelValues),
+		Values: slices.Collect(maps.Values(cacheEntryTypeLabelValues)),
 	}
 	errorLabel = metrics.ConstrainedLabel{
 		Name:   "error",
-		Values: maps.Values(cacheErrorLabelValues),
+		Values: slices.Collect(maps.Values(cacheErrorLabelValues)),
 	}
 )
 

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -4,7 +4,8 @@
 package eventmetrics
 
 import (
-	"golang.org/x/exp/maps"
+	"maps"
+	"slices"
 
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/tetragon/api/v1/tetragon"
@@ -32,7 +33,7 @@ var (
 	}
 	perfEventErrorLabel = metrics.ConstrainedLabel{
 		Name:   "error",
-		Values: maps.Values(perfEventErrors),
+		Values: slices.Collect(maps.Values(perfEventErrors)),
 	}
 )
 

--- a/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
+++ b/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
@@ -4,7 +4,8 @@
 package policyfiltermetrics
 
 import (
-	"golang.org/x/exp/maps"
+	"maps"
+	"slices"
 
 	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
@@ -68,17 +69,17 @@ func (s OperationErr) String() string {
 var (
 	subsysLabel = metrics.ConstrainedLabel{
 		Name:   "subsys",
-		Values: maps.Values(subsysLabelValues),
+		Values: slices.Collect(maps.Values(subsysLabelValues)),
 	}
 
 	operationLabel = metrics.ConstrainedLabel{
 		Name:   "operation",
-		Values: maps.Values(operationLabelValues),
+		Values: slices.Collect(maps.Values(operationLabelValues)),
 	}
 
 	errorLabel = metrics.ConstrainedLabel{
 		Name:   "error",
-		Values: maps.Values(operationErrLabels),
+		Values: slices.Collect(maps.Values(operationErrLabels)),
 	}
 )
 


### PR DESCRIPTION
Use the `maps` and `slices` packages from the Go standard library instead of the respective `golang.org/x/exp` packages.

Also add a linter check enforcing use of these packages.
