### PR TITLE
[v1.1 backport] workflows: use GitHub arm64 runners instead of actuated

### DIFF
--- a/.github/workflows/bpf-unit-tests.yml
+++ b/.github/workflows/bpf-unit-tests.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'bpf/**'
+      - '.github/workflows/bpf-unit-tests.yml'
   push:
     branches:
       - main
@@ -14,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, actuated-arm64-4cpu-8gb ]
+        os: [ ubuntu-22.04, ubuntu-22.04-arm64 ]
     steps:
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, actuated-arm64-4cpu-8gb ]
+        os: [ ubuntu-20.04, ubuntu-22.04-arm64 ]
     steps:
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -76,7 +76,7 @@ jobs:
             match_arch: x86-64
             cross_compile: no
             upload_path: upload/
-          - os: actuated-arm64-4cpu-8gb
+          - os: ubuntu-22.04-arm64
             arch: arm64
             match_arch: arm64
             cross_compile: yes

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, actuated-arm64-4cpu-16gb ]
+        os: [ ubuntu-22.04, ubuntu-22.04-arm64 ]
         package: ${{fromJson(needs.list-e2e-pkg.outputs.packages)}}
     steps:
     - name: Checkout Code

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -97,6 +97,8 @@ jobs:
           docker pull ${{ steps.vars.outputs.operatorImage }}
 
     - name: Run e2e Tests
+      env:
+        GHA_OS: ${{matrix.os}}
       run: |
         cd go/src/github.com/cilium/tetragon
 

--- a/contrib/tester-progs/direct-write-tester.c
+++ b/contrib/tester-progs/direct-write-tester.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 // Copyright Authors of Tetragon
 
+#define _GNU_SOURCE
 #include <fcntl.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -10,7 +11,6 @@
 #include <stdio.h>
 
 #define BLOCKSIZE 4096
-#define O_DIRECT  00040000
 
 int main(int argc, char **argv)
 {

--- a/pkg/sensors/tracing/enforcer_test.go
+++ b/pkg/sensors/tracing/enforcer_test.go
@@ -294,7 +294,7 @@ func testSecurity(t *testing.T, tracingPolicy, tempFile string) {
 	}
 }
 
-func enforcerSecurityTempFile(t *testing.T) string {
+func directWriteTempFile(t *testing.T) string {
 	// We can't use t.TempDir as it writes into /tmp by default.
 	// The direct-write-tester.c program opens and writes using the O_DIRECT
 	// flag that is unsupported and return EINVAL on tmpfs, while it works on a
@@ -339,7 +339,7 @@ func TestEnforcerSecuritySigKill(t *testing.T) {
 		t.Skip("Older kernels do not support matchArgs for more than one arguments")
 	}
 
-	tempFile := enforcerSecurityTempFile(t)
+	tempFile := directWriteTempFile(t)
 
 	tracingPolicy := `
 apiVersion: cilium.io/v1alpha1
@@ -426,7 +426,7 @@ func TestEnforcerSecurityNotifyEnforcer(t *testing.T) {
 		t.Skip("Older kernels do not support matchArgs for more than one arguments")
 	}
 
-	tempFile := enforcerSecurityTempFile(t)
+	tempFile := directWriteTempFile(t)
 
 	tracingPolicy := `
 apiVersion: cilium.io/v1alpha1

--- a/tests/e2e/tests/labels/labels_test.go
+++ b/tests/e2e/tests/labels/labels_test.go
@@ -7,6 +7,7 @@ package labels_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -93,6 +94,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestLabelsDemoApp(t *testing.T) {
+	if os.Getenv("GHA_OS") == "ubuntu-22.04-arm64" {
+		t.Skip("Skipping, see: ://github.com/cilium/tetragon/issues/3060")
+	}
+
 	// Must be called at the beginning of every test
 	runner.SetupExport(t)
 


### PR DESCRIPTION
Backport of #3034 for deps update to work (like https://github.com/cilium/tetragon/pull/3136).