### PR TITLE
generic_calls.h : Extract arg in map instead of variable

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -114,7 +114,7 @@ FUNC_INLINE long generic_read_arg(void *ctx, int index, long off, struct bpf_map
 	struct msg_generic_kprobe *e;
 	struct event_config *config;
 	int am, zero = 0;
-	unsigned long a;
+	unsigned long *a;
 	long ty;
 
 	e = map_lookup_elem(&process_call_heap, &zero);
@@ -130,14 +130,14 @@ FUNC_INLINE long generic_read_arg(void *ctx, int index, long off, struct bpf_map
 		     : "i"(MAX_SELECTORS_MASK));
 	ty = (&config->arg0)[index];
 
-	a = (&e->a0)[index];
-	extract_arg(config, index, &a);
+	a = &(&e->a0)[index];
+	extract_arg(config, index, a);
 
 	if (should_offload_path(ty))
-		return generic_path_offload(ctx, ty, a, index, off, tailcals);
+		return generic_path_offload(ctx, ty, *a, index, off, tailcals);
 
 	am = (&config->arg0m)[index];
-	return read_arg(ctx, e, index, ty, off, a, am, data_heap_ptr);
+	return read_arg(ctx, e, index, ty, off, *a, am, data_heap_ptr);
 }
 
 FUNC_INLINE int


### PR DESCRIPTION
### Description

Currently, the argument in extracted and stored inside a simple variable. But if we want to reorder the tail calls and still be able to access the argument, we need to store it inside the map.

```release-note
Extract arg in map instead of variable
```
