### PR TITLE
ProcessCache: Disable interval test in VM

### DIFF
--- a/pkg/vmtests/skip.go
+++ b/pkg/vmtests/skip.go
@@ -19,6 +19,7 @@ type skipRule struct {
 var rules = []skipRule{
 	skipRule{TestNameRe: "pkg.sensors.tracing.TestLoader", KernelRe: "(6\\.6|6\\.1)"},
 	skipRule{TestNameRe: "pkg.tracepoint.TestTracepointLoadFormat", KernelRe: "(6\\.1|bpf-next)"},
+	skipRule{TestNameRe: "pkg.sensors.exec.TestProcessCacheInterval", KernelRe: ""},
 }
 
 func init() {


### PR DESCRIPTION
The TestProcessCacheInterval test is flaky in VMs, probably because it relies on timing. This commit disables the test in the vmtests.
