### PR TITLE
[backport/v1.2] Add the ability to get process cache entries

### DIFF
--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -231,3 +231,16 @@ func (pc *Cache) dump(opts *tetragon.DumpProcessCacheReqArgs) []*tetragon.Proces
 	}
 	return processes
 }
+
+func (pc *Cache) getEntries() []*tetragon.ProcessInternal {
+	var processes []*tetragon.ProcessInternal
+	for _, v := range pc.cache.Values() {
+		processes = append(processes, &tetragon.ProcessInternal{
+			Process:   v.process,
+			Refcnt:    &wrapperspb.UInt32Value{Value: v.refcnt},
+			RefcntOps: v.refcntOps,
+			Color:     colorStr[v.color],
+		})
+	}
+	return processes
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -541,3 +541,12 @@ func GetK8s() watcher.K8sResourceWatcher {
 func DumpProcessCache(opts *tetragon.DumpProcessCacheReqArgs) []*tetragon.ProcessInternal {
 	return procCache.dump(opts)
 }
+
+// This function returns the process cache entries (and not the copies
+// of them as opposed to dump function). Thus any changes to the return
+// value results in affecting the process cache entries.
+// This is mainly for tests where we want to check the values of the
+// process cache.
+func GetCacheEntries() []*tetragon.ProcessInternal {
+	return procCache.getEntries()
+}


### PR DESCRIPTION
[upstream commit 5e46dc7d2f4d4a28d6e3c5e044f2aecf2e953701]

This will be used in follow-up PRs for creating tests check process cache entries.
