### PR TITLE
Backports/v1.1: fix enforcer test

### DIFF
--- a/pkg/sensors/tracing/enforcer_test.go
+++ b/pkg/sensors/tracing/enforcer_test.go
@@ -294,7 +294,7 @@ func testSecurity(t *testing.T, tracingPolicy, tempFile string) {
 	}
 }
 
-func enforcerSecurityTempFile(t *testing.T) string {
+func directWriteTempFile(t *testing.T) string {
 	// We can't use t.TempDir as it writes into /tmp by default.
 	// The direct-write-tester.c program opens and writes using the O_DIRECT
 	// flag that is unsupported and return EINVAL on tmpfs, while it works on a
@@ -339,7 +339,7 @@ func TestEnforcerSecuritySigKill(t *testing.T) {
 		t.Skip("Older kernels do not support matchArgs for more than one arguments")
 	}
 
-	tempFile := enforcerSecurityTempFile(t)
+	tempFile := directWriteTempFile(t)
 
 	tracingPolicy := `
 apiVersion: cilium.io/v1alpha1
@@ -426,7 +426,7 @@ func TestEnforcerSecurityNotifyEnforcer(t *testing.T) {
 		t.Skip("Older kernels do not support matchArgs for more than one arguments")
 	}
 
-	tempFile := enforcerSecurityTempFile(t)
+	tempFile := directWriteTempFile(t)
 
 	tracingPolicy := `
 apiVersion: cilium.io/v1alpha1


### PR DESCRIPTION
Couple of backports (see commits) to help #3140.