### PR TITLE
tetra: Fix tetra debug progs fail

### DIFF
--- a/cmd/tetra/debug/progs.go
+++ b/cmd/tetra/debug/progs.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"text/tabwriter"
 	"time"
@@ -330,6 +331,9 @@ func getTetragonProgs(base string) ([]*prog, error) {
 			}
 			if finfo.IsDir() {
 				return nil
+			}
+			if strings.HasSuffix(path, "/link") || strings.HasSuffix(path, "/link_override") {
+				return nil // skip BPF links, they make the syscall fail since cilium/ebpf@78074c59
 			}
 			p, err := ebpf.LoadPinnedProgram(path, nil)
 			if err != nil {

--- a/docs/content/en/docs/concepts/performance-stats.md
+++ b/docs/content/en/docs/concepts/performance-stats.md
@@ -70,9 +70,8 @@ Ovh(%)  Id      Cnt     Time    Name            Pin
 ...
 ```
 
-Above commands should run properly on top of the tetragon sources.
-At the moment to run it properly under Kubernetes you need to specify extra
-directory flags:
+The bpffs mount and iterator object path are auto detected by default, but
+it's possible to override them with --bpf-lib and and --bpf-lib options, like:
 
 ```shell
 kubectl exec -ti -n kube-system tetragon-66rk4 -c tetragon -- tetra debug progs --bpf-dir /run/cilium/bpffs/tetragon/ --all --bpf-lib /var/lib/tetragon/
@@ -106,8 +105,8 @@ Aliases:
 
 Flags:
       --all              Get all programs
-      --bpf-dir string   Location of bpffs tetragon directory (default "/sys/fs/bpf/tetragon")
-      --bpf-lib string   Location of Tetragon libs (btf and bpf files) (default "bpf/objs/")
+      --bpf-dir string   Location of bpffs tetragon directory (auto detect by default)
+      --bpf-lib string   Location of Tetragon libs, btf and bpf files (auto detect by default)
   -h, --help             help for progs
       --no-clear         Do not clear screen between rounds
       --once             Run in one shot mode

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.28.0
+	golang.org/x/term v0.27.0
 	golang.org/x/time v0.8.0
 	google.golang.org/grpc v1.69.0
 	google.golang.org/protobuf v1.35.2
@@ -155,7 +156,6 @@ require (
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
-	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/tools v0.27.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/pkg/bugtool/maps.go
+++ b/pkg/bugtool/maps.go
@@ -160,7 +160,7 @@ func mapIDsFromPinnedProgs(path string) (iter.Seq[int], error) {
 		if d.IsDir() {
 			return nil // skip directories
 		}
-		if strings.HasSuffix(path, "link") {
+		if strings.HasSuffix(path, "/link") || strings.HasSuffix(path, "/link_override") {
 			return nil // skip BPF links, they make the syscall fail since cilium/ebpf@78074c59
 		}
 		prog, err := ebpf.LoadPinnedProgram(path, nil)


### PR DESCRIPTION
Recent ebpf changes make ebpf.LoadPinnedProgram fail on opening link path. We want to open only programs, so failing on opening links/maps is fine ad we just want to continue scanning.

Fixes: https://github.com/cilium/tetragon/issues/3234