### PR TITLE
fix: correcting the script path for minikube installation steps in do…

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/k8s-filtering.md
+++ b/docs/content/en/docs/concepts/tracing-policy/k8s-filtering.md
@@ -59,7 +59,7 @@ First, let us start minikube, build and load images, and install Tetragon and OC
 
 ```shell
 minikube start --container-runtime=containerd
-./contrib/tetragon-rthooks/minikube-containerd-install-hook.sh
+./contrib/tetragon-rthooks/scripts/minikube-install-hook.sh
 make image image-operator
 minikube image load --daemon=true cilium/tetragon:latest cilium/tetragon-operator:latest
 minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf


### PR DESCRIPTION
### Describe what changes this pull request brings
- Updated the docs with the correct path for `minikube-install-hook.sh` script.

### Related issue
#2980 

### Before change
![image](https://github.com/user-attachments/assets/19059b5f-800e-4155-83bd-0e3017f1cd4f)

### After Change
![image](https://github.com/user-attachments/assets/b0c7959b-a7ab-442b-99d8-a8c381a8b00a)

