### PR TITLE
tetragon: add get_current_task_btf

### DIFF
--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -235,6 +235,7 @@ static int BPF_FUNC(fib_lookup, void *ctx, struct bpf_fib_lookup *params, uint32
 
 /* Current Process Info */
 static uint64_t BPF_FUNC(get_current_task);
+static uint64_t BPF_FUNC(get_current_task_btf);
 static uint64_t BPF_FUNC(get_current_cgroup_id);
 static uint64_t BPF_FUNC(get_current_ancestor_cgroup_id, int ancestor_level);
 static uint64_t BPF_FUNC(get_current_uid_gid);


### PR DESCRIPTION
Add get_current_task_btf so we can reduce bpf_probe_read usage and start using BTF pointer walking on newer kernels.