### PR TITLE
fix: increase loop iteration count in pid lookup

### DIFF
--- a/bpf/lib/bpf_task.h
+++ b/bpf/lib/bpf_task.h
@@ -115,7 +115,7 @@ __event_find_parent(struct task_struct *task)
 	int i;
 
 #pragma unroll
-	for (i = 0; i < 4; i++) {
+	for (i = 0; i < 6; i++) {
 		probe_read_kernel(&task, sizeof(task), _(&task->real_parent));
 		if (!task)
 			break;
@@ -157,7 +157,7 @@ FUNC_INLINE struct execve_map_value *event_find_curr(__u32 *ppid, bool *walked)
 	__u32 pid;
 
 #pragma unroll
-	for (i = 0; i < 4; i++) {
+	for (i = 0; i < 6; i++) {
 		probe_read_kernel(&pid, sizeof(pid), _(&task->tgid));
 		value = execve_map_get_noinit(pid);
 		if (value && value->key.ktime != 0)


### PR DESCRIPTION
### Description

the process level is bigger than 4 in container like envs.   If we start tetragon late after my process start, process may miss some parent process.

For example, in the popular orbstack(https://orbstack.dev/) implementation. Starting from the current process to the root process with pid 1, it takes `5` steps. Change the loop count to a higher value make tetragon work in orbstack vms. Or Tetragon will find parent failed, and affect many functions.

```
zsh-79260   [007] ....1 80569.428901: bpf_trace_printk: >>>>__event_find_parent: fork, pid=28997, value is null:1
 zsh-79260   [007] ....1 80569.428901: bpf_trace_printk: >>>>__event_find_parent: fork, pid=544, value is null:1
 zsh-79260   [007] ....1 80569.428902: bpf_trace_printk: >>>>__event_find_parent: fork, pid=508, value is null:1
 zsh-79260   [007] ....1 80569.428902: bpf_trace_printk: >>>>__event_find_parent: fork, pid=507, value is null:1
 zsh-79260   [007] ....1 80569.428902: bpf_trace_printk: >>>>__event_find_parent: fork, pid=1, value is null:0
```

### Changelog

```
increase loop iteration count in event_find_curr function from 4 to 6
```
