### PR TITLE
cgtracker: add policyfilter support

### DIFF
--- a/bpf/process/policy_filter.h
+++ b/bpf/process/policy_filter.h
@@ -5,6 +5,7 @@
 #define POLICY_FILTER_MAPS_H__
 
 #include "bpf_tracing.h"
+#include "cgroup/cgtracker.h"
 
 #define POLICY_FILTER_MAX_POLICIES   128
 #define POLICY_FILTER_MAX_NAMESPACES 1024
@@ -35,7 +36,7 @@ struct {
 FUNC_INLINE bool policy_filter_check(u32 policy_id)
 {
 	void *policy_map;
-	__u64 cgroupid;
+	__u64 cgroupid, trackerid;
 
 	if (!policy_id)
 		return true;
@@ -47,6 +48,10 @@ FUNC_INLINE bool policy_filter_check(u32 policy_id)
 	cgroupid = tg_get_current_cgroup_id();
 	if (!cgroupid)
 		return false;
+
+	trackerid = cgrp_get_tracker_id(cgroupid);
+	if (trackerid)
+		cgroupid = trackerid;
 
 	return map_lookup_elem(policy_map, &cgroupid);
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/tetragon/pkg/arch"
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/btf"
+	"github.com/cilium/tetragon/pkg/cgtracker"
 	"github.com/cilium/tetragon/pkg/eventhandler"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/idtable"
@@ -363,6 +364,10 @@ func createMultiKprobeSensor(policyName string, multiIDs []idtable.EntryID, has 
 
 	if has.enforcer {
 		maps = append(maps, enforcerMapsUser(load)...)
+	}
+
+	if option.Config.EnableCgTrackerID {
+		maps = append(maps, program.MapUser(cgtracker.MapName, load))
 	}
 
 	filterMap.SetMaxEntries(len(multiIDs))
@@ -990,6 +995,10 @@ func createKprobeSensorFromEntry(kprobeEntry *genericKprobe,
 
 	if has.enforcer {
 		maps = append(maps, enforcerMapsUser(load)...)
+	}
+
+	if option.Config.EnableCgTrackerID {
+		maps = append(maps, program.MapUser(cgtracker.MapName, load))
 	}
 
 	overrideTasksMap := program.MapBuilderProgram("override_tasks", load)

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
+	"github.com/cilium/tetragon/pkg/cgtracker"
 	"github.com/cilium/tetragon/pkg/eventhandler"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/idtable"
@@ -572,6 +573,10 @@ func createGenericTracepointSensor(
 
 		if has.enforcer {
 			maps = append(maps, enforcerMapsUser(prog0)...)
+		}
+
+		if option.Config.EnableCgTrackerID {
+			maps = append(maps, program.MapUser(cgtracker.MapName, prog0))
 		}
 
 		selMatchBinariesMap := program.MapBuilderProgram("tg_mb_sel_opts", prog0)

--- a/pkg/testutils/perfring/perfring.go
+++ b/pkg/testutils/perfring/perfring.go
@@ -197,6 +197,25 @@ func RunTestEventReduce[K any, V any](
 	return ret
 }
 
+func RunTestEventReduceCount[K comparable](
+	t *testing.T,
+	ctx context.Context,
+	selfOperations func(),
+	filterFn func(notify.Message) bool,
+	mapFn func(notify.Message) K,
+) map[K]int {
+	return RunTestEventReduce[K, map[K]int](
+		t, ctx, selfOperations, filterFn, mapFn,
+		func(v map[K]int, k K) map[K]int {
+			if v == nil {
+				v = make(map[K]int)
+			}
+			v[k]++
+			return v
+		},
+	)
+}
+
 // similar to RunTest, but uses t.Run()
 func RunSubTest(t *testing.T, ctx context.Context, name string, selfOperations func(t *testing.T), eventFn EventFn) bool {
 	return t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
This PR is a follow-up of https://github.com/cilium/tetragon/pull/3170.

#3170 added pod association using cgroup tracking.
This PR adds policy filtering using cgroup tracking.

This means that namespaced policies and policies with pod-label filters will work with nested cgroups (when cgtracker is enabled). 

See commits.