### PR TITLE
Pr/jrfastab/config map testing

### DIFF
--- a/cmd/tetragon/conf.go
+++ b/cmd/tetragon/conf.go
@@ -20,7 +20,7 @@ var (
 	}
 )
 
-func readConfigSettings(defaultConfDir string, defaultConfDropIn string, dropInsDir []string) {
+func ReadConfigSettings(defaultConfDir string, defaultConfDropIn string, dropInsDir []string) {
 	viper.SetEnvPrefix("tetragon")
 	replacer := strings.NewReplacer("-", "_")
 	viper.SetEnvKeyReplacer(replacer)

--- a/cmd/tetragon/conf_test.go
+++ b/cmd/tetragon/conf_test.go
@@ -1117,7 +1117,7 @@ func runTestCases(t *testing.T) {
 		packageConfDropIns = append(packageConfDropIns, filepath.Join(testDir, c))
 	}
 	log.Infof("Test %s index %d dumping settings before: %+v", c.description, globalTestIndex, viper.AllSettings())
-	readConfigSettings(defaultConfYamlFile, defaultConfDropIn, packageConfDropIns)
+	ReadConfigSettings(defaultConfYamlFile, defaultConfDropIn, packageConfDropIns)
 	log.Infof("Test %s index %d expected settings: %+v", c.description, globalTestIndex, c.expectedOptions)
 	log.Infof("Test %s index %d dumping settings after: %+v", c.description, globalTestIndex, viper.AllSettings())
 

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -858,7 +858,7 @@ func execute() error {
 	}
 
 	cobra.OnInitialize(func() {
-		readConfigSettings(adminTgConfDir, adminTgConfDropIn, packageTgConfDropIns)
+		ReadConfigSettings(adminTgConfDir, adminTgConfDropIn, packageTgConfDropIns)
 	})
 
 	flags := rootCmd.PersistentFlags()

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -677,6 +677,22 @@ func WaitForProcess(process string) error {
 	return fmt.Errorf("process '%s' did not start", process)
 }
 
+func WriteConfigMap(dir, key, value string) error {
+	fileName := filepath.Join(dir, key)
+	if err := os.MkdirAll(filepath.Dir(fileName), 0777); err != nil {
+		return err
+	}
+
+	out, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	if _, err := out.Write([]byte(value)); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
 func WriteConfigFile(fileName, config string) error {
 	out, err := os.Create(fileName)
 	if err != nil {


### PR DESCRIPTION
I got a bug report that a config file option did not work when pushed through the config map as a file in systemd. It turned out to be a typo but this adds infrastructure and a test to add go tests to check this works.

For now I just add one test but we can add more easily now.