### PR TITLE
refactor: remove deprecated installTailCalls function and its usage

### DIFF
--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -692,44 +692,6 @@ func slimVerifierError(errStr string) string {
 	return errStr[:headEnd] + "\n...\n" + errStr[tailStart:]
 }
 
-func installTailCalls(bpfDir string, spec *ebpf.CollectionSpec, coll *ebpf.Collection, load *Program) error {
-	// FIXME(JM): This should be replaced by using the cilium/ebpf prog array initialization.
-
-	secToProgName := make(map[string]string)
-	for name, prog := range spec.Programs {
-		secToProgName[prog.SectionName] = name
-	}
-
-	install := func(pinPath string, secPrefix string) error {
-		tailCallsMap, err := ebpf.LoadPinnedMap(filepath.Join(bpfDir, pinPath), nil)
-		if err != nil {
-			return nil
-		}
-		defer tailCallsMap.Close()
-
-		for i := 0; i < 13; i++ {
-			secName := fmt.Sprintf("%s/%d", secPrefix, i)
-			if progName, ok := secToProgName[secName]; ok {
-				if prog, ok := coll.Programs[progName]; ok {
-					err := tailCallsMap.Update(uint32(i), uint32(prog.FD()), ebpf.UpdateAny)
-					if err != nil {
-						return fmt.Errorf("update of tail-call map '%s' failed: %w", pinPath, err)
-					}
-				}
-			}
-		}
-		return nil
-	}
-
-	if load.TcMap != nil {
-		if err := install(load.TcMap.PinPath, load.TcPrefix); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // MissingConstantsError is returned by [rewriteConstants].
 type MissingConstantsError struct {
 	// The constants missing from .rodata.
@@ -936,11 +898,6 @@ func doLoadProgram(
 			}
 			load.LoadedMapsInfo[int(id)] = xInfo
 		}
-	}
-
-	err = installTailCalls(bpfDir, spec, coll, load)
-	if err != nil {
-		return nil, fmt.Errorf("installing tail calls failed: %s", err)
 	}
 
 	for _, mapLoad := range load.MapLoad {


### PR DESCRIPTION
Since we do tailcall map initialize in ebpf side, we do not need do in go files.

### Description
we refract tail call map initialize in ebpf c code like this, and remove sec name from "kprobe/#idx" to "kprobe", the go code is useless.

```c
struct {
	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
	__uint(max_entries, 13);
	__uint(key_size, sizeof(__u32));
	__array(values, int(void *));
} kprobe_calls SEC(".maps") = {
	.values = {
		[0] = (void *)&generic_kprobe_setup_event,
		[1] = (void *)&generic_kprobe_process_event,
		[2] = (void *)&generic_kprobe_process_filter,
		[3] = (void *)&generic_kprobe_filter_arg,
		[4] = (void *)&generic_kprobe_actions,
		[5] = (void *)&generic_kprobe_output,
	},
};
```

previous:

```c
__attribute__((section("kprobe/0"), used)) int
generic_kprobe_setup_event(void *ctx)
```

current: 

```c
__attribute__((section("kprobe"), used)) int
generic_kprobe_setup_event(void *ctx)
```

