### PR TITLE
gitattributes: auto resolve merge conflicts for generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,13 @@
 /docs/content/en/docs/reference/grpc-api.md linguist-generated
 /docs/content/en/docs/reference/metrics.md linguist-generated
 /docs/data/tetragon_flags.yaml linguist-generated
+
+# Pick the "ours" merge strategy for code generated files. This avoids the
+# changes showing up in git mergetool since we would need to re-run the code
+# generation as part of the rebase anyway.
+./**/*.pb merge=ours
+./**/*.pb.* merge=ours
+./api/v1/README.md merge=ours
+./pkg/k8s/client/**/*.go merge=ours
+./pkg/k8s/apis/**/*.go merge=ours
+./install/kubernetes/tetragon/README.md merge=ours


### PR DESCRIPTION
Since our generated files need to be updated via codegen targets after a rebase anyway, it makes no sense to manually resolve conflicts in them with mergetool. Therefore, let's have git automatically choose a dummy merge strategy for our generated files to streamline the process of making rebases.
