### PR TITLE
Create an AUTHORS file for tetragon

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -109,7 +109,7 @@ Tim Swanson <tiswanso@cisco.com>
 Tobias Klauser <tobias@cilium.io>
 Tom Meadows <djw0bbl3@protonmail.com>
 Tony Norlin <tony.norlin@localdomain.se>
-Tristan D'audibert <tristan.daudibert@gmail.com>
+Tristan d'Audibert <tristan.daudibert@orange.com>
 Trung-DV <TrungDV.PMB@gmail.com>
 Walter Lee <quietwalter@gmail.com>
 willfindlay <will@isovalent.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,132 @@
+Akshay Gaikwad <akgaikwad001@gmail.com>
+Alex In <reexistent@gmail.com>
+Alex Tomic <atomic777@gmail.com>
+Aliaksei Sofin <sofin.moffin@gmail.com>
+Anastasios Papagiannis <anastasios.papagiannis@isovalent.com>
+Anastasios Papagiannis <tasos.papagiannnis@gmail.com>
+Andrei Fedotov <anfedotoff@yandex-team.ru>
+anjmao <andzej.maciusovic@gmail.com>
+Anna Artemova <annartmva@gmail.com>
+Anna Kapuscinska <anna@isovalent.com>
+aohoyd <gh@aohoy.dev>
+arthur-zhang <happyzhangya@gmail.com>
+Ashish Kurmi <akurmi@stepsecurity.io>
+Ashish Naware <ashishnaware3@gmail.com>
+Barun Debnath <barundebnath91@gmail.com>
+Bill Mulligan <billmulligan516@gmail.com>
+Canux <canuxcheng@gmail.com>
+carolina valencia <krol3@users.noreply.github.com>
+Chaiyapruek Muangsiri <cmp.poon@gmail.com>
+Chance Zibolski <chance.zibolski@gmail.com>
+Cheithanya PR <cheithanya2002@gmail.com>
+chenlitw <chenli3792@gmail.com>
+christian2 <christian2@univie.ac.at>
+Christopher Paplham <36825497+cpaplham@users.noreply.github.com>
+cilium-renovate[bot] <134692979+cilium-renovate[bot]@users.noreply.github.com>
+darox <maderdario@gmail.com>
+David Windsor <dawindso@cisco.com>
+Dax McDonald <31839142+daxmc99@users.noreply.github.com>
+Dean <22192242+saintdle@users.noreply.github.com>
+dechengyuan <dechengyuan@tencent.com>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Djalal Harouni <tixxdz@gmail.com>
+Dmitry Savintsev <dmitris@users.noreply.github.com>
+Dmitry Savintsev <dsavints@gmail.com>
+Doğukan ÇELİK <dogukan.celik@itu.edu.tr>
+ekoops <leonardodigiovanna1@gmail.com>
+Eng Zer Jun <engzerjun@gmail.com>
+Feroz Salam <feroz.salam@isovalent.com>
+Filip Nikolic <oss.filipn@gmail.com>
+Frederic Giloux <frederic.giloux@isovalent.com>
+Guozhen She <guozhen.she@snowflake.com>
+hacktivist123 <akintayoshedrack@gmail.com>
+Haiyu Zuo <958474674@qq.com>
+HIHIA <283304489@qq.com>
+hungran <26101787+hungran@users.noreply.github.com>
+Huweicai <i@huweicai.com>
+Ioannis Androulidakis <androulidakis.ioannis@gmail.com>
+Jack-R-lantern <tjdfkr2421@gmail.com>
+James Strong <james.strong@isovalent.com>
+janvi01 <janvibajo1@gmail.com>
+Jianlin Lv <jianlv@ebay.com>
+Jinna C <jinnatim@gmail.com>
+Jiri Olsa <jolsa@kernel.org>
+Joe Stringer <joe@cilium.io>
+John Fastabend <john.fastabend@gmail.com>
+Josh Biggley <jbiggley@users.noreply.github.com>
+Joshua Jorel Lee <joshua.jorel.lee@gmail.com>
+Julien Acroute <julien.acroute@camptocamp.com>
+Justin Chen <mail@justin0u0.com>
+Kevin Conner <kev.conner@getupcloud.com>
+Kevin Sheldrake <kevin.sheldrake@isovalent.com>
+Kohei Morita <mrtc0@ssrf.in>
+Kornilios Kourtis <kornilios@gmail.com>
+Kornilios Kourtis <kornilios@isovalent.com>
+Lancelot <1984737645@qq.com>
+Liang Deng <283304489@qq.com>
+Liz Rice <liz@lizrice.com>
+Lorenz Bauer <lmb@isovalent.com>
+Lucas Fernando Cardoso Nunes <lucasfc.nunes@gmail.com>
+Luigi De Matteis <eilidh3773@gmail.com>
+Mahé <mahe.tardy@gmail.com>
+Mahé <mahe.tardy@isovalent.com>
+Mahe Tardy <mahe.tardy@gmail.com>
+Mahe Tardy <mahe.tardy@isovalent.com>
+Marwan Nour <38836519+MarwanNour@users.noreply.github.com>
+Matteo Golinelli <34921879+Golim@users.noreply.github.com>
+Mauricio Vásquez <mauriciov@microsoft.com>
+Michael Friedrich <mfriedrich@gitlab.com>
+michael h <mhyatt8008 at g mail com>
+Michael Hyatt <mhyatt 8 0 8 0 a t g m i a l dot com>
+Michael Hyatt <mhyatt8080@gmail.com>
+michalzarsm <michalzarsm@gmail.com>
+Michi Mutsuzaki <michi@isovalent.com>
+mozillazg <mozillazg101@gmail.com>
+mtardy <mahe5397@hotmail.fr>
+Natalia Ivanko <70883409+sharlns@users.noreply.github.com>
+Natalia Reka Ivanko <natalia@isovalent.com>
+Nick Peluso <10912027+nap32@users.noreply.github.com>
+Oleh Neichev <oleg.neichev@gmail.com>
+Oleksandr Kubashov <okubashov@gmail.com>
+Paul Arah <paularah.self@gmail.com>
+Peihao Yang <peihao.young@gmail.com>
+Philip Schmid <philip.schmid@isovalent.com>
+Philip Schmid <phisch@cisco.com>
+Prateek Singh <prateeksingh9741@gmail.com>
+prosazhin <prosazhin@gmail.com>
+Rafael Ribeiro <rafael.ntw@gmail.com>
+Raman Yasel <raman.yasel@gmail.com>
+Ramsés Rodríguez Martínez <91434530+next-ramses@users.noreply.github.com>
+Raphaël Pinson <raphael@isovalent.com>
+renovate[bot] <bot@renovateapp.com>
+Rico Pahlisch <rico.pahlisch@grayc.de>
+Robin Hahling <robin.hahling@gw-computing.net>
+Russell Bryant <russell.bryant@gmail.com>
+sadath-12 <sadathsadu2002@gmail.com>
+sandeshv <sandeshkv92@gmail.com>
+Sandipan Panda <samparksandipan@gmail.com>
+Sarah Fujimori <sarah.fujimori@isovalent.com>
+Scott Lowe <scott.lowe@isovalent.com>
+Sean P. Kane <spkane00@gmail.com>
+Shedrack akintayo <akintayoshedrack@gmail.com>
+SimonB <simonb@kaizo.org>
+sunnoy <sunnoy@users.noreply.github.com>
+Sven Pfennig <s.pfennig@reply.de>
+Thomas Graf <thomas@cilium.io>
+Thomas Schubart <thomas@gitpod.io>
+Tim Swanson <tiswanso@cisco.com>
+Tobias Klauser <tobias@cilium.io>
+Tom Meadows <djw0bbl3@protonmail.com>
+Tony Norlin <tony.norlin@localdomain.se>
+Tristan d'Audibert <tristan.daudibert@gmail.com>
+Tristan D'audibert <tristan.daudibert@gmail.com>
+Trung-DV <TrungDV.PMB@gmail.com>
+Walter Lee <quietwalter@gmail.com>
+willfindlay <will@isovalent.com>
+William Findlay <william.findlay@isovalent.com>
+William Findlay <william@williamfindlay.com>
+William Findlay <will@isovalent.com>
+yukinakanaka <yuki.nakamura@mapbox.com>
+zazathomas <thomas.kyle6@gmail.com>
+zhangchao <zchao9100@gmail.com>
+Zhiyu Wang <cloudsky.newbis@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,9 +1,11 @@
+The following people, in alphabetical order, have either authored or signed
+off on commits in the Tetragon repository:
+
 Akshay Gaikwad <akgaikwad001@gmail.com>
 Alex In <reexistent@gmail.com>
 Alex Tomic <atomic777@gmail.com>
 Aliaksei Sofin <sofin.moffin@gmail.com>
 Anastasios Papagiannis <anastasios.papagiannis@isovalent.com>
-Anastasios Papagiannis <tasos.papagiannnis@gmail.com>
 Andrei Fedotov <anfedotoff@yandex-team.ru>
 anjmao <andzej.maciusovic@gmail.com>
 Anna Artemova <annartmva@gmail.com>
@@ -22,13 +24,11 @@ Cheithanya PR <cheithanya2002@gmail.com>
 chenlitw <chenli3792@gmail.com>
 christian2 <christian2@univie.ac.at>
 Christopher Paplham <36825497+cpaplham@users.noreply.github.com>
-cilium-renovate[bot] <134692979+cilium-renovate[bot]@users.noreply.github.com>
 darox <maderdario@gmail.com>
 David Windsor <dawindso@cisco.com>
 Dax McDonald <31839142+daxmc99@users.noreply.github.com>
 Dean <22192242+saintdle@users.noreply.github.com>
 dechengyuan <dechengyuan@tencent.com>
-dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Djalal Harouni <tixxdz@gmail.com>
 Dmitry Savintsev <dmitris@users.noreply.github.com>
 Dmitry Savintsev <dsavints@gmail.com>
@@ -60,7 +60,6 @@ Justin Chen <mail@justin0u0.com>
 Kevin Conner <kev.conner@getupcloud.com>
 Kevin Sheldrake <kevin.sheldrake@isovalent.com>
 Kohei Morita <mrtc0@ssrf.in>
-Kornilios Kourtis <kornilios@gmail.com>
 Kornilios Kourtis <kornilios@isovalent.com>
 Lancelot <1984737645@qq.com>
 Liang Deng <283304489@qq.com>
@@ -68,29 +67,22 @@ Liz Rice <liz@lizrice.com>
 Lorenz Bauer <lmb@isovalent.com>
 Lucas Fernando Cardoso Nunes <lucasfc.nunes@gmail.com>
 Luigi De Matteis <eilidh3773@gmail.com>
-Mahé <mahe.tardy@gmail.com>
-Mahé <mahe.tardy@isovalent.com>
-Mahe Tardy <mahe.tardy@gmail.com>
 Mahe Tardy <mahe.tardy@isovalent.com>
 Marwan Nour <38836519+MarwanNour@users.noreply.github.com>
 Matteo Golinelli <34921879+Golim@users.noreply.github.com>
 Mauricio Vásquez <mauriciov@microsoft.com>
 Michael Friedrich <mfriedrich@gitlab.com>
 michael h <mhyatt8008 at g mail com>
-Michael Hyatt <mhyatt 8 0 8 0 a t g m i a l dot com>
 Michael Hyatt <mhyatt8080@gmail.com>
 michalzarsm <michalzarsm@gmail.com>
 Michi Mutsuzaki <michi@isovalent.com>
 mozillazg <mozillazg101@gmail.com>
-mtardy <mahe5397@hotmail.fr>
-Natalia Ivanko <70883409+sharlns@users.noreply.github.com>
 Natalia Reka Ivanko <natalia@isovalent.com>
 Nick Peluso <10912027+nap32@users.noreply.github.com>
 Oleh Neichev <oleg.neichev@gmail.com>
 Oleksandr Kubashov <okubashov@gmail.com>
 Paul Arah <paularah.self@gmail.com>
 Peihao Yang <peihao.young@gmail.com>
-Philip Schmid <philip.schmid@isovalent.com>
 Philip Schmid <phisch@cisco.com>
 Prateek Singh <prateeksingh9741@gmail.com>
 prosazhin <prosazhin@gmail.com>
@@ -98,7 +90,6 @@ Rafael Ribeiro <rafael.ntw@gmail.com>
 Raman Yasel <raman.yasel@gmail.com>
 Ramsés Rodríguez Martínez <91434530+next-ramses@users.noreply.github.com>
 Raphaël Pinson <raphael@isovalent.com>
-renovate[bot] <bot@renovateapp.com>
 Rico Pahlisch <rico.pahlisch@grayc.de>
 Robin Hahling <robin.hahling@gw-computing.net>
 Russell Bryant <russell.bryant@gmail.com>
@@ -118,14 +109,11 @@ Tim Swanson <tiswanso@cisco.com>
 Tobias Klauser <tobias@cilium.io>
 Tom Meadows <djw0bbl3@protonmail.com>
 Tony Norlin <tony.norlin@localdomain.se>
-Tristan d'Audibert <tristan.daudibert@gmail.com>
 Tristan D'audibert <tristan.daudibert@gmail.com>
 Trung-DV <TrungDV.PMB@gmail.com>
 Walter Lee <quietwalter@gmail.com>
 willfindlay <will@isovalent.com>
 William Findlay <william.findlay@isovalent.com>
-William Findlay <william@williamfindlay.com>
-William Findlay <will@isovalent.com>
 yukinakanaka <yuki.nakamura@mapbox.com>
 zazathomas <thomas.kyle6@gmail.com>
 zhangchao <zchao9100@gmail.com>

--- a/api/vendor/github.com/cilium/tetragon/AUTHORS
+++ b/api/vendor/github.com/cilium/tetragon/AUTHORS
@@ -1,0 +1,120 @@
+The following people, in alphabetical order, have either authored or signed
+off on commits in the Tetragon repository:
+
+Akshay Gaikwad <akgaikwad001@gmail.com>
+Alex In <reexistent@gmail.com>
+Alex Tomic <atomic777@gmail.com>
+Aliaksei Sofin <sofin.moffin@gmail.com>
+Anastasios Papagiannis <anastasios.papagiannis@isovalent.com>
+Andrei Fedotov <anfedotoff@yandex-team.ru>
+anjmao <andzej.maciusovic@gmail.com>
+Anna Artemova <annartmva@gmail.com>
+Anna Kapuscinska <anna@isovalent.com>
+aohoyd <gh@aohoy.dev>
+arthur-zhang <happyzhangya@gmail.com>
+Ashish Kurmi <akurmi@stepsecurity.io>
+Ashish Naware <ashishnaware3@gmail.com>
+Barun Debnath <barundebnath91@gmail.com>
+Bill Mulligan <billmulligan516@gmail.com>
+Canux <canuxcheng@gmail.com>
+carolina valencia <krol3@users.noreply.github.com>
+Chaiyapruek Muangsiri <cmp.poon@gmail.com>
+Chance Zibolski <chance.zibolski@gmail.com>
+Cheithanya PR <cheithanya2002@gmail.com>
+chenlitw <chenli3792@gmail.com>
+christian2 <christian2@univie.ac.at>
+Christopher Paplham <36825497+cpaplham@users.noreply.github.com>
+darox <maderdario@gmail.com>
+David Windsor <dawindso@cisco.com>
+Dax McDonald <31839142+daxmc99@users.noreply.github.com>
+Dean <22192242+saintdle@users.noreply.github.com>
+dechengyuan <dechengyuan@tencent.com>
+Djalal Harouni <tixxdz@gmail.com>
+Dmitry Savintsev <dmitris@users.noreply.github.com>
+Dmitry Savintsev <dsavints@gmail.com>
+Doğukan ÇELİK <dogukan.celik@itu.edu.tr>
+ekoops <leonardodigiovanna1@gmail.com>
+Eng Zer Jun <engzerjun@gmail.com>
+Feroz Salam <feroz.salam@isovalent.com>
+Filip Nikolic <oss.filipn@gmail.com>
+Frederic Giloux <frederic.giloux@isovalent.com>
+Guozhen She <guozhen.she@snowflake.com>
+hacktivist123 <akintayoshedrack@gmail.com>
+Haiyu Zuo <958474674@qq.com>
+HIHIA <283304489@qq.com>
+hungran <26101787+hungran@users.noreply.github.com>
+Huweicai <i@huweicai.com>
+Ioannis Androulidakis <androulidakis.ioannis@gmail.com>
+Jack-R-lantern <tjdfkr2421@gmail.com>
+James Strong <james.strong@isovalent.com>
+janvi01 <janvibajo1@gmail.com>
+Jianlin Lv <jianlv@ebay.com>
+Jinna C <jinnatim@gmail.com>
+Jiri Olsa <jolsa@kernel.org>
+Joe Stringer <joe@cilium.io>
+John Fastabend <john.fastabend@gmail.com>
+Josh Biggley <jbiggley@users.noreply.github.com>
+Joshua Jorel Lee <joshua.jorel.lee@gmail.com>
+Julien Acroute <julien.acroute@camptocamp.com>
+Justin Chen <mail@justin0u0.com>
+Kevin Conner <kev.conner@getupcloud.com>
+Kevin Sheldrake <kevin.sheldrake@isovalent.com>
+Kohei Morita <mrtc0@ssrf.in>
+Kornilios Kourtis <kornilios@isovalent.com>
+Lancelot <1984737645@qq.com>
+Liang Deng <283304489@qq.com>
+Liz Rice <liz@lizrice.com>
+Lorenz Bauer <lmb@isovalent.com>
+Lucas Fernando Cardoso Nunes <lucasfc.nunes@gmail.com>
+Luigi De Matteis <eilidh3773@gmail.com>
+Mahe Tardy <mahe.tardy@isovalent.com>
+Marwan Nour <38836519+MarwanNour@users.noreply.github.com>
+Matteo Golinelli <34921879+Golim@users.noreply.github.com>
+Mauricio Vásquez <mauriciov@microsoft.com>
+Michael Friedrich <mfriedrich@gitlab.com>
+michael h <mhyatt8008 at g mail com>
+Michael Hyatt <mhyatt8080@gmail.com>
+michalzarsm <michalzarsm@gmail.com>
+Michi Mutsuzaki <michi@isovalent.com>
+mozillazg <mozillazg101@gmail.com>
+Natalia Reka Ivanko <natalia@isovalent.com>
+Nick Peluso <10912027+nap32@users.noreply.github.com>
+Oleh Neichev <oleg.neichev@gmail.com>
+Oleksandr Kubashov <okubashov@gmail.com>
+Paul Arah <paularah.self@gmail.com>
+Peihao Yang <peihao.young@gmail.com>
+Philip Schmid <phisch@cisco.com>
+Prateek Singh <prateeksingh9741@gmail.com>
+prosazhin <prosazhin@gmail.com>
+Rafael Ribeiro <rafael.ntw@gmail.com>
+Raman Yasel <raman.yasel@gmail.com>
+Ramsés Rodríguez Martínez <91434530+next-ramses@users.noreply.github.com>
+Raphaël Pinson <raphael@isovalent.com>
+Rico Pahlisch <rico.pahlisch@grayc.de>
+Robin Hahling <robin.hahling@gw-computing.net>
+Russell Bryant <russell.bryant@gmail.com>
+sadath-12 <sadathsadu2002@gmail.com>
+sandeshv <sandeshkv92@gmail.com>
+Sandipan Panda <samparksandipan@gmail.com>
+Sarah Fujimori <sarah.fujimori@isovalent.com>
+Scott Lowe <scott.lowe@isovalent.com>
+Sean P. Kane <spkane00@gmail.com>
+Shedrack akintayo <akintayoshedrack@gmail.com>
+SimonB <simonb@kaizo.org>
+sunnoy <sunnoy@users.noreply.github.com>
+Sven Pfennig <s.pfennig@reply.de>
+Thomas Graf <thomas@cilium.io>
+Thomas Schubart <thomas@gitpod.io>
+Tim Swanson <tiswanso@cisco.com>
+Tobias Klauser <tobias@cilium.io>
+Tom Meadows <djw0bbl3@protonmail.com>
+Tony Norlin <tony.norlin@localdomain.se>
+Tristan d'Audibert <tristan.daudibert@orange.com>
+Trung-DV <TrungDV.PMB@gmail.com>
+Walter Lee <quietwalter@gmail.com>
+willfindlay <will@isovalent.com>
+William Findlay <william.findlay@isovalent.com>
+yukinakanaka <yuki.nakamura@mapbox.com>
+zazathomas <thomas.kyle6@gmail.com>
+zhangchao <zchao9100@gmail.com>
+Zhiyu Wang <cloudsky.newbis@gmail.com>


### PR DESCRIPTION
See: https://github.com/cncf/foundation/blob/main/copyright-notices.md#why-not-list-every-copyright-holder

CC: @tpapagian @mtardy @michaelhyatt @will-isovalent @ScriptSathi please have a look at the second patch and let me know if you have another preference for the email address in the AUTHORS file.

TODO: add a step in the release process to update the AUTHORS file.