### PR TITLE
docs: remove redundance CLI command in tracing policy example

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/example.md
+++ b/docs/content/en/docs/concepts/tracing-policy/example.md
@@ -150,7 +150,7 @@ remove the BPF programs.
 
 Once the Tetragon starts, you can monitor events using `tetra`, the tetragon CLI:
 ```shell
-./tetra tetra getevents -o compact
+./tetra getevents -o compact
 ```
 
 Reading the `/tmp/tetragon` file with `cat`:


### PR DESCRIPTION
Doc update

### Description
docs: remove redundant  CLI command in tracing policy example
