### PR TITLE
rthooks: Fix rootDir in createRuntime hook

### DIFF
--- a/contrib/tetragon-rthooks/cmd/oci-hook/main.go
+++ b/contrib/tetragon-rthooks/cmd/oci-hook/main.go
@@ -263,7 +263,7 @@ func createContainerHook(log *slog.Logger) (error, map[string]string) {
 	// In "containerd (createContainer)" and "cri-o" we are already in the
 	// container root directory. In "containerd (createRuntime)" we need to
 	// append the rootDir the root path from the spec.
-	if configName == "config.json" {
+	if configName == filepath.Join(rootDir, "config.json") {
 		rootDir = path.Join(rootDir, spec.Root.Path)
 	}
 


### PR DESCRIPTION
In https://github.com/cilium/tetragon/pull/3057 we tried to fix an issue with the rootDir in createRuntime hook. But this fix didn't seem to be enough.

The issue is that we compare configName with "config.json". But in https://github.com/cilium/tetragon/blob/e540d11870958a71be87bd29c9c0db47c8e8e035/contrib/tetragon-rthooks/cmd/oci-hook/main.go#L235-L237 the configName points to the full path of the config file. So this patch fixes the comparison to be with the full path instead of the file name.