### PR TITLE
tetragon: Fix storing of flags and mode for path

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -363,8 +363,8 @@ FUNC_INLINE long copy_path(char *args, const struct path *arg)
 	 * -----------------------------------------
 	 * Next we set up the flags.
 	 */
-	args[size] = (u32)flags;
-	args[size + sizeof(u32)] = (u16)i_mode;
+	*(u32 *)&args[size] = (u32)flags;
+	*(u16 *)&args[size + sizeof(u32)] = (u16)i_mode;
 	size += sizeof(u32) + sizeof(u16); // for the flags + i_mode
 
 	return size;


### PR DESCRIPTION
[ upstream commit ad5c2b02412136e2a095a889eab681e186e79cc8 ]

Currently we only store first byte of flags and mode from path retrieval, which ends up with wrong flags and permissions in all arguments that goes through path retrieval.

fixing it by properly storing the value in argument byte array.
