### PR TITLE
[sensors] Add optional PostLoadHook

### DIFF
--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -182,6 +182,12 @@ func (s *Sensor) Load(bpfDir string) (err error) {
 	progsAdd(s.Progs)
 	AllMaps = append(AllMaps, s.Maps...)
 
+	if s.PostLoadHook != nil {
+		if err := s.PostLoadHook(); err != nil {
+			logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Post load hook failed")
+		}
+	}
+
 	// cleanup the BTF once we have loaded all sensor's program
 	btf.FlushKernelSpec()
 

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -57,6 +57,10 @@ type Sensor struct {
 	Loaded bool
 	// Destroyed indicates whether the sensor had been destroyed.
 	Destroyed bool
+	// PostLoadHook can optionally contain a pointer to a function to be
+	// called during sensor loading, after the programs and maps being
+	// loaded.
+	PostLoadHook SensorHook
 	// PreUnloadHook can optionally contain a pointer to a function to be
 	// called during sensor unloading, prior to the programs and maps being
 	// unloaded.


### PR DESCRIPTION
This will provide the ability to run sensor-specific code right after loading all maps/programs.

This can be used for cleanup etc.
