### PR TITLE
tetragon/windows: Compilation only change for pkg/metricconfig package on Windows

### DIFF
--- a/pkg/metricsconfig/healthmetrics.go
+++ b/pkg/metricsconfig/healthmetrics.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/tetragon/pkg/metrics/enforcermetrics"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
-	"github.com/cilium/tetragon/pkg/metrics/kprobemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/opcodemetrics"
 	"github.com/cilium/tetragon/pkg/metrics/overhead"
 	"github.com/cilium/tetragon/pkg/metrics/policyfiltermetrics"
@@ -87,15 +86,14 @@ func registerHealthMetrics(group metrics.Group) {
 	exporter.RegisterMetrics(group)
 	// cgrup rate metrics
 	cgroupratemetrics.RegisterMetrics(group)
-	// kprobe metrics
-	kprobemetrics.RegisterMetrics(group)
-	group.ExtendInitForDocs(kprobemetrics.InitMetricsForDocs)
+
+	// extended metrics, Linux only
+	registerHealthMetricsEx(group)
+
 	// policy metrics
 	group.MustRegister(policymetrics.NewPolicyCollector())
 	// gRPC metrics
 	group.MustRegister(grpcmetrics.NewServerMetrics())
-	// missed metris
-	group.MustRegister(kprobemetrics.NewBPFCollector())
 	// enforcer metrics
 	group.MustRegister(enforcermetrics.NewCollector())
 	// overhead metris

--- a/pkg/metricsconfig/healthmetrics_linux.go
+++ b/pkg/metricsconfig/healthmetrics_linux.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metricsconfig
+
+import (
+	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/kprobemetrics"
+)
+
+func registerHealthMetricsEx(group metrics.Group) {
+	// kprobe metrics
+	kprobemetrics.RegisterMetrics(group)
+	group.ExtendInitForDocs(kprobemetrics.InitMetricsForDocs)
+	// missed metrics
+	group.MustRegister(kprobemetrics.NewBPFCollector())
+}

--- a/pkg/metricsconfig/healthmetrics_windows.go
+++ b/pkg/metricsconfig/healthmetrics_windows.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metricsconfig
+
+import "github.com/cilium/tetragon/pkg/metrics"
+
+func registerHealthMetricsEx(group metrics.Group) {
+
+}


### PR DESCRIPTION
### Description
Compilation-only change.
Add windows specific stub-function: `registerHealthMetricsEx` in an otherwise platform independent metricsconfig package This enables compilation of `pkg/metricsconfig` on Windows. 

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```
Compile the package pkg/metricsconfig on Windows
```
