### PR TITLE
add dentry type

### DIFF
--- a/examples/tracingpolicy/security_inode_follow_link.yaml
+++ b/examples/tracingpolicy/security_inode_follow_link.yaml
@@ -1,0 +1,11 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "follow-symlink"
+spec:
+  kprobes:
+  - call: "security_inode_follow_link"
+    syscall: false
+    args:
+    - index: 0
+      type: "dentry"

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -205,6 +205,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -309,6 +310,7 @@ spec:
                           - data_loc
                           - net_device
                           - bpf_cmd
+                          - dentry
                           type: string
                       required:
                       - index
@@ -928,6 +930,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -1584,6 +1587,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -2175,6 +2179,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -205,6 +205,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -309,6 +310,7 @@ spec:
                           - data_loc
                           - net_device
                           - bpf_cmd
+                          - dentry
                           type: string
                       required:
                       - index
@@ -928,6 +930,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -1584,6 +1587,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -2175,6 +2179,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -64,6 +64,8 @@ const (
 	GenericSockaddrType = 40
 	GenericSocketType   = 41
 
+	GenericDentryType = 42
+
 	GenericNopType     = -1
 	GenericInvalidType = -2
 )
@@ -122,6 +124,7 @@ var GenericStringToType = map[string]int{
 	"net_device":      GenericNetDev,
 	"sockaddr":        GenericSockaddrType,
 	"socket":          GenericSocketType,
+	"dentry":          GenericDentryType,
 }
 
 var GenericTypeToStringTable = map[int]string{

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -205,6 +205,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -309,6 +310,7 @@ spec:
                           - data_loc
                           - net_device
                           - bpf_cmd
+                          - dentry
                           type: string
                       required:
                       - index
@@ -928,6 +930,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -1584,6 +1587,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -2175,6 +2179,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -205,6 +205,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -309,6 +310,7 @@ spec:
                           - data_loc
                           - net_device
                           - bpf_cmd
+                          - dentry
                           type: string
                       required:
                       - index
@@ -928,6 +930,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -1584,6 +1587,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -2175,6 +2179,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -60,7 +60,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=auto;int;int8;uint8;int16;uint16;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;sockaddr;socket;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd
+	// +kubebuilder:validation:Enum=auto;int;int8;uint8;int16;uint16;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;sockaddr;socket;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd;dentry;
 	// +kubebuilder:default=auto
 	// Argument type.
 	Type string `json:"type"`

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.4.2"
+const CustomResourceDefinitionSchemaVersion = "1.4.3"

--- a/pkg/sensors/tracing/args.go
+++ b/pkg/sensors/tracing/args.go
@@ -140,7 +140,7 @@ func getArg(r *bytes.Reader, a argPrinter) api.MsgGenericKprobeArg {
 		arg.Flags = flags
 		arg.Label = a.label
 		return arg
-	case gt.GenericPathType:
+	case gt.GenericPathType, gt.GenericDentryType:
 		var arg api.MsgGenericKprobeArgPath
 		var flags uint32
 		var mode uint16

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -41,11 +41,13 @@ import (
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 	"github.com/cilium/tetragon/pkg/metricsconfig"
+	"github.com/cilium/tetragon/pkg/mountinfo"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	"github.com/cilium/tetragon/pkg/reader/namespace"
+	pathr "github.com/cilium/tetragon/pkg/reader/path"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tuo "github.com/cilium/tetragon/pkg/testutils/observer"
@@ -7287,6 +7289,83 @@ spec:
 	require.NoError(t, err)
 
 	checker := ec.NewUnorderedEventChecker(kprobeLongFileArgChecker, processLongCWDChecker)
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}
+
+func TestKprobeDentryPath(t *testing.T) {
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	file, err := os.CreateTemp(t.TempDir(), "dentry-unlink")
+	if err != nil {
+		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
+	}
+	defer assert.NoError(t, file.Close())
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	infos, err := mountinfo.GetMountInfo()
+	if err != nil {
+		t.Fatalf("mountinfo.GetMountInfo() err %s", err)
+	}
+
+	// We can extract dentry type until first mount point,
+	// so let's detect that and find final path portion for
+	// checking.
+	check := file.Name()
+	for _, info := range infos {
+		if len(info.MountPoint) > 1 && strings.HasPrefix(file.Name(), info.MountPoint) {
+			check = info.MountPoint[len(info.MountPoint):]
+			break
+		}
+	}
+
+	hook := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "multiple-symbols"
+spec:
+  kprobes:
+  - call: "security_path_unlink"
+    syscall: false
+    args:
+    - index: 1
+      type: "dentry"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Postfix"
+        values:
+        - "` + check + `"
+`
+	createCrdFile(t, hook)
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	t.Logf("Removing file %s, mode %s, check %s\n", file.Name(), pathr.FilePathModeToStr(syscall.O_RDWR), check)
+	syscall.Unlink(file.Name())
+
+	kpChecker := ec.NewProcessKprobeChecker("").
+		WithFunctionName(sm.Full("security_path_unlink")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithPathArg(ec.NewKprobePathChecker().
+					WithPath(sm.Full(check)),
+				),
+			)).
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Suffix(tus.Conf().SelfBinary)))
+
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
 	err = jsonchecker.JsonTestCheck(t, checker)
 	assert.NoError(t, err)
 }

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -205,6 +205,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -309,6 +310,7 @@ spec:
                           - data_loc
                           - net_device
                           - bpf_cmd
+                          - dentry
                           type: string
                       required:
                       - index
@@ -928,6 +930,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -1584,6 +1587,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -2175,6 +2179,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -205,6 +205,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -309,6 +310,7 @@ spec:
                           - data_loc
                           - net_device
                           - bpf_cmd
+                          - dentry
                           type: string
                       required:
                       - index
@@ -928,6 +930,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -1584,6 +1587,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index
@@ -2175,6 +2179,7 @@ spec:
                             - data_loc
                             - net_device
                             - bpf_cmd
+                            - dentry
                             type: string
                         required:
                         - index

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -60,7 +60,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=auto;int;int8;uint8;int16;uint16;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;sockaddr;socket;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd
+	// +kubebuilder:validation:Enum=auto;int;int8;uint8;int16;uint16;uint32;int32;uint64;int64;char_buf;char_iovec;size_t;skb;sock;sockaddr;socket;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd;dentry;
 	// +kubebuilder:default=auto
 	// Argument type.
 	Type string `json:"type"`

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.4.2"
+const CustomResourceDefinitionSchemaVersion = "1.4.3"


### PR DESCRIPTION
Adding support to extract dentry full path via new 'dentry' type,
which presents the data as as path_arg argument.

So following spec:

```
  spec:
    kprobes:
    - call: "security_path_unlink"
      syscall: false
      args:
      - index: 1
        type: "dentry"
```
gives you:

`   args{"path_arg":{"path":"/tmp/TestKprobeDentryPath4036433650/001/dentry-unlink872807283", "permission":"-rw-------"}}
`

**Note** dentry type can extract path only to the first mount point.

Note this patch is based on work of David Windsor, adding his SOB.
