### PR TITLE
tetragon: Fix override program pin for fmodret and kprobe multi

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -461,6 +461,7 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 	observer.GetSensorManager().LogSensorsAndProbes(ctx)
 	defer func() {
 		observer.RemoveSensors(ctx)
+		os.Remove(observerDir)
 	}()
 
 	pm, err := tetragonGrpc.NewProcessManager(

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -250,7 +250,7 @@ func fmodretAttachOverride(load *Program, bpfDir string,
 		return fmt.Errorf("failed to clone generic_fmodret_override program: %w", err)
 	}
 
-	pinPath := filepath.Join(bpfDir, fmt.Sprint(load.PinPath, "-override"))
+	pinPath := filepath.Join(bpfDir, filepath.Join(load.PinPath, "prog_override"))
 
 	if err := prog.Pin(pinPath); err != nil {
 		return fmt.Errorf("pinning '%s' to '%s' failed: %w", load.Label, pinPath, err)
@@ -501,7 +501,7 @@ func MultiKprobeAttach(load *Program, bpfDir string) AttachFunc {
 				return nil, fmt.Errorf("failed to clone program '%s': %w", load.Label, err)
 			}
 
-			pinPath := filepath.Join(bpfDir, fmt.Sprint(load.PinPath, "-override"))
+			pinPath := filepath.Join(bpfDir, filepath.Join(load.PinPath, "prog_override"))
 
 			if err := progOverride.Pin(pinPath); err != nil {
 				return nil, fmt.Errorf("pinning '%s' to '%s' failed: %w", load.Label, pinPath, err)


### PR DESCRIPTION
Currently we pin override program with -override suffix, like:

  .../generic_kprobe/security_inode_mkdir-override

It's leftover from before we had the the bpffs directory structure, now we should pin it like:

  .../generic_kprobe/security_inode_mkdir/prog_override