### PR TITLE
doc: fix some links in documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@ Thanks for contributing! Please ensure your pull request adheres to the followin
 - [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
 - [ ] All code is covered by unit and/or end-to-end tests where feasible.
 - [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
-- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
-- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
+- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
+- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
 - [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
 -->
 

--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -387,7 +387,7 @@ arguments to include in the trace output. Tetragon's BPF code requires
 information about the types of arguments to properly read, print and
 filter on its arguments. This information needs to be provided by the user under the
 `args` section. For the [available
-types](https://github.com/cilium/tetragon/blob/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml#L64-L88),
+types](https://github.com/cilium/tetragon/blob/v1.4.0/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml#L166-L208),
 check the [`TracingPolicy`
 CRD](https://github.com/cilium/tetragon/blob/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml).
 
@@ -416,7 +416,7 @@ args:
 To properly read and hook onto the `fd_install(unsigned int fd, struct file
 *file)` function, the YAML snippet above tells the BPF code that the first
 argument is an `int` and the second argument is a `file`, which is the
-[`struct file`](https://elixir.bootlin.com/linux/latest/source/include/linux/fs.h#L940)
+[`struct file`](https://elixir.bootlin.com/linux/v6.13.7/source/include/linux/fs.h#L1035)
 of the kernel. In this way, the BPF code and its printer can properly collect
 and print the arguments.
 


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes some reference links on Hook points page

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Some links in the documentation are broken.