### PR TITLE
1.4 backports

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -751,7 +751,7 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 			if err != nil {
 				return errFn(fmt.Errorf("Error on hook %q for index %d : %v", f.Call, a.Index, err))
 			}
-			allBtfArgs[j] = btfArg
+			allBtfArgs[a.Index] = btfArg
 			argType = findTypeFromBtfType(a, lastBtfType)
 		}
 

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7516,3 +7516,56 @@ spec:
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(kpChecker))
 	assert.NoError(t, err)
 }
+
+func TestKprobeResolveSecondArg(t *testing.T) {
+	if !kernels.MinKernelVersion("5.4") {
+		t.Skip("Test requires kernel 5.4+")
+	}
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	hook := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "resolve-sockaddr"
+spec:
+  kprobes:
+  - call: "security_socket_connect"
+    syscall: false
+    args:
+    - index: 1
+      type: "uint16"
+      resolve: "sa_family"
+`
+
+	createCrdFile(t, hook)
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	// NB: it does not matter if this connect succeeds
+	net.Dial("tcp", "127.0.0.1:1234")
+
+	kpChecker := ec.NewProcessKprobeChecker("").
+		WithFunctionName(sm.Full("security_socket_connect")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithUintArg(unix.AF_INET),
+			)).
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Suffix(tus.Conf().SelfBinary)))
+
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Backported PRs

  * https://github.com/cilium/tetragon/pull/3725
       * [tetragon: Fix kprobe argument printers order](https://github.com/cilium/tetragon/commit/3b2c8b659acc1562b804b8da4cb7fe20fc36784a)
       * [tetragon: Add test for argument printers order](https://github.com/cilium/tetragon/commit/ad0b696885d33ced7fc694d865d873db0125b5e6)
  * https://github.com/cilium/tetragon/pull/3737
       * [tetragon: fix resolve issue with argument order](https://github.com/cilium/tetragon/commit/ba2b79851674e616a884e9e61f45123e137f815c)
