### PR TITLE
examples: use explicit wording about guarantees

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,8 +6,9 @@ This folder contains examples of resources YAML and configuration files.
   (TracingPolicy custom resources). These examples are generally well
   documented, either in the file itself or in Tetragon documentation.
 - See [`tracingpolicy`](tracingpolicy) directory for more policy examples.
-  Files in this directory are valid policies, but they are not curated in terms
-  of suitability for their purpose. Add more examples if you feel like it.
+  The policies in this directory are provided as a samples only, and do not provide any security
+  observability guarantees. Users are strongly encouraged to evaluate the functionality defined in
+  this policy and make any modifications necessary to achieve their desired security posture.
 - See [`configuration`](configuration) directory for an example of
   configuration file for Tetragon and and directory structure.
 

--- a/examples/tracingpolicy/hardlink-observe.yaml
+++ b/examples/tracingpolicy/hardlink-observe.yaml
@@ -1,3 +1,8 @@
+# This policy is provided as a sample only, and does not provide any security observability
+# guarantees. Users are strongly encouraged to evaluate the functionality defined in this policy and
+# make any modifications necessary to achieve their desired security posture. In particular, syscall
+# tracing suffers from Time-of-Check-to-Time-of-Use (TOCTOU) issues that may limit the utility of
+# this policy.
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:

--- a/examples/tracingpolicy/hardlink-override.yaml
+++ b/examples/tracingpolicy/hardlink-override.yaml
@@ -1,3 +1,8 @@
+# This policy is provided as a sample only, and does not provide any security observability
+# guarantees. Users are strongly encouraged to evaluate the functionality defined in this policy and
+# make any modifications necessary to achieve their desired security posture. In particular, syscall
+# tracing suffers from Time-of-Check-to-Time-of-Use (TOCTOU) issues that may limit the utility of
+# this policy.
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:

--- a/examples/tracingpolicy/openat_write.yaml
+++ b/examples/tracingpolicy/openat_write.yaml
@@ -1,3 +1,8 @@
+# This policy is provided as a sample only, and does not provide any security observability
+# guarantees. Users are strongly encouraged to evaluate the functionality defined in this policy and
+# make any modifications necessary to achieve their desired security posture. In particular, syscall
+# tracing suffers from Time-of-Check-to-Time-of-Use (TOCTOU) issues that may limit the utility of
+# this policy.
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:

--- a/examples/tracingpolicy/symlink-observe.yaml
+++ b/examples/tracingpolicy/symlink-observe.yaml
@@ -1,3 +1,8 @@
+# This policy is provided as a sample only, and does not provide any security observability
+# guarantees. Users are strongly encouraged to evaluate the functionality defined in this policy and
+# make any modifications necessary to achieve their desired security posture. In particular, syscall
+# tracing suffers from Time-of-Check-to-Time-of-Use (TOCTOU) issues that may limit the utility of
+# this policy.
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:

--- a/examples/tracingpolicy/symlink-override.yaml
+++ b/examples/tracingpolicy/symlink-override.yaml
@@ -1,3 +1,8 @@
+# This policy is provided as a sample only, and does not provide any security observability
+# guarantees. Users are strongly encouraged to evaluate the functionality defined in this policy and
+# make any modifications necessary to achieve their desired security posture. In particular, syscall
+# tracing suffers from Time-of-Check-to-Time-of-Use (TOCTOU) issues that may limit the utility of
+# this policy.
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:


### PR DESCRIPTION
Example policies are meant to illustrate the Tetragon features, and not to be used unmodified in for security. Clarify this in the README and in some of the policies that have TOCTU issues.


