### PR TITLE
ProcessCache: Make GC interval configurable

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -424,7 +424,12 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 	}
 	k8sWatcher.Start()
 
-	if err := process.InitCache(k8sWatcher, option.Config.ProcessCacheSize); err != nil {
+	pcGCInterval := option.Config.ProcessCacheGCInterval
+	if pcGCInterval <= 0 {
+		pcGCInterval = defaults.DefaultProcessCacheGCInterval
+	}
+
+	if err := process.InitCache(k8sWatcher, option.Config.ProcessCacheSize, pcGCInterval); err != nil {
 		return err
 	}
 

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -120,6 +120,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.pprof.address | string | `"localhost"` | The address at which to expose pprof. |
 | tetragon.pprof.enabled | bool | `false` | Whether to enable exposing pprof server. |
 | tetragon.pprof.port | int | `6060` | The port at which to expose pprof. |
+| tetragon.processCacheGCInterval | string | `"30s"` | Configure the interval (suffixed with s for seconds, m for minutes, etc) for the process cache garbage collector. |
 | tetragon.processCacheSize | int | `65536` | Tetragon puts processes in an LRU cache. The cache is used to find ancestors for subsequently exec'ed processes. |
 | tetragon.prometheus.address | string | `""` | The address at which to expose metrics. Set it to "" to expose on all available interfaces. |
 | tetragon.prometheus.enabled | bool | `true` | Whether to enable exposing Tetragon metrics. |

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -176,6 +176,9 @@ options:
     - name: pprof-address
       usage: |
         Serves runtime profile data via HTTP (e.g. 'localhost:6060'). Disabled by default
+    - name: process-cache-gc-interval
+      default_value: 30s
+      usage: Time between checking the process cache for old entries
     - name: process-cache-size
       default_value: "65536"
       usage: Size of the process cache

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -102,6 +102,7 @@ Helm chart for Tetragon
 | tetragon.pprof.address | string | `"localhost"` | The address at which to expose pprof. |
 | tetragon.pprof.enabled | bool | `false` | Whether to enable exposing pprof server. |
 | tetragon.pprof.port | int | `6060` | The port at which to expose pprof. |
+| tetragon.processCacheGCInterval | string | `"30s"` | Configure the interval (suffixed with s for seconds, m for minutes, etc) for the process cache garbage collector. |
 | tetragon.processCacheSize | int | `65536` | Tetragon puts processes in an LRU cache. The cache is used to find ancestors for subsequently exec'ed processes. |
 | tetragon.prometheus.address | string | `""` | The address at which to expose metrics. Set it to "" to expose on all available interfaces. |
 | tetragon.prometheus.enabled | bool | `true` | Whether to enable exposing Tetragon metrics. |

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -77,3 +77,4 @@ data:
   keep-sensors-on-exit: "true"
   release-pinned-bpf: "false"
 {{- end }}
+  process-cache-gc-interval: {{ .Values.tetragon.processCacheGCInterval | quote }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -233,6 +233,8 @@ tetragon:
   eventCacheRetryDelay: 2
   # -- Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone.
   enableKeepSensorsOnExit: false
+  # -- Configure the interval (suffixed with s for seconds, m for minutes, etc) for the process cache garbage collector.
+  processCacheGCInterval: 30s
 # Tetragon Operator settings
 tetragonOperator:
   # -- Enables the Tetragon Operator.

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -208,7 +208,7 @@ func startBenchmarkExporter(ctx context.Context, obs *observer.Observer, summary
 	dataCacheSize := 1024
 
 	watcher := watcher.NewFakeK8sWatcher(nil)
-	if err := process.InitCache(watcher, processCacheSize); err != nil {
+	if err := process.InitCache(watcher, processCacheSize, defaults.DefaultProcessCacheGCInterval); err != nil {
 		return err
 	}
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -3,6 +3,8 @@
 
 package defaults
 
+import "time"
+
 const (
 	// DefaultMapRoot is the default path where BPFFS should be mounted
 	DefaultMapRoot = "/sys/fs/bpf"
@@ -49,6 +51,9 @@ const (
 	// defaults for the event cache
 	DefaultEventCacheNumRetries = 15
 	DefaultEventCacheRetryDelay = 2
+
+	// defaults for the process cache
+	DefaultProcessCacheGCInterval = 30 * time.Second
 )
 
 var (

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	tetragonAPI "github.com/cilium/tetragon/pkg/api/processapi"
+	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/eventcache"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
@@ -311,7 +312,7 @@ func CreateCloneEvents[CLONE notify.Message, EXIT notify.Message](Pid uint32, Kt
 }
 
 func InitEnv[EXEC notify.Message, EXIT notify.Message](t *testing.T, watcher watcher.K8sResourceWatcher) DummyNotifier[EXEC, EXIT] {
-	if err := process.InitCache(watcher, 65536); err != nil {
+	if err := process.InitCache(watcher, 65536, defaults.DefaultProcessCacheGCInterval); err != nil {
 		t.Fatalf("failed to call process.InitCache %s", err)
 	}
 

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/api/processapi"
+	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
@@ -60,7 +61,7 @@ func TestProcessManager_getPodInfo(t *testing.T) {
 	}
 
 	pods := []interface{}{&podA}
-	err := process.InitCache(watcher.NewFakeK8sWatcher(pods), 10)
+	err := process.InitCache(watcher.NewFakeK8sWatcher(pods), 10, defaults.DefaultProcessCacheGCInterval)
 	assert.NoError(t, err)
 	defer process.FreeCache()
 	pod := process.GetPodInfo(0, "container-id-not-found", "", "", 0)
@@ -125,7 +126,7 @@ func TestProcessManager_getPodInfoMaybeExecProbe(t *testing.T) {
 		},
 	}
 	pods := []interface{}{&podA}
-	err := process.InitCache(watcher.NewFakeK8sWatcher(pods), 10)
+	err := process.InitCache(watcher.NewFakeK8sWatcher(pods), 10, defaults.DefaultProcessCacheGCInterval)
 	assert.NoError(t, err)
 	defer process.FreeCache()
 	pod := process.GetPodInfo(0, "aaaaaaa", "/bin/command", "arg-a arg-b", 1234)
@@ -145,7 +146,7 @@ func TestProcessManager_getPodInfoMaybeExecProbe(t *testing.T) {
 }
 
 func TestProcessManager_GetProcessExec(t *testing.T) {
-	err := process.InitCache(watcher.NewFakeK8sWatcher(nil), 10)
+	err := process.InitCache(watcher.NewFakeK8sWatcher(nil), 10, defaults.DefaultProcessCacheGCInterval)
 	assert.NoError(t, err)
 	defer process.FreeCache()
 	var wg sync.WaitGroup
@@ -215,7 +216,7 @@ func TestProcessManager_GetProcessID(t *testing.T) {
 	assert.NoError(t, os.Setenv("NODE_NAME", "my-node"))
 	node.SetNodeName()
 
-	err := process.InitCache(watcher.NewFakeK8sWatcher([]interface{}{}), 10)
+	err := process.InitCache(watcher.NewFakeK8sWatcher([]interface{}{}), 10, defaults.DefaultProcessCacheGCInterval)
 	assert.NoError(t, err)
 	defer process.FreeCache()
 	id := process.GetProcessID(1, 2)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -46,8 +46,9 @@ type config struct {
 	RBSizeTotal int
 	RBQueueSize int
 
-	ProcessCacheSize int
-	DataCacheSize    int
+	ProcessCacheSize       int
+	DataCacheSize          int
+	ProcessCacheGCInterval time.Duration
 
 	MetricsServer      string
 	MetricsLabelFilter metrics.LabelFilter

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -17,18 +17,19 @@ import (
 )
 
 const (
-	KeyConfigDir        = "config-dir"
-	KeyDebug            = "debug"
-	KeyHubbleLib        = "bpf-lib"
-	KeyBTF              = "btf"
-	KeyProcFS           = "procfs"
-	KeyKernelVersion    = "kernel"
-	KeyVerbosity        = "verbose"
-	KeyProcessCacheSize = "process-cache-size"
-	KeyDataCacheSize    = "data-cache-size"
-	KeyForceSmallProgs  = "force-small-progs"
-	KeyForceLargeProgs  = "force-large-progs"
-	KeyClusterName      = "cluster-name"
+	KeyConfigDir              = "config-dir"
+	KeyDebug                  = "debug"
+	KeyHubbleLib              = "bpf-lib"
+	KeyBTF                    = "btf"
+	KeyProcFS                 = "procfs"
+	KeyKernelVersion          = "kernel"
+	KeyVerbosity              = "verbose"
+	KeyProcessCacheSize       = "process-cache-size"
+	KeyDataCacheSize          = "data-cache-size"
+	KeyProcessCacheGCInterval = "process-cache-gc-interval"
+	KeyForceSmallProgs        = "force-small-progs"
+	KeyForceLargeProgs        = "force-large-progs"
+	KeyClusterName            = "cluster-name"
 
 	KeyLogLevel  = "log-level"
 	KeyLogFormat = "log-format"
@@ -170,6 +171,11 @@ func ReadAndSetFlags() error {
 
 	Config.ProcessCacheSize = viper.GetInt(KeyProcessCacheSize)
 	Config.DataCacheSize = viper.GetInt(KeyDataCacheSize)
+	Config.ProcessCacheGCInterval = viper.GetDuration(KeyProcessCacheGCInterval)
+
+	if Config.ProcessCacheGCInterval <= 0 {
+		return fmt.Errorf("failed to parse process-cache-gc-interval value. Must be >= 0")
+	}
 
 	Config.MetricsServer = viper.GetString(KeyMetricsServer)
 	Config.MetricsLabelFilter = DefaultLabelFilter().WithEnabledLabels(ParseMetricsLabelFilter(viper.GetString(KeyMetricsLabelFilter)))
@@ -296,6 +302,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Int(KeyVerbosity, 0, "set verbosity level for eBPF verifier dumps. Pass 0 for silent, 1 for truncated logs, 2 for a full dump")
 	flags.Int(KeyProcessCacheSize, 65536, "Size of the process cache")
 	flags.Int(KeyDataCacheSize, 1024, "Size of the data events cache")
+	flags.Duration(KeyProcessCacheGCInterval, defaults.DefaultProcessCacheGCInterval, "Time between checking the process cache for old entries")
 	flags.Bool(KeyForceSmallProgs, false, "Force loading small programs, even in kernels with >= 5.3 versions")
 	flags.Bool(KeyForceLargeProgs, false, "Force loading large programs, even in kernels with < 5.3 versions")
 	flags.String(KeyExportFilename, "", "Filename for JSON export. Disabled by default")

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -40,12 +40,7 @@ var colorStr = map[int]string{
 	deleted:       "deleted",
 }
 
-// garbage collection run interval
-const (
-	intervalGC = time.Second * 30
-)
-
-func (pc *Cache) cacheGarbageCollector() {
+func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 	ticker := time.NewTicker(intervalGC)
 	pc.deleteChan = make(chan *ProcessInternal)
 	pc.stopChan = make(chan bool)
@@ -147,6 +142,7 @@ func (pc *Cache) purge() {
 
 func NewCache(
 	processCacheSize int,
+	GCInterval time.Duration,
 ) (*Cache, error) {
 	lruCache, err := lru.NewWithEvict(
 		processCacheSize,
@@ -161,7 +157,7 @@ func NewCache(
 		cache: lruCache,
 		size:  processCacheSize,
 	}
-	pm.cacheGarbageCollector()
+	pm.cacheGarbageCollector(GCInterval)
 	return pm, nil
 }
 

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -14,7 +15,7 @@ import (
 
 func TestProcessCache(t *testing.T) {
 	// add a process to the cache.
-	cache, err := NewCache(10)
+	cache, err := NewCache(10, defaults.DefaultProcessCacheGCInterval)
 	require.NoError(t, err)
 	pid := wrapperspb.UInt32Value{Value: 1234}
 	execID := "process1"

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cilium/tetragon/pkg/cgidmap"
 	"github.com/cilium/tetragon/pkg/fieldfilters"
@@ -73,7 +74,7 @@ var (
 	ErrProcessInfoMissing = errors.New("failed process info missing")
 )
 
-func InitCache(w watcher.K8sResourceWatcher, size int) error {
+func InitCache(w watcher.K8sResourceWatcher, size int, GCInterval time.Duration) error {
 	var err error
 
 	if procCache != nil {
@@ -81,7 +82,7 @@ func InitCache(w watcher.K8sResourceWatcher, size int) error {
 	}
 
 	k8s = w
-	procCache, err = NewCache(size)
+	procCache, err = NewCache(size, GCInterval)
 	if err != nil {
 		k8s = nil
 	}

--- a/pkg/sensors/exec/cache_test.go
+++ b/pkg/sensors/exec/cache_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package exec
+
+import (
+	"context"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
+	"github.com/cilium/tetragon/pkg/process"
+	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func processInList(pid uint32, processes []*tetragon.ProcessInternal) bool {
+	for _, p := range processes {
+		if p.Process.Pid.Value == pid {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProcessCacheInterval(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	sleepBin := "/bin/sleep"
+
+	obs, err := observertesthelper.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, observertesthelper.WithProcCacheGCInterval(100*time.Millisecond))
+	if err != nil {
+		t.Fatalf("GetDefaultObserver error: %s", err)
+	}
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+
+	readyWG.Wait()
+	cmd := exec.Command(sleepBin, "0.001")
+	assert.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	time.Sleep(50 * time.Millisecond)
+
+	processes := process.DumpProcessCache(&tetragon.DumpProcessCacheReqArgs{SkipZeroRefcnt: false, ExcludeExecveMapProcesses: false})
+	// Should find our sleep process in the list, even though the process should have finished.
+	require.True(t, processInList(uint32(pid), processes))
+
+	time.Sleep(500 * time.Millisecond)
+	processes = process.DumpProcessCache(&tetragon.DumpProcessCacheReqArgs{SkipZeroRefcnt: false, ExcludeExecveMapProcesses: false})
+	// Should not find our sleep process in the list, as it should have been evicted by now.
+	require.False(t, processInList(uint32(pid), processes))
+}


### PR DESCRIPTION
The process cache delays removal of exited processes. The first time the garbage collector sees a process (marked deletePending), it changes it to deleteReady. The second time it sees the process, it deletes it from the cache. The garbage collector runs every 30s.

This PR makes the GC interval configurable with the --process-cache-gc-interval switch.
