### PR TITLE
bpf: remove unused fields in msg_k8s

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -265,8 +265,6 @@ struct msg_ns {
 }; // All fields aligned so no 'packed' attribute.
 
 struct msg_k8s {
-	__u32 net_ns;
-	__u32 cid;
 	__u64 cgrpid;
 	char docker_id[DOCKER_ID_LENGTH];
 }; // All fields aligned so no 'packed' attribute.

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -256,8 +256,6 @@ event_execve(struct trace_event_raw_sched_process_exec *ctx)
 	event->common.ktime = p->ktime;
 	event->common.size = offsetof(struct msg_execve_event, process) + p->size;
 
-	BPF_CORE_READ_INTO(&event->kube.net_ns, task, nsproxy, net_ns, ns.inum);
-
 	get_current_subj_creds(&event->creds, task);
 	/**
 	 * Instead of showing the task owner, we want to display the effective

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -94,8 +94,6 @@ type MsgCommon struct {
 }
 
 type MsgK8s struct {
-	NetNS  uint32
-	Cid    uint32
 	Cgrpid uint64
 	Docker [DOCKER_ID_LENGTH]byte
 }

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -125,8 +125,6 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 				Ktime:  0,
 			},
 			Kube: tetragonAPI.MsgK8s{
-				NetNS:  0,
-				Cid:    0,
 				Cgrpid: 0,
 			},
 			Parent: tetragonAPI.MsgExecveKey{
@@ -166,8 +164,6 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 				Ktime:  21034975106173,
 			},
 			Kube: tetragonAPI.MsgK8s{
-				NetNS:  4026531992,
-				Cid:    0,
 				Cgrpid: 0,
 			},
 			Parent: tetragonAPI.MsgExecveKey{
@@ -207,8 +203,6 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 				Ktime:  21034975106173,
 			},
 			Kube: tetragonAPI.MsgK8s{
-				NetNS:  4026531992,
-				Cid:    0,
 				Cgrpid: 0,
 			},
 			Parent: tetragonAPI.MsgExecveKey{

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -234,8 +234,6 @@ func pushExecveEvents(p procs) {
 		m.Unix.Msg.Common.Op = ops.MSG_OP_EXECVE
 		m.Unix.Msg.Common.Size = processapi.MsgUnixSize + p.psize + p.size
 
-		m.Unix.Msg.Kube.NetNS = 0
-		m.Unix.Msg.Kube.Cid = 0
 		m.Unix.Msg.Kube.Cgrpid = 0
 		if p.pid > 0 {
 			m.Unix.Kube.Docker, err = procsDockerId(p.pid)


### PR DESCRIPTION
This was supposed to be a simple cleanup but ended up encountering complexity issues.
The second patch improves the complexity of the programs by moving error handling outside of the loops.

The PR ends up improving the complexity overall. See:  https://github.com/cilium/tetragon/actions/runs/11903505830?pr=3127.

Some sample numbers  from the link above:

| file | program | Insns (A) | Insns (B)    | Diff     |
|------|---------------|---------------| ---------------|--------- |
| `bpf_execve_event.o` | `event_execve` | 39760   |   25181 |  -14579 (-36.67%) |
| `bpf_execve_event_v53.o` | `event_execve` | 173713 |    144552 |  -29161  (-16.79%)  |

Loading time is also reduced which is nice.