### PR TITLE
tetragon/windows: Compilation only change to build encoder package 

### DIFF
--- a/pkg/encoder/raw_syscall_enter.go
+++ b/pkg/encoder/raw_syscall_enter.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
-//go:build linux || darwin || windows
+//go:build !windows
 
 package encoder
 

--- a/pkg/encoder/raw_syscall_enter_windows.go
+++ b/pkg/encoder/raw_syscall_enter_windows.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package encoder
+
+import "github.com/cilium/tetragon/api/v1/tetragon"
+
+func rawSyscallEnter(tp *tetragon.ProcessTracepoint) string {
+	return "unknown win32"
+
+}


### PR DESCRIPTION

### Description
Added windows specific stub of the function `rawSyscallEnter()` in `encoder/raw_syscall_enter.go` listing of encoder package to allow it to compile on Windows

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```
Compile  the package pkg/encoder on Windows
```
