### PR TITLE
tetragon/windows: Run unit tests on Windows

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -96,3 +96,26 @@ jobs:
         name: btf-vmlinux-${{ matrix.os }}
         path: /sys/kernel/btf/vmlinux
         retention-days: 5
+
+  build_windows:
+    runs-on: windows-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      with:
+        # renovate: datasource=golang-version depName=go
+        go-version: '1.24.2'
+
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        path: go/src/github.com/cilium/tetragon/
+
+    
+    - name: Run go tests
+      working-directory: ${{ github.workspace }}\go\src\github.com\cilium\tetragon
+      run: |
+        go test --failfast .\pkg\... .\cmd\...

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ all: tetragon-bpf tetragon tetra generate-flags test-compile tester-progs protoc
 .PHONY: clean
 clean: cli-clean tarball-clean
 	$(MAKE) -C ./bpf clean
-	rm -f go-tests/*.test ./ksyms ./tetragon ./tetragon-operator ./tetra ./alignchecker
+	rm -f go-tests/*.test ./ksyms ./tetragon ./tetragon-operator ./tetra ./alignchecker ./tetragon.exe
 	rm -f contrib/sigkill-tester/sigkill-tester contrib/namespace-tester/test_ns contrib/capabilities-tester/test_caps
 	$(MAKE) -C $(TESTER_PROGS_DIR) clean
 

--- a/cmd/tetragon/main_test.go
+++ b/cmd/tetragon/main_test.go
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Tetragon
 
+//go:build !windows
+
 package main
 
 import (
@@ -28,6 +30,8 @@ func TestMain(m *testing.M) {
 // The test starts tetragon with minimal setup and stops it
 // when it observer is ready. By that time we should have
 // exec events generated, make sure it's done.
+// ToDo: Enable on Windows once windows programs start compiling
+// and are present in the obj directory
 func TestGeneratedExecEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/pkg/grpc/process_manager_test_windows.go
+++ b/pkg/grpc/process_manager_test_windows.go
@@ -26,4 +26,5 @@ func TestProcessManager_GetProcessID(t *testing.T) {
 	decoded, err := base64.StdEncoding.DecodeString(id)
 	assert.NoError(t, err)
 	assert.Equal(t, "1:1:1", string(decoded))
+	assert.NoError(t, os.Unsetenv("NODE_NAME"))
 }

--- a/pkg/sensors/exec/procevents/proc_reader_test.go
+++ b/pkg/sensors/exec/procevents/proc_reader_test.go
@@ -5,6 +5,7 @@ package procevents
 
 import (
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -29,7 +30,7 @@ func TestListRunningProcs(t *testing.T) {
 }
 
 func TestInInitTreeProcfs(t *testing.T) {
-	if err := exec.Command("docker", "version").Run(); err != nil {
+	if err := exec.Command("docker", "version").Run(); (err != nil) || (runtime.GOOS == "windows") {
 		t.Skipf("docker not available. skipping test: %s", err)
 	}
 


### PR DESCRIPTION
### Description
This PR enabled running unit tests on Windows on a windows-latest runner. Tests are run on cmd and pkg folders
