### PR TITLE
vmtests: disable TestFastK8s

### DIFF
--- a/pkg/vmtests/skip.go
+++ b/pkg/vmtests/skip.go
@@ -20,6 +20,7 @@ var rules = []skipRule{
 	skipRule{TestNameRe: "pkg.sensors.tracing.TestLoader", KernelRe: "(6\\.6|6\\.1)"},
 	skipRule{TestNameRe: "pkg.tracepoint.TestTracepointLoadFormat", KernelRe: "(6\\.1|bpf-next)"},
 	skipRule{TestNameRe: "pkg.sensors.exec.TestProcessCacheInterval", KernelRe: ""},
+	skipRule{TestNameRe: "pkg.watcher.TestFastK8s", KernelRe: ""},
 }
 
 func init() {


### PR DESCRIPTION
TestFastK8s was introduced in 7043d06fc5d79be8a9147e6fa98387739a0b41ba.

TestFastK8s has been flaky (see issue 2972). Not sure why this is the case. Maybe some timing issue with respect to the k8s controller and fake client initialization.

This commit disables it for vmtests since it does not load any bpf programs and so it is not kernel dependent.


Fixes: https://github.com/cilium/tetragon/issues/2972

