### PR TITLE
k8s: Remove the logic to handle v1beta1 CRDs

### DIFF
--- a/pkg/k8s/crdutils/register.go
+++ b/pkg/k8s/crdutils/register.go
@@ -13,12 +13,9 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/versioncheck"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
-	v1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -26,7 +23,6 @@ import (
 
 	ciliumio "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
-	k8sversion "github.com/cilium/tetragon/pkg/k8s/version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -123,20 +119,6 @@ func createUpdateCRD(
 	opts CRDOptions,
 ) error {
 	scopedLog := log.WithField("name", crdName)
-
-	if !k8sversion.Capabilities().APIExtensionsV1CRD {
-		log.Infof("K8s apiserver does not support v1 CRDs, falling back to v1beta1")
-
-		return createUpdateV1beta1CRD(
-			scopedLog,
-			clientset.ApiextensionsV1beta1(),
-			crdName,
-			crd,
-			poller,
-			opts,
-		)
-	}
-
 	v1CRDClient := clientset.ApiextensionsV1()
 	// get the CRD if it is already registered.
 	clusterCRD, err := v1CRDClient.CustomResourceDefinitions().Get(
@@ -361,193 +343,3 @@ func (p defaultPoll) Poll(
 	return wait.Poll(interval, duration, conditionFn)
 }
 
-func createUpdateV1beta1CRD(
-	scopedLog *logrus.Entry,
-	client v1beta1client.CustomResourceDefinitionsGetter,
-	crdName string,
-	crd *apiextensionsv1.CustomResourceDefinition,
-	poller poller,
-	opts CRDOptions,
-) error {
-	v1beta1CRD, err := convertToV1Beta1CRD(crd)
-	if err != nil {
-		return err
-	}
-
-	clusterCRD, err := client.CustomResourceDefinitions().Get(
-		context.TODO(),
-		v1beta1CRD.ObjectMeta.Name,
-		metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		scopedLog.Info("Creating CRD (CustomResourceDefinition)...")
-
-		clusterCRD, err = client.CustomResourceDefinitions().Create(
-			context.TODO(),
-			v1beta1CRD,
-			metav1.CreateOptions{})
-		// This occurs when multiple agents race to create the CRD. Since another has
-		// created it, it will also update it, hence the non-error return.
-		if errors.IsAlreadyExists(err) {
-			return nil
-		}
-	}
-	if err != nil {
-		return err
-	}
-
-	if err := updateV1beta1CRD(scopedLog, v1beta1CRD, clusterCRD, client, poller, opts); err != nil {
-		return err
-	}
-	if err := waitForV1beta1CRD(scopedLog, crdName, clusterCRD, client, poller); err != nil {
-		return err
-	}
-
-	scopedLog.Info("CRD (CustomResourceDefinition) is installed and up-to-date")
-
-	return nil
-}
-
-func needsUpdateV1beta1(clusterCRD *apiextensionsv1beta1.CustomResourceDefinition, opts CRDOptions) bool {
-
-	if opts.ForceUpdate {
-		return true
-	}
-
-	if clusterCRD.Spec.Validation == nil {
-		// no validation detected
-		return true
-	}
-	v, ok := clusterCRD.Labels[CustomResourceDefinitionSchemaVersionKey]
-	if !ok {
-		// no schema version detected
-		return true
-	}
-
-	clusterVersion, err := versioncheck.Version(v)
-	if err != nil || clusterVersion.LT(comparableCRDSchemaVersion) {
-		// version in cluster is either unparsable or smaller than current version
-		return true
-	}
-
-	return false
-}
-
-func convertToV1Beta1CRD(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
-	internalCRD := new(apiextensions.CustomResourceDefinition)
-	v1beta1CRD := new(apiextensionsv1beta1.CustomResourceDefinition)
-
-	if err := apiextensionsv1.Convert_v1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(
-		crd,
-		internalCRD,
-		nil,
-	); err != nil {
-		return nil, fmt.Errorf("unable to convert v1 CRD to internal representation: %v", err)
-	}
-
-	if err := apiextensionsv1beta1.Convert_apiextensions_CustomResourceDefinition_To_v1beta1_CustomResourceDefinition(
-		internalCRD,
-		v1beta1CRD,
-		nil,
-	); err != nil {
-		return nil, fmt.Errorf("unable to convert internally represented CRD to v1beta1: %v", err)
-	}
-
-	return v1beta1CRD, nil
-}
-
-func updateV1beta1CRD(
-	scopedLog *logrus.Entry,
-	crd, clusterCRD *apiextensionsv1beta1.CustomResourceDefinition,
-	client v1beta1client.CustomResourceDefinitionsGetter,
-	poller poller,
-	opts CRDOptions,
-) error {
-	scopedLog.Debug("Checking if CRD (CustomResourceDefinition) needs update...")
-
-	if crd.Spec.Validation != nil && needsUpdateV1beta1(clusterCRD, opts) {
-		scopedLog.Info("Updating CRD (CustomResourceDefinition)...")
-
-		// Update the CRD with the validation schema.
-		err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-			var err error
-			if clusterCRD, err = client.CustomResourceDefinitions().Get(
-				context.TODO(),
-				crd.ObjectMeta.Name,
-				metav1.GetOptions{},
-			); err != nil {
-				return false, err
-			}
-
-			// This seems too permissive but we only get here if the version is
-			// different per needsUpdate above. If so, we want to update on any
-			// validation change including adding or removing validation.
-			if needsUpdateV1beta1(clusterCRD, opts) {
-				scopedLog.Debug("CRD validation is different, updating it...")
-
-				clusterCRD.ObjectMeta.Labels = crd.ObjectMeta.Labels
-				clusterCRD.Spec = crd.Spec
-
-				_, err := client.CustomResourceDefinitions().Update(
-					context.TODO(),
-					clusterCRD,
-					metav1.UpdateOptions{})
-				if err == nil {
-					return true, nil
-				}
-
-				scopedLog.WithError(err).Debug("Unable to update CRD validation")
-
-				return false, err
-			}
-
-			return true, nil
-		})
-		if err != nil {
-			scopedLog.WithError(err).Error("Unable to update CRD")
-			return err
-		}
-	}
-
-	return nil
-}
-
-func waitForV1beta1CRD(
-	scopedLog *logrus.Entry,
-	crdName string,
-	crd *apiextensionsv1beta1.CustomResourceDefinition,
-	client v1beta1client.CustomResourceDefinitionsGetter,
-	poller poller,
-) error {
-	scopedLog.Debug("Waiting for CRD (CustomResourceDefinition) to be available...")
-
-	err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		for _, cond := range crd.Status.Conditions {
-			switch cond.Type {
-			case apiextensionsv1beta1.Established:
-				if cond.Status == apiextensionsv1beta1.ConditionTrue {
-					return true, nil
-				}
-			case apiextensionsv1beta1.NamesAccepted:
-				if cond.Status == apiextensionsv1beta1.ConditionFalse {
-					err := goerrors.New(cond.Reason)
-					scopedLog.WithError(err).Error("Name conflict for CRD")
-					return false, err
-				}
-			}
-		}
-
-		var err error
-		if crd, err = client.CustomResourceDefinitions().Get(
-			context.TODO(),
-			crd.ObjectMeta.Name,
-			metav1.GetOptions{}); err != nil {
-			return false, err
-		}
-		return false, err
-	})
-	if err != nil {
-		return fmt.Errorf("error occurred waiting for CRD: %w", err)
-	}
-
-	return nil
-}

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/crdutils/register.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/crdutils/register.go
@@ -13,12 +13,9 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/versioncheck"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
-	v1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -26,7 +23,6 @@ import (
 
 	ciliumio "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
-	k8sversion "github.com/cilium/tetragon/pkg/k8s/version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -123,20 +119,6 @@ func createUpdateCRD(
 	opts CRDOptions,
 ) error {
 	scopedLog := log.WithField("name", crdName)
-
-	if !k8sversion.Capabilities().APIExtensionsV1CRD {
-		log.Infof("K8s apiserver does not support v1 CRDs, falling back to v1beta1")
-
-		return createUpdateV1beta1CRD(
-			scopedLog,
-			clientset.ApiextensionsV1beta1(),
-			crdName,
-			crd,
-			poller,
-			opts,
-		)
-	}
-
 	v1CRDClient := clientset.ApiextensionsV1()
 	// get the CRD if it is already registered.
 	clusterCRD, err := v1CRDClient.CustomResourceDefinitions().Get(
@@ -361,193 +343,3 @@ func (p defaultPoll) Poll(
 	return wait.Poll(interval, duration, conditionFn)
 }
 
-func createUpdateV1beta1CRD(
-	scopedLog *logrus.Entry,
-	client v1beta1client.CustomResourceDefinitionsGetter,
-	crdName string,
-	crd *apiextensionsv1.CustomResourceDefinition,
-	poller poller,
-	opts CRDOptions,
-) error {
-	v1beta1CRD, err := convertToV1Beta1CRD(crd)
-	if err != nil {
-		return err
-	}
-
-	clusterCRD, err := client.CustomResourceDefinitions().Get(
-		context.TODO(),
-		v1beta1CRD.ObjectMeta.Name,
-		metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		scopedLog.Info("Creating CRD (CustomResourceDefinition)...")
-
-		clusterCRD, err = client.CustomResourceDefinitions().Create(
-			context.TODO(),
-			v1beta1CRD,
-			metav1.CreateOptions{})
-		// This occurs when multiple agents race to create the CRD. Since another has
-		// created it, it will also update it, hence the non-error return.
-		if errors.IsAlreadyExists(err) {
-			return nil
-		}
-	}
-	if err != nil {
-		return err
-	}
-
-	if err := updateV1beta1CRD(scopedLog, v1beta1CRD, clusterCRD, client, poller, opts); err != nil {
-		return err
-	}
-	if err := waitForV1beta1CRD(scopedLog, crdName, clusterCRD, client, poller); err != nil {
-		return err
-	}
-
-	scopedLog.Info("CRD (CustomResourceDefinition) is installed and up-to-date")
-
-	return nil
-}
-
-func needsUpdateV1beta1(clusterCRD *apiextensionsv1beta1.CustomResourceDefinition, opts CRDOptions) bool {
-
-	if opts.ForceUpdate {
-		return true
-	}
-
-	if clusterCRD.Spec.Validation == nil {
-		// no validation detected
-		return true
-	}
-	v, ok := clusterCRD.Labels[CustomResourceDefinitionSchemaVersionKey]
-	if !ok {
-		// no schema version detected
-		return true
-	}
-
-	clusterVersion, err := versioncheck.Version(v)
-	if err != nil || clusterVersion.LT(comparableCRDSchemaVersion) {
-		// version in cluster is either unparsable or smaller than current version
-		return true
-	}
-
-	return false
-}
-
-func convertToV1Beta1CRD(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
-	internalCRD := new(apiextensions.CustomResourceDefinition)
-	v1beta1CRD := new(apiextensionsv1beta1.CustomResourceDefinition)
-
-	if err := apiextensionsv1.Convert_v1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(
-		crd,
-		internalCRD,
-		nil,
-	); err != nil {
-		return nil, fmt.Errorf("unable to convert v1 CRD to internal representation: %v", err)
-	}
-
-	if err := apiextensionsv1beta1.Convert_apiextensions_CustomResourceDefinition_To_v1beta1_CustomResourceDefinition(
-		internalCRD,
-		v1beta1CRD,
-		nil,
-	); err != nil {
-		return nil, fmt.Errorf("unable to convert internally represented CRD to v1beta1: %v", err)
-	}
-
-	return v1beta1CRD, nil
-}
-
-func updateV1beta1CRD(
-	scopedLog *logrus.Entry,
-	crd, clusterCRD *apiextensionsv1beta1.CustomResourceDefinition,
-	client v1beta1client.CustomResourceDefinitionsGetter,
-	poller poller,
-	opts CRDOptions,
-) error {
-	scopedLog.Debug("Checking if CRD (CustomResourceDefinition) needs update...")
-
-	if crd.Spec.Validation != nil && needsUpdateV1beta1(clusterCRD, opts) {
-		scopedLog.Info("Updating CRD (CustomResourceDefinition)...")
-
-		// Update the CRD with the validation schema.
-		err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-			var err error
-			if clusterCRD, err = client.CustomResourceDefinitions().Get(
-				context.TODO(),
-				crd.ObjectMeta.Name,
-				metav1.GetOptions{},
-			); err != nil {
-				return false, err
-			}
-
-			// This seems too permissive but we only get here if the version is
-			// different per needsUpdate above. If so, we want to update on any
-			// validation change including adding or removing validation.
-			if needsUpdateV1beta1(clusterCRD, opts) {
-				scopedLog.Debug("CRD validation is different, updating it...")
-
-				clusterCRD.ObjectMeta.Labels = crd.ObjectMeta.Labels
-				clusterCRD.Spec = crd.Spec
-
-				_, err := client.CustomResourceDefinitions().Update(
-					context.TODO(),
-					clusterCRD,
-					metav1.UpdateOptions{})
-				if err == nil {
-					return true, nil
-				}
-
-				scopedLog.WithError(err).Debug("Unable to update CRD validation")
-
-				return false, err
-			}
-
-			return true, nil
-		})
-		if err != nil {
-			scopedLog.WithError(err).Error("Unable to update CRD")
-			return err
-		}
-	}
-
-	return nil
-}
-
-func waitForV1beta1CRD(
-	scopedLog *logrus.Entry,
-	crdName string,
-	crd *apiextensionsv1beta1.CustomResourceDefinition,
-	client v1beta1client.CustomResourceDefinitionsGetter,
-	poller poller,
-) error {
-	scopedLog.Debug("Waiting for CRD (CustomResourceDefinition) to be available...")
-
-	err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		for _, cond := range crd.Status.Conditions {
-			switch cond.Type {
-			case apiextensionsv1beta1.Established:
-				if cond.Status == apiextensionsv1beta1.ConditionTrue {
-					return true, nil
-				}
-			case apiextensionsv1beta1.NamesAccepted:
-				if cond.Status == apiextensionsv1beta1.ConditionFalse {
-					err := goerrors.New(cond.Reason)
-					scopedLog.WithError(err).Error("Name conflict for CRD")
-					return false, err
-				}
-			}
-		}
-
-		var err error
-		if crd, err = client.CustomResourceDefinitions().Get(
-			context.TODO(),
-			crd.ObjectMeta.Name,
-			metav1.GetOptions{}); err != nil {
-			return false, err
-		}
-		return false, err
-	})
-	if err != nil {
-		return fmt.Errorf("error occurred waiting for CRD: %w", err)
-	}
-
-	return nil
-}


### PR DESCRIPTION
CustomResourceDefinition apiextensions.k8s.io/v1 has been available since Kubernetes v1.16, and apiextensions.k8s.io/v1beta1 has been removed since Kubernetes v1.22 [^1]. Let's move on and clean up the logic to handle v1beta1 CRDs.

[^1]: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122