### PR TITLE
tetragon/windows: Port Unit Tests in cmd/tetragon on Windows

### DIFF
--- a/cmd/tetragon/main_test.go
+++ b/cmd/tetragon/main_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/constants"
 	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/option"
@@ -70,7 +71,7 @@ func TestGeneratedExecEvents(t *testing.T) {
 	// Make sure exec event with pid 1 was generated
 	checker := ec.NewUnorderedEventChecker(
 		ec.NewProcessExecChecker("").WithProcess(
-			ec.NewProcessChecker().WithPid(1)),
+			ec.NewProcessChecker().WithPid(constants.INIT_PROC_ID)),
 	)
 
 	// Try it 5 times and make sure exporter is up and processed all data

--- a/pkg/constants/constants_linux.go
+++ b/pkg/constants/constants_linux.go
@@ -61,4 +61,6 @@ const (
 	AF_XDP               = unix.AF_XDP
 	AF_MCTP              = unix.AF_MCTP
 	S_IFMT               = syscall.S_IFMT
+	DEFAULT_TEMP_DIR     = "/tmp"
+	INIT_PROC_ID         = 1
 )

--- a/pkg/constants/constants_windows.go
+++ b/pkg/constants/constants_windows.go
@@ -20,6 +20,8 @@ const (
 	CGROUP2_SUPER_MAGIC  = 0x63677270
 	BPF_STATS_RUN_TIME   = 0
 	S_IFMT               = 0xf000
+	DEFAULT_TEMP_DIR     = ""
+	INIT_PROC_ID         = 0
 )
 
 var (

--- a/pkg/testutils/filenames.go
+++ b/pkg/testutils/filenames.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/cilium/tetragon/pkg/constants"
 )
 
 // t.Name() -> ExportFile
@@ -68,7 +70,7 @@ func CreateExportFile(tb testing.TB) (*ExportFile, error) {
 	// Test names with / (e.g. subtests) will be rejected by os.CreateTemp due to path
 	// separator in the template string. Replace / with - to avoid this.
 	fname := fmt.Sprintf("tetragon.gotest.%s.*.json", testName)
-	f, err := os.CreateTemp("/tmp", fname)
+	f, err := os.CreateTemp(constants.DEFAULT_TEMP_DIR, fname)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create export file for test %s: %w", tb.Name(), err)
 	}


### PR DESCRIPTION
### Description
Testcases in `cmd/tetragon/main_test.go` work on both OS - Windows and Linux except some constants like /tmp and the init process id, which are added in constants via this PR
