### PR TITLE
tetragon/windows: Compilation only change to build config package

### DIFF
--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package config
+
+// ExecObj returns the exec object based on the kernel version
+func ExecObj() string {
+	return ""
+}
+
+// GenericKprobeObjs returns the generic kprobe and generic retprobe objects
+func GenericKprobeObjs() (string, string) {
+	return "", ""
+}
+
+func EnableV61Progs() bool {
+	return false
+}
+
+func EnableLargeProgs() bool {
+	return false
+}


### PR DESCRIPTION
### Description
Add Windows specific stub in config_windows.go to allow compilation of pkg/config package on Windows.

### Changelog

```
Compile  the package pkg/config on Windows
```
