### PR TITLE
helm: rthooks: fix extraHookArgs

### DIFF
--- a/install/kubernetes/tetragon/templates/_container_rthooks.tpl
+++ b/install/kubernetes/tetragon/templates/_container_rthooks.tpl
@@ -17,10 +17,9 @@
     - {{ if .Values.rthooks.failAllowNamespaces }}{{ printf "%s,%s" .Release.Namespace .Values.rthooks.failAllowNamespaces }}{{ else }}{{ .Release.Namespace }}{{ end }}
    {{- range $key, $value := .Values.rthooks.extraHookArgs }}
    {{- if eq nil $value }}
-    - {{ $key }}
-    - {{ $value }}
+    - --{{ $key }}
    {{- else }}
-    - {{ $key }}
+    - --{{ $key }}={{ $value }}
   {{- end }}
   {{- end }}
   volumeMounts:


### PR DESCRIPTION
extraHookArgs was wrong: we should use the value if the value is not null. Also, let's add -- to the options to make things easier to write.


```release-note
helm: fix extraHookargs in rthooks
```
