### PR TITLE
tetragon/windows: Compilation only Change for pkg/procsyms on Windows

### DIFF
--- a/pkg/procsyms/procsyms.go
+++ b/pkg/procsyms/procsyms.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package procsyms
+
+import (
+	"fmt"
+)
+
+// FnSym is a function location (function name, module path + offset)
+type FnSym struct {
+	Name   string
+	Module string
+	Offset uint64
+}
+
+// ToString returns a string representation of FnSym
+func (fsym *FnSym) ToString() string {
+	return fmt.Sprintf("%s (%s+0x%x)", fsym.Name, fsym.Module, fsym.Offset)
+}

--- a/pkg/procsyms/procsyms_linux.go
+++ b/pkg/procsyms/procsyms_linux.go
@@ -21,18 +21,6 @@ var (
 	setCache sync.Once
 )
 
-// FnSym is a function location (function name, module path + offset)
-type FnSym struct {
-	Name   string
-	Module string
-	Offset uint64
-}
-
-// ToString returns a string representation of FnSym
-func (fsym *FnSym) ToString() string {
-	return fmt.Sprintf("%s (%s+0x%x)", fsym.Name, fsym.Module, fsym.Offset)
-}
-
 // GetFnSymbol -- returns the FnSym for a given address and PID
 func GetFnSymbol(pid int, addr uint64) (*FnSym, error) {
 	// TODO: Think about cache [pid+addr] -> [module+offset]

--- a/pkg/procsyms/procsyms_windows.go
+++ b/pkg/procsyms/procsyms_windows.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package procsyms
+
+import (
+	"errors"
+)
+
+// GetFnSymbol -- returns the FnSym for a given address and PID
+func GetFnSymbol(pid int, addr uint64) (*FnSym, error) {
+	return nil, errors.New("not implemented on windows ")
+
+}


### PR DESCRIPTION

### Description
Stubbing out the GetFnSymbol function on Windows to make sure pkg/procsysms compiles on Windows.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```
Compile the package pkg/procsyms on Windows
```
