### PR TITLE
buf: enable protoc-gen-go-tetragon

### DIFF
--- a/.github/workflows/lint-proto.yaml
+++ b/.github/workflows/lint-proto.yaml
@@ -23,6 +23,7 @@ jobs:
           fetch-depth: 0
       - name: Lint protobuf
         run: |
+          make protoc-gen-go-tetragon
           # TODO: enable linting once we have a chance to fix the underlying issues
           # make -C api lint EXTRA_BUF_FLAGS="--error-format=github-actions"
           if ${{ github.event_name == 'push' }}; then
@@ -48,6 +49,7 @@ jobs:
         run: |
           set -ex
           # Don't run 'make protogen' here, as it duplicates linting and vendoring checks.
+          make protoc-gen-go-tetragon
           make -C api vendor proto
           test -z "$(git status --porcelain)"
           if [ $? != 0 ]; then

--- a/api/buf.gen.yaml
+++ b/api/buf.gen.yaml
@@ -4,7 +4,7 @@ plugins:
     out: ./v1
     opt:
       - paths=source_relative
-  - local: protoc-gen-go-grpc
+  - local: /src/bin/protoc-gen-go-tetragon
     out: ./v1
     opt:
       - paths=source_relative


### PR DESCRIPTION
When we transitioned in using buf in eea39fd71e5b, we did not add the plugin for the custom tetragon code generator for eventchecker and other helpers. This commit adds it.

Fixes: eea39fd71e5b ("api: build using buf")