### PR TITLE
Aggregate overhead metrics in userspace before reporting

### DIFF
--- a/pkg/metrics/overhead/overhead.go
+++ b/pkg/metrics/overhead/overhead.go
@@ -15,9 +15,9 @@ var (
 		nil, nil, []metrics.UnconstrainedLabel{
 			metrics.LabelPolicyNamespace,
 			metrics.LabelPolicy,
-			metrics.UnconstrainedLabel{Name: "sensor", ExampleValue: "generic_kprobe"},
-			metrics.UnconstrainedLabel{Name: "attach", ExampleValue: "sys_open"},
-			metrics.UnconstrainedLabel{Name: "section", ExampleValue: "kprobe/sys_open"},
+			{Name: "sensor", ExampleValue: "generic_kprobe"},
+			{Name: "attach", ExampleValue: "sys_open"},
+			{Name: "section", ExampleValue: "kprobe/sys_open"},
 		},
 	))
 
@@ -27,9 +27,9 @@ var (
 		nil, nil, []metrics.UnconstrainedLabel{
 			metrics.LabelPolicyNamespace,
 			metrics.LabelPolicy,
-			metrics.UnconstrainedLabel{Name: "sensor", ExampleValue: "generic_kprobe"},
-			metrics.UnconstrainedLabel{Name: "attach", ExampleValue: "sys_open"},
-			metrics.UnconstrainedLabel{Name: "section", ExampleValue: "kprobe/sys_open"},
+			{Name: "sensor", ExampleValue: "generic_kprobe"},
+			{Name: "attach", ExampleValue: "sys_open"},
+			{Name: "section", ExampleValue: "kprobe/sys_open"},
 		},
 	))
 )

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -93,14 +93,18 @@ func sanitize(name string) string {
 	return strings.ReplaceAll(name, "/", "_")
 }
 
-type ProgOverhead struct {
+type Prog struct {
 	Namespace string
 	Policy    string
 	Sensor    string
 	Attach    string
 	Label     string
-	RunTime   uint64
-	RunCnt    uint64
+}
+
+type ProgOverhead struct {
+	Prog
+	RunTime uint64
+	RunCnt  uint64
 }
 
 // SensorIface is an interface for sensors.Sensor that allows implementing sensors for testing.
@@ -131,9 +135,11 @@ func (s *Sensor) Overhead() ([]ProgOverhead, bool) {
 		runCnt, _ := info.RunCount()
 
 		list = append(list, ProgOverhead{
-			Attach:  p.Attach,
-			Label:   p.Label,
-			Sensor:  s.Name,
+			Prog: Prog{
+				Attach: p.Attach,
+				Label:  p.Label,
+				Sensor: s.Name,
+			},
 			RunTime: uint64(runTime),
 			RunCnt:  runCnt,
 		})


### PR DESCRIPTION
This is done to avoid duplicate metrics, that would cause the entire metrics collection job to fail.