### PR TITLE
tetra/getevents: add a --reconnect option

### DIFF
--- a/cmd/tetra/getevents/getevents.go
+++ b/cmd/tetra/getevents/getevents.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/cmd/tetra/common"
@@ -39,6 +40,8 @@ type Opts struct {
 	ImaHash       bool
 	PolicyNames   []string
 	CelExpression []string
+	Reconnect     bool
+	ReconnectWait time.Duration
 }
 
 var Options Opts
@@ -191,13 +194,32 @@ redirection of events to the stdin. Examples:
 				// read events from stdin
 				return getEvents(context.Background(), newIOReaderClient(os.Stdin, common.Debug))
 			}
-			// connect to server
-			c, err := common.NewClientWithDefaultContextAndAddress()
-			if err != nil {
-				return fmt.Errorf("failed create gRPC client: %w", err)
+
+			reconnect := Options.Reconnect
+			tryGetEvents := func() error {
+				// connect to server
+				c, err := common.NewClientWithDefaultContextAndAddress()
+				if err != nil {
+					return fmt.Errorf("failed create gRPC client: %w", err)
+				}
+				defer c.Close()
+				ret := getEvents(c.SignalCtx, c.Client)
+				if ctxErr := c.SignalCtx.Err(); ctxErr != nil && errors.Is(ctxErr, context.Canceled) {
+					// we got a signal, so we should not try to reconnect
+					reconnect = false
+				}
+				return ret
 			}
-			defer c.Close()
-			return getEvents(c.SignalCtx, c.Client)
+
+			for {
+				err := tryGetEvents()
+				if !reconnect {
+					return err
+				}
+				fmt.Fprintf(os.Stderr, "getevents: err:%v retrying in %v\n", err, Options.ReconnectWait)
+				time.Sleep(Options.ReconnectWait)
+			}
+
 		},
 	}
 
@@ -227,5 +249,7 @@ redirection of events to the stdin. Examples:
 	flags.BoolVar(&Options.ImaHash, "ima-hash", true, "Include ima hashes in compact output")
 	flags.StringSliceVar(&Options.PolicyNames, "policy-names", nil, "Get events by tracing policy names")
 	flags.StringSliceVar(&Options.CelExpression, "cel-expression", nil, "Get events satisfying the CEL expression")
+	flags.BoolVar(&Options.Reconnect, "reconnect", false, "Keep trying to connect even if an error occurred")
+	flags.DurationVar(&Options.ReconnectWait, "reconnect-wait", 2*time.Second, "wait time before attempting to reconnect")
 	return &cmd
 }


### PR DESCRIPTION
In certain situations (e.g., development) it's useful to have a tetra client constantly running as you are restarting the tetragon agent. Add a --reconnect option in the tetra getevents command to support this.

```release-note
tetra: add a --reconnect option to getevents command
```
