### PR TITLE
Add condition for procfs/version if procfs/version_signature fails

### DIFF
--- a/pkg/kernels/kernels.go
+++ b/pkg/kernels/kernels.go
@@ -70,6 +70,8 @@ func GetKernelVersion(kernelVersion, procfs string) (int, string, error) {
 
 		if versionSig, err := os.ReadFile(procfs + "/version_signature"); err == nil {
 			versionStrings = strings.Fields(string(versionSig))
+		} else if versionSig, err := os.ReadFile(procfs + "/version"); err == nil {
+			versionStrings = strings.Fields(string(versionSig))
 		}
 
 		if len(versionStrings) > 0 {


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x ] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
-->

### Description
Previously func GetKernelVersion(kernelVersion string, procfs string) (int, string, error) helper only checks the procfs/version_signature. I have added a condition to check procfs/version if first check fails. 
