### PR TITLE
tetragon/windows: Port unit tests in grpc package into  Windows

### DIFF
--- a/pkg/grpc/exec/exec_test.go
+++ b/pkg/grpc/exec/exec_test.go
@@ -69,11 +69,3 @@ func TestGrpcExecPodInfoDelayedInOrder(t *testing.T) {
 func TestGrpcDelayedExecK8sOutOfOrder(t *testing.T) {
 	GrpcDelayedExecK8sOutOfOrder[*MsgExecveEventUnix, *MsgExitEventUnix](t)
 }
-
-func TestGrpcExecAncestorsInOrder(t *testing.T) {
-	GrpcExecAncestorsInOrder[*MsgExecveEventUnix, *MsgCloneEventUnix, *MsgExitEventUnix](t)
-}
-
-func TestGrpcExecAncestorsOutOfOrder(t *testing.T) {
-	GrpcExecAncestorsOutOfOrder[*MsgExecveEventUnix, *MsgCloneEventUnix, *MsgExitEventUnix](t)
-}

--- a/pkg/grpc/exec/exec_test_linux.go
+++ b/pkg/grpc/exec/exec_test_linux.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// go test -gcflags="" -c ./pkg/grpc/exec/ -o go-tests/grpc-exec.test
+// sudo ./go-tests/grpc-exec.test  [ -test.run TestGrpcExec ]
+
+package exec
+
+import (
+	"testing"
+)
+
+func TestGrpcExecAncestorsInOrder(t *testing.T) {
+	GrpcExecAncestorsInOrder[*MsgExecveEventUnix, *MsgCloneEventUnix, *MsgExitEventUnix](t)
+}
+
+func TestGrpcExecAncestorsOutOfOrder(t *testing.T) {
+	GrpcExecAncestorsOutOfOrder[*MsgExecveEventUnix, *MsgCloneEventUnix, *MsgExitEventUnix](t)
+}

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -5,8 +5,6 @@ package grpc
 
 import (
 	"context"
-	"encoding/base64"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -17,7 +15,6 @@ import (
 	"github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
-	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/rthooks"
 	"github.com/cilium/tetragon/pkg/watcher"
 	"github.com/stretchr/testify/assert"
@@ -210,18 +207,4 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 			Setuid: val10000, Setgid: val10000,
 		},
 		exec.GetProcessExec(pi, false).Process.BinaryProperties)
-}
-
-func TestProcessManager_GetProcessID(t *testing.T) {
-	assert.NoError(t, os.Setenv("NODE_NAME", "my-node"))
-	node.SetExportNodeName()
-
-	err := process.InitCache(watcher.NewFakeK8sWatcher([]interface{}{}), 10, defaults.DefaultProcessCacheGCInterval)
-	assert.NoError(t, err)
-	defer process.FreeCache()
-	id := process.GetProcessID(1, 2)
-	decoded, err := base64.StdEncoding.DecodeString(id)
-	assert.NoError(t, err)
-	assert.Equal(t, "my-node:2:1", string(decoded))
-	assert.NoError(t, os.Unsetenv("NODE_NAME"))
 }

--- a/pkg/grpc/process_manager_test_linux.go
+++ b/pkg/grpc/process_manager_test_linux.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package grpc
+
+import (
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/cilium/tetragon/pkg/defaults"
+	"github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/reader/node"
+	"github.com/cilium/tetragon/pkg/watcher"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessManager_GetProcessID(t *testing.T) {
+	assert.NoError(t, os.Setenv("NODE_NAME", "my-node"))
+	node.SetExportNodeName()
+
+	err := process.InitCache(watcher.NewFakeK8sWatcher([]interface{}{}), 10, defaults.DefaultProcessCacheGCInterval)
+	assert.NoError(t, err)
+	defer process.FreeCache()
+	id := process.GetProcessID(1, 2)
+	decoded, err := base64.StdEncoding.DecodeString(id)
+	assert.NoError(t, err)
+	assert.Equal(t, "my-node:2:1", string(decoded))
+	assert.NoError(t, os.Unsetenv("NODE_NAME"))
+}

--- a/pkg/grpc/process_manager_test_windows.go
+++ b/pkg/grpc/process_manager_test_windows.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package grpc
+
+import (
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/cilium/tetragon/pkg/defaults"
+	"github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/reader/node"
+	"github.com/cilium/tetragon/pkg/watcher"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessManager_GetProcessID(t *testing.T) {
+	assert.NoError(t, os.Setenv("NODE_NAME", "my-node"))
+	node.SetExportNodeName()
+
+	err := process.InitCache(watcher.NewFakeK8sWatcher([]interface{}{}), 10, defaults.DefaultProcessCacheGCInterval)
+	assert.NoError(t, err)
+	defer process.FreeCache()
+	id := process.GetProcessID(1, 2)
+	decoded, err := base64.StdEncoding.DecodeString(id)
+	assert.NoError(t, err)
+	assert.Equal(t, "1:1:1", string(decoded))
+}


### PR DESCRIPTION


### Description
This PR changs the unit tests in grpc package to also run and succeed on Windows. Some exec based unit tests are excluded due to ktime not being present in Windows exec event.
