### PR TITLE
Fix discrepancy between export and k8s node name

### DIFF
--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -172,7 +172,7 @@ func Test_rateLimitExport(t *testing.T) {
 		}
 		defer os.Unsetenv(hubbleNodeNameEnv)
 	}
-	node.SetNodeName()
+	node.SetExportNodeName()
 
 	tests := []struct {
 		name              string

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -214,7 +214,7 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 
 func TestProcessManager_GetProcessID(t *testing.T) {
 	assert.NoError(t, os.Setenv("NODE_NAME", "my-node"))
-	node.SetNodeName()
+	node.SetExportNodeName()
 
 	err := process.InitCache(watcher.NewFakeK8sWatcher([]interface{}{}), 10, defaults.DefaultProcessCacheGCInterval)
 	assert.NoError(t, err)

--- a/pkg/reader/node/node.go
+++ b/pkg/reader/node/node.go
@@ -11,42 +11,73 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 )
 
+const (
+	hubbleNodeNameEnvVar = "HUBBLE_NODE_NAME"
+	nodeNameEnvVar       = "NODE_NAME"
+)
+
 var (
-	nodeName string
+	kubernetesNodeName string
+	exportNodeName     string
 )
 
 func init() {
-	SetNodeName()
+	SetExportNodeName()
+	SetKubernetesNodeName()
 }
 
-// SetNodeName initializes the nodeName variable. It's defined separately from
+// SetExportNodeName initializes the exportNodeName variable. It's defined separately from
 // init() so that it can be called from unit tests.
-func SetNodeName() {
+func SetExportNodeName() {
 	var err error
-	nodeName = os.Getenv("HUBBLE_NODE_NAME")
-	if nodeName == "" {
-		nodeName = os.Getenv("NODE_NAME")
+	if exportNodeName = os.Getenv(hubbleNodeNameEnvVar); exportNodeName != "" {
+		return
 	}
-	if nodeName == "" {
-		nodeName, err = os.Hostname()
-		if err != nil {
-			logger.GetLogger().WithError(err).Warn("failed to retrieve hostname")
-		}
+	if exportNodeName = os.Getenv(nodeNameEnvVar); exportNodeName != "" {
+		return
+	}
+	exportNodeName, err = os.Hostname()
+	if err != nil {
+		logger.GetLogger().WithError(err).Warn("failed to retrieve hostname")
 	}
 }
 
-// GetNodeNameForExport returns node name string for JSON export. It uses NODE_NAME
-// env variable by default, which is also used by k8s watcher to watch for local pods:
-//
-//	https://github.com/cilium/tetragon/blob/a7be620c9fecdc2b693e3633506aca35d46cd3b2/pkg/grpc/watcher.go#L32
-//
-// Set HUBBLE_NODE_NAME to override the node_name field for JSON export.
+// SetKubernetesNodeName initializes the kubernetesNodeName variable. It's defined separately from
+// init() so that it can be called from unit tests.
+func SetKubernetesNodeName() {
+	var err error
+	if kubernetesNodeName = os.Getenv(nodeNameEnvVar); kubernetesNodeName != "" {
+		return
+	}
+	if kubernetesNodeName = os.Getenv(hubbleNodeNameEnvVar); kubernetesNodeName != "" {
+		return
+	}
+	kubernetesNodeName, err = os.Hostname()
+	if err != nil {
+		logger.GetLogger().WithError(err).Warn("failed to retrieve hostname")
+	}
+}
+
+// GetNodeNameForExport returns node name string for JSON export. It uses the HUBBLE_NODE_NAME
+// env variable by default, and falls back to NODE_NAME if the former is missing. If both
+// are missing, it will use the host name reported by the kernel
 func GetNodeNameForExport() string {
-	return nodeName
+	return exportNodeName
+}
+
+// GetKubernetesNodeName returns node name string for the given node in Kubernetes. It uses the NODE_NAME
+// env variable by default, and falls back to HUBBLE_NODE_NAME if the former is missing. If both
+// are missing, it will use the host name reported by the kernel. This value is used when watching for
+// pods running on the node in Kubernetes.
+//
+// NOTE: This is different from the Export equivalent for cases where nodes in kubernetes are named different
+// from the desired node name in the JSON export.
+func GetKubernetesNodeName() string {
+	return kubernetesNodeName
 }
 
 // SetCommonFields set fields that are common in all the events.
 func SetCommonFields(ev *tetragon.GetEventsResponse) {
-	ev.NodeName = nodeName
+	ev.NodeName = exportNodeName
 	ev.ClusterName = option.Config.ClusterName
 }

--- a/pkg/reader/node/node_test.go
+++ b/pkg/reader/node/node_test.go
@@ -15,10 +15,10 @@ import (
 func TestGetNodeNameForExport(t *testing.T) {
 	assert.NotEqual(t, "", GetNodeNameForExport()) // we should get the hostname here
 	assert.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
-	SetNodeName()
+	SetExportNodeName()
 	assert.Equal(t, "from-node-name", GetNodeNameForExport())
 	assert.NoError(t, os.Setenv("HUBBLE_NODE_NAME", "from-hubble-node-name"))
-	SetNodeName()
+	SetExportNodeName()
 	assert.Equal(t, "from-hubble-node-name", GetNodeNameForExport())
 	assert.NoError(t, os.Unsetenv("NODE_NAME"))
 	assert.NoError(t, os.Unsetenv("HUBBLE_NODE_NAME"))
@@ -30,10 +30,22 @@ func TestSetCommonFields(t *testing.T) {
 	assert.Empty(t, ev.ClusterName)
 	nodeName := "my-node-name"
 	assert.NoError(t, os.Setenv("NODE_NAME", nodeName))
-	SetNodeName()
+	SetExportNodeName()
 	option.Config.ClusterName = "my-cluster-name"
 	SetCommonFields(&ev)
 	assert.Equal(t, nodeName, ev.GetNodeName())
 	assert.Equal(t, option.Config.ClusterName, ev.GetClusterName())
 	assert.NoError(t, os.Unsetenv("NODE_NAME"))
+}
+
+func TestGetKubernetesNodeName(t *testing.T) {
+	assert.NotEqual(t, "", GetKubernetesNodeName()) // we should get the hostname here
+	assert.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
+	SetKubernetesNodeName()
+	assert.Equal(t, "from-node-name", GetKubernetesNodeName())
+	assert.NoError(t, os.Setenv("HUBBLE_NODE_NAME", "from-hubble-node-name"))
+	SetKubernetesNodeName()
+	assert.Equal(t, "from-node-name", GetKubernetesNodeName())
+	assert.NoError(t, os.Unsetenv("NODE_NAME"))
+	assert.NoError(t, os.Unsetenv("HUBBLE_NODE_NAME"))
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -56,7 +56,7 @@ func NewK8sWatcher(
 			k8sClient, stateSyncInterval, informers.WithTweakListOptions(
 				func(options *metav1.ListOptions) {
 					// watch local pods only
-					options.FieldSelector = "spec.nodeName=" + node.GetNodeNameForExport()
+					options.FieldSelector = "spec.nodeName=" + node.GetKubernetesNodeName()
 				}))
 	}
 	if crdClient != nil {


### PR DESCRIPTION
The HUBBLE_NODE_NAME env var is useful to add extra metadata to the "node_name" field for exported events. Often the Kubernetes node name is not very descriptive, and additional information is useful. This can be archived by eg. overriding the following helm values, where k8s will replace the $(NODE_NAME) with the existing NODE_NAME env var in the helm chart, populated from the actual node name.

```
tetragon.extraEnv=[{"name":"HUBBLE_NODE_NAME", "value":"$(NODE_NAME)-additional-info-here.domain.tld"}]
```

Prior to bcf9429 ("Watcher: fix NODE_NAME if missing") this worked as expected where the export events keep this value, and the Kubernetes pod watcher used the existing NODE_NAME. After that commit, the node watcher stated using the HUBBLE_NODE_NAME, resulting in it not receiving any pod events and pod attribution not working for exported events.

Fixes: bcf9429 ("Watcher: fix NODE_NAME if missing")

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes <!-- #issue-number -->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Fix event source pod attribution when env var HUBBLE_NODE_NAME is set
```
