### PR TITLE
tetragon: fix resolve issue with argument order

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -754,7 +754,7 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 			if err != nil {
 				return errFn(fmt.Errorf("error on hook %q for index %d : %w", f.Call, a.Index, err))
 			}
-			allBTFArgs[j] = btfArg
+			allBTFArgs[a.Index] = btfArg
 			argType = findTypeFromBTFType(a, lastBTFType)
 		}
 


### PR DESCRIPTION
Running the following policy:
```
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "resolve-sockaddr"
spec:
  kprobes:
  - call: "security_socket_connect"
    syscall: false
    args:
    - index: 1
      type: "uint16"
      resolve: "sa_family"
```

Leads to an event wih the wrong value. The issue is that when setting allBTFArgs we need to use the index in the function order rather than the index in the spec order.

This commit fixes the issue, and adds a test for it.

Fixes: https://github.com/cilium/tetragon/issues/3734

```release-note
tracingpolicy: fix issue in argument order with the resolve argument option
```
