### PR TITLE
tetragon: Add map_errors_update_total/map_errors_delete_total metrics

### DIFF
--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -23,4 +23,4 @@ Depending on your setup, changes listed here might require a manual intervention
 
 ### Metrics
 
-* TBD
+* `tetragon_map_errors_total` metric is replaced by `map_errors_update_total` and `map_errors_delete_total`.

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -198,9 +198,17 @@ The total number of in-use entries per map.
 | ----- | ------ |
 | `map  ` | `execve_map, tg_execve_joined_info_map` |
 
-### `tetragon_map_errors_total`
+### `tetragon_map_errors_delete_total`
 
-The number of errors per map.
+The number of failed deletes per map.
+
+| label | values |
+| ----- | ------ |
+| `map  ` | `execve_map, tg_execve_joined_info_map` |
+
+### `tetragon_map_errors_update_total`
+
+The number of failed updates per map.
 
 | label | values |
 | ----- | ------ |

--- a/pkg/metrics/mapmetrics/mapmetrics.go
+++ b/pkg/metrics/mapmetrics/mapmetrics.go
@@ -26,9 +26,14 @@ var (
 		"Capacity of a BPF map. Expected to be constant.",
 		nil, []metrics.ConstrainedLabel{MapLabel}, nil,
 	))
-	MapErrors = metrics.MustNewCustomGauge(metrics.NewOpts(
-		consts.MetricsNamespace, "", "map_errors_total",
-		"The number of errors per map.",
+	MapErrorsUpdate = metrics.MustNewCustomGauge(metrics.NewOpts(
+		consts.MetricsNamespace, "", "map_errors_update_total",
+		"The number of failed updates per map.",
+		nil, []metrics.ConstrainedLabel{MapLabel}, nil,
+	))
+	MapErrorsDelete = metrics.MustNewCustomGauge(metrics.NewOpts(
+		consts.MetricsNamespace, "", "map_errors_delete_total",
+		"The number of failed deletes per map.",
 		nil, []metrics.ConstrainedLabel{MapLabel}, nil,
 	))
 )


### PR DESCRIPTION
Adding map_errors_update_total/map_errors_delete_total metrics, which replace current tetragon_map_errors_total.
