### PR TITLE
tetragon: Add extra bounds check to extract_arg

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -83,6 +83,9 @@ FUNC_INLINE void extract_arg(struct event_config *config, int index, unsigned lo
 	if (index >= EVENT_CONFIG_MAX_ARG)
 		return;
 
+	asm volatile("%[index] &= %1 ;\n"
+		     : [index] "+r"(index)
+		     : "i"(MAX_SELECTORS_MASK));
 	btf_config = config->btf_arg[index];
 	if (btf_config->is_initialized) {
 		struct extract_arg_data extract_data = {


### PR DESCRIPTION
We are facing issues when compiling bpf code with another clang version, adding the index bounds check fixes it.