### PR TITLE
Add tetra policyfilter listpolicies command

### DIFF
--- a/bpf/process/policy_filter.h
+++ b/bpf/process/policy_filter.h
@@ -9,6 +9,7 @@
 
 #define POLICY_FILTER_MAX_POLICIES   128
 #define POLICY_FILTER_MAX_NAMESPACES 1024
+#define POLICY_FILTER_MAX_CGROUP_IDS 1024
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
@@ -29,6 +30,23 @@ struct {
 			__type(value, __u8); /* empty  */
 		});
 } policy_filter_maps SEC(".maps");
+
+// This map keeps exactly the same information as policy_filter_maps
+// but keeps the reverse mappings. i.e.
+// policy_filter_maps maps policy_id to cgroup_ids
+// policy_filter_cgroup_maps maps cgroup_id to policy_ids
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
+	__uint(max_entries, POLICY_FILTER_MAX_CGROUP_IDS);
+	__uint(key_size, sizeof(__u64)); /* cgroup id */
+	__array(
+		values, struct {
+			__uint(type, BPF_MAP_TYPE_HASH);
+			__uint(max_entries, POLICY_FILTER_MAX_POLICIES);
+			__type(key, __u32); /* policy id */
+			__type(value, __u8); /* empty  */
+		});
+} policy_filter_cgroup_maps SEC(".maps");
 
 // policy_filter_check checks whether the policy applies on the current process.
 // Returns true if it does, false otherwise.

--- a/cmd/tetra/common/utils.go
+++ b/cmd/tetra/common/utils.go
@@ -3,7 +3,14 @@
 
 package common
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+)
 
 // HumanizeByteCount transforms bytes count into a quickly-readable version, for
 // example it transforms 4458824 into "4.46 MB". I copied this code from
@@ -20,4 +27,58 @@ func HumanizeByteCount(b int) string {
 	}
 	return fmt.Sprintf("%.2f %cB",
 		float64(b)/float64(div), "kMGTPE"[exp])
+}
+
+func PrintTracingPolicies(output io.Writer, policies []*tetragon.TracingPolicyStatus, skipPolicy func(pol *tetragon.TracingPolicyStatus) bool) {
+	// tabwriter config imitates kubectl default output, i.e. 3 spaces padding
+	w := tabwriter.NewWriter(output, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tSTATE\tFILTERID\tNAMESPACE\tSENSORS\tKERNELMEMORY")
+
+	for _, pol := range policies {
+		if skipPolicy != nil && skipPolicy(pol) {
+			continue
+		}
+
+		namespace := pol.Namespace
+		if namespace == "" {
+			namespace = "(global)"
+		}
+
+		sensors := strings.Join(pol.Sensors, ",")
+
+		// From v0.11 and before, enabled, filterID and error were
+		// bundled in a string. To have a retro-compatible tetra
+		// command, we scan the string. If the scan fails, it means
+		// something else might be in Info and we print it.
+		//
+		// we can drop the following block (and comment) when we
+		// feel tetra should support only version after v0.11
+		if pol.Info != "" {
+			var parsedEnabled bool
+			var parsedFilterID uint64
+			var parsedError string
+			var parsedName string
+			str := strings.NewReader(pol.Info)
+			_, err := fmt.Fscanf(str, "%253s enabled:%t filterID:%d error:%512s", &parsedName, &parsedEnabled, &parsedFilterID, &parsedError)
+			if err == nil {
+				if parsedEnabled {
+					pol.State = tetragon.TracingPolicyState_TP_STATE_ENABLED
+				}
+				pol.FilterId = parsedFilterID
+				pol.Error = parsedError
+				pol.Info = ""
+			}
+		}
+
+		fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\t%s\t%s\t\n",
+			pol.Id,
+			pol.Name,
+			strings.TrimPrefix(strings.ToLower(pol.State.String()), "tp_state_"),
+			pol.FilterId,
+			namespace,
+			sensors,
+			HumanizeByteCount(int(pol.KernelMemoryBytes)),
+		)
+	}
+	w.Flush()
 }

--- a/cmd/tetra/debug/dump.go
+++ b/cmd/tetra/debug/dump.go
@@ -200,18 +200,20 @@ func PolicyfilterState(fname string) {
 		fmt.Printf("%d: %s\n", polId, strings.Join(ids, ","))
 	}
 
-	fmt.Println("--- CgroupID to PolicyIDs mapping ---")
+	if data.Cgroup != nil {
+		fmt.Println("--- CgroupID to PolicyIDs mapping ---")
 
-	if len(data.Cgroup) == 0 {
-		fmt.Printf("(empty)\n")
-	}
-
-	for cgIDs, polIds := range data.Cgroup {
-		ids := make([]string, 0, len(polIds))
-		for id := range polIds {
-			ids = append(ids, strconv.FormatUint(uint64(id), 10))
+		if len(data.Cgroup) == 0 {
+			fmt.Printf("(empty)\n")
 		}
-		fmt.Printf("%d: %s\n", cgIDs, strings.Join(ids, ","))
+
+		for cgIDs, polIds := range data.Cgroup {
+			ids := make([]string, 0, len(polIds))
+			for id := range polIds {
+				ids = append(ids, strconv.FormatUint(uint64(id), 10))
+			}
+			fmt.Printf("%d: %s\n", cgIDs, strings.Join(ids, ","))
+		}
 	}
 }
 

--- a/cmd/tetra/debug/dump.go
+++ b/cmd/tetra/debug/dump.go
@@ -186,17 +186,32 @@ func PolicyfilterState(fname string) {
 		return
 	}
 
-	if len(data) == 0 {
+	fmt.Println("--- PolicyID to CgroupIDs mapping ---")
+
+	if len(data.Policy) == 0 {
 		fmt.Printf("(empty)\n")
-		return
 	}
 
-	for polId, cgIDs := range data {
+	for polId, cgIDs := range data.Policy {
 		ids := make([]string, 0, len(cgIDs))
 		for id := range cgIDs {
 			ids = append(ids, strconv.FormatUint(uint64(id), 10))
 		}
 		fmt.Printf("%d: %s\n", polId, strings.Join(ids, ","))
+	}
+
+	fmt.Println("--- CgroupID to PolicyIDs mapping ---")
+
+	if len(data.Cgroup) == 0 {
+		fmt.Printf("(empty)\n")
+	}
+
+	for cgIDs, polIds := range data.Cgroup {
+		ids := make([]string, 0, len(polIds))
+		for id := range polIds {
+			ids = append(ids, strconv.FormatUint(uint64(id), 10))
+		}
+		fmt.Printf("%d: %s\n", cgIDs, strings.Join(ids, ","))
 	}
 }
 

--- a/cmd/tetra/policyfilter/policyfilter.go
+++ b/cmd/tetra/policyfilter/policyfilter.go
@@ -4,12 +4,18 @@
 package policyfilter
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/cmd/tetra/common"
 	"github.com/cilium/tetragon/cmd/tetra/debug"
 	"github.com/cilium/tetragon/pkg/cgroups"
+	"github.com/cilium/tetragon/pkg/cri"
 	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/policyfilter"
@@ -29,6 +35,7 @@ func New() *cobra.Command {
 		addCommand(),
 		cgroupGetIDCommand(),
 		dumpDebugCmd(),
+		listPoliciesForContainer(),
 	)
 
 	return ret
@@ -137,4 +144,85 @@ func addCgroup(fname string, polID policyfilter.PolicyID, cgID policyfilter.Cgro
 		logger.GetLogger().WithError(err).Fatal("Failed to add cgroup id")
 	}
 
+}
+
+func listPoliciesForContainer() *cobra.Command {
+	var endpoint, cgroupMnt string
+	mapFname := filepath.Join(defaults.DefaultMapRoot, defaults.DefaultMapPrefix, policyfilter.MapName)
+	ret := &cobra.Command{
+		Use:   "listpolicies [container id]",
+		Short: "list all Kubernetes Identity Aware policies that apply to a specific container",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			ctx := context.Background()
+			client, err := cri.NewClient(ctx, endpoint)
+			if err != nil {
+				return err
+			}
+
+			cgroupPath, err := cri.CgroupPath(ctx, client, args[0])
+			if err != nil {
+				return err
+			}
+
+			if cgroupMnt == "" {
+				cgroupMnt = defaults.Cgroup2Dir
+			}
+			fullCgroupPath := path.Join(cgroupMnt, cgroupPath)
+			if common.Debug {
+				logger.GetLogger().WithField("path", fullCgroupPath).Info("cgroup")
+			}
+
+			cgID, err := cgroups.GetCgroupIdFromPath(fullCgroupPath)
+			if err != nil {
+				logger.GetLogger().WithError(err).Fatal("Failed to parse cgroup")
+			}
+
+			if common.Debug {
+				logger.GetLogger().WithField("id", cgID).Info("cgroup")
+			}
+
+			m, err := policyfilter.OpenMap(mapFname)
+			if err != nil {
+				logger.GetLogger().WithError(err).Fatal("Failed to open policyfilter map")
+				return err
+			}
+			defer m.Close()
+
+			data, err := m.Dump()
+			if err != nil {
+				logger.GetLogger().WithError(err).Fatal("Failed to open policyfilter map")
+				return err
+			}
+
+			policyIds, ok := data.Cgroup[policyfilter.CgroupID(cgID)]
+			if !ok {
+				return nil
+			}
+
+			c, err := common.NewClientWithDefaultContextAndAddress()
+			if err != nil {
+				return fmt.Errorf("failed create gRPC client: %w", err)
+			}
+			defer c.Close()
+
+			res, err := c.Client.ListTracingPolicies(c.Ctx, &tetragon.ListTracingPoliciesRequest{})
+			if err != nil || res == nil {
+				return fmt.Errorf("failed to list tracing policies: %w", err)
+			}
+
+			common.PrintTracingPolicies(os.Stdout, res.Policies, func(pol *tetragon.TracingPolicyStatus) bool {
+				_, ok := policyIds[policyfilter.PolicyID(pol.FilterId)]
+				return !ok
+			})
+
+			return nil
+		},
+	}
+
+	flags := ret.Flags()
+	flags.StringVarP(&endpoint, "runtime-endpoint", "r", "", "CRI endpoint")
+	flags.StringVar(&mapFname, "map-fname", mapFname, "policyfilter map filename")
+	flags.StringVar(&cgroupMnt, "cgroup-mount", cgroupMnt, "cgroupFS mount point")
+	return ret
 }

--- a/cmd/tetra/tracingpolicy/tracingpolicy.go
+++ b/cmd/tetra/tracingpolicy/tracingpolicy.go
@@ -6,8 +6,6 @@ package tracingpolicy
 import (
 	"fmt"
 	"os"
-	"strings"
-	"text/tabwriter"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/cmd/tetra/common"
@@ -161,53 +159,7 @@ func New() *cobra.Command {
 				}
 				cmd.Println(string(b))
 			case "text":
-				// tabwriter config imitates kubectl default output, i.e. 3 spaces padding
-				w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', 0)
-				fmt.Fprintln(w, "ID\tNAME\tSTATE\tFILTERID\tNAMESPACE\tSENSORS\tKERNELMEMORY")
-
-				for _, pol := range res.Policies {
-					namespace := pol.Namespace
-					if namespace == "" {
-						namespace = "(global)"
-					}
-
-					sensors := strings.Join(pol.Sensors, ",")
-
-					// From v0.11 and before, enabled, filterID and error were
-					// bundled in a string. To have a retro-compatible tetra
-					// command, we scan the string. If the scan fails, it means
-					// something else might be in Info and we print it.
-					//
-					// we can drop the following block (and comment) when we
-					// feel tetra should support only version after v0.11
-					if pol.Info != "" {
-						var parsedEnabled bool
-						var parsedFilterID uint64
-						var parsedError string
-						var parsedName string
-						str := strings.NewReader(pol.Info)
-						_, err := fmt.Fscanf(str, "%253s enabled:%t filterID:%d error:%512s", &parsedName, &parsedEnabled, &parsedFilterID, &parsedError)
-						if err == nil {
-							if parsedEnabled {
-								pol.State = tetragon.TracingPolicyState_TP_STATE_ENABLED
-							}
-							pol.FilterId = parsedFilterID
-							pol.Error = parsedError
-							pol.Info = ""
-						}
-					}
-
-					fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\t%s\t%s\t\n",
-						pol.Id,
-						pol.Name,
-						strings.TrimPrefix(strings.ToLower(pol.State.String()), "tp_state_"),
-						pol.FilterId,
-						namespace,
-						sensors,
-						common.HumanizeByteCount(int(pol.KernelMemoryBytes)),
-					)
-				}
-				w.Flush()
+				common.PrintTracingPolicies(cmd.OutOrStdout(), res.Policies, nil)
 			}
 
 			return nil

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -79,6 +79,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.enableKeepSensorsOnExit | bool | `false` | Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone. |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |
 | tetragon.enablePolicyFilter | bool | `true` | Enable policy filter. This is required for K8s namespace and pod-label filtering. |
+| tetragon.enablePolicyFilterCgroupMap | bool | `false` | Enable policy filter cgroup map. |
 | tetragon.enablePolicyFilterDebug | bool | `false` | Enable policy filter debug messages. |
 | tetragon.enableProcessCred | bool | `false` | Enable Capabilities visibility in exec and kprobe events. |
 | tetragon.enableProcessNs | bool | `false` | Enable Namespaces visibility in exec and kprobe events. |

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -69,6 +69,9 @@ options:
     - name: enable-policy-filter
       default_value: "false"
       usage: Enable policy filter code
+    - name: enable-policy-filter-cgroup-map
+      default_value: "false"
+      usage: Enable cgroup mappings for policy filter maps
     - name: enable-policy-filter-debug
       default_value: "false"
       usage: Enable policy filter debug messages

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -61,6 +61,7 @@ Helm chart for Tetragon
 | tetragon.enableKeepSensorsOnExit | bool | `false` | Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone. |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |
 | tetragon.enablePolicyFilter | bool | `true` | Enable policy filter. This is required for K8s namespace and pod-label filtering. |
+| tetragon.enablePolicyFilterCgroupMap | bool | `false` | Enable policy filter cgroup map. |
 | tetragon.enablePolicyFilterDebug | bool | `false` | Enable policy filter debug messages. |
 | tetragon.enableProcessCred | bool | `false` | Enable Capabilities visibility in exec and kprobe events. |
 | tetragon.enableProcessNs | bool | `false` | Enable Namespaces visibility in exec and kprobe events. |

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -59,6 +59,9 @@ data:
 {{- if .Values.tetragon.enablePolicyFilter }}
   enable-policy-filter: "true"
 {{- end }}
+{{- if .Values.tetragon.enablePolicyFilterCgroupMap }}
+  enable-policy-filter-cgroup-map: "true"
+{{- end }}
 {{- if .Values.tetragon.enablePolicyFilterDebug }}
   enable-policy-filter-debug: "true"
 {{- end }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -193,6 +193,8 @@ tetragon:
     port: 6060
   # -- Enable policy filter. This is required for K8s namespace and pod-label filtering.
   enablePolicyFilter: True
+  # -- Enable policy filter cgroup map.
+  enablePolicyFilterCgroupMap: false
   # -- Enable policy filter debug messages.
   enablePolicyFilterDebug: false
   # -- Enable latency monitoring in message handling

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -77,8 +77,9 @@ type config struct {
 
 	ReleasePinned bool
 
-	EnablePolicyFilter      bool
-	EnablePolicyFilterDebug bool
+	EnablePolicyFilter          bool
+	EnablePolicyFilterCgroupMap bool
+	EnablePolicyFilterDebug     bool
 
 	EnablePidSetFilter bool
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -81,8 +81,9 @@ const (
 
 	KeyReleasePinnedBPF = "release-pinned-bpf"
 
-	KeyEnablePolicyFilter      = "enable-policy-filter"
-	KeyEnablePolicyFilterDebug = "enable-policy-filter-debug"
+	KeyEnablePolicyFilter          = "enable-policy-filter"
+	KeyEnablePolicyFilterCgroupMap = "enable-policy-filter-cgroup-map"
+	KeyEnablePolicyFilterDebug     = "enable-policy-filter-debug"
 
 	KeyEnablePidSetFilter = "enable-pid-set-filter"
 
@@ -202,6 +203,7 @@ func ReadAndSetFlags() error {
 
 	Config.ReleasePinned = viper.GetBool(KeyReleasePinnedBPF)
 	Config.EnablePolicyFilter = viper.GetBool(KeyEnablePolicyFilter)
+	Config.EnablePolicyFilterCgroupMap = viper.GetBool(KeyEnablePolicyFilterCgroupMap)
 	Config.EnablePolicyFilterDebug = viper.GetBool(KeyEnablePolicyFilterDebug)
 	Config.EnableMsgHandlingLatency = viper.GetBool(KeyEnableMsgHandlingLatency)
 
@@ -378,6 +380,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	// Provide option to enable policy filtering. Because the code is new,
 	// this is set to false by default.
 	flags.Bool(KeyEnablePolicyFilter, false, "Enable policy filter code")
+	flags.Bool(KeyEnablePolicyFilterCgroupMap, false, "Enable cgroup mappings for policy filter maps")
 	flags.Bool(KeyEnablePolicyFilterDebug, false, "Enable policy filter debug messages")
 
 	// Provide option to enable the pidSet export filters.

--- a/pkg/policyfilter/k8s_test.go
+++ b/pkg/policyfilter/k8s_test.go
@@ -739,7 +739,7 @@ func TestK8s(t *testing.T) {
 
 	// testState implements cgFinder
 	ts := newTestState(client)
-	st, err := newState(log, ts)
+	st, err := newState(log, ts, true)
 	if err != nil {
 		t.Skipf("failed to initialize policy filter state: %s", err)
 	}

--- a/pkg/policyfilter/map_test.go
+++ b/pkg/policyfilter/map_test.go
@@ -21,7 +21,7 @@ func requirePfmEqualTo(t *testing.T, m PfMap, val map[uint64][]uint64) {
 
 	mapVals, err := m.readAll()
 	require.NoError(t, err)
-	require.EqualValues(t, checkVals, mapVals)
+	require.EqualValues(t, checkVals, mapVals.Policy)
 }
 
 // TestPfMapOps tests some simple map operations
@@ -42,9 +42,11 @@ func TestPfMapOps(t *testing.T) {
 
 	err = pm1.addCgroupIDs([]CgroupID{30})
 	require.NoError(t, err)
+	err = addPolicyIDMapping(pm1.cgroupMap, polID1, 30)
+	require.NoError(t, err)
 	requirePfmEqualTo(t, pfm, map[uint64][]uint64{100: {10, 20, 30}})
 
-	err = pm1.delCgroupIDs([]CgroupID{20, 10})
+	err = pm1.delCgroupIDs(polID1, []CgroupID{20, 10})
 	require.NoError(t, err)
 	requirePfmEqualTo(t, pfm, map[uint64][]uint64{100: {30}})
 

--- a/pkg/policyfilter/map_test.go
+++ b/pkg/policyfilter/map_test.go
@@ -40,7 +40,7 @@ func TestPfMapOps(t *testing.T) {
 	if !bpffsReady {
 		t.Skip("failed to initialize bpffs")
 	}
-	pfm, err := newPfMap()
+	pfm, err := newPfMap(true)
 	require.NoError(t, err)
 	defer pfm.release()
 

--- a/pkg/policyfilter/map_test.go
+++ b/pkg/policyfilter/map_test.go
@@ -19,9 +19,20 @@ func requirePfmEqualTo(t *testing.T, m PfMap, val map[uint64][]uint64) {
 		}
 	}
 
+	checkCgroupVals := map[CgroupID]map[PolicyID]struct{}{}
+	for k, ids := range val {
+		for _, id := range ids {
+			if checkCgroupVals[CgroupID(id)] == nil {
+				checkCgroupVals[CgroupID(id)] = map[PolicyID]struct{}{}
+			}
+			checkCgroupVals[CgroupID(id)][PolicyID(k)] = struct{}{}
+		}
+	}
+
 	mapVals, err := m.readAll()
 	require.NoError(t, err)
 	require.EqualValues(t, checkVals, mapVals.Policy)
+	require.EqualValues(t, checkCgroupVals, mapVals.Cgroup)
 }
 
 // TestPfMapOps tests some simple map operations

--- a/pkg/policyfilter/policyfilter.go
+++ b/pkg/policyfilter/policyfilter.go
@@ -25,7 +25,7 @@ func GetState() (State, error) {
 	setGlobalPf.Do(func() {
 		if option.Config.EnablePolicyFilter {
 			logger.GetLogger().Info("Enabling policy filtering")
-			glblState, glblError = New()
+			glblState, glblError = New(option.Config.EnablePolicyFilterCgroupMap)
 		} else {
 			glblState = &disabled{}
 			glblError = nil
@@ -45,7 +45,7 @@ func resetStateOnlyForTesting() {
 	}
 	if option.Config.EnablePolicyFilter {
 		logger.GetLogger().Info("Enabling policy filtering")
-		glblState, glblError = New()
+		glblState, glblError = New(true)
 	} else {
 		glblState = &disabled{}
 		glblError = nil

--- a/pkg/policyfilter/state.go
+++ b/pkg/policyfilter/state.go
@@ -269,17 +269,19 @@ type state struct {
 // allocated resources (namely the bpf map).
 //
 //revive:disable:unexported-return
-func New() (*state, error) {
+func New(enableCgroupMap bool) (*state, error) {
 	log := logger.GetLogger().WithField("subsystem", "policy-filter")
 	return newState(
 		log,
 		&cgfsFinder{fsscan.New(), log},
+		enableCgroupMap,
 	)
 }
 
 func newState(
 	log logrus.FieldLogger,
 	cgidFinder cgidFinder,
+	enableCgroupMap bool,
 ) (*state, error) {
 	var err error
 	ret := &state{
@@ -288,7 +290,7 @@ func newState(
 		DebugLogger: logger.NewDebugLogger(log, option.Config.EnablePolicyFilterDebug),
 	}
 
-	ret.pfMap, err = newPfMap()
+	ret.pfMap, err = newPfMap(enableCgroupMap)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/policyfilter/state_test.go
+++ b/pkg/policyfilter/state_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestState(t *testing.T) {
-	s, err := New()
+	s, err := New(true)
 	if err != nil {
 		t.Skipf("failed to inialize policy filter state: %s", err)
 	}


### PR DESCRIPTION
Add `tetra policyfilter listpolicies` to determine which Kubernetes Identity Aware policies should be applied on a specific container.

Example:
```
$ kubectl exec -it ds/tetragon -n kube-system -c tetragon -- tetra policyfilter -r "unix:///procRoot/1/root/run/containerd/containerd.sock" listpolicies ff433e9e16467787a60ac853d9b313150091968731f620776d6d7c514b1e8d6c
ID   NAME                    STATE     FILTERID   NAMESPACE   SENSORS          KERNELMEMORY
5    lseek-podfilter-usage   enabled   5          (global)    generic_kprobe   1.72 MB
1    lseek-podfilter-app     enabled   1          (global)    generic_kprobe   1.72 MB
```

Details on how this works can be found on specific commits.