### PR TITLE
helm: enableLsmSensor flag

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -80,6 +80,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.debug | bool | `false` | If you want to run Tetragon in debug mode change this value to true |
 | tetragon.enableK8sAPI | bool | `true` | Access Kubernetes API to associate Tetragon events with Kubernetes pods. |
 | tetragon.enableKeepSensorsOnExit | bool | `false` | Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone. |
+| tetragon.enableLsmSensor | bool | `false` | Read-only mount /sys/kernel/security into Tetragon container to check if LSM BPF is enabled on the host. |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |
 | tetragon.enablePolicyFilter | bool | `true` | Enable policy filter. This is required for K8s namespace and pod-label filtering. |
 | tetragon.enablePolicyFilterCgroupMap | bool | `false` | Enable policy filter cgroup map. |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -62,6 +62,7 @@ Helm chart for Tetragon
 | tetragon.debug | bool | `false` | If you want to run Tetragon in debug mode change this value to true |
 | tetragon.enableK8sAPI | bool | `true` | Access Kubernetes API to associate Tetragon events with Kubernetes pods. |
 | tetragon.enableKeepSensorsOnExit | bool | `false` | Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone. |
+| tetragon.enableLsmSensor | bool | `false` | Read-only mount /sys/kernel/security into Tetragon container to check if LSM BPF is enabled on the host. |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |
 | tetragon.enablePolicyFilter | bool | `true` | Enable policy filter. This is required for K8s namespace and pod-label filtering. |
 | tetragon.enablePolicyFilterCgroupMap | bool | `false` | Enable policy filter cgroup map. |

--- a/install/kubernetes/tetragon/templates/_container_tetragon.tpl
+++ b/install/kubernetes/tetragon/templates/_container_tetragon.tpl
@@ -42,6 +42,11 @@
     - mountPath: {{ quote .Values.tetragon.cri.socketHostPath }}
       name: cri-socket
 {{- end }}
+{{- if and (.Values.tetragon.enableLsmSensor) }}
+    - mountPath: "/sys/kernel/security"
+      name: lsm-volume
+      readOnly: true
+{{- end }}
 {{- range .Values.extraHostPathMounts }}
     - name: {{ .name }}
       mountPath: {{ .mountPath }}

--- a/install/kubernetes/tetragon/templates/daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/daemonset.yaml
@@ -114,6 +114,12 @@ spec:
           path: {{ quote .Values.tetragon.cri.socketHostPath }}
           type: Socket
 {{- end }}
+{{- if .Values.tetragon.enableLsmSensor }}
+      - name: lsm-volume
+        hostPath:
+          path: /sys/kernel/security
+          type: Directory
+{{- end }}
 {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -247,6 +247,8 @@ tetragon:
   # pod association. This feature depends on cri being enabled.
   cgidmap:
     enabled: false
+  # -- Read-only mount /sys/kernel/security into Tetragon container to check if LSM BPF is enabled on the host.
+  enableLsmSensor: false
 # Tetragon Operator settings
 tetragonOperator:
   # -- Enables the Tetragon Operator.


### PR DESCRIPTION
This flag allows to mount (read-only) `/sys/kernel/security` directory in Tetragon container.  `/sys/kernel/security/lsm` file is used to check if LSM BPF is enabled on system.

### Description

It was a long story about how we tried to fix LSM sensor for k8s environment: #3392 #3404 #3456.
The only way is to mount  `/sys/kernel/security directory`  to Tetragon container .  It works fine, I tested on my minikube cluster.

```bash
minikube start --driver=docker --mount --mount-string="/sys/kernel/security:/sys/kernel/security"   --memory=8096 --cpus=8
minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf
```

Install Tetragon:

```bash
helm install --namespace kube-system \
        --set tetragon.grpc.address="unix:///var/run/cilium/tetragon/tetragon.sock" \
--set tetragon.enableLsmSensor=true \
tetragon .
```
Demo Pod:

```bash
kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.15.3/examples/minikube/http-sw-app.yaml
```
Apply Policy and monitor logs:

```bash
kubectl apply -f ./go/src/github.com/cilium/tetragon/examples/tracingpolicy/lsm_file_open.yaml
kubectl exec -ti -n kube-system ds/tetragon -c tetragon -- tetra getevents -o compact --pods xwing
```
Check policy:
```bash
kubectl exec -ti xwing -- bash -c 'cat /etc/passwd'
```

```release-note/minor
```

