### PR TITLE
tetragon/windows: Port package errmetrics to Windows

### DIFF
--- a/pkg/errmetrics/err_msg_windows.go
+++ b/pkg/errmetrics/err_msg_windows.go
@@ -1,0 +1,17 @@
+package errmetrics
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func GetErrorMessage(err uint16) (message string) {
+	const flags uint32 = syscall.FORMAT_MESSAGE_FROM_SYSTEM
+	buf := make([]uint16, 300)
+	_, error := windows.FormatMessage(flags, 0, uint32(err), 0, buf, nil)
+	if error != nil {
+		return "unknown error code "
+	}
+	return windows.UTF16ToString(buf[:])
+}

--- a/pkg/errmetrics/err_msg_windows_test.go
+++ b/pkg/errmetrics/err_msg_windows_test.go
@@ -1,0 +1,18 @@
+package errmetrics
+
+import (
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrMessage(t *testing.T) {
+	s1 := GetErrorMessage(uint16(syscall.ERROR_ACCESS_DENIED))
+	assert.Equal(t, strings.HasPrefix(s1, "Access is denied."), true)
+
+	s2 := GetErrorMessage(uint16(syscall.ERROR_INSUFFICIENT_BUFFER))
+	assert.Equal(t, strings.HasPrefix(s2, "The data area passed to a system call is too small."), true)
+
+}


### PR DESCRIPTION
### Description
Add windows specific definition of GetErrorMessage() function to convert error code into string, using the sys/Windows package.

Added unit test to check strings related to common Windows errors.

### Changelog

```
Compile and run unit tests on the package pkg/errmetrics on Windows
```
