### PR TITLE
renovate: Group cel-go together with k8s dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -434,7 +434,7 @@
       ],
       "draftPR": true,
       "prBodyNotes": [
-        ":warning: Manual steps need to be performed (explaining why this PR is only a draft). First replace directives must be synchronized with cilium/cilium, see the `go.mod` and `pkg/k8s/go.mod` for more info. Then dependencies ignore in `.github/renovate.json5` for the replace directive must be updated accordingly. Finally, make sure that k8s dependencies were also bumped along Cilium."
+        ":warning: Manual steps need to be performed (explaining why this PR is only a draft). First replace directives must be synchronized with cilium/cilium, see the `go.mod` and `pkg/k8s/go.mod` for more info. Then dependencies ignore in `.github/renovate.json5` for the replace directive must be updated accordingly. Finally, make sure that k8s and cel-go dependencies were also bumped along Cilium."
       ]
     },
     {
@@ -442,7 +442,8 @@
       "matchPackageNames": [
         // k8s dependencies will be updated manually along cilium updates
         "k8s\\.io/*",
-        "sigs\\.k8s\\.io/*"
+        "sigs\\.k8s\\.io/*",
+        "github.com/google/cel-go", // cel-go is a dependency of k8s apiserver
       ],
       "matchUpdateTypes": [
         "major",


### PR DESCRIPTION
Recently Renovate tried to to update google/cel-go to 0.23, but it turns out incompatible with k8s.io/apiserver 0.32. As Go dependencies are grouped, this is now blocking updates of other packages (cilium/tetragon#3290). Let's group cel-go together with k8s packages for now, so that it's not getting updated until we update to k8s 1.33.
