### PR TITLE
tetragon: Move loadInitialSensor after server is started

### DIFF
--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -87,7 +87,7 @@ func runTetragon(ctx context.Context, configFile string, args *Arguments, summar
 	option.Config.BpfDir = bpf.MapPrefixPath()
 	obs := observer.NewObserver()
 
-	if err := obs.InitSensorManager(); err != nil {
+	if err := obs.InitSensorManager(true); err != nil {
 		logger.GetLogger().Fatalf("InitSensorManager failed: %v", err)
 	}
 

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -341,8 +341,8 @@ func (k *Observer) Start(ctx context.Context) error {
 }
 
 // InitSensorManager starts the sensor controller
-func (k *Observer) InitSensorManager() error {
-	mgr, err := sensors.StartSensorManager(option.Config.BpfDir)
+func (k *Observer) InitSensorManager(ready bool) error {
+	mgr, err := sensors.StartSensorManager(option.Config.BpfDir, ready)
 	if err != nil {
 		return err
 	}

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -358,7 +358,7 @@ func loadExporter(tb testing.TB, ctx context.Context, obs *observer.Observer, op
 	processCacheSize := 32768
 	dataCacheSize := 1024
 
-	if err := obs.InitSensorManager(); err != nil {
+	if err := obs.InitSensorManager(true); err != nil {
 		return err
 	}
 

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -43,7 +43,7 @@ func TestAddPolicy(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("")
+	mgr, err := StartSensorManager("", true)
 	assert.NoError(t, err)
 	policy.ObjectMeta.Name = "test-policy"
 	err = mgr.AddTracingPolicy(ctx, &policy)
@@ -66,7 +66,7 @@ func TestAddPolicies(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("")
+	mgr, err := StartSensorManager("", true)
 	assert.NoError(t, err)
 	policy.ObjectMeta.Name = "test-policy"
 	err = mgr.AddTracingPolicy(ctx, &policy)
@@ -92,7 +92,7 @@ func TestAddPolicySpecError(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("")
+	mgr, err := StartSensorManager("", true)
 	assert.NoError(t, err)
 	policy.ObjectMeta.Name = "test-policy"
 	err = mgr.AddTracingPolicy(ctx, &policy)
@@ -119,7 +119,7 @@ func TestAddPolicyLoadError(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("")
+	mgr, err := StartSensorManager("", true)
 	assert.NoError(t, err)
 	policy.ObjectMeta.Name = "test-policy"
 	addError := mgr.AddTracingPolicy(ctx, &policy)
@@ -137,7 +137,7 @@ func TestPolicyFilterDisabled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	mgr, err := StartSensorManagerWithPF("", policyfilter.DisabledState())
+	mgr, err := StartSensorManagerWithPF("", policyfilter.DisabledState(), true)
 	assert.NoError(t, err)
 
 	policy := v1alpha1.TracingPolicy{}
@@ -188,7 +188,7 @@ func TestPolicyStates(t *testing.T) {
 		})
 
 		policy := v1alpha1.TracingPolicy{}
-		mgr, err := StartSensorManager("")
+		mgr, err := StartSensorManager("", true)
 		require.NoError(t, err)
 		policy.ObjectMeta.Name = "test-policy"
 		addError := mgr.AddTracingPolicy(ctx, &policy)
@@ -208,7 +208,7 @@ func TestPolicyStates(t *testing.T) {
 		})
 
 		policy := v1alpha1.TracingPolicy{}
-		mgr, err := StartSensorManager("")
+		mgr, err := StartSensorManager("", true)
 		require.NoError(t, err)
 		policy.ObjectMeta.Name = "test-policy"
 		err = mgr.AddTracingPolicy(ctx, &policy)
@@ -243,7 +243,7 @@ func TestPolicyLoadErrorOverride(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("")
+	mgr, err := StartSensorManager("", true)
 	require.NoError(t, err)
 	policy.ObjectMeta.Name = "test-policy"
 	addError := mgr.AddTracingPolicy(ctx, &policy)
@@ -277,7 +277,7 @@ func TestPolicyListingWhileLoadUnload(t *testing.T) {
 	polName := "test-policy"
 	testSensor := makeTestDelayedSensor(t)
 
-	mgr, err := StartSensorManager("")
+	mgr, err := StartSensorManager("", true)
 	require.NoError(t, err)
 
 	checkPolicy := func(t *testing.T, statuses []*tetragon.TracingPolicyStatus, state tetragon.TracingPolicyState) {
@@ -399,7 +399,7 @@ func TestPolicyKernelMemoryBytes(t *testing.T) {
 	})
 
 	policy := v1alpha1.TracingPolicy{}
-	mgr, err := StartSensorManager("")
+	mgr, err := StartSensorManager("", true)
 	require.NoError(t, err)
 	policy.ObjectMeta.Name = "test-policy"
 	addError := mgr.AddTracingPolicy(ctx, &policy)

--- a/pkg/sensors/tracing/generickprobe_test.go
+++ b/pkg/sensors/tracing/generickprobe_test.go
@@ -144,7 +144,7 @@ func Test_DisableEnablePolicy_Kprobe(t *testing.T) {
 
 	tus.LoadSensor(t, base.GetInitialSensor())
 	path := bpf.MapPrefixPath()
-	mgr, err := sensors.StartSensorManager(path)
+	mgr, err := sensors.StartSensorManager(path, true)
 	assert.NoError(t, err)
 
 	t.Run("sensor", func(t *testing.T) {
@@ -185,7 +185,7 @@ func Test_DisableEnablePolicy_KernelMemoryBytes(t *testing.T) {
 
 	tus.LoadSensor(t, base.GetInitialSensor())
 	path := bpf.MapPrefixPath()
-	mgr, err := sensors.StartSensorManager(path)
+	mgr, err := sensors.StartSensorManager(path, true)
 	require.NoError(t, err)
 
 	err = mgr.AddTracingPolicy(ctx, &tcpConnectPolicy)

--- a/pkg/testutils/sensors/sensors.go
+++ b/pkg/testutils/sensors/sensors.go
@@ -67,7 +67,7 @@ func getTestSensorManager(t *testing.T, pfState policyfilter.State) *TestSensorM
 	}
 
 	path := bpf.MapPrefixPath()
-	mgr, err = sensors.StartSensorManagerWithPF(path, pfState)
+	mgr, err = sensors.StartSensorManagerWithPF(path, pfState, true)
 	if err != nil {
 		t.Fatalf("StartSensorManagerWithPF failed: %s", err)
 	}


### PR DESCRIPTION
It turned out we need observer listener to be ready when loading initial sensor because the generated exec events need to land there.

Moving loadInitialSensor after server is started and adding ready 'lock' on AddTracingPolicy manager, so we won't allow to add tracing policy only after initial sensor is loaded.