### PR TITLE
tetragon/windows: Port bpf package into Windows

### DIFF
--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bpf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/cilium/tetragon/pkg/defaults"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/mountinfo"
+)
+
+var (
+	// Path to where bpffs is mounted
+	mapRoot = defaults.DefaultMapRoot
+
+	// Path to where debugfs is mounted
+	debugFSRoot = "/sys/kernel/debug"
+
+	// Prefix for all maps (default: tc/globals)
+	mapPrefix = defaults.DefaultMapPrefix
+
+	// Set to true on first get request to detect misorder
+	lockedDown      = false
+	once            sync.Once
+	readMountInfo   sync.Once
+	mountInfoPrefix string
+)
+
+func lockDown() {
+	lockedDown = true
+}
+
+func SetMapRoot(path string) {
+	if lockedDown {
+		panic("SetMapRoot() call after MapRoot was read")
+	}
+	mapRoot = path
+}
+
+func GetMapRoot() string {
+	once.Do(lockDown)
+	return mapRoot
+}
+
+func SetMapPrefix(path string) {
+	if lockedDown {
+		panic("SetMapPrefix() call after MapPrefix was read")
+	}
+	mapPrefix = path
+}
+
+func MapPrefixPath() string {
+	once.Do(lockDown)
+	return filepath.Join(mapRoot, mapPrefix)
+}
+
+func mapPathFromMountInfo(name string) string {
+	readMountInfo.Do(func() {
+		mountInfos, err := mountinfo.GetMountInfo()
+		if err != nil {
+			logger.GetLogger().WithError(err).Warn("Could not get mount info for map root lookup")
+		}
+
+		for _, mountInfo := range mountInfos {
+			if mountInfo.FilesystemType == mountinfo.FilesystemTypeBPFFS {
+				mountInfoPrefix = filepath.Join(mountInfo.MountPoint, mapPrefix)
+				return
+			}
+		}
+
+		logger.GetLogger().Warn("Could not find BPF map root")
+	})
+
+	return filepath.Join(mountInfoPrefix, name)
+}
+
+// MapPath returns a path for a BPF map with a given name.
+func MapPath(name string) string {
+	return mapPathFromMountInfo(name)
+}
+
+// LocalMapName returns the name for a BPF map that is local to the specified ID.
+func LocalMapName(name string, id uint16) string {
+	return fmt.Sprintf("%s%05d", name, id)
+}
+
+// LocalMapPath returns the path for a BPF map that is local to the specified ID.
+func LocalMapPath(name string, id uint16) string {
+	return MapPath(LocalMapName(name, id))
+}
+
+// Environment returns a list of environment variables which are needed to make
+// BPF programs and tc aware of the actual BPFFS mount path.
+func Environment() []string {
+	return append(
+		os.Environ(),
+		fmt.Sprintf("CILIUM_BPF_MNT=%s", GetMapRoot()),
+		fmt.Sprintf("TC_BPF_MNT=%s", GetMapRoot()),
+	)
+}
+
+var (
+	mountOnce sync.Once
+)

--- a/pkg/bpf/bpffs.go
+++ b/pkg/bpf/bpffs.go
@@ -18,9 +18,6 @@ var (
 	// Path to where bpffs is mounted
 	mapRoot = defaults.DefaultMapRoot
 
-	// Path to where debugfs is mounted
-	debugFSRoot = "/sys/kernel/debug"
-
 	// Prefix for all maps (default: tc/globals)
 	mapPrefix = defaults.DefaultMapPrefix
 

--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -1,16 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-//go:build linux
-// +build linux
-
 package bpf
 
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"sync"
 	"syscall"
 
 	"github.com/cilium/ebpf/rlimit"
@@ -20,100 +15,8 @@ import (
 )
 
 var (
-	// Path to where bpffs is mounted
-	mapRoot = defaults.DefaultMapRoot
-
-	// Path to where debugfs is mounted
-	debugFSRoot = "/sys/kernel/debug"
-
 	// Path to where cgroup2 is mounted
 	cgroup2Root = defaults.Cgroup2Dir
-
-	// Prefix for all maps (default: tc/globals)
-	mapPrefix = defaults.DefaultMapPrefix
-
-	// Set to true on first get request to detect misorder
-	lockedDown      = false
-	once            sync.Once
-	readMountInfo   sync.Once
-	mountInfoPrefix string
-)
-
-func lockDown() {
-	lockedDown = true
-}
-
-func SetMapRoot(path string) {
-	if lockedDown {
-		panic("SetMapRoot() call after MapRoot was read")
-	}
-	mapRoot = path
-}
-
-func GetMapRoot() string {
-	once.Do(lockDown)
-	return mapRoot
-}
-
-func SetMapPrefix(path string) {
-	if lockedDown {
-		panic("SetMapPrefix() call after MapPrefix was read")
-	}
-	mapPrefix = path
-}
-
-func MapPrefixPath() string {
-	once.Do(lockDown)
-	return filepath.Join(mapRoot, mapPrefix)
-}
-
-func mapPathFromMountInfo(name string) string {
-	readMountInfo.Do(func() {
-		mountInfos, err := mountinfo.GetMountInfo()
-		if err != nil {
-			logger.GetLogger().WithError(err).Warn("Could not get mount info for map root lookup")
-		}
-
-		for _, mountInfo := range mountInfos {
-			if mountInfo.FilesystemType == mountinfo.FilesystemTypeBPFFS {
-				mountInfoPrefix = filepath.Join(mountInfo.MountPoint, mapPrefix)
-				return
-			}
-		}
-
-		logger.GetLogger().Warn("Could not find BPF map root")
-	})
-
-	return filepath.Join(mountInfoPrefix, name)
-}
-
-// MapPath returns a path for a BPF map with a given name.
-func MapPath(name string) string {
-	return mapPathFromMountInfo(name)
-}
-
-// LocalMapName returns the name for a BPF map that is local to the specified ID.
-func LocalMapName(name string, id uint16) string {
-	return fmt.Sprintf("%s%05d", name, id)
-}
-
-// LocalMapPath returns the path for a BPF map that is local to the specified ID.
-func LocalMapPath(name string, id uint16) string {
-	return MapPath(LocalMapName(name, id))
-}
-
-// Environment returns a list of environment variables which are needed to make
-// BPF programs and tc aware of the actual BPFFS mount path.
-func Environment() []string {
-	return append(
-		os.Environ(),
-		fmt.Sprintf("CILIUM_BPF_MNT=%s", GetMapRoot()),
-		fmt.Sprintf("TC_BPF_MNT=%s", GetMapRoot()),
-	)
-}
-
-var (
-	mountOnce sync.Once
 )
 
 // mountFS mounts the BPFFS filesystem into the desired mapRoot directory.

--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -15,6 +15,8 @@ import (
 )
 
 var (
+	// Path to where debugfs is mounted
+	debugFSRoot = "/sys/kernel/debug"
 	// Path to where cgroup2 is mounted
 	cgroup2Root = defaults.Cgroup2Dir
 )

--- a/pkg/bpf/bpffs_windows.go
+++ b/pkg/bpf/bpffs_windows.go
@@ -11,12 +11,6 @@ var (
 	notSupportedWinErr = errors.New("not supported on windows")
 )
 
-// mountFS mounts the BPFFS filesystem into the desired mapRoot directory.
-func mountFS(root, kind string) error {
-
-	return notSupportedWinErr
-}
-
 func CheckOrMountFS(bpfRoot string) {
 
 }

--- a/pkg/bpf/bpffs_windows.go
+++ b/pkg/bpf/bpffs_windows.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bpf
+
+import (
+	"errors"
+)
+
+var (
+	notSupportedWinErr = errors.New("not supported on windows")
+)
+
+// mountFS mounts the BPFFS filesystem into the desired mapRoot directory.
+func mountFS(root, kind string) error {
+
+	return notSupportedWinErr
+}
+
+func CheckOrMountFS(bpfRoot string) {
+
+}
+
+func CheckOrMountDebugFS() error {
+	return notSupportedWinErr
+}
+
+func CheckOrMountCgroup2() error {
+	return notSupportedWinErr
+}
+
+func ConfigureResourceLimits() error {
+	return notSupportedWinErr
+}

--- a/pkg/bpf/detect_windows.go
+++ b/pkg/bpf/detect_windows.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package bpf
+
+import "fmt"
+
+func HasOverrideHelper() bool {
+	return false
+}
+
+func HasSignalHelper() bool {
+	return false
+}
+
+func HasBuildId() bool {
+	return false
+}
+
+func HasModifyReturn() bool {
+	return false
+}
+
+func HasModifyReturnSyscall() bool {
+	return false
+}
+
+func HasProgramLargeSize() bool {
+	return false
+}
+
+func HasLinkPin() bool {
+	return false
+}
+
+func HasKprobeMulti() bool {
+	return false
+}
+
+func LogFeatures() string {
+	return fmt.Sprintf("override_return: %t, buildid: %t, fmodret: %t, fmodret_syscall: %t, signal: %t, large: %t, link_pin: %t",
+		HasOverrideHelper(), HasBuildId(), HasModifyReturn(), HasModifyReturnSyscall(), HasSignalHelper(), HasProgramLargeSize(),
+		HasLinkPin())
+}

--- a/pkg/bpf/perf_windows.go
+++ b/pkg/bpf/perf_windows.go
@@ -6,17 +6,18 @@ package bpf
 import (
 	"fmt"
 
-	"golang.org/x/sys/unix"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	EbpfApi = windows.NewLazyDLL("ebpfapi.dll")
+	BPF     = EbpfApi.NewProc("bpf")
 )
 
 func UpdateElementFromPointers(fd int, structPtr, sizeOfStruct uintptr) error {
-	ret, _, err := unix.Syscall(
-		unix.SYS_BPF,
-		BPF_MAP_UPDATE_ELEM,
-		structPtr,
-		sizeOfStruct,
-	)
-	if ret != 0 || err != 0 {
+
+	ret, _, err := BPF.Call(BPF_MAP_LOOKUP_ELEM, structPtr, sizeOfStruct)
+	if ret != 0 || err != nil {
 		return fmt.Errorf("Unable to update element for map with file descriptor %d: %s", fd, err)
 	}
 	return nil


### PR DESCRIPTION
### Description
This PR has commits that contribute to compiling and running pkg/bpf package into Windows. 
The bpffs and and kernel features checking functions are stubbed out in Windows specific go listings
The per event based functions stay the same, except the `UpdateElementFromPointers()` function which uses the `bpf()` function available in `ebpfapi.dll`. 

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```
Compile pkg/ebpf package on Windows
```
