### PR TITLE
ci: In "Tetragon Go Test" add vmlinux in artifact when test fails

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -88,3 +88,11 @@ jobs:
         name: tetragon-bugtool
         path: /tmp/tetragon-bugtool*
         retention-days: 5
+
+    - name: Upload vmlinux file
+      if: failure()
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      with:
+        name: btf-vmlinux-${{ matrix.os }}
+        path: /sys/kernel/btf/vmlinux
+        retention-days: 5


### PR DESCRIPTION
To help debugging between arch, I think it is a great idea to upload the vmlinux file when this test fails

This will help fixing https://github.com/cilium/tetragon/issues/3492

### Motivation

`TestSpecs` uses `ksys_lseek`  symbol which is inlined (I think) on ARM but not on x86_64. If we upload the vmlinux, we can load the BTF spec and check what hooks are shared
https://github.com/cilium/tetragon/pull/3414#issuecomment-2733004356

### Description

Kprobes are not exactly the same between ARM and x86_64. To help understand why some tests fail on one architecture and not the other, it can be helpful to use the vmlinux file directly from the CI instead of deploying a specific VM with the same architecture for debugging.