### PR TITLE
renovate: disable digest update on Dockerfiles

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -470,6 +470,14 @@
         "major",
       ],
     },
+    {
+      // Disable digest updates on Docker images except for the base image of
+      // our build that needs to have all deps updated
+      "enabled": false,
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["digest"],
+      "matchPackageNames": ["!docker.io/library/alpine"]
+    },
   ],
   // Those regexes manage version strings in variousfiles, similar to the
   // examples shown here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture


### PR DESCRIPTION
This only generates noise and is not needed except for our base image.
