### PR TITLE
Remove kernel version check for LSM Resolve flag

### DIFF
--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -123,6 +123,11 @@ func FindBtfFuncParamFromHook(hook string, argIndex int) (*btf.FuncParam, error)
 	}
 
 	if err = spec.TypeByName(hook, &hookFn); err != nil {
+		if strings.HasPrefix(hook, "bpf_lsm_") {
+			return nil, fmt.Errorf("failed to find BTF type for hook %q: %w."+
+				"Please check if the hook exists or if your kernel supports BTF for lsm hooks."+
+				"As an alternative, consider switching to kprobes. ", hook, err)
+		}
 		return nil, fmt.Errorf("failed to find BTF type for hook %q: %w", hook, err)
 	}
 

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -243,12 +243,6 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 			if !bpf.HasProgramLargeSize() {
 				return errFn(fmt.Errorf("Error: Resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag"))
 			}
-			if !kernels.MinKernelVersion("5.7.0") {
-				// bpf_lsm_<hook_name> does not exist in BTF file before 5.7
-				// https://lore.kernel.org/bpf/20200329004356.27286-4-kpsingh@chromium.org/
-				return errFn(fmt.Errorf("Error: LSM programs can not use Resolve flag for your kernel version." +
-					"Please use Kprobe instead or update your kernel to version 5.7 or higher"))
-			}
 			lastBtfType, btfArg, err := resolveBtfArg("bpf_lsm_"+f.Hook, a)
 			if err != nil {
 				return errFn(fmt.Errorf("Error on hook %q for index %d : %v", f.Hook, a.Index, err))


### PR DESCRIPTION
This PR is the follow-up to this comment https://github.com/cilium/tetragon/pull/3143#discussion_r1948562130

In `genericlsm.go` we check the kernel version for the use of the Resolve flag. But it is not reliable because vendors may (like rhel) may have kernels with additional patches, but they are detected as lower than the required version. 