### PR TITLE
syscallmetrics: use syscall type

### DIFF
--- a/pkg/metrics/metricwithpod_test.go
+++ b/pkg/metrics/metricwithpod_test.go
@@ -48,8 +48,8 @@ func TestPodDelete(t *testing.T) {
 						},
 						Args: []*tetragon.KprobeArgument{
 							{
-								Arg: &tetragon.KprobeArgument_LongArg{
-									LongArg: 0,
+								Arg: &tetragon.KprobeArgument_SyscallId{
+									SyscallId: &tetragon.SyscallId{Id: 0, Abi: "x64"},
 								},
 							},
 						},

--- a/pkg/metrics/syscallmetrics/syscallmetrics.go
+++ b/pkg/metrics/syscallmetrics/syscallmetrics.go
@@ -66,19 +66,18 @@ func Handle(event interface{}) {
 
 func rawSyscallName(tp *tetragon.ProcessTracepoint) string {
 	sysID := int64(-1)
-	if len(tp.Args) > 0 && tp.Args[0] != nil {
-		if x, ok := tp.Args[0].GetArg().(*tetragon.KprobeArgument_LongArg); ok {
-			sysID = x.LongArg
+	var sysABI string
+	for _, x := range tp.Args {
+		if x, ok := x.GetArg().(*tetragon.KprobeArgument_SyscallId); ok {
+			sysID = int64(x.SyscallId.Id)
+			sysABI = x.SyscallId.Abi
+			break
 		}
 	}
 	if sysID == -1 {
 		return ""
 	}
-	abi, err := syscallinfo.DefaultABI()
-	if err != nil {
-		return ""
-	}
-	name, err := syscallinfo.GetSyscallName(abi, int(sysID))
+	name, err := syscallinfo.GetSyscallName(sysABI, int(sysID))
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
Use syscall type to generate metrics. Now that we have a syscall-specific type, we can check for it across all arguments.
