### PR TITLE
tetragon: setup to let match binary names use args as well

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -277,6 +277,8 @@ struct heap_exe {
 	char end[STRING_POSTFIX_MAX_LENGTH];
 	__u32 len;
 	__u32 error;
+	__u32 arg_len;
+	__u32 arg_start;
 }; // All fields aligned so no 'packed' attribute.
 
 struct msg_execve_event {
@@ -322,6 +324,8 @@ struct binary {
 	char end[STRING_POSTFIX_MAX_LENGTH];
 	// STRING_POSTFIX_MAX_LENGTH reversed last bytes of the path
 	char end_r[STRING_POSTFIX_MAX_LENGTH];
+	// args for the binary
+	char args[MAXARGLENGTH];
 	// matchBinary bitset for binary
 	// NB: everything after and including ->mb_bitset will not be zeroed on a new exec. See
 	// binary_reset().

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -46,6 +46,7 @@ const (
 	MSG_COMMON_FLAG_IMA_HASH          = 0x8
 
 	BINARY_PATH_MAX_LEN = 256
+	MAX_ARG_LENGTH      = 256
 
 	STRING_POSTFIX_MAX_LENGTH = 128
 )
@@ -158,6 +159,7 @@ type Binary struct {
 	Path       [BINARY_PATH_MAX_LEN]byte
 	End        [STRING_POSTFIX_MAX_LENGTH]byte
 	End_r      [STRING_POSTFIX_MAX_LENGTH]byte
+	Args       [MAX_ARG_LENGTH]byte
 	MBSet      uint64
 }
 


### PR DESCRIPTION
Setting up ability to match args as well as binary names. This is useful for matching 'java beaches.jar' or 'python palmTree.py' where the binary itself is an interpretor and the actual thing being called is what matters.