### PR TITLE
tetragon: add raw tracepoints

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -44,7 +44,8 @@ PROCESS += bpf_execve_event_v310.o bpf_exit_v310.o bpf_fork_v310.o
 PROCESS += bpf_execve_event.o bpf_fork.o bpf_exit.o bpf_execve_bprm_commit_creds.o
 # generic probes
 PROCESS += bpf_generic_kprobe.o bpf_generic_retkprobe.o bpf_generic_tracepoint.o \
-	   bpf_generic_uprobe.o
+	   bpf_generic_uprobe.o bpf_generic_rawtp.o
+
 # lsm
 PROCESS += bpf_generic_lsm_core.o bpf_generic_lsm_output.o
 
@@ -54,7 +55,8 @@ PROCESS += bpf_execve_event_v53.o
 # generic probes
 PROCESS += bpf_generic_kprobe_v53.o bpf_generic_retkprobe_v53.o \
 	   bpf_multi_kprobe_v53.o bpf_multi_retkprobe_v53.o \
-	   bpf_generic_tracepoint_v53.o bpf_generic_uprobe_v53.o
+	   bpf_generic_tracepoint_v53.o bpf_generic_uprobe_v53.o \
+	   bpf_generic_rawtp_v53.o
 
 # v5.11
 # base sensor
@@ -62,7 +64,9 @@ PROCESS += bpf_execve_event_v511.o
 # generic probes
 PROCESS += bpf_generic_kprobe_v511.o bpf_generic_retkprobe_v511.o \
 	   bpf_multi_kprobe_v511.o bpf_multi_retkprobe_v511.o \
-	   bpf_generic_tracepoint_v511.o bpf_generic_uprobe_v511.o
+	   bpf_generic_tracepoint_v511.o bpf_generic_uprobe_v511.o \
+	   bpf_generic_rawtp_v511.o
+
 # lsm
 PROCESS += bpf_generic_lsm_core_v511.o bpf_generic_lsm_output_v511.o \
 	   bpf_generic_lsm_ima_file_v511.o bpf_generic_lsm_ima_bprm_v511.o
@@ -74,7 +78,9 @@ PROCESS += bpf_execve_event_v61.o
 PROCESS += bpf_generic_kprobe_v61.o bpf_generic_retkprobe_v61.o \
 	   bpf_multi_kprobe_v61.o bpf_multi_retkprobe_v61.o \
 	   bpf_generic_tracepoint_v61.o bpf_generic_uprobe_v61.o \
-	   bpf_multi_uprobe_v61.o
+	   bpf_multi_uprobe_v61.o \
+	   bpf_generic_rawtp_v61.o
+
 # lsm
 PROCESS += bpf_generic_lsm_core_v61.o bpf_generic_lsm_output_v61.o \
 	   bpf_generic_lsm_ima_file_v61.o bpf_generic_lsm_ima_bprm_v61.o

--- a/bpf/process/bpf_generic_rawtp.c
+++ b/bpf/process/bpf_generic_rawtp.c
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "vmlinux.h"
+#include "api.h"
+
+#define GENERIC_RAWTP
+
+#include "compiler.h"
+#include "bpf_event.h"
+#include "bpf_task.h"
+#include "retprobe_map.h"
+#include "types/operations.h"
+#include "types/basic.h"
+#include "policy_filter.h"
+
+char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
+
+int generic_rawtp_setup_event(void *ctx);
+int generic_rawtp_process_event(void *ctx);
+int generic_rawtp_process_filter(void *ctx);
+int generic_rawtp_filter_arg(void *ctx);
+int generic_rawtp_actions(void *ctx);
+int generic_rawtp_output(void *ctx);
+int generic_rawtp_path(void *ctx);
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(max_entries, 13);
+	__type(key, __u32);
+	__array(values, int(void *));
+} tp_calls SEC(".maps") = {
+	.values = {
+		[TAIL_CALL_SETUP] = (void *)&generic_rawtp_setup_event,
+		[TAIL_CALL_PROCESS] = (void *)&generic_rawtp_process_event,
+		[TAIL_CALL_FILTER] = (void *)&generic_rawtp_process_filter,
+		[TAIL_CALL_ARGS] = (void *)&generic_rawtp_filter_arg,
+		[TAIL_CALL_ACTIONS] = (void *)&generic_rawtp_actions,
+		[TAIL_CALL_SEND] = (void *)&generic_rawtp_output,
+#ifndef __V61_BPF_PROG
+		[TAIL_CALL_PATH] = (void *)&generic_rawtp_path,
+#endif
+	},
+};
+
+#include "generic_maps.h"
+#include "generic_calls.h"
+
+/* Generic kprobe pseudocode is the following
+ *
+ *  filter_pids -> drop if no matches
+ *  filter_namespaces -> drop if no matches
+ *  filter_capabilities -> drop if no matches
+ *  filter_namespace_changes -> drop if no matches
+ *  filter_capability_changes -> drop if no matches
+ *  copy arguments buffer
+ *  filter selectors -> drop if no matches
+ *  generate ring buffer event
+ *
+ * First we filter by pids this allows us to quickly drop events
+ * that are not relevant. This is helpful if we end up copying
+ * large string values.
+ *
+ * Then we copy arguments then run full selectors logic. We keep
+ * track of pids that passed initial filter so we avoid running
+ * pid filters twice.
+ *
+ * For 4.19 kernels we have to use the tail call infrastructure
+ * to get below 4k insns. For 5.x+ kernels with 1m.insns its not
+ * an issue.
+ */
+__attribute__((section("raw_tp/generic_tracepoint"), used)) int
+generic_rawtp_event(void *ctx)
+{
+	return generic_start_process_filter(ctx, (struct bpf_map_def *)&tp_calls);
+}
+
+__attribute__((section("raw_tp"), used)) int
+generic_rawtp_setup_event(void *ctx)
+{
+	return generic_process_event_and_setup(ctx, (struct bpf_map_def *)&tp_calls);
+}
+
+__attribute__((section("raw_tp"), used)) int
+generic_rawtp_process_event(void *ctx)
+{
+	return generic_process_event(ctx, (struct bpf_map_def *)&tp_calls);
+}
+
+__attribute__((section("raw_tp"), used)) int
+generic_rawtp_process_filter(void *ctx)
+{
+	int ret;
+
+	ret = generic_process_filter();
+	if (ret == PFILTER_CONTINUE)
+		tail_call(ctx, &tp_calls, TAIL_CALL_FILTER);
+	else if (ret == PFILTER_ACCEPT)
+		tail_call(ctx, &tp_calls, TAIL_CALL_SETUP);
+	/* If filter does not accept drop it. Ideally we would
+	 * log error codes for later review, TBD.
+	 */
+	return PFILTER_REJECT;
+}
+
+__attribute__((section("raw_tp"), used)) int
+generic_rawtp_filter_arg(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&tp_calls, true);
+}
+
+__attribute__((section("raw_tp"), used)) int
+generic_rawtp_actions(void *ctx)
+{
+	generic_actions(ctx, (struct bpf_map_def *)&tp_calls);
+	return 0;
+}
+
+__attribute__((section("raw_tp"), used)) int
+generic_rawtp_output(void *ctx)
+{
+	return generic_output(ctx, MSG_OP_GENERIC_TRACEPOINT);
+}
+
+#ifndef __V61_BPF_PROG
+__attribute__((section("raw_tp"), used)) int
+generic_rawtp_path(void *ctx)
+{
+	return generic_path(ctx, (struct bpf_map_def *)&tp_calls);
+}
+#endif

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -273,6 +273,16 @@ generic_process_event_and_setup(struct pt_regs *ctx, struct bpf_map_def *tailcal
 	generic_process_init(e, MSG_OP_GENERIC_UPROBE, config);
 #endif
 
+#ifdef GENERIC_RAWTP
+	struct bpf_raw_tracepoint_args *raw_args = (struct bpf_raw_tracepoint_args *)ctx;
+
+	e->a0 = BPF_CORE_READ(raw_args, args[0]);
+	e->a1 = BPF_CORE_READ(raw_args, args[1]);
+	e->a2 = BPF_CORE_READ(raw_args, args[2]);
+	e->a3 = BPF_CORE_READ(raw_args, args[3]);
+	e->a4 = BPF_CORE_READ(raw_args, args[4]);
+	generic_process_init(e, MSG_OP_GENERIC_TRACEPOINT, config);
+#endif
 	return generic_process_event(ctx, tailcals);
 }
 

--- a/examples/tracingpolicy/rawtp.yaml
+++ b/examples/tracingpolicy/rawtp.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "rawtp"
+spec:
+  tracepoints:
+    - subsystem: "sched"
+      event: "sched_process_exec"
+      raw: true
+      args:
+        - index: 2
+          type: "linux_binprm"

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -1614,6 +1614,9 @@ spec:
                         A short message of 256 characters max that will be included
                         in the event output to inform users what is going on.
                       type: string
+                    raw:
+                      description: Enable raw tracepoint arguments
+                      type: boolean
                     selectors:
                       description: Selectors to apply before producing trace output.
                         Selectors are ORed.

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1614,6 +1614,9 @@ spec:
                         A short message of 256 characters max that will be included
                         in the event output to inform users what is going on.
                       type: string
+                    raw:
+                      description: Enable raw tracepoint arguments
+                      type: boolean
                     selectors:
                       description: Selectors to apply before producing trace output.
                         Selectors are ORed.

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -575,6 +575,16 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 					Abi: v.ABI,
 				},
 			}})
+		case tracingapi.MsgGenericKprobeArgLinuxBinprm:
+			bprm := &tetragon.KprobeLinuxBinprm{
+				Path:       v.Value,
+				Flags:      path.FilePathFlagsToStr(v.Flags),
+				Permission: path.FilePathModeToStr(v.Permission),
+			}
+
+			tetragonArgs = append(tetragonArgs, &tetragon.KprobeArgument{Arg: &tetragon.KprobeArgument_LinuxBinprmArg{
+				LinuxBinprmArg: bprm,
+			}})
 
 		default:
 			logger.GetLogger().Warnf("handleGenericTracepointMessage: unhandled value: %+v (%T)", arg, arg)

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -586,6 +586,16 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 				LinuxBinprmArg: bprm,
 			}})
 
+		case tracingapi.MsgGenericKprobeArgFile:
+			fileArg := &tetragon.KprobeFile{
+				Path:       v.Value,
+				Flags:      path.FilePathFlagsToStr(v.Flags),
+				Permission: path.FilePathModeToStr(v.Permission),
+			}
+
+			tetragonArgs = append(tetragonArgs, &tetragon.KprobeArgument{Arg: &tetragon.KprobeArgument_FileArg{
+				FileArg: fileArg,
+			}})
 		default:
 			logger.GetLogger().Warnf("handleGenericTracepointMessage: unhandled value: %+v (%T)", arg, arg)
 		}

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -1614,6 +1614,9 @@ spec:
                         A short message of 256 characters max that will be included
                         in the event output to inform users what is going on.
                       type: string
+                    raw:
+                      description: Enable raw tracepoint arguments
+                      type: boolean
                     selectors:
                       description: Selectors to apply before producing trace output.
                         Selectors are ORed.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1614,6 +1614,9 @@ spec:
                         A short message of 256 characters max that will be included
                         in the event output to inform users what is going on.
                       type: string
+                    raw:
+                      description: Enable raw tracepoint arguments
+                      type: boolean
                     selectors:
                       description: Selectors to apply before producing trace output.
                         Selectors are ORed.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -286,6 +286,9 @@ type TracepointSpec struct {
 	// Tags to categorize the event, will be include in the event output.
 	// Maximum of 16 Tags are supported.
 	Tags []string `json:"tags,omitempty"`
+	// +kubebuilder:validation:Optional
+	// Enable raw tracepoint arguments
+	Raw bool `json:"raw,omitempty"`
 }
 
 type UProbeSpec struct {

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.5.1"
+const CustomResourceDefinitionSchemaVersion = "1.5.2"

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -27,10 +27,16 @@ func addPaddingOnNestedPtr(ty ebtf.Type, path []string) []string {
 	return path
 }
 
-func resolveBTFArg(hook string, arg v1alpha1.KProbeArg) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {
+func resolveBTFArg(hook string, arg v1alpha1.KProbeArg, tp bool) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {
 	btfArg := [api.MaxBTFArgDepth]api.ConfigBTFArg{}
 
-	param, err := btf.FindBTFFuncParamFromHook(hook, int(arg.Index))
+	// tracepoints have extra first internal argument, so we need to adjust the index
+	index := int(arg.Index)
+	if tp {
+		index++
+	}
+
+	param, err := btf.FindBTFFuncParamFromHook(hook, index)
 	if err != nil {
 		return nil, btfArg, err
 	}

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -51,7 +51,7 @@ spec:
 	successHook := policy.TpSpec().KProbes[:2]
 	for _, hook := range successHook {
 		for _, arg := range hook.Args {
-			lastBTFType, btfArg, err := resolveBTFArg(hook.Call, arg)
+			lastBTFType, btfArg, err := resolveBTFArg(hook.Call, arg, false)
 
 			if err != nil {
 				t.Fatal(hook.Call, err)
@@ -66,7 +66,7 @@ spec:
 
 	failHook := policy.TpSpec().KProbes[2]
 	for _, arg := range failHook.Args {
-		_, _, err := resolveBTFArg(failHook.Call, arg)
+		_, _, err := resolveBTFArg(failHook.Call, arg, false)
 
 		if !assert.ErrorContains(t, err, "The maximum depth allowed is") {
 			t.Fatalf("The path %q must have len < %d", arg.Resolve, api.MaxBTFArgDepth)

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -749,7 +749,7 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 			if !bpf.HasProgramLargeSize() {
 				return errFn(errors.New("error: Resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag"))
 			}
-			lastBTFType, btfArg, err := resolveBTFArg(f.Call, a)
+			lastBTFType, btfArg, err := resolveBTFArg(f.Call, a, false)
 			if err != nil {
 				return errFn(fmt.Errorf("error on hook %q for index %d : %w", f.Call, a.Index, err))
 			}

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -246,7 +246,7 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 			if !bpf.HasProgramLargeSize() {
 				return errFn(errors.New("error: Resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag"))
 			}
-			lastBTFType, btfArg, err := resolveBTFArg("bpf_lsm_"+f.Hook, a)
+			lastBTFType, btfArg, err := resolveBTFArg("bpf_lsm_"+f.Hook, a, false)
 			if err != nil {
 				return errFn(fmt.Errorf("error on hook %q for index %d : %w", f.Hook, a.Index, err))
 			}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
+	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/cgtracker"
 	"github.com/cilium/tetragon/pkg/config"
 	"github.com/cilium/tetragon/pkg/eventhandler"
@@ -132,6 +133,9 @@ type genericTracepointArg struct {
 
 	// user type overload
 	userType string
+
+	// data for config.BTFArg
+	btf [tracingapi.MaxBTFArgDepth]tracingapi.ConfigBTFArg
 }
 
 // tracepointTable is, for now, an array.
@@ -330,6 +334,8 @@ func buildArgs(info *tracepoint.Tracepoint, specArgs []v1alpha1.KProbeArg) ([]ge
 func buildArgsRaw(info *tracepoint.Tracepoint, specArgs []v1alpha1.KProbeArg) ([]genericTracepointArg, error) {
 	ret := make([]genericTracepointArg, 0, len(specArgs))
 	for i, tpArg := range specArgs {
+		var btf [tracingapi.MaxBTFArgDepth]tracingapi.ConfigBTFArg
+
 		if tpArg.Index > 5 {
 			return nil, fmt.Errorf("raw tracepoint (%s/%s) can read up to %d arguments, but %d was requested",
 				info.Subsys, info.Event, 5, tpArg.Index)
@@ -347,6 +353,21 @@ func buildArgsRaw(info *tracepoint.Tracepoint, specArgs []v1alpha1.KProbeArg) ([
 			return nil, fmt.Errorf("output argument %v unsupported: %w", tpArg, err)
 		}
 
+		if tpArg.Resolve != "" {
+			if !bpf.HasProgramLargeSize() {
+				return nil, errors.New("error: Resolve flag can be used on v5.4 kernel or higher")
+			}
+			fn := "__bpf_trace_" + info.Event
+
+			lastBTFType, btfArg, err := resolveBTFArg(fn, tpArg, true)
+			if err != nil {
+				return nil, fmt.Errorf("error on hook %q for index %d : %w", fn, tpArg.Index, err)
+			}
+			btf = btfArg
+			argType = findTypeFromBTFType(tpArg, lastBTFType)
+		}
+
+		arg.btf = btf
 		arg.genericTypeId = argType
 		ret = append(ret, arg)
 	}
@@ -714,6 +735,7 @@ func (tp *genericTracepoint) eventConfigRaw(config *tracingapi.EventConfig) (*tr
 
 	// iterate over output arguments
 	for i, tpArg := range tp.args {
+		config.BTFArg[tpArg.TpIdx] = tpArg.btf
 		config.Arg[tpArg.TpIdx] = int32(tpArg.genericTypeId)
 		config.ArgM[tpArg.TpIdx] = uint32(tpArg.MetaArg)
 

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -1054,6 +1054,49 @@ func handleMsgGenericTracepoint(
 			arg.Permission = mode
 			unix.Args = append(unix.Args, arg)
 
+		case gt.GenericFileType, gt.GenericFdType, gt.GenericKiocb:
+			var arg tracingapi.MsgGenericKprobeArgFile
+			var flags uint32
+			var b int32
+			var mode uint16
+			var err error
+
+			/* Eat file descriptor its not used in userland */
+			if out.genericTypeId == gt.GenericFdType {
+				binary.Read(r, binary.LittleEndian, &b)
+			}
+
+			arg.Value, err = parseString(r)
+			if err != nil {
+				if errors.Is(err, errParseStringSize) {
+					// If no size then path walk was not possible and file was
+					// either a mount point or not a "file" at all which can
+					// happen if running without any filters and kernel opens an
+					// anonymous inode. For this lets just report its on "/" all
+					// though pid filtering will mostly catch this.
+					arg.Value = "/"
+				} else {
+					logger.GetLogger().WithError(err).Warn("error parsing arg type file")
+				}
+			}
+
+			// read the first byte that keeps the flags
+			err = binary.Read(r, binary.LittleEndian, &flags)
+			if err != nil {
+				flags = 0
+			}
+
+			if out.genericTypeId == gt.GenericFileType || out.genericTypeId == gt.GenericKiocb {
+				err = binary.Read(r, binary.LittleEndian, &mode)
+				if err != nil {
+					mode = 0
+				}
+				arg.Permission = mode
+			}
+
+			arg.Flags = flags
+			unix.Args = append(unix.Args, arg)
+
 		default:
 			logger.GetLogger().Warnf("handleGenericTracepoint: ignoring:  %+v", out)
 		}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -1026,6 +1026,34 @@ func handleMsgGenericTracepoint(
 				unix.Args = append(unix.Args, val)
 			}
 
+		case gt.GenericLinuxBinprmType:
+			var arg tracingapi.MsgGenericKprobeArgLinuxBinprm
+			var flags uint32
+			var mode uint16
+			var err error
+
+			arg.Value, err = parseString(r)
+			if err != nil {
+				if errors.Is(err, errParseStringSize) {
+					arg.Value = "/"
+				} else {
+					logger.GetLogger().WithError(err).Warn("error parsing arg type linux_binprm")
+				}
+			}
+
+			err = binary.Read(r, binary.LittleEndian, &flags)
+			if err != nil {
+				flags = 0
+			}
+
+			err = binary.Read(r, binary.LittleEndian, &mode)
+			if err != nil {
+				mode = 0
+			}
+			arg.Flags = flags
+			arg.Permission = mode
+			unix.Args = append(unix.Args, arg)
+
 		default:
 			logger.GetLogger().Warnf("handleGenericTracepoint: ignoring:  %+v", out)
 		}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -374,10 +374,8 @@ func tpValidateAndAdjustEnforcerAction(
 	spec *v1alpha1.TracingPolicySpec) error {
 
 	registeredEnforcerMetrics := false
-	for si := range tp.Selectors {
-		sel := &tp.Selectors[si]
-		for ai := range sel.MatchActions {
-			act := &sel.MatchActions[ai]
+	for _, sel := range tp.Selectors {
+		for _, act := range sel.MatchActions {
 			if act.Action == "NotifyEnforcer" {
 				if len(spec.Enforcers) == 0 {
 					return errors.New("NotifyEnforcer action specified, but spec contains no enforcers")
@@ -446,13 +444,12 @@ func createGenericTracepointSensor(
 	}
 
 	tracepoints := make([]*genericTracepoint, 0, len(confs))
-	for i := range confs {
-		tpSpec := &confs[i]
-		err := tpValidateAndAdjustEnforcerAction(ret, tpSpec, i, polInfo.name, spec)
+	for i, tpSpec := range confs {
+		err := tpValidateAndAdjustEnforcerAction(ret, &tpSpec, i, polInfo.name, spec)
 		if err != nil {
 			return nil, err
 		}
-		tp, err := createGenericTracepoint(name, tpSpec, polInfo)
+		tp, err := createGenericTracepoint(name, &tpSpec, polInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -604,13 +601,11 @@ func (tp *genericTracepoint) InitKernelSelectors(lists []v1alpha1.ListSpec) erro
 	// rewrite arg index
 	selArgs := make([]v1alpha1.KProbeArg, 0, len(tp.args))
 	selSelectors := make([]v1alpha1.KProbeSelector, 0, len(tp.Spec.Selectors))
-	for i := range tp.Spec.Selectors {
-		origSel := &tp.Spec.Selectors[i]
+	for _, origSel := range tp.Spec.Selectors {
 		selSelectors = append(selSelectors, *origSel.DeepCopy())
 	}
 
-	for i := range tp.args {
-		tpArg := &tp.args[i]
+	for _, tpArg := range tp.args {
 		selType, err := gt.GenericTypeToString(tpArg.genericTypeId)
 		if err != nil {
 			return fmt.Errorf("output argument %v type not found: %w", tpArg, err)
@@ -652,8 +647,7 @@ func (tp *genericTracepoint) EventConfig() (tracingapi.EventConfig, error) {
 	config.PolicyID = uint32(tp.policyID)
 	config.FuncId = uint32(tp.tableIdx)
 	// iterate over output arguments
-	for i := range tp.args {
-		tpArg := &tp.args[i]
+	for i, tpArg := range tp.args {
 		config.ArgTpCtxOff[i] = uint32(tpArg.CtxOffset)
 		config.Arg[i] = int32(tpArg.genericTypeId)
 		config.ArgM[i] = uint32(tpArg.MetaArg)

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -236,7 +236,18 @@ func (out *genericTracepointArg) getGenericTypeId() (int, error) {
 	return gt.GenericInvalidType, fmt.Errorf("unknown type: %T", out.format.Field.Type)
 }
 
-func buildGenericTracepointArgs(info *tracepoint.Tracepoint, specArgs []v1alpha1.KProbeArg) ([]genericTracepointArg, error) {
+func buildGenericTracepointArgs(tp *tracepoint.Tracepoint, specArgs []v1alpha1.KProbeArg, raw bool) ([]genericTracepointArg, error) {
+	if raw {
+		return buildArgsRaw(tp, specArgs)
+	}
+
+	if err := tp.LoadFormat(); err != nil {
+		return nil, fmt.Errorf("tracepoint %s/%s not supported: %w", tp.Subsys, tp.Event, err)
+	}
+	return buildArgs(tp, specArgs)
+}
+
+func buildArgs(info *tracepoint.Tracepoint, specArgs []v1alpha1.KProbeArg) ([]genericTracepointArg, error) {
 	ret := make([]genericTracepointArg, 0, len(specArgs))
 	nfields := uint32(len(info.Format.Fields))
 
@@ -316,6 +327,32 @@ func buildGenericTracepointArgs(info *tracepoint.Tracepoint, specArgs []v1alpha1
 	return ret, nil
 }
 
+func buildArgsRaw(info *tracepoint.Tracepoint, specArgs []v1alpha1.KProbeArg) ([]genericTracepointArg, error) {
+	ret := make([]genericTracepointArg, 0, len(specArgs))
+	for i, tpArg := range specArgs {
+		if tpArg.Index > 5 {
+			return nil, fmt.Errorf("raw tracepoint (%s/%s) can read up to %d arguments, but %d was requested",
+				info.Subsys, info.Event, 5, tpArg.Index)
+		}
+
+		arg := genericTracepointArg{
+			ArgIdx:   uint32(i),
+			TpIdx:    int(tpArg.Index),
+			MetaTp:   getTracepointMetaValue(&tpArg),
+			userType: tpArg.Type,
+		}
+
+		argType, err := arg.getGenericTypeId()
+		if err != nil {
+			return nil, fmt.Errorf("output argument %v unsupported: %w", tpArg, err)
+		}
+
+		arg.genericTypeId = argType
+		ret = append(ret, arg)
+	}
+	return ret, nil
+}
+
 // createGenericTracepoint creates the genericTracepoint information based on
 // the user-provided configuration
 func createGenericTracepoint(
@@ -344,11 +381,7 @@ func createGenericTracepoint(
 		return nil, err
 	}
 
-	if err := tp.LoadFormat(); err != nil {
-		return nil, fmt.Errorf("tracepoint %s/%s not supported: %w", tp.Subsys, tp.Event, err)
-	}
-
-	tpArgs, err := buildGenericTracepointArgs(&tp, conf.Args)
+	tpArgs, err := buildGenericTracepointArgs(&tp, conf.Args, conf.Raw)
 	if err != nil {
 		return nil, err
 	}
@@ -657,15 +690,40 @@ func (tp *genericTracepoint) InitKernelSelectors(lists []v1alpha1.ListSpec) erro
 	return nil
 }
 
-func (tp *genericTracepoint) EventConfig() (tracingapi.EventConfig, error) {
+func (tp *genericTracepoint) EventConfig() (*tracingapi.EventConfig, error) {
 
 	if len(tp.args) > tracingapi.EventConfigMaxArgs {
-		return tracingapi.EventConfig{}, fmt.Errorf("number of arguments (%d) larger than max (%d)", len(tp.args), tracingapi.EventConfigMaxArgs)
+		return nil, fmt.Errorf("number of arguments (%d) larger than max (%d)", len(tp.args), tracingapi.EventConfigMaxArgs)
 	}
 
 	config := tracingapi.EventConfig{}
 	config.PolicyID = uint32(tp.policyID)
 	config.FuncId = uint32(tp.tableIdx)
+
+	if tp.raw {
+		return tp.eventConfigRaw(&config)
+	}
+	return tp.eventConfig(&config)
+}
+
+func (tp *genericTracepoint) eventConfigRaw(config *tracingapi.EventConfig) (*tracingapi.EventConfig, error) {
+	for i := range config.Arg {
+		config.Arg[i] = int32(gt.GenericNopType)
+		config.ArgM[i] = uint32(0)
+	}
+
+	// iterate over output arguments
+	for i, tpArg := range tp.args {
+		config.Arg[tpArg.TpIdx] = int32(tpArg.genericTypeId)
+		config.ArgM[tpArg.TpIdx] = uint32(tpArg.MetaArg)
+
+		tracepointLog.Debugf("configured argument #%d: %+v (type:%d)", i, tpArg, tpArg.genericTypeId)
+	}
+	return config, nil
+}
+
+func (tp *genericTracepoint) eventConfig(config *tracingapi.EventConfig) (*tracingapi.EventConfig, error) {
+
 	// iterate over output arguments
 	for i, tpArg := range tp.args {
 		config.ArgTpCtxOff[i] = uint32(tpArg.CtxOffset)
@@ -706,7 +764,7 @@ func LoadGenericTracepointSensor(bpfDir string, load *program.Program, maps []*p
 		return fmt.Errorf("failed to generate config data for generic tracepoint: %w", err)
 	}
 	var binBuf bytes.Buffer
-	binary.Write(&binBuf, binary.LittleEndian, config)
+	binary.Write(&binBuf, binary.LittleEndian, *config)
 	cfg := &program.MapLoad{
 		Index: 0,
 		Name:  "config_map",

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -97,6 +97,9 @@ type genericTracepoint struct {
 
 	// custom event handler
 	customHandler eventhandler.Handler
+
+	// is raw tracepoint
+	raw bool
 }
 
 // genericTracepointArg is the internal representation of an output value of a
@@ -359,6 +362,7 @@ func createGenericTracepoint(
 		customHandler: polInfo.customHandler,
 		message:       msgField,
 		tags:          tagsField,
+		raw:           conf.Raw,
 	}
 
 	genericTracepointTable.addTracepoint(ret)
@@ -456,13 +460,25 @@ func createGenericTracepointSensor(
 		tracepoints = append(tracepoints, tp)
 	}
 
-	progName := "bpf_generic_tracepoint.o"
-	if config.EnableV61Progs() {
-		progName = "bpf_generic_tracepoint_v61.o"
-	} else if kernels.MinKernelVersion("5.11") {
-		progName = "bpf_generic_tracepoint_v511.o"
-	} else if config.EnableLargeProgs() {
-		progName = "bpf_generic_tracepoint_v53.o"
+	progName := func(raw bool) string {
+		if raw {
+			if config.EnableV61Progs() {
+				return "bpf_generic_rawtp_v61.o"
+			} else if kernels.MinKernelVersion("5.11") {
+				return "bpf_generic_rawtp_v511.o"
+			} else if config.EnableLargeProgs() {
+				return "bpf_generic_rawtp_v53.o"
+			}
+			return "bpf_generic_rawtp.o"
+		}
+		if config.EnableV61Progs() {
+			return "bpf_generic_tracepoint_v61.o"
+		} else if kernels.MinKernelVersion("5.11") {
+			return "bpf_generic_tracepoint_v511.o"
+		} else if config.EnableLargeProgs() {
+			return "bpf_generic_tracepoint_v53.o"
+		}
+		return "bpf_generic_tracepoint.o"
 	}
 
 	has := hasMaps{
@@ -474,10 +490,14 @@ func createGenericTracepointSensor(
 	for _, tp := range tracepoints {
 		pinProg := sensors.PathJoin(fmt.Sprintf("%s:%s", tp.Info.Subsys, tp.Info.Event))
 		attach := fmt.Sprintf("%s/%s", tp.Info.Subsys, tp.Info.Event)
+		label := "tracepoint/generic_tracepoint"
+		if tp.raw {
+			label = "raw_tp/generic_tracepoint"
+		}
 		prog0 := program.Builder(
-			path.Join(option.Config.HubbleLib, progName),
+			path.Join(option.Config.HubbleLib, progName(tp.raw)),
 			attach,
-			"tracepoint/generic_tracepoint",
+			label,
 			pinProg,
 			"generic_tracepoint",
 		).SetPolicy(polInfo.name)
@@ -696,12 +716,15 @@ func LoadGenericTracepointSensor(bpfDir string, load *program.Program, maps []*p
 	}
 	load.MapLoad = append(load.MapLoad, cfg)
 
-	if err := program.LoadTracepointProgram(bpfDir, load, maps, verbose); err == nil {
-		logger.GetLogger().Infof("Loaded generic tracepoint program: %s -> %s", load.Name, load.Attach)
+	if tp.raw {
+		err = program.LoadRawTracepointProgram(bpfDir, load, maps, verbose)
 	} else {
-		return err
+		err = program.LoadTracepointProgram(bpfDir, load, maps, verbose)
 	}
 
+	if err == nil {
+		logger.GetLogger().Infof("Loaded generic tracepoint program: %s -> %s", load.Name, load.Attach)
+	}
 	return err
 }
 

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -881,3 +881,62 @@ spec:
 
 	testListSyscallsDupsRange(t, checker, configHook)
 }
+
+func TestTracepointResolve(t *testing.T) {
+	if !kernels.MinKernelVersion("5.4") {
+		t.Skip("Test requires kernel 5.4+")
+	}
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	hook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "rawtp"
+spec:
+  tracepoints:
+    - subsystem: "sched"
+      event: "sched_process_exec"
+      raw: true
+      args:
+        - index: 2
+          type: "file"
+          resolve: "file"
+`
+
+	createCrdFile(t, hook)
+
+	testNop := testutils.RepoRootPath("contrib/tester-progs/nop")
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	if err := exec.Command(testNop).Run(); err != nil {
+		fmt.Printf("Failed to execute test binary: %s\n", err)
+	}
+
+	tpChecker := ec.NewProcessTracepointChecker("").
+		WithSubsys(stringmatcher.Full("sched")).
+		WithEvent(stringmatcher.Full("sched_process_exec")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithFileArg(ec.NewKprobeFileChecker().
+					WithPath(stringmatcher.Full(testNop)),
+				),
+			))
+
+	checker := ec.NewUnorderedEventChecker(tpChecker)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -1614,6 +1614,9 @@ spec:
                         A short message of 256 characters max that will be included
                         in the event output to inform users what is going on.
                       type: string
+                    raw:
+                      description: Enable raw tracepoint arguments
+                      type: boolean
                     selectors:
                       description: Selectors to apply before producing trace output.
                         Selectors are ORed.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1614,6 +1614,9 @@ spec:
                         A short message of 256 characters max that will be included
                         in the event output to inform users what is going on.
                       type: string
+                    raw:
+                      description: Enable raw tracepoint arguments
+                      type: boolean
                     selectors:
                       description: Selectors to apply before producing trace output.
                         Selectors are ORed.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -286,6 +286,9 @@ type TracepointSpec struct {
 	// Tags to categorize the event, will be include in the event output.
 	// Maximum of 16 Tags are supported.
 	Tags []string `json:"tags,omitempty"`
+	// +kubebuilder:validation:Optional
+	// Enable raw tracepoint arguments
+	Raw bool `json:"raw,omitempty"`
 }
 
 type UProbeSpec struct {

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.5.1"
+const CustomResourceDefinitionSchemaVersion = "1.5.2"


### PR DESCRIPTION
adding support for raw tracepoints, which allows to use raw tracepoint arguments, like:
```
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "rawtp"
spec:
  tracepoints:
    - subsystem: "sched"
      event: "sched_process_exec"
      raw: true
      args:
        - index: 2
          type: "linux_binprm"
```

also there's support for argument resolve keyword