### PR TITLE
fix: increase loop iteration count in event_find_curr function

### DIFF
--- a/bpf/lib/bpf_task.h
+++ b/bpf/lib/bpf_task.h
@@ -157,7 +157,7 @@ FUNC_INLINE struct execve_map_value *event_find_curr(__u32 *ppid, bool *walked)
 	__u32 pid;
 
 #pragma unroll
-	for (i = 0; i < 4; i++) {
+	for (i = 0; i < 8; i++) {
 		probe_read_kernel(&pid, sizeof(pid), _(&task->tgid));
 		value = execve_map_get_noinit(pid);
 		if (value && value->key.ktime != 0)


### PR DESCRIPTION
Maybe current loop count is too small. 

### Description

For example, in the popular orbstack(https://orbstack.dev/) implementation.  Starting from the current process to the process with pid 1, it takes `5` steps to find the parent processes. Change the loop count to a higher value make tetragon work in orbstack vms.

```
zsh-79260   [007] ....1 80569.428901: bpf_trace_printk: >>>>__event_find_parent: fork, pid=28997, value is null:1
 zsh-79260   [007] ....1 80569.428901: bpf_trace_printk: >>>>__event_find_parent: fork, pid=544, value is null:1
 zsh-79260   [007] ....1 80569.428902: bpf_trace_printk: >>>>__event_find_parent: fork, pid=508, value is null:1
 zsh-79260   [007] ....1 80569.428902: bpf_trace_printk: >>>>__event_find_parent: fork, pid=507, value is null:1
 zsh-79260   [007] ....1 80569.428902: bpf_trace_printk: >>>>__event_find_parent: fork, pid=1, value is null:0
```

### Changelog

```
increase loop iteration count in event_find_curr function from 4 to 8
```
