### PR TITLE
tetragon/windows: Add default definitions for Windows

### DIFF
--- a/pkg/defaults/defaults_windows.go
+++ b/pkg/defaults/defaults_windows.go
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-//go:build !windows
-
 package defaults
 
 import "time"
 
 const (
 	// DefaultMapRoot is the default path where BPFFS should be mounted
-	DefaultMapRoot = "/sys/fs/bpf"
+	DefaultMapRoot = `C:\Program Files\ebpf-for-windows`
 
 	// DefaultMapPrefix is the default path prefix where Tetragon maps should be pinned
 	DefaultMapPrefix = "tetragon"
@@ -19,22 +17,16 @@ const (
 
 	// DefaultMapRootFallback is the path which is used when /sys/fs/bpf has
 	// a mount, but with the other filesystem than BPFFS.
-	DefaultMapRootFallback = "/run/cilium/bpffs"
+	DefaultMapRootFallback = `C:\Program Files\Tetragon\bpffs`
 
 	// DefaultRunDir is the default run directory for runtime
-	DefaultRunDir = "/var/run/tetragon/"
+	DefaultRunDir = `C:\Program Files\Tetragon\`
 
 	// Default Path to where cgroup2 is mounted (Prefix with /run)
-	Cgroup2Dir = "/run/tetragon/cgroup2"
-
-	// DedfaultNetnsDir is the default network namespace directory for runtime
-	DefaultNetnsDir = "/var/run/docker/netns/"
-
-	// Default kernel exposed BTF file path
-	DefaultBTFFile = "/sys/kernel/btf/vmlinux"
+	Cgroup2Dir = ""
 
 	// Default location for BPF programs and BTF files
-	DefaultTetragonLib = "/var/lib/tetragon/"
+	DefaultTetragonLib = `C:\Program Files\Tetragon\BPF`
 
 	// InitInfoFile is the file location for the info file.
 	// After initialization, InitInfoFile will contain a json representation of InitInfo
@@ -42,7 +34,7 @@ const (
 	InitInfoFile = DefaultRunDir + "tetragon-info.json"
 
 	// Default directory from where to load tracing policies.
-	DefaultTpDir = "/etc/tetragon/tetragon.tp.d"
+	DefaultTpDir = DefaultRunDir + "tetragon.tp.d"
 
 	// Default secure export logs permissions
 	DefaultLogsPermission = "600"
@@ -56,9 +48,4 @@ const (
 
 	// defaults for the process cache
 	DefaultProcessCacheGCInterval = 30 * time.Second
-)
-
-var (
-	// NetnsDir is the network namespace directory for runtime
-	NetnsDir = DefaultNetnsDir
 )


### PR DESCRIPTION
### Description
Moved over `defaults.go` to `defaults_linux.go` .
Added `defaults_windows.go` to add set of default paths and names for Windows. 
Some default definitions are stubbed out for compilation.

### Changelog

```
Port the package defaults to Windows
```
