### PR TITLE
tetragon: add support for path offload

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -36,6 +36,19 @@ struct msg_selector_data {
 /* value to mask an offsset into msg_generic_kprobe->args */
 #define GENERIC_MSG_ARGS_MASK 0x7ff
 
+struct generic_path {
+	int state;
+	int off;
+	int cnt;
+	struct path path_buf;
+	const struct path *path;
+	struct dentry *root_dentry;
+	struct vfsmount *root_mnt;
+	struct dentry *dentry;
+	struct vfsmount *vfsmnt;
+	struct mount *mnt;
+};
+
 struct msg_generic_kprobe {
 	struct msg_common common;
 	struct msg_execve_key current;
@@ -64,6 +77,9 @@ struct msg_generic_kprobe {
 	};
 	struct execve_map_value curr;
 	struct heap_exe exe;
+#ifndef __V61_BPF_PROG
+	struct generic_path path;
+#endif
 };
 
 FUNC_INLINE size_t generic_kprobe_common_size(void)

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -22,6 +22,7 @@ int generic_kprobe_process_filter(void *ctx);
 int generic_kprobe_filter_arg(void *ctx);
 int generic_kprobe_actions(void *ctx);
 int generic_kprobe_output(void *ctx);
+int generic_kprobe_path(void *ctx);
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
@@ -36,6 +37,9 @@ struct {
 		[TAIL_CALL_ARGS] = (void *)&generic_kprobe_filter_arg,
 		[TAIL_CALL_ACTIONS] = (void *)&generic_kprobe_actions,
 		[TAIL_CALL_SEND] = (void *)&generic_kprobe_output,
+#ifndef __V61_BPF_PROG
+		[TAIL_CALL_PATH] = (void *)&generic_kprobe_path,
+#endif
 	},
 };
 
@@ -125,6 +129,14 @@ generic_kprobe_output(void *ctx)
 {
 	return generic_output(ctx, MSG_OP_GENERIC_KPROBE);
 }
+
+#ifndef __V61_BPF_PROG
+__attribute__((section("kprobe"), used)) int
+generic_kprobe_path(void *ctx)
+{
+	return generic_path(ctx, (struct bpf_map_def *)&kprobe_calls);
+}
+#endif
 
 __attribute__((section(OVERRIDE), used)) int
 generic_kprobe_override(void *ctx)

--- a/bpf/process/bpf_generic_lsm_core.c
+++ b/bpf/process/bpf_generic_lsm_core.c
@@ -23,6 +23,7 @@ int generic_lsm_process_event(void *ctx);
 int generic_lsm_process_filter(void *ctx);
 int generic_lsm_filter_arg(void *ctx);
 int generic_lsm_actions(void *ctx);
+int generic_lsm_path(void *ctx);
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
@@ -36,6 +37,9 @@ struct {
 		[TAIL_CALL_FILTER] = (void *)&generic_lsm_process_filter,
 		[TAIL_CALL_ARGS] = (void *)&generic_lsm_filter_arg,
 		[TAIL_CALL_ACTIONS] = (void *)&generic_lsm_actions,
+#ifndef __V61_BPF_PROG
+		[TAIL_CALL_PATH] = (void *)&generic_lsm_path,
+#endif
 	},
 };
 
@@ -113,3 +117,11 @@ generic_lsm_actions(void *ctx)
 
 	return 0;
 }
+
+#ifndef __V61_BPF_PROG
+__attribute__((section("lsm"), used)) int
+generic_lsm_path(void *ctx)
+{
+	return generic_path(ctx, (struct bpf_map_def *)&lsm_calls);
+}
+#endif

--- a/bpf/process/generic_path.h
+++ b/bpf/process/generic_path.h
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#ifndef __GENERIC_PATH_H__
+#define __GENERIC_PATH_H__
+
+#include "bpf_d_path.h"
+#include "compiler.h"
+
+enum {
+	STATE_INIT,
+	STATE_WORK,
+};
+
+#ifndef __V61_BPF_PROG
+
+FUNC_INLINE int get_off(char *buffer, char *buf)
+{
+	return buf - buffer;
+}
+
+FUNC_INLINE char *get_buf(char *buffer, int off)
+{
+	asm volatile("%[off] &= 0xfff;\n" : [off] "+r"(off));
+	return buffer + off;
+}
+
+FUNC_INLINE long path_init(void *ctx, struct generic_path *gp, struct bpf_map_def *tailcals)
+{
+	const struct path *path = gp->path;
+	struct task_struct *task;
+	const struct path *root;
+	struct dentry *dentry;
+	struct fs_struct *fs;
+	char *buffer, *buf;
+	int zero = 0, buflen = MAX_BUF_LEN;
+
+	buffer = map_lookup_elem(&buffer_heap_map, &zero);
+	if (!buffer)
+		return 0;
+
+	buf = buffer + MAX_BUF_LEN - 1;
+	probe_read(&dentry, sizeof(dentry), _(&path->dentry));
+	if (d_unlinked(dentry)) {
+		// prepend will never return a value != 0
+		prepend(&buf, &buflen, " (deleted)", 10);
+	}
+
+	task = (struct task_struct *)get_current_task();
+	probe_read(&fs, sizeof(fs), _(&task->fs));
+
+	root = _(&fs->root);
+	path = gp->path;
+
+	probe_read(&gp->root_dentry, sizeof(gp->root_dentry), _(&root->dentry));
+	probe_read(&gp->root_mnt, sizeof(gp->root_mnt), _(&root->mnt));
+	probe_read(&gp->dentry, sizeof(gp->dentry), _(&path->dentry));
+	probe_read(&gp->vfsmnt, sizeof(gp->vfsmnt), _(&path->mnt));
+	gp->mnt = real_mount(gp->vfsmnt);
+
+	gp->cnt = 0;
+	gp->off = get_off(buffer, buf);
+	gp->state = STATE_WORK;
+	tail_call(ctx, tailcals, TAIL_CALL_PATH);
+	return 0;
+}
+
+#define GENERIC_PATH_CALLS 8
+
+#ifdef __LARGE_BPF_PROG
+#define GENERIC_PATH_ITERATIONS 512
+#else
+#define GENERIC_PATH_ITERATIONS 32
+#endif
+
+FUNC_INLINE long path_work(void *ctx, struct generic_path *gp, struct bpf_map_def *tailcals)
+{
+	struct cwd_read_data data = {
+		.root_dentry = gp->root_dentry,
+		.root_mnt = gp->root_mnt,
+		.dentry = gp->dentry,
+		.vfsmnt = gp->vfsmnt,
+		.mnt = gp->mnt,
+	};
+	char *buffer;
+	int zero = 0;
+
+	buffer = map_lookup_elem(&buffer_heap_map, &zero);
+	if (!buffer)
+		return 0;
+
+	data.bf = buffer;
+	data.bptr = get_buf(buffer, gp->off);
+	data.blen = gp->off;
+
+#pragma unroll
+	for (int i = 0; i < GENERIC_PATH_ITERATIONS; ++i) {
+		if (cwd_read(&data))
+			break;
+	}
+
+	gp->cnt++;
+	gp->off = get_off(buffer, data.bptr);
+
+	if (data.resolved || gp->cnt == GENERIC_PATH_CALLS) {
+		tail_call(ctx, tailcals, TAIL_CALL_PROCESS);
+		return 0;
+	}
+
+	gp->dentry = data.dentry;
+	gp->vfsmnt = data.vfsmnt;
+	gp->mnt = data.mnt;
+
+	tail_call(ctx, tailcals, TAIL_CALL_PATH);
+	return 0;
+}
+
+FUNC_INLINE long generic_path(void *ctx, struct bpf_map_def *tailcals)
+{
+	struct msg_generic_kprobe *e;
+	int zero = 0;
+
+	e = map_lookup_elem(&process_call_heap, &zero);
+	if (!e)
+		return 0;
+
+	switch (e->path.state) {
+	case STATE_INIT:
+		return path_init(ctx, &e->path, tailcals);
+	case STATE_WORK:
+		return path_work(ctx, &e->path, tailcals);
+	}
+
+	return 0;
+}
+
+FUNC_INLINE void generic_path_init(struct msg_generic_kprobe *e)
+{
+	e->path.state = STATE_INIT;
+}
+
+/*
+ * The path offload is plugged in roughly as follows:
+ *
+ * TAIL_CALL_PROCESS:               <-----.
+ *   generic_process_event                |
+ *     generic_path_offload               |
+ *       if type is path                  |
+ *         tail_call TAIL_CALL_PATH -.    |
+ *       if path is resolved         |    |
+ *         store_path                |    |
+ *                                   |    |
+ * TAIL_CALL_PATH:          <--------'    |
+ *   generic_path                         |
+ *     path_init                          |
+ *       tail_call TAIL_CALL_PATH -----.  |
+ *                                     |  |
+ * TAIL_CALL_PATH:          <------.<--'  |
+ *   generic_path                  |      |
+ *     path_work                   |      |
+ *       read directory entry      |      |
+ *       tail_call TAIL_CALL_PATH -'      |
+ *                                        |
+ *       if final entry                   |
+ *         tail_call TAIL_CALL_PROCESS ---'
+ */
+FUNC_INLINE long generic_path_offload(void *ctx, long ty, unsigned long arg,
+				      int index, unsigned long orig_off,
+				      struct bpf_map_def *tailcals)
+{
+	struct msg_generic_kprobe *e;
+	struct generic_path *gp;
+	const struct path *path;
+	char *args, *buffer, *buf;
+	int zero = 0;
+
+	e = map_lookup_elem(&process_call_heap, &zero);
+	if (!e)
+		return 0;
+
+	gp = &e->path;
+	if (gp->state == STATE_INIT) {
+		path = get_path(ty, arg, &gp->path_buf);
+		if (!path)
+			return 0;
+		gp->path = path;
+		tail_call(ctx, tailcals, TAIL_CALL_PATH);
+		return 0;
+	}
+
+	/* initialize for next argument */
+	generic_path_init(e);
+
+	buffer = map_lookup_elem(&buffer_heap_map, &zero);
+	if (!buffer)
+		return 0;
+
+	e->argsoff[index & MAX_SELECTORS_MASK] = orig_off;
+	args = args_off(e, orig_off);
+	buf = get_buf(buffer, gp->off);
+	return store_path(args, buf, gp->path, MAX_BUF_LEN - gp->off - 1, 0);
+}
+
+FUNC_INLINE bool should_offload_path(long type)
+{
+	switch (type) {
+	case kiocb_type:
+	case file_ty:
+	case path_ty:
+	case dentry_type:
+	case linux_binprm_type:
+		return true;
+	}
+	return false;
+}
+#else
+FUNC_INLINE void generic_path_init(struct msg_generic_kprobe *e) {}
+
+FUNC_INLINE long generic_path_offload(void *ctx, long ty, unsigned long arg,
+				      int index, unsigned long orig_off,
+				      struct bpf_map_def *tailcals)
+{
+	return 0;
+}
+
+FUNC_INLINE bool should_offload_path(long ty)
+{
+	return false;
+}
+#endif /* !__V61_BPF_PROG */
+
+#endif /* __GENERIC_PATH_H__ */

--- a/bpf/process/heap.h
+++ b/bpf/process/heap.h
@@ -22,7 +22,7 @@ struct {
 
 struct heap_value {
 	union {
-		char fdinstall[264];
+		char fdinstall[4104]; /* 4096B paths + 4B length + 4B flags */
 	};
 };
 

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -132,6 +132,7 @@ enum {
 	TAIL_CALL_ARGS = 3,
 	TAIL_CALL_ACTIONS = 4,
 	TAIL_CALL_SEND = 5,
+	TAIL_CALL_PATH = 6,
 };
 
 struct selector_action {

--- a/docs/content/en/docs/concepts/tracing-policy/argument_types.md
+++ b/docs/content/en/docs/concepts/tracing-policy/argument_types.md
@@ -1,0 +1,246 @@
+---
+title: "Argument types"
+weight: 2
+description: "Argument types for data retrieval"
+---
+
+Each argument definition specifies data type to be retrieved from kernel
+argument. The list contains simple POD types and several complex kernel
+objects that are represented by extracted data type.
+
+List of described data types:
+- [`sint8, int8`](#int8)
+- [`uint8`](#uint8)
+- [`sint16, int16`](#int16)
+- [`uint16`](#uint16)
+- [`int, sint32, int32`](#int)
+- [`uint32`]($uint32)
+- [`long, sint64, int64`](#long)
+- [`ulong, uint64, size_t`](#ulong)
+- [`string`](#string)
+- [`skb`](#skb)
+- [`sock`](#sock)
+- [`char_buf`](#char_buf)
+- [`char_iovec`](#char_iovec)
+- [`filename`](#filename)
+- [`path`](#path)
+- [`fd`](#fd)
+- [`cred`](#cred)
+- [`const_buf`](#const_buf)
+- [`nop`](#nop)
+- [`bpf_attr`](#bpf_attr)
+- [`perf_event`](#perf_event)
+- [`bpf_map`](#bpf_map)
+- [`user_namespace`](#user_namespace)
+- [`capability`](#capability)
+- [`kiocb`](#kiocb)
+- [`iov_iter`](#iov_iter)
+- [`load_info`](#load_info)
+- [`module`](#module)
+- [`syscall64`](#syscall64)
+- [`kernel_cap_t`](#kernel_cap_t)
+- [`cap_inheritable`](#cap_inheritable)
+- [`cap_permitted`](#cap_permitted)
+- [`cap_effective`](#cap_effective)
+- [`linux_binprm`](#linux_binprm)
+- [`data_loc`](#data_loc)
+- [`net_device`](#net_device)
+- [`sockaddr`](#sockaddr)
+- [`socket`](#socket)
+- [`file`](#file)
+- [`dentry`](#dentry)
+
+<a name="int8"></a>
+
+## `sint8, int8`
+
+The data type extracts 8-bit signed value.
+
+## `uint8`
+
+The data type extracts 8-bit unsigned value.
+
+<a name="int16"></a>
+
+## `sint16, int16`
+
+The data type extracts 16-bit signed value.
+
+## `uint16`
+
+The data type extracts 16-bit unsigned value.
+
+<a name="int"></a>
+
+## `int, sint32, int32`
+
+The data type extracts 32-bit signed value.
+
+## `uint32`
+
+The data type extracts 32-bit unsigned value.
+
+<a name="long"></a>
+
+## `long, sint64, int64`
+
+The data type extracts 64-bit signed value.
+
+<a name="ulong"></a>
+
+## `ulong, uint64, size_t`
+
+The data type extracts  64-bit unsigned value.
+
+## `string`
+
+The data type extracts string terminated with zero byte.
+
+## `skb`
+
+TBD
+
+## `sock`
+
+TBD
+
+## `char_buf`
+
+TBD
+
+## `char_iovec`
+
+TBD
+
+## `filename`
+
+TBD
+
+## `fd`
+
+TBD
+
+## `cred`
+
+TBD
+
+## `const_buf`
+
+TBD
+
+## `nop`
+
+TBD
+
+## `bpf_attr`
+
+TBD
+
+## `perf_event`
+
+TBD
+
+## `bpf_map`
+
+TBD
+
+## `user_namespace`
+
+TBD
+
+## `capability`
+
+TBD
+
+## `kiocb`
+
+TBD
+
+## `iov_iter`
+
+TBD
+
+## `load_info`
+
+TBD
+
+## `module`
+
+TBD
+
+## `syscall64`
+
+TBD
+
+## `kernel_cap_t`
+
+TBD
+
+## `cap_inheritable`
+
+TBD
+
+## `cap_permitted`
+
+TBD
+
+## `cap_effective`
+
+TBD
+
+## `linux_binprm`
+
+The `linux_binprm` data type represents kernel `struct linux_binprm` object
+and retrieves the `struct linux_binprm::file` full path.
+
+See general path limitations in [path retrieval limits](#pathlimits))
+
+## `data_loc`
+
+TBD
+
+## `net_device`
+
+TBD
+
+## `sockaddr`
+
+TBD
+
+## `socket`
+
+TBD
+
+## `file`
+
+The `file` data type represents kernel `struct file` object and retrieves
+the file's full path.
+
+See general path limitations in [path retrieval limits](#pathlimits))
+
+## `dentry`
+
+The `dentry` data type represents kernel `struct dentry` object retrieves
+the related path within **one mountpoint**.
+
+This stems from the fact that with just `struct dentry` tetragon does not have
+mount information and does not have enough data to pass through main point within
+the path.
+
+See general path limitations in [path retrieval limits](#pathlimits))
+
+## `path`
+
+The `path` data type represents kernel `struct path` object retrieves
+the related path.
+
+See general path limitations in [path retrieval limits](#pathlimits))
+
+<a name="pathlimits"></a>
+## path retrieval limits
+
+We allow to retrieve full path when running on kernels v5.3 and later.
+
+When running on older kernels there's limit of 256 path components,
+which means we can retrieve maximum path (4096) but only with 256
+path entries (directories and file name).

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -244,3 +244,11 @@ func GenericTypeToString(ty int) (string, error) {
 	}
 	return arg, nil
 }
+
+func PathType(ty int) bool {
+	return ty == GenericPathType ||
+		ty == GenericFileType ||
+		ty == GenericDentryType ||
+		ty == GenericLinuxBinprmType ||
+		ty == GenericKiocb
+}

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1420,3 +1420,14 @@ func HasSigkillAction(kspec *v1alpha1.KProbeSpec) bool {
 	}
 	return false
 }
+
+func HasFilter(selectors []v1alpha1.KProbeSelector, index uint32) bool {
+	for _, s := range selectors {
+		for _, a := range s.MatchArgs {
+			if a.Index == index {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -784,6 +784,8 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 		argsBTFSet[a.Index] = true
 		argP := argPrinter{index: j, ty: argType, userType: userArgType, maxData: a.MaxData, label: a.Label}
 		argSigPrinters = append(argSigPrinters, argP)
+
+		pathArgWarning(a.Index, argType, f.Selectors)
 	}
 
 	// Parse ReturnArg, we have two types of return arg parsing. We

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -281,6 +281,8 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 		argsBTFSet[a.Index] = true
 		argP := argPrinter{index: j, ty: argType, maxData: a.MaxData, label: a.Label}
 		argSigPrinters = append(argSigPrinters, argP)
+
+		pathArgWarning(a.Index, argType, f.Selectors)
 	}
 
 	config.BTFArg = allBTFArgs

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2202,11 +2202,7 @@ func testMultipleMountPathFiltered(t *testing.T, readHook string) {
 	})
 
 	filePath := path + "/testfile"
-	writeChecker := getWriteChecker(t, "/7/8/9/10/11/12/13/14/15/16/testfile", "unresolvedPathComponents")
-	if config.EnableLargeProgs() {
-		writeChecker = getWriteChecker(t, "/tmp2/tmp3/tmp4/tmp5/0/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/testfile", "")
-	}
-
+	writeChecker := getWriteChecker(t, "/tmp2/tmp3/tmp4/tmp5/0/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/testfile", "")
 	corePathTest(t, filePath, readHook, writeChecker)
 }
 

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4346,64 +4346,122 @@ spec:
 }
 
 func TestLoadKprobeSensor(t *testing.T) {
-	var sensorProgs = []tus.SensorProg{
-		// kprobe
-		0: tus.SensorProg{Name: "generic_kprobe_event", Type: ebpf.Kprobe},
-		1: tus.SensorProg{Name: "generic_kprobe_setup_event", Type: ebpf.Kprobe},
-		2: tus.SensorProg{Name: "generic_kprobe_process_event", Type: ebpf.Kprobe},
-		3: tus.SensorProg{Name: "generic_kprobe_filter_arg", Type: ebpf.Kprobe},
-		4: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
-		5: tus.SensorProg{Name: "generic_kprobe_actions", Type: ebpf.Kprobe},
-		6: tus.SensorProg{Name: "generic_kprobe_output", Type: ebpf.Kprobe},
-		// retkprobe
-		7:  tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
-		8:  tus.SensorProg{Name: "generic_retkprobe_filter_arg", Type: ebpf.Kprobe},
-		9:  tus.SensorProg{Name: "generic_retkprobe_actions", Type: ebpf.Kprobe},
-		10: tus.SensorProg{Name: "generic_retkprobe_output", Type: ebpf.Kprobe},
-	}
+	var sensorProgs []tus.SensorProg
+	var sensorMaps []tus.SensorMap
 
-	var sensorMaps = []tus.SensorMap{
-		// all kprobe programs
-		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+	if config.EnableV61Progs() {
+		sensorProgs = []tus.SensorProg{
+			// kprobe
+			0: tus.SensorProg{Name: "generic_kprobe_event", Type: ebpf.Kprobe},
+			1: tus.SensorProg{Name: "generic_kprobe_setup_event", Type: ebpf.Kprobe},
+			2: tus.SensorProg{Name: "generic_kprobe_process_event", Type: ebpf.Kprobe},
+			3: tus.SensorProg{Name: "generic_kprobe_filter_arg", Type: ebpf.Kprobe},
+			4: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
+			5: tus.SensorProg{Name: "generic_kprobe_actions", Type: ebpf.Kprobe},
+			6: tus.SensorProg{Name: "generic_kprobe_output", Type: ebpf.Kprobe},
+			// retkprobe
+			7:  tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
+			8:  tus.SensorProg{Name: "generic_retkprobe_filter_arg", Type: ebpf.Kprobe},
+			9:  tus.SensorProg{Name: "generic_retkprobe_actions", Type: ebpf.Kprobe},
+			10: tus.SensorProg{Name: "generic_retkprobe_output", Type: ebpf.Kprobe},
+		}
+		sensorMaps = []tus.SensorMap{
+			// all kprobe programs
+			tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 
-		// all but generic_kprobe_output
-		tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5}},
+			// all but generic_kprobe_output
+			tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5}},
 
-		// generic_retkprobe_event
-		tus.SensorMap{Name: "retkprobe_calls", Progs: []uint{7, 8, 9}},
+			// generic_retkprobe_event
+			tus.SensorMap{Name: "retkprobe_calls", Progs: []uint{7, 8, 9}},
 
-		// generic_kprobe_process_filter,generic_kprobe_filter_arg,
-		// generic_kprobe_actions,generic_kprobe_output
-		tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}},
+			// generic_kprobe_process_filter,generic_kprobe_filter_arg,
+			// generic_kprobe_actions,generic_kprobe_output
+			tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}},
 
-		// generic_kprobe_actions
-		tus.SensorMap{Name: "override_tasks", Progs: []uint{5}},
+			// generic_kprobe_actions
+			tus.SensorMap{Name: "override_tasks", Progs: []uint{5}},
 
-		// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
-		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2}},
+			// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
+			tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2}},
 
-		// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
-		tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 5, 7, 9}},
+			// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
+			tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 5, 7, 9}},
 
-		// generic_kprobe_event
-		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
-	}
+			// generic_kprobe_event
+			tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
 
-	if config.EnableLargeProgs() {
-		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4, 5, 6, 7, 9}})
+			// shared with base sensor
+			tus.SensorMap{Name: "execve_map", Progs: []uint{4, 5, 6, 7, 9}},
 
-		// generic_kprobe_process_event*,generic_kprobe_output,generic_retkprobe_output
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 6, 10}})
+			// generic_kprobe_process_event*,generic_kprobe_output,generic_retkprobe_output
+			tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 6, 10}},
 
-		// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "socktrack_map", Progs: []uint{1, 2, 5, 7, 9}})
+			// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
+			tus.SensorMap{Name: "socktrack_map", Progs: []uint{1, 2, 5, 7, 9}},
+		}
+
 	} else {
-		// shared with base sensor
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4, 7}})
+		sensorProgs = []tus.SensorProg{
+			// kprobe
+			0: tus.SensorProg{Name: "generic_kprobe_event", Type: ebpf.Kprobe},
+			1: tus.SensorProg{Name: "generic_kprobe_setup_event", Type: ebpf.Kprobe},
+			2: tus.SensorProg{Name: "generic_kprobe_process_event", Type: ebpf.Kprobe},
+			3: tus.SensorProg{Name: "generic_kprobe_filter_arg", Type: ebpf.Kprobe},
+			4: tus.SensorProg{Name: "generic_kprobe_process_filter", Type: ebpf.Kprobe},
+			5: tus.SensorProg{Name: "generic_kprobe_actions", Type: ebpf.Kprobe},
+			6: tus.SensorProg{Name: "generic_kprobe_output", Type: ebpf.Kprobe},
+			7: tus.SensorProg{Name: "generic_kprobe_path", Type: ebpf.Kprobe},
+			// retkprobe
+			8:  tus.SensorProg{Name: "generic_retkprobe_event", Type: ebpf.Kprobe},
+			9:  tus.SensorProg{Name: "generic_retkprobe_filter_arg", Type: ebpf.Kprobe},
+			10: tus.SensorProg{Name: "generic_retkprobe_actions", Type: ebpf.Kprobe},
+			11: tus.SensorProg{Name: "generic_retkprobe_output", Type: ebpf.Kprobe},
+		}
 
-		// generic_kprobe_output,generic_retkprobe_output
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{6, 10}})
+		sensorMaps = []tus.SensorMap{
+			// all kprobe programs
+			tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
+
+			// all but generic_kprobe_output
+			tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7}},
+
+			// generic_retkprobe_event
+			tus.SensorMap{Name: "retkprobe_calls", Progs: []uint{8, 9, 10}},
+
+			// generic_kprobe_process_filter,generic_kprobe_filter_arg,
+			// generic_kprobe_actions,generic_kprobe_output
+			tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}},
+
+			// generic_kprobe_actions
+			tus.SensorMap{Name: "override_tasks", Progs: []uint{5}},
+
+			// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
+			tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2}},
+
+			// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
+			tus.SensorMap{Name: "fdinstall_map", Progs: []uint{1, 2, 5, 8, 10}},
+
+			// generic_kprobe_event
+			tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
+		}
+
+		if config.EnableLargeProgs() {
+			// shared with base sensor
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4, 5, 6, 8, 10}})
+
+			// generic_kprobe_process_event*,generic_kprobe_output,generic_retkprobe_output
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 6, 11}})
+
+			// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "socktrack_map", Progs: []uint{1, 2, 5, 8, 10}})
+		} else {
+			// shared with base sensor
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4, 8}})
+
+			// generic_kprobe_output,generic_retkprobe_output
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tcpmon_map", Progs: []uint{6, 11}})
+		}
 	}
 
 	readHook := `

--- a/pkg/sensors/tracing/lsm_test.go
+++ b/pkg/sensors/tracing/lsm_test.go
@@ -37,41 +37,84 @@ func TestLSMObjectLoad(t *testing.T) {
 		t.Skip()
 	}
 
-	var sensorProgs = []tus.SensorProg{
-		// lsm
-		0: tus.SensorProg{Name: "generic_lsm_event", Type: ebpf.LSM},
-		1: tus.SensorProg{Name: "generic_lsm_setup_event", Type: ebpf.LSM},
-		2: tus.SensorProg{Name: "generic_lsm_process_event", Type: ebpf.LSM},
-		3: tus.SensorProg{Name: "generic_lsm_filter_arg", Type: ebpf.LSM},
-		4: tus.SensorProg{Name: "generic_lsm_process_filter", Type: ebpf.LSM},
-		5: tus.SensorProg{Name: "generic_lsm_actions", Type: ebpf.LSM},
-		6: tus.SensorProg{Name: "generic_lsm_output", Type: ebpf.LSM},
-	}
-	var sensorMaps = []tus.SensorMap{
-		// all LSM programs
-		tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6}},
+	var sensorProgs []tus.SensorProg
+	var sensorMaps []tus.SensorMap
 
-		// all but generic_lsm_output
-		tus.SensorMap{Name: "lsm_calls", Progs: []uint{0, 1, 2, 3, 4, 5}},
+	if config.EnableV61Progs() {
+		sensorProgs = []tus.SensorProg{
+			// lsm
+			0: tus.SensorProg{Name: "generic_lsm_event", Type: ebpf.LSM},
+			1: tus.SensorProg{Name: "generic_lsm_setup_event", Type: ebpf.LSM},
+			2: tus.SensorProg{Name: "generic_lsm_process_event", Type: ebpf.LSM},
+			3: tus.SensorProg{Name: "generic_lsm_filter_arg", Type: ebpf.LSM},
+			4: tus.SensorProg{Name: "generic_lsm_process_filter", Type: ebpf.LSM},
+			5: tus.SensorProg{Name: "generic_lsm_actions", Type: ebpf.LSM},
+			6: tus.SensorProg{Name: "generic_lsm_output", Type: ebpf.LSM},
+		}
+		sensorMaps = []tus.SensorMap{
+			// all LSM programs
+			tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6}},
 
-		// generic_lsm_process_filter,generic_lsm_filter_arg,
-		// generic_lsm_actions
-		tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}},
+			// all but generic_lsm_output
+			tus.SensorMap{Name: "lsm_calls", Progs: []uint{0, 1, 2, 3, 4, 5}},
 
-		// generic_lsm_actions, generic_lsm_output
-		tus.SensorMap{Name: "override_tasks", Progs: []uint{5, 6}},
+			// generic_lsm_process_filter,generic_lsm_filter_arg,
+			// generic_lsm_actions
+			tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}},
 
-		// all lsm but generic_lsm_process_filter
-		tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2}},
+			// generic_lsm_actions, generic_lsm_output
+			tus.SensorMap{Name: "override_tasks", Progs: []uint{5, 6}},
 
-		// generic_lsm_event
-		tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
+			// all lsm but generic_lsm_process_filter
+			tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2}},
 
-		// shared with base sensor
-		tus.SensorMap{Name: "execve_map", Progs: []uint{4, 5, 6}},
+			// generic_lsm_event
+			tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
 
-		// generic_lsm_process_event*,generic_lsm_output
-		tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 6}},
+			// shared with base sensor
+			tus.SensorMap{Name: "execve_map", Progs: []uint{4, 5, 6}},
+
+			// generic_lsm_process_event*,generic_lsm_output
+			tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 6}},
+		}
+	} else {
+		sensorProgs = []tus.SensorProg{
+			// lsm
+			0: tus.SensorProg{Name: "generic_lsm_event", Type: ebpf.LSM},
+			1: tus.SensorProg{Name: "generic_lsm_setup_event", Type: ebpf.LSM},
+			2: tus.SensorProg{Name: "generic_lsm_process_event", Type: ebpf.LSM},
+			3: tus.SensorProg{Name: "generic_lsm_filter_arg", Type: ebpf.LSM},
+			4: tus.SensorProg{Name: "generic_lsm_process_filter", Type: ebpf.LSM},
+			5: tus.SensorProg{Name: "generic_lsm_actions", Type: ebpf.LSM},
+			6: tus.SensorProg{Name: "generic_lsm_output", Type: ebpf.LSM},
+			7: tus.SensorProg{Name: "generic_lsm_path", Type: ebpf.LSM},
+		}
+		sensorMaps = []tus.SensorMap{
+			// all LSM programs
+			tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7}},
+
+			// all but generic_lsm_output
+			tus.SensorMap{Name: "lsm_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7}},
+
+			// generic_lsm_process_filter,generic_lsm_filter_arg,
+			// generic_lsm_actions
+			tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}},
+
+			// generic_lsm_actions, generic_lsm_output
+			tus.SensorMap{Name: "override_tasks", Progs: []uint{5, 6}},
+
+			// all lsm but generic_lsm_process_filter
+			tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2}},
+
+			// generic_lsm_event
+			tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}},
+
+			// shared with base sensor
+			tus.SensorMap{Name: "execve_map", Progs: []uint{4, 5, 6}},
+
+			// generic_lsm_process_event*,generic_lsm_output
+			tus.SensorMap{Name: "tcpmon_map", Progs: []uint{1, 2, 6}},
+		}
 	}
 
 	configHook := `


### PR DESCRIPTION
adding support to retrieve full path from kprobe/lsm arguments from most kernels,
4.19 has still some limits, but it's better