### PR TITLE
helm: Allow extending clusterroles and operator configmap

### DIFF
--- a/install/kubernetes/tetragon/templates/_extensions.tpl
+++ b/install/kubernetes/tetragon/templates/_extensions.tpl
@@ -5,3 +5,9 @@
 {{- define "tetragon.volumemounts.extra" -}}{{- end }}
 
 {{- define "initcontainers.extra" -}}{{- end }}
+
+{{- define "clusterrole.extra" -}}{{- end }}
+
+{{- define "operatorconfigmap.extra" -}}{{- end }}
+
+{{- define "operatorclusterrole.extra" -}}{{- end }}

--- a/install/kubernetes/tetragon/templates/clusterrole.yaml
+++ b/install/kubernetes/tetragon/templates/clusterrole.yaml
@@ -35,4 +35,5 @@ rules:
       - get
       - list
       - watch
+  {{- include "clusterrole.extra" . | nindent 2 }}
 {{- end }}

--- a/install/kubernetes/tetragon/templates/operator_clusterrole.yaml
+++ b/install/kubernetes/tetragon/templates/operator_clusterrole.yaml
@@ -47,4 +47,5 @@ rules:
       - get
       - list
       - watch
+  {{- include "operatorclusterrole.extra" . | nindent 2 }}
 {{- end }}

--- a/install/kubernetes/tetragon/templates/operator_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/operator_configmap.yaml
@@ -15,4 +15,5 @@ data:
   skip-pod-info-crd: {{ not .Values.tetragonOperator.podInfo.enabled | quote }}
   skip-tracing-policy-crd: {{ not .Values.tetragonOperator.tracingPolicy.enabled | quote }}
   force-update-crds: {{ .Values.tetragonOperator.forceUpdateCRDs | quote }}
+  {{- include "operatorconfigmap.extra" . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Add three more extensions points to the Helm chart. This is useful e.g. when extending the Helm chart with new CRDs.
