### PR TITLE
bug: fix assign vfsmnt correctly

### DIFF
--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -202,8 +202,7 @@ FUNC_INLINE long cwd_read(struct cwd_read_data *data)
 			probe_read(&data->dentry, sizeof(data->dentry),
 				   _(&mnt->mnt_mountpoint));
 			data->mnt = parent;
-			probe_read(&data->vfsmnt, sizeof(data->vfsmnt),
-				   _(&mnt->mnt));
+			data->vfsmnt = _(&parent->mnt);
 			return 0;
 		}
 		// resolved all path components successfully


### PR DESCRIPTION
Fixes 

### Description
cwd_read do not assign data->vfsmnt correctly. 

reproduce:
```
sudo mount -t nfs  x.x.x.x:/data/dev/nfs_dir /home/arthur/my_run

$ mount -t
x.x.x.x:/data/dev/nfs_dir on /home/arthur/my_run
/dev/nvme0n1p5 on /home type ext4 (rw,relatime)
```

and cat a file in my_run dir

```
cat /home/arthur/my_run/a.txt
```

in tetragon side, it will get a path : `/home/home/arthur/my_run/a.txt`, but  it should be `/home/arthur/my_run/a.txt`

```
cat-2152134 [003] d...1 3725192.671779: bpf_trace_printk: copy path: /home/home/arthur/my_run/a.txt
```

and in another production env, i found it will get path more than expected when i cat `/tmp/tetragon`. the prefix `/scon/containers/01J6HEV7R29R4WXXS1N2CS9ATP/rootfs/` should not be obtained.

```
/scon/containers/01J6HEV7R29R4WXXS1N2CS9ATP/rootfs/tmp/tetragon
```



in the old code, mnt is pointer to the old data->mnt, which is not correct.
```
struct mount *mnt = data->mnt;
...
if (data->mnt != parent) {
    probe_read(&data->dentry, sizeof(data->dentry),
			    _(&mnt->mnt_mountpoint));
    data->mnt = parent;
    probe_read(&data->vfsmnt, sizeof(data->vfsmnt),
			    _(&mnt->mnt));
    return 0;
}
```

### Changelog

```
Fix vfsmnt assign bug in bpf/process/bpf_process_event.h
```