### PR TITLE
watcher: Fix K8sWatcher.FindPod

### DIFF
--- a/pkg/watcher/fake.go
+++ b/pkg/watcher/fake.go
@@ -40,7 +40,7 @@ func (watcher *FakeK8sWatcher) FindMirrorPod(_ string) (*corev1.Pod, error) {
 }
 
 func (watcher *FakeK8sWatcher) FindPod(podID string) (*corev1.Pod, error) {
-	ret, ok := findPod(watcher.pods)
+	ret, ok := findPod(podID, watcher.pods)
 	if ok {
 		return ret, nil
 	}


### PR DESCRIPTION
The K8sWatcher.FindPod method first tries to find a pod using index, then, if
unsuccessful, falls back to walking the entire pods list. This fallback was
incorrect - fix it.

I'm not sure how often or if ever this code path was being hit in the wild - it
would be hit only if the index got out-of-sync. It would be good to understand
it, but for now let's just fix the bug.