### PR TITLE
[fix] fix probe_read_str return type

### DIFF
--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -130,7 +130,7 @@ FUNC_INLINE __u32
 read_path(void *ctx, struct msg_execve_event *event, void *filename)
 {
 	struct msg_process *p = &event->process;
-	__u32 size = 0;
+	int size = 0;
 	__u32 flags = 0;
 	char *earg;
 


### PR DESCRIPTION
Fixes potential bug

Since size is an unsigned type (__u32), it will never be less than 0. Therefore, the following code logic will never be executed:

```c
__u32 size = 0;

if (size < 0) {
    flags |= EVENT_ERROR_FILENAME;
    size = 0;
}
```