### PR TITLE
tetragon: Move procevents.GetRunningProcs call from base sensor load

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -205,7 +205,10 @@ func loadInitialSensor(ctx context.Context) error {
 func tetragonExecute() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	return tetragonExecuteCtx(ctx, cancel, func() {})
+}
 
+func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready func()) error {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
@@ -514,7 +517,7 @@ func tetragonExecute() error {
 		go logStatus(ctx, obs)
 	}
 
-	return obs.Start(ctx)
+	return obs.StartReady(ctx, ready)
 }
 
 func waitCRDs(config *rest.Config) error {

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cilium/tetragon/pkg/reader/proc"
 	"github.com/cilium/tetragon/pkg/rthooks"
 	"github.com/cilium/tetragon/pkg/sensors/base"
+	"github.com/cilium/tetragon/pkg/sensors/exec/procevents"
 	"github.com/cilium/tetragon/pkg/sensors/program"
 	"github.com/cilium/tetragon/pkg/server"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
@@ -485,6 +486,10 @@ func tetragonExecute() error {
 	}
 
 	obs.LogPinnedBpf(observerDir)
+
+	if err = procevents.GetRunningProcs(); err != nil {
+		return err
+	}
 
 	cgrouprate.NewCgroupRate(ctx, pm, base.CgroupRateMap, &option.Config.CgroupRate)
 	cgrouprate.Config(base.CgroupRateOptionsMap)

--- a/cmd/tetragon/main_test.go
+++ b/cmd/tetragon/main_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/defaults"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/testutils"
+	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	ec := tus.TestSensorsRun(m, "Exec")
+	os.Exit(ec)
+}
+
+// The test starts tetragon with minimal setup and stops it
+// when it observer is ready. By that time we should have
+// exec events generated, make sure it's done.
+func TestGeneratedExecEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ready := func() {
+		cancel()
+	}
+
+	// Minimal config to start tetragon
+	option.Config.ExportRateLimit = -1
+	option.Config.DataCacheSize = 1024
+	option.Config.ProcessCacheSize = 65536
+	option.Config.BpfDir = defaults.DefaultMapPrefix
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	option.Config.TracingPolicyDir = defaults.DefaultTpDir
+
+	// Configure export file
+	f, err := testutils.CreateExportFile(t)
+	if err != nil {
+		t.Fatalf("testutils.CreateExportFilefailed: %v\n", err)
+	}
+	defer f.Close()
+
+	fname, err := testutils.GetExportFilename(t)
+	if err != nil {
+		t.Fatalf("testutils.GetExportFilename failed: %v\n", err)
+	}
+	option.Config.ExportFilename = fname
+
+	err = tetragonExecuteCtx(ctx, cancel, ready)
+	assert.NoError(t, err)
+
+	// Make sure exec event with pid 1 was generated
+	checker := ec.NewUnorderedEventChecker(
+		ec.NewProcessExecChecker("").WithProcess(
+			ec.NewProcessChecker().WithPid(1)),
+	)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}

--- a/pkg/bugtool/maps_test.go
+++ b/pkg/bugtool/maps_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cilium/tetragon/pkg/sensors/base"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
 
@@ -30,7 +29,7 @@ func TestFindMaps(t *testing.T) {
 	})
 
 	t.Run("BaseSensorMemlock", func(t *testing.T) {
-		tus.LoadSensor(t, base.GetInitialSensor())
+		tus.LoadInitialSensor(t)
 
 		const path = "/sys/fs/bpf/testSensorBugtool"
 		pinnedMaps, err := FindPinnedMaps(path)

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -331,10 +331,14 @@ func (k *Observer) UpdateRuntimeConf(bpfDir string) error {
 
 // Start starts the observer
 func (k *Observer) Start(ctx context.Context) error {
+	return k.StartReady(ctx, func() {})
+}
+
+func (k *Observer) StartReady(ctx context.Context, ready func()) error {
 	k.PerfConfig = bpf.DefaultPerfEventConfig()
 
 	var err error
-	if err = k.RunEvents(ctx, func() {}); err != nil {
+	if err = k.RunEvents(ctx, ready); err != nil {
 		return fmt.Errorf("tetragon, aborting runtime error: %w", err)
 	}
 	return nil

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/tetragon/pkg/rthooks"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/base"
+	"github.com/cilium/tetragon/pkg/sensors/exec/procevents"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/cilium/tetragon/pkg/watcher"
 	"github.com/cilium/tetragon/pkg/watcher/crd"
@@ -437,6 +438,10 @@ func loadObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor,
 		base.Unload()
 	})
 
+	if err := procevents.GetRunningProcs(); err != nil {
+		return err
+	}
+
 	if tp != nil {
 		if err := observer.GetSensorManager().AddTracingPolicy(ctx, tp); err != nil {
 			tb.Fatalf("SensorManager.AddTracingPolicy error: %s\n", err)
@@ -452,6 +457,10 @@ func loadObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor,
 func loadSensors(tb testing.TB, base sensors.SensorIface, sens []sensors.SensorIface) error {
 	if err := base.Load(option.Config.BpfDir); err != nil {
 		tb.Fatalf("Load base error: %s\n", err)
+	}
+
+	if err := procevents.GetRunningProcs(); err != nil {
+		tb.Fatalf("procevents.GetRunningProcs: %s", err)
 	}
 
 	for _, s := range sens {

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
-	"github.com/cilium/tetragon/pkg/sensors/base"
 	"github.com/cilium/tetragon/pkg/sensors/cgroup/cgrouptrackmap"
 	"github.com/cilium/tetragon/pkg/sensors/config/confmap"
 	"github.com/cilium/tetragon/pkg/sensors/exec/procevents"
@@ -605,7 +604,7 @@ func TestLoadCgroupsPrograms(t *testing.T) {
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 	option.Config.Verbosity = 5
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 	tus.LoadSensor(t, testsensor.GetCgroupSensor())
 }
@@ -617,7 +616,7 @@ func TestTgRuntimeConf(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 	option.Config.Verbosity = 5
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 
 	val, err := testutils.GetTgRuntimeConf()
 	assert.NoError(t, err)
@@ -648,7 +647,7 @@ func TestCgroupNoEvents(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 	option.Config.Verbosity = 5
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 
 	testManager := setupObserver(t)
 
@@ -700,7 +699,7 @@ func TestCgroupEventMkdirRmdir(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 	option.Config.Verbosity = 5
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 
 	testManager := setupObserver(t)
 
@@ -1051,7 +1050,7 @@ func TestCgroupv2K8sHierarchyInUnified(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 	option.Config.Verbosity = 5
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 
 	// Probe full environment detection
 	setupTgRuntimeConf(t, invalidValue, invalidValue, invalidValue, invalidValue)
@@ -1073,7 +1072,7 @@ func TestCgroupv2K8sHierarchyInHybrid(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 	option.Config.Verbosity = 5
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 
 	// Probe full environment detection
 	setupTgRuntimeConf(t, invalidValue, invalidValue, invalidValue, invalidValue)
@@ -1093,7 +1092,7 @@ func testCgroupv1K8sHierarchyInHybrid(t *testing.T, withExec bool, selectedContr
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 	option.Config.Verbosity = 5
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 
 	testManager := setupObserver(t)
 
@@ -1350,7 +1349,7 @@ func TestCgroupv2ExecK8sHierarchyInUnified(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
 	option.Config.Verbosity = 5
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 
 	// Probe full environment detection
 	_, err := testutils.GetTgRuntimeConf()

--- a/pkg/sensors/exec/exec.go
+++ b/pkg/sensors/exec/exec.go
@@ -250,11 +250,7 @@ func handleThrottleEvent(r *bytes.Reader) ([]observer.Event, error) {
 type execProbe struct{}
 
 func (e *execProbe) LoadProbe(args sensors.LoadProbeArgs) error {
-	err := program.LoadTracepointProgram(args.BPFDir, args.Load, args.Verbose)
-	if err == nil {
-		err = procevents.GetRunningProcs()
-	}
-	return err
+	return program.LoadTracepointProgram(args.BPFDir, args.Load, args.Verbose)
 }
 
 func init() {

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -679,7 +679,7 @@ func TestExecPerfring(t *testing.T) {
 	}
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 
 	ops := func() {

--- a/pkg/sensors/exec/threads_test.go
+++ b/pkg/sensors/exec/threads_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/option"
-	"github.com/cilium/tetragon/pkg/sensors/base"
+	"github.com/cilium/tetragon/pkg/sensors/exec/procevents"
 	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/cilium/tetragon/pkg/testutils/perfring"
@@ -98,7 +98,12 @@ func TestMatchCloneThreadsIDs(t *testing.T) {
 	}
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
+
+	if err := procevents.GetRunningProcs(); err != nil {
+		t.Fatalf("procevents.GetRunningProcs: %s", err)
+	}
+
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 
 	testBinPath := "contrib/tester-progs/threads-tester"

--- a/pkg/sensors/tracing/enforcer_test.go
+++ b/pkg/sensors/tracing/enforcer_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/sensors"
-	"github.com/cilium/tetragon/pkg/sensors/base"
 	"github.com/cilium/tetragon/pkg/syscallinfo"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
@@ -624,7 +623,7 @@ spec:
 	}
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 
 	sensor1, err := gEnforcerPolicy.PolicyHandler(policy1, policyfilter.NoFilterID)
 	assert.NoError(t, err)

--- a/pkg/sensors/tracing/generickprobe_test.go
+++ b/pkg/sensors/tracing/generickprobe_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/tetragon/pkg/idtable"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/sensors"
-	"github.com/cilium/tetragon/pkg/sensors/base"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,7 +141,7 @@ func Test_DisableEnablePolicy_Kprobe(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	path := bpf.MapPrefixPath()
 	mgr, err := sensors.StartSensorManager(path)
 	assert.NoError(t, err)
@@ -183,7 +182,7 @@ func Test_DisableEnablePolicy_KernelMemoryBytes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	path := bpf.MapPrefixPath()
 	mgr, err := sensors.StartSensorManager(path)
 	require.NoError(t, err)

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3973,7 +3973,7 @@ func matchBinariesPerfringTest(t *testing.T, operator string, values []string) {
 	}
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 	sm := tus.GetTestSensorManager(t)
 
@@ -4087,7 +4087,7 @@ func TestKprobeMatchBinariesEarlyExec(t *testing.T) {
 	}
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 	sm := tus.GetTestSensorManager(t)
 
@@ -4154,7 +4154,7 @@ func TestKprobeMatchBinariesPrefixMatchArgs(t *testing.T) {
 	}
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 	sm := tus.GetTestSensorManager(t)
 
@@ -6092,7 +6092,7 @@ func TestLinuxBinprmExtractPath(t *testing.T) {
 	}
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 	sm := tus.GetTestSensorManager(t)
 

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/reader/notify"
-	"github.com/cilium/tetragon/pkg/sensors/base"
 	"github.com/cilium/tetragon/pkg/sensors/config/confmap"
 	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
 	"github.com/cilium/tetragon/pkg/testutils"
@@ -114,7 +113,7 @@ func TestNamespacedPolicies(t *testing.T) {
 
 	policyfilter.TestingEnableAndReset(t)
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 	sm := tus.GetTestSensorManager(t)
 

--- a/pkg/sensors/tracing/selectors_test.go
+++ b/pkg/sensors/tracing/selectors_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/reader/notify"
 	"github.com/cilium/tetragon/pkg/sensors"
-	"github.com/cilium/tetragon/pkg/sensors/base"
 	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/cilium/tetragon/pkg/testutils/perfring"
@@ -47,7 +46,7 @@ func loadGenericSensorTest(t *testing.T, spec *v1alpha1.TracingPolicySpec) *sens
 		Spec:     *spec,
 	}
 
-	tus.LoadSensor(t, base.GetInitialSensor())
+	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 
 	ret, err := sensors.SensorsFromPolicy(tp, policyfilter.NoFilterID)

--- a/pkg/testutils/sensors/sensors.go
+++ b/pkg/testutils/sensors/sensors.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/base"
+	"github.com/cilium/tetragon/pkg/sensors/exec/procevents"
 )
 
 // LoadSensor is a helper for loading a sensor in tests
@@ -31,6 +33,14 @@ func LoadSensor(t *testing.T, sensori sensors.SensorIface) {
 	t.Cleanup(func() {
 		sensor.Unload()
 	})
+}
+
+func LoadInitialSensor(t *testing.T) {
+	LoadSensor(t, base.GetInitialSensor())
+
+	if err := procevents.GetRunningProcs(); err != nil {
+		t.Fatalf("procevents.GetRunningProcs: %s", err)
+	}
 }
 
 // TestSensorManager sensor manager used in tests


### PR DESCRIPTION
We need to call procevents.GetRunningProcs after server is started observer listeners are configured.

Currently it's called within base sensor load, but it's now loaded before server is started, so we don't get any initial exec events.