### PR TITLE
tetragon/windows: Exclude some unit tests for Windows 

### DIFF
--- a/pkg/alignchecker/alignchecker_test.go
+++ b/pkg/alignchecker/alignchecker_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package alignchecker
 
 import (

--- a/pkg/bugtool/maps_test.go
+++ b/pkg/bugtool/maps_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package bugtool
 
 import (

--- a/pkg/cgrouprate/cgrouprate_test.go
+++ b/pkg/cgrouprate/cgrouprate_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package cgrouprate
 
 import (

--- a/pkg/metrics/metricwithpod_test.go
+++ b/pkg/metrics/metricwithpod_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package metrics_test
 
 import (

--- a/pkg/policyfilter/map_test.go
+++ b/pkg/policyfilter/map_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package policyfilter
 
 import (

--- a/pkg/policyfilter/state_test.go
+++ b/pkg/policyfilter/state_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package policyfilter
 
 import (

--- a/pkg/server/addr_test.go
+++ b/pkg/server/addr_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package server
 
 import "testing"

--- a/pkg/tracepoint/tracepoint_test.go
+++ b/pkg/tracepoint/tracepoint_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package tracepoint
 
 import (


### PR DESCRIPTION
### Description
This PR includes changes so that bpftool, cgrouprate, alignchecker, addr_test, tracepoint, and metricwithpod tests do not run on Windows.
Also excludes policyfilter/map_test and policyfilter/state_test on Windows due to difference in behavior on Windows,