### PR TITLE
Sensors: Use require over assert in tests

### DIFF
--- a/pkg/sensors/exec/cache_test.go
+++ b/pkg/sensors/exec/cache_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cilium/tetragon/pkg/process"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +46,7 @@ func TestProcessCacheInterval(t *testing.T) {
 
 	readyWG.Wait()
 	cmd := exec.Command(sleepBin, "0.001")
-	assert.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Start())
 	pid := cmd.Process.Pid
 	time.Sleep(50 * time.Millisecond)
 

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -210,7 +210,7 @@ func mountCgroupv1Controllers(t *testing.T, cgroupRoot string, usedController st
 	for i, controller := range controllers {
 		hierarchy := filepath.Join(cgroupRoot, controller.name)
 		err := os.MkdirAll(hierarchy, 0555)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, err = mountCgroup(t, hierarchy, "cgroup", controller.name)
 		if err != nil {
 			t.Logf("mountCgroup() %s failed: %v", hierarchy, err)
@@ -623,17 +623,17 @@ func TestTgRuntimeConf(t *testing.T) {
 	tus.LoadInitialSensor(t)
 
 	val, err := testutils.GetTgRuntimeConf()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.NotZero(t, val.NSPID)
 	assert.NotZero(t, val.CgrpFsMagic)
 
 	mapDir := bpf.MapPrefixPath()
 	err = confmap.UpdateConfMap(mapDir, val)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ret, err := testutils.ReadTgRuntimeConf(mapDir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.EqualValues(t, ret, val)
 
@@ -663,7 +663,7 @@ func TestCgroupNoEvents(t *testing.T) {
 	setupTgRuntimeConf(t, trackingCgrpLevel, uint32(logrus.TraceLevel), invalidValue, invalidValue)
 
 	cgroupFSPath := cgroups.GetCgroupFSPath()
-	assert.NotEmpty(t, cgroupFSPath)
+	require.NotEmpty(t, cgroupFSPath)
 
 	dir, hierarchy := getTestCgroupDirAndHierarchy(t)
 	cgroupRmdir(t, cgroupFSPath, hierarchy, tetragonCgrpRoot)
@@ -680,7 +680,7 @@ func TestCgroupNoEvents(t *testing.T) {
 
 	trigger := func() {
 		err = cgroupMkdir(t, cgroupFSPath, hierarchy, dir)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	events := perfring.RunTestEvents(t, ctx, trigger)
@@ -718,7 +718,7 @@ func TestCgroupEventMkdirRmdir(t *testing.T) {
 	setupTgRuntimeConf(t, trackingCgrpLevel, uint32(logrus.TraceLevel), invalidValue, invalidValue)
 
 	cgroupFSPath := cgroups.GetCgroupFSPath()
-	assert.NotEmpty(t, cgroupFSPath)
+	require.NotEmpty(t, cgroupFSPath)
 
 	dir, hierarchy := getTestCgroupDirAndHierarchy(t)
 	cgroupRmdir(t, cgroupFSPath, hierarchy, tetragonCgrpRoot)
@@ -736,10 +736,10 @@ func TestCgroupEventMkdirRmdir(t *testing.T) {
 
 	trigger := func() {
 		err = cgroupMkdir(t, cgroupFSPath, hierarchy, dir)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = cgroupRmdir(t, cgroupFSPath, hierarchy, dir)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	mkdir := false
@@ -801,7 +801,7 @@ func TestCgroupEventMkdirRmdir(t *testing.T) {
 
 	// Should be removed from the tracking map
 	_, err = cgrouptrackmap.LookupTrackingCgroup(cgrpMapPath, cgrpTrackingId)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testCgroupv2HierarchyInHybrid(ctx context.Context, t *testing.T,
@@ -918,7 +918,7 @@ func testCgroupv2K8sHierarchy(ctx context.Context, t *testing.T, mode cgroups.Cg
 	logDefaultCgroupConfig(t)
 	logTetragonConfig(t, bpf.MapPrefixPath())
 	err = logCgroupMountInfo(t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kubeCgroupHierarchy := make([]cgroupHierarchy, 0)
 	for i, c := range defaultKubeCgroupHierarchy {
@@ -1163,7 +1163,7 @@ func testCgroupv1K8sHierarchyInHybrid(t *testing.T, withExec bool, selectedContr
 	logDefaultCgroupConfig(t)
 	logTetragonConfig(t, bpf.MapPrefixPath())
 	err = logCgroupMountInfo(t)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	triggerCgroupMkdir := func() {
 		for hierarchy, cgroupHierarchy := range kubeCgroupHierarchiesMap {

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -164,7 +164,7 @@ func TestNamespaces(t *testing.T) {
 	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestEventExitThreads(t *testing.T) {
@@ -247,9 +247,9 @@ func TestEventExitThreads(t *testing.T) {
 	checker := testsensor.NewTestChecker(&checker_)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.True(t, seenAll, "did not see all exit events")
+	require.True(t, seenAll, "did not see all exit events")
 }
 
 func TestEventExecve(t *testing.T) {
@@ -284,7 +284,7 @@ func TestEventExecve(t *testing.T) {
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestEventExecveWithUsername(t *testing.T) {
@@ -333,7 +333,7 @@ func TestEventExecveWithUsername(t *testing.T) {
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestEventExecveLongPath(t *testing.T) {
@@ -415,7 +415,7 @@ func TestEventExecveLongPath(t *testing.T) {
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestEventExecveLongArgs(t *testing.T) {
@@ -462,7 +462,7 @@ func TestEventExecveLongArgs(t *testing.T) {
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestEventExecveLongPathLongArgs(t *testing.T) {
@@ -560,7 +560,7 @@ func TestEventExecveLongPathLongArgs(t *testing.T) {
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestLoadInitialSensor(t *testing.T) {
@@ -627,7 +627,7 @@ func TestDocker(t *testing.T) {
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestInInitTree(t *testing.T) {
@@ -707,7 +707,7 @@ func TestInInitTree(t *testing.T) {
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUpdateStatsMap(t *testing.T) {
@@ -824,7 +824,7 @@ func TestExecParse(t *testing.T) {
 		reader := bytes.NewReader(buf.Bytes())
 
 		process, empty, err := execParse(reader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, string(filename), process.Filename)
 		assert.Equal(t, string(cwd), process.Args)
@@ -858,7 +858,7 @@ func TestExecParse(t *testing.T) {
 		reader := bytes.NewReader(buf.Bytes())
 
 		process, empty, err := execParse(reader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// execParse check
 		assert.Equal(t, string(filename), process.Filename)
@@ -884,7 +884,7 @@ func TestExecParse(t *testing.T) {
 		id := dataapi.DataEventId{Pid: 1, Time: 2}
 		desc := dataapi.DataEventDesc{Error: 0, Pad: 0, Leftover: 0, Size: uint32(len(args[:])), Id: id}
 		err = observer.DataAdd(id, args)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		exec.Flags = api.EventDataArgs
 		exec.Size = uint32(processapi.MSG_SIZEOF_EXECVE + len(filename) + binary.Size(desc) + len(cwd) + 1)
@@ -899,7 +899,7 @@ func TestExecParse(t *testing.T) {
 		reader := bytes.NewReader(buf.Bytes())
 
 		process, empty, err := execParse(reader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// execParse check
 		assert.Equal(t, string(filename), process.Filename)
@@ -922,7 +922,7 @@ func TestExecParse(t *testing.T) {
 		id1 := dataapi.DataEventId{Pid: 1, Time: 1}
 		desc1 := dataapi.DataEventDesc{Error: 0, Pad: 0, Leftover: 0, Size: uint32(len(filename[:])), Id: id1}
 		err = observer.DataAdd(id1, filename)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		var args []byte
 		args = append(args, 'a', 'r', 'g', '1', 0, 'a', 'r', 'g', '2', 0)
@@ -930,7 +930,7 @@ func TestExecParse(t *testing.T) {
 		id2 := dataapi.DataEventId{Pid: 1, Time: 2}
 		desc2 := dataapi.DataEventDesc{Error: 0, Pad: 0, Leftover: 0, Size: uint32(len(args[:])), Id: id2}
 		err = observer.DataAdd(id2, args)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		exec.Flags = api.EventDataFilename | api.EventDataArgs
 		exec.Size = uint32(processapi.MSG_SIZEOF_EXECVE + binary.Size(desc1) + binary.Size(desc2) + len(cwd))
@@ -944,7 +944,7 @@ func TestExecParse(t *testing.T) {
 		reader := bytes.NewReader(buf.Bytes())
 
 		process, empty, err := execParse(reader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// execParse check
 		assert.Equal(t, string(filename), process.Filename)
@@ -970,7 +970,7 @@ func TestExecParse(t *testing.T) {
 		id := dataapi.DataEventId{Pid: 1, Time: 2}
 		desc := dataapi.DataEventDesc{Error: 0, Pad: 0, Leftover: 0, Size: uint32(len(args[:])), Id: id}
 		err = observer.DataAdd(id, args)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		exec.Flags = api.EventDataArgs
 		exec.Size = uint32(processapi.MSG_SIZEOF_EXECVE + len(filename) + binary.Size(desc) + len(cwd) + 1)
@@ -985,7 +985,7 @@ func TestExecParse(t *testing.T) {
 		reader := bytes.NewReader(buf.Bytes())
 
 		process, empty, err := execParse(reader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// execParse check
 		assert.Equal(t, strutils.UTF8FromBPFBytes(filename), process.Filename)
@@ -1066,7 +1066,7 @@ func TestExecProcessCredentials(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(execChecker, execGidChecker, exitChecker, exitGidChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Test ensures that running as fully privileged root and executing a setuid or
@@ -1126,7 +1126,7 @@ func TestExecProcessCredentialsSuidRootNoPrivsChange(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(execNoPrivilegesChangedChecker, execSetuidRootNoPrivilegesChangedChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Test running with different combinations of setgid bit set
@@ -1245,7 +1245,7 @@ func TestExecProcessCredentialsSetgidChanges(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(execNoGidsCredsChangedChecker, execSetgidRootChecker, exitSetgidRootChecker, execSetgidNoRootChecker, exitSetgidNoRootChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Test running with different combinations of setuid bit set
@@ -1345,7 +1345,7 @@ func TestExecProcessCredentialsSetuidChanges(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(execSetuidNoRootChecker, exitSetuidNoRootChecker, execSetuidRootChecker, exitSetuidRootChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Detect execution of binaries with file capability sets
@@ -1409,7 +1409,7 @@ func TestExecProcessCredentialsFileCapChanges(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(execChecker, exitChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestExecInodeNotDeleted(t *testing.T) {
@@ -1441,7 +1441,7 @@ func TestExecInodeNotDeleted(t *testing.T) {
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestExecDeletedBinaryMemfd(t *testing.T) {
@@ -1509,7 +1509,7 @@ func TestExecDeletedBinaryMemfd(t *testing.T) {
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestExecDeletedBinary(t *testing.T) {
@@ -1582,7 +1582,7 @@ func TestExecDeletedBinary(t *testing.T) {
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func testThrottle(t *testing.T) {
@@ -1625,7 +1625,7 @@ func testThrottle(t *testing.T) {
 	time.Sleep(8 * time.Second)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestThrottle1(t *testing.T) {

--- a/pkg/sensors/exec/exit_test.go
+++ b/pkg/sensors/exec/exit_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -57,7 +57,7 @@ func TestExit(t *testing.T) {
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestExitLeader(t *testing.T) {
@@ -178,7 +178,7 @@ func TestExitZombie(t *testing.T) {
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // TestExitCode tests whether we properly return the exit code of the process.
@@ -245,7 +245,7 @@ func TestExitCode(t *testing.T) {
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // TestExitSignal tests whether we properly return the exit signal of the process.
@@ -299,5 +299,5 @@ func TestExitSignal(t *testing.T) {
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/sensors/exec/fork_test.go
+++ b/pkg/sensors/exec/fork_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestFork checks that tetragon properly handles processes that fork() but do not exec()
@@ -79,7 +80,7 @@ func TestFork(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(exitCheck)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 type forkTesterInfo struct {

--- a/pkg/sensors/exec/threads_test.go
+++ b/pkg/sensors/exec/threads_test.go
@@ -224,5 +224,5 @@ func TestExecThreads(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(execCheck, exitCheck)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -44,12 +44,12 @@ func TestAddPolicy(t *testing.T) {
 
 	policy := v1alpha1.TracingPolicy{}
 	mgr, err := StartSensorManager("")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	policy.Name = "test-policy"
 	err = mgr.AddTracingPolicy(ctx, &policy)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	l, err := mgr.ListSensors(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []SensorStatus{{Name: "dummy-sensor", Enabled: true, Collection: "test-policy (object:0/) (type:/)"}}, *l)
 }
 
@@ -67,12 +67,12 @@ func TestAddPolicies(t *testing.T) {
 
 	policy := v1alpha1.TracingPolicy{}
 	mgr, err := StartSensorManager("")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	policy.Name = "test-policy"
 	err = mgr.AddTracingPolicy(ctx, &policy)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	l, err := mgr.ListSensors(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ElementsMatch(t, []SensorStatus{
 		{Name: "dummy-sensor1", Enabled: true, Collection: "test-policy (object:0/) (type:/)"},
 		{Name: "dummy-sensor2", Enabled: true, Collection: "test-policy (object:0/) (type:/)"},
@@ -93,13 +93,13 @@ func TestAddPolicySpecError(t *testing.T) {
 
 	policy := v1alpha1.TracingPolicy{}
 	mgr, err := StartSensorManager("")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	policy.Name = "test-policy"
 	err = mgr.AddTracingPolicy(ctx, &policy)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 	t.Logf("got error (as expected): %s", err)
 	l, err := mgr.ListSensors(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []SensorStatus{}, *l)
 }
 
@@ -120,14 +120,14 @@ func TestAddPolicyLoadError(t *testing.T) {
 
 	policy := v1alpha1.TracingPolicy{}
 	mgr, err := StartSensorManager("")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	policy.Name = "test-policy"
 	addError := mgr.AddTracingPolicy(ctx, &policy)
-	assert.NotNil(t, addError)
+	require.NotNil(t, addError)
 	t.Logf("got error (as expected): %s", addError)
 
 	l, err := mgr.ListTracingPolicies(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, l.Policies, 1)
 	assert.Equal(t, LoadErrorState.ToTetragonState(), l.Policies[0].State)
 	assert.Equal(t, addError.Error(), l.Policies[0].Error)
@@ -138,7 +138,7 @@ func TestPolicyFilterDisabled(t *testing.T) {
 	defer cancel()
 
 	mgr, err := StartSensorManagerWithPF("", policyfilter.DisabledState())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	policy := v1alpha1.TracingPolicy{}
 
@@ -192,10 +192,10 @@ func TestPolicyStates(t *testing.T) {
 		require.NoError(t, err)
 		policy.Name = "test-policy"
 		addError := mgr.AddTracingPolicy(ctx, &policy)
-		assert.NotNil(t, addError)
+		require.NotNil(t, addError)
 
 		l, err := mgr.ListTracingPolicies(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, l.Policies, 1)
 		assert.Equal(t, LoadErrorState.ToTetragonState(), l.Policies[0].State)
 		assert.Equal(t, addError.Error(), l.Policies[0].Error)
@@ -212,17 +212,17 @@ func TestPolicyStates(t *testing.T) {
 		require.NoError(t, err)
 		policy.Name = "test-policy"
 		err = mgr.AddTracingPolicy(ctx, &policy)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		l, err := mgr.ListTracingPolicies(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, l.Policies, 1)
 		assert.Equal(t, EnabledState.ToTetragonState(), l.Policies[0].State)
 
 		err = mgr.DisableTracingPolicy(ctx, policy.Name, policy.Namespace)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		l, err = mgr.ListTracingPolicies(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, l.Policies, 1)
 		assert.Equal(t, DisabledState.ToTetragonState(), l.Policies[0].State)
 	})
@@ -247,10 +247,10 @@ func TestPolicyLoadErrorOverride(t *testing.T) {
 	require.NoError(t, err)
 	policy.Name = "test-policy"
 	addError := mgr.AddTracingPolicy(ctx, &policy)
-	assert.NotNil(t, addError)
+	require.NotNil(t, addError)
 
 	l, err := mgr.ListTracingPolicies(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, l.Policies, 1)
 	assert.Equal(t, LoadErrorState.ToTetragonState(), l.Policies[0].State)
 	assert.Equal(t, addError.Error(), l.Policies[0].Error)
@@ -262,10 +262,10 @@ func TestPolicyLoadErrorOverride(t *testing.T) {
 		delete(registeredPolicyHandlers, "dummy")
 	})
 	addError = mgr.AddTracingPolicy(ctx, &policy)
-	assert.NoError(t, addError)
+	require.NoError(t, addError)
 
 	l, err = mgr.ListTracingPolicies(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, l.Policies, 1)
 	assert.Equal(t, EnabledState.ToTetragonState(), l.Policies[0].State)
 }

--- a/pkg/sensors/test/lseek_test.go
+++ b/pkg/sensors/test/lseek_test.go
@@ -17,7 +17,7 @@ import (
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
 	tuo "github.com/cilium/tetragon/pkg/testutils/observer"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -54,7 +54,7 @@ func TestSensorLseekLoad(t *testing.T) {
 	unix.Seek(BogusFd, 0, BogusWhenceVal)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSensorLseekEnable(t *testing.T) {
@@ -87,5 +87,5 @@ func TestSensorLseekEnable(t *testing.T) {
 	unix.Seek(BogusFd, 0, BogusWhenceVal)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/sensors/test/sensors_test.go
+++ b/pkg/sensors/test/sensors_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/tetragon/pkg/sensors/program"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMapBuildersSingle(t *testing.T) {
@@ -253,12 +254,12 @@ func TestMapUser(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s1.Unload(true)
-		assert.NoError(t, err)
 
 		err = s2.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s2.Unload(true)
-		assert.NoError(t, err)
 	})
 
 	// Create sensor with user map (via opts) and make sure it's
@@ -285,12 +286,12 @@ func TestMapUser(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s1.Unload(true)
-		assert.NoError(t, err)
 
 		err = s2.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s2.Unload(true)
-		assert.NoError(t, err)
 	})
 
 	// Create sensor with user map (via MapUser builder) and make sure
@@ -317,12 +318,12 @@ func TestMapUser(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s1.Unload(true)
-		assert.NoError(t, err)
 
 		err = s2.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s2.Unload(true)
-		assert.NoError(t, err)
 	})
 
 	// Create sensor with user map with wrong name (no existing pinned
@@ -372,12 +373,12 @@ func TestMapUser(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s1.Unload(true)
-		assert.NoError(t, err)
 
 		err = s2.Load(bpf.MapPrefixPath())
+		require.Error(t, err)
 		defer s2.Unload(true)
-		assert.Error(t, err)
 	})
 
 	// Create sensor with user map with different spec from real owner
@@ -404,12 +405,12 @@ func TestMapUser(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s1.Unload(true)
-		assert.NoError(t, err)
 
 		err = s3.Load(bpf.MapPrefixPath())
+		require.Error(t, err)
 		defer s3.Unload(true)
-		assert.Error(t, err)
 	})
 }
 
@@ -589,7 +590,7 @@ func TestCleanup(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		s1.Unload(true)
 		verifyRemoved("m1", "m2", "policy")
@@ -614,9 +615,9 @@ func TestCleanup(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = s2.Load(bpf.MapPrefixPath())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		s1.Unload(true)
 		verifyRemoved("policy/sensor1")
@@ -663,10 +664,10 @@ func TestCleanup(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = s3.Load(bpf.MapPrefixPath())
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		s1.Unload(true)
 		verifyRemoved("m1", "policy")
@@ -693,9 +694,9 @@ func TestCleanup(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = s2.Load(bpf.MapPrefixPath())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		s1.Unload(true)
 		verifyRemoved("ns1:policy")
@@ -731,13 +732,13 @@ func TestCleanup(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = s2.Load(bpf.MapPrefixPath())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = s2.Unload(true)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// s1 is still loaded and we just unloaded s2 with m1 being user map,
 		// m1 should be untouched
@@ -747,7 +748,7 @@ func TestCleanup(t *testing.T) {
 		verifyRemoved("policy/sensor2")
 
 		err = s1.Unload(true)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// s1 unload takes down everything
 		verifyRemoved("policy", "m1", "m2")
@@ -795,12 +796,12 @@ func TestNamespace(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s1.Unload(true)
-		assert.NoError(t, err)
 
 		err = s2.Load(bpf.MapPrefixPath())
+		require.NoError(t, err)
 		defer s2.Unload(true)
-		assert.NoError(t, err)
 
 		assert.Equal(t, "ns1:policy/sensor1/p1", p1.PinPath)
 		assert.Equal(t, "ns2:policy/sensor2/p2", p2.PinPath)

--- a/pkg/sensors/tracing/enforcer_test.go
+++ b/pkg/sensors/tracing/enforcer_test.go
@@ -86,7 +86,7 @@ func testEnforcer(t *testing.T, configHook string,
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestEnforcerOverride(t *testing.T) {
@@ -258,7 +258,7 @@ func TestEnforcerMultiNotSupported(t *testing.T) {
 		WithOverrideValue(-17). // EEXIST
 		MustYAML()
 	err := checkCrd(t, yaml)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func testSecurity(t *testing.T, tracingPolicy, tempFile string) {
@@ -282,7 +282,7 @@ func testSecurity(t *testing.T, tracingPolicy, tempFile string) {
 
 	cmd := exec.Command(testBin, tempFile)
 	err = cmd.Run()
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	t.Logf("Running: %s %v\n", cmd.String(), err)
 
@@ -300,12 +300,12 @@ func testSecurity(t *testing.T, tracingPolicy, tempFile string) {
 
 	checker := eventchecker.NewUnorderedEventChecker(kpCheckerPwrite)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// check the pwrite syscall did not write anything
 	fileInfo, err := os.Stat(tempFile)
 	if assert.NoError(t, err) {
-		assert.NotEqual(t, 0, fileInfo.Size())
+		require.NotEqual(t, 0, fileInfo.Size())
 	}
 }
 
@@ -627,16 +627,16 @@ spec:
 	tus.LoadInitialSensor(t)
 
 	sensor1, err := gEnforcerPolicy.PolicyHandler(policy1, policyfilter.NoFilterID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sensor2, err := policyHandler{}.PolicyHandler(policy1, policyfilter.NoFilterID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sensor3, err := gEnforcerPolicy.PolicyHandler(policy2, policyfilter.NoFilterID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	sensor4, err := policyHandler{}.PolicyHandler(policy2, policyfilter.NoFilterID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Loading all policies
 	tus.LoadSensor(t, sensor1)
@@ -736,7 +736,7 @@ func testEnforcerPersistentKeep(t *testing.T, builder func() *EnforcerSpecBuilde
 	tus.LoadInitialSensor(t)
 	path := bpf.MapPrefixPath()
 	mgr, err := sensors.StartSensorManager(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	run := func(idx int, exp string) {
 		cmd := exec.Command(test, "0xfffe")
@@ -749,10 +749,10 @@ func testEnforcerPersistentKeep(t *testing.T, builder func() *EnforcerSpecBuilde
 	}
 
 	tp, err := builder().WithoutMultiKprobe().Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = mgr.AddTracingPolicy(ctx, tp)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// first run - sensors are loaded, we should get kill/override
 	run(1, expected)
@@ -797,7 +797,7 @@ func testEnforcerPersistentNoKeep(t *testing.T, builder func() *EnforcerSpecBuil
 	tus.LoadInitialSensor(t)
 	path := bpf.MapPrefixPath()
 	mgr, err := sensors.StartSensorManager(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	run := func(idx int, exp string) {
 		cmd := exec.Command(test, "0xfffe")
@@ -810,10 +810,10 @@ func testEnforcerPersistentNoKeep(t *testing.T, builder func() *EnforcerSpecBuil
 	}
 
 	tp, err := builder().WithoutMultiKprobe().Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = mgr.AddTracingPolicy(ctx, tp)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// first run - sensors are loaded, we should get kill/override
 	run(1, expected)
@@ -853,7 +853,7 @@ func testEnforcerPersistentUnload(t *testing.T, builder func() *EnforcerSpecBuil
 	tus.LoadInitialSensor(t)
 	path := bpf.MapPrefixPath()
 	mgr, err := sensors.StartSensorManager(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	run := func(idx int, exp string) {
 		cmd := exec.Command(test, "0xfffe")
@@ -866,17 +866,17 @@ func testEnforcerPersistentUnload(t *testing.T, builder func() *EnforcerSpecBuil
 	}
 
 	tp, err := builder().WithoutMultiKprobe().Build()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = mgr.AddTracingPolicy(ctx, tp)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// first run - sensors are loaded, we should get kill/override
 	run(1, expected)
 
 	// disable the policy and we should get rid of the enforcement
 	err = mgr.DisableTracingPolicy(ctx, tp.TpName(), "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// bpf pinned links removal is asynchronous, we need to wait to be sure it's gone
 	time.Sleep(2 * time.Second)
@@ -886,14 +886,14 @@ func testEnforcerPersistentUnload(t *testing.T, builder func() *EnforcerSpecBuil
 
 	// enable the policy and we should get the enforcement
 	err = mgr.EnableTracingPolicy(ctx, tp.TpName(), "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// third run - sensors are loaded, we should get kill/override
 	run(3, expected)
 
 	// remove the policy and we should get rid of the enforcement
 	err = mgr.DeleteTracingPolicy(ctx, tp.TpName(), "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// bpf pinned links removal is asynchronous, we need to wait to be sure it's gone
 	time.Sleep(2 * time.Second)

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -12,6 +12,7 @@ import (
 	gt "github.com/cilium/tetragon/pkg/generictypes"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // This test attempt to test the Resolve flag in tracing policies.
@@ -46,7 +47,7 @@ spec:
       resolve: 'mm.owner.real_parent.real_parent.real_parent.real_parent.real_parent.real_parent.real_parent.real_parent.comm'
   `
 	policy, err := tracingpolicy.FromYAML(rawPolicy)
-	assert.NoError(t, err, "FromYAML rawPolicy error %q", err)
+	require.NoError(t, err, "FromYAML rawPolicy error %q", err)
 
 	successHook := policy.TpSpec().KProbes[:2]
 	for _, hook := range successHook {
@@ -56,11 +57,11 @@ spec:
 			if err != nil {
 				t.Fatal(hook.Call, err)
 			}
-			assert.NotNil(t, lastBTFType)
+			require.NotNil(t, lastBTFType)
 			assert.NotNil(t, btfArg)
 
 			argType := findTypeFromBTFType(arg, lastBTFType)
-			assert.NotEqual(t, gt.GenericInvalidType, argType, "Type %q is not supported", (*lastBTFType).TypeName())
+			require.NotEqual(t, gt.GenericInvalidType, argType, "Type %q is not supported", (*lastBTFType).TypeName())
 		}
 	}
 

--- a/pkg/sensors/tracing/generickprobe_test.go
+++ b/pkg/sensors/tracing/generickprobe_test.go
@@ -149,34 +149,34 @@ func Test_DisableEnablePolicy_Kprobe(t *testing.T) {
 	tus.LoadInitialSensor(t)
 	path := bpf.MapPrefixPath()
 	mgr, err := sensors.StartSensorManager(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("sensor", func(t *testing.T) {
 		err = mgr.AddTracingPolicy(ctx, &tcpConnectPolicy)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = mgr.DeleteTracingPolicy(ctx, tcpConnectPolicyName, tcpConnectPolicyNamespace)
 			assert.NoError(t, err)
 		})
 
 		err = mgr.DisableSensor(ctx, tcpConnectPolicyName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = mgr.EnableSensor(ctx, tcpConnectPolicyName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("tracing-policy", func(t *testing.T) {
 		err = mgr.AddTracingPolicy(ctx, &tcpConnectPolicy)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = mgr.DeleteTracingPolicy(ctx, tcpConnectPolicyName, tcpConnectPolicyNamespace)
 			assert.NoError(t, err)
 		})
 
 		err = mgr.DisableTracingPolicy(ctx, tcpConnectPolicyName, tcpConnectPolicyNamespace)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = mgr.EnableTracingPolicy(ctx, tcpConnectPolicyName, tcpConnectPolicyNamespace)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 

--- a/pkg/sensors/tracing/kprobe_amd64_test.go
+++ b/pkg/sensors/tracing/kprobe_amd64_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+	"github.com/stretchr/testify/require"
 
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
 
-	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 )
 
@@ -113,7 +113,7 @@ spec:
 	syscall.Ioperm(io_delay, 1, 0)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeListSyscallDups(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_copyfd_test.go
+++ b/pkg/sensors/tracing/kprobe_copyfd_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
 )
@@ -108,5 +108,5 @@ func TestCopyFd(t *testing.T) {
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/sensors/tracing/kprobe_filterchange_test.go
+++ b/pkg/sensors/tracing/kprobe_filterchange_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
 )
@@ -105,7 +105,7 @@ func TestKprobeNSChanges(t *testing.T) {
 		kprobeChecker,
 	)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func testKprobeCapChanges(t *testing.T, spec string, op string, value string) {
@@ -188,7 +188,7 @@ func testKprobeCapChanges(t *testing.T, spec string, op string, value string) {
 	)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeCapChangesIn(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_process_credentials_test.go
+++ b/pkg/sensors/tracing/kprobe_process_credentials_test.go
@@ -21,11 +21,10 @@ import (
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/reader/caps"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestKprobeTraceCommitCreds(t *testing.T) {
@@ -174,7 +173,7 @@ spec:
 
 	checker := ec.NewUnorderedEventChecker(kpChangeGidChecker, kpChangeUidChecker, kpPrivilegedChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeTraceSecureBits(t *testing.T) {
@@ -336,5 +335,5 @@ spec:
 
 	checker := ec.NewUnorderedEventChecker(kpChangeGidChecker, kpChangeUidChecker, kpPrivilegedChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/sensors/tracing/kprobe_sigkill_test.go
+++ b/pkg/sensors/tracing/kprobe_sigkill_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
 )
@@ -81,7 +81,7 @@ func testSigkill(t *testing.T, makeSpecFile func(pid string) string, checker *ev
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSigkill(t *testing.T) {
@@ -300,7 +300,7 @@ func testUnprivilegedUsernsKill(t *testing.T, pidns bool) {
 	checker := eventchecker.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKillUnprivilegedUserns(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -183,7 +183,7 @@ spec:
 	unix.Seek(-1, 0, 4444)
 
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(kpChecker))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func getTestKprobeObjectWRChecker(t *testing.T) ec.MultiEventChecker {
@@ -227,10 +227,10 @@ func runKprobeObjectWriteRead(t *testing.T, writeReadHook string) {
 	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()
 	_, err = syscall.Write(1, []byte("hello world"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeObjectWriteReadHostNs(t *testing.T) {
@@ -503,7 +503,7 @@ func runKprobeObjectRead(t *testing.T, readHook string, checker ec.MultiEventChe
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeObjectRead(t *testing.T) {
@@ -681,9 +681,9 @@ func testKprobeObjectFiltered(t *testing.T,
 	data := "hello world"
 	n, err := syscall.Write(fd2, []byte(data))
 	assert.Equal(t, len(data), n)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = jsonchecker.JsonTestCheckExpect(t, checker, expectFailure)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // String matches should not require the '\0' null character on the end.
@@ -783,7 +783,7 @@ func testKprobeStringMatch(t *testing.T,
 	readyWG.Wait()
 	syscall.Open(filePath, syscall.O_RDONLY, 0)
 	err = jsonchecker.JsonTestCheckExpect(t, checker, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func testKprobeStringMatchHook(pidStr string, dir string) string {
@@ -1629,7 +1629,7 @@ func testKprobeObjectFilteredReturnValue(t *testing.T,
 	fd2, _ := syscall.Open(path, syscall.O_RDWR, 0x770)
 	t.Cleanup(func() { syscall.Close(fd2) })
 	err = jsonchecker.JsonTestCheckExpect(t, checker, expectFailure)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeObjectFilterReturnValueGTOk(t *testing.T) {
@@ -1807,10 +1807,10 @@ spec:
 	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()
 	err = helloIovecWorldWritev()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func getFilpOpenChecker(dir string) ec.MultiEventChecker {
@@ -2067,9 +2067,9 @@ func corePathTest(t *testing.T, filePath string, readHook string, writeChecker e
 	data := "hello world"
 	n, err := syscall.Write(fd2, []byte(data))
 	assert.Equal(t, len(data), n)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = jsonchecker.JsonTestCheck(t, writeChecker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func testMultipleMountsFiltered(t *testing.T, readHook string) {
@@ -2316,7 +2316,7 @@ spec:
 		uintptr(flags), 0)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // override
@@ -2362,9 +2362,9 @@ func runKprobeOverride(t *testing.T, hook string, checker ec.MultiEventChecker,
 	err = jsonchecker.JsonTestCheck(t, checker)
 
 	if nopost {
-		assert.Error(t, err)
+		require.Error(t, err)
 	} else {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -2375,7 +2375,7 @@ func TestKprobeOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer assert.NoError(t, file.Close())
+	defer require.NoError(t, file.Close())
 
 	openAtHook := `
 apiVersion: cilium.io/v1alpha1
@@ -2440,7 +2440,7 @@ func TestKprobeOverrideSecurity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer assert.NoError(t, file.Close())
+	defer require.NoError(t, file.Close())
 
 	openAtHook := `
 apiVersion: cilium.io/v1alpha1
@@ -2498,7 +2498,7 @@ func TestKprobeOverrideNopostAction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer assert.NoError(t, file.Close())
+	defer require.NoError(t, file.Close())
 
 	openAtHook := `
 apiVersion: cilium.io/v1alpha1
@@ -2603,9 +2603,9 @@ func runKprobeOverrideSignal(t *testing.T, hook string, checker ec.MultiEventChe
 	err = jsonchecker.JsonTestCheck(t, checker)
 
 	if nopost {
-		assert.Error(t, err)
+		require.Error(t, err)
 	} else {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -2619,7 +2619,7 @@ func TestKprobeOverrideSignal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer assert.NoError(t, file.Close())
+	defer require.NoError(t, file.Close())
 
 	openAtHook := `
 apiVersion: cilium.io/v1alpha1
@@ -2685,7 +2685,7 @@ func TestKprobeSignalOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer assert.NoError(t, file.Close())
+	defer require.NoError(t, file.Close())
 
 	openAtHook := `
 apiVersion: cilium.io/v1alpha1
@@ -2751,7 +2751,7 @@ func TestKprobeSignalOverrideNopost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer assert.NoError(t, file.Close())
+	defer require.NoError(t, file.Close())
 
 	openAtHook := `
 apiVersion: cilium.io/v1alpha1
@@ -2864,7 +2864,7 @@ func runKprobeOverrideMulti(t *testing.T, hook string, checker ec.MultiEventChec
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeOverrideMulti(t *testing.T) {
@@ -2882,7 +2882,7 @@ func TestKprobeOverrideMulti(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTemp failed: %s", err)
 	}
-	defer assert.NoError(t, file.Close())
+	defer require.NoError(t, file.Close())
 
 	link, err := os.CreateTemp(t.TempDir(), "kprobe-override-")
 	if err != nil {
@@ -3093,7 +3093,7 @@ func runKprobe_char_iovec(t *testing.T, configHook string,
 
 	iovw[0] = buffer
 	_, err = unix.Writev(fdw, iovw)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	syscall.Fsync(fdw)
 
@@ -3107,10 +3107,10 @@ func runKprobe_char_iovec(t *testing.T, configHook string,
 	iovr[7] = make([]byte, 1700)
 
 	_, err = unix.Readv(fdr, iovr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobe_char_iovec(t *testing.T) {
@@ -3471,7 +3471,7 @@ func TestKprobeMatchArgsFileEqual(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeMatchArgsFilePostfix(t *testing.T) {
@@ -3511,7 +3511,7 @@ func TestKprobeMatchArgsFilePostfix(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeMatchArgsFilePrefix(t *testing.T) {
@@ -3551,7 +3551,7 @@ func TestKprobeMatchArgsFilePrefix(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeMatchArgsFdEqual(t *testing.T) {
@@ -3587,7 +3587,7 @@ func TestKprobeMatchArgsFdEqual(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeMatchArgsFdPostfix(t *testing.T) {
@@ -3623,7 +3623,7 @@ func TestKprobeMatchArgsFdPostfix(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeMatchArgsFdPrefix(t *testing.T) {
@@ -3659,7 +3659,7 @@ func TestKprobeMatchArgsFdPrefix(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func getMatchArgsFileFIMCrd(vals []string) string {
@@ -3719,7 +3719,7 @@ func TestKprobeMatchArgsFileMonitoringPrefix(t *testing.T) {
 
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeMatchArgsNonPrefix(t *testing.T) {
@@ -3789,7 +3789,7 @@ spec:
 
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// now check that there is no read event for "/etc/passwd" and "/etc/group"
 	kpErrCheckers := make([]ec.EventChecker, 2)
@@ -3806,7 +3806,7 @@ spec:
 
 	errChecker := ec.NewUnorderedEventChecker(kpErrCheckers...)
 	err = jsonchecker.JsonTestCheck(t, errChecker)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func getMatchBinariesCrd(opStr string, vals []string) string {
@@ -3872,7 +3872,7 @@ func matchBinariesTest(t *testing.T, operator string, values []string, kpChecker
 
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 const skipMatchBinaries = "kernels without large progs do not support matchBinaries Prefix/NotPrefix/Postfix/NotPostfix"
@@ -3935,7 +3935,7 @@ func matchBinariesLargePathTest(t *testing.T, operator string, values []string, 
 		WithProcess(ec.NewProcessChecker().WithBinary(sm.Full(binary))).
 		WithFunctionName(sm.Full("fd_install")))
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 }
 func TestKprobeMatchBinariesLargePath(t *testing.T) {
@@ -4021,16 +4021,16 @@ func matchBinariesPerfringTest(t *testing.T, operator string, values []string) {
 		headCmd := exec.Command("/usr/bin/head", "/etc/passwd")
 
 		err := tailCmd.Start()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		tailPID = tailCmd.Process.Pid
 		err = headCmd.Start()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		headPID = headCmd.Process.Pid
 
 		err = tailCmd.Wait()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = headCmd.Wait()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	events := perfring.RunTestEvents(t, ctx, ops)
 
@@ -4079,7 +4079,7 @@ func TestKprobeMatchBinariesEarlyExec(t *testing.T) {
 
 	// create a temporary file
 	file, err := os.CreateTemp("/tmp", fmt.Sprintf("tetragon.%s.", t.Name()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		file.Close()
 		os.Remove(file.Name())
@@ -4087,7 +4087,7 @@ func TestKprobeMatchBinariesEarlyExec(t *testing.T) {
 	// execute commands before Tetragon starts
 	tailCommand := exec.Command("/usr/bin/tail", "-f", file.Name())
 	err = tailCommand.Start()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer tailCommand.Process.Kill()
 
 	if err := observer.InitDataCache(1024); err != nil {
@@ -4217,21 +4217,21 @@ func TestKprobeMatchBinariesPrefixMatchArgs(t *testing.T) {
 		headCmd := exec.Command("/usr/bin/head", "/etc/passwd")
 
 		err := tailEtcCmd.Start()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		tailEtcPID = tailEtcCmd.Process.Pid
 		err = tailProcCmd.Start()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		tailProcPID = tailProcCmd.Process.Pid
 		err = headCmd.Start()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		headPID = headCmd.Process.Pid
 
 		err = tailEtcCmd.Wait()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = tailProcCmd.Wait()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = headCmd.Wait()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	events := perfring.RunTestEvents(t, ctx, ops)
 
@@ -4330,7 +4330,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestLoadKprobeSensor(t *testing.T) {
@@ -4510,15 +4510,15 @@ spec:
 `
 
 	_, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, "", tus.Conf().TetragonLib, observertesthelper.WithMyPid())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tp, err := tracingpolicy.FromYAML(testHook)
-	assert.NoError(t, err)
-	assert.NotNil(t, tp)
+	require.NoError(t, err)
+	require.NotNil(t, tp)
 
 	sens, err := sensors.GetMergedSensorFromParserPolicy(tp)
-	assert.Error(t, err)
-	assert.Nil(t, sens)
+	require.Error(t, err)
+	require.Nil(t, sens)
 
 	t.Logf("got error (as expected): %s", err)
 }
@@ -4545,10 +4545,10 @@ func testMaxData(t *testing.T, data []byte, checker *ec.UnorderedEventChecker, c
 	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()
 	_, err = syscall.Write(fd, data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeWriteMaxDataTrunc(t *testing.T) {
@@ -4827,9 +4827,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -4844,7 +4844,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockNotPort(t *testing.T) {
@@ -4916,9 +4916,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -4933,7 +4933,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockMultiplePorts(t *testing.T) {
@@ -5009,9 +5009,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -5026,7 +5026,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockPortRange(t *testing.T) {
@@ -5098,9 +5098,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -5115,7 +5115,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockPrivPorts(t *testing.T) {
@@ -5183,9 +5183,9 @@ spec:
 	go miniTcpNopServerWithPort(tcpReady, 1020, false)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:1020")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -5200,7 +5200,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockNotPrivPorts(t *testing.T) {
@@ -5268,9 +5268,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -5285,7 +5285,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockNotCIDR(t *testing.T) {
@@ -5357,9 +5357,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -5374,7 +5374,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockNotCIDRWrongAF(t *testing.T) {
@@ -5446,9 +5446,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -5463,7 +5463,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockMultipleCIDRs(t *testing.T) {
@@ -5539,9 +5539,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -5556,7 +5556,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockState(t *testing.T) {
@@ -5639,9 +5639,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-state-checker").
 		WithFunctionName(sm.Full("tcp_set_state")).
@@ -5657,7 +5657,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockFamily(t *testing.T) {
@@ -5733,9 +5733,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -5751,7 +5751,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSocketAndSockaddr(t *testing.T) {
@@ -5831,9 +5831,9 @@ spec:
 	go miniTcpNopServer(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("security-socket-connect-checker").
 		WithFunctionName(sm.Full("security_socket_connect")).
@@ -5851,7 +5851,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSkb(t *testing.T) {
@@ -5946,7 +5946,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSockIpv6(t *testing.T) {
@@ -6018,9 +6018,9 @@ spec:
 	go miniTcpNopServer6(tcpReady)
 	<-tcpReady
 	addr, err := net.ResolveTCPAddr("tcp", "[::1]:9919")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = net.DialTCP("tcp", nil, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kpChecker := ec.NewProcessKprobeChecker("tcp-connect-checker").
 		WithFunctionName(sm.Full("tcp_connect")).
@@ -6035,7 +6035,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeSkbIpv6(t *testing.T) {
@@ -6130,7 +6130,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func testKprobeRateLimit(t *testing.T, rateLimit bool) {
@@ -6187,7 +6187,7 @@ spec:
 
 	server := "nc.openbsd"
 	cmdServer := exec.Command(server, "-unvlp", "9468", "-s", "127.0.0.1")
-	assert.NoError(t, cmdServer.Start())
+	require.NoError(t, cmdServer.Start())
 	time.Sleep(1 * time.Second)
 
 	// Generate 5 datagrams
@@ -6230,9 +6230,9 @@ spec:
 	cmdServer.Process.Kill()
 
 	err = jsonchecker.JsonTestCheck(t, checkerSuccess)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = jsonchecker.JsonTestCheckExpect(t, checkerFailure, true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeNoRateLimit(t *testing.T) {
@@ -6401,9 +6401,9 @@ func TestLinuxBinprmExtractPath(t *testing.T) {
 
 	ops := func() {
 		err = targetCommand.Start()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = filteredCommand.Start()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer targetCommand.Process.Kill()
 		defer filteredCommand.Process.Kill()
 	}
@@ -6589,7 +6589,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker1, kpChecker2, kpChecker3, kpChecker4)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeKernelStackTrace(t *testing.T) {
@@ -6649,7 +6649,7 @@ spec:
 
 	checker := ec.NewUnorderedEventChecker(stackTraceChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 func TestKprobeUserStackTrace(t *testing.T) {
 	var doneWG, readyWG sync.WaitGroup
@@ -6716,7 +6716,7 @@ spec:
 	// Kill test because of endless loop in the test for stable stack trace extraction
 	test_cmd.Process.Kill()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeMultiMatcArgs(t *testing.T) {
@@ -6828,7 +6828,7 @@ spec:
 
 	checker := ec.NewUnorderedEventChecker(kpCheckersRead, kpCheckersMmap)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func trigger(t *testing.T) {
@@ -7030,7 +7030,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(check1, check2, check3, check4, check5)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Detect changing capabilities
@@ -7158,7 +7158,7 @@ spec:
 
 	checker := ec.NewUnorderedEventChecker(kpCheckers1, kpCheckers2)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestMissedProgStatsKprobeMulti(t *testing.T) {
@@ -7221,7 +7221,7 @@ tetragon_missed_prog_probes_total{attach="security_bprm_committing_creds",policy
 tetragon_missed_prog_probes_total{attach="wake_up_new_task",policy="__base__"} 0
 `)
 
-	assert.NoError(t, testutil.GatherAndCompare(metricsconfig.GetRegistry(), expected,
+	require.NoError(t, testutil.GatherAndCompare(metricsconfig.GetRegistry(), expected,
 		prometheus.BuildFQName(consts.MetricsNamespace, "", "missed_prog_probes_total")))
 
 }
@@ -7287,7 +7287,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(mapCreate, progLoad, btfLoad)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeMultiSymbolInstancesOk(t *testing.T) {
@@ -7351,7 +7351,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kp_8888, kp_9999)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // TestLongPath could be split into a test checking for long args from kprobe
@@ -7428,7 +7428,7 @@ spec:
 
 	checker := ec.NewUnorderedEventChecker(kprobeLongFileArgChecker, processLongCWDChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestMaxPath(t *testing.T) {
@@ -7514,7 +7514,7 @@ spec:
 
 		checker := ec.NewUnorderedEventChecker(kprobeCheck)
 		err = jsonchecker.JsonTestCheck(t, checker)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("path", func(t *testing.T) {
@@ -7560,7 +7560,7 @@ spec:
 
 		checker := ec.NewUnorderedEventChecker(kprobeChecker)
 		err = jsonchecker.JsonTestCheck(t, checker)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("dentry", func(t *testing.T) {
@@ -7649,7 +7649,7 @@ spec:
 		checker := ec.NewUnorderedEventChecker(kpChecker)
 
 		err = jsonchecker.JsonTestCheck(t, checker)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -7666,7 +7666,7 @@ func TestKprobeDentryPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer assert.NoError(t, file_1.Close())
+	defer require.NoError(t, file_1.Close())
 
 	file_2, err := os.CreateTemp(t.TempDir(), "dentry-unlink-2")
 	if err != nil {
@@ -7746,11 +7746,11 @@ spec:
 
 	// We filter for file_1 (check_1) so we should get event for that
 	err = jsonchecker.JsonTestCheck(t, getChecker(check_1))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// ... but not for file_2 (check_2).
 	err = jsonchecker.JsonTestCheck(t, getChecker(check_2))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestKprobeResolvePid(t *testing.T) {
@@ -7804,7 +7804,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeArgsReverse(t *testing.T) {
@@ -7871,7 +7871,7 @@ spec:
 	unix.Seek(0, 1, 2)
 
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(kpChecker))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeResolveSecondArg(t *testing.T) {
@@ -7924,5 +7924,5 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/sensors/tracing/kprobe_threads_test.go
+++ b/pkg/sensors/tracing/kprobe_threads_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
@@ -23,7 +24,6 @@ import (
 	"github.com/cilium/tetragon/pkg/reader/namespace"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestKprobeCloneThreads(t *testing.T) {
@@ -132,5 +132,5 @@ spec:
 	checker := ec.NewUnorderedEventChecker(execCheck, child1KpChecker, thread1KpChecker, exitCheck)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/sensors/tracing/kprobe_validation_test.go
+++ b/pkg/sensors/tracing/kprobe_validation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func checkCrd(t *testing.T, crd string) error {
@@ -45,7 +46,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestKprobeValidationListWrongOverride(t *testing.T) {
@@ -73,7 +74,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestKprobeValidationListWrongName(t *testing.T) {
@@ -97,7 +98,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestKprobeValidationListGeneratedSyscallsNotEmpty(t *testing.T) {
@@ -121,7 +122,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestKprobeValidationListGeneratedFtraceNotEmpty(t *testing.T) {
@@ -145,7 +146,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestKprobeValidationListGeneratedFtraceNoPattern(t *testing.T) {
@@ -166,7 +167,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 func TestKprobeValidationWrongSyscallName(t *testing.T) {
 
@@ -183,7 +184,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestKprobeValidationWrongOverride(t *testing.T) {
@@ -205,7 +206,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestKprobeValidationNonSyscallOverride(t *testing.T) {
@@ -231,7 +232,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 }
 
@@ -252,7 +253,7 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestKprobeLTOp(t *testing.T) {
@@ -280,9 +281,9 @@ spec:
 
 	err := checkCrd(t, crd)
 	if config.EnableLargeProgs() {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	} else {
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -311,9 +312,9 @@ spec:
 
 	err := checkCrd(t, crd)
 	if config.EnableLargeProgs() {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	} else {
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -362,7 +363,7 @@ spec:
 	assert.NoError(t, err)
 
 	_, err = tracingpolicy.FromYAML(crd3)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKprobeMultiSymbolInstancesFail(t *testing.T) {
@@ -384,5 +385,5 @@ spec:
 `
 
 	err := checkCrd(t, crd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/sensors/tracing/loader_test.go
+++ b/pkg/sensors/tracing/loader_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type note struct {
@@ -137,8 +137,8 @@ spec:
 	if err := exec.Command(testNop).Run(); err != nil {
 		t.Fatalf("Failed to execute test binary: %s\n", err)
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/sensors/tracing/lsm_test.go
+++ b/pkg/sensors/tracing/lsm_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLSMObjectLoad(t *testing.T) {
@@ -211,7 +212,7 @@ spec:
 	}
 
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(lsmChecker))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestLSMOverrideAction(t *testing.T) {
@@ -283,7 +284,7 @@ spec:
 	assert.Equal(t, -1, testCmd.ProcessState.ExitCode(), "Exit code should be -1")
 
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(lsmChecker))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestLSMIMAHash(t *testing.T) {
@@ -366,5 +367,5 @@ spec:
 		}
 		return true
 	}
-	assert.Condition(t, checkFunc)
+	require.Condition(t, checkFunc)
 }

--- a/pkg/sensors/tracing/tracepoint_amd64_test.go
+++ b/pkg/sensors/tracing/tracepoint_amd64_test.go
@@ -20,7 +20,7 @@ import (
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testListSyscallsDups(t *testing.T, checker *ec.UnorderedEventChecker, configHook string) {
@@ -47,7 +47,7 @@ func testListSyscallsDups(t *testing.T, checker *ec.UnorderedEventChecker, confi
 	syscall.Dup3(9999, 2222, 0)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestTracepointListSyscallDups(t *testing.T) {

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cilium/tetragon/pkg/testutils/perfring"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
@@ -110,7 +109,7 @@ func TestGenericTracepointSimple(t *testing.T) {
 	unix.Seek(-1, 0, whenceBogusValue)
 	time.Sleep(1000 * time.Millisecond)
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // doTestGenericTracepointPidFilter is a utility function for doing generic
@@ -293,7 +292,7 @@ func TestGenericTracepointMeta(t *testing.T) {
 	// We want to write to a file so we can filter by non-stdout fd and thus avoid
 	// catching all the writes to test logs
 	fd, err := syscall.Open("/tmp/testificate", syscall.O_CREAT|syscall.O_WRONLY, 0o644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { syscall.Unlink("/tmp/testificate") }()
 
 	tracepointConf := v1alpha1.TracepointSpec{
@@ -620,7 +619,7 @@ func TestTracepointCloneThreads(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(execCheck, child1TpChecker, thread1TpChecker, exitCheck)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestTracepointForceType(t *testing.T) {
@@ -730,7 +729,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(execCheck, child1TpChecker, thread1TpChecker, exitCheck)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestStringTracepoint(t *testing.T) {
@@ -816,7 +815,7 @@ func testListSyscallsDupsRange(t *testing.T, checker *ec.UnorderedEventChecker, 
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestTracepointListSyscallDupsRange(t *testing.T) {
@@ -938,5 +937,5 @@ spec:
 	checker := ec.NewUnorderedEventChecker(tpChecker)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -28,7 +28,7 @@ import (
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -148,12 +148,12 @@ spec:
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func uprobePidMatch(t *testing.T, pid uint32) error {
 	path, err := os.Executable()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	pidStr := strconv.Itoa(int(pid))
 
@@ -207,12 +207,12 @@ spec:
 
 func TestUprobePidMatch(t *testing.T) {
 	err := uprobePidMatch(t, observertesthelper.GetMyPid())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUprobePidMatchNot(t *testing.T) {
 	err := uprobePidMatch(t, observertesthelper.GetMyPid()+1)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func uprobeBinariesMatch(t *testing.T, execBinary string) error {
@@ -271,13 +271,13 @@ spec:
 func TestUprobeBinariesMatch(t *testing.T) {
 	uprobeTest1 := testutils.RepoRootPath("contrib/tester-progs/uprobe-test-1")
 	err := uprobeBinariesMatch(t, uprobeTest1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUprobeBinariesMatchNot(t *testing.T) {
 	uprobeTest2 := testutils.RepoRootPath("contrib/tester-progs/uprobe-test-2")
 	err := uprobeBinariesMatch(t, uprobeTest2)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestUprobeCloneThreads(t *testing.T) {
@@ -378,7 +378,7 @@ spec:
 	checker := ec.NewUnorderedEventChecker(execCheck, child1UpChecker, thread1UpChecker, exitCheck)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var (
@@ -607,7 +607,7 @@ func testUprobeArgs(t *testing.T, checkers [5]*ec.ProcessUprobeChecker, tp traci
 	}
 
 	err = jsonchecker.JsonTestCheck(t, checker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUprobeArgsWithOffset(t *testing.T) {


### PR DESCRIPTION
Most of the places where we have been using assert in tests, we really wanted the tests to fail at those points and not continue. In these cases, we should use require instead as it does just that. This commit changes a lot of asserts to requires.
