### PR TITLE
tetragon: Move some event_config values to arrays

### DIFF
--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -166,7 +166,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	msg->retprobe_id = 0;
 
 	msg->a0 = ({
-		unsigned long ctx_off = config->t_arg0_ctx_off;
+		unsigned long ctx_off = config->off[0];
 		int ty = config->arg[0];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));
@@ -174,7 +174,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	});
 
 	msg->a1 = ({
-		unsigned long ctx_off = config->t_arg1_ctx_off;
+		unsigned long ctx_off = config->off[1];
 		int ty = config->arg[1];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));
@@ -182,7 +182,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	});
 
 	msg->a2 = ({
-		unsigned long ctx_off = config->t_arg2_ctx_off;
+		unsigned long ctx_off = config->off[2];
 		int ty = config->arg[2];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));
@@ -190,7 +190,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	});
 
 	msg->a3 = ({
-		unsigned long ctx_off = config->t_arg3_ctx_off;
+		unsigned long ctx_off = config->off[3];
 		int ty = config->arg[3];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));
@@ -198,7 +198,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	});
 
 	msg->a4 = ({
-		unsigned long ctx_off = config->t_arg4_ctx_off;
+		unsigned long ctx_off = config->off[4];
 		int ty = config->arg[4];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -167,7 +167,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 
 	msg->a0 = ({
 		unsigned long ctx_off = config->t_arg0_ctx_off;
-		int ty = config->arg0;
+		int ty = config->arg[0];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);
@@ -175,7 +175,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 
 	msg->a1 = ({
 		unsigned long ctx_off = config->t_arg1_ctx_off;
-		int ty = config->arg1;
+		int ty = config->arg[1];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);
@@ -183,7 +183,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 
 	msg->a2 = ({
 		unsigned long ctx_off = config->t_arg2_ctx_off;
-		int ty = config->arg2;
+		int ty = config->arg[2];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);
@@ -191,7 +191,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 
 	msg->a3 = ({
 		unsigned long ctx_off = config->t_arg3_ctx_off;
-		int ty = config->arg3;
+		int ty = config->arg[3];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);
@@ -199,7 +199,7 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 
 	msg->a4 = ({
 		unsigned long ctx_off = config->t_arg4_ctx_off;
-		int ty = config->arg4;
+		int ty = config->arg[4];
 		asm volatile("%[ctx_off] &= 0xffff;\n"
 			     : [ctx_off] "+r"(ctx_off));
 		get_ctx_ul((char *)ctx + ctx_off, ty);

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -128,7 +128,7 @@ FUNC_INLINE long generic_read_arg(void *ctx, int index, long off, struct bpf_map
 	asm volatile("%[index] &= %1 ;\n"
 		     : [index] "+r"(index)
 		     : "i"(MAX_SELECTORS_MASK));
-	ty = (&config->arg0)[index];
+	ty = config->arg[index];
 
 	a = (&e->a0)[index];
 	extract_arg(config, index, &a);

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -136,7 +136,7 @@ FUNC_INLINE long generic_read_arg(void *ctx, int index, long off, struct bpf_map
 	if (should_offload_path(ty))
 		return generic_path_offload(ctx, ty, a, index, off, tailcals);
 
-	am = (&config->arg0m)[index];
+	am = config->arm[index];
 	return read_arg(ctx, e, index, ty, off, a, am, data_heap_ptr);
 }
 

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -170,11 +170,7 @@ struct extract_arg_data {
 struct event_config {
 	__u32 func_id;
 	__s32 arg[EVENT_CONFIG_MAX_ARG];
-	__u32 arg0m;
-	__u32 arg1m;
-	__u32 arg2m;
-	__u32 arg3m;
-	__u32 arg4m;
+	__u32 arm[EVENT_CONFIG_MAX_ARG];
 	__u32 t_arg0_ctx_off;
 	__u32 t_arg1_ctx_off;
 	__u32 t_arg2_ctx_off;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -171,11 +171,7 @@ struct event_config {
 	__u32 func_id;
 	__s32 arg[EVENT_CONFIG_MAX_ARG];
 	__u32 arm[EVENT_CONFIG_MAX_ARG];
-	__u32 t_arg0_ctx_off;
-	__u32 t_arg1_ctx_off;
-	__u32 t_arg2_ctx_off;
-	__u32 t_arg3_ctx_off;
-	__u32 t_arg4_ctx_off;
+	__u32 off[EVENT_CONFIG_MAX_ARG];
 	__u32 syscall;
 	__s32 argreturncopy;
 	__s32 argreturn;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -169,11 +169,7 @@ struct extract_arg_data {
 
 struct event_config {
 	__u32 func_id;
-	__s32 arg0;
-	__s32 arg1;
-	__s32 arg2;
-	__s32 arg3;
-	__s32 arg4;
+	__s32 arg[EVENT_CONFIG_MAX_ARG];
 	__u32 arg0m;
 	__u32 arg1m;
 	__u32 arg2m;

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -610,7 +610,7 @@ type EventConfig struct {
 	FuncId          uint32                                           `align:"func_id"`
 	Arg             [EventConfigMaxArgs]int32                        `align:"arg"`
 	ArgM            [EventConfigMaxArgs]uint32                       `align:"arm"`
-	ArgTpCtxOff     [EventConfigMaxArgs]uint32                       `align:"t_arg0_ctx_off"`
+	ArgTpCtxOff     [EventConfigMaxArgs]uint32                       `align:"off"`
 	Syscall         uint32                                           `align:"syscall"`
 	ArgReturnCopy   int32                                            `align:"argreturncopy"`
 	ArgReturn       int32                                            `align:"argreturn"`

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -609,7 +609,7 @@ const MaxBTFArgDepth = 10 // Artificial value for compilation, may be extended
 type EventConfig struct {
 	FuncId          uint32                                           `align:"func_id"`
 	Arg             [EventConfigMaxArgs]int32                        `align:"arg"`
-	ArgM            [EventConfigMaxArgs]uint32                       `align:"arg0m"`
+	ArgM            [EventConfigMaxArgs]uint32                       `align:"arm"`
 	ArgTpCtxOff     [EventConfigMaxArgs]uint32                       `align:"t_arg0_ctx_off"`
 	Syscall         uint32                                           `align:"syscall"`
 	ArgReturnCopy   int32                                            `align:"argreturncopy"`

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -608,7 +608,7 @@ const MaxBTFArgDepth = 10 // Artificial value for compilation, may be extended
 
 type EventConfig struct {
 	FuncId          uint32                                           `align:"func_id"`
-	Arg             [EventConfigMaxArgs]int32                        `align:"arg0"`
+	Arg             [EventConfigMaxArgs]int32                        `align:"arg"`
 	ArgM            [EventConfigMaxArgs]uint32                       `align:"arg0m"`
 	ArgTpCtxOff     [EventConfigMaxArgs]uint32                       `align:"t_arg0_ctx_off"`
 	Syscall         uint32                                           `align:"syscall"`


### PR DESCRIPTION
We plan to increase number of supported arguments and it's more convenient with array size.
