### PR TITLE
tetragon/windows: Fix exec/exit event timestamp in event json

### DIFF
--- a/bpf/windows/process_monitor.c
+++ b/bpf/windows/process_monitor.c
@@ -115,13 +115,16 @@ int ProcessMonitor(process_md_t *ctx)
 	if (ctx->operation == PROCESS_OPERATION_CREATE) {
 		struct process_create_info_t process_create_info;
 
-		memset(&process_create_info, 0, sizeof(process_create_info));
+		int size = sizeof(process_create_info);
+
+		memset(&process_create_info, 0, size);
 		process_create_info.common.op = MSG_OP_EXECVE;
+		process_create_info.common.size = size;
+		process_create_info.common.ktime = ctx->creation_time;
 		process_create_info.process_id = ctx->process_id;
 		process_create_info.parent_process_id = ctx->parent_process_id;
 		process_create_info.creating_process_id = ctx->creating_process_id;
 		process_create_info.creating_thread_id = ctx->creating_thread_id;
-		process_create_info.common.ktime = ctx->creation_time;
 		process_create_info.creation_time = ctx->creation_time;
 
 		void *buffer = get_scratch_space();
@@ -147,13 +150,15 @@ int ProcessMonitor(process_md_t *ctx)
 
 	} else if (ctx->operation == PROCESS_OPERATION_DELETE) {
 		struct process_exit_info_t process_exit_info;
+		int size = sizeof(process_exit_info);
 
-		memset(&process_exit_info, 0, sizeof(process_exit_info));
+		memset(&process_exit_info, 0, size);
 		process_exit_info.process_id = ctx->process_id;
+		process_exit_info.common.op = MSG_OP_EXIT;
 		process_exit_info.common.ktime = ctx->exit_time;
+		process_exit_info.common.size = size;
 		process_exit_info.exit_time = ctx->exit_time;
 		process_exit_info.process_exit_code = ctx->process_exit_code;
-		process_exit_info.common.op = MSG_OP_EXIT;
 		bpf_ringbuf_output(&process_ringbuf, &process_exit_info, sizeof(process_exit_info), 0);
 	}
 	return 0;

--- a/pkg/ktime/ktime_windows_test.go
+++ b/pkg/ktime/ktime_windows_test.go
@@ -25,3 +25,8 @@ func TestBoottime(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Greater(t, ktime1.UnixMilli(), int64(0))
 }
+
+func TestKernelTime(t *testing.T) {
+	uTime, _ := DecodeKtime(133918958189958838, false)
+	assert.Equal(t, uTime.Unix(), int64(1747422218))
+}

--- a/pkg/sensors/exec/procevents/proc_reader_windows.go
+++ b/pkg/sensors/exec/procevents/proc_reader_windows.go
@@ -397,7 +397,8 @@ func NewProcess(procEntry windows.ProcessEntry32) (procs, error) {
 	if err != nil {
 		logger.GetLogger().WithError(err).Warnf("Reading process times error")
 	}
-	ktime = uint64(times.CreationTime.Nanoseconds())
+	ct := times.CreationTime
+	ktime = uint64((int64(ct.HighDateTime) << 32) + int64(ct.LowDateTime))
 	// Initialize with invalid uid
 	uids := []uint32{proc.InvalidUid, proc.InvalidUid, proc.InvalidUid, proc.InvalidUid}
 	gids := []uint32{proc.InvalidUid, proc.InvalidUid, proc.InvalidUid, proc.InvalidUid}


### PR DESCRIPTION
### Description
On Windows the exec/exit event timestamp was serialized incorrectly. All timestamps in Windows are 100 Nanoseconds from 1 Jan 1600. The protobuf serialization routine assumed nanoseconds wrt boot time or monotonic time, which were then converted to Linux Epoch.

This change converts the Windows Epoch based 100 Nanoseconds to Linux Epoch based time before Event is generated. Both existing and new processes are made to report time wrt to Windows Epoch.