### PR TITLE
tetragon/windows: Use a package-level 'not supported' error variable

### DIFF
--- a/pkg/cgroups/cgroups_windows.go
+++ b/pkg/cgroups/cgroups_windows.go
@@ -4,6 +4,8 @@ package cgroups
 
 import (
 	"errors"
+
+	"github.com/cilium/tetragon/pkg/constants"
 )
 
 func CgroupFsMagicStr(magic uint64) string {
@@ -11,7 +13,7 @@ func CgroupFsMagicStr(magic uint64) string {
 }
 
 func GetCgroupIdFromPath(cgroupPath string) (uint64, error) {
-	return 0, errors.New("not Supported on windows")
+	return 0, constants.ErrWindowsNotSupported
 }
 
 func DiscoverSubSysIds() error {
@@ -39,26 +41,26 @@ func GetCgrpControllerName() string {
 }
 
 func DetectCgroupMode() (CgroupModeCode, error) {
-	return CGROUP_UNDEF, errors.New("not Supported on windows")
+	return CGROUP_UNDEF, constants.ErrWindowsNotSupported
 }
 
 func DetectDeploymentMode() (DeploymentCode, error) {
-	return DEPLOY_UNKNOWN, errors.New("not Supported on windows")
+	return DEPLOY_UNKNOWN, constants.ErrWindowsNotSupported
 }
 
 func DetectCgroupFSMagic() (uint64, error) {
-	return CGROUP_UNSET_VALUE, errors.New("not Supported on windows")
+	return CGROUP_UNSET_VALUE, constants.ErrWindowsNotSupported
 }
 
 func HostCgroupRoot() (string, error) {
-	return "", errors.New("not Supported on windows")
+	return "", constants.ErrWindowsNotSupported
 }
 
 func CgroupIDFromPID(pid uint32) (uint64, error) {
-	return 0, errors.New("not Supported on windows")
+	return 0, constants.ErrWindowsNotSupported
 }
 
 func GetCgroupIDFromSubCgroup(p string) (uint64, error) {
 
-	return 0, errors.New("not Supported on windows")
+	return 0, constants.ErrWindowsNotSupported
 }

--- a/pkg/constants/constants_windows.go
+++ b/pkg/constants/constants_windows.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"errors"
+
 	"golang.org/x/sys/windows"
 )
 
@@ -17,4 +19,8 @@ const (
 	AF_BTH               = windows.AF_BTH
 	CGROUP2_SUPER_MAGIC  = 0x63677270
 	BPF_STATS_RUN_TIME   = 0
+)
+
+var (
+	ErrWindowsNotSupported = errors.New("This functionality is not supported on windows")
 )

--- a/pkg/sensors/tracing/lists_windows.go
+++ b/pkg/sensors/tracing/lists_windows.go
@@ -4,13 +4,8 @@
 package tracing
 
 import (
-	"errors"
-
+	"github.com/cilium/tetragon/pkg/constants"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
-)
-
-var (
-	notSupportedWinErr = errors.New("not supported on windows")
 )
 
 // isList checks if a value specifies a list, and if so it returns it (or nil if list does not exist)
@@ -19,7 +14,7 @@ func isList(val string, lists []v1alpha1.ListSpec) (bool, *v1alpha1.ListSpec) {
 }
 
 func preValidateLists(lists []v1alpha1.ListSpec) (err error) {
-	return notSupportedWinErr
+	return constants.ErrWindowsNotSupported
 }
 
 type listReader struct {
@@ -27,9 +22,9 @@ type listReader struct {
 }
 
 func (lr *listReader) Read(name string, ty uint32) ([]uint32, error) {
-	return []uint32{}, notSupportedWinErr
+	return []uint32{}, constants.ErrWindowsNotSupported
 }
 
 func getSyscallListSymbols(list *v1alpha1.ListSpec) ([]string, error) {
-	return nil, notSupportedWinErr
+	return nil, constants.ErrWindowsNotSupported
 }

--- a/pkg/sensors/tracing/policyhandler_windows.go
+++ b/pkg/sensors/tracing/policyhandler_windows.go
@@ -4,8 +4,7 @@
 package tracing
 
 import (
-	"errors"
-
+	"github.com/cilium/tetragon/pkg/constants"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
@@ -15,5 +14,5 @@ func (h policyHandler) PolicyHandler(
 	policy tracingpolicy.TracingPolicy,
 	policyID policyfilter.PolicyID,
 ) (sensors.SensorIface, error) {
-	return nil, errors.New("not supported on windows")
+	return nil, constants.ErrWindowsNotSupported
 }


### PR DESCRIPTION
### Description
Certain stub functions on Windows that are added for compilation support return an `errors.New("not supported on windows")` error which can be a package-level variable. This PR attempts to declare and use such a variable for packages that use that error more than once.

