### PR TITLE
docs: fix typo referencing kube-system as kubesystem

### DIFF
--- a/docs/content/en/docs/getting-started/enforcement.md
+++ b/docs/content/en/docs/getting-started/enforcement.md
@@ -86,7 +86,7 @@ events.
 kubectl exec -ti -n kube-system ds/tetragon -c tetragon -- tetra getevents -o compact --pods xwing
 {{< /tab >}}
 {{< tab "Kubernetes (multiple nodes)" >}}
-POD=$(kubectl -n kubesystem get pods -l 'app.kubernetes.io/name=tetragon' -o name --field-selector spec.nodeName=$(kubectl get pod xwing -o jsonpath='{.spec.nodeName}'))
+POD=$(kubectl -n kube-system get pods -l 'app.kubernetes.io/name=tetragon' -o name --field-selector spec.nodeName=$(kubectl get pod xwing -o jsonpath='{.spec.nodeName}'))
 kubectl exec -ti -n kube-system $POD -c tetragon -- tetra getevents -o compact --pods xwing
 {{< /tab >}}
 {{< /tabpane >}}
@@ -165,7 +165,7 @@ outputting events to the terminal.
 kubectl exec -ti -n kube-system ds/tetragon -c tetragon -- tetra getevents -o compact --pods xwing
 {{< /tab >}}
 {{< tab "Kubernetes (multiple nodes)" >}}
-POD=$(kubectl -n kubesystem get pods -l 'app.kubernetes.io/name=tetragon' -o name --field-selector spec.nodeName=$(kubectl get pod xwing -o jsonpath='{.spec.nodeName}'))
+POD=$(kubectl -n kube-system get pods -l 'app.kubernetes.io/name=tetragon' -o name --field-selector spec.nodeName=$(kubectl get pod xwing -o jsonpath='{.spec.nodeName}'))
 kubectl exec -ti -n kube-system $POD -c tetragon -- tetra getevents -o compact --pods xwing
 {{< /tab >}}
 {{< tab Docker >}}

--- a/docs/content/en/docs/getting-started/file-events.md
+++ b/docs/content/en/docs/getting-started/file-events.md
@@ -56,7 +56,7 @@ With the tracing policy applied you can attach `tetra` to observe events again:
 kubectl exec -ti -n kube-system ds/tetragon -c tetragon -- tetra getevents -o compact --pods xwing
 {{< /tab >}}
 {{< tab "Kubernetes (multiple nodes)" >}}
-POD=$(kubectl -n kubesystem get pods -l 'app.kubernetes.io/name=tetragon' -o name --field-selector spec.nodeName=$(kubectl get pod xwing -o jsonpath='{.spec.nodeName}'))
+POD=$(kubectl -n kube-system get pods -l 'app.kubernetes.io/name=tetragon' -o name --field-selector spec.nodeName=$(kubectl get pod xwing -o jsonpath='{.spec.nodeName}'))
 kubectl exec -ti -n kube-system $POD -c tetragon -- tetra getevents -o compact --pods xwing
 {{< /tab >}}
 {{< tab Docker >}}

--- a/docs/content/en/docs/getting-started/network.md
+++ b/docs/content/en/docs/getting-started/network.md
@@ -63,7 +63,7 @@ kubectl exec -ti -n kube-system ds/tetragon -c tetragon -- tetra getevents -o co
 {{< /tab >}}
 
 {{< tab "Kubernetes (multiple nodes" >}}
-POD=$(kubectl -n kubesystem get pods -l 'app.kubernetes.io/name=tetragon' -o name --field-selector spec.nodeName=$(kubectl get pod xwing -o jsonpath='{.spec.nodeName}'))
+POD=$(kubectl -n kube-system get pods -l 'app.kubernetes.io/name=tetragon' -o name --field-selector spec.nodeName=$(kubectl get pod xwing -o jsonpath='{.spec.nodeName}'))
 kubectl exec -ti -n kube-system $POD -c tetragon -- tetra getevents -o compact --pods xwing --processes curl
 {{< /tab >}}
 {{< /tabpane >}}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes https://github.com/cilium/tetragon/issues/3304

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Fix typo "kubesystem".