### PR TITLE
tetragon/windows: Port cmd/tetra binary into Windows

### DIFF
--- a/cmd/tetra/cgtracker/cgtracker_windows.go
+++ b/cmd/tetra/cgtracker/cgtracker_windows.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package cgtracker
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	ret := &cobra.Command{
+		Use:          "cgtracker",
+		Short:        "manage cgtracker map (only for debugging)",
+		Hidden:       true,
+		SilenceUsage: true,
+	}
+
+	ret.AddCommand(
+		dumpCmd(),
+		addCommand(),
+	)
+
+	return ret
+}
+
+func dumpCmd() *cobra.Command {
+
+	return nil
+}
+
+func addCommand() *cobra.Command {
+
+	return nil
+}

--- a/cmd/tetra/debug/debug_windows.go
+++ b/cmd/tetra/debug/debug_windows.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package debug
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	cmd := cobra.Command{
+		Use:    "debug",
+		Short:  "Tools to debug tetragon",
+		Hidden: true,
+	}
+	//ToDo: Enable this for Windows
+	return &cmd
+}

--- a/cmd/tetra/tracingpolicy/generate/all_syscalls.go
+++ b/cmd/tetra/tracingpolicy/generate/all_syscalls.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package generate
+
+import (
+	"github.com/cilium/tetragon/pkg/btf"
+)
+
+func AvailableSyscalls() ([]string, error) {
+	return btf.AvailableSyscalls()
+}

--- a/cmd/tetra/tracingpolicy/generate/all_syscalls_windows.go
+++ b/cmd/tetra/tracingpolicy/generate/all_syscalls_windows.go
@@ -1,0 +1,5 @@
+package generate
+
+func AvailableSyscalls() ([]string, error) {
+	return nil, nil
+}

--- a/cmd/tetra/tracingpolicy/generate/generate.go
+++ b/cmd/tetra/tracingpolicy/generate/generate.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/ftrace"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/tracingpolicy/generate"
@@ -54,7 +53,7 @@ func New() *cobra.Command {
 		Short: "all system calls",
 		Run: func(_ *cobra.Command, _ []string) {
 			tp := generate.NewTracingPolicy("syscalls")
-			syscalls, err := btf.AvailableSyscalls()
+			syscalls, err := AvailableSyscalls()
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -78,7 +77,7 @@ func New() *cobra.Command {
 		Short: "all system calls using a list",
 		Run: func(_ *cobra.Command, _ []string) {
 			tp := generate.NewTracingPolicy("syscalls")
-			syscalls, err := btf.AvailableSyscalls()
+			syscalls, err := AvailableSyscalls()
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
### Description
Compilation changes so tetra binary could compile and  run on Windows. This accomodates changes made to various pkg/ packages in previous PRs Most changes just add stubs to windows specific listing, while keeping Linux and Darwin build unchanged

### Changelog
```
Compile and run tetra.exe on Windows 
```
