### PR TITLE
proc_reader: handle in_init_tree

### DIFF
--- a/pkg/observer/observertesthelper/docker/docker.go
+++ b/pkg/observer/observertesthelper/docker/docker.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package docker
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Create creates a new docker container in the background. The container will
+// be killed and removed on test cleanup.
+// It returns the containerId on success, or an error if spawning the container failed.
+func Create(tb testing.TB, args ...string) (containerId string) {
+	// note: we are not using `--rm` so we can choose to wait on the container
+	// with `docker wait`. We remove it manually below in t.Cleanup instead
+	args = append([]string{"create"}, args...)
+	id, err := exec.Command("docker", args...).Output()
+	if err != nil {
+		tb.Fatalf("failed to spawn docker container %v: %s", args, err)
+	}
+
+	containerId = strings.TrimSpace(string(id))
+	tb.Cleanup(func() {
+		err := exec.Command("docker", "rm", "--force", containerId).Run()
+		if err != nil {
+			tb.Logf("failed to remove container %s: %s", containerId, err)
+		}
+	})
+
+	return containerId
+}
+
+// Start starts a new docker container with a given ID.
+func Start(tb testing.TB, id string) {
+	err := exec.Command("docker", "start", id).Run()
+	if err != nil {
+		tb.Fatalf("failed to start docker container %s: %s", id, err)
+	}
+}
+
+// dockerRun starts a new docker container in the background. The container will
+// be killed and removed on test cleanup.
+// It returns the containerId on success, or an error if spawning the container failed.
+func Run(tb testing.TB, args ...string) (containerId string) {
+	// note: we are not using `--rm` so we can choose to wait on the container
+	// with `docker wait`. We remove it manually below in t.Cleanup instead
+	args = append([]string{"run", "--detach"}, args...)
+	id, err := exec.Command("docker", args...).Output()
+	if err != nil {
+		tb.Fatalf("failed to spawn docker container %v: %s", args, err)
+	}
+
+	containerId = strings.TrimSpace(string(id))
+	tb.Cleanup(func() {
+		err := exec.Command("docker", "rm", "--force", containerId).Run()
+		if err != nil {
+			tb.Logf("failed to remove container %s: %s", containerId, err)
+		}
+	})
+
+	return containerId
+}
+
+// dockerExec executes a command in a container.
+func Exec(tb testing.TB, id string, args ...string) {
+	args = append([]string{"exec", id}, args...)
+	err := exec.Command("docker", args...).Run()
+	if err != nil {
+		tb.Fatalf("failed to exec in docker container %v: %s", args, err)
+	}
+}

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -521,69 +521,6 @@ func ExecWGCurl(readyWG *sync.WaitGroup, retries uint, args ...string) error {
 	return err
 }
 
-// DockerCreate creates a new docker container in the background. The container will
-// be killed and removed on test cleanup.
-// It returns the containerId on success, or an error if spawning the container failed.
-func DockerCreate(tb testing.TB, args ...string) (containerId string) {
-	// note: we are not using `--rm` so we can choose to wait on the container
-	// with `docker wait`. We remove it manually below in t.Cleanup instead
-	args = append([]string{"create"}, args...)
-	id, err := exec.Command("docker", args...).Output()
-	if err != nil {
-		tb.Fatalf("failed to spawn docker container %v: %s", args, err)
-	}
-
-	containerId = strings.TrimSpace(string(id))
-	tb.Cleanup(func() {
-		err := exec.Command("docker", "rm", "--force", containerId).Run()
-		if err != nil {
-			tb.Logf("failed to remove container %s: %s", containerId, err)
-		}
-	})
-
-	return containerId
-}
-
-// DockerStart starts a new docker container with a given ID.
-func DockerStart(tb testing.TB, id string) {
-	err := exec.Command("docker", "start", id).Run()
-	if err != nil {
-		tb.Fatalf("failed to start docker container %s: %s", id, err)
-	}
-}
-
-// dockerRun starts a new docker container in the background. The container will
-// be killed and removed on test cleanup.
-// It returns the containerId on success, or an error if spawning the container failed.
-func DockerRun(tb testing.TB, args ...string) (containerId string) {
-	// note: we are not using `--rm` so we can choose to wait on the container
-	// with `docker wait`. We remove it manually below in t.Cleanup instead
-	args = append([]string{"run", "--detach"}, args...)
-	id, err := exec.Command("docker", args...).Output()
-	if err != nil {
-		tb.Fatalf("failed to spawn docker container %v: %s", args, err)
-	}
-
-	containerId = strings.TrimSpace(string(id))
-	tb.Cleanup(func() {
-		err := exec.Command("docker", "rm", "--force", containerId).Run()
-		if err != nil {
-			tb.Logf("failed to remove container %s: %s", containerId, err)
-		}
-	})
-
-	return containerId
-}
-
-// dockerExec executes a command in a container.
-func DockerExec(tb testing.TB, id string, args ...string) {
-	args = append([]string{"exec", id}, args...)
-	err := exec.Command("docker", args...).Run()
-	if err != nil {
-		tb.Fatalf("failed to exec in docker container %v: %s", args, err)
-	}
-}
-
 type fakeK8sWatcher struct {
 	fakePod, fakeNamespace string
 }

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -4,12 +4,10 @@
 package procevents
 
 import (
-	"cmp"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -660,10 +658,6 @@ func listRunningProcs(procPath string) ([]procs, error) {
 	}
 
 	logger.GetLogger().Infof("Read ProcFS %s appended %d/%d entries", option.Config.ProcFS, len(processes), len(procFS))
-
-	slices.SortFunc(processes, func(a, b procs) int {
-		return cmp.Compare(a.pid, b.pid)
-	})
 
 	return processes, nil
 }

--- a/pkg/sensors/exec/procevents/proc_reader_test.go
+++ b/pkg/sensors/exec/procevents/proc_reader_test.go
@@ -4,8 +4,15 @@
 package procevents
 
 import (
+	"os/exec"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/cilium/tetragon/pkg/api"
+	"github.com/cilium/tetragon/pkg/observer/observertesthelper/docker"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,5 +25,37 @@ func TestListRunningProcs(t *testing.T) {
 	for _, p := range procs {
 		require.NotZero(t, p.pid)
 		require.Equal(t, p.pid, p.tid)
+	}
+}
+
+func TestInInitTreeProcfs(t *testing.T) {
+	if err := exec.Command("docker", "version").Run(); err != nil {
+		t.Skipf("docker not available. skipping test: %s", err)
+	}
+
+	containerID := docker.Create(t, "--name", "procfs-in-init-tree-test", "bash", "bash", "-c", "sleep infinity")
+
+	docker.Start(t, "procfs-in-init-tree-test")
+	time.Sleep(1 * time.Second)
+
+	rootPidOutput, err := exec.Command("docker", "inspect", "-f", "{{.State.Pid}}", containerID).Output()
+	require.NoError(t, err, "root pid should fetch")
+	rootPid, err := strconv.Atoi(strings.TrimSpace(string(rootPidOutput)))
+	require.NoError(t, err, "root pid should parse")
+
+	procs, err := listRunningProcs("/proc")
+	require.NoError(t, err)
+	require.NotNil(t, procs)
+	require.NotEqual(t, 0, len(procs))
+
+	inInitTree := make(map[uint32]struct{})
+	for _, p := range procs {
+		require.NotZero(t, p.pid)
+		require.Equal(t, p.pid, p.tid)
+		_, v := procToKeyValue(p, inInitTree)
+		if v.Process.Pid == uint32(rootPid) || v.Parent.Pid == uint32(rootPid) {
+			isInInitTree := v.Flags&api.EventInInitTree == api.EventInInitTree
+			assert.True(t, isInInitTree)
+		}
 	}
 }

--- a/pkg/sensors/exec/procevents/proc_test.go
+++ b/pkg/sensors/exec/procevents/proc_test.go
@@ -165,6 +165,11 @@ func TestProcsFindContainerId(t *testing.T) {
 	assert.Equal(t, i, 80, "ContainerId offset wrong")
 	assert.Equal(t, d, "0ca2b3cd20e5f55a2bbe8d4aa3f811c", "ContainerId wrong")
 
+	p = "11:pids:/actions_job/ec5fd62ba68d0b75a3cbdb7f7f78b526440b7969e22b2b362fb6f429ded42fdc"
+	d, i = procsFindDockerId(p)
+	assert.Equal(t, i, 20, "ContainerId offset wrong")
+	assert.Equal(t, d, "ec5fd62ba68d0b75a3cbdb7f7f78b52", "ContainerId wrong")
+
 	p = ""
 	d, i = procsFindDockerId(p)
 	assert.Equal(t, d, "", "Expect output '' empty string")


### PR DESCRIPTION
Recently we introduced the in_init_tree flag into execve map values to indicate whether
a process is a member of the initial process tree for a container. This worked well for
containers started after Tetragon, but broke for cases where the container was started
before Tetragon, since our procfs walk did not account for the in_init_tree flag. Fix this
behaviour by introducing logic in the procfs walk to account for this.

```release-note
Fix in_init_tree flag for processes started before Tetragon.
```
