### PR TITLE
workflows: only run cron jobs on main repo

### DIFF
--- a/.github/workflows/check-links-cron.yaml
+++ b/.github/workflows/check-links-cron.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   links-checker:
+    if: ${{ github.repository == 'cilium/tetragon' || github.event_name != 'schedule' }}
     env:
       ISSUE_NAME: 'Documentation: broken links automatic report'
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   renovate:
+    if: ${{ github.repository == 'cilium/tetragon' || github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     env:
       buildx_version: 'v0.10.5'


### PR DESCRIPTION
Fixes https://github.com/cilium/tetragon/issues/3107.

Avoid running cron jobs, especially renovate, on forks which would fail because of the absence of secrets.