### PR TITLE
loaderCache: copy map spec before using it

### DIFF
--- a/pkg/sensors/load_linux.go
+++ b/pkg/sensors/load_linux.go
@@ -64,6 +64,10 @@ func (s *Sensor) loadMap(bpfDir string, loaderCache *loaderCache, m *program.Map
 		return fmt.Errorf("map '%s' not found from '%s'", m.Name, m.Prog.Name)
 	}
 
+	// code below will modify mapSpec. Crate a copy so that the original spec (which is reused
+	// via the loaderCache for different inscanes of the map) is not modified.
+	mapSpec = mapSpec.Copy()
+
 	s.setMapPinPath(m)
 	pinPath := filepath.Join(bpfDir, m.PinPath)
 


### PR DESCRIPTION
Commit 8ce47efeab7a, introduced a cache for the program specs when loading maps. The go tests did not run in the corresponding PR (https://github.com/cilium/tetragon/pull/3685) and, as a result, we ended up with the following failure in main for some (rhel8.9, 5.15, 5.10, 5.3) kernels for the TestKproveOverideMulti test:

    observer_test_helper.go:465: SensorManager.AddTracingPolicy error: sensor generic_kprobe from collection sys-openat-signal-override failed to load: failed prog /home/kkourt/src/tetragon/bpf/objs/bpf_generic_kprobe_v511.o kern_version 331700 loadInstance: opening collection '/home/kkourt/src/tetragon/bpf/objs/bpf_generic_kprobe_v511.o' failed: using replacement map override_tasks: MaxEntries: 32768 changed to 1: map spec is incompatible with existing map

The problem is that the map spec is updated and, because it is now cached, it is reused across multiple instances of the map. These instances have different pin paths and may have different configurations. Specifically, in the TestKprobeOverrideMulti one instance of the map is configured with a single entry, while all others are configured with 32768 entries.

To address this problem, this commits makes a copy of the mapSpec before modifying it. Compared to 8ce47efeab7a, this leads to worse performance but still better than without the cache.

Running:
  go test -exec sudo  ./pkg/sensors/tracing -bpf-lib $(pwd)/bpf/objs -test.run TestKprobeSelectors -count 1

This commit:
ok      github.com/cilium/tetragon/pkg/sensors/tracing  7.831s
ok      github.com/cilium/tetragon/pkg/sensors/tracing  7.849s
ok      github.com/cilium/tetragon/pkg/sensors/tracing  7.781s

Without the cache (21b326c830d491b62816eedbe9c55d57afeaf9da):
ok      github.com/cilium/tetragon/pkg/sensors/tracing  9.078s
ok      github.com/cilium/tetragon/pkg/sensors/tracing  9.074s
ok      github.com/cilium/tetragon/pkg/sensors/tracing  9.068s

Which is a ~13.5% improvement.

NB: not sure why the "without the cache" numbers are different from the ones reported in 8ce47efeab7a. Maybe something changed in overhead in the meantime.

Fixes: 8ce47efeab7a ("sensors: cache spec when loading maps")
