### PR TITLE
fix(deps): Remove metallb dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -399,19 +399,6 @@
       "enabled": false
     },
     {
-      // do not update dependencies from the replace directive from cilium/cilium
-      // see go.mod second replace directive comments for more info
-      "enabled": false,
-      "matchPackageNames": [
-        // All of these packages are maintained on a Cilium fork. Thus, we don't
-        // want to update them automatically.
-        "go.universe.tf/metallb",
-        "github.com/cilium/metallb",
-        // metallb is still using an old version of "github.com/mdlayher/arp"
-        "github.com/mdlayher/arp",
-      ]
-    },
-    {
       // not an ignore but almost, please automate this if you have the energy
       // require manual steps for minor and major cilium/cilium updates
       "matchPackageNames": [

--- a/go.mod
+++ b/go.mod
@@ -174,10 +174,3 @@ replace (
 	github.com/cilium/tetragon/api => ./api
 	github.com/cilium/tetragon/pkg/k8s => ./pkg/k8s
 )
-
-// This replace directive has to be in sync with with github.com/cilium/cilium
-// except for sigs.k8s.io/controller-tools.  If the github.com/cilium/cilium
-// version is bumped, the sync must be refreshed. As of now we use, see the
-// replace directive:
-// https://github.com/cilium/cilium/blob/cdf10116cea7a3babc493214b4ac856128734bcc/go.mod#L332-L338
-replace go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7

--- a/pkg/k8s/go.mod
+++ b/pkg/k8s/go.mod
@@ -68,6 +68,3 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 )
-
-// See main go.mod for more about this replace directive
-replace go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7

--- a/pkg/k8s/vendor/modules.txt
+++ b/pkg/k8s/vendor/modules.txt
@@ -608,4 +608,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1527,4 +1527,3 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/cilium/tetragon/api => ./api
 # github.com/cilium/tetragon/pkg/k8s => ./pkg/k8s
-# go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7


### PR DESCRIPTION
Cilium stopped depending on this package back in upstream commit
https://github.com/cilium/cilium/commit/c2b935042f3e ("bgp: remove metallb bgp integration"). No need to
replicate any go.mod replace tricks here for it or its dependencies.
