### PR TITLE
tetragon/windows: Exclude vmtests unit tests from being compiled on Windows

### DIFF
--- a/cmd/tetragon-vmtests-run/conf.go
+++ b/cmd/tetragon-vmtests-run/conf.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package main
 
 import (

--- a/cmd/tetragon-vmtests-run/image.go
+++ b/cmd/tetragon-vmtests-run/image.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package main
 
 import (

--- a/cmd/tetragon-vmtests-run/qemu.go
+++ b/cmd/tetragon-vmtests-run/qemu.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package main
 
 import (


### PR DESCRIPTION
### Description
This PR excludes listings in tetragon-vmtests-run so that `go test .` does not break in that folder on a Windows runner.

