### PR TITLE
pkg/sensors: RawDetachUnloader do not detach on unpin false

### DIFF
--- a/pkg/sensors/unloader/unloader.go
+++ b/pkg/sensors/unloader/unloader.go
@@ -110,10 +110,15 @@ type TcAttachment struct {
 	IsIngress bool
 }
 
-func (tu TcUnloader) Unload(_ bool) error {
-	for _, att := range tu.Attachments {
-		if err := detachTC(att.LinkName, att.IsIngress); err != nil {
-			return err
+func (tu TcUnloader) Unload(unpin bool) error {
+	// PROG_ATTACH does not return any link, so there's nothing to unpin,
+	// but we must skip the detach operation for 'unpin == false' otherwise
+	// the pinned program will be un-attached
+	if unpin {
+		for _, att := range tu.Attachments {
+			if err := detachTC(att.LinkName, att.IsIngress); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
I'm really unfamiliar with this part of the code, do we need something similar for tc? Does it make sense to not detach on `unpin=false`?

```release-note
Fix a bug where unloading programs where detaching them even in the case of unpin false (i.e.) --keep-sensors-on-exit
```