### PR TITLE
renovate: fix for config change 70ad4e78d5b4

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -474,9 +474,9 @@
       // Disable digest updates on Docker images except for the base image of
       // our build that needs to have all deps updated
       "enabled": false,
-      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
       "matchUpdateTypes": ["digest"],
-      "matchPackageNames": ["!docker.io/library/alpine"]
+      "matchPackageNames": ["!docker.io/library/alpine"],
     },
   ],
   // Those regexes manage version strings in variousfiles, similar to the


### PR DESCRIPTION
Fix for 70ad4e78d5b4 ("renovate: disable digest update on Dockerfiles"), for some reason datasources works while managers doesn't.

I tested this one on a fork [a3f46d4df4ff07e829e604c68074ea78db4f80d3](https://github.com/mtardy/tetragon/commit/a3f46d4df4ff07e829e604c68074ea78db4f80d3) and it worked.