### PR TITLE
install/kubernetes: fix typo

### DIFF
--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -82,7 +82,7 @@ data:
 {{- end }}
   process-cache-gc-interval: {{ .Values.tetragon.processCacheGCInterval | quote }}
   enable-cri: {{ .Values.tetragon.cri.enabled | quote }}
-{{- if and (.Values.tetragon.cri.enable) (.Values.tetragon.cri.socketHostPath) }}
+{{- if and (.Values.tetragon.cri.enabled) (.Values.tetragon.cri.socketHostPath) }}
   cri-endpoint: "unix://{{ .Values.tetragon.cri.socketHostPath }}"
 {{- end }}
   enable-cgidmap: {{ .Values.tetragon.cgidmap.enabled | quote }}


### PR DESCRIPTION
fixes 3b043f1f926b2cba93f4c4a34a1be786ada4556b

See: https://github.com/cilium/tetragon/issues/2639#issuecomment-2718853910
