### PR TITLE
v1.4 backports 20250326

### DIFF
--- a/tests/e2e/helpers/grpc/grpc.go
+++ b/tests/e2e/helpers/grpc/grpc.go
@@ -11,34 +11,23 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
-	"github.com/cilium/tetragon/cmd/tetra/common"
 	"github.com/cilium/tetragon/tests/e2e/state"
+	"google.golang.org/grpc"
 )
 
 // WaitForTracingPolicy checks that a tracing policy exists in all tetragon pods.
 func WaitForTracingPolicy(ctx context.Context, policyName string) error {
-	tetraPorts, ok := ctx.Value(state.GrpcForwardedPorts).(map[string]int)
+	tetraConns, ok := ctx.Value(state.GrpcForwardedConns).(map[string]*grpc.ClientConn)
 	if !ok {
 		return fmt.Errorf("failed to find tetragon grpc forwarded ports")
 	}
 
 	maxTries := 20
-	for podName, grpcPort := range tetraPorts {
-		addr := fmt.Sprintf("127.0.0.1:%d", grpcPort)
-		// https://github.com/grpc/grpc-go/pull/7905 requires the number of retries to
-		// be greater than 1 in google.golang.org/grpc v1.7.0.
-		// We already do that + 1 in retryPolicy() so it is safe to make that 1.
-		common.Retries = 1
-		// NB(kkourt): maybe it would make sense to cache the grpc connections in the
-		// context, but we keep things simple for now.
-		c, err := common.NewClient(ctx, addr, 10*time.Second)
-		if err != nil {
-			return fmt.Errorf("failed to create gRPC client to pod (%s) at forwared port (%d): %w", podName, grpcPort, err)
-		}
-		defer c.Close()
-
+	for podName, grpcConn := range tetraConns {
+		client := tetragon.NewFineGuidanceSensorsClient(grpcConn)
+		var err error
 		for i := 0; i < maxTries; i++ {
-			err = ensureTracingPolicy(c.Ctx, policyName, c.Client)
+			err = ensureTracingPolicy(ctx, policyName, client)
 			if err == nil {
 				break
 			}

--- a/tests/e2e/state/state.go
+++ b/tests/e2e/state/state.go
@@ -13,6 +13,8 @@ var (
 	InstallOpts = Key{slug: "InstallOpts"}
 	// Key for storing a list of ports we forwarded for gRPC
 	GrpcForwardedPorts = Key{slug: "GrpcForwardedPorts"}
+	// Key for storing a list of forwarded connections for gRPC
+	GrpcForwardedConns = Key{slug: "GrpcForwardedConns"}
 	// Key for storing a list of ports we forwarded for prometheus metics
 	PromForwardedPorts = Key{slug: "PromForwardedPorts"}
 	// Key for storing a list of ports we forwarded for the pprof server


### PR DESCRIPTION
Backported PRs

  * https://github.com/cilium/tetragon/pull/3555
       * [e2e tests: fix port-forwading race](https://github.com/cilium/tetragon/commit/b5962e4b432b54760a8398fe87af7b604befbd74)
       * [e2e tests: use existing connections.](https://github.com/cilium/tetragon/commit/1365b31cb719ac064e05d002dcb739a850b732df)