### PR TITLE
Refactor Pod watcher

### DIFF
--- a/pkg/watcher/deleted_pod_cache.go
+++ b/pkg/watcher/deleted_pod_cache.go
@@ -16,19 +16,19 @@ type deletedPodCacheEntry struct {
 	contStatus *corev1.ContainerStatus
 }
 
-type deletedPodCache struct {
+type DeletedPodCache struct {
 	*lru.Cache[string, deletedPodCacheEntry]
 }
 
-func newDeletedPodCache() (*deletedPodCache, error) {
+func NewDeletedPodCache() (*DeletedPodCache, error) {
 	c, err := lru.New[string, deletedPodCacheEntry](128)
 	if err != nil {
 		return nil, err
 	}
-	return &deletedPodCache{c}, nil
+	return &DeletedPodCache{c}, nil
 }
 
-func (c *deletedPodCache) eventHandler() cache.ResourceEventHandler {
+func (c *DeletedPodCache) EventHandler() cache.ResourceEventHandler {
 	return cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
 			var pod *corev1.Pod
@@ -75,7 +75,7 @@ func (c *deletedPodCache) eventHandler() cache.ResourceEventHandler {
 	}
 }
 
-func (c *deletedPodCache) findContainer(containerID string) (*corev1.Pod, *corev1.ContainerStatus, bool) {
+func (c *DeletedPodCache) FindContainer(containerID string) (*corev1.Pod, *corev1.ContainerStatus, bool) {
 	v, ok := c.Get(containerID)
 	if !ok {
 		return nil, nil, false

--- a/pkg/watcher/pod.go
+++ b/pkg/watcher/pod.go
@@ -54,7 +54,7 @@ func AddPodInformer(w *K8sWatcher, local bool) error {
 
 	// initialize deleted pod cache
 	var err error
-	w.deletedPodCache, err = newDeletedPodCache()
+	w.deletedPodCache, err = NewDeletedPodCache()
 	if err != nil {
 		return fmt.Errorf("failed to initialize deleted pod cache: %w", err)
 	}
@@ -67,7 +67,7 @@ func AddPodInformer(w *K8sWatcher, local bool) error {
 	})
 
 	// add event handlers to the informer
-	informer.AddEventHandler(w.deletedPodCache.eventHandler())
+	informer.AddEventHandler(w.deletedPodCache.EventHandler())
 	podhooks.InstallHooks(informer)
 
 	return nil
@@ -161,7 +161,7 @@ func (watcher *K8sWatcher) FindContainer(containerID string) (*corev1.Pod, *core
 		return pod, cont, found
 	}
 
-	return watcher.deletedPodCache.findContainer(indexedContainerID)
+	return watcher.deletedPodCache.FindContainer(indexedContainerID)
 }
 
 // TODO(michi) Not the most efficient implementation. Optimize as needed.

--- a/pkg/watcher/pod_test.go
+++ b/pkg/watcher/pod_test.go
@@ -280,11 +280,11 @@ func TestFindPodWalk(t *testing.T) {
 // simplified version of AddPodInformer for testing
 func addPodInformerDummyIndexer(w *K8sWatcher) {
 	factory := w.GetK8sInformerFactory()
-	w.deletedPodCache, _ = newDeletedPodCache()
+	w.deletedPodCache, _ = NewDeletedPodCache()
 	informer := factory.Core().V1().Pods().Informer()
 	w.AddInformer(podInformerName, informer, map[string]cache.IndexFunc{
 		podIdx: func(any) ([]string, error) { return nil, nil },
 	})
-	informer.AddEventHandler(w.deletedPodCache.eventHandler())
+	informer.AddEventHandler(w.deletedPodCache.EventHandler())
 	podhooks.InstallHooks(informer)
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -31,7 +31,7 @@ type Watcher interface {
 	GetCRDInformerFactory() externalversions.SharedInformerFactory
 }
 
-// NB(anna): localK8sInformerFactory and deletedPodCache are relevant only when
+// NB(anna): localK8sInformerFactory and DeletedPodCache are relevant only when
 // watching pods. If a K8sWatcher instance is e.g. watching only policies, they
 // are unused. If needed, they can be factored out to make the K8sWatcher
 // struct more generic.
@@ -40,7 +40,7 @@ type K8sWatcher struct {
 	localK8sInformerFactory informers.SharedInformerFactory        // for k8s built-in resources local to the node
 	crdInformerFactory      externalversions.SharedInformerFactory // for Tetragon CRDs
 	informers               map[string]cache.SharedIndexInformer
-	deletedPodCache         *deletedPodCache
+	deletedPodCache         *DeletedPodCache
 }
 
 // NewK8sWatcher creates a new K8sWatcher with initialized informer factories.


### PR DESCRIPTION
2 commits:

- export DeletedPodCache so that controller-runtime can use it.
- refactor PodAccessor so that controller-runtime can re-use the common code with its pod informer.