### PR TITLE
tetragon/windows: Build reader/path and reader/network packages on Windows

### DIFF
--- a/pkg/constants/constants_linux.go
+++ b/pkg/constants/constants_linux.go
@@ -4,6 +4,8 @@
 package constants
 
 import (
+	"syscall"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -58,4 +60,5 @@ const (
 	AF_SMC               = unix.AF_SMC
 	AF_XDP               = unix.AF_XDP
 	AF_MCTP              = unix.AF_MCTP
+	S_IFMT               = syscall.S_IFMT
 )

--- a/pkg/constants/constants_windows.go
+++ b/pkg/constants/constants_windows.go
@@ -17,4 +17,5 @@ const (
 	AF_BTH               = windows.AF_BTH
 	CGROUP2_SUPER_MAGIC  = 0x63677270
 	BPF_STATS_RUN_TIME   = 0
+	S_IFMT               = 0xf000
 )

--- a/pkg/reader/network/inet_family_windows.go
+++ b/pkg/reader/network/inet_family_windows.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package network
+
+import (
+	"github.com/cilium/tetragon/pkg/constants"
+)
+
+var inetFamily = map[uint16]string{
+	0:                    "AF_UNSPEC",
+	constants.AF_UNIX:    "AF_UNIX",
+	constants.AF_INET:    "AF_INET",
+	constants.AF_INET6:   "AF_INET6",
+	constants.AF_IRDA:    "AF_IRDA",
+	constants.AF_NETBIOS: "AF_NETBIOS",
+	constants.AF_BTH:     "AF_BTH",
+}

--- a/pkg/reader/path/path.go
+++ b/pkg/reader/path/path.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 
 	"github.com/cilium/tetragon/pkg/api/processapi"
+	"github.com/cilium/tetragon/pkg/constants"
 )
 
 func GetBinaryAbsolutePath(binary string, cwd string) string {
@@ -64,7 +65,7 @@ func permString(bits uint16, rwx string, sticky byte) string {
 func FilePathModeToStr(mode uint16) string {
 	var str strings.Builder
 
-	switch mode & syscall.S_IFMT {
+	switch mode & constants.S_IFMT {
 	case syscall.S_IFBLK:
 		str.WriteString("b")
 	case syscall.S_IFCHR:


### PR DESCRIPTION
### Description
Two commits added to compile sub packages in reader package. 
1. pkg/reader/path can be compiled on Windows by using a platform dependent S_IFMT bitflag constant
2. pkg/reader/network can be compiled on Windows by adding correct values into the inetFamily map variables.

Both changes depend on constants package, added [here](https://github.com/cilium/tetragon/commit/0055bd6bd29a7e641bb124102932fd0e21aadb80) 
