### PR TITLE
fix: returnArg index of TracingPolicy is not specified

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -416,6 +416,7 @@ set to `true`, and the `returnArg` parameter needs to be set to specify the
     type: int
     label: "family"
   returnArg:
+    index: 0
     type: sock
 ```
 
@@ -450,6 +451,7 @@ See [`TrackSock`](/docs/concepts/tracing-policy/selectors/#tracksock-action) and
     type: int
     label: "family"
   returnArg:
+    index: 0
     type: sock
   returnArgAction: TrackSock
 ```

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -1193,6 +1193,7 @@ generate any event about that.
   - index: 2
     type: "int"
   returnArg:
+    index: 0
     type: "int"
   selectors:
   - matchPIDs:

--- a/examples/tracingpolicy/tcp-listen.yaml
+++ b/examples/tracingpolicy/tcp-listen.yaml
@@ -13,6 +13,7 @@ spec:
       type: int
       label: "family"
     returnArg:
+      index: 0
       type: "sock"
     returnArgAction: "TrackSock"
     selectors:

--- a/pkg/bench/trace_bench_rw.go
+++ b/pkg/bench/trace_bench_rw.go
@@ -150,6 +150,7 @@ spec:
     - index: 2
       type: "size_t"
     returnArg:
+      index: 0
       type: "size_t"
     selectors:
     - matchPIDs:

--- a/pkg/sensors/tracing/kprobe_amd64_test.go
+++ b/pkg/sensors/tracing/kprobe_amd64_test.go
@@ -58,6 +58,7 @@ spec:
     - index: 2
       type: "capability"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchPIDs:

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -565,6 +565,7 @@ spec:
     - index: 2
       type: "size_t"
     returnArg:
+      index: 0
       type: "size_t"
     selectors:
     - matchPIDs:
@@ -1531,6 +1532,7 @@ func testKprobeObjectFilterReturnValueGTHook(pidStr, path string) string {
       - index: 2
         type: "int"
       returnArg:
+        index: 0
         type: int
       selectors:
       - matchPIDs:
@@ -1570,6 +1572,7 @@ func testKprobeObjectFilterReturnValueLTHook(pidStr, path string) string {
       - index: 2
         type: "int"
       returnArg:
+        index: 0
         type: int
       selectors:
       - matchPIDs:
@@ -1861,6 +1864,7 @@ spec:
     - index: 1
       type: "filename"
     returnArg:
+      index: 0
       type: file
     selectors:
     - matchPIDs:
@@ -2396,6 +2400,7 @@ spec:
     - index: 2
       type: "int"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchPIDs:
@@ -2459,6 +2464,7 @@ spec:
     - index: 0
       type: "file"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchPIDs:
@@ -2517,6 +2523,7 @@ spec:
     - index: 2
       type: "int"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchPIDs:
@@ -2637,6 +2644,7 @@ spec:
     - index: 2
       type: "int"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchPIDs:
@@ -2702,6 +2710,7 @@ spec:
     - index: 2
       type: "int"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchPIDs:
@@ -2767,6 +2776,7 @@ spec:
     - index: 2
       type: "int"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchPIDs:
@@ -2910,6 +2920,7 @@ spec:
     - index: 2
       type: "int"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchPIDs:
@@ -2940,6 +2951,7 @@ spec:
     - index: 4
       type: "int"
     returnArg:
+      index: 0
       type: "int"
     selectors:
     - matchPIDs:
@@ -4406,6 +4418,7 @@ spec:
     - index: 2
       type: "size_t"
     returnArg:
+      index: 0
       type: "size_t"
 `
 


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes https://github.com/cilium/tetragon/issues/3369

### Description
`.returnArg.index` was lacking.
In addition to the documentation, i also fix the examples and source code.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
```
