### PR TITLE
docs: fix the Example jq filter in Observability Policies

### DIFF
--- a/docs/content/en/docs/policy-library/observability/_index.md
+++ b/docs/content/en/docs/policy-library/observability/_index.md
@@ -158,7 +158,7 @@ No policy needs to be loaded, standard process execution observability is suffic
 ### Example jq Filter
 
 ```shell
-jq 'select(.process_exec != null) | select(.process_exec.process.binary_properties != null) | select(.process_exec.process.binary_properties.privileges_changed != null) | "\(.time) \(.process_exec.process.pod.namespace) \(.process_exec.process.pod.name) \(.process_exec.process.binary) \(.process_exec.process.arguments) uid=\(.process_exec.process.process_credentials.uid) euid=\(.process_exec.process.process_credentials.euid)  gid=\(.process_exec.process.process_credentials.gid) egid=\(.process_exec.process.process_credentials.egid) caps=\(.process_exec.process.cap) binary_properties=\(.process_exec.process.binary_properties)"''
+jq 'select(.process_exec != null) | select(.process_exec.process.binary_properties != null) | select(.process_exec.process.binary_properties.privileges_changed != null) | "\(.time) \(.process_exec.process.pod.namespace) \(.process_exec.process.pod.name) \(.process_exec.process.binary) \(.process_exec.process.arguments) uid=\(.process_exec.process.process_credentials.uid) euid=\(.process_exec.process.process_credentials.euid)  gid=\(.process_exec.process.process_credentials.gid) egid=\(.process_exec.process.process_credentials.egid) caps=\(.process_exec.process.cap) binary_properties=\(.process_exec.process.binary_properties)"'
 ```
 
 ### Example Output


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Fixed the Example jq filter command in Observability Policies "Privileges Escalation via File Capabilities Execution".