### PR TITLE
fix: nspid assign is not correct

### DIFF
--- a/bpf/cgroup/bpf_cgroup_events.h
+++ b/bpf/cgroup/bpf_cgroup_events.h
@@ -41,7 +41,7 @@ send_cgrp_event(struct bpf_raw_tracepoint_args *ctx,
 	}
 	msg->cgrp_op = op;
 	msg->pid = pid;
-	msg->nspid = get_task_pid_vnr();
+	msg->nspid = get_task_pid_vnr_curr();
 	msg->cgrpid = cgrpid;
 	/* It is same as we are not tracking nested cgroups */
 	msg->cgrpid_tracker = cgrpid;

--- a/bpf/lib/bpf_task.h
+++ b/bpf/lib/bpf_task.h
@@ -57,9 +57,8 @@ FUNC_INLINE struct task_struct *get_task_from_pid(__u32 pid)
 	return task;
 }
 
-FUNC_INLINE __u32 get_task_pid_vnr(void)
+FUNC_INLINE __u32 get_task_pid_vnr_by_task(struct task_struct *task)
 {
-	struct task_struct *task = (struct task_struct *)get_current_task();
 	int thread_pid_exists;
 	unsigned int level;
 	struct upid upid;
@@ -94,6 +93,13 @@ FUNC_INLINE __u32 get_task_pid_vnr(void)
 	probe_read_kernel(&upid, upid_sz,
 			  (void *)_(&pid->numbers) + (level * upid_sz));
 	return upid.nr;
+}
+
+FUNC_INLINE __u32 get_task_pid_vnr_curr(void)
+{
+	struct task_struct *task = (struct task_struct *)get_current_task();
+
+	return get_task_pid_vnr_by_task(task);
 }
 
 FUNC_INLINE __u32 event_find_parent_pid(struct task_struct *t)

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -259,7 +259,7 @@ event_execve(struct trace_event_raw_sched_process_exec *ctx)
 	 */
 	p->pid = pid >> 32;
 	p->tid = (__u32)pid;
-	p->nspid = get_task_pid_vnr();
+	p->nspid = get_task_pid_vnr_curr();
 	p->ktime = ktime_get_ns();
 	p->size = offsetof(struct msg_process, args);
 	p->auid = get_auid();

--- a/bpf/process/bpf_fork.c
+++ b/bpf/process/bpf_fork.c
@@ -56,7 +56,7 @@ BPF_KPROBE(event_wake_up_new_task, struct task_struct *task)
 	curr->flags = EVENT_COMMON_FLAG_CLONE;
 	curr->key.pid = tgid;
 	curr->key.ktime = ktime_get_ns();
-	curr->nspid = get_task_pid_vnr();
+	curr->nspid = get_task_pid_vnr_by_task(task);
 	memcpy(&curr->bin, &parent->bin, sizeof(curr->bin));
 	curr->pkey = parent->key;
 


### PR DESCRIPTION
### Description
`curr->nspid` should be obtained from the child `task` arguments, not from the current `task_struct` (the parent process). 

This will lead to a mismatch between `pid` and `nspid`.

```c
__attribute__((section("kprobe/wake_up_new_task"), used)) int
BPF_KPROBE(event_wake_up_new_task, struct task_struct *task) {
struct execve_map_value *curr;

  tgid = BPF_CORE_READ(task, tgid); 
  curr->key.pid = tgid; // curr->key.pid is obtained from the task argument
  // is not correct.
  curr->nspid = get_task_pid_vnr(); // curr->nspid is obtained from the current task_struct (parent)!
}
```

for example. if we run in docker, we run a app which  fork process every second, the pid in container will be like this
```
Hello from child process (PID: 485), parent: 1
Hello from child process (PID: 486), parent: 1
Hello from child process (PID: 487), parent: 1
Hello from child process (PID: 488), parent: 1
Hello from child process (PID: 489), parent: 1
Hello from child process (PID: 490), parent: 1
```

but when we get from bpf side, pid is the real host pid ,but nspid is always 1(the root parent process in container)

```
       fork_test-2040715 [002] d...1 3632982.277835: bpf_trace_printk: >>>>, pid: 2052883, nspid:1
       fork_test-2040333 [000] d...1 3632985.145937: bpf_trace_printk: >>>>, pid: 2052884, nspid:1
       fork_test-2040715 [002] d...1 3632985.278018: bpf_trace_printk: >>>>, pid: 2052885, nspid:1
```

### Changelog

```
fix nspid value in bpf/process/bpf_fork.c
```