### PR TITLE
Windows: Build tetragon on Windows (Part -2)

### DIFF
--- a/pkg/constants/constants_windows.go
+++ b/pkg/constants/constants_windows.go
@@ -1,0 +1,20 @@
+package constants
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+const (
+	AF_INET              = windows.AF_INET
+	AF_INET6             = windows.AF_INET6
+	PERF_MAX_STACK_DEPTH = 0x7f
+	CBitFieldMaskBit34   = 0x400000000
+	CAP_LAST_CAP         = 0x28
+	CAP_CHOWN            = 0
+	AF_UNIX              = windows.AF_UNIX
+	AF_NETBIOS           = windows.AF_NETBIOS
+	AF_IRDA              = windows.AF_IRDA
+	AF_BTH               = windows.AF_BTH
+	CGROUP2_SUPER_MAGIC  = 0x63677270
+	BPF_STATS_RUN_TIME   = 0
+)

--- a/pkg/ktime/ktime.go
+++ b/pkg/ktime/ktime.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package ktime
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func ToProto(ktime uint64) *timestamppb.Timestamp {
+	return ToProtoOpt(ktime, true)
+}
+
+func ToProtoOpt(ktime uint64, monotonic bool) *timestamppb.Timestamp {
+	decodedTime, err := DecodeKtime(int64(ktime), monotonic)
+	if err != nil {
+		logrus.WithError(err).WithField("ktime", ktime).Warn("Failed to decode ktime")
+		return timestamppb.Now()
+	}
+	return timestamppb.New(decodedTime)
+}
+
+func DiffKtime(start, end uint64) time.Duration {
+	return time.Duration(int64(end - start))
+}

--- a/pkg/ktime/ktime_linux.go
+++ b/pkg/ktime/ktime_linux.go
@@ -6,27 +6,8 @@ package ktime
 import (
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-func ToProto(ktime uint64) *timestamppb.Timestamp {
-	return ToProtoOpt(ktime, true)
-}
-
-func ToProtoOpt(ktime uint64, monotonic bool) *timestamppb.Timestamp {
-	decodedTime, err := DecodeKtime(int64(ktime), monotonic)
-	if err != nil {
-		logrus.WithError(err).WithField("ktime", ktime).Warn("Failed to decode ktime")
-		return timestamppb.Now()
-	}
-	return timestamppb.New(decodedTime)
-}
-
-func DiffKtime(start, end uint64) time.Duration {
-	return time.Duration(int64(end - start))
-}
 
 func NanoTimeSince(ktime int64) (time.Duration, error) {
 	clk := int32(unix.CLOCK_MONOTONIC)

--- a/pkg/ktime/ktime_test_windows.go
+++ b/pkg/ktime/ktime_test_windows.go
@@ -1,0 +1,24 @@
+package ktime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKtime(t *testing.T) {
+	time1, err := NanoTimeSince(0)
+	assert.NoError(t, err)
+	assert.Greater(t, time1.Milliseconds(), int64(0))
+	time2, err := NanoTimeSince(0)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, time2, time1)
+}
+
+func TestBoottime(t *testing.T) {
+	time1, err := NanoTimeSince(0)
+	assert.NoError(t, err)
+	ktime1, err := DecodeKtime(time1.Nanoseconds(), false)
+	assert.NoError(t, err)
+	assert.Greater(t, ktime1.UnixMilli(), int64(0))
+}

--- a/pkg/ktime/ktime_windows.go
+++ b/pkg/ktime/ktime_windows.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package ktime
+
+import (
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+var (
+	dll            = syscall.MustLoadDLL("kernel32.dll")
+	queryCounter   = dll.MustFindProc("QueryPerformanceCounter")
+	queryFrequency = dll.MustFindProc("QueryPerformanceFrequency")
+)
+
+func NanoTimeSince(ktime int64) (time.Duration, error) {
+	nowTime := int64(time.Now().Nanosecond())
+	diff := nowTime - ktime
+	return time.Duration(diff), nil
+}
+
+func Monotonic() (time.Duration, error) {
+	return time.Duration(time.Now().Nanosecond()), nil
+}
+
+func getBootTimeNanoseconds() int64 {
+	var freq, counter int64
+	queryFrequency.Call(uintptr(unsafe.Pointer(&freq)))
+	queryCounter.Call(uintptr(unsafe.Pointer(&counter)))
+	return (counter * 1e9) / freq
+}
+
+func DecodeKtime(ktime int64, monotonic bool) (time.Time, error) {
+	var nowTime int64
+	if monotonic {
+		nowTime = int64(time.Now().Nanosecond())
+	} else {
+		nowTime = getBootTimeNanoseconds()
+	}
+	diff := ktime - nowTime
+	t := time.Now().Add(time.Duration(diff))
+	return t, nil
+}

--- a/pkg/sensors/exec/exec_windows.go
+++ b/pkg/sensors/exec/exec_windows.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package exec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/cilium/tetragon/pkg/api"
+	"github.com/cilium/tetragon/pkg/api/ops"
+	"github.com/cilium/tetragon/pkg/api/processapi"
+	exec "github.com/cilium/tetragon/pkg/grpc/exec"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/exec/userinfo"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+	"github.com/cilium/tetragon/pkg/strutils"
+	"github.com/sirupsen/logrus"
+)
+
+func msgToExecveUnix(m *processapi.MsgExecveEvent) *exec.MsgExecveEventUnix {
+	unix := &exec.MsgExecveEventUnix{}
+	unix.Unix = &processapi.MsgExecveEventUnix{}
+	unix.Unix.Msg = m
+	return unix
+}
+
+func execParse(reader *bytes.Reader) (processapi.MsgProcess, bool, error) {
+	proc := processapi.MsgProcess{}
+	exec := processapi.MsgExec{}
+
+	if err := binary.Read(reader, binary.LittleEndian, &exec); err != nil {
+		logger.GetLogger().WithError(err).Debug("Failed to read exec event")
+		return proc, true, err
+	}
+
+	proc.Size = exec.Size
+	proc.PID = exec.PID
+	proc.TID = exec.TID
+	proc.NSPID = exec.NSPID
+	proc.UID = exec.UID
+	proc.Flags = exec.Flags
+	proc.Ktime = exec.Ktime
+	proc.AUID = exec.AUID
+	proc.SecureExec = exec.SecureExec
+	proc.Nlink = exec.Nlink
+	proc.Ino = exec.Ino
+
+	size := exec.Size - processapi.MSG_SIZEOF_EXECVE
+	if size > processapi.MSG_SIZEOF_BUFFER-processapi.MSG_SIZEOF_EXECVE {
+		err := fmt.Errorf("msg exec size larger than argsbuffer")
+		exec.Size = processapi.MSG_SIZEOF_EXECVE
+		proc.Args = "enomem enomem"
+		proc.Filename = "enomem"
+		return proc, false, err
+	}
+
+	args := make([]byte, size) //+2)
+	if err := binary.Read(reader, binary.LittleEndian, &args); err != nil {
+		proc.Size = processapi.MSG_SIZEOF_EXECVE
+		proc.Args = "enomem enomem"
+		proc.Filename = "enomem"
+		return proc, false, err
+	}
+
+	n := bytes.Index(args, []byte{0x00})
+	if n != -1 {
+		proc.Filename = strings.TrimPrefix(strutils.UTF8FromBPFBytes(args[:n]), "\\??\\")
+		args = args[n+1:]
+	}
+	remFileName := proc.Filename
+	if args[0] == '"' {
+		remFileName = "\"" + proc.Filename + "\""
+	}
+
+	proc.Args = strings.TrimPrefix(strutils.UTF8FromBPFBytes(args), remFileName)
+	proc.Args = strings.TrimPrefix(proc.Args, " ")
+	proc.Flags = api.EventNoCWDSupport
+	return proc, false, nil
+}
+
+func nopMsgProcess() processapi.MsgProcess {
+	return processapi.MsgProcess{
+		Filename: "<enomem>",
+		Args:     "<enomem>",
+	}
+}
+
+func handleExecve(r *bytes.Reader) ([]observer.Event, error) {
+	var empty bool
+
+	m := processapi.MsgExecveEvent{}
+	err := binary.Read(r, binary.LittleEndian, &m)
+	if err != nil {
+		return nil, err
+	}
+	//ToDo: Function Name
+	msgUnix := msgToExecveUnix(&m)
+	msgUnix.Unix.Process, empty, err = execParse(r)
+	if err != nil && empty {
+		msgUnix.Unix.Process = nopMsgProcess()
+	}
+	if err == nil && !empty {
+		err = userinfo.MsgToExecveAccountUnix(msgUnix.Unix)
+		if err != nil {
+			logger.GetLogger().WithFields(logrus.Fields{
+				"process.pid":    msgUnix.Unix.Process.PID,
+				"process.binary": msgUnix.Unix.Process.Filename,
+				"process.uid":    msgUnix.Unix.Process.UID,
+			}).WithError(err).Trace("Resolving process uid to username record failed")
+		}
+	}
+	return []observer.Event{msgUnix}, nil
+}
+
+func msgToExitUnix(m *processapi.MsgExitEvent) *exec.MsgExitEventUnix {
+	return &exec.MsgExitEventUnix{MsgExitEvent: *m}
+}
+
+func handleExit(r *bytes.Reader) ([]observer.Event, error) {
+	m := processapi.MsgExitEvent{}
+	err := binary.Read(r, binary.LittleEndian, &m)
+	if err != nil {
+		return nil, err
+	}
+	msgUnix := msgToExitUnix(&m)
+	return []observer.Event{msgUnix}, nil
+}
+
+type execProbe struct{}
+
+func (e *execProbe) LoadProbe(args sensors.LoadProbeArgs) error {
+	return program.LoadTracepointProgram(args.BPFDir, args.Load, args.Maps, args.Verbose)
+}
+
+func init() {
+	AddExec()
+}
+
+func AddExec() {
+	sensors.RegisterProbeType("execve", &execProbe{})
+
+	observer.RegisterEventHandlerAtInit(ops.MSG_OP_EXECVE, handleExecve)
+	observer.RegisterEventHandlerAtInit(ops.MSG_OP_EXIT, handleExit)
+}

--- a/pkg/sensors/load.go
+++ b/pkg/sensors/load.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package sensors
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+	"github.com/cilium/tetragon/pkg/tracingpolicy"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	BPF_PROG_TYPE_UNSPEC                  = 0
+	BPF_PROG_TYPE_SOCKET_FILTER           = 1
+	BPF_PROG_TYPE_KPROBE                  = 2
+	BPF_PROG_TYPE_SCHED_CLS               = 3
+	BPF_PROG_TYPE_SCHED_ACT               = 4
+	BPF_PROG_TYPE_TRACEPOINT              = 5
+	BPF_PROG_TYPE_XDP                     = 6
+	BPF_PROG_TYPE_PERF_EVENT              = 7
+	BPF_PROG_TYPE_CGROUP_SKB              = 8
+	BPF_PROG_TYPE_CGROUP_SOCK             = 9
+	BPF_PROG_TYPE_LWT_IN                  = 10
+	BPF_PROG_TYPE_LWT_OUT                 = 11
+	BPF_PROG_TYPE_LWT_XMIT                = 12
+	BPF_PROG_TYPE_SOCK_OPS                = 13
+	BPF_PROG_TYPE_SK_SKB                  = 14
+	BPF_PROG_TYPE_CGROUP_DEVICE           = 15
+	BPF_PROG_TYPE_SK_MSG                  = 16
+	BPF_PROG_TYPE_RAW_TRACEPOINT          = 17
+	BPF_PROG_TYPE_CGROUP_SOCK_ADDR        = 18
+	BPF_PROG_TYPE_LWT_SEG6LOCAL           = 19
+	BPF_PROG_TYPE_LIRC_MODE2              = 20
+	BPF_PROG_TYPE_SK_REUSEPORT            = 21
+	BPF_PROG_TYPE_FLOW_DISSECTOR          = 22
+	BPF_PROG_TYPE_CGROUP_SYSCTL           = 23
+	BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE = 24
+	BPF_PROG_TYPE_CGROUP_SOCKOPT          = 25
+	BPF_PROG_TYPE_TRACING                 = 26
+	BPF_PROG_TYPE_STRUCT_OPS              = 27
+	BPF_PROG_TYPE_EXT                     = 28
+	BPF_PROG_TYPE_LSM                     = 29
+)
+
+// LoadConfig loads the default sensor, including any from the configuration file.
+func LoadConfig(bpfDir string, sens []*Sensor) error {
+	load := mergeSensors(sens)
+	if err := load.Load(bpfDir); err != nil {
+		return fmt.Errorf("tetragon, aborting could not load BPF programs: %w", err)
+	}
+	return nil
+}
+
+func (s *Sensor) policyDir() string {
+	return tracingpolicy.PolicyDir(s.Namespace, s.Policy)
+}
+
+func (s *Sensor) createDirs(bpfDir string) {
+	for _, p := range s.Progs {
+		// setup sensor based program pin path
+		p.PinPath = filepath.Join(s.policyDir(), s.Name, p.PinName)
+		// and make the path
+		if err := os.MkdirAll(filepath.Join(bpfDir, p.PinPath), os.ModeDir); err != nil {
+			logger.GetLogger().WithError(err).
+				WithField("prog", p.PinName).
+				WithField("dir", p.PinPath).
+				Warn("Failed to create program dir")
+		}
+	}
+	s.BpfDir = bpfDir
+}
+
+func (s *Sensor) removeDirs() {
+	// Remove all the program dirs
+	for _, p := range s.Progs {
+		if err := os.Remove(filepath.Join(s.BpfDir, p.PinPath)); err != nil {
+			logger.GetLogger().WithError(err).
+				WithField("prog", p.PinName).
+				WithField("dir", p.PinPath).
+				Warn("Failed to remove program dir")
+		}
+	}
+	// Remove sensor dir
+	if err := os.Remove(filepath.Join(s.BpfDir, s.policyDir(), s.Name)); err != nil {
+		logger.GetLogger().WithError(err).
+			WithField("sensor", s.Name).
+			WithField("dir", filepath.Join(s.policyDir(), s.Name)).
+			Warn("Failed to remove sensor dir")
+	}
+
+	// For policy dir the last one switches off the light.. there still
+	// might be other sensors in the policy, so the last sensors removed
+	// will succeed in removal policy dir.
+	os.Remove(filepath.Join(s.BpfDir, s.policyDir()))
+}
+
+func (s *Sensor) Unload(unpin bool) error {
+	logger.GetLogger().Infof("Unloading sensor %s", s.Name)
+	if !s.Loaded {
+		return fmt.Errorf("unload of sensor %s failed: sensor not loaded", s.Name)
+	}
+
+	if s.PreUnloadHook != nil {
+		if err := s.PreUnloadHook(); err != nil {
+			logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Pre unload hook failed")
+		}
+	}
+
+	var progs []string
+	for _, p := range s.Progs {
+		unloadProgram(p, unpin)
+		progs = append(progs, p.String())
+	}
+
+	var mapsOk, mapsErr []string
+	for _, m := range s.Maps {
+		if err := m.Unload(unpin); err != nil {
+			logger.GetLogger().WithError(err).WithField("map", s.Name).Warn("Failed to unload map")
+			mapsErr = append(mapsErr, m.String())
+		} else {
+			mapsOk = append(mapsOk, m.String())
+		}
+	}
+
+	if unpin {
+		s.removeDirs()
+	}
+
+	s.Loaded = false
+
+	if s.PostUnloadHook != nil {
+		if err := s.PostUnloadHook(); err != nil {
+			logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Post unload hook failed")
+		}
+	}
+
+	progsCleanup()
+	logger.GetLogger().WithFields(logrus.Fields{
+		"maps":       mapsOk,
+		"maps-error": mapsErr,
+		"progs":      progs,
+	}).Infof("Sensor unloaded")
+	return nil
+}
+
+// Destroy will unload the hook and call DestroyHook, this hook is usually used
+// to clean up resources that were created during creation of the sensor.
+func (s *Sensor) Destroy(unpin bool) {
+	err := s.Unload(unpin)
+	if err != nil {
+		// do not return on error but just log since Unload can only error on
+		// sensor being already not loaded
+		logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Unload failed during destroy")
+	}
+
+	if s.DestroyHook != nil {
+		err = s.DestroyHook()
+		if err != nil {
+			logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Destroy hook failed")
+		}
+	}
+	s.Destroyed = true
+}
+
+func (s *Sensor) findProgram(p *program.Program) error {
+	logger.GetLogger().WithField("file", p.Name).Debug("Checking for bpf file")
+	if _, err := os.Stat(p.Name); err == nil {
+		logger.GetLogger().WithField("file", p.Name).Debug("Found bpf file")
+		return nil
+	}
+	logger.GetLogger().WithField("file", p.Name).Debug("Candidate bpf file does not exist")
+	last := strings.Split(p.Name, "/")
+	filename := last[len(last)-1]
+
+	path := path.Join(option.Config.HubbleLib, filename)
+	if _, err := os.Stat(path); err == nil {
+		p.Name = path
+		logger.GetLogger().WithField("file", path).Debug("Found bpf file")
+		return nil
+	}
+	logger.GetLogger().WithField("file", path).Debug("Candidate bpf file does not exist")
+
+	return fmt.Errorf("sensor program %q can not be found", p.Name)
+}
+
+// FindPrograms finds all the BPF programs in the sensor on the filesytem.
+func (s *Sensor) FindPrograms() error {
+	for _, p := range s.Progs {
+		if err := s.findProgram(p); err != nil {
+			return err
+		}
+	}
+	for _, m := range s.Maps {
+		if err := s.findProgram(m.Prog); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mergeSensors(sensors []*Sensor) *Sensor {
+	var progs []*program.Program
+	var maps []*program.Map
+
+	for _, s := range sensors {
+		progs = append(progs, s.Progs...)
+		maps = append(maps, s.Maps...)
+	}
+	return &Sensor{
+		Name:  "__main__",
+		Progs: progs,
+		Maps:  maps,
+	}
+}
+
+func unloadProgram(prog *program.Program, unpin bool) {
+	log := logger.GetLogger().WithField("label", prog.Label).WithField("pin", prog.PinPath)
+
+	if !prog.LoadState.IsLoaded() {
+		log.Debugf("Refusing to remove %s, program not loaded", prog.Label)
+		return
+	}
+	if count := prog.LoadState.RefDec(); count > 0 {
+		log.Debugf("Program reference count %d, not unloading yet", count)
+		return
+	}
+
+	if err := prog.Unload(unpin); err != nil {
+		logger.GetLogger().WithField("name", prog.Name).WithError(err).Warn("Failed to unload program")
+	}
+
+	log.Debug("BPF prog was unloaded")
+}
+
+func UnloadSensors(sens []SensorIface) {
+	for i := range sens {
+		if err := sens[i].Unload(true); err != nil {
+			logger.GetLogger().Warnf("Failed to unload sensor: %s", err)
+		}
+	}
+}

--- a/pkg/sensors/load_linux.go
+++ b/pkg/sensors/load_linux.go
@@ -5,10 +5,7 @@ package sensors
 
 import (
 	"fmt"
-	"os"
-	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
@@ -17,95 +14,8 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors/program"
-	"github.com/cilium/tetragon/pkg/tracingpolicy"
-
 	"github.com/sirupsen/logrus"
 )
-
-const (
-	BPF_PROG_TYPE_UNSPEC                  = 0
-	BPF_PROG_TYPE_SOCKET_FILTER           = 1
-	BPF_PROG_TYPE_KPROBE                  = 2
-	BPF_PROG_TYPE_SCHED_CLS               = 3
-	BPF_PROG_TYPE_SCHED_ACT               = 4
-	BPF_PROG_TYPE_TRACEPOINT              = 5
-	BPF_PROG_TYPE_XDP                     = 6
-	BPF_PROG_TYPE_PERF_EVENT              = 7
-	BPF_PROG_TYPE_CGROUP_SKB              = 8
-	BPF_PROG_TYPE_CGROUP_SOCK             = 9
-	BPF_PROG_TYPE_LWT_IN                  = 10
-	BPF_PROG_TYPE_LWT_OUT                 = 11
-	BPF_PROG_TYPE_LWT_XMIT                = 12
-	BPF_PROG_TYPE_SOCK_OPS                = 13
-	BPF_PROG_TYPE_SK_SKB                  = 14
-	BPF_PROG_TYPE_CGROUP_DEVICE           = 15
-	BPF_PROG_TYPE_SK_MSG                  = 16
-	BPF_PROG_TYPE_RAW_TRACEPOINT          = 17
-	BPF_PROG_TYPE_CGROUP_SOCK_ADDR        = 18
-	BPF_PROG_TYPE_LWT_SEG6LOCAL           = 19
-	BPF_PROG_TYPE_LIRC_MODE2              = 20
-	BPF_PROG_TYPE_SK_REUSEPORT            = 21
-	BPF_PROG_TYPE_FLOW_DISSECTOR          = 22
-	BPF_PROG_TYPE_CGROUP_SYSCTL           = 23
-	BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE = 24
-	BPF_PROG_TYPE_CGROUP_SOCKOPT          = 25
-	BPF_PROG_TYPE_TRACING                 = 26
-	BPF_PROG_TYPE_STRUCT_OPS              = 27
-	BPF_PROG_TYPE_EXT                     = 28
-	BPF_PROG_TYPE_LSM                     = 29
-)
-
-// LoadConfig loads the default sensor, including any from the configuration file.
-func LoadConfig(bpfDir string, sens []*Sensor) error {
-	load := mergeSensors(sens)
-	if err := load.Load(bpfDir); err != nil {
-		return fmt.Errorf("tetragon, aborting could not load BPF programs: %w", err)
-	}
-	return nil
-}
-
-func (s *Sensor) policyDir() string {
-	return tracingpolicy.PolicyDir(s.Namespace, s.Policy)
-}
-
-func (s *Sensor) createDirs(bpfDir string) {
-	for _, p := range s.Progs {
-		// setup sensor based program pin path
-		p.PinPath = filepath.Join(s.policyDir(), s.Name, p.PinName)
-		// and make the path
-		if err := os.MkdirAll(filepath.Join(bpfDir, p.PinPath), os.ModeDir); err != nil {
-			logger.GetLogger().WithError(err).
-				WithField("prog", p.PinName).
-				WithField("dir", p.PinPath).
-				Warn("Failed to create program dir")
-		}
-	}
-	s.BpfDir = bpfDir
-}
-
-func (s *Sensor) removeDirs() {
-	// Remove all the program dirs
-	for _, p := range s.Progs {
-		if err := os.Remove(filepath.Join(s.BpfDir, p.PinPath)); err != nil {
-			logger.GetLogger().WithError(err).
-				WithField("prog", p.PinName).
-				WithField("dir", p.PinPath).
-				Warn("Failed to remove program dir")
-		}
-	}
-	// Remove sensor dir
-	if err := os.Remove(filepath.Join(s.BpfDir, s.policyDir(), s.Name)); err != nil {
-		logger.GetLogger().WithError(err).
-			WithField("sensor", s.Name).
-			WithField("dir", filepath.Join(s.policyDir(), s.Name)).
-			Warn("Failed to remove sensor dir")
-	}
-
-	// For policy dir the last one switches off the light.. there still
-	// might be other sensors in the policy, so the last sensors removed
-	// will succeed in removal policy dir.
-	os.Remove(filepath.Join(s.BpfDir, s.policyDir()))
-}
 
 // Load loads the sensor, by loading all the BPF programs and maps.
 func (s *Sensor) Load(bpfDir string) (err error) {
@@ -198,110 +108,6 @@ func (s *Sensor) Load(bpfDir string) (err error) {
 	return nil
 }
 
-func (s *Sensor) Unload(unpin bool) error {
-	logger.GetLogger().Infof("Unloading sensor %s", s.Name)
-	if !s.Loaded {
-		return fmt.Errorf("unload of sensor %s failed: sensor not loaded", s.Name)
-	}
-
-	if s.PreUnloadHook != nil {
-		if err := s.PreUnloadHook(); err != nil {
-			logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Pre unload hook failed")
-		}
-	}
-
-	var progs []string
-	for _, p := range s.Progs {
-		unloadProgram(p, unpin)
-		progs = append(progs, p.String())
-	}
-
-	var mapsOk, mapsErr []string
-	for _, m := range s.Maps {
-		if err := m.Unload(unpin); err != nil {
-			logger.GetLogger().WithError(err).WithField("map", s.Name).Warn("Failed to unload map")
-			mapsErr = append(mapsErr, m.String())
-		} else {
-			mapsOk = append(mapsOk, m.String())
-		}
-	}
-
-	if unpin {
-		s.removeDirs()
-	}
-
-	s.Loaded = false
-
-	if s.PostUnloadHook != nil {
-		if err := s.PostUnloadHook(); err != nil {
-			logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Post unload hook failed")
-		}
-	}
-
-	progsCleanup()
-	logger.GetLogger().WithFields(logrus.Fields{
-		"maps":       mapsOk,
-		"maps-error": mapsErr,
-		"progs":      progs,
-	}).Infof("Sensor unloaded")
-	return nil
-}
-
-// Destroy will unload the hook and call DestroyHook, this hook is usually used
-// to clean up resources that were created during creation of the sensor.
-func (s *Sensor) Destroy(unpin bool) {
-	err := s.Unload(unpin)
-	if err != nil {
-		// do not return on error but just log since Unload can only error on
-		// sensor being already not loaded
-		logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Unload failed during destroy")
-	}
-
-	if s.DestroyHook != nil {
-		err = s.DestroyHook()
-		if err != nil {
-			logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Destroy hook failed")
-		}
-	}
-	s.Destroyed = true
-}
-
-func (s *Sensor) findProgram(p *program.Program) error {
-	logger.GetLogger().WithField("file", p.Name).Debug("Checking for bpf file")
-	if _, err := os.Stat(p.Name); err == nil {
-		logger.GetLogger().WithField("file", p.Name).Debug("Found bpf file")
-		return nil
-	}
-	logger.GetLogger().WithField("file", p.Name).Debug("Candidate bpf file does not exist")
-	last := strings.Split(p.Name, "/")
-	filename := last[len(last)-1]
-
-	path := path.Join(option.Config.HubbleLib, filename)
-	if _, err := os.Stat(path); err == nil {
-		p.Name = path
-		logger.GetLogger().WithField("file", path).Debug("Found bpf file")
-		return nil
-	}
-	logger.GetLogger().WithField("file", path).Debug("Candidate bpf file does not exist")
-
-	return fmt.Errorf("sensor program %q can not be found", p.Name)
-}
-
-// FindPrograms finds all the BPF programs in the sensor on the filesytem.
-func (s *Sensor) FindPrograms() error {
-	for _, p := range s.Progs {
-		if err := s.findProgram(p); err != nil {
-			return err
-		}
-	}
-	for _, m := range s.Maps {
-		if err := s.findProgram(m.Prog); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (s *Sensor) setMapPinPath(m *program.Map) {
 	policy := s.policyDir()
 	switch m.Type {
@@ -391,21 +197,6 @@ func (s *Sensor) loadMap(bpfDir string, m *program.Map) error {
 	return nil
 }
 
-func mergeSensors(sensors []*Sensor) *Sensor {
-	var progs []*program.Program
-	var maps []*program.Map
-
-	for _, s := range sensors {
-		progs = append(progs, s.Progs...)
-		maps = append(maps, s.Maps...)
-	}
-	return &Sensor{
-		Name:  "__main__",
-		Progs: progs,
-		Maps:  maps,
-	}
-}
-
 func observerLoadInstance(bpfDir string, load *program.Program, maps []*program.Map) error {
 	version, _, err := kernels.GetKernelVersion(option.Config.KernelVersion, option.Config.ProcFS)
 	if err != nil {
@@ -490,31 +281,4 @@ func observerMinReqs() (bool, error) {
 		return false, fmt.Errorf("kernel version lookup failed, required for kprobe")
 	}
 	return true, nil
-}
-
-func unloadProgram(prog *program.Program, unpin bool) {
-	log := logger.GetLogger().WithField("label", prog.Label).WithField("pin", prog.PinPath)
-
-	if !prog.LoadState.IsLoaded() {
-		log.Debugf("Refusing to remove %s, program not loaded", prog.Label)
-		return
-	}
-	if count := prog.LoadState.RefDec(); count > 0 {
-		log.Debugf("Program reference count %d, not unloading yet", count)
-		return
-	}
-
-	if err := prog.Unload(unpin); err != nil {
-		logger.GetLogger().WithField("name", prog.Name).WithError(err).Warn("Failed to unload program")
-	}
-
-	log.Debug("BPF prog was unloaded")
-}
-
-func UnloadSensors(sens []SensorIface) {
-	for i := range sens {
-		if err := sens[i].Unload(true); err != nil {
-			logger.GetLogger().Warnf("Failed to unload sensor: %s", err)
-		}
-	}
 }

--- a/pkg/sensors/load_windows.go
+++ b/pkg/sensors/load_windows.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package sensors
+
+import (
+	"fmt"
+
+	"github.com/cilium/tetragon/pkg/kernels"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Load loads the sensor, by loading all the BPF programs and maps.
+func (s *Sensor) Load(bpfDir string) (err error) {
+	if s == nil {
+		return nil
+	}
+
+	if s.Destroyed {
+		return fmt.Errorf("sensor %s has been previously destroyed, please recreate it before loading", s.Name)
+	}
+	if _, err = observerMinReqs(); err != nil {
+		return fmt.Errorf("tetragon, aborting minimum requirements not met: %w", err)
+	}
+
+	var (
+		loadedMaps  []*program.Map
+		loadedProgs []*program.Program
+	)
+
+	s.createDirs(bpfDir)
+	defer func() {
+		if err != nil {
+			for _, m := range loadedMaps {
+				m.Unload(true)
+			}
+			for _, p := range loadedProgs {
+				unloadProgram(p, true)
+			}
+			s.removeDirs()
+		}
+	}()
+
+	l := logger.GetLogger()
+
+	l.WithField("name", s.Name).Info("Loading sensor")
+	if s.Loaded {
+		return fmt.Errorf("loading sensor %s failed: sensor already loaded", s.Name)
+	}
+
+	if err = s.FindPrograms(); err != nil {
+		return fmt.Errorf("tetragon, aborting could not find BPF programs: %w", err)
+	}
+	// Comparing with Linux, why are maps not loaded here ?
+	// In windows, we load collection directly and do not load specs.
+	// The collection loads maps for us.
+	for _, p := range s.Progs {
+		if p.LoadState.IsLoaded() {
+			l.WithField("prog", p.Name).Info("BPF prog is already loaded, incrementing reference count")
+			p.LoadState.RefInc()
+			continue
+		}
+
+		if err = observerLoadInstance(bpfDir, p, s.Maps); err != nil {
+			return err
+		}
+		p.LoadState.RefInc()
+		loadedProgs = append(loadedProgs, p)
+		l.WithField("prog", p.Name).WithField("label", p.Label).Debugf("BPF prog was loaded")
+	}
+
+	// Add the *loaded* programs and maps, so they can be unloaded later
+	progsAdd(s.Progs)
+	AllMaps = append(AllMaps, s.Maps...)
+
+	if s.PostLoadHook != nil {
+		if err := s.PostLoadHook(); err != nil {
+			logger.GetLogger().WithError(err).WithField("sensor", s.Name).Warn("Post load hook failed")
+		}
+	}
+
+	l.WithFields(logrus.Fields{
+		"sensor": s.Name,
+		"maps":   loadedMaps,
+		"progs":  loadedProgs,
+	}).Infof("Loaded BPF maps and events for sensor successfully")
+	s.Loaded = true
+	return nil
+}
+
+func observerLoadInstance(bpfDir string, load *program.Program, maps []*program.Map) error {
+	version, _, err := kernels.GetKernelVersion(option.Config.KernelVersion, option.Config.ProcFS)
+	if err != nil {
+		return err
+	}
+
+	l := logger.GetLogger()
+	l.WithFields(logrus.Fields{
+		"prog":         load.Name,
+		"kern_version": version,
+	}).Debugf("observerLoadInstance %s %d", load.Name, version)
+
+	err = loadInstance(bpfDir, load, maps, version, option.Config.Verbosity)
+	if err != nil && load.ErrorFatal {
+		return fmt.Errorf("failed prog %s kern_version %d loadInstance: %w",
+			load.Name, version, err)
+	}
+	return nil
+}
+
+func loadInstance(bpfDir string, load *program.Program, maps []*program.Map, version, verbose int) error {
+	// Check if the load.type is a standard program type. If so, use the standard loader.
+	loadFn, ok := standardTypes[load.Type]
+	if ok {
+		logger.GetLogger().WithField("Program", load.Name).
+			WithField("Type", load.Type).
+			WithField("Attach", load.Attach).
+			Debug("Loading BPF program")
+		return loadFn(bpfDir, load, maps, verbose)
+	}
+
+	return fmt.Errorf("program %s has unregistered type '%s'", load.Label, load.Type)
+}
+
+func observerMinReqs() (bool, error) {
+	return true, nil
+}

--- a/pkg/sensors/sensor_types_linux.go
+++ b/pkg/sensors/sensor_types_linux.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package sensors
+
+import (
+	"github.com/cilium/tetragon/pkg/sensors/program"
+	"github.com/cilium/tetragon/pkg/sensors/program/cgroup"
+)
+
+var (
+	// list of registered policy handlers, see RegisterPolicyHandlerAtInit()
+	registeredPolicyHandlers = map[string]policyHandler{}
+	// list of registers loaders, see registerProbeType()
+	registeredProbeLoad = map[string]probeLoader{}
+	standardTypes       = map[string]func(string, *program.Program, []*program.Map, int) error{
+		"tracepoint":     program.LoadTracepointProgram,
+		"raw_tracepoint": program.LoadRawTracepointProgram,
+		"raw_tp":         program.LoadRawTracepointProgram,
+		"cgrp_socket":    cgroup.LoadCgroupProgram,
+		"kprobe":         program.LoadKprobeProgram,
+		"lsm":            program.LoadLSMProgram,
+	}
+)

--- a/pkg/sensors/sensor_types_windows.go
+++ b/pkg/sensors/sensor_types_windows.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package sensors
+
+import (
+	"strings"
+
+	"github.com/cilium/tetragon/pkg/sensors/program"
+)
+
+func sanitize(name string) string {
+	return strings.ReplaceAll(name, "/", "_")
+}
+
+var (
+	// list of registered policy handlers, see RegisterPolicyHandlerAtInit()
+	registeredPolicyHandlers = map[string]policyHandler{}
+	// list of registers loaders, see registerProbeType()
+	registeredProbeLoad = map[string]probeLoader{}
+	standardTypes       = map[string]func(string, *program.Program, []*program.Map, int) error{
+		"windows": program.LoadWindowsProgram,
+	}
+)

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/sensors/program"
-	"github.com/cilium/tetragon/pkg/sensors/program/cgroup"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 
 	// load rthooks for policy filter
@@ -212,21 +211,6 @@ type policyHandler interface {
 type probeLoader interface {
 	LoadProbe(args LoadProbeArgs) error
 }
-
-var (
-	// list of registered policy handlers, see RegisterPolicyHandlerAtInit()
-	registeredPolicyHandlers = map[string]policyHandler{}
-	// list of registers loaders, see registerProbeType()
-	registeredProbeLoad = map[string]probeLoader{}
-	standardTypes       = map[string]func(string, *program.Program, []*program.Map, int) error{
-		"tracepoint":     program.LoadTracepointProgram,
-		"raw_tracepoint": program.LoadRawTracepointProgram,
-		"raw_tp":         program.LoadRawTracepointProgram,
-		"cgrp_socket":    cgroup.LoadCgroupProgram,
-		"kprobe":         program.LoadKprobeProgram,
-		"lsm":            program.LoadLSMProgram,
-	}
-)
 
 // RegisterPolicyHandlerAtInit registers a handler for a tracing policy.
 func RegisterPolicyHandlerAtInit(name string, h policyHandler) {

--- a/pkg/sensors/tracing/lists_windows.go
+++ b/pkg/sensors/tracing/lists_windows.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"errors"
+
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+)
+
+var (
+	notSupportedWinErr = errors.New("not supported on windows")
+)
+
+// isList checks if a value specifies a list, and if so it returns it (or nil if list does not exist)
+func isList(val string, lists []v1alpha1.ListSpec) (bool, *v1alpha1.ListSpec) {
+	return false, nil
+}
+
+func preValidateLists(lists []v1alpha1.ListSpec) (err error) {
+	return notSupportedWinErr
+}
+
+type listReader struct {
+	lists []v1alpha1.ListSpec
+}
+
+func (lr *listReader) Read(name string, ty uint32) ([]uint32, error) {
+	return []uint32{}, notSupportedWinErr
+}
+
+func getSyscallListSymbols(list *v1alpha1.ListSpec) ([]string, error) {
+	return nil, notSupportedWinErr
+}

--- a/pkg/sensors/tracing/loader_windows.go
+++ b/pkg/sensors/tracing/loader_windows.go
@@ -1,0 +1,8 @@
+package tracing
+
+import "errors"
+
+func createLoaderEvents() error {
+
+	return errors.New("not supported on windows")
+}

--- a/pkg/sensors/tracing/policyhandler.go
+++ b/pkg/sensors/tracing/policyhandler.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/eventhandler"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/policyconf"
+	"github.com/cilium/tetragon/pkg/policyfilter"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+	"github.com/cilium/tetragon/pkg/tracingpolicy"
+)
+
+type policyHandler struct{}
+
+func init() {
+	sensors.RegisterPolicyHandlerAtInit("tracing", policyHandler{})
+}
+
+type policyInfo struct {
+	name          string
+	namespace     string
+	policyID      policyfilter.PolicyID
+	customHandler eventhandler.Handler
+	policyConf    *program.Map
+	specOpts      *specOptions
+}
+
+func newPolicyInfo(
+	policy tracingpolicy.TracingPolicy,
+	policyID policyfilter.PolicyID,
+) (*policyInfo, error) {
+	namespace := ""
+	if tpn, ok := policy.(tracingpolicy.TracingPolicyNamespaced); ok {
+		namespace = tpn.TpNamespace()
+	}
+
+	return newPolicyInfoFromSpec(
+		namespace,
+		policy.TpName(),
+		policyID,
+		policy.TpSpec(),
+		eventhandler.GetCustomEventhandler(policy),
+	)
+
+}
+
+func newPolicyInfoFromSpec(
+	namespace, name string,
+	policyID policyfilter.PolicyID,
+	spec *v1alpha1.TracingPolicySpec,
+	customHandler eventhandler.Handler,
+) (*policyInfo, error) {
+	opts, err := getSpecOptions(spec.Options)
+	if err != nil {
+		return nil, err
+	}
+	return &policyInfo{
+		name:          name,
+		namespace:     namespace,
+		policyID:      policyID,
+		customHandler: customHandler,
+		policyConf:    nil,
+		specOpts:      opts,
+	}, nil
+}
+
+func (pi *policyInfo) policyConfMap(prog *program.Program) *program.Map {
+	if pi.policyConf != nil {
+		return program.MapUserFrom(pi.policyConf)
+	}
+	pi.policyConf = program.MapBuilderPolicy("policy_conf", prog)
+	prog.MapLoad = append(prog.MapLoad, &program.MapLoad{
+		Index: 0,
+		Name:  policyconf.PolicyConfMapName,
+		Load: func(m *ebpf.Map, _ string, _ uint32) error {
+			mode := policyconf.EnforceMode
+			if pi.specOpts != nil {
+				mode = pi.specOpts.policyMode
+			}
+			conf := policyconf.PolicyConf{
+				Mode: mode,
+			}
+			key := uint32(0)
+			return m.Update(key, &conf, ebpf.UpdateAny)
+		},
+	})
+	return pi.policyConf
+}

--- a/pkg/sensors/tracing/policyhandler_linux.go
+++ b/pkg/sensors/tracing/policyhandler_linux.go
@@ -7,92 +7,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/tetragon/pkg/eventhandler"
-	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
-	"github.com/cilium/tetragon/pkg/policyconf"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/sensors"
-	"github.com/cilium/tetragon/pkg/sensors/program"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
-
-type policyHandler struct{}
-
-func init() {
-	sensors.RegisterPolicyHandlerAtInit("tracing", policyHandler{})
-}
-
-type policyInfo struct {
-	name          string
-	namespace     string
-	policyID      policyfilter.PolicyID
-	customHandler eventhandler.Handler
-	policyConf    *program.Map
-	specOpts      *specOptions
-}
-
-func newPolicyInfo(
-	policy tracingpolicy.TracingPolicy,
-	policyID policyfilter.PolicyID,
-) (*policyInfo, error) {
-	namespace := ""
-	if tpn, ok := policy.(tracingpolicy.TracingPolicyNamespaced); ok {
-		namespace = tpn.TpNamespace()
-	}
-
-	return newPolicyInfoFromSpec(
-		namespace,
-		policy.TpName(),
-		policyID,
-		policy.TpSpec(),
-		eventhandler.GetCustomEventhandler(policy),
-	)
-
-}
-
-func newPolicyInfoFromSpec(
-	namespace, name string,
-	policyID policyfilter.PolicyID,
-	spec *v1alpha1.TracingPolicySpec,
-	customHandler eventhandler.Handler,
-) (*policyInfo, error) {
-	opts, err := getSpecOptions(spec.Options)
-	if err != nil {
-		return nil, err
-	}
-	return &policyInfo{
-		name:          name,
-		namespace:     namespace,
-		policyID:      policyID,
-		customHandler: customHandler,
-		policyConf:    nil,
-		specOpts:      opts,
-	}, nil
-}
-
-func (pi *policyInfo) policyConfMap(prog *program.Program) *program.Map {
-	if pi.policyConf != nil {
-		return program.MapUserFrom(pi.policyConf)
-	}
-	pi.policyConf = program.MapBuilderPolicy("policy_conf", prog)
-	prog.MapLoad = append(prog.MapLoad, &program.MapLoad{
-		Index: 0,
-		Name:  policyconf.PolicyConfMapName,
-		Load: func(m *ebpf.Map, _ string, _ uint32) error {
-			mode := policyconf.EnforceMode
-			if pi.specOpts != nil {
-				mode = pi.specOpts.policyMode
-			}
-			conf := policyconf.PolicyConf{
-				Mode: mode,
-			}
-			key := uint32(0)
-			return m.Update(key, &conf, ebpf.UpdateAny)
-		},
-	})
-	return pi.policyConf
-}
 
 func (h policyHandler) PolicyHandler(
 	policy tracingpolicy.TracingPolicy,

--- a/pkg/sensors/tracing/policyhandler_windows.go
+++ b/pkg/sensors/tracing/policyhandler_windows.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"errors"
+
+	"github.com/cilium/tetragon/pkg/policyfilter"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/tracingpolicy"
+)
+
+func (h policyHandler) PolicyHandler(
+	policy tracingpolicy.TracingPolicy,
+	policyID policyfilter.PolicyID,
+) (sensors.SensorIface, error) {
+	return nil, errors.New("not supported on windows")
+}

--- a/pkg/sensors/unloader/unloader.go
+++ b/pkg/sensors/unloader/unloader.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package unloader
+
+import (
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+)
+
+// Unloader describes how to unload a sensor resource, e.g.
+// programs or maps.
+type Unloader interface {
+	Unload(unpin bool) error
+}
+
+// chainUnloader is an unloader for multiple resources.
+// Useful when a loading operation needs to be unwinded due to an error.
+type ChainUnloader []Unloader
+
+type chainUnloaderErrors struct {
+	errors []error
+}
+
+func (cue chainUnloaderErrors) Error() string {
+	strs := []string{}
+	for _, e := range cue.errors {
+		strs = append(strs, e.Error())
+	}
+	return strings.Join(strs, "; ")
+}
+
+func (cu ChainUnloader) Unload(unpin bool) error {
+	var cue chainUnloaderErrors
+	for i := len(cu) - 1; i >= 0; i-- {
+		if err := (cu)[i].Unload(unpin); err != nil {
+			cue.errors = append(cue.errors, err)
+		}
+	}
+	if len(cue.errors) > 0 {
+		return cue
+	}
+	return nil
+}
+
+// ProgUnloader unpins and closes a BPF program.
+type ProgUnloader struct {
+	Prog *ebpf.Program
+}
+
+func (pu ProgUnloader) Unload(unpin bool) error {
+	if unpin {
+		pu.Prog.Unpin()
+	}
+	return pu.Prog.Close()
+}
+
+// ProgUnloader unpins and closes a BPF program.
+type LinkUnloader struct {
+	Link link.Link
+}
+
+func (lu LinkUnloader) Unload(unpin bool) error {
+	if unpin {
+		lu.Link.Unpin()
+	}
+	return lu.Link.Close()
+}

--- a/pkg/sensors/unloader/unloader_linux.go
+++ b/pkg/sensors/unloader/unloader_linux.go
@@ -6,7 +6,6 @@ package unloader
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -14,65 +13,6 @@ import (
 	"go.uber.org/multierr"
 	"golang.org/x/sys/unix"
 )
-
-// Unloader describes how to unload a sensor resource, e.g.
-// programs or maps.
-type Unloader interface {
-	Unload(unpin bool) error
-}
-
-// chainUnloader is an unloader for multiple resources.
-// Useful when a loading operation needs to be unwinded due to an error.
-type ChainUnloader []Unloader
-
-type chainUnloaderErrors struct {
-	errors []error
-}
-
-func (cue chainUnloaderErrors) Error() string {
-	strs := []string{}
-	for _, e := range cue.errors {
-		strs = append(strs, e.Error())
-	}
-	return strings.Join(strs, "; ")
-}
-
-func (cu ChainUnloader) Unload(unpin bool) error {
-	var cue chainUnloaderErrors
-	for i := len(cu) - 1; i >= 0; i-- {
-		if err := (cu)[i].Unload(unpin); err != nil {
-			cue.errors = append(cue.errors, err)
-		}
-	}
-	if len(cue.errors) > 0 {
-		return cue
-	}
-	return nil
-}
-
-// ProgUnloader unpins and closes a BPF program.
-type ProgUnloader struct {
-	Prog *ebpf.Program
-}
-
-func (pu ProgUnloader) Unload(unpin bool) error {
-	if unpin {
-		pu.Prog.Unpin()
-	}
-	return pu.Prog.Close()
-}
-
-// ProgUnloader unpins and closes a BPF program.
-type LinkUnloader struct {
-	Link link.Link
-}
-
-func (lu LinkUnloader) Unload(unpin bool) error {
-	if unpin {
-		lu.Link.Unpin()
-	}
-	return lu.Link.Close()
-}
 
 // rawDetachUnloader can be used to unload cgroup and sockmap programs.
 type RawDetachUnloader struct {


### PR DESCRIPTION
### Description

This change attempts to port `ktime`, `constants` and `pkg/sensors` package to Windows following changes made via #3445. This is the strategy
    
    1. Windows specific .go files are added in this PR for ktime, constants and sensors package
    2. We bring back `pkg/sensors/unloader/unloader.go` , `pkg/sensors/tracing/policyhandler.go` and `pkg/sensors/sensors.go` and separate only platform specific code in these listings. 
    3. Lot of code, we know not used on Windows is removed. Examples include LSM, multi kprobes etc. 
    4. Functions required to build on Windows, but are not supported return "not supported on windows" error

### Caveats
This is a change to prepare for Windows build and port. This does not compile on Windows yet, as more changes to dependent packages will be added in subsequent PR. 

### Changelog

```
Add windows implementation to ktime, constants and sensor packages. 
```
