### PR TITLE
pkg/bpf: remove redundant check from HasLSMPrograms

### DIFF
--- a/pkg/bpf/detect.go
+++ b/pkg/bpf/detect.go
@@ -9,9 +9,7 @@ package bpf
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"unsafe"
 
@@ -231,39 +229,31 @@ func detectLSM() bool {
 	if features.HaveProgramType(ebpf.LSM) != nil {
 		return false
 	}
-	b, err := os.ReadFile("/sys/kernel/security/lsm")
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "probe_lsm_file_open",
+		Type: ebpf.LSM,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		AttachTo:   "file_open",
+		AttachType: ebpf.AttachLSMMac,
+		License:    "Dual BSD/GPL",
+	})
 	if err != nil {
-		logger.GetLogger().WithError(err).Error("failed to read /sys/kernel/security/lsm")
+		logger.GetLogger().WithError(err).Error("failed to load lsm probe")
 		return false
 	}
-	if strings.Contains(string(b), "bpf") {
-		prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-			Name: "probe_lsm_file_open",
-			Type: ebpf.LSM,
-			Instructions: asm.Instructions{
-				asm.Mov.Imm(asm.R0, 0),
-				asm.Return(),
-			},
-			AttachTo:   "file_open",
-			AttachType: ebpf.AttachLSMMac,
-			License:    "Dual BSD/GPL",
-		})
-		if err != nil {
-			logger.GetLogger().WithError(err).Error("failed to load lsm probe")
-			return false
-		}
-		defer prog.Close()
+	defer prog.Close()
 
-		link, err := link.AttachLSM(link.LSMOptions{
-			Program: prog,
-		})
-		if err != nil {
-			logger.GetLogger().WithError(err).Error("failed to attach lsm probe")
-			return false
-		}
-		link.Close()
-		return true
+	link, err := link.AttachLSM(link.LSMOptions{
+		Program: prog,
+	})
+	if err != nil {
+		logger.GetLogger().WithError(err).Error("failed to attach lsm probe")
+		return false
 	}
+	link.Close()
 
 	return false
 }

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -354,7 +354,8 @@ func createGenericLsmSensor(
 	var err error
 
 	if !bpf.HasLSMPrograms() || !kernels.EnableLargeProgs() {
-		return nil, fmt.Errorf("Does you kernel support the bpf LSM? You can enable LSM BPF by modifying" +
+		return nil, fmt.Errorf("Unable to load simple LSM BPF program. " +
+			"Does you kernel support the bpf LSM? You can enable LSM BPF by modifying " +
 			"the GRUB configuration /etc/default/grub with GRUB_CMDLINE_LINUX=\"lsm=bpf\"")
 	}
 


### PR DESCRIPTION
Checking the contents of `/sys/kernel/security/lsm` file is redundant because later simple LSM program is loaded. File check makes problems when you trying to load LSM sensor in k8s cluster. We can remove this check without losing stability.

Fixes #3392 

Some discussion can be found here: #3404 