### PR TITLE
tetragon/windows: Fix observer to make it event independent

### DIFF
--- a/.github/workflows/windows-build-smoke-test.yml
+++ b/.github/workflows/windows-build-smoke-test.yml
@@ -28,6 +28,11 @@ jobs:
         run: mkdir D:\temp
         shell: pwsh
 
+      - name: Checkout Tetragon Repo 
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: go/src/github.com/cilium/tetragon/
+      
       - name: Set MSVC Environment Variables
         shell: cmd
         run: |
@@ -64,6 +69,13 @@ jobs:
           cd ${{ env.TEMP }}\ntosebpfext
           git checkout e7dc209a8be0da2ff5d75f5772a0ee0bf4a10383
       
+      - name: Copy Process_monitor.c file
+        run: |
+            $sourcePath = "${{ github.workspace }}\go\src\github.com\cilium\tetragon\bpf\windows\process_monitor.c"
+            $destinationPath = "${{ env.TEMP }}\ntosebpfext\tools\process_monitor_bpf\process_monitor.c"
+            Copy-Item -Path $sourcePath -Destination $destinationPath -Force
+        shell: powershell
+
       - name: Configuring repo for first build
         if: steps.skip_check.outputs.should_skip != 'true'
         working-directory: ${{ env.TEMP }}\ntosebpfext
@@ -72,7 +84,6 @@ jobs:
           LDFLAGS: ${{ env.LD_FLAGS }}
         run: |
             .\scripts\initialize_repo.ps1
-
       - name: Build
         working-directory: ${{ env.TEMP }}\ntosebpfext
         run: msbuild -target:Tools\process_monitor_bpf:Rebuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /bl:${{env.BUILD_PLATFORM}}_${{env.BUILD_CONFIGURATION}}\build_logs\build.binlog ${{env.BUILD_OPTIONS}} ${{env.SOLUTION_FILE_PATH}}

--- a/bpf/windows/process_monitor.c
+++ b/bpf/windows/process_monitor.c
@@ -1,44 +1,51 @@
-
-// This BPF program listens for process events and logs the process id, parent process id, creating process id, creating
-// thread id, and operation to a ring buffer. It also logs the image path and command line of the process to LRU hash
-// maps.
-
 #include "bpf_helpers.h"
-#include "process_event.h"
+#include "ebpf_ntos_hooks.h"
 
 #define IMAGE_PATH_SIZE (1024)
 
-// 64k bytes is the max byte count that fits in a UNICODE_STRING (because Length is USHORT).  Exactly 64k seems
+// 64k bytes is the max byte count that fits in a UNICODE_STRING (because Length is a USHORT).  Exactly 64k seems
 // to be a little too high for eBPF, so we subtract a few bytes and the likelihood this actually truncates anything
 // important is pretty low.
 #define COMMAND_SCRATCH_SIZE ((64 * 1024) - 16)
 
+#define MSG_OP_EXECVE 5
+
+struct msg_common {
+	uint8_t op;
+	uint8_t flags; // internal flags not exported
+	uint8_t pad[2];
+	uint32_t size;
+	uint64_t ktime;
+};
+
 // Declare a per-CPU array to be used as scratch space.
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__type(key, uint64_t); // key is pid
+	__type(key, uint64_t); // key is pid_tgid
 	__uint(value_size, COMMAND_SCRATCH_SIZE);
 	__uint(max_entries, 1);
 } temp SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
-	__type(key, uint64_t); // key is pid
+	__type(key, uint64_t); // key is pid_tgid
 	__uint(value_size, COMMAND_SCRATCH_SIZE);
 	__uint(max_entries, 1024);
 } scratch_space SEC(".maps");
 
-// The non variable fields from the process_event struct.
-struct {
+// The non variable fields from the process_md_t struct.
+// Note: this must be kept in sync with the C# version in process_monitor.Library's ProcessMonitorBPFLoader.cs
+struct process_info_t {
+	struct msg_common common;
 	uint32_t process_id;
 	uint32_t parent_process_id;
 	uint32_t creating_process_id;
 	uint32_t creating_thread_id;
-	uint64_t creation_time;
-	uint64_t exit_time;
+	uint64_t creation_time; ///< Process creation time.
+	uint64_t exit_time; ///< Process exit time.
 	uint32_t process_exit_code;
 	uint8_t operation;
-} process_event;
+} process_info_t;
 
 // LRU hash for storing the image path of a process.
 struct {
@@ -56,18 +63,23 @@ struct {
 	__uint(max_entries, 1024);
 } command_map SEC(".maps");
 
-// Ring-buffer for process_event.
+// Ring-buffer for process_info_t.
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
 	__uint(max_entries, 1024 * 64);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } process_ringbuf SEC(".maps");
+
+// The following line is optional, but is used to verify
+// that the ProcesMonitor prototype is correct or the compiler
+// would complain when the function is actually defined below.
+process_hook_t ProcessMonitor;
 
 inline __attribute__((always_inline)) void *
 get_scratch_space()
 {
 	uint64_t current_pid_tgid_key = bpf_get_current_pid_tgid();
 	void *scratch = bpf_map_lookup_elem(&temp, &current_pid_tgid_key);
-
 	if (!scratch) {
 		uint32_t temp_key = 0;
 		// Allocate scratch space for this CPU.
@@ -90,20 +102,19 @@ get_scratch_space()
 	return scratch;
 }
 
-char __ebpf_go_platform[] SEC(".ebpf_go_platform") = "windows";
-
 SEC("process")
-int process_monitor(process_event_t *ctx)
+int ProcessMonitor(process_md_t *ctx)
 {
-	process_event process_info;
+	struct process_info_t process_info;
 
 	memset(&process_info, 0, sizeof(process_info));
-
+	process_info.common.op = MSG_OP_EXECVE;
 	process_info.process_id = ctx->process_id;
 	process_info.parent_process_id = ctx->parent_process_id;
 	process_info.creating_process_id = ctx->creating_process_id;
 	process_info.creating_thread_id = ctx->creating_thread_id;
 	process_info.creation_time = ctx->creation_time;
+	process_info.common.ktime = bpf_ktime_get_ns();
 	process_info.exit_time = ctx->exit_time;
 	process_info.process_exit_code = ctx->process_exit_code;
 	process_info.operation = ctx->operation;
@@ -115,9 +126,8 @@ int process_monitor(process_event_t *ctx)
 			return 0;
 
 		int command_length = ctx->command_end - ctx->command_start;
-
 		if (command_length > COMMAND_SCRATCH_SIZE)
-			command_length = COMMAND_SCRATCH_SIZE; // Better to truncate than to get nothing
+			command_length = COMMAND_SCRATCH_SIZE;
 
 		// Use COMMAND_SCRATCH_SIZE -1 to ensure the last byte stays a 0 for null termination
 		memcpy_s(buffer, COMMAND_SCRATCH_SIZE - 1, ctx->command_start, command_length);

--- a/pkg/api/processapi/processapi_windows.go
+++ b/pkg/api/processapi/processapi_windows.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package processapi
+
+type MsgCreateProcessEvent struct {
+	Common            MsgCommon
+	ProcessID         uint32
+	ParentProcessID   uint32
+	CreatingProcessID uint32
+	CreatingThreadID  uint32
+	CreationTime      uint64
+}
+
+type MsgExitProcessEvent struct {
+	Common          MsgCommon
+	ProcessID       uint32
+	ExitTime        uint64
+	ProcessExitCode uint32
+}

--- a/pkg/bpf/coll_windows.go
+++ b/pkg/bpf/coll_windows.go
@@ -4,6 +4,7 @@ package bpf
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/cilium/ebpf"
 )
@@ -13,19 +14,24 @@ type CollectionStore struct {
 }
 
 var (
-	store CollectionStore
+	store          CollectionStore
+	collstoreMutex sync.RWMutex
 )
 
 func SetCollection(name string, coll *ebpf.Collection) {
+	collstoreMutex.Lock()
 	store.collMap[name] = coll
+	collstoreMutex.Unlock()
 }
 
 func GetCollection(name string) (*ebpf.Collection, error) {
+	collstoreMutex.RLock()
 	coll, ok := store.collMap[name]
+	collstoreMutex.RUnlock()
 	if ok {
 		return coll, nil
 	}
-	return nil, errors.New("Collection object not found")
+	return nil, errors.New("collection object not found")
 }
 
 func init() {

--- a/pkg/bpf/coll_windows.go
+++ b/pkg/bpf/coll_windows.go
@@ -3,17 +3,31 @@
 package bpf
 
 import (
+	"errors"
+
 	"github.com/cilium/ebpf"
 )
 
-var (
-	execColl *ebpf.Collection
-)
-
-func SetExecCollection(coll *ebpf.Collection) {
-	execColl = coll
+type CollectionStore struct {
+	collMap map[string]*ebpf.Collection
 }
 
-func GetExecCollection() *ebpf.Collection {
-	return execColl
+var (
+	store CollectionStore
+)
+
+func SetCollection(name string, coll *ebpf.Collection) {
+	store.collMap[name] = coll
+}
+
+func GetCollection(name string) (*ebpf.Collection, error) {
+	coll, ok := store.collMap[name]
+	if ok {
+		return coll, nil
+	}
+	return nil, errors.New("Collection object not found")
+}
+
+func init() {
+	store.collMap = make(map[string]*ebpf.Collection)
 }

--- a/pkg/bpf/ringbuf_windows.go
+++ b/pkg/bpf/ringbuf_windows.go
@@ -66,7 +66,19 @@ type RingBufferRecord struct {
 	data        [1]uint8
 }
 
+type MsgCommon struct {
+	Op uint8
+	// Flags is used to:
+	//  - distinguish between an entry and a return kprobe event
+	//  - indicate if a stack trace id was passed in the event
+	Flags  uint8
+	Pad_v2 [2]uint8
+	Size   uint32
+	Ktime  uint64
+}
+
 type ProcessInfo struct {
+	Common            MsgCommon
 	ProcessId         uint32
 	ParentProcessID   uint32
 	CreatingProcessID uint32

--- a/pkg/observer/observer_windows.go
+++ b/pkg/observer/observer_windows.go
@@ -214,7 +214,7 @@ func getExecRecordFromProcInfo(processInfo *bpf.ProcessInfo, command_map *ebpf.M
 }
 
 func (observer *Observer) RunEvents(stopCtx context.Context, ready func()) error {
-	coll := bpf.GetExecCollection()
+	coll, err := bpf.GetCollection("ProcessMonitor")
 	if coll == nil {
 		return errors.New("exec Preloaded collection is nil")
 	}
@@ -222,7 +222,7 @@ func (observer *Observer) RunEvents(stopCtx context.Context, ready func()) error
 	ringBufMap := coll.Maps["process_ringbuf"]
 	imageMap := coll.Maps["process_map"]
 	reader := bpf.GetNewWindowsRingBufReader()
-	err := reader.Init(ringBufMap.FD(), int(ringBufMap.MaxEntries()))
+	err = reader.Init(ringBufMap.FD(), int(ringBufMap.MaxEntries()))
 	if err != nil {
 		return fmt.Errorf("failed initializing ringbuf reader: %w", err)
 	}

--- a/pkg/sensors/exec/args_windows.go
+++ b/pkg/sensors/exec/args_windows.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package exec
+
+import (
+	"errors"
+	"strings"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/tetragon/pkg/bpf"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	cmd_map   *ebpf.Map
+	image_map *ebpf.Map
+)
+
+func getArgsFromPID(PID uint32) (string, string, error) {
+
+	if (cmd_map == nil) || (image_map == nil) {
+		coll, _ := bpf.GetCollection("ProcessMonitor")
+		if coll == nil {
+			return "", "", errors.New("exec Preloaded collection is nil")
+		}
+		var ok bool
+		cmd_map, ok = coll.Maps["command_map"]
+		if !ok {
+			return "", "", errors.New("commad_map not found or not pinned")
+		}
+		image_map, ok = coll.Maps["process_map"]
+		if !ok {
+			return "", "", errors.New("commad_map not found or not pinned")
+		}
+	}
+	var wideCmd [2048]uint16
+	err := cmd_map.Lookup(PID, &wideCmd)
+	if err == nil {
+		cmd_map.Delete(PID)
+	}
+	strCmd := windows.UTF16ToString(wideCmd[:])
+
+	var wideImagePath [1024]byte
+	err = image_map.Lookup(PID, &wideImagePath)
+	if err == nil {
+		image_map.Delete(PID)
+	}
+	var s = (*uint16)(unsafe.Pointer(&wideImagePath[0]))
+	strImagePath := windows.UTF16PtrToString(s)
+
+	strImagePath = strings.TrimPrefix(strImagePath, "\\??\\")
+	stringToTrim := strImagePath
+
+	if strings.HasPrefix(strCmd, "\"") {
+		stringToTrim = "\"" + stringToTrim + "\""
+	}
+	strCmd = strings.TrimPrefix(strCmd, stringToTrim)
+	strCmd = strings.TrimPrefix(strCmd, " ")
+	return strImagePath, strCmd, nil
+
+}

--- a/pkg/sensors/program/loader_windows.go
+++ b/pkg/sensors/program/loader_windows.go
@@ -103,7 +103,7 @@ func doLoadProgram(
 		logger.GetLogger().WithError(err).WithField("Error ", err.Error()).Warn(" Failed to load Native Windows Collection ")
 		return nil, err
 	}
-	bpf.SetExecCollection(coll)
+	bpf.SetCollection(load.Label, coll)
 
 	collMaps := map[ebpf.MapID]*ebpf.Map{}
 	// we need a mapping by ID


### PR DESCRIPTION
### Description
This PR has three commits:
1. Change the bpf program to use  `LIBBPF_PIN_BY_NAME` flag while creating ringbuf map in Windows. This lets the ringbuf map be re-usable across programs. 

2. While porting observer to windows, pkg/observer became dependent on event type and was highly specific to exec event. 
This PR fixes that by adding event specific parsing in sensor 

3. Fix the CI to match changes in bpf program