### PR TITLE
tetragon/windows: Port pidfile package on Windows

### DIFF
--- a/pkg/pidfile/pid_alive_linux.go
+++ b/pkg/pidfile/pid_alive_linux.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package pidfile
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/tetragon/pkg/option"
+)
+
+func isPidAlive(pid string) bool {
+	_, err := os.Stat(filepath.Join(option.Config.ProcFS, pid))
+	return err == nil
+}

--- a/pkg/pidfile/pid_alive_windows.go
+++ b/pkg/pidfile/pid_alive_windows.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package pidfile
+
+import (
+	"os"
+	"strconv"
+)
+
+func isPidAlive(pid string) bool {
+	int32pid, err := strconv.ParseInt(pid, 0, 32)
+	if err == nil {
+		_, err = os.FindProcess(int(int32pid))
+	}
+	return err == nil
+}

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/cilium/tetragon/pkg/defaults"
@@ -33,8 +32,7 @@ func readPidFile() (uint64, error) {
 	}
 
 	pid := string(bytes.TrimSpace(data))
-	_, err = os.Stat(filepath.Join(option.Config.ProcFS, pid))
-	if err != nil {
+	if !isPidAlive(pid) {
 		return 0, ErrPidIsNotAlive
 	}
 

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -5,6 +5,7 @@ package pidfile
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,4 +32,11 @@ func TestCreatePidFile(t *testing.T) {
 	pid1, err = readPidFile()
 	require.ErrorIs(t, err, ErrPidFileAccess)
 	require.Zero(t, pid1)
+}
+
+func TestIsPidRunning(t *testing.T) {
+	pid := os.Getpid()
+	strPid := strconv.Itoa(pid)
+	isPidRunning := isPidAlive((strPid))
+	require.True(t, isPidRunning)
 }


### PR DESCRIPTION
### Description
pidfile package works well on windows, except readPidFile() function, which needs to access the proc filesystem. 

In Windows, we directly query the os to check if the pid is running.

This change results in compiled pidfile package in Windows and passed unit tests.

### Changelog
```
Compile and run unit tests on the package pkg/pidfile on Windows
```
