### PR TITLE
Added support to run multiple Tetragon operator replicas simultaneously

### DIFF
--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -11,7 +11,9 @@ Depending on your setup, changes listed here might require a manual intervention
 
 ### Helm Values
 
-* TBD
+* It's now supported to run multiple Tetragon operator replicas simultaneously. Enable it by setting `tetragonOperator.replicas=2` and `tetragonOperator.failoverLease.enabled=true`.
+* `tetragonOperator.strategy` now sets a default `rollingUpdate` strategy (`maxSurge=1`, `maxUnavailable=0`) to reduce downtime during an upgrade.
+* The Tetragon operator Deployment now sets a default `podAntiAffinity` (`preferredDuringSchedulingIgnoredDuringExecution`) to improve the Pod distribution (if possible), without enforcing it to avoid being stuck during upgrades on single or two node clusters.
 
 ### TracingPolicy (k8s CRD)
 

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -137,13 +137,21 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.redactionFilters | string | `""` | Filters to redact secrets from the args fields in Tetragon events. To perform redactions, redaction filters define RE2 regular expressions in the `redact` field. Any capture groups in these RE2 regular expressions are redacted and replaced with "*****".  For more control, you can select which binary or binaries should have their arguments redacted with the `binary_regex` field.  NOTE: This feature uses RE2 as its regular expression library. Make sure that you follow RE2 regular expression guidelines as you may observe unexpected results otherwise. More information on RE2 syntax can be found [here](https://github.com/google/re2/wiki/Syntax).  NOTE: When writing regular expressions in JSON, it is important to escape backslash characters. For instance `\Wpasswd\W?` would be written as `{"redact": "\\Wpasswd\\W?"}`.  As a concrete example, the following will redact all passwords passed to processes with the "--password" argument:    {"redact": ["--password(?:\\s+|=)(\\S*)"]}  Now, an event which contains the string "--password=foo" would have that string replaced with "--password=*****".  Suppose we also see some passwords passed via the -p shorthand for a specific binary, foo. We can also redact these as follows:    {"binary_regex": ["(?:^|/)foo$"], "redact": ["-p(?:\\s+|=)(\\S*)"]}  With both of the above redaction filters in place, we are now redacting all password arguments. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
-| tetragonOperator.affinity | object | `{}` |  |
+| tetragonOperator.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels."app.kubernetes.io/name" | string | `"tetragon-operator"` |  |
+| tetragonOperator.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"kubernetes.io/hostname"` |  |
+| tetragonOperator.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | tetragonOperator.annotations | object | `{}` | Annotations for the Tetragon Operator Deployment. |
 | tetragonOperator.enabled | bool | `true` | Enables the Tetragon Operator. |
 | tetragonOperator.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment. |
 | tetragonOperator.extraPodLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment Pods. |
 | tetragonOperator.extraVolumeMounts | list | `[]` |  |
 | tetragonOperator.extraVolumes | list | `[]` | Extra volumes for the Tetragon Operator Deployment. |
+| tetragonOperator.failoverLease | object | `{"enabled":false,"leaseDuration":"15s","leaseRenewDeadline":"5s","leaseRetryPeriod":"2s","namespace":""}` | Lease handling for an automated failover when running multiple replicas |
+| tetragonOperator.failoverLease.enabled | bool | `false` | Enable lease failover functionality |
+| tetragonOperator.failoverLease.leaseDuration | string | `"15s"` | If a lease is not renewed for X duration, the current leader is considered dead, a new leader is picked |
+| tetragonOperator.failoverLease.leaseRenewDeadline | string | `"5s"` | The interval at which the leader will renew the lease |
+| tetragonOperator.failoverLease.leaseRetryPeriod | string | `"2s"` | The timeout between retries if renewal fails |
+| tetragonOperator.failoverLease.namespace | string | `""` | Kubernetes Namespace in which the Lease resource is created. Defaults to the namespace where Tetragon is deployed in, if it's empty. |
 | tetragonOperator.forceUpdateCRDs | bool | `false` |  |
 | tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.3.0"}` | tetragon-operator image. |
 | tetragonOperator.nodeSelector | object | `{}` | Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules. |
@@ -158,10 +166,11 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragonOperator.prometheus.serviceMonitor.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator ServiceMonitor. |
 | tetragonOperator.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
 | tetragonOperator.prometheus.serviceMonitor.scrapeInterval | string | `"10s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
+| tetragonOperator.replicas | int | `1` | Number of replicas to run for the tetragon-operator deployment |
 | tetragonOperator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | resources for the Tetragon Operator Deployment Pod container. |
 | tetragonOperator.securityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pods. |
 | tetragonOperator.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | tetragon-operator service account. |
-| tetragonOperator.strategy | object | `{}` | resources for the Tetragon Operator Deployment update strategy |
+| tetragonOperator.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | resources for the Tetragon Operator Deployment update strategy |
 | tetragonOperator.tolerations | list | `[]` |  |
 | tetragonOperator.tracingPolicy.enabled | bool | `true` | Enables the TracingPolicy and TracingPolicyNamespaced CRD creation. |
 | tolerations[0].operator | string | `"Exists"` |  |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -119,13 +119,21 @@ Helm chart for Tetragon
 | tetragon.redactionFilters | string | `""` | Filters to redact secrets from the args fields in Tetragon events. To perform redactions, redaction filters define RE2 regular expressions in the `redact` field. Any capture groups in these RE2 regular expressions are redacted and replaced with "*****".  For more control, you can select which binary or binaries should have their arguments redacted with the `binary_regex` field.  NOTE: This feature uses RE2 as its regular expression library. Make sure that you follow RE2 regular expression guidelines as you may observe unexpected results otherwise. More information on RE2 syntax can be found [here](https://github.com/google/re2/wiki/Syntax).  NOTE: When writing regular expressions in JSON, it is important to escape backslash characters. For instance `\Wpasswd\W?` would be written as `{"redact": "\\Wpasswd\\W?"}`.  As a concrete example, the following will redact all passwords passed to processes with the "--password" argument:    {"redact": ["--password(?:\\s+|=)(\\S*)"]}  Now, an event which contains the string "--password=foo" would have that string replaced with "--password=*****".  Suppose we also see some passwords passed via the -p shorthand for a specific binary, foo. We can also redact these as follows:    {"binary_regex": ["(?:^|/)foo$"], "redact": ["-p(?:\\s+|=)(\\S*)"]}  With both of the above redaction filters in place, we are now redacting all password arguments. |
 | tetragon.resources | object | `{}` |  |
 | tetragon.securityContext.privileged | bool | `true` |  |
-| tetragonOperator.affinity | object | `{}` |  |
+| tetragonOperator.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels."app.kubernetes.io/name" | string | `"tetragon-operator"` |  |
+| tetragonOperator.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"kubernetes.io/hostname"` |  |
+| tetragonOperator.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight | int | `100` |  |
 | tetragonOperator.annotations | object | `{}` | Annotations for the Tetragon Operator Deployment. |
 | tetragonOperator.enabled | bool | `true` | Enables the Tetragon Operator. |
 | tetragonOperator.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment. |
 | tetragonOperator.extraPodLabels | object | `{}` | Extra labels to be added on the Tetragon Operator Deployment Pods. |
 | tetragonOperator.extraVolumeMounts | list | `[]` |  |
 | tetragonOperator.extraVolumes | list | `[]` | Extra volumes for the Tetragon Operator Deployment. |
+| tetragonOperator.failoverLease | object | `{"enabled":false,"leaseDuration":"15s","leaseRenewDeadline":"5s","leaseRetryPeriod":"2s","namespace":""}` | Lease handling for an automated failover when running multiple replicas |
+| tetragonOperator.failoverLease.enabled | bool | `false` | Enable lease failover functionality |
+| tetragonOperator.failoverLease.leaseDuration | string | `"15s"` | If a lease is not renewed for X duration, the current leader is considered dead, a new leader is picked |
+| tetragonOperator.failoverLease.leaseRenewDeadline | string | `"5s"` | The interval at which the leader will renew the lease |
+| tetragonOperator.failoverLease.leaseRetryPeriod | string | `"2s"` | The timeout between retries if renewal fails |
+| tetragonOperator.failoverLease.namespace | string | `""` | Kubernetes Namespace in which the Lease resource is created. Defaults to the namespace where Tetragon is deployed in, if it's empty. |
 | tetragonOperator.forceUpdateCRDs | bool | `false` |  |
 | tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.3.0"}` | tetragon-operator image. |
 | tetragonOperator.nodeSelector | object | `{}` | Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules. |
@@ -140,10 +148,11 @@ Helm chart for Tetragon
 | tetragonOperator.prometheus.serviceMonitor.extraLabels | object | `{}` | Extra labels to be added on the Tetragon Operator ServiceMonitor. |
 | tetragonOperator.prometheus.serviceMonitor.labelsOverride | object | `{}` | The set of labels to place on the 'ServiceMonitor' resource. |
 | tetragonOperator.prometheus.serviceMonitor.scrapeInterval | string | `"10s"` | Interval at which metrics should be scraped. If not specified, Prometheus' global scrape interval is used. |
+| tetragonOperator.replicas | int | `1` | Number of replicas to run for the tetragon-operator deployment |
 | tetragonOperator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | resources for the Tetragon Operator Deployment Pod container. |
 | tetragonOperator.securityContext | object | `{}` | securityContext for the Tetragon Operator Deployment Pods. |
 | tetragonOperator.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | tetragon-operator service account. |
-| tetragonOperator.strategy | object | `{}` | resources for the Tetragon Operator Deployment update strategy |
+| tetragonOperator.strategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | resources for the Tetragon Operator Deployment update strategy |
 | tetragonOperator.tolerations | list | `[]` |  |
 | tetragonOperator.tracingPolicy.enabled | bool | `true` | Enables the TracingPolicy and TracingPolicyNamespaced CRD creation. |
 | tolerations[0].operator | string | `"Exists"` |  |

--- a/install/kubernetes/tetragon/templates/operator_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/operator_configmap.yaml
@@ -15,5 +15,10 @@ data:
   skip-pod-info-crd: {{ not .Values.tetragonOperator.podInfo.enabled | quote }}
   skip-tracing-policy-crd: {{ not .Values.tetragonOperator.tracingPolicy.enabled | quote }}
   force-update-crds: {{ .Values.tetragonOperator.forceUpdateCRDs | quote }}
+  leader-election: {{ .Values.tetragonOperator.failoverLease.enabled | quote }}
+  leader-election-namespace: {{ .Values.tetragonOperator.failoverLease.namespace | quote }}
+  leader-election-lease-duration: {{ .Values.tetragonOperator.failoverLease.leaseDuration | quote }}
+  leader-election-renew-deadline: {{ .Values.tetragonOperator.failoverLease.leaseRenewDeadline | quote }}
+  leader-election-retry-period: {{ .Values.tetragonOperator.failoverLease.leaseRetryPeriod | quote }}
   {{- include "operatorconfigmap.extra" . | nindent 2 }}
 {{- end }}

--- a/install/kubernetes/tetragon/templates/operator_deployment.yaml
+++ b/install/kubernetes/tetragon/templates/operator_deployment.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     matchLabels:
       {{- include "tetragon-operator.selectorLabels" . | nindent 6 }}
-  replicas: 1
+  replicas: {{ .Values.tetragonOperator.replicas }}
   template:
     metadata:
       {{- with .Values.tetragonOperator.podAnnotations }}
@@ -107,8 +107,8 @@ spec:
       {{- with .Values.tetragonOperator.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- with .Values.tetragonOperator.strategy }}
+  {{- with .Values.tetragonOperator.strategy }}
   strategy:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/install/kubernetes/tetragon/templates/operator_role.yaml
+++ b/install/kubernetes/tetragon/templates/operator_role.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.tetragonOperator.enabled .Values.serviceAccount.create .Values.tetragonOperator.failoverLease.enabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+rules:
+# For tetragon-operator running with multiple replicas
+#
+# Tetragon operator running in HA mode requires the use of ResourceLock for Leader Election
+# between multiple running instances.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+# A Lease changes will result in Kubernetes events. Thus, allow the operator ServiceAccount
+# to create them.
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+{{- end }}

--- a/install/kubernetes/tetragon/templates/operator_rolebinding.yaml
+++ b/install/kubernetes/tetragon/templates/operator_rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.tetragonOperator.enabled .Values.serviceAccount.create .Values.tetragonOperator.failoverLease.enabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-operator-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-operator
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "tetragon-operator.serviceAccount" . }}
+{{- end }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -251,6 +251,20 @@ tetragon:
 tetragonOperator:
   # -- Enables the Tetragon Operator.
   enabled: true
+  # -- Number of replicas to run for the tetragon-operator deployment
+  replicas: 1
+  # -- Lease handling for an automated failover when running multiple replicas
+  failoverLease:
+    # -- Enable lease failover functionality
+    enabled: false
+    # -- Kubernetes Namespace in which the Lease resource is created. Defaults to the namespace where Tetragon is deployed in, if it's empty.
+    namespace: ""
+    # -- If a lease is not renewed for X duration, the current leader is considered dead, a new leader is picked
+    leaseDuration: 15s
+    # -- The interval at which the leader will renew the lease
+    leaseRenewDeadline: 5s
+    # -- The timeout between retries if renewal fails
+    leaseRetryPeriod: 2s
   # -- Annotations for the Tetragon Operator Deployment.
   annotations: {}
   # -- Annotations for the Tetragon Operator Deployment Pods.
@@ -283,11 +297,23 @@ tetragonOperator:
       cpu: 10m
       memory: 64Mi
   # -- resources for the Tetragon Operator Deployment update strategy
-  strategy: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   # -- Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules.
   nodeSelector: {}
   tolerations: []
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: tetragon-operator
   # -- tetragon-operator image.
   image:
     override: ~

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -4,6 +4,8 @@
 package option
 
 import (
+	"time"
+
 	"github.com/spf13/viper"
 )
 
@@ -34,6 +36,27 @@ const (
 	// ForceUpdateCRDs specifies whether operator should ignore current CRD version
 	// and forcefully update it.
 	ForceUpdateCRDs = "force-update-crds"
+
+	// MetricsAddr is the address the metric endpoint binds to.
+	MetricsAddr = "metrics-bind-address"
+
+	// ProbeAddr is the address the probe endpoint binds to.
+	ProbeAddr = "health-probe-bind-address"
+
+	// EnableLeaderElection enables leader election for controller manager.
+	EnableLeaderElection = "leader-election"
+
+	// LeaderElectionNamespace is the Kubernetes namespace in which the leader election Lease resource should be created.
+	LeaderElectionNamespace = "leader-election-namespace"
+
+	// LeaderElectionLeaseDuration is the duration that non-leader operator candidates will wait before forcing to acquire leadership.
+	LeaderElectionLeaseDuration = "leader-election-lease-duration"
+
+	// LeaderElectionRenewDeadline is the duration that current acting master will retry refreshing leadership in before giving up the lock.
+	LeaderElectionRenewDeadline = "leader-election-renew-deadline"
+
+	// LeaderElectionRetryPeriod is the duration that LeaderElector clients should wait between retries of the actions.
+	LeaderElectionRetryPeriod = "leader-election-retry-period"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -58,6 +81,27 @@ type OperatorConfig struct {
 	// ForceUpdateCRDs forces the CRD to be updated even if it's version
 	// is lower than the one in the cluster.
 	ForceUpdateCRDs bool
+
+	// MetricsAddr is the address the metric endpoint binds to.
+	MetricsAddr string
+
+	// ProbeAddr is the address the probe endpoint binds to.
+	ProbeAddr string
+
+	// EnableLeaderElection enables leader election for controller manager.
+	EnableLeaderElection bool
+
+	// LeaderElectionNamespace is the Kubernetes namespace in which the leader election Lease resource should be created.
+	LeaderElectionNamespace string
+
+	// LeaderElectionLeaseDuration is the duration that non-leader operator candidates will wait before forcing to acquire leadership.
+	LeaderElectionLeaseDuration time.Duration
+
+	// LeaderElectionRenewDeadline is the duration that current acting master will retry refreshing leadership in before giving up the lock.
+	LeaderElectionRenewDeadline time.Duration
+
+	// LeaderElectionRetryPeriod is the duration that LeaderElector clients should wait between retries of the actions.
+	LeaderElectionRetryPeriod time.Duration
 }
 
 // Config represents the operator configuration.
@@ -71,4 +115,11 @@ func ConfigPopulate() {
 	Config.SkipPodInfoCRD = viper.GetBool(SkipPodInfoCRD)
 	Config.SkipTracingPolicyCRD = viper.GetBool(SkipTracingPolicyCRD)
 	Config.ForceUpdateCRDs = viper.GetBool(ForceUpdateCRDs)
+	Config.MetricsAddr = viper.GetString(MetricsAddr)
+	Config.ProbeAddr = viper.GetString(ProbeAddr)
+	Config.EnableLeaderElection = viper.GetBool(EnableLeaderElection)
+	Config.LeaderElectionNamespace = viper.GetString(LeaderElectionNamespace)
+	Config.LeaderElectionLeaseDuration = viper.GetDuration(LeaderElectionLeaseDuration)
+	Config.LeaderElectionRenewDeadline = viper.GetDuration(LeaderElectionRenewDeadline)
+	Config.LeaderElectionRetryPeriod = viper.GetDuration(LeaderElectionRetryPeriod)
 }


### PR DESCRIPTION
### Description
Required changes to leverage the already built-in `LeaderElection` support from https://github.com/cilium/tetragon/blob/main/operator/cmd/serve/serve.go. 

Added support to run multiple Tetragon Operator replicas. This also includes minor Helm adjustments regarding the rollingUpdate strategy and the affinity (podAntiAffinity). That's required to prevent situations where upgrades are stuck because of impossible-to-reach `maxUnavailable` values and both replicas are running on the same node.

### Motivation
> Besides installing CRDs, Tetragon Operator provides some functionality required to annotate events with additional metadata. If Tetragon Operator is disabled, some fields might be missing from generated events.

Hence, depending on how important this metadata is to somebody, the operator can still be seen as relevant.

### Changelog
```release-note
operator: Support running multiple operator replicas simultaneously
```

### Manual Testing

It seems to work correctly:

<details>
<summary>Manual Testing</summary>

Replica 1:
```bash
$ k logs -f tetragon-operator-7784567fb8-l7n57
time="2025-02-28T18:29:43.882321854Z" level=info msg="Loaded config from directory" config-dir=/etc/tetragon/operator.conf.d/ subsys=tetragon-operator
time="2025-02-28T18:29:43.887089659Z" level=info msg="Starting Tetragon Operator" config="&{SkipCRDCreation:false KubeCfgPath: ConfigDir:/etc/tetragon/operator.conf.d/ SkipPodInfoCRD:true SkipTracingPolicyCRD:false ForceUpdateCRDs:false MetricsAddr::2113 ProbeAddr::8081 EnableLeaderElection:true LeaderElectionNamespace: LeaderElectionLeaseDuration:15s LeaderElectionRenewDeadline:5s LeaderElectionRetryPeriod:2s}" subsys=crd version=v1.4.0-pre.0-309-g39ce86c7c
time="2025-02-28T18:29:44.412873444Z" level=info msg="CRD (CustomResourceDefinition) is installed and up-to-date" name=TracingPolicy/v1alpha1 subsys=k8s
time="2025-02-28T18:29:44.924969665Z" level=info msg="CRD (CustomResourceDefinition) is installed and up-to-date" name=TracingPolicyNamespaced/v1alpha1 subsys=k8s
time="2025-02-28T18:29:44.925005436Z" level=info msg="Initialization complete" subsys=crd
time="2025-02-28T18:29:44.927255371Z" level=info msg="starting manager" leaderElection=true logger=setup metricsAddr=":2113" probeAddr=":8081" subsys=operator
time="2025-02-28T18:29:44.927480887Z" level=info msg="Starting metrics server" logger=controller-runtime.metrics subsys=operator
time="2025-02-28T18:29:44.927569747Z" level=info msg="Serving metrics server" bindAddress=":2113" logger=controller-runtime.metrics secure=false subsys=operator
time="2025-02-28T18:29:44.927666191Z" level=info msg="starting server" addr="[::]:8081" name="health probe" subsys=operator
I0228 18:29:44.927746       1 leaderelection.go:257] attempting to acquire leader lease kube-system/tetragon-operator-resource-lock...
I0228 18:29:44.939524       1 leaderelection.go:271] successfully acquired lease kube-system/tetragon-operator-resource-lock
time="2025-02-28T18:29:44.939810512Z" level=info msg="elected leader" lease=tetragon-operator-resource-lock logger=setup namespace= subsys=operator
^C⏎
$ k delete pod tetragon-operator-7784567fb8-l7n57
pod "tetragon-operator-7784567fb8-l7n57" deleted
```

Replica 2:
```bash
$ k logs -f tetragon-operator-7784567fb8-8mks4
time="2025-02-28T18:26:16.791538287Z" level=info msg="Loaded config from directory" config-dir=/etc/tetragon/operator.conf.d/ subsys=tetragon-operator
time="2025-02-28T18:26:16.796193344Z" level=info msg="Starting Tetragon Operator" config="&{SkipCRDCreation:false KubeCfgPath: ConfigDir:/etc/tetragon/operator.conf.d/ SkipPodInfoCRD:true SkipTracingPolicyCRD:false ForceUpdateCRDs:false MetricsAddr::2113 ProbeAddr::8081 EnableLeaderElection:true LeaderElectionNamespace: LeaderElectionLeaseDuration:15s LeaderElectionRenewDeadline:5s LeaderElectionRetryPeriod:2s}" subsys=crd version=v1.4.0-pre.0-309-g39ce86c7c
time="2025-02-28T18:26:17.309539125Z" level=info msg="CRD (CustomResourceDefinition) is installed and up-to-date" name=TracingPolicy/v1alpha1 subsys=k8s
time="2025-02-28T18:26:17.821911928Z" level=info msg="CRD (CustomResourceDefinition) is installed and up-to-date" name=TracingPolicyNamespaced/v1alpha1 subsys=k8s
time="2025-02-28T18:26:17.821957678Z" level=info msg="Initialization complete" subsys=crd
time="2025-02-28T18:26:17.824209975Z" level=info msg="starting manager" leaderElection=true logger=setup metricsAddr=":2113" probeAddr=":8081" subsys=operator
time="2025-02-28T18:26:17.824535998Z" level=info msg="Starting metrics server" logger=controller-runtime.metrics subsys=operator
time="2025-02-28T18:26:17.824571733Z" level=info msg="starting server" addr="[::]:8081" name="health probe" subsys=operator
time="2025-02-28T18:26:17.824621313Z" level=info msg="Serving metrics server" bindAddress=":2113" logger=controller-runtime.metrics secure=false subsys=operator
I0228 18:26:17.824764       1 leaderelection.go:257] attempting to acquire leader lease kube-system/tetragon-operator-resource-lock..
```

When terminating replica 1, replica 2 changed to:
```bash
I0228 18:31:02.917411       1 leaderelection.go:271] successfully acquired lease kube-system/tetragon-operator-resource-lock
time="2025-02-28T18:31:02.917689399Z" level=info msg="elected leader" lease=tetragon-operator-resource-lock logger=setup namespace= subsys=operator
```

The Lease handover happens very quickly (feels like 1-2s) when the operator is terminated correctly (because of `LeaderElectionReleaseOnCancel=true`):

```bash
$ k get lease -w tetragon-operator-resource-lock
NAME                              HOLDER                                                                    AGE
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-l7n57_bb4a4a89-b5ac-4fc8-834d-a5f7f308ba7a   62m
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-l7n57_bb4a4a89-b5ac-4fc8-834d-a5f7f308ba7a   62m
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-l7n57_bb4a4a89-b5ac-4fc8-834d-a5f7f308ba7a   62m
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-l7n57_bb4a4a89-b5ac-4fc8-834d-a5f7f308ba7a   62m
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-l7n57_bb4a4a89-b5ac-4fc8-834d-a5f7f308ba7a   62m
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-l7n57_bb4a4a89-b5ac-4fc8-834d-a5f7f308ba7a   62m
tetragon-operator-resource-lock                                                                             62m
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-8mks4_6cb98856-85b5-44ed-93bb-d051fdfc57fc   62m
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-8mks4_6cb98856-85b5-44ed-93bb-d051fdfc57fc   62m
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-8mks4_6cb98856-85b5-44ed-93bb-d051fdfc57fc   62m
tetragon-operator-resource-lock   tetragon-operator-7784567fb8-8mks4_6cb98856-85b5-44ed-93bb-d051fdfc57fc   62m
$ k get events
...
2m57s       Normal    LeaderElection      lease/tetragon-operator-resource-lock     tetragon-operator-7784567fb8-8mks4_6cb98856-85b5-44ed-93bb-d051fdfc57fc became leader
...
```

</details>