### PR TITLE
Temporarily disable controller-runtime metrics

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -47,7 +47,7 @@ type ControllerManager struct {
 func Get() *ControllerManager {
 	var err error
 	initOnce.Do(func() {
-		manager, err = newControllerManager(true)
+		manager, err = newControllerManager()
 		if err != nil {
 			panic(err)
 		}
@@ -58,7 +58,7 @@ func Get() *ControllerManager {
 // newControllerManager creates a new controller manager. The enableMetrics flag
 // is for unit tests so that we can instantiate multiple ControllerManager instances
 // without them trying to bind to the same port 8080.
-func newControllerManager(enableMetrics bool) (*ControllerManager, error) {
+func newControllerManager() (*ControllerManager, error) {
 	ctrl.SetLogger(logrusr.New(logger.GetLogger()))
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -71,10 +71,7 @@ func newControllerManager(enableMetrics bool) (*ControllerManager, error) {
 			},
 		},
 	}
-	metricsOptions := metricsserver.Options{}
-	if !enableMetrics {
-		metricsOptions.BindAddress = "0"
-	}
+	metricsOptions := metricsserver.Options{BindAddress: "0"}
 	controllerOptions := ctrl.Options{Scheme: scheme, Cache: cacheOptions, Metrics: metricsOptions}
 	controllerManager, err := ctrl.NewManager(ctrl.GetConfigOrDie(), controllerOptions)
 	if err != nil {

--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -127,7 +127,7 @@ func (suite *ManagerTestSuite) TestLocalPods() {
 	err := os.Setenv("NODE_NAME", "nonexistent-node")
 	assert.NoError(suite.T(), err)
 	node.SetKubernetesNodeName()
-	controllerManager, err := newControllerManager(false)
+	controllerManager, err := newControllerManager()
 	assert.NoError(suite.T(), err)
 	go func() {
 		assert.NoError(suite.T(), controllerManager.Manager.Start(ctx))


### PR DESCRIPTION
controller-runtime runs its own metrics server on port 8080 by default. It would be good if we can avoid running multiple metric servers. I need some time to think about how to consolidate Tetragon's metric server and controller-runtime metric server.