### PR TITLE
tests: replace panic with t.Fatal

### DIFF
--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -44,7 +44,7 @@ func TestAddPolicy(t *testing.T) {
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
-			panic("failed to stop sensor manager")
+			t.Fatal("failed to stop sensor manager")
 		}
 	})
 	policy.ObjectMeta.Name = "test-policy"
@@ -72,7 +72,7 @@ func TestAddPolicies(t *testing.T) {
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
-			panic("failed to stop sensor manager")
+			t.Fatal("failed to stop sensor manager")
 		}
 	})
 	policy.ObjectMeta.Name = "test-policy"
@@ -103,7 +103,7 @@ func TestAddPolicySpecError(t *testing.T) {
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
-			panic("failed to stop sensor manager")
+			t.Fatal("failed to stop sensor manager")
 		}
 	})
 	policy.ObjectMeta.Name = "test-policy"
@@ -135,7 +135,7 @@ func TestAddPolicyLoadError(t *testing.T) {
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
-			panic("failed to stop sensor manager")
+			t.Fatal("failed to stop sensor manager")
 		}
 	})
 	policy.ObjectMeta.Name = "test-policy"
@@ -211,7 +211,7 @@ func TestPolicyStates(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			if err := mgr.StopSensorManager(ctx); err != nil {
-				panic("failed to stop sensor manager")
+				t.Fatal("failed to stop sensor manager")
 			}
 		})
 		policy.ObjectMeta.Name = "test-policy"
@@ -236,7 +236,7 @@ func TestPolicyStates(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			if err := mgr.StopSensorManager(ctx); err != nil {
-				panic("failed to stop sensor manager")
+				t.Fatal("failed to stop sensor manager")
 			}
 		})
 		policy.ObjectMeta.Name = "test-policy"
@@ -276,7 +276,7 @@ func TestPolicyLoadErrorOverride(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
-			panic("failed to stop sensor manager")
+			t.Fatal("failed to stop sensor manager")
 		}
 	})
 	policy.ObjectMeta.Name = "test-policy"

--- a/pkg/sensors/tracing/generickprobe_test.go
+++ b/pkg/sensors/tracing/generickprobe_test.go
@@ -127,7 +127,7 @@ func Test_Kprobe_DisableEnablePolicy(t *testing.T) {
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		if err := mgr.StopSensorManager(ctx); err != nil {
-			panic("failed to stop sensor manager")
+			t.Fatal("failed to stop sensor manager")
 		}
 	})
 

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5842,15 +5842,13 @@ spec:
 	// Generate 5 datagrams
 	socket, err := net.Dial("udp", "127.0.0.1:9468")
 	if err != nil {
-		fmt.Printf("ERROR dialing socket\n")
-		t.Fatal(err)
+		t.Fatalf("failed dialing socket: %s", err)
 	}
 
 	for i := 0; i < 5; i++ {
 		_, err := socket.Write([]byte("data"))
 		if err != nil {
-			fmt.Printf("ERROR writing to socket\n")
-			t.Fatal(err)
+			t.Fatalf("failed writing to socket: %s", err)
 		}
 	}
 

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5843,14 +5843,14 @@ spec:
 	socket, err := net.Dial("udp", "127.0.0.1:9468")
 	if err != nil {
 		fmt.Printf("ERROR dialing socket\n")
-		panic(err)
+		t.Fatal(err)
 	}
 
 	for i := 0; i < 5; i++ {
 		_, err := socket.Write([]byte("data"))
 		if err != nil {
 			fmt.Printf("ERROR writing to socket\n")
-			panic(err)
+			t.Fatal(err)
 		}
 	}
 

--- a/tests/vmtests/fetch-data.sh
+++ b/tests/vmtests/fetch-data.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 
 OCIORG=quay.io/lvh-images
-ROOTIMG=$OCIORG/root-images
+ROOTIMG=$OCIORG/root-images:20240717.161638@sha256:62a9890111ab39749792fda4f59c8f736fa350ecaedb0667e3eecbbe790d82ed
 KERNIMG=$OCIORG/kernel-images
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
 KERNEL_VERS="$@"


### PR DESCRIPTION
Panicking in tests is bad as it fails to tell the test handler that the test failed. Instead we should use t.Fatal(). This commit changes instances of panic in tests to t.Fatal().

[Upstream PR: #2685]