### PR TITLE
go.mod: Consistently add replace directives

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -23,4 +23,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/cilium/tetragon => ../
+replace (
+	github.com/cilium/tetragon => ../
+	github.com/cilium/tetragon/pkg/k8s => ../pkg/k8s
+)

--- a/api/vendor/modules.txt
+++ b/api/vendor/modules.txt
@@ -148,3 +148,4 @@ gopkg.in/yaml.v3
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/cilium/tetragon => ../
+# github.com/cilium/tetragon/pkg/k8s => ../pkg/k8s

--- a/contrib/tetragon-rthooks/go.mod
+++ b/contrib/tetragon-rthooks/go.mod
@@ -56,4 +56,8 @@ require (
 	k8s.io/cri-api v0.31.2 // indirect
 )
 
-replace github.com/cilium/tetragon/api => ../../api
+replace (
+	github.com/cilium/tetragon => ../../
+	github.com/cilium/tetragon/api => ../../api
+	github.com/cilium/tetragon/pkg/k8s => ../../pkg/k8s
+)

--- a/contrib/tetragon-rthooks/vendor/modules.txt
+++ b/contrib/tetragon-rthooks/vendor/modules.txt
@@ -326,4 +326,6 @@ gopkg.in/yaml.v3
 # k8s.io/cri-api v0.31.2
 ## explicit; go 1.22.0
 k8s.io/cri-api/pkg/apis/runtime/v1
+# github.com/cilium/tetragon => ../../
 # github.com/cilium/tetragon/api => ../../api
+# github.com/cilium/tetragon/pkg/k8s => ../../pkg/k8s


### PR DESCRIPTION
The top level go.mod uses the v0.0.0-00010101000000-000000000000 pseudo version for github.com/cilium/tetragon/{api,pkg/k8s} packages, and replaces them with local directories. IDEs like GoLand runs "go list -m" on all the go.mod files. It fails in api/ and contrib/tetragon-rthooks/ with an error like this:

    % go list -m -mod=mod all
    go: github.com/cilium/tetragon/pkg/k8s@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000

because they don't replace indirect dependencies. Replace these indirect dependencies to get rid of the IDE warning.