### PR TITLE
helm: mount /sys/kernel/security/lsm for generic_lsm sensor

### DIFF
--- a/install/kubernetes/tetragon/templates/daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/daemonset.yaml
@@ -114,6 +114,9 @@ spec:
           path: {{ quote .Values.tetragon.cri.socketHostPath }}
           type: Socket
 {{- end }}
+      - name: security-lsm
+        hostPath:
+          path: /sys/kernel/security/lsm
 {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
We need to mount `/sys/kernel/security/lsm` from host  to check if lsm bpf is enabled.

Fixes  #3392