### PR TITLE
main: Split k8s watchers into process metadata and policy

### DIFF
--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -39,22 +39,22 @@ type K8sWatcher struct {
 
 // NewK8sWatcher creates a new K8sWatcher with initialized informer factories.
 func NewK8sWatcher(
-	k8sClient kubernetes.Interface, crdClient versioned.Interface, stateSyncIntervalSec time.Duration,
+	k8sClient kubernetes.Interface, crdClient versioned.Interface, stateSyncInterval time.Duration,
 ) *K8sWatcher {
 	var k8sInformerFactory, localK8sInformerFactory informers.SharedInformerFactory
 	var crdInformerFactory externalversions.SharedInformerFactory
 
 	if k8sClient != nil {
-		k8sInformerFactory = informers.NewSharedInformerFactory(k8sClient, stateSyncIntervalSec)
+		k8sInformerFactory = informers.NewSharedInformerFactory(k8sClient, stateSyncInterval)
 		localK8sInformerFactory = informers.NewSharedInformerFactoryWithOptions(
-			k8sClient, stateSyncIntervalSec, informers.WithTweakListOptions(
+			k8sClient, stateSyncInterval, informers.WithTweakListOptions(
 				func(options *metav1.ListOptions) {
 					// watch local pods only
 					options.FieldSelector = "spec.nodeName=" + node.GetNodeNameForExport()
 				}))
 	}
 	if crdClient != nil {
-		crdInformerFactory = externalversions.NewSharedInformerFactory(crdClient, stateSyncIntervalSec)
+		crdInformerFactory = externalversions.NewSharedInformerFactory(crdClient, stateSyncInterval)
 	}
 
 	return &K8sWatcher{


### PR DESCRIPTION
Commit https://github.com/cilium/tetragon/commit/7dc13f82781ec6d0258e398281f847217d252513 ("crdwatcher: Reuse watcher.K8sWatcher to watch TracingPolicy")
reorganized the order of execution in the main function to start watching all
Kubernetes resources at once. In hindsight, this was a bit shortsighted. There
are two purposes Tetragon is watching Kubernetes API for:
1. retrieving Kubernetes metadata for processes
2. managing policies

These two should kick off at different times in the startup order. The former
should happen before the sensors are loaded, as otherwise events will be stuck
waiting for Kubernetes metadata. The latter should happen after the sensors are
loaded, as otherwise existing policies will fail to load on the first attempt.

To solve the problem, split informers used for these two purposes into separate
K8sWatcher instances, one started before the sensors are loaded, and one after.
Both use the same watcher.Watcher interface. Currently the "process metadata"
watcher watches only k8s built-in resources, and the "policy" watcher - only
Tetragon CRDs. However, it's quite likely to change in the future - the split
here is based on the purpose, not where the resources are defined.

The previous change wasn't released yet, so marking the PR as `release-note/misc`.