### PR TITLE
Add dynamic extraction of a parameter attribute

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -63,6 +63,17 @@ generic_start_process_filter(void *ctx, struct bpf_map_def *calls)
 }
 
 FUNC_INLINE int
+extract_arg_depth(u32 i, struct extract_arg_data *data)
+{
+	if (i >= MAX_BTF_ARG_DEPTH || !data->btf_config[i].is_initialized)
+		return 1;
+	*data->arg = *data->arg + data->btf_config[i].offset;
+	if (data->btf_config[i].is_pointer)
+		probe_read((void *)data->arg, sizeof(char *), (void *)*data->arg);
+	return 0;
+}
+
+FUNC_INLINE int
 generic_process_event(void *ctx, struct bpf_map_def *tailcals)
 {
 	struct msg_generic_kprobe *e;
@@ -70,6 +81,9 @@ generic_process_event(void *ctx, struct bpf_map_def *tailcals)
 	int index, zero = 0;
 	unsigned long a;
 	long ty, total;
+#ifdef __LARGE_BPF_PROG
+	struct config_btf_arg *btf_config;
+#endif /* __LARGE_BPF_PROG */
 
 	e = map_lookup_elem(&process_call_heap, &zero);
 	if (!e)
@@ -86,6 +100,25 @@ generic_process_event(void *ctx, struct bpf_map_def *tailcals)
 
 	a = (&e->a0)[index];
 	total = e->common.size;
+
+#ifdef __LARGE_BPF_PROG
+	btf_config = config->btf_arg[index];
+	if (index < EVENT_CONFIG_MAX_ARG && btf_config->is_initialized) {
+		struct extract_arg_data extract_data = {
+			.btf_config = btf_config,
+			.arg = &a,
+		};
+#ifndef __V61_BPF_PROG
+#pragma unroll
+		for (int i = 0; i < MAX_BTF_ARG_DEPTH; ++i) {
+			if (extract_arg_depth(i, &extract_data))
+				break;
+		}
+#else
+		loop(MAX_BTF_ARG_DEPTH, extract_arg_depth, &extract_data, 0);
+#endif /* __V61_BPF_PROG */
+	}
+#endif /* __LARGE_BPF_PROG */
 
 	/* Read out args1-5 */
 	ty = (&config->arg0)[index];

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -148,6 +148,20 @@ struct selector_arg_filters {
 	__u32 argoff[5];
 } __attribute__((packed));
 
+struct config_btf_arg {
+	__u32 offset;
+	__u16 is_pointer;
+	__u16 is_initialized;
+} __attribute__((packed));
+
+struct extract_arg_data {
+	struct config_btf_arg *btf_config;
+	unsigned long *arg;
+};
+
+#define MAX_BTF_ARG_DEPTH    10
+#define EVENT_CONFIG_MAX_ARG 5
+
 struct event_config {
 	__u32 func_id;
 	__s32 arg0;
@@ -178,6 +192,7 @@ struct event_config {
 	 */
 	__u32 policy_id;
 	__u32 flags;
+	struct config_btf_arg btf_arg[EVENT_CONFIG_MAX_ARG][MAX_BTF_ARG_DEPTH];
 } __attribute__((packed));
 
 #define MAX_ARGS_SIZE	 80

--- a/examples/tracingpolicy/lsm_track_grandparent.yml
+++ b/examples/tracingpolicy/lsm_track_grandparent.yml
@@ -1,0 +1,14 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "lsm"
+spec:
+  lsmhooks:
+  - hook: "bprm_check_security"
+    args:
+      - index: 0
+        type: "string"
+        resolve: "mm.owner.real_parent.real_parent.comm"
+    selectors:
+      - matchActions:
+        - action: Post

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -139,6 +139,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -239,6 +243,10 @@ spec:
                             will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                             supports fetching up to 327360 bytes if this flag is turned on
                           type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
                         returnCopy:
                           default: false
                           description: |-
@@ -854,6 +862,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -1506,6 +1518,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -2093,6 +2109,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -139,6 +139,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -239,6 +243,10 @@ spec:
                             will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                             supports fetching up to 327360 bytes if this flag is turned on
                           type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
                         returnCopy:
                           default: false
                           description: |-
@@ -854,6 +862,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -1506,6 +1518,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -2093,6 +2109,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -597,17 +597,25 @@ type KprobeArgs struct {
 	Args4 []byte
 }
 
+type ConfigBtfArg struct {
+	Offset        uint32 `align:"offset"`
+	IsPointer     uint16 `align:"is_pointer"`
+	IsInitialized uint16 `align:"is_initialized"`
+}
+
 const EventConfigMaxArgs = 5
+const MaxBtfArgDepth = 10 // Artificial value for compilation, may be extended
 
 type EventConfig struct {
-	FuncId          uint32                     `align:"func_id"`
-	Arg             [EventConfigMaxArgs]int32  `align:"arg0"`
-	ArgM            [EventConfigMaxArgs]uint32 `align:"arg0m"`
-	ArgTpCtxOff     [EventConfigMaxArgs]uint32 `align:"t_arg0_ctx_off"`
-	Syscall         uint32                     `align:"syscall"`
-	ArgReturnCopy   int32                      `align:"argreturncopy"`
-	ArgReturn       int32                      `align:"argreturn"`
-	ArgReturnAction int32                      `align:"argreturnaction"`
-	PolicyID        uint32                     `align:"policy_id"`
-	Flags           uint32                     `align:"flags"`
+	FuncId          uint32                                           `align:"func_id"`
+	Arg             [EventConfigMaxArgs]int32                        `align:"arg0"`
+	ArgM            [EventConfigMaxArgs]uint32                       `align:"arg0m"`
+	ArgTpCtxOff     [EventConfigMaxArgs]uint32                       `align:"t_arg0_ctx_off"`
+	Syscall         uint32                                           `align:"syscall"`
+	ArgReturnCopy   int32                                            `align:"argreturncopy"`
+	ArgReturn       int32                                            `align:"argreturn"`
+	ArgReturnAction int32                                            `align:"argreturnaction"`
+	PolicyID        uint32                                           `align:"policy_id"`
+	Flags           uint32                                           `align:"flags"`
+	BtfArg          [EventConfigMaxArgs][MaxBtfArgDepth]ConfigBtfArg `align:"btf_arg"`
 }

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -219,6 +219,8 @@ func processMembers(
 	if t, ok := currentType.(*btf.Pointer); ok {
 		(*btfArgs)[i].IsPointer = uint16(1)
 		currentType = t.Target
+	} else if _, ok := currentType.(*btf.Int); ok {
+		(*btfArgs)[i].IsPointer = uint16(1)
 	}
 	return &currentType, nil
 }

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -105,6 +105,16 @@ func GetCachedBTFFile() string {
 	return btfFile
 }
 
+func LoadBTF() (*btf.Spec, error) {
+	if btfFile != "" {
+		return NewBTF()
+	}
+	if err := InitCachedBTF(defaults.DefaultTetragonLib, ""); err != nil {
+		return nil, err
+	}
+	return NewBTF()
+}
+
 func ResolveNestedTypes(ty btf.Type) btf.Type {
 	switch t := ty.(type) {
 	case *btf.Restrict:

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
+	"strings"
 
 	"github.com/cilium/ebpf/btf"
+	api "github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/option"
@@ -100,4 +103,122 @@ func InitCachedBTF(lib, btf string) error {
 
 func GetCachedBTFFile() string {
 	return btfFile
+}
+
+func ResolveNestedTypes(ty btf.Type) btf.Type {
+	switch t := ty.(type) {
+	case *btf.Restrict:
+		return ResolveNestedTypes(t.Type)
+	case *btf.Volatile:
+		return ResolveNestedTypes(t.Type)
+	case *btf.Const:
+		return ResolveNestedTypes(t.Type)
+	case *btf.Typedef:
+		return ResolveNestedTypes(t.Type)
+	}
+	return ty
+}
+
+// ResolveBtfPath function recursively search in a btf structure in order to
+// found a specific path until it reach the target or fail.
+
+// The function also search in embedded anonymous structures or unions to cover as
+// much use cases as possible. For instance, mm_struct have 2 fields, anonymous
+// struct and another type. But you are still able to look into the anonymous
+// struct by specifying a path like "mm.pgd.pgd".
+
+// @btfArgs: dest array for storing btf informations to reach the target on the
+// bpf side.
+// @currentType: The current type being proccessed, starts with root type.
+// @pathToFound: The string representation of the path to reach in the structures.
+// @i: The current depth, until last element of pathToFound.
+
+// Return: The last type found matching the path, or error.
+func ResolveBtfPath(
+	btfArgs *[api.MaxBtfArgDepth]api.ConfigBtfArg,
+	currentType btf.Type,
+	pathToFound []string,
+	i int,
+) (*btf.Type, error) {
+	switch t := currentType.(type) {
+	case *btf.Struct:
+		return processMembers(btfArgs, currentType, t.Members, pathToFound, i)
+	case *btf.Union:
+		return processMembers(btfArgs, currentType, t.Members, pathToFound, i)
+	case *btf.Pointer:
+		if len(pathToFound[i]) == 0 {
+			(*btfArgs)[i].IsPointer = uint16(1)
+			(*btfArgs)[i].IsInitialized = uint16(1)
+			return ResolveBtfPath(btfArgs, ResolveNestedTypes(t.Target), pathToFound, i+1)
+		}
+		(*btfArgs)[i-1].IsPointer = uint16(1)
+		return ResolveBtfPath(btfArgs, ResolveNestedTypes(t.Target), pathToFound, i)
+	default:
+		ty := currentType.TypeName()
+		if len(ty) == 0 {
+			ty = reflect.TypeOf(currentType).String()
+		}
+		currentPath := pathToFound[i]
+		if i > 0 {
+			currentPath = pathToFound[i-1]
+		}
+		return nil, fmt.Errorf("Unexpected type : %q has type %q", currentPath, ty)
+	}
+}
+
+func processMembers(
+	btfArgs *[api.MaxBtfArgDepth]api.ConfigBtfArg,
+	currentType btf.Type,
+	members []btf.Member,
+	pathToFound []string,
+	i int,
+) (*btf.Type, error) {
+	var lastError error
+	memberWasFound := false
+	for _, member := range members {
+		if len(member.Name) == 0 { // If anonymous struct, fallthrough
+			(*btfArgs)[i].Offset = member.Offset.Bytes()
+			(*btfArgs)[i].IsInitialized = uint16(1)
+			lastTy, err := ResolveBtfPath(btfArgs, ResolveNestedTypes(member.Type), pathToFound, i)
+			if err != nil {
+				if lastError != nil {
+					idx := i + 1
+					// If the error raised originates from a depth greater than the current one, we stop the search.
+					if idx < len(pathToFound) && strings.Contains(lastError.Error(), pathToFound[idx]) {
+						break
+					}
+				}
+				lastError = err
+				continue
+			}
+			return lastTy, nil
+		}
+		if member.Name == pathToFound[i] {
+			memberWasFound = true
+			(*btfArgs)[i].Offset = member.Offset.Bytes()
+			(*btfArgs)[i].IsInitialized = uint16(1)
+			isNotLastChild := i < len(pathToFound)-1 && i < api.MaxBtfArgDepth
+			if isNotLastChild {
+				return ResolveBtfPath(btfArgs, ResolveNestedTypes(member.Type), pathToFound, i+1)
+			}
+			currentType = ResolveNestedTypes(member.Type)
+			break
+		}
+	}
+	if !memberWasFound {
+		if lastError != nil {
+			return nil, lastError
+		}
+		return nil, fmt.Errorf(
+			"Attribute %q not found in structure %q found %v",
+			pathToFound[i],
+			currentType.TypeName(),
+			members,
+		)
+	}
+	if t, ok := currentType.(*btf.Pointer); ok {
+		(*btfArgs)[i].IsPointer = uint16(1)
+		currentType = t.Target
+	}
+	return &currentType, nil
 }

--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -7,8 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/cilium/ebpf/btf"
+	api "github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
@@ -202,4 +206,312 @@ func TestFindBtfFuncParamFromHook(t *testing.T) {
 	expectedName = "p"
 	err = genericTestFindBtfFuncParamFromHook(t, hook, argIndex, expectedName)
 	assert.ErrorContains(t, err, fmt.Sprintf("index %d is out of range", argIndex))
+}
+
+func fatalOnError(t *testing.T, err error) {
+	if err != nil {
+		assert.Error(t, err)
+		t.Fatal(err.Error())
+	}
+}
+
+func getBtfStruct(ty btf.Type) (*btf.Struct, error) {
+	t, ok := ty.(*btf.Struct)
+	if ok {
+		return t, nil
+	}
+	return nil, fmt.Errorf("Invalid type for \"%v\", expected \"*btf.Struct\", got %q", t, reflect.TypeOf(ty).String())
+}
+
+func getBtfPointer(ty btf.Type) (*btf.Pointer, error) {
+	t, ok := ty.(*btf.Pointer)
+	if ok {
+		return t, nil
+	}
+	return nil, fmt.Errorf("Invalid type for \"%v\", expected \"*btf.Pointer\", got %q", t, reflect.TypeOf(ty).String())
+}
+
+func findMemberInBtfStruct(structTy *btf.Struct, memberName string) (*btf.Member, error) {
+	for _, member := range structTy.Members {
+		if member.Name == memberName {
+			return &member, nil
+		}
+
+		if anonymousStructTy, ok := member.Type.(*btf.Struct); ok && len(member.Name) == 0 {
+			for _, m := range anonymousStructTy.Members {
+				if m.Name == memberName {
+					return &m, nil
+				}
+			}
+		}
+
+		if unionTy, ok := member.Type.(*btf.Union); ok {
+			for _, m := range unionTy.Members {
+				if m.Name == memberName {
+					return &m, nil
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("Member %q not found in struct %v", memberName, structTy)
+}
+
+func getBtfPointerAndSetConfig(ty btf.Type, btfConfig *api.ConfigBtfArg) (*btf.Pointer, error) {
+	ptr, err := getBtfPointer(ty)
+	if err != nil {
+		return nil, err
+	}
+	btfConfig.IsInitialized = uint16(1)
+	btfConfig.IsPointer = uint16(1)
+
+	return ptr, nil
+}
+
+func getConfigAndNextType(structTy *btf.Struct, memberName string) (*btf.Type, *api.ConfigBtfArg, error) {
+	btfConfig := api.ConfigBtfArg{}
+
+	member, err := findMemberInBtfStruct(structTy, memberName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	btfConfig.Offset = uint32(member.Offset.Bytes())
+	btfConfig.IsInitialized = uint16(1)
+
+	ty := ResolveNestedTypes(member.Type)
+
+	ptr, _ := getBtfPointerAndSetConfig(ty, &btfConfig)
+	if ptr != nil {
+		return &ptr.Target, &btfConfig, err
+	}
+	if _, ok := ty.(*btf.Int); ok {
+		btfConfig.IsPointer = uint16(1)
+	}
+	return &ty, &btfConfig, err
+}
+
+func getConfigAndNextStruct(structTy *btf.Struct, memberName string) (*btf.Struct, *api.ConfigBtfArg, error) {
+	btfConfig := api.ConfigBtfArg{}
+
+	member, err := findMemberInBtfStruct(structTy, memberName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	btfConfig.Offset = uint32(member.Offset.Bytes())
+	btfConfig.IsInitialized = uint16(1)
+
+	ty := ResolveNestedTypes(member.Type)
+
+	ptr, _ := getBtfPointerAndSetConfig(ty, &btfConfig)
+	if ptr != nil {
+		t, err := getBtfStruct(ptr.Target)
+		return t, &btfConfig, err
+	}
+	t, err := getBtfStruct(ty)
+	return t, &btfConfig, err
+}
+
+func addPaddingOnNestedPtr(ty btf.Type, path []string) []string {
+	if t, ok := ty.(*btf.Pointer); ok {
+		updatedPath := append([]string{""}, path...)
+		return addPaddingOnNestedPtr(t.Target, updatedPath)
+	}
+	return path
+}
+
+func resolveNestedPtr(rootType btf.Type, btfArgs *[api.MaxBtfArgDepth]api.ConfigBtfArg, i int) (btf.Type, int) {
+	if ptr, ok := rootType.(*btf.Pointer); ok {
+		btfArgs[i] = api.ConfigBtfArg{}
+		ty, err := getBtfPointerAndSetConfig(ptr, &btfArgs[i])
+		if err != nil {
+			return ty.Target, i
+		}
+		return resolveNestedPtr(ty.Target, btfArgs, i+1)
+	}
+	return rootType, i
+}
+
+func manuallyResolveBtfPath(t *testing.T, rootType btf.Type, p []string) [api.MaxBtfArgDepth]api.ConfigBtfArg {
+	var btfArgs [api.MaxBtfArgDepth]api.ConfigBtfArg
+	var i int
+
+	rootType, i = resolveNestedPtr(rootType, &btfArgs, 0)
+
+	currentStruct, err := getBtfStruct(rootType)
+	fatalOnError(t, err)
+
+	for ; i < len(p); i++ {
+		step := p[i]
+		if len(step) == 0 {
+			btfArgs[i] = api.ConfigBtfArg{}
+			ptr, err := getBtfPointerAndSetConfig(ResolveNestedTypes(rootType), &btfArgs[i])
+			fatalOnError(t, err)
+			currentStruct, err = getBtfStruct(ptr.Target)
+			fatalOnError(t, err)
+		} else if i < len(p)-1 {
+			ty, nextConfig, err := getConfigAndNextStruct(currentStruct, step)
+			fatalOnError(t, err)
+			currentStruct = ty
+			btfArgs[i] = *nextConfig
+		} else {
+			_, nextConfig, err := getConfigAndNextType(currentStruct, step)
+			fatalOnError(t, err)
+			btfArgs[i] = *nextConfig
+			return btfArgs
+		}
+	}
+	return btfArgs
+}
+
+func buildPathFromString(t *testing.T, rootType btf.Type, pathStr string) []string {
+	pathBase := strings.Split(pathStr, ".")
+	path := addPaddingOnNestedPtr(rootType, pathBase)
+	if len(path) > api.MaxBtfArgDepth {
+		assert.Fail(t, "Unable to resolve %q. The maximum depth allowed is %d", pathStr, api.MaxBtfArgDepth)
+	}
+	return path
+}
+
+func buildResolveBtfConfig(t *testing.T, rootType btf.Type, pathStr string) [api.MaxBtfArgDepth]api.ConfigBtfArg {
+	var btfArgs [api.MaxBtfArgDepth]api.ConfigBtfArg
+
+	path := buildPathFromString(t, rootType, pathStr)
+	_, err := ResolveBtfPath(&btfArgs, rootType, path, 0)
+	fatalOnError(t, err)
+
+	return btfArgs
+}
+
+func buildExpectedBtfConfig(t *testing.T, rootType btf.Type, pathStr string) [api.MaxBtfArgDepth]api.ConfigBtfArg {
+	path := buildPathFromString(t, rootType, pathStr)
+	return manuallyResolveBtfPath(t, rootType, path)
+}
+
+func testPathIsAccessible(rootType btf.Type, strPath string) (*[api.MaxBtfArgDepth]api.ConfigBtfArg, *btf.Type, error) {
+	var btfArgs [api.MaxBtfArgDepth]api.ConfigBtfArg
+	path := strings.Split(strPath, ".")
+
+	lastBtfType, err := ResolveBtfPath(&btfArgs, ResolveNestedTypes(rootType), path, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &btfArgs, lastBtfType, nil
+}
+
+func testAssertEqualPath(t *testing.T) {
+	hook := "security_bprm_check"
+	argIndex := 0 // struct linux_binprm *bprm
+	funcParamTy, err := FindBtfFuncParamFromHook(hook, argIndex)
+	fatalOnError(t, err)
+
+	bprmTy := funcParamTy.Type
+	if ty, ok := bprmTy.(*btf.Pointer); ok {
+		bprmTy = ty.Target
+	}
+
+	// Test default behaviour
+	path := "file.f_path.dentry.d_name.name"
+	assert.Equal(t,
+		buildExpectedBtfConfig(t, bprmTy, path),
+		buildResolveBtfConfig(t, bprmTy, path),
+	)
+
+	// Test anonymous struct
+	path = "mm.arg_start"
+	assert.Equal(t,
+		buildExpectedBtfConfig(t, bprmTy, path),
+		buildResolveBtfConfig(t, bprmTy, path),
+	)
+
+	// Test Union
+	path = "file.f_inode.i_dir_seq"
+	assert.Equal(t,
+		buildExpectedBtfConfig(t, bprmTy, path),
+		buildResolveBtfConfig(t, bprmTy, path),
+	)
+
+	// Test if param is double ptr
+	hook = "security_inode_copy_up"
+	argIndex = 1 // struct cred **new
+	funcParamTy, err = FindBtfFuncParamFromHook(hook, argIndex)
+	fatalOnError(t, err)
+
+	newTy := funcParamTy.Type
+	if ty, ok := newTy.(*btf.Pointer); ok {
+		newTy = ty.Target
+	}
+	path = "uid.val"
+	assert.Equal(t,
+		buildExpectedBtfConfig(t, newTy, path),
+		buildResolveBtfConfig(t, newTy, path),
+	)
+}
+
+func testAssertPathIsAccessible(t *testing.T) {
+	hook := "wake_up_new_task"
+	argIndex := 0 //struct task_struct *p
+	funcParamTy, err := FindBtfFuncParamFromHook(hook, argIndex)
+	fatalOnError(t, err)
+
+	taskStructTy := funcParamTy.Type
+	if ty, ok := taskStructTy.(*btf.Pointer); ok {
+		taskStructTy = ty.Target
+	}
+
+	_, _, err = testPathIsAccessible(taskStructTy, "sched_task_group.css.id")
+	assert.NoError(t, err)
+
+	hook = "security_bprm_check"
+	argIndex = 0 // struct linux_binprm *bprm
+	funcParamTy, err = FindBtfFuncParamFromHook(hook, argIndex)
+	fatalOnError(t, err)
+
+	bprmTy := funcParamTy.Type
+	if ty, ok := bprmTy.(*btf.Pointer); ok {
+		bprmTy = ty.Target
+	}
+
+	_, _, err = testPathIsAccessible(bprmTy, "mm.pgd.pgd")
+	assert.NoError(t, err)
+}
+
+func testAssertErrorOnInvalidPath(t *testing.T) {
+	hook := "security_bprm_check"
+	argIndex := 0 // struct linux_binprm *bprm
+	funcParamTy, err := FindBtfFuncParamFromHook(hook, argIndex)
+	fatalOnError(t, err)
+
+	rootType := funcParamTy.Type
+	if rootTy, ok := rootType.(*btf.Pointer); ok {
+		rootType = rootTy.Target
+	}
+
+	// Assert an error is raised when attribute does not exists
+	_, _, err = testPathIsAccessible(rootType, "fail")
+	assert.ErrorContains(t, err, "Attribute \"fail\" not found in structure")
+
+	_, _, err = testPathIsAccessible(rootType, "mm.fail")
+	assert.ErrorContains(t, err, "Attribute \"fail\" not found in structure")
+
+	_, _, err = testPathIsAccessible(rootType, "mm.pgd.fail")
+	assert.ErrorContains(t, err, "Attribute \"fail\" not found in structure")
+
+	hook = "do_sys_open"
+	argIndex = 0 // int dfd
+	funcParamTy, err = FindBtfFuncParamFromHook(hook, argIndex)
+	fatalOnError(t, err)
+
+	rootType = funcParamTy.Type
+
+	// Assert an error is raised when attribute has invalid type
+	_, _, err = testPathIsAccessible(rootType, "fail")
+	assert.ErrorContains(t, err, fmt.Sprintf("Unexpected type : \"fail\" has type %q", rootType.TypeName()))
+}
+
+func TestResolveBtfPath(t *testing.T) {
+	t.Run("PathIsAccessible", testAssertPathIsAccessible)
+	t.Run("AssertErrorOnInvalidPath", testAssertErrorOnInvalidPath)
+	t.Run("AssertEqualPath", testAssertEqualPath)
 }

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -3,7 +3,11 @@
 
 package generictypes
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/btf"
+)
 
 const (
 	GenericIntType    = 1
@@ -190,6 +194,27 @@ func GenericUserToKernelType(arg int) int {
 	ty, ok := GenericUserToKernel[arg]
 	if !ok {
 		ty = GenericInvalidType
+	}
+	return ty
+}
+
+func GenericTypeFromBTF(arg btf.Type) int {
+	ty, ok := GenericStringToType[arg.TypeName()]
+	if !ok {
+		switch t := arg.(type) {
+		case *btf.Restrict:
+			return GenericTypeFromBTF(t.Type)
+		case *btf.Volatile:
+			return GenericTypeFromBTF(t.Type)
+		case *btf.Const:
+			return GenericTypeFromBTF(t.Type)
+		case *btf.Typedef:
+			return GenericTypeFromBTF(t.Type)
+		case *btf.Pointer:
+			return GenericTypeFromBTF(t.Target)
+		default:
+			return GenericInvalidType
+		}
 	}
 	return ty
 }

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -139,6 +139,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -239,6 +243,10 @@ spec:
                             will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                             supports fetching up to 327360 bytes if this flag is turned on
                           type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
                         returnCopy:
                           default: false
                           description: |-
@@ -854,6 +862,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -1506,6 +1518,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -2093,6 +2109,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -139,6 +139,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -239,6 +243,10 @@ spec:
                             will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                             supports fetching up to 327360 bytes if this flag is turned on
                           type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
                         returnCopy:
                           default: false
                           description: |-
@@ -854,6 +862,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -1506,6 +1518,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -2093,6 +2109,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -65,6 +65,10 @@ type KProbeArg struct {
 	// Argument type.
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=""
+	// Resolve the path to a specific attribute
+	Resolve string `json:"resolve"`
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=0
 	// Specifies the position of the corresponding size argument for this argument.
 	// This field is used only for char_buf and char_iovec types.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.4.1"
+const CustomResourceDefinitionSchemaVersion = "1.4.2"

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"fmt"
+	"strings"
+
+	ebtf "github.com/cilium/ebpf/btf"
+	api "github.com/cilium/tetragon/pkg/api/tracingapi"
+	"github.com/cilium/tetragon/pkg/btf"
+	gt "github.com/cilium/tetragon/pkg/generictypes"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+)
+
+func addPaddingOnNestedPtr(ty ebtf.Type, path []string) []string {
+	if t, ok := ty.(*ebtf.Pointer); ok {
+		updatedPath := append([]string{""}, path...)
+		return addPaddingOnNestedPtr(t.Target, updatedPath)
+	}
+	return path
+}
+
+func resolveBtfArg(hook string, arg v1alpha1.KProbeArg) (*ebtf.Type, [api.MaxBtfArgDepth]api.ConfigBtfArg, error) {
+	btfArg := [api.MaxBtfArgDepth]api.ConfigBtfArg{}
+
+	param, err := btf.FindBtfFuncParamFromHook(hook, int(arg.Index))
+	if err != nil {
+		return nil, btfArg, err
+	}
+
+	rootType := param.Type
+	if rootTy, isPointer := param.Type.(*ebtf.Pointer); isPointer {
+		rootType = rootTy.Target
+	}
+
+	pathBase := strings.Split(arg.Resolve, ".")
+	path := addPaddingOnNestedPtr(rootType, pathBase)
+	if len(path) > api.MaxBtfArgDepth {
+		return nil, btfArg, fmt.Errorf("Unable to resolve %q. The maximum depth allowed is %d", arg.Resolve, api.MaxBtfArgDepth)
+	}
+
+	lastBtfType, err := resolveBtfPath(&btfArg, btf.ResolveNestedTypes(rootType), path)
+	return lastBtfType, btfArg, err
+}
+
+func resolveBtfPath(btfArg *[api.MaxBtfArgDepth]api.ConfigBtfArg, rootType ebtf.Type, path []string) (*ebtf.Type, error) {
+	return btf.ResolveBtfPath(btfArg, rootType, path, 0)
+}
+
+func findTypeFromBtfType(arg v1alpha1.KProbeArg, btfType *ebtf.Type) int {
+	ty := gt.GenericTypeFromBTF(*btfType)
+	if ty == gt.GenericInvalidType {
+		return gt.GenericTypeFromString(arg.Type)
+	}
+	return ty
+}

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"testing"
+
+	api "github.com/cilium/tetragon/pkg/api/tracingapi"
+	gt "github.com/cilium/tetragon/pkg/generictypes"
+	"github.com/cilium/tetragon/pkg/tracingpolicy"
+	"github.com/stretchr/testify/assert"
+)
+
+// This test attempt to test the Resolve flag in tracing policies.
+//   - The 2 first hooks assert no error occures when searching for the BTF config
+//   - The last test is used to assert an error occures when path length is
+//     higher than api.MaxBtfArgDepth
+func TestResolveBtfArgFromKprobePolicy(t *testing.T) {
+	rawPolicy := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "kprobes"
+spec:
+  kprobes:
+  - call: "security_bprm_check"
+    args:
+    - index: 0
+      type: "int"
+      resolve: 'mm.arg_start'
+  - call: "security_inode_copy_up"
+    args:
+    - index: 0
+      type: "uint32"
+      resolve: 'd_flags'
+    - index: 1
+      type: "int"
+      resolve: 'user.uid.val'
+  - call: "security_bprm_check"
+    args:
+    - index: 0
+      type: "string"
+      resolve: 'mm.owner.real_parent.real_parent.real_parent.real_parent.real_parent.real_parent.real_parent.real_parent.comm'
+  `
+	policy, err := tracingpolicy.FromYAML(rawPolicy)
+	assert.NoError(t, err, "FromYAML rawPolicy error %q", err)
+
+	successHook := policy.TpSpec().KProbes[:2]
+	for _, hook := range successHook {
+		for _, arg := range hook.Args {
+			lastBtfType, btfArg, err := resolveBtfArg(hook.Call, arg)
+
+			if err != nil {
+				t.Fatal(hook.Call, err)
+			}
+			assert.NotNil(t, lastBtfType)
+			assert.NotNil(t, btfArg)
+
+			argType := findTypeFromBtfType(arg, lastBtfType)
+			assert.NotEqual(t, gt.GenericInvalidType, argType, "Type %q is not supported", (*lastBtfType).TypeName())
+		}
+	}
+
+	failHook := policy.TpSpec().KProbes[2]
+	for _, arg := range failHook.Args {
+		_, _, err := resolveBtfArg(failHook.Call, arg)
+
+		if !assert.ErrorContains(t, err, "The maximum depth allowed is") {
+			t.Fatalf("The path %q must have len < %d", arg.Resolve, api.MaxBtfArgDepth)
+		}
+	}
+}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -693,6 +693,7 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 	var setRetprobe bool
 	var argRetprobe *v1alpha1.KProbeArg
 	var argsBTFSet [api.MaxArgsSupported]bool
+	var allBtfArgs [api.EventConfigMaxArgs][api.MaxBtfArgDepth]api.ConfigBtfArg
 
 	errFn := func(err error) (idtable.EntryID, error) {
 		return idtable.UninitializedEntryID, err
@@ -759,6 +760,18 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 			argType = gt.GenericTypeFromString(a.Type)
 		}
 
+		if a.Resolve != "" && j < api.EventConfigMaxArgs {
+			if !bpf.HasProgramLargeSize() {
+				return errFn(fmt.Errorf("Error: Resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag"))
+			}
+			lastBtfType, btfArg, err := resolveBtfArg(f.Call, a)
+			if err != nil {
+				return errFn(fmt.Errorf("Error on hook %q for index %d : %v", f.Call, a.Index, err))
+			}
+			allBtfArgs[j] = btfArg
+			argType = findTypeFromBtfType(a, lastBtfType)
+		}
+
 		if argType == gt.GenericInvalidType {
 			return errFn(fmt.Errorf("Arg(%d) type '%s' unsupported", j, a.Type))
 		}
@@ -782,6 +795,7 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 			return errFn(fmt.Errorf("Error add arg: ArgType %s Index %d out of bounds",
 				a.Type, int(a.Index)))
 		}
+		config.BtfArg = allBtfArgs
 		config.Arg[a.Index] = int32(argType)
 		config.ArgM[a.Index] = uint32(argMValue)
 

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -242,6 +242,12 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 			if !bpf.HasProgramLargeSize() {
 				return errFn(fmt.Errorf("Error: Resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag"))
 			}
+			if !kernels.MinKernelVersion("5.7.0") {
+				// bpf_lsm_<hook_name> does not exist in BTF file before 5.7
+				// https://lore.kernel.org/bpf/20200329004356.27286-4-kpsingh@chromium.org/
+				return errFn(fmt.Errorf("Error: LSM programs can not use Resolve flag for your kernel version." +
+					"Please use Kprobe instead or update your kernel to version 5.7 or higher"))
+			}
 			lastBtfType, btfArg, err := resolveBtfArg("bpf_lsm_"+f.Hook, a)
 			if err != nil {
 				return errFn(fmt.Errorf("Error on hook %q for index %d : %v", f.Hook, a.Index, err))

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -209,6 +209,7 @@ type addLsmIn struct {
 func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err error) {
 	var argSigPrinters []argPrinter
 	var argsBTFSet [api.MaxArgsSupported]bool
+	var allBtfArgs [api.EventConfigMaxArgs][api.MaxBtfArgDepth]api.ConfigBtfArg
 
 	errFn := func(err error) (idtable.EntryID, error) {
 		return idtable.UninitializedEntryID, err
@@ -236,9 +237,23 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 	// Parse Arguments
 	for j, a := range f.Args {
 		argType := gt.GenericTypeFromString(a.Type)
+
+		if a.Resolve != "" && j < api.EventConfigMaxArgs {
+			if !bpf.HasProgramLargeSize() {
+				return errFn(fmt.Errorf("Error: Resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag"))
+			}
+			lastBtfType, btfArg, err := resolveBtfArg("bpf_lsm_"+f.Hook, a)
+			if err != nil {
+				return errFn(fmt.Errorf("Error on hook %q for index %d : %v", f.Hook, a.Index, err))
+			}
+			allBtfArgs[j] = btfArg
+			argType = findTypeFromBtfType(a, lastBtfType)
+		}
+
 		if argType == gt.GenericInvalidType {
 			return errFn(fmt.Errorf("Arg(%d) type '%s' unsupported", j, a.Type))
 		}
+
 		if a.MaxData {
 			if argType != gt.GenericCharBuffer {
 				logger.GetLogger().Warnf("maxData flag is ignored (supported for char_buf type)")
@@ -263,6 +278,7 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 		argSigPrinters = append(argSigPrinters, argP)
 	}
 
+	config.BtfArg = allBtfArgs
 	config.ArgReturn = int32(0)
 	config.ArgReturnCopy = int32(0)
 

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -341,6 +341,10 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 			return nil, fmt.Errorf("Error add arg: ArgType %s Index %d out of bounds",
 				a.Type, int(a.Index))
 		}
+
+		if a.Resolve != "" {
+			return nil, fmt.Errorf("Resolving attributes for Uprobes is not supported")
+		}
 		argTypes[a.Index] = int32(argType)
 		argMeta[a.Index] = uint32(argMValue)
 		argSet[a.Index] = true

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -139,6 +139,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -239,6 +243,10 @@ spec:
                             will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                             supports fetching up to 327360 bytes if this flag is turned on
                           type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
                         returnCopy:
                           default: false
                           description: |-
@@ -854,6 +862,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -1506,6 +1518,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -2093,6 +2109,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -139,6 +139,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -239,6 +243,10 @@ spec:
                             will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                             supports fetching up to 327360 bytes if this flag is turned on
                           type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
                         returnCopy:
                           default: false
                           description: |-
@@ -854,6 +862,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -1506,6 +1518,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-
@@ -2093,6 +2109,10 @@ spec:
                               will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
                               supports fetching up to 327360 bytes if this flag is turned on
                             type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
                           returnCopy:
                             default: false
                             description: |-

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -65,6 +65,10 @@ type KProbeArg struct {
 	// Argument type.
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=""
+	// Resolve the path to a specific attribute
+	Resolve string `json:"resolve"`
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=0
 	// Specifies the position of the corresponding size argument for this argument.
 	// This field is used only for char_buf and char_iovec types.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.4.1"
+const CustomResourceDefinitionSchemaVersion = "1.4.2"


### PR DESCRIPTION
The discussion for this PR can be found here https://github.com/cilium/tetragon/issues/3142

Take this PR in the today state as a proof of concept for dynamic parameter extraction. I will continue to work on this PR until the below checks are done.

At the current state, the PR is able to
- [x] Extract parameters from LSM programs
- [x] Extract parameters from kprobes programs
- [x] Handle exception for uprobes as it is not part of BTF
- [x] Have unit tests for all cases
- [x] - Validate CI for all kernel versions

### Description
This PR introduce the dynamic extraction of a custom attribute

### Test the PR

You can use the following config
```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "lsm"
spec:
  lsmhooks:
  - hook: "bprm_check_security"
    args:
      - index: 0
        type: "string"
        resolve: "file.f_path.dentry.d_name.name"
    selectors:
      - matchArgs:
        - index: 0
          operator: "Postfix"
          values:
            - "ls"
            - "sh"
            - "bash"
```

### Release-note

```release-note
Add attribute resolution
```