### PR TITLE
crdutils: Move test helpers to dedicated file and export them

### DIFF
--- a/pkg/crdutils/testhelpers.go
+++ b/pkg/crdutils/testhelpers.go
@@ -37,16 +37,29 @@ func (gtp *GenericTracingPolicy) GetObjectMetaStruct() *metav1.ObjectMeta {
 	return &gtp.Metadata
 }
 
-func FileConfigWithTemplate(fileName string, data any) (*GenericTracingPolicy, error) {
+// Read a template file and apply data to it, returning the resulting string
+func ReadFileTemplate(fileName string, data any) (string, error) {
 	templ, err := template.ParseFiles(fileName)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	err = templ.Execute(&buf, data)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func FileConfigWithTemplate(fileName string, data any) (*GenericTracingPolicy, error) {
+	polyaml, err := ReadFileTemplate(fileName, data)
 	if err != nil {
 		return nil, err
 	}
 
-	var buf bytes.Buffer
-	templ.Execute(&buf, data)
-
-	pol, err := TPContext.FromYAML(buf.String())
+	pol, err := TPContext.FromYAML(polyaml)
 	if err != nil {
 		return nil, fmt.Errorf("TPContext.FromYAML error %w", err)
 	}

--- a/pkg/eventcheckertests/yaml/yaml_test.go
+++ b/pkg/eventcheckertests/yaml/yaml_test.go
@@ -4,62 +4,32 @@
 package yaml_test
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"testing"
-	"text/template"
 
 	"github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/yaml"
+	"github.com/cilium/tetragon/pkg/crdutils"
 	"github.com/cilium/tetragon/pkg/eventcheckertests/yamlhelpers"
-	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
-var examplesDir string
-
-func init() {
-	_, filename, _, _ := runtime.Caller(0)
-	examplesDir = filepath.Join(filepath.Dir(filename), "../../../examples/eventchecker")
-}
-
-// Read a template file and apply data to it, returning the restulting string
-func readFileTemplate(fileName string, data interface{}) (string, error) {
-	templ, err := template.ParseFiles(fileName)
-	if err != nil {
-		return "", err
-	}
-
-	var buf bytes.Buffer
-	err = templ.Execute(&buf, data)
-	if err != nil {
-		return "", err
-	}
-
-	return buf.String(), nil
-}
-
 func TestExamplesSmoke(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	examplesDir := filepath.Join(filepath.Dir(filename), "../../../examples/eventchecker")
+
 	err := filepath.Walk(examplesDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
-		// Skip directories
-		if info.IsDir() {
+		// Skip directories and non-yaml files
+		if info.IsDir() || (!strings.HasSuffix(info.Name(), "yaml") && !strings.HasSuffix(info.Name(), "yml")) {
 			return nil
 		}
-
-		// Skip non-yaml files with a warning
-		if !strings.HasSuffix(info.Name(), "yaml") || strings.HasSuffix(info.Name(), "yml") {
-			logger.GetLogger().WithField("path", path).Warn("skipping non-yaml file")
-			return nil
-		}
-
-		logger.GetLogger().WithField("path", path).Info("verifying file")
 
 		// Fill this in with template data as needed
 		templateData := map[string]string{
@@ -67,10 +37,8 @@ func TestExamplesSmoke(t *testing.T) {
 		}
 
 		// Attempt to parse the file
-		data, err := readFileTemplate(path, templateData)
+		data, err := crdutils.ReadFileTemplate(path, templateData)
 		assert.NoError(t, err, "example %s must parse correctly", info.Name())
-
-		assert.NoError(t, err)
 
 		var conf yaml.EventCheckerConf
 		yamlhelpers.AssertUnmarshalRoundTrip(t, []byte(data), &conf)


### PR DESCRIPTION
This is done to improve reusability - the helpers can now be imported from
different packages.