### PR TITLE
bpf: declare maps with __type for key and value

### DIFF
--- a/bpf/process/addr_lpm_maps.h
+++ b/bpf/process/addr_lpm_maps.h
@@ -14,7 +14,7 @@ struct addr4_lpm_trie {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, ADDR_LPM_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_LPM_TRIE);
@@ -33,7 +33,7 @@ struct addr6_lpm_trie {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, ADDR_LPM_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_LPM_TRIE);

--- a/bpf/process/argfilter_maps.h
+++ b/bpf/process/argfilter_maps.h
@@ -9,7 +9,7 @@
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, ARGFILTER_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -23,7 +23,7 @@ int execve_send(void *ctx);
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, 2);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(values, int(void *));
 } execve_calls SEC(".maps") = {
 	.values = {

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -26,7 +26,7 @@ int generic_kprobe_output(void *ctx);
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, 13);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(values, int(void *));
 } kprobe_calls SEC(".maps") = {
 	.values = {

--- a/bpf/process/bpf_generic_lsm_core.c
+++ b/bpf/process/bpf_generic_lsm_core.c
@@ -27,7 +27,7 @@ int generic_lsm_actions(void *ctx);
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, 13);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(values, int(void *));
 } lsm_calls SEC(".maps") = {
 	.values = {

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -24,7 +24,7 @@ int generic_retkprobe_output(struct pt_regs *ctx);
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, 6);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(values, int(struct pt_regs *));
 } retkprobe_calls SEC(".maps") = {
 	.values = {

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -25,7 +25,7 @@ int generic_tracepoint_output(void *ctx);
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, 13);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(values, int(void *));
 } tp_calls SEC(".maps") = {
 	.values = {

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -25,7 +25,7 @@ int generic_uprobe_output(void *ctx);
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, 13);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(values, int(void *));
 } uprobe_calls SEC(".maps") = {
 	.values = {

--- a/bpf/process/policy_filter.h
+++ b/bpf/process/policy_filter.h
@@ -14,14 +14,14 @@
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__uint(max_entries, POLICY_FILTER_MAX_NAMESPACES);
-	__uint(key_size, sizeof(u64));
-	__uint(value_size, sizeof(u64));
+	__type(key, u64);
+	__type(value, u64);
 } tg_cgroup_namespace_map SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
 	__uint(max_entries, POLICY_FILTER_MAX_POLICIES);
-	__uint(key_size, sizeof(u32)); /* policy id */
+	__type(key, u32); /* policy id */
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -38,7 +38,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
 	__uint(max_entries, POLICY_FILTER_MAX_CGROUP_IDS);
-	__uint(key_size, sizeof(__u64)); /* cgroup id */
+	__type(key, __u64); /* cgroup id */
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);

--- a/bpf/process/string_maps.h
+++ b/bpf/process/string_maps.h
@@ -65,7 +65,7 @@
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -78,7 +78,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -91,7 +91,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -104,7 +104,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -117,7 +117,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -130,7 +130,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -143,7 +143,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -156,7 +156,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -170,7 +170,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -183,7 +183,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -196,7 +196,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -210,14 +210,14 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__uint(value_size, STRING_MAPS_HEAP_SIZE);
 } string_maps_heap SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__uint(value_size, STRING_MAPS_HEAP_SIZE);
 } string_maps_ro_zero SEC(".maps");
 
@@ -231,7 +231,7 @@ struct string_prefix_lpm_trie {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_LPM_TRIE);
@@ -245,8 +245,8 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
-	__uint(key_size, sizeof(__u32));
-	__uint(value_size, sizeof(struct string_prefix_lpm_trie));
+	__type(key, __u32);
+	__type(value, struct string_prefix_lpm_trie);
 } string_prefix_maps_heap SEC(".maps");
 
 #define STRING_POSTFIX_MAX_LENGTH 128
@@ -265,7 +265,7 @@ struct string_postfix_lpm_trie {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, STRING_MAPS_OUTER_MAX_ENTRIES);
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_LPM_TRIE);
@@ -279,8 +279,8 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
-	__uint(key_size, sizeof(__u32));
-	__uint(value_size, sizeof(struct string_postfix_lpm_trie));
+	__type(key, __u32);
+	__type(value, struct string_postfix_lpm_trie);
 } string_postfix_maps_heap SEC(".maps");
 
 #endif // STRING_MAPS_H__

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1532,7 +1532,7 @@ struct {
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
 	__uint(max_entries, MAX_SELECTORS); // only one matchBinaries per selector
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__array(
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
@@ -2114,7 +2114,7 @@ update_pid_tid_from_sock(struct msg_generic_kprobe *e, __u64 sockaddr)
 struct {
 	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
 	__uint(max_entries, 1); // Agent is resizing this if the feature is needed during kprobe load
-	__uint(key_size, sizeof(__u32));
+	__type(key, __u32);
 	__uint(value_size, sizeof(__u64) * PERF_MAX_STACK_DEPTH);
 } stack_trace_map SEC(".maps");
 


### PR DESCRIPTION
Using __type(key, type) instead of __uint(key_size, sizeof(type)), and similarly for value, adds BTF information on the map which can be useful. When using 'bpftool map dump' with the BTF information, the formatting is then correct according to the types.

This patch is the result of running:

	find bpf -type f -exec sed -i -E 's/__uint\(value_size,\s*sizeof\(([^)]+)\)\)/__type(value, \1)/g' {} +
	find bpf -type f -exec sed -i -E 's/__uint\(key_size,\s*sizeof\(([^)]+)\)\)/__type(key, \1)/g' {} +

Some __uint(value_size were kept because they did not use sizeof but literal integers.
