### PR TITLE
tetragon/windows: Compilation only change to compile cgroups package

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package cgroups
+
+import "bytes"
+
+const (
+	// Generic unset value that means undefined or not set
+	CGROUP_UNSET_VALUE = 0
+
+	// Max cgroup subsystems count that is used from BPF side
+	// to define a max index for the default controllers on tasks.
+	// For further documentation check BPF part.
+	CGROUP_SUBSYS_COUNT = 15
+
+	// The default hierarchy for cgroupv2
+	CGROUP_DEFAULT_HIERARCHY = 0
+)
+
+type CgroupModeCode int
+
+const (
+	/* Cgroup Mode:
+	 * https://systemd.io/CGROUP_DELEGATION/
+	 * But this should work also for non-systemd environments: where
+	 * only legacy or unified are available by default.
+	 */
+	CGROUP_UNDEF   CgroupModeCode = iota
+	CGROUP_LEGACY  CgroupModeCode = 1
+	CGROUP_HYBRID  CgroupModeCode = 2
+	CGROUP_UNIFIED CgroupModeCode = 3
+)
+
+type DeploymentCode int
+
+type deploymentEnv struct {
+	id       DeploymentCode
+	str      string
+	endsWith string
+}
+
+const (
+	// Deployment modes
+	DEPLOY_UNKNOWN    DeploymentCode = iota
+	DEPLOY_K8S        DeploymentCode = 1  // K8s deployment
+	DEPLOY_CONTAINER  DeploymentCode = 2  // Container docker, podman, etc
+	DEPLOY_SD_SERVICE DeploymentCode = 10 // Systemd service
+	DEPLOY_SD_USER    DeploymentCode = 11 // Systemd user session
+)
+
+func (op DeploymentCode) String() string {
+	return [...]string{
+		DEPLOY_UNKNOWN:    "unknown",
+		DEPLOY_K8S:        "Kubernetes",
+		DEPLOY_CONTAINER:  "Container",
+		DEPLOY_SD_SERVICE: "systemd service",
+		DEPLOY_SD_USER:    "systemd user session",
+	}[op]
+}
+
+// CgroupNameFromCstr() Returns a Golang string from the passed C language format string.
+func CgroupNameFromCStr(cstr []byte) string {
+	i := bytes.IndexByte(cstr, 0)
+	if i == -1 {
+		i = len(cstr)
+	}
+	return string(cstr[:i])
+}

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -28,50 +28,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// Generic unset value that means undefined or not set
-	CGROUP_UNSET_VALUE = 0
-
-	// Max cgroup subsystems count that is used from BPF side
-	// to define a max index for the default controllers on tasks.
-	// For further documentation check BPF part.
-	CGROUP_SUBSYS_COUNT = 15
-
-	// The default hierarchy for cgroupv2
-	CGROUP_DEFAULT_HIERARCHY = 0
-)
-
-type CgroupModeCode int
-
-const (
-	/* Cgroup Mode:
-	 * https://systemd.io/CGROUP_DELEGATION/
-	 * But this should work also for non-systemd environments: where
-	 * only legacy or unified are available by default.
-	 */
-	CGROUP_UNDEF   CgroupModeCode = iota
-	CGROUP_LEGACY  CgroupModeCode = 1
-	CGROUP_HYBRID  CgroupModeCode = 2
-	CGROUP_UNIFIED CgroupModeCode = 3
-)
-
-type DeploymentCode int
-
-type deploymentEnv struct {
-	id       DeploymentCode
-	str      string
-	endsWith string
-}
-
-const (
-	// Deployment modes
-	DEPLOY_UNKNOWN    DeploymentCode = iota
-	DEPLOY_K8S        DeploymentCode = 1  // K8s deployment
-	DEPLOY_CONTAINER  DeploymentCode = 2  // Container docker, podman, etc
-	DEPLOY_SD_SERVICE DeploymentCode = 10 // Systemd service
-	DEPLOY_SD_USER    DeploymentCode = 11 // Systemd user session
-)
-
 type CgroupController struct {
 	Id     uint32 // Hierarchy unique ID
 	Idx    uint32 // Cgroup SubSys index
@@ -135,16 +91,6 @@ func (code CgroupModeCode) String() string {
 		CGROUP_HYBRID:  "Hybrid mode (Cgroupv1 and Cgroupv2)",
 		CGROUP_UNIFIED: "Unified mode (Cgroupv2)",
 	}[code]
-}
-
-func (op DeploymentCode) String() string {
-	return [...]string{
-		DEPLOY_UNKNOWN:    "unknown",
-		DEPLOY_K8S:        "Kubernetes",
-		DEPLOY_CONTAINER:  "Container",
-		DEPLOY_SD_SERVICE: "systemd service",
-		DEPLOY_SD_USER:    "systemd user session",
-	}[op]
 }
 
 // DetectCgroupFSMagic() runs by default DetectCgroupMode()
@@ -731,15 +677,6 @@ func DetectCgroupFSMagic() (uint64, error) {
 	}
 
 	return cgroupFSMagic, nil
-}
-
-// CgroupNameFromCstr() Returns a Golang string from the passed C language format string.
-func CgroupNameFromCStr(cstr []byte) string {
-	i := bytes.IndexByte(cstr, 0)
-	if i == -1 {
-		i = len(cstr)
-	}
-	return string(cstr[:i])
 }
 
 func tryHostCgroup(path string) error {

--- a/pkg/cgroups/cgroups_windows.go
+++ b/pkg/cgroups/cgroups_windows.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package cgroups
+
+import (
+	"errors"
+)
+
+func CgroupFsMagicStr(magic uint64) string {
+	return ""
+}
+
+func GetCgroupIdFromPath(cgroupPath string) (uint64, error) {
+	return 0, errors.New("not Supported on windows")
+}
+
+func DiscoverSubSysIds() error {
+	return errors.New("could not detect cgroup filesystem on windows")
+}
+
+func GetDeploymentMode() DeploymentCode {
+	return DEPLOY_UNKNOWN
+}
+
+func GetCgroupMode() CgroupModeCode {
+	return CGROUP_UNDEF
+}
+
+func GetCgrpHierarchyID() uint32 {
+	return 0
+}
+
+func GetCgrpv1SubsystemIdx() uint32 {
+	return 0
+}
+
+func GetCgrpControllerName() string {
+	return ""
+}
+
+func DetectCgroupMode() (CgroupModeCode, error) {
+	return CGROUP_UNDEF, errors.New("not Supported on windows")
+}
+
+func DetectDeploymentMode() (DeploymentCode, error) {
+	return DEPLOY_UNKNOWN, errors.New("not Supported on windows")
+}
+
+func DetectCgroupFSMagic() (uint64, error) {
+	return CGROUP_UNSET_VALUE, errors.New("not Supported on windows")
+}
+
+func HostCgroupRoot() (string, error) {
+	return "", errors.New("not Supported on windows")
+}
+
+func CgroupIDFromPID(pid uint32) (uint64, error) {
+	return 0, errors.New("not Supported on windows")
+}
+
+func GetCgroupIDFromSubCgroup(p string) (uint64, error) {
+
+	return 0, errors.New("not Supported on windows")
+}


### PR DESCRIPTION

### Description
Add windows specific stub function definitions to compile pkg/cgroups package on Windows. 
Common types and functions added in cgroups.go
### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```
Compile  the package pkg/cgroups on Windows
```
