### PR TITLE
[optimize] Avoid heavy  kallsyms load multiple times

### DIFF
--- a/pkg/ksyms/ksyms.go
+++ b/pkg/ksyms/ksyms.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/option"
@@ -18,8 +19,17 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
+var (
+	ksymsInstance *Ksyms
+	ksymsOnce     sync.Once
+	ksymsErr      error
+)
+
 func KernelSymbols() (*Ksyms, error) {
-	return NewKsyms(option.Config.ProcFS)
+	ksymsOnce.Do(func() {
+		ksymsInstance, ksymsErr = NewKsyms(option.Config.ProcFS)
+	})
+	return ksymsInstance, ksymsErr
 }
 
 type ksym struct {


### PR DESCRIPTION
Optimize heavy kallsyms initialization using sync.Once

### Description

Improve the performance by caching the result of NewKsyms operation using
sync.Once to ensure it's only executed once.

In current implement，kallsyms will be loaded multiple times

eg:
```
ksyms.NewKsyms (/home/arthur/tetra/tetragon-1.2.1/pkg/ksyms/ksyms.go:62)
ksyms.KernelSymbols (/home/arthur/tetra/tetragon-1.2.1/pkg/ksyms/ksyms.go:22)
base.setupPrograms (/home/arthur/tetra/tetragon-1.2.1/pkg/sensors/base/base.go:104)
base.GetInitialSensor.func1 (/home/arthur/tetra/tetragon-1.2.1/pkg/sensors/base/base.go:170)
```

and  multiple times in btf.ValidateKprobeSpec in every probe calls

```
ksyms.KernelSymbols (/home/arthur/tetra/tetragon-1.2.1/pkg/ksyms/ksyms.go:32)
btf.ValidateKprobeSpec (/home/arthur/tetra/tetragon-1.2.1/pkg/btf/validation.go:51)
tracing.preValidateKprobes (/home/arthur/tetra/tetragon-1.2.1/pkg/sensors/tracing/generickprobe.go:512)
```

and tracing...

### Changelog

```release-note
optimize kallsyms initialization using sync.Once
```
