### PR TITLE
helm: Removed default tolerations for the operator

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -162,7 +162,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragonOperator.securityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pods. |
 | tetragonOperator.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | tetragon-operator service account. |
 | tetragonOperator.strategy | object | `{}` | resources for the Tetragon Operator Deployment update strategy |
-| tetragonOperator.tolerations[0].operator | string | `"Exists"` |  |
+| tetragonOperator.tolerations | list | `[]` |  |
 | tetragonOperator.tracingPolicy.enabled | bool | `true` | Enables the TracingPolicy and TracingPolicyNamespaced CRD creation. |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -144,7 +144,7 @@ Helm chart for Tetragon
 | tetragonOperator.securityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pods. |
 | tetragonOperator.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | tetragon-operator service account. |
 | tetragonOperator.strategy | object | `{}` | resources for the Tetragon Operator Deployment update strategy |
-| tetragonOperator.tolerations[0].operator | string | `"Exists"` |  |
+| tetragonOperator.tolerations | list | `[]` |  |
 | tetragonOperator.tracingPolicy.enabled | bool | `true` | Enables the TracingPolicy and TracingPolicyNamespaced CRD creation. |
 | tolerations[0].operator | string | `"Exists"` |  |
 | updateStrategy | object | `{}` |  |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -286,8 +286,7 @@ tetragonOperator:
   strategy: {}
   # -- Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules.
   nodeSelector: {}
-  tolerations:
-    - operator: Exists
+  tolerations: []
   affinity: {}
   # -- tetragon-operator image.
   image:


### PR DESCRIPTION
This PR adjusts the default  `operator: Exists` toleration for the Tetragon Operator Deployment introduced in https://github.com/cilium/tetragon/pull/1817.

The Tetragon Operator deployment doesn't need that; it should usually only be scheduled when the node(s) are ready. It typically doesn't need to be running before (as it would be for a CNI, for example). Also, if specific tolerations for node taints are still required in some corner cases, the Helm default value can still be overridden.

The reason for this change is that an `operator: Exists` toleration can lead to situations where it conflicts with the [ContainerStatusUnknown admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#defaulttolerationseconds). For example, when a (single-)node cluster is rebooted, it triggers the ReplicaSet to create dozens of pods that are then stuck in a `ContainerStatusUnknown` state.

```bash
$ kgp
NAME                                      READY   STATUS                   RESTARTS        AGE
...
tetragon-99ds6                            2/2     Running                  0               9m17s
tetragon-operator-7975859865-24zh2        0/1     ContainerStatusUnknown   0               12m
tetragon-operator-7975859865-2h4js        0/1     ContainerStatusUnknown   0               12m
tetragon-operator-7975859865-2k4np        0/1     Completed                0               40m
tetragon-operator-7975859865-2mp8c        0/1     ContainerStatusUnknown   0               12m
tetragon-operator-7975859865-2zhk6        0/1     ContainerStatusUnknown   0               12m
tetragon-operator-7975859865-45cl7        0/1     ContainerStatusUnknown   0               12m
tetragon-operator-7975859865-482rd        0/1     ContainerStatusUnknown   0               12m
tetragon-operator-7975859865-4crsv        0/1     ContainerStatusUnknown   0               12m
tetragon-operator-7975859865-4gjhk        0/1     ContainerStatusUnknown   0               12m
tetragon-operator-7975859865-4k6jk        0/1     ContainerStatusUnknown   0               12m
...
$ kgp -o yaml tetragon-operator-7975859865-24zh2
...
  tolerations:
  - operator: Exists
...
  containerStatuses:
  - image: quay.io/cilium/tetragon-operator:...
    imageID: ""
    lastState: {}
    name: tetragon-operator
    ready: false
    restartCount: 0
    started: false
    state:
      terminated:
        exitCode: 137
        finishedAt: null
        message: The container could not be located when the pod was terminated
        reason: ContainerStatusUnknown
        startedAt: null
....
  message: 'Pod was rejected: Pod was rejected as the node is shutting down.'
  phase: Failed
  qosClass: Burstable
  reason: NodeShutdown
  startTime: "2025-02-27T12:44:29Z"
```

BTW, for the Cilium Operator, which also sets the `operator: Exists` toleration, we would see the same issue if it wouldn't also set `priorityClassName: system-cluster-critical` (I briefly verified this on a test environment).

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
helm: Removed default toleration (`operator: Exists`) for the operator Deployment
```
