### PR TITLE
tetragon/windows: Port process cache package on Windows

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -4,7 +4,6 @@
 package process
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -25,7 +24,6 @@ import (
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	"github.com/cilium/tetragon/pkg/reader/exec"
 	"github.com/cilium/tetragon/pkg/reader/namespace"
-	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/reader/path"
 	"github.com/cilium/tetragon/pkg/reader/proc"
 	"github.com/cilium/tetragon/pkg/watcher"
@@ -258,10 +256,6 @@ func UpdateEventProcessTid(process *tetragon.Process, tid *uint32) {
 	if process != nil && tid != nil {
 		process.Tid = &wrapperspb.UInt32Value{Value: *tid}
 	}
-}
-
-func GetProcessID(pid uint32, ktime uint64) string {
-	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%d:%d", node.GetNodeNameForExport(), ktime, pid)))
 }
 
 func GetExecID(proc *tetragonAPI.MsgProcess) string {

--- a/pkg/process/process_id_linux.go
+++ b/pkg/process/process_id_linux.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package process
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/cilium/tetragon/pkg/reader/node"
+)
+
+func GetProcessID(pid uint32, ktime uint64) string {
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%d:%d", node.GetNodeNameForExport(), ktime, pid)))
+}

--- a/pkg/process/process_id_windows.go
+++ b/pkg/process/process_id_windows.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package process
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+func GetProcessID(pid uint32, ktime uint64) string {
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%d:%d:%d", pid, pid, pid)))
+}


### PR DESCRIPTION
### Description
This PR compiles and ports process cache into Windows. The only difference on Windows is how the pid for cache is computed. Currently on Windows, we are not using ktime as an input into process identifier.
The PID re-use is not a very big problem on Windows and the current bpf program does not communicate the parent's ktime to usermode. 
So the cache pid  on windows is based on numeric PID issued by kernel.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```
Compile and port the pkg/process package into Windows
```
