### PR TITLE
tetra: Set default for retries to 1

### DIFF
--- a/cmd/tetra/main.go
+++ b/cmd/tetra/main.go
@@ -45,6 +45,6 @@ func New() *cobra.Command {
 	flags.BoolVarP(&common.Debug, common.KeyDebug, "d", false, "Enable debug messages")
 	flags.StringVar(&common.ServerAddress, common.KeyServerAddress, "", "gRPC server address")
 	flags.DurationVar(&common.Timeout, common.KeyTimeout, 10*time.Second, "Connection timeout")
-	flags.IntVar(&common.Retries, common.KeyRetries, 0, "Connection retries with exponential backoff")
+	flags.IntVar(&common.Retries, common.KeyRetries, 1, "Connection retries with exponential backoff")
 	return rootCmd
 }


### PR DESCRIPTION
The grpc update to v1.70.0 and especially [1] requires retries to be > 1 in order to have a valid retry policy.

As we already do +1 later, let's set the default to 1.

[1] https://github.com/grpc/grpc-go/pull/7905
Suggested-by: Anastasios Papagiannis <anastasios.papagiannis@isovalent.com>
Signed-off-by: Jiri Olsa <jolsa@kernel.org>