### PR TITLE
tetragon/windows: Compilation only change for pkg/metrics/syscallmetrics

### DIFF
--- a/pkg/metrics/syscallmetrics/raw_syscall_name_windows.go
+++ b/pkg/metrics/syscallmetrics/raw_syscall_name_windows.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package syscallmetrics
+
+import (
+	"github.com/cilium/tetragon/api/v1/tetragon"
+)
+
+func rawSyscallName(tp *tetragon.ProcessTracepoint) string {
+	return ""
+}


### PR DESCRIPTION
### Description
Adding stub function to compile metrics package on Windows

### Changelog
<!-- Enter the release note text in the code block below if needed or remove this section! -->

```
Compile the package pkg/metrics on Windows
```
