### PR TITLE
vmtests CI: avoid running duplicate tests

### DIFF
--- a/pkg/vmtests/list.go
+++ b/pkg/vmtests/list.go
@@ -79,20 +79,20 @@ func LoadTestsFromFile(testDir string, fname string) ([]GoTest, error) {
 func ListTests(
 	testDir string,
 	packagesOnly bool,
-	blacklist []GoTest,
+	ignorelist []GoTest,
 ) ([]GoTest, error) {
 
-	progs, err := listTestProgs(testDir, blacklist)
+	progs, err := listTestProgs(testDir, ignorelist)
 	if err != nil {
 		return nil, err
 	}
 
-	blacklistMap := make(map[GoTest]struct{})
-	for _, b := range blacklist {
+	ignorelistMap := make(map[GoTest]struct{})
+	for _, b := range ignorelist {
 		if b.Test == "" {
 			continue
 		}
-		blacklistMap[b] = struct{}{}
+		ignorelistMap[b] = struct{}{}
 	}
 
 	ret := []GoTest{}
@@ -111,7 +111,7 @@ func ListTests(
 
 		for _, test := range tests {
 			t := GoTest{PackageProg: prog, Test: test}
-			if _, ok := blacklistMap[t]; ok {
+			if _, ok := ignorelistMap[t]; ok {
 				continue
 			}
 			ret = append(ret, t)
@@ -122,16 +122,16 @@ func ListTests(
 }
 
 // listTestProgs lists tests programs from the filesystem (typically, this is the go-tests directory)
-func listTestProgs(testDir string, blacklist []GoTest) ([]string, error) {
+func listTestProgs(testDir string, ignoreList []GoTest) ([]string, error) {
 	files, err := os.ReadDir(testDir)
 	if err != nil {
 		return nil, err
 	}
 
-	blackListedPackages := make(map[string]struct{})
-	for _, t := range blacklist {
+	ignoredPackages := make(map[string]struct{})
+	for _, t := range ignoreList {
 		if t.Test == "" {
-			blackListedPackages[t.PackageProg] = struct{}{}
+			ignoredPackages[t.PackageProg] = struct{}{}
 		}
 	}
 
@@ -144,7 +144,7 @@ func listTestProgs(testDir string, blacklist []GoTest) ([]string, error) {
 		if !strings.HasPrefix(name, "pkg.") {
 			continue
 		}
-		if _, ok := blackListedPackages[name]; ok {
+		if _, ok := ignoredPackages[name]; ok {
 			continue
 		}
 		ret = append(ret, name)

--- a/pkg/vmtests/list.go
+++ b/pkg/vmtests/list.go
@@ -20,11 +20,12 @@ type GoTest struct {
 	PackageProg, Test string
 }
 
-func (t *GoTest) ToString() string {
+func (t *GoTest) ToPattern() string {
 	if t.Test == "" {
 		return t.PackageProg
 	}
-	return fmt.Sprintf("%s:%s", t.PackageProg, t.Test)
+	// some tests are substrings of others. Use an exact pattern to avoid running tests twice.
+	return fmt.Sprintf("%s:^%s$", t.PackageProg, t.Test)
 }
 
 func fromString(testDir, s string) []GoTest {
@@ -86,12 +87,12 @@ func ListTests(
 		return nil, err
 	}
 
-	blacklistMap := make(map[string]struct{})
+	blacklistMap := make(map[GoTest]struct{})
 	for _, b := range blacklist {
 		if b.Test == "" {
 			continue
 		}
-		blacklistMap[b.ToString()] = struct{}{}
+		blacklistMap[b] = struct{}{}
 	}
 
 	ret := []GoTest{}
@@ -110,7 +111,7 @@ func ListTests(
 
 		for _, test := range tests {
 			t := GoTest{PackageProg: prog, Test: test}
-			if _, ok := blacklistMap[t.ToString()]; ok {
+			if _, ok := blacklistMap[t]; ok {
 				continue
 			}
 			ret = append(ret, t)

--- a/tools/split-tetragon-gotests/main.go
+++ b/tools/split-tetragon-gotests/main.go
@@ -19,8 +19,8 @@ var (
 	outDir      = filepath.Join(tetragonDir, "tests", "vmtests")
 )
 
-func splitProgs(n int, blacklist []vmtests.GoTest) error {
-	tests, err := vmtests.ListTests(goTestsDir, false, blacklist)
+func splitProgs(n int, ignorelist []vmtests.GoTest) error {
+	tests, err := vmtests.ListTests(goTestsDir, false, ignorelist)
 	if err != nil || len(tests) == 0 {
 		return fmt.Errorf("no tests found (err:%w). Is %s accesible? Did you run `make test-compile`?", err, goTestsDir)
 	}
@@ -47,7 +47,7 @@ func splitProgs(n int, blacklist []vmtests.GoTest) error {
 	return nil
 }
 
-var CiBlacklist = []vmtests.GoTest{
+var CiIgnorelist = []vmtests.GoTest{
 	// pkg.exporter has a rate limit test, which is time-dependent. There
 	// was a previous attempt to fix the test, but failed. Ignore it for
 	// now.
@@ -71,7 +71,7 @@ func usage() {
 func main() {
 
 	var cirun bool
-	flag.BoolVar(&cirun, "ci-run", false, "This option enables CI blacklist for tests")
+	flag.BoolVar(&cirun, "ci-run", false, "This option enables CI ignorelist for tests")
 	flag.Parse()
 
 	if flag.NArg() != 1 {
@@ -85,11 +85,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	var blacklist []vmtests.GoTest
+	var ignorelist []vmtests.GoTest
 	if cirun {
-		blacklist = CiBlacklist
+		ignorelist = CiIgnorelist
 	}
-	err = splitProgs(n, blacklist)
+	err = splitProgs(n, ignorelist)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		os.Exit(1)

--- a/tools/split-tetragon-gotests/main.go
+++ b/tools/split-tetragon-gotests/main.go
@@ -40,7 +40,7 @@ func splitProgs(n int, blacklist []vmtests.GoTest) error {
 	// load-balance between the groups.
 	i := 0
 	for _, test := range tests {
-		fmt.Fprintf(files[i%n], "%s\n", test.ToString())
+		fmt.Fprintf(files[i%n], "%s\n", test.ToPattern())
 		i++
 	}
 


### PR DESCRIPTION
The way the vmtest action works, is that it uses `./tools/split-tetragon-gotests` to create a list of tests to run.

Originally, this was used to speedup testing by running different tests in different GHA jobs (138bde54e8b5383fe19fab5b7661afe94a1103fc, 476ab862502c7a6ac92aebb1587e7c5a0b95c564), and, also, exclude some tests from being run.

We ended up moving away from the multiple groups approach (24c06e4c4274cbcaff786c140d1623db8ad62a74), but split-tetragon-gotests was still used for test exclusion in vmtests.

split-tetragon-gotests creates a file that specifies which tests to run. Currently, the file allows patterns that work similarly to how an argument to -test.run or -test.list would work.

The problem is that some tests are substrings of others, which results in some tests being executed twice(b798f59eb9a3cdace4c56bb18a4b4ea8f46cf393). For example, TestKprobeOverrideMulti is executed twice: once for itself and once for TestKprobeOverride.

This commit modifies split-tetragon-gotests to create a file that has exact patterns, and avoids running tests multiple times in CI.
