### PR TITLE
linters: enable testifylints and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - perfsprint
     - revive
     - staticcheck
+    - testifylint
     - unused
   settings:
     dupword:

--- a/bpf/tests/prepend_name_test.go
+++ b/bpf/tests/prepend_name_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -148,13 +149,13 @@ func Test_PrependName(t *testing.T) {
 	// This part is factorized since it's the setup used in many of the tests below
 	SetupCatBinHelper := func() {
 		err = state.UpdateDentry("cat")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code := runPrependName()
 		assert.Equal(t, 0, code)
 		assert.Equal(t, "/cat", state.BufferToString())
 
 		err = state.UpdateDentry("bin")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code = runPrependName()
 		assert.Equal(t, 0, code)
 		assert.Equal(t, "/bin/cat", state.BufferToString())
@@ -166,7 +167,7 @@ func Test_PrependName(t *testing.T) {
 		SetupCatBinHelper()
 
 		err = state.UpdateDentry("usr")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code := runPrependName()
 		assert.Equal(t, 0, code)
 		assert.Equal(t, "/usr/bin/cat", state.BufferToString())
@@ -178,7 +179,7 @@ func Test_PrependName(t *testing.T) {
 		SetupCatBinHelper()
 
 		err = state.UpdateDentry("usr")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code := runPrependName()
 		assert.Equal(t, 0, code)
 		assert.NotEqual(t, byte(0), state.Buf()[0])
@@ -191,7 +192,7 @@ func Test_PrependName(t *testing.T) {
 		SetupCatBinHelper()
 
 		err = state.UpdateDentry("usr")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code := runPrependName()
 		assert.Equal(t, -int(unix.ENAMETOOLONG), code)
 		assert.Equal(t, "usr/bin/cat", state.BufferToString())
@@ -203,7 +204,7 @@ func Test_PrependName(t *testing.T) {
 		SetupCatBinHelper()
 
 		err = state.UpdateDentry("usr")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code := runPrependName()
 		assert.Equal(t, 0, code)
 		assert.Equal(t, "/usr/bin/cat", state.BufferToString())
@@ -216,7 +217,7 @@ func Test_PrependName(t *testing.T) {
 		SetupCatBinHelper()
 
 		err = state.UpdateDentry("usr")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code := runPrependName()
 		assert.Equal(t, -int(unix.ENAMETOOLONG), code)
 		assert.Equal(t, "/bin/cat", state.BufferToString())
@@ -228,7 +229,7 @@ func Test_PrependName(t *testing.T) {
 		SetupCatBinHelper()
 
 		err = state.UpdateDentry("usr")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code := runPrependName()
 		assert.Equal(t, -int(unix.ENAMETOOLONG), code)
 		assert.Equal(t, "sr/bin/cat", state.BufferToString())
@@ -242,14 +243,14 @@ func Test_PrependName(t *testing.T) {
 		state.ResetStateWithBuflen(bufsize)
 
 		err = state.UpdateDentry(longDentry)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code := runPrependName()
 		assert.Equal(t, 0, code)
 		assert.Equal(t, "/"+longDentry, state.BufferToString())
 
 		// length is 15, so 239 + 15 + 2 slash chars = 256
 		err = state.UpdateDentry("favorite_recipe")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code = runPrependName()
 		assert.Equal(t, 0, code)
 		assert.Equal(t, "/favorite_recipe"+"/"+longDentry, state.BufferToString())
@@ -264,7 +265,7 @@ func Test_PrependName(t *testing.T) {
 		// (len("/") + 255) * 16 = 4096
 		for range 16 {
 			err = state.UpdateDentry(maxDentry)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			code := runPrependName()
 			assert.Equal(t, 0, code)
 			expectedState += "/" + maxDentry
@@ -280,7 +281,7 @@ func Test_PrependName(t *testing.T) {
 		// (len("/") + 240) * 16 = 3856
 		for range 16 {
 			err = state.UpdateDentry(largeDentry)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			code := runPrependName()
 			assert.Equal(t, 0, code)
 			expectedState = "/" + largeDentry + expectedState
@@ -289,7 +290,7 @@ func Test_PrependName(t *testing.T) {
 		// at this stage, there should be 240 chars left in the buf which leaves
 		// no space for the remaining root slash character
 		err = state.UpdateDentry(largeDentry)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		code := runPrependName()
 		assert.Equal(t, -int(unix.ENAMETOOLONG), code)
 		// note that I intentionally don't add the '/' char

--- a/bpf/tests/prepend_name_test.go
+++ b/bpf/tests/prepend_name_test.go
@@ -253,7 +253,7 @@ func Test_PrependName(t *testing.T) {
 		code = runPrependName()
 		assert.Equal(t, 0, code)
 		assert.Equal(t, "/favorite_recipe"+"/"+longDentry, state.BufferToString())
-		assert.Equal(t, bufsize, len(state.BufferToString()))
+		assert.Len(t, state.BufferToString(), bufsize)
 	})
 
 	t.Run("MaxSizeBufFull", func(t *testing.T) {

--- a/cmd/tetra/getevents/getevents_test.go
+++ b/cmd/tetra/getevents/getevents_test.go
@@ -139,7 +139,7 @@ func Test_GetEvents_FilterFields(t *testing.T) {
 		// remove last trailing newline for splitting
 		output = bytes.TrimSpace(output)
 		lines := bytes.Split(output, []byte("\n"))
-		assert.Equal(t, 2, len(lines))
+		assert.Len(t, lines, 2)
 		for _, line := range lines {
 			var res tetragon.GetEventsResponse
 			err := json.Unmarshal(line, &res)
@@ -148,7 +148,7 @@ func Test_GetEvents_FilterFields(t *testing.T) {
 			}
 			class, ok := res.GetProcessExec().Process.Pod.PodLabels["class"]
 			assert.True(t, ok, "Class label should be present")
-			assert.Equal(t, class, "deathstar")
+			assert.Equal(t, "deathstar", class)
 		}
 	})
 }

--- a/cmd/tetra/getevents/getevents_test.go
+++ b/cmd/tetra/getevents/getevents_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_GetEvents_Namespaces(t *testing.T) {
@@ -52,7 +53,7 @@ func Test_GetEvents_EventTypes(t *testing.T) {
 		cmd.SetOut(&devNull)
 
 		err := cmd.Execute()
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 

--- a/cmd/tetra/getevents/io_reader_client_test.go
+++ b/cmd/tetra/getevents/io_reader_client_test.go
@@ -11,19 +11,19 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/testutils"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ioReaderClient_GetEvents(t *testing.T) {
 	events, err := os.Open(testutils.RepoRootPath("testdata/events.json"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	client := newIOReaderClient(events, false)
 	getEventsClient, err := client.GetEvents(context.Background(), &tetragon.GetEventsRequest{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	for range 3 {
 		_, err := getEventsClient.Recv()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	_, err = getEventsClient.Recv()
-	assert.ErrorIs(t, err, io.EOF)
+	require.ErrorIs(t, err, io.EOF)
 }

--- a/cmd/tetragon/conf_test.go
+++ b/cmd/tetragon/conf_test.go
@@ -1125,16 +1125,16 @@ func runTestCases(t *testing.T) {
 		switch expected := v.(type) {
 		case int:
 			actual := viper.GetInt(opt)
-			require.EqualValuesf(t, expected, actual, "failed to match int option '%s' at test %s", opt, c.description)
+			require.Equalf(t, expected, actual, "failed to match int option '%s' at test %s", opt, c.description)
 		case uint:
 			actual := viper.GetUint(opt)
-			require.EqualValuesf(t, expected, actual, "failed to match uint option '%s' at test %s", opt, c.description)
+			require.Equalf(t, expected, actual, "failed to match uint option '%s' at test %s", opt, c.description)
 		case string:
 			actual := viper.GetString(opt)
-			require.EqualValuesf(t, expected, actual, "failed to match string option '%s' at test %s", opt, c.description)
+			require.Equalf(t, expected, actual, "failed to match string option '%s' at test %s", opt, c.description)
 		case bool:
 			actual := viper.GetBool(opt)
-			require.EqualValuesf(t, expected, actual, "failed to match bool option '%s' at test %s", opt, c.description)
+			require.Equalf(t, expected, actual, "failed to match bool option '%s' at test %s", opt, c.description)
 		}
 	}
 

--- a/cmd/tetragon/main_test.go
+++ b/cmd/tetragon/main_test.go
@@ -62,11 +62,12 @@ func TestGeneratedExecEvents(t *testing.T) {
 		wg.Done()
 	}
 
+	errCh := make(chan error, 1)
 	// Start tetragon in separate process so we can keep the whole
 	// export/server machinery running until we get expected results.
 	go func() {
 		err = tetragonExecuteCtx(ctx, cancel, ready)
-		require.NoError(t, err)
+		errCh <- err
 	}()
 
 	// Wait till tetragon's observer is up and running
@@ -90,5 +91,8 @@ func TestGeneratedExecEvents(t *testing.T) {
 	}
 
 	cancel()
+	require.NoError(t, err)
+	// blocking on terminating tetragon
+	err = <-errCh
 	require.NoError(t, err)
 }

--- a/cmd/tetragon/main_test.go
+++ b/cmd/tetragon/main_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -66,7 +66,7 @@ func TestGeneratedExecEvents(t *testing.T) {
 	// export/server machinery running until we get expected results.
 	go func() {
 		err = tetragonExecuteCtx(ctx, cancel, ready)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}()
 
 	// Wait till tetragon's observer is up and running
@@ -90,5 +90,5 @@ func TestGeneratedExecEvents(t *testing.T) {
 	}
 
 	cancel()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/operator/podinfo/podinfo_controller_suite_test.go
+++ b/operator/podinfo/podinfo_controller_suite_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,17 +37,17 @@ func (suite *ControllerTestSuite) SetupSuite() {
 		UseExistingCluster: &useExistingCluster,
 	}
 	cfg, err := suite.testEnv.Start()
-	assert.NoError(suite.T(), err)
-	assert.NoError(suite.T(), v1alpha1.AddToScheme(scheme.Scheme))
+	require.NoError(suite.T(), err)
+	require.NoError(suite.T(), v1alpha1.AddToScheme(scheme.Scheme))
 	suite.k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 }
 
 // TestPodInfoCreation checks if PodInfo gets created / deleted for a Pod.
 func (suite *ControllerTestSuite) TestPodInfoCreateAndDelete() {
 	ctx := context.Background()
 	pod := getRandomPod("default")
-	assert.NoError(suite.T(), suite.k8sClient.Create(ctx, pod))
+	require.NoError(suite.T(), suite.k8sClient.Create(ctx, pod))
 
 	podLookupKey := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 	assert.Eventually(suite.T(), func() bool {
@@ -66,7 +67,7 @@ func (suite *ControllerTestSuite) TestPodInfoCreateAndDelete() {
 		return equal(pod, podInfo)
 	}, 20*time.Second, 1*time.Second)
 
-	assert.NoError(suite.T(), suite.k8sClient.Delete(ctx, pod))
+	require.NoError(suite.T(), suite.k8sClient.Delete(ctx, pod))
 	assert.Eventually(suite.T(), func() bool {
 		return apierrors.IsNotFound(suite.k8sClient.Get(ctx, podLookupKey, podInfo))
 	}, 20*time.Second, 1*time.Second)
@@ -76,7 +77,7 @@ func (suite *ControllerTestSuite) TestPodInfoCreateAndDelete() {
 func (suite *ControllerTestSuite) TestPodInfoUpdate() {
 	ctx := context.Background()
 	pod := getRandomPod("default")
-	assert.NoError(suite.T(), suite.k8sClient.Create(ctx, pod))
+	require.NoError(suite.T(), suite.k8sClient.Create(ctx, pod))
 	podLookupKey := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 	assert.Eventually(suite.T(), func() bool {
 		err := suite.k8sClient.Get(ctx, podLookupKey, pod)
@@ -98,7 +99,7 @@ func (suite *ControllerTestSuite) TestPodInfoUpdate() {
 
 	// Update the pod labels.
 	pod.ObjectMeta.Labels = getRandMap()
-	assert.NoError(suite.T(), suite.k8sClient.Update(ctx, pod))
+	require.NoError(suite.T(), suite.k8sClient.Update(ctx, pod))
 
 	// Get the updated podInfo
 	assert.Eventually(suite.T(), func() bool {
@@ -133,7 +134,7 @@ func getRandomPod(namespace string) *corev1.Pod {
 
 // TearDownSuite will close the test environment and close the go-routine running the controller.
 func (suite *ControllerTestSuite) TearDownSuite() {
-	assert.NoError(suite.T(), suite.testEnv.Stop())
+	require.NoError(suite.T(), suite.testEnv.Stop())
 }
 
 func TestControllerSuite(t *testing.T) {

--- a/operator/podinfo/podinfo_controller_test.go
+++ b/operator/podinfo/podinfo_controller_test.go
@@ -14,6 +14,7 @@ import (
 	ciliumv1alpha1 "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/podhelpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -307,9 +308,9 @@ func TestReconcile(t *testing.T) {
 	reconciler := Reconciler{client}
 	namespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 	res, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue)
-	assert.NoError(t, client.Get(context.Background(), namespacedName, &ciliumv1alpha1.PodInfo{}))
+	require.NoError(t, client.Get(context.Background(), namespacedName, &ciliumv1alpha1.PodInfo{}))
 }
 
 func TestReconcileWithDeletionTimestamp(t *testing.T) {
@@ -321,7 +322,7 @@ func TestReconcileWithDeletionTimestamp(t *testing.T) {
 	reconciler := Reconciler{client}
 	namespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 	res, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: namespacedName})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue)
 	err = client.Get(context.Background(), namespacedName, &ciliumv1alpha1.PodInfo{})
 	assert.True(t, errors.IsNotFound(err))

--- a/pkg/alignchecker/alignchecker_test.go
+++ b/pkg/alignchecker/alignchecker_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var tetragonLib string
@@ -30,5 +30,5 @@ func Test_Alignments(t *testing.T) {
 	bpfObjPath := filepath.Join(tetragonLib, "bpf_alignchecker.o")
 
 	err := CheckStructAlignments(bpfObjPath)
-	assert.NoError(t, err, "structs must align")
+	require.NoError(t, err, "structs must align")
 }

--- a/pkg/arch/arch_test.go
+++ b/pkg/arch/arch_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_addSyscallPrefix(t *testing.T) {
@@ -17,21 +18,21 @@ func Test_addSyscallPrefix(t *testing.T) {
 
 	// adding prefix
 	res, err := addSyscallPrefix(symbol, arch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, prefixedSymbol, res)
 
 	// doing nothing
 	res, err = addSyscallPrefix(prefixedSymbol, arch)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, prefixedSymbol, res)
 
 	// wrong prefix for current arch
 	res, err = addSyscallPrefix("__x64_"+symbol, arch)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Empty(t, res)
 
 	// not supported arch
 	res, err = addSyscallPrefix(symbol, "unsupported64")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Empty(t, res)
 }

--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -413,7 +413,7 @@ func buildPathFromString(t *testing.T, rootType btf.Type, pathStr string) []stri
 	pathBase := strings.Split(pathStr, ".")
 	path := addPaddingOnNestedPtr(rootType, pathBase)
 	if len(path) > api.MaxBTFArgDepth {
-		assert.Fail(t, "Unable to resolve %q. The maximum depth allowed is %d", pathStr, api.MaxBTFArgDepth)
+		t.Errorf("Unable to resolve %q. The maximum depth allowed is %d", pathStr, api.MaxBTFArgDepth)
 	}
 	return path
 }

--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -170,7 +170,7 @@ func TestObserverFindBTFEnv(t *testing.T) {
 	assert.NoError(t, err)
 	btf, err := observerFindBTF(lib, "")
 	assert.Error(t, err)
-	assert.Equal(t, "", btf)
+	assert.Empty(t, btf)
 }
 
 func TestInitCachedBTF(t *testing.T) {
@@ -181,7 +181,7 @@ func TestInitCachedBTF(t *testing.T) {
 		if btffile != "" {
 			assert.NoError(t, err)
 			file := GetCachedBTFFile()
-			assert.EqualValues(t, btffile, file, "GetCachedBTFFile()  -  want:'%s'  - got:'%s'", btffile, file)
+			assert.Equal(t, btffile, file, "GetCachedBTFFile()  -  want:'%s'  - got:'%s'", btffile, file)
 		} else {
 			assert.Error(t, err)
 		}
@@ -190,7 +190,7 @@ func TestInitCachedBTF(t *testing.T) {
 		assert.NoError(t, err)
 
 		btffile := GetCachedBTFFile()
-		assert.EqualValues(t, defaults.DefaultBTFFile, btffile, "GetCachedBTFFile()  -  want:'%s'  - got:'%s'", defaults.DefaultBTFFile, btffile)
+		assert.Equal(t, defaults.DefaultBTFFile, btffile, "GetCachedBTFFile()  -  want:'%s'  - got:'%s'", defaults.DefaultBTFFile, btffile)
 	}
 }
 

--- a/pkg/btf/validation_test.go
+++ b/pkg/btf/validation_test.go
@@ -103,13 +103,13 @@ func TestSpecs(t *testing.T) {
 
 func TestEnum(t *testing.T) {
 	require.Equal(t,
-		getKernelType(&btf.Enum{
+		"u16", getKernelType(&btf.Enum{
 			Size:   2,
 			Signed: false,
-		}), "u16")
+		}))
 	require.Equal(t,
-		getKernelType(&btf.Enum{
+		"s32", getKernelType(&btf.Enum{
 			Size:   4,
 			Signed: true,
-		}), "s32")
+		}))
 }

--- a/pkg/bugtool/bugtool_test.go
+++ b/pkg/bugtool/bugtool_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSaveAndLoad(t *testing.T) {
@@ -19,7 +19,7 @@ func TestSaveAndLoad(t *testing.T) {
 	if err != nil {
 		t.Error("failed to create temporary file")
 	}
-	defer assert.NoError(t, tmpFile.Close())
+	defer require.NoError(t, tmpFile.Close())
 
 	info1 := InitInfo{
 		ExportFname: "1",

--- a/pkg/bugtool/maps_test.go
+++ b/pkg/bugtool/maps_test.go
@@ -11,6 +11,7 @@ import (
 
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	// needed to register the probe type execve for the base sensor
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
@@ -25,9 +26,9 @@ func TestFindMaps(t *testing.T) {
 	t.Run("NoSuchFile", func(t *testing.T) {
 		const path = "/sys/fs/bpf/nosuchfile"
 		_, err := FindPinnedMaps(path)
-		assert.Error(t, err)
+		require.Error(t, err)
 		_, err = FindMapsUsedByPinnedProgs(path)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("BaseSensorMemlock", func(t *testing.T) {
@@ -35,19 +36,19 @@ func TestFindMaps(t *testing.T) {
 
 		const path = "/sys/fs/bpf/testSensorBugtool"
 		pinnedMaps, err := FindPinnedMaps(path)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if assert.NotEmpty(t, pinnedMaps) {
 			assert.NotZero(t, pinnedMaps[0].Memlock)
 		}
 
 		mapsUsedByProgs, err := FindMapsUsedByPinnedProgs(path)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if assert.NotEmpty(t, mapsUsedByProgs) {
 			assert.NotZero(t, mapsUsedByProgs[0].Memlock)
 		}
 
 		allMaps, err := FindAllMaps()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if assert.NotEmpty(t, allMaps) {
 			assert.NotZero(t, allMaps[0].Memlock)
 		}

--- a/pkg/cgrouprate/cgrouprate_test.go
+++ b/pkg/cgrouprate/cgrouprate_test.go
@@ -243,7 +243,7 @@ func TestProcessCgroup(t *testing.T) {
 
 		// setup cgrouprate cgroup
 		glSt.handle.cgroups[key.Id] = cgroup
-		assert.NotEqual(t, nil, glSt.handle)
+		assert.NotNil(t, glSt.handle)
 
 		// store hash values
 		values[0] = d.values[0]

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -158,10 +158,10 @@ misc	10	1	1
 	require.NoError(t, err)
 	for _, c := range CgroupControllers {
 		if strings.Contains(d.used, c.Name) {
-			require.Equal(t, true, c.Active)
+			require.True(t, c.Active)
 			require.NotZero(t, c.Id)
 		} else {
-			require.Equal(t, false, c.Active)
+			require.False(t, c.Active)
 			require.Zero(t, c.Id)
 		}
 	}
@@ -274,7 +274,7 @@ func TestDetectCgroupFSMagic(t *testing.T) {
 		assert.Equal(t, uint64(unix.CGROUP_SUPER_MAGIC), fs)
 		mounted, err := isDirMountFsType(filepath.Join(cgroupFSPath, "unified"), mountinfo.FilesystemTypeCgroup2)
 		assert.NoError(t, err)
-		assert.Equal(t, true, mounted)
+		assert.True(t, mounted)
 	case CGROUP_LEGACY:
 		assert.Equal(t, uint64(unix.CGROUP_SUPER_MAGIC), fs)
 	default:
@@ -284,7 +284,7 @@ func TestDetectCgroupFSMagic(t *testing.T) {
 	assert.NotEqual(t, uint64(CGROUP_UNDEF), GetCgroupFSMagic())
 	assert.NotEmpty(t, CgroupFsMagicStr(fs))
 	assert.NotEmpty(t, GetCgroupFSPath())
-	assert.Equal(t, true, filepath.IsAbs(GetCgroupFSPath()))
+	assert.True(t, filepath.IsAbs(GetCgroupFSPath()))
 }
 
 // Test discovery of compiled-in Cgroups controllers
@@ -328,7 +328,7 @@ func TestDiscoverCgroupv1SubSysIdsDefault(t *testing.T) {
 		}
 	}
 
-	assert.Equalf(t, true, fixed, "TestDiscoverSubSysIdsDefault() could not detect active cgroup controllers")
+	assert.Truef(t, fixed, "TestDiscoverSubSysIdsDefault() could not detect active cgroup controllers")
 }
 
 func TestGetCgroupIdFromPath(t *testing.T) {

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -189,7 +189,7 @@ func TestCheckCgroupv2Controllers(t *testing.T) {
 // Test cgroup mode detection on an invalid directory
 func TestDetectCgroupModeInvalid(t *testing.T) {
 	mode, err := detectCgroupMode("invalid-cgroupfs-path")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, CGROUP_UNDEF, mode)
 }
 
@@ -203,7 +203,7 @@ func TestDetectCgroupModeDefault(t *testing.T) {
 	}
 
 	mode, err := detectCgroupMode(defaultCgroupRoot)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	switch st.Type {
 	case unix.CGROUP2_SUPER_MAGIC:
@@ -216,7 +216,7 @@ func TestDetectCgroupModeDefault(t *testing.T) {
 
 			// Extra detection
 			mode, err = detectCgroupMode(unified)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, CGROUP_UNIFIED, mode)
 		} else {
 			assert.Equal(t, CGROUP_LEGACY, mode)
@@ -231,14 +231,14 @@ func TestDetectCgroupModeDefault(t *testing.T) {
 func TestDetectCgroupModeCustomLocation(t *testing.T) {
 	// We also mount cgroup2 on /run/tetragon/cgroup2 let's test it
 	mounted, err := isDirMountFsType(defaults.Cgroup2Dir, mountinfo.FilesystemTypeCgroup2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mode, err := detectCgroupMode(defaults.Cgroup2Dir)
 	if mounted {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, CGROUP_UNIFIED, mode)
 	} else {
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, CGROUP_UNDEF, mode)
 	}
 }
@@ -251,7 +251,7 @@ func TestDetectCgroupModeCustomLocation(t *testing.T) {
 // they are properly set.
 func TestDetectCgroupMode(t *testing.T) {
 	mode, err := DetectCgroupMode()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, CGROUP_UNDEF, mode)
 	assert.NotEqual(t, CGROUP_UNDEF, cgroupMode)
 	assert.NotEmpty(t, cgroupFSPath)
@@ -265,7 +265,7 @@ func TestDetectCgroupMode(t *testing.T) {
 // TODO Setup multiple cgroupv1 and cgroupv2 combinations
 func TestDetectCgroupFSMagic(t *testing.T) {
 	fs, err := DetectCgroupFSMagic()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, CGROUP_UNDEF, fs)
 	switch cgroupMode {
 	case CGROUP_UNIFIED:
@@ -273,7 +273,7 @@ func TestDetectCgroupFSMagic(t *testing.T) {
 	case CGROUP_HYBRID:
 		assert.Equal(t, uint64(unix.CGROUP_SUPER_MAGIC), fs)
 		mounted, err := isDirMountFsType(filepath.Join(cgroupFSPath, "unified"), mountinfo.FilesystemTypeCgroup2)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, mounted)
 	case CGROUP_LEGACY:
 		assert.Equal(t, uint64(unix.CGROUP_SUPER_MAGIC), fs)
@@ -294,11 +294,11 @@ func TestDetectCgroupFSMagic(t *testing.T) {
 // - Their css index
 func TestDiscoverCgroupv1SubSysIdsDefault(t *testing.T) {
 	fs, err := DetectCgroupFSMagic()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, CGROUP_UNDEF, fs)
 
 	err = DiscoverSubSysIds()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	accessFs := false
 	fixed := false
@@ -333,19 +333,19 @@ func TestDiscoverCgroupv1SubSysIdsDefault(t *testing.T) {
 
 func TestGetCgroupIdFromPath(t *testing.T) {
 	mode, err := DetectCgroupMode()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEqual(t, CGROUP_UNDEF, mode)
 
 	err = DiscoverSubSysIds()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	pid := os.Getpid()
 	path, err := findMigrationPath(uint32(pid))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, path)
 
 	id, err := GetCgroupIdFromPath(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotZero(t, id)
 
 	// Log data useful to inspect different hierarchies

--- a/pkg/cgtracker/test/cgtracker_test.go
+++ b/pkg/cgtracker/test/cgtracker_test.go
@@ -7,7 +7,6 @@ package cgtracker
 
 import (
 	"context"
-	"fmt"
 	"iter"
 	"os"
 	"path/filepath"
@@ -110,8 +109,8 @@ func doMapTest(t *testing.T, cgfsPath string) {
 		var val uint64
 		err = fs.cgTrackerMap.Lookup(&trackedID, &val)
 		if strings.HasPrefix(p, "tracked") {
-			assert.NoError(t, err, fmt.Sprintf("cgroup (%x) id for %s should exist in the map", trackedID, p))
-			assert.Equal(t, trackerID, val, fmt.Sprintf("tracker ID value should match tracker for key 0x%x (%s)", trackedID, p))
+			assert.NoError(t, err, "cgroup (%x) id for %s should exist in the map", trackedID, p)
+			assert.Equal(t, trackerID, val, "tracker ID value should match tracker for key 0x%x (%s)", trackedID, p)
 		} else {
 			assert.Error(t, err)
 		}
@@ -126,7 +125,7 @@ func doMapTest(t *testing.T, cgfsPath string) {
 	time.Sleep(1 * time.Second)
 	vals, err := cgfs.cgTrackerMap.Dump()
 	require.NoError(t, err)
-	assert.Equal(t, vals, map[uint64][]uint64{})
+	assert.Equal(t, map[uint64][]uint64{}, vals)
 }
 
 func TestCgTrackerMap(t *testing.T) {
@@ -307,7 +306,7 @@ func TestCgTrackerPolicyFilter(t *testing.T) {
 				}
 				return 0
 			})
-		assert.Equal(t, tc.expectEvents, res[1] >= 1, fmt.Sprintf("path:%s expectEvents:%t eventsNR:%d\n", tc.cgPath, tc.expectEvents, res[1]))
+		assert.Equal(t, tc.expectEvents, res[1] >= 1, "path:%s expectEvents:%t eventsNR:%d\n", tc.cgPath, tc.expectEvents, res[1])
 	}
 
 }

--- a/pkg/cgtracker/test/cgtracker_test.go
+++ b/pkg/cgtracker/test/cgtracker_test.go
@@ -109,10 +109,10 @@ func doMapTest(t *testing.T, cgfsPath string) {
 		var val uint64
 		err = fs.cgTrackerMap.Lookup(&trackedID, &val)
 		if strings.HasPrefix(p, "tracked") {
-			assert.NoError(t, err, "cgroup (%x) id for %s should exist in the map", trackedID, p)
+			require.NoError(t, err, "cgroup (%x) id for %s should exist in the map", trackedID, p)
 			assert.Equal(t, trackerID, val, "tracker ID value should match tracker for key 0x%x (%s)", trackedID, p)
 		} else {
-			assert.Error(t, err)
+			require.Error(t, err)
 		}
 
 	})

--- a/pkg/crdutils/crdutils_test.go
+++ b/pkg/crdutils/crdutils_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
@@ -406,20 +407,20 @@ metadata:
 
 func TestReadConfigYamlInvalidName(t *testing.T) {
 	_, err := TPContext.FromYAML(invalidNameYaml)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestEmptyTracingPolicy(t *testing.T) {
 	path := CreateTempFile(t, "")
 	_, err := TPContext.FromFile(path)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "validation failed: metadata.name: Required value: name or generateName is required")
 }
 
 func TestInvalidYAMLInTracingPolicy(t *testing.T) {
 	path := CreateTempFile(t, "<not-quite-yaml>")
 	_, err := TPContext.FromFile(path)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to unmarshal YAML: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}")
 }
 
@@ -432,7 +433,7 @@ metadata: {}
 func TestTracingPolicyWithoutMetadata(t *testing.T) {
 	path := CreateTempFile(t, tpWithoutMetadata)
 	_, err := TPContext.FromFile(path)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "metadata.name: Required value: name or generateName is required")
 }
 
@@ -448,6 +449,6 @@ spec:
 func TestTracingPolicyNotCoveredBySpec(t *testing.T) {
 	path := CreateTempFile(t, tpNotCoveredBySpec)
 	_, err := TPContext.FromFile(path)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to unmarshal into typed object: error unmarshaling JSON: while decoding JSON: json: unknown field \"some_field\"")
 }

--- a/pkg/crdutils/testhelpers.go
+++ b/pkg/crdutils/testhelpers.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/stretchr/testify/require"
 )
 
 // TPContext and GenericTracingPolicy replicate definitions from tracingpolicy
@@ -79,11 +79,11 @@ func CheckPolicies(t *testing.T, policiesDir string, fromFile func(string) error
 
 		// Attempt to parse the file
 		err = fromFile(path)
-		assert.NoError(t, err, "example %s must parse correctly: %s", info.Name(), err)
+		require.NoError(t, err, "example %s must parse correctly: %s", info.Name(), err)
 
 		return nil
 	})
-	assert.NoError(t, err, "failed to walk examples directory")
+	require.NoError(t, err, "failed to walk examples directory")
 }
 
 func CreateTempFile(t *testing.T, data string) string {

--- a/pkg/encoder/encoder_test.go
+++ b/pkg/encoder/encoder_test.go
@@ -25,7 +25,7 @@ func TestCompactEncoder_InvalidEventToString(t *testing.T) {
 
 	// should fail if the event field is nil.
 	_, err := p.EventToString(&tetragon.GetEventsResponse{})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestCompactEncoder_ExecEventToString(t *testing.T) {
@@ -37,7 +37,7 @@ func TestCompactEncoder_ExecEventToString(t *testing.T) {
 			ProcessExec: &tetragon.ProcessExec{},
 		},
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// without pod info
 	result, err := p.EventToString(&tetragon.GetEventsResponse{
@@ -51,7 +51,7 @@ func TestCompactEncoder_ExecEventToString(t *testing.T) {
 		},
 		NodeName: "my-node",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "🚀 process my-node /usr/bin/curl cilium.io", result)
 
 	// with pod info
@@ -69,7 +69,7 @@ func TestCompactEncoder_ExecEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "🚀 process kube-system/tetragon /usr/bin/curl cilium.io", result)
 }
 
@@ -82,7 +82,7 @@ func TestCompactEncoder_ExitEventToString(t *testing.T) {
 			ProcessExit: &tetragon.ProcessExit{},
 		},
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// with status
 	result, err := p.EventToString(&tetragon.GetEventsResponse{
@@ -100,7 +100,7 @@ func TestCompactEncoder_ExitEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "💥 exit    kube-system/tetragon /usr/bin/curl cilium.io 1", result)
 
 	// with signal
@@ -119,7 +119,7 @@ func TestCompactEncoder_ExitEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "💥 exit    kube-system/tetragon /usr/bin/curl cilium.io SIGKILL", result)
 }
 
@@ -134,7 +134,7 @@ func TestCompactEncoder_KprobeEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// unknown function
 	result, err := p.EventToString(&tetragon.GetEventsResponse{
@@ -151,7 +151,7 @@ func TestCompactEncoder_KprobeEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "❓ syscall kube-system/tetragon /usr/bin/curl unhandled_function", result)
 
 }
@@ -174,7 +174,7 @@ func TestCompactEncoder_KprobeOpenEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "📬 open    kube-system/tetragon /usr/bin/curl ", result)
 
 	// open with args
@@ -196,7 +196,7 @@ func TestCompactEncoder_KprobeOpenEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "📬 open    kube-system/tetragon /usr/bin/curl /etc/password", result)
 }
 
@@ -218,7 +218,7 @@ func TestCompactEncoder_KprobeWriteEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "📝 write   kube-system/tetragon /usr/bin/curl  ", result)
 
 	// write with args
@@ -241,7 +241,7 @@ func TestCompactEncoder_KprobeWriteEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "📝 write   kube-system/tetragon /usr/bin/curl /etc/password 1234 bytes", result)
 }
 
@@ -263,7 +263,7 @@ func TestCompactEncoder_KprobeCloseEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "📪 close   kube-system/tetragon /usr/bin/curl ", result)
 
 	// open with args
@@ -284,7 +284,7 @@ func TestCompactEncoder_KprobeCloseEventToString(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "📪 close   kube-system/tetragon /usr/bin/curl /etc/password", result)
 }
 
@@ -305,7 +305,7 @@ func TestCompactEncoder_KprobeBPFEventToString(t *testing.T) {
 				FunctionName: "bpf_check",
 			},
 		}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "🐝 bpf_load kube-system/tetragon /usr/bin/bpftool ", result)
 
 	// bpf with args
@@ -332,7 +332,7 @@ func TestCompactEncoder_KprobeBPFEventToString(t *testing.T) {
 				},
 			},
 		}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "🐝 bpf_load kube-system/tetragon /usr/bin/bpftool BPF_PROG_TYPE_KPROBE amazing-program instruction count 2048", result)
 }
 
@@ -353,7 +353,7 @@ func TestCompactEncoder_KprobePerfEventAllocEventToString(t *testing.T) {
 				FunctionName: "security_perf_event_alloc",
 			},
 		}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "🐝 perf_event_alloc kube-system/tetragon /usr/bin/bpftool ", result)
 
 	// perf event alloc with args
@@ -379,7 +379,7 @@ func TestCompactEncoder_KprobePerfEventAllocEventToString(t *testing.T) {
 				},
 			},
 		}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "🐝 perf_event_alloc kube-system/tetragon /usr/bin/bpftool PERF_TYPE_TRACEPOINT commit_creds", result)
 }
 
@@ -400,7 +400,7 @@ func TestCompactEncoder_KprobeBPFMapAllocEventToString(t *testing.T) {
 				FunctionName: "security_bpf_map_alloc",
 			},
 		}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "🗺 bpf_map_create kube-system/tetragon /usr/bin/bpftool ", result)
 
 	// bpf map with args
@@ -429,7 +429,7 @@ func TestCompactEncoder_KprobeBPFMapAllocEventToString(t *testing.T) {
 				},
 			},
 		}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "🗺 bpf_map_create kube-system/tetragon /usr/bin/bpftool BPF_MAP_TYPE_HASH amazing-map key size 8 value size 8 max entries 1024", result)
 }
 
@@ -439,11 +439,11 @@ func TestCompactEncoder_Encode(t *testing.T) {
 
 	// invalid event
 	err := p.Encode(nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// more invalid event
 	err = p.Encode(&tetragon.GetEventsResponse{})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// valid event
 	err = p.Encode(&tetragon.GetEventsResponse{
@@ -460,7 +460,7 @@ func TestCompactEncoder_Encode(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "🚀 process kube-system/tetragon /usr/bin/curl cilium.io\n", b.String())
 }
 
@@ -470,11 +470,11 @@ func TestCompactEncoder_EncodeWithTimestamp(t *testing.T) {
 
 	// invalid event
 	err := p.Encode(nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// more invalid event
 	err = p.Encode(&tetragon.GetEventsResponse{})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// valid event
 	err = p.Encode(&tetragon.GetEventsResponse{
@@ -492,7 +492,7 @@ func TestCompactEncoder_EncodeWithTimestamp(t *testing.T) {
 		},
 		Time: &timestamppb.Timestamp{},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "1970-01-01T00:00:00.000000000Z 🚀 process kube-system/tetragon /usr/bin/curl cilium.io\n", b.String())
 }
 

--- a/pkg/errmetrics/err_msg_windows_test.go
+++ b/pkg/errmetrics/err_msg_windows_test.go
@@ -13,9 +13,9 @@ import (
 
 func TestErrMessage(t *testing.T) {
 	s1 := GetErrorMessage(uint16(syscall.ERROR_ACCESS_DENIED))
-	assert.Equal(t, strings.HasPrefix(s1, "Access is denied."), true)
+	assert.True(t, strings.HasPrefix(s1, "Access is denied."))
 
 	s2 := GetErrorMessage(uint16(syscall.ERROR_INSUFFICIENT_BUFFER))
-	assert.Equal(t, strings.HasPrefix(s2, "The data area passed to a system call is too small."), true)
+	assert.True(t, strings.HasPrefix(s2, "The data area passed to a system call is too small."))
 
 }

--- a/pkg/eventcheckertests/yaml/yaml_test.go
+++ b/pkg/eventcheckertests/yaml/yaml_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/yaml"
 	"github.com/cilium/tetragon/pkg/crdutils"
 	"github.com/cilium/tetragon/pkg/eventcheckertests/yamlhelpers"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExamplesSmoke(t *testing.T) {
@@ -38,7 +38,7 @@ func TestExamplesSmoke(t *testing.T) {
 
 		// Attempt to parse the file
 		data, err := crdutils.ReadFileTemplate(path, templateData)
-		assert.NoError(t, err, "example %s must parse correctly", info.Name())
+		require.NoError(t, err, "example %s must parse correctly", info.Name())
 
 		var conf yaml.EventCheckerConf
 		yamlhelpers.AssertUnmarshalRoundTrip(t, []byte(data), &conf)
@@ -46,5 +46,5 @@ func TestExamplesSmoke(t *testing.T) {
 		return nil
 	})
 
-	assert.NoError(t, err, "failed to walk examples directory")
+	require.NoError(t, err, "failed to walk examples directory")
 }

--- a/pkg/eventcheckertests/yamlhelpers/yamlhelpers.go
+++ b/pkg/eventcheckertests/yamlhelpers/yamlhelpers.go
@@ -15,12 +15,14 @@ import (
 // produces the same object.
 func AssertMarshalRoundTrip(t *testing.T, o interface{}) bool {
 	out, err := yaml.Marshal(o)
+	// nolint:testifylint
 	if !assert.NoError(t, err, "`%#v` should marshal", o) {
 		return false
 	}
 
 	o2 := reflect.New(reflect.TypeOf(o).Elem()).Interface()
 	err = yaml.UnmarshalStrict(out, o2)
+	// nolint:testifylint
 	if !assert.NoError(t, err, "`%#v` should unmarshal from marshaled value", o) {
 		return false
 	}
@@ -32,6 +34,7 @@ func AssertMarshalRoundTrip(t *testing.T, o interface{}) bool {
 // makes sure that unmarshalling again produces the same object.
 func AssertUnmarshalRoundTrip(t *testing.T, b []byte, o interface{}) bool {
 	err := yaml.Unmarshal(b, o)
+	// nolint:testifylint
 	if !assert.NoError(t, err, "`%s` should unmarshal", string(b)) {
 		return false
 	}

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/tetragon/pkg/rthooks"
 	"github.com/cilium/tetragon/pkg/server"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type arrayWriter struct {
@@ -92,7 +93,7 @@ func TestExporter_Send(t *testing.T) {
 	encoder := encoder.NewProtojsonEncoder(results)
 	request := tetragon.GetEventsRequest{DenyList: []*tetragon.Filter{{BinaryRegex: []string{"b"}}}}
 	exporter := NewExporter(ctx, &request, grpcServer, encoder, results, nil)
-	assert.NoError(t, exporter.Start(), "exporter must start without errors")
+	require.NoError(t, exporter.Start(), "exporter must start without errors")
 	eventNotifier.NotifyListener(nil, &tetragon.GetEventsResponse{
 		Event: &tetragon.GetEventsResponse_ProcessExec{
 			ProcessExec: &tetragon.ProcessExec{Process: &tetragon.Process{Binary: "a"}},
@@ -204,7 +205,7 @@ func Test_rateLimitExport(t *testing.T) {
 				results,
 				ratelimit.NewRateLimiter(ctx, 50*time.Millisecond, tt.rateLimit, encoder),
 			)
-			assert.NoError(t, exporter.Start(), "exporter must start without errors")
+			require.NoError(t, exporter.Start(), "exporter must start without errors")
 			for i := range tt.totalEvents {
 				eventNotifier.NotifyListener(nil, &tetragon.GetEventsResponse{
 					Event: &tetragon.GetEventsResponse_ProcessExec{

--- a/pkg/fieldfilters/benchmark_test.go
+++ b/pkg/fieldfilters/benchmark_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon/codegen/helpers"
 	"github.com/cilium/tetragon/pkg/encoder"
 	"github.com/sryoya/protorand"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
@@ -78,7 +77,7 @@ func BenchmarkSerialize(b *testing.B) {
 	for i := range b.N {
 		ev := evs[i]
 		err := encoder.Encode(ev)
-		assert.NoError(b, err, "event must encode")
+		require.NoError(b, err, "event must encode")
 	}
 }
 
@@ -95,7 +94,7 @@ func BenchmarkSerialize_DeepCopy(b *testing.B) {
 		ev := evs[i]
 		ev = proto.Clone(ev).(*tetragon.GetEventsResponse)
 		err := encoder.Encode(ev)
-		assert.NoError(b, err, "event must encode")
+		require.NoError(b, err, "event must encode")
 	}
 }
 
@@ -115,7 +114,7 @@ func BenchmarkSerialize_DeepCopyProcess(b *testing.B) {
 			setter.SetProcess(proc)
 		}
 		err := encoder.Encode(ev)
-		assert.NoError(b, err, "event must encode")
+		require.NoError(b, err, "event must encode")
 	}
 }
 
@@ -133,9 +132,9 @@ func BenchmarkSerialize_FieldFilters(b *testing.B) {
 	for i := range b.N {
 		ev := evs[i]
 		ev, err = ff.Filter(ev)
-		assert.NoError(b, err, "event must filter")
+		require.NoError(b, err, "event must filter")
 		err := encoder.Encode(ev)
-		assert.NoError(b, err, "event must encode")
+		require.NoError(b, err, "event must encode")
 	}
 }
 
@@ -152,9 +151,9 @@ func BenchmarkSerialize_FieldFilters_NoProcessInfo(b *testing.B) {
 	for i := range b.N {
 		ev := evs[i]
 		ev, err = ff.Filter(ev)
-		assert.NoError(b, err, "event must filter")
+		require.NoError(b, err, "event must filter")
 		err := encoder.Encode(ev)
-		assert.NoError(b, err, "event must encode")
+		require.NoError(b, err, "event must encode")
 	}
 }
 
@@ -172,9 +171,9 @@ func BenchmarkSerialize_FieldFilters_NoProcesInfoKeepExecid(b *testing.B) {
 	for i := range b.N {
 		ev := evs[i]
 		ev, err = ff.Filter(ev)
-		assert.NoError(b, err, "event must filter")
+		require.NoError(b, err, "event must filter")
 		err = encoder.Encode(ev)
-		assert.NoError(b, err, "event must encode")
+		require.NoError(b, err, "event must encode")
 	}
 }
 
@@ -197,6 +196,6 @@ func BenchmarkSerialize_RedactionFilters(b *testing.B) {
 			process.Arguments = ff.Redact(process.Binary, process.Arguments)
 		}
 		err := encoder.Encode(ev)
-		assert.NoError(b, err, "event must encode")
+		require.NoError(b, err, "event must encode")
 	}
 }

--- a/pkg/fieldfilters/fields_test.go
+++ b/pkg/fieldfilters/fields_test.go
@@ -91,7 +91,7 @@ func TestEventFieldFilters(t *testing.T) {
 	require.NoError(t, err)
 	for _, filter := range filters {
 		ev, err = filter.Filter(ev)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	// These fields should all have been included and so should not be empty

--- a/pkg/fieldfilters/fields_test.go
+++ b/pkg/fieldfilters/fields_test.go
@@ -623,7 +623,7 @@ func TestSlimExecEventsFieldFilterExample(t *testing.T) {
 		}
 	}
 	for i := range evs {
-		if !assert.True(t, proto.Equal(evs[i], expected[i]), fmt.Sprintf("event %d should be equal after filter", i)) {
+		if !assert.True(t, proto.Equal(evs[i], expected[i]), "event %d should be equal after filter", i) {
 			fmt.Println("expected: ", expected[i])
 			fmt.Println("actual: ", evs[i])
 		}

--- a/pkg/fieldfilters/parse_test.go
+++ b/pkg/fieldfilters/parse_test.go
@@ -21,5 +21,5 @@ func TestParseFieldFilterList(t *testing.T) {
 	filters, err := ParseFieldFilterList(`{"event_set":["PROCESS_EXEC","PROCESS_EXIT"], "fields":"process.start_time,process.binary,process.arguments,process.cap,process.ns,parent.binary", "action":"INCLUDE"}
 {"event_set":["PROCESS_KPROBE"], "fields":"process.start_time,process.binary,process.arguments,process.cap,process.ns,parent.binary,function_name", "action":"INCLUDE"}`)
 	require.NoError(t, err, "must parse")
-	assert.Equal(t, filters[0].Fields.Paths[0], "process.start_time")
+	assert.Equal(t, "process.start_time", filters[0].Fields.Paths[0])
 }

--- a/pkg/filters/arguments_regex_test.go
+++ b/pkg/filters/arguments_regex_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestArgumentsRegexFilterBasic(t *testing.T) {
@@ -19,7 +20,7 @@ func TestArgumentsRegexFilterBasic(t *testing.T) {
 		"^--log /run/containerd/io.containerd.runtime.v2.task/moby/\\w+/log.json --log-format json$",
 	}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&ArgumentsRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	process := tetragon.Process{Arguments: "-namespace moby -id 1234abcd -address /run/containerd/containerd.sock"}
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
@@ -45,7 +46,7 @@ func TestParentArgumentsRegexFilter(t *testing.T) {
 		"^--bar \\d+$",
 	}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&ParentArgumentsRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	process := tetragon.Process{Arguments: "foo"}
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
@@ -66,13 +67,13 @@ func TestParentArgumentsRegexFilter(t *testing.T) {
 func TestArgumentsRegexFilterInvalidRegex(t *testing.T) {
 	f := []*tetragon.Filter{{ArgumentsRegex: []string{"*"}}}
 	_, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&ArgumentsRegexFilter{}})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestArgumentsRegexFilterInvalidEvent(t *testing.T) {
 	f := []*tetragon.Filter{{ArgumentsRegex: []string{".*"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&ArgumentsRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, fl.MatchOne(nil))
 	assert.False(t, fl.MatchOne(&event.Event{Event: nil}))
 	assert.False(t, fl.MatchOne(&event.Event{Event: struct{}{}}))

--- a/pkg/filters/binary_regex_test.go
+++ b/pkg/filters/binary_regex_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBinaryRegexFilterBasic(t *testing.T) {
 	f := []*tetragon.Filter{{BinaryRegex: []string{"iptable", "systemd"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&BinaryRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{
@@ -77,7 +78,7 @@ func TestBinaryRegexFilterBasic(t *testing.T) {
 func TestBinaryRegexFilterAdvanced(t *testing.T) {
 	f := []*tetragon.Filter{{BinaryRegex: []string{"/usr/sbin/.*", "^/usr/lib/systemd/systemd$"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&BinaryRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{
@@ -131,13 +132,13 @@ func TestBinaryRegexFilterAdvanced(t *testing.T) {
 func TestBinaryRegexFilterInvalidRegex(t *testing.T) {
 	f := []*tetragon.Filter{{BinaryRegex: []string{"*"}}}
 	_, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&BinaryRegexFilter{}})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBinaryRegexFilterInvalidEvent(t *testing.T) {
 	f := []*tetragon.Filter{{BinaryRegex: []string{".*"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&BinaryRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, fl.MatchOne(nil))
 	assert.False(t, fl.MatchOne(&event.Event{Event: nil}))
 	assert.False(t, fl.MatchOne(&event.Event{Event: struct{}{}}))
@@ -156,7 +157,7 @@ func TestBinaryRegexFilterInvalidEvent(t *testing.T) {
 func TestParentBinaryRegexFilter(t *testing.T) {
 	f := []*tetragon.Filter{{ParentBinaryRegex: []string{"bash", "zsh"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&ParentBinaryRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{
@@ -208,7 +209,7 @@ func TestAncestorBinaryRegexFilter(t *testing.T) {
 		AncestorBinaryRegex: []string{"bash", "zsh"},
 	}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&AncestorBinaryRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{

--- a/pkg/filters/caps_test.go
+++ b/pkg/filters/caps_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCapFilterAny(t *testing.T) {
@@ -17,7 +18,7 @@ func TestCapFilterAny(t *testing.T) {
 		Any: []tetragon.CapabilitiesType{tetragon.CapabilitiesType_CAP_SYS_ADMIN, tetragon.CapabilitiesType_CAP_BPF},
 	}}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&CapsFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	process := tetragon.Process{Cap: &tetragon.Capabilities{}}
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
@@ -62,7 +63,7 @@ func TestCapFilterAll(t *testing.T) {
 		All: []tetragon.CapabilitiesType{tetragon.CapabilitiesType_CAP_SYS_ADMIN, tetragon.CapabilitiesType_CAP_BPF},
 	}}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&CapsFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	process := tetragon.Process{Cap: &tetragon.Capabilities{}}
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
@@ -107,7 +108,7 @@ func TestCapFilterExactly(t *testing.T) {
 		Exactly: []tetragon.CapabilitiesType{tetragon.CapabilitiesType_CAP_SYS_ADMIN, tetragon.CapabilitiesType_CAP_BPF},
 	}}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&CapsFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	process := tetragon.Process{Cap: &tetragon.Capabilities{}}
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
@@ -152,7 +153,7 @@ func TestCapFilterNone(t *testing.T) {
 		None: []tetragon.CapabilitiesType{tetragon.CapabilitiesType_CAP_SYS_ADMIN, tetragon.CapabilitiesType_CAP_BPF},
 	}}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&CapsFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	process := tetragon.Process{Cap: &tetragon.Capabilities{}}
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{

--- a/pkg/filters/cel_expression_test.go
+++ b/pkg/filters/cel_expression_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -19,14 +20,14 @@ func TestInvalidFilter(t *testing.T) {
 	f := tetragon.Filter{CelExpression: []string{"process_exec.process.bad_field_name == 'curl'"}}
 	celFilter := NewCELExpressionFilter(log)
 	_, err := celFilter.OnBuildFilter(context.Background(), &f)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestProcessExecFilter(t *testing.T) {
 	log := logrus.New()
 	f := []*tetragon.Filter{{CelExpression: []string{"process_exec.process.pid > uint(1)"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{NewCELExpressionFilter(log)})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{
@@ -49,7 +50,7 @@ func TestProcessKprobeFilter(t *testing.T) {
 	log := logrus.New()
 	f := []*tetragon.Filter{{CelExpression: []string{"process_kprobe.function_name == 'security_file_permission'"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{NewCELExpressionFilter(log)})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessKprobe{
@@ -70,7 +71,7 @@ func TestCIDR(t *testing.T) {
 	log := logrus.New()
 	f := []*tetragon.Filter{{CelExpression: []string{"cidr('10.0.0.0/16').containsIP(process_kprobe.args[0].sock_arg.saddr)"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{NewCELExpressionFilter(log)})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessKprobe{
@@ -91,7 +92,7 @@ func TestIP(t *testing.T) {
 	log := logrus.New()
 	f := []*tetragon.Filter{{CelExpression: []string{"ip(process_kprobe.args[0].sock_arg.saddr).family() == 4"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{NewCELExpressionFilter(log)})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessKprobe{

--- a/pkg/filters/container_test.go
+++ b/pkg/filters/container_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -18,7 +19,7 @@ func TestContainerID(t *testing.T) {
 		"^2f00a73446e0",
 	}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&ContainerIDFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	process := tetragon.Process{Docker: "2f00a73446e0"}
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
@@ -37,7 +38,7 @@ func TestContainerID(t *testing.T) {
 func TestInInitTree(t *testing.T) {
 	f := []*tetragon.Filter{{InInitTree: &wrapperspb.BoolValue{Value: true}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&InInitTreeFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	process := tetragon.Process{}
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
@@ -57,7 +58,7 @@ func TestInInitTree(t *testing.T) {
 
 	f = []*tetragon.Filter{{InInitTree: &wrapperspb.BoolValue{Value: false}}}
 	fl, err = BuildFilterList(context.Background(), f, []OnBuildFilter{&InInitTreeFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	process.InInitTree = &wrapperspb.BoolValue{Value: true}
 	assert.False(t, fl.MatchOne(&ev))

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -37,7 +38,7 @@ func TestParseFilterList(t *testing.T) {
 {"capabilities": {"effective": {"all": ["CAP_BPF", "CAP_SYS_ADMIN"]}}}
 {"cel_expression": ["process_exec.process.bad_field_name == 'curl'"]}`
 	filterProto, err := ParseFilterList(f, true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if diff := cmp.Diff(
 		[]*tetragon.Filter{
 			{Namespace: []string{"kube-system", ""}},
@@ -63,12 +64,12 @@ func TestParseFilterList(t *testing.T) {
 		t.Errorf("filter mismatch (-want +got):\n%s", diff)
 	}
 	_, err = ParseFilterList("invalid filter json", true)
-	assert.Error(t, err)
+	require.Error(t, err)
 	filterProto, err = ParseFilterList("", true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, filterProto)
 	filterProto, err = ParseFilterList(`{"pid_set":[1]}`, false)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Empty(t, filterProto)
 }
 
@@ -80,7 +81,7 @@ func TestEventTypeFilterMatch(t *testing.T) {
 	}}
 
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&EventTypeFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{
@@ -99,7 +100,7 @@ func TestEventTypeFilterNoMatch(t *testing.T) {
 	}}
 
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&EventTypeFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{

--- a/pkg/filters/health_check_test.go
+++ b/pkg/filters/health_check_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -62,11 +63,11 @@ func Test_healthCheckFilter(t *testing.T) {
 	maybeHealthCheck, err := BuildFilterList(context.Background(),
 		[]*tetragon.Filter{{HealthCheck: &wrapperspb.BoolValue{Value: true}}},
 		[]OnBuildFilter{&HealthCheckFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	notHealthCheck, err := BuildFilterList(context.Background(),
 		[]*tetragon.Filter{{HealthCheck: &wrapperspb.BoolValue{Value: false}}},
 		[]OnBuildFilter{&HealthCheckFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	process := event.Event{
 		Event: &tetragon.GetEventsResponse{

--- a/pkg/filters/labels_test.go
+++ b/pkg/filters/labels_test.go
@@ -10,18 +10,19 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLabelSelectorFilterInvalidFilter(t *testing.T) {
 	filter := []*tetragon.Filter{{Labels: []string{"!@#$%"}}}
 	_, err := BuildFilterList(context.Background(), filter, []OnBuildFilter{&LabelsFilter{}})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestLabelSelectorFilterInvalidEvent(t *testing.T) {
 	filter := []*tetragon.Filter{{Labels: []string{"key1,key2"}}}
 	fl, err := BuildFilterList(context.Background(), filter, []OnBuildFilter{&LabelsFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// nil pod should not match.
 	exec := tetragon.GetEventsResponse_ProcessExec{
@@ -38,7 +39,7 @@ func TestLabelSelectorFilterInvalidEvent(t *testing.T) {
 func TestLabelSelectorFilterNoValue(t *testing.T) {
 	filter := []*tetragon.Filter{{Labels: []string{"key1,key2"}}}
 	fl, err := BuildFilterList(context.Background(), filter, []OnBuildFilter{&LabelsFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	exec := tetragon.GetEventsResponse_ProcessExec{
 		ProcessExec: &tetragon.ProcessExec{Process: &tetragon.Process{Pod: &tetragon.Pod{PodLabels: map[string]string{}}}},
 	}
@@ -57,7 +58,7 @@ func TestLabelSelectorFilterNoValue(t *testing.T) {
 func TestLabelSelectorFilterWithValue(t *testing.T) {
 	filter := []*tetragon.Filter{{Labels: []string{"key1=val1,key2=val2"}}}
 	fl, err := BuildFilterList(context.Background(), filter, []OnBuildFilter{&LabelsFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	exec := tetragon.GetEventsResponse_ProcessExec{
 		ProcessExec: &tetragon.ProcessExec{Process: &tetragon.Process{Pod: &tetragon.Pod{PodLabels: map[string]string{}}}},
 	}
@@ -78,7 +79,7 @@ func TestLabelSelectorFilterWithValue(t *testing.T) {
 func TestLabelSelectorFilterEmptySelector(t *testing.T) {
 	filter := []*tetragon.Filter{{Labels: []string{""}}}
 	fl, err := BuildFilterList(context.Background(), filter, []OnBuildFilter{&LabelsFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	exec := tetragon.GetEventsResponse_ProcessExec{
 		ProcessExec: &tetragon.ProcessExec{Process: &tetragon.Process{Pod: &tetragon.Pod{PodLabels: map[string]string{}}}},
 	}
@@ -101,7 +102,7 @@ func TestLabelSelectorFilterEmptySelector(t *testing.T) {
 func TestLabelSelectorFilterSetSelector(t *testing.T) {
 	filter := []*tetragon.Filter{{Labels: []string{"key1 in (foo, bar), key2 notin (baz)"}}}
 	fl, err := BuildFilterList(context.Background(), filter, []OnBuildFilter{&LabelsFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	exec := tetragon.GetEventsResponse_ProcessExec{
 		ProcessExec: &tetragon.ProcessExec{Process: &tetragon.Process{Pod: &tetragon.Pod{PodLabels: map[string]string{}}}},
 	}

--- a/pkg/filters/namespace_test.go
+++ b/pkg/filters/namespace_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNamespace(t *testing.T) {
 	f := []*tetragon.Filter{{Namespace: []string{"kube-system", ""}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&NamespaceFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{

--- a/pkg/filters/pod_regex_test.go
+++ b/pkg/filters/pod_regex_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPodRegexFilterBasic(t *testing.T) {
 	f := []*tetragon.Filter{{PodRegex: []string{"client", "server"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&PodRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{
@@ -91,7 +92,7 @@ func TestPodRegexFilterBasic(t *testing.T) {
 func TestPodRegexFilterAdvanced(t *testing.T) {
 	f := []*tetragon.Filter{{PodRegex: []string{"client.*", "^server$"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&PodRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ev := event.Event{
 		Event: &tetragon.GetEventsResponse{
 			Event: &tetragon.GetEventsResponse_ProcessExec{
@@ -167,13 +168,13 @@ func TestPodRegexFilterAdvanced(t *testing.T) {
 func TestPodRegexFilterInvalidRegex(t *testing.T) {
 	f := []*tetragon.Filter{{PodRegex: []string{"*"}}}
 	_, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&PodRegexFilter{}})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestPodRegexFilterInvalidEvent(t *testing.T) {
 	f := []*tetragon.Filter{{PodRegex: []string{".*"}}}
 	fl, err := BuildFilterList(context.Background(), f, []OnBuildFilter{&PodRegexFilter{}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, fl.MatchOne(nil))
 	assert.False(t, fl.MatchOne(&event.Event{Event: nil}))
 	assert.False(t, fl.MatchOne(&event.Event{Event: struct{}{}}))

--- a/pkg/filters/policies_test.go
+++ b/pkg/filters/policies_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPolicyNamesFilterInvalidEvent(t *testing.T) {
@@ -17,7 +18,7 @@ func TestPolicyNamesFilterInvalidEvent(t *testing.T) {
 	filters := []*tetragon.Filter{{PolicyNames: []string{"red-policy"}}}
 	filterFuncs := []OnBuildFilter{&PolicyNamesFilter{}}
 	fs, err := BuildFilterList(ctx, filters, filterFuncs)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	events := eventsWithPolicyName("")
 	for _, ev := range events {
@@ -30,7 +31,7 @@ func TestPolicyNamesFilterCorrectValue(t *testing.T) {
 	filters := []*tetragon.Filter{{PolicyNames: []string{"red-policy", "blue-policy"}}}
 	filterFuncs := []OnBuildFilter{&PolicyNamesFilter{}}
 	fs, err := BuildFilterList(ctx, filters, filterFuncs)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testCases := []struct {
 		policyName string
@@ -54,7 +55,7 @@ func TestPolicyNamesFilterEmptyValue(t *testing.T) {
 	filters := []*tetragon.Filter{{PolicyNames: []string{""}}}
 	filterFuncs := []OnBuildFilter{&PolicyNamesFilter{}}
 	fs, err := BuildFilterList(ctx, filters, filterFuncs)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// empty selector matches nothing
 	events := eventsWithPolicyName("red-policy")
 	for _, ev := range events {
@@ -67,7 +68,7 @@ func TestPolicyNamesFilterNilValue(t *testing.T) {
 	filters := []*tetragon.Filter{{PolicyNames: nil}}
 	filterFuncs := []OnBuildFilter{&PolicyNamesFilter{}}
 	fs, err := BuildFilterList(ctx, filters, filterFuncs)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// nil selector matches everything, i.e., does not filter events
 	events := eventsWithPolicyName("red-policy")
 	for _, ev := range events {

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -407,7 +407,7 @@ func GetProcessRefcntFromCache(t *testing.T, Pid uint32, Ktime uint64) uint32 {
 }
 
 func GetEvents(t *testing.T, events []*tetragon.GetEventsResponse) (*tetragon.ProcessExec, *tetragon.ProcessExit) {
-	assert.Equal(t, len(events), 2)
+	assert.Equal(t, 2, len(events))
 
 	var execEv *tetragon.ProcessExec
 	var exitEv *tetragon.ProcessExit
@@ -441,7 +441,7 @@ func CheckProcessEqual(t *testing.T, p1, p2 *tetragon.Process) {
 }
 
 func CheckExecEvents(t *testing.T, events []*tetragon.GetEventsResponse, parentPid uint32, currentPid uint32) {
-	assert.Equal(t, len(events), 4)
+	assert.Equal(t, 4, len(events))
 
 	var execRootEv, execParentEv, execEv *tetragon.ProcessExec
 	var exitEv *tetragon.ProcessExit
@@ -467,9 +467,9 @@ func CheckExecEvents(t *testing.T, events []*tetragon.GetEventsResponse, parentP
 	assert.NotNil(t, execEv)
 	assert.NotNil(t, exitEv)
 
-	assert.Equal(t, GetProcessRefcntFromCache(t, 1, 0), uint32(2))
-	assert.Equal(t, GetProcessRefcntFromCache(t, parentPid, 75200000000), uint32(1))
-	assert.Equal(t, GetProcessRefcntFromCache(t, currentPid, 21034975089403), uint32(0))
+	assert.Equal(t, uint32(2), GetProcessRefcntFromCache(t, 1, 0))
+	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, parentPid, 75200000000))
+	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, currentPid, 21034975089403))
 
 	// check parents
 	assert.Nil(t, execRootEv.Parent)
@@ -559,12 +559,12 @@ func GrpcExecMisingParent[EXEC notify.Message, EXIT notify.Message](t *testing.T
 
 	dn.WaitNotifier(1)
 
-	if !assert.Equal(t, 1, len(AllEvents)) {
+	if !assert.Len(t, AllEvents, 1) {
 		t.FailNow()
 	}
 	execEv := AllEvents[0].GetProcessExec()
 	assert.NotNil(t, execEv)
-	assert.Equal(t, GetProcessRefcntFromCache(t, currentPid, 21034975089403), uint32(1))
+	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, currentPid, 21034975089403))
 	assert.Nil(t, execEv.Parent)
 }
 
@@ -584,16 +584,16 @@ func GrpcMissingExec[EXEC notify.Message, EXIT notify.Message](t *testing.T) {
 
 	dn.WaitNotifier(2)
 
-	assert.Equal(t, len(AllEvents), 1)
+	assert.Equal(t, 1, len(AllEvents))
 	ev := AllEvents[0]
 	assert.NotNil(t, ev.GetProcessExit())
 
 	// this events misses process info
-	assert.Equal(t, ev.GetProcessExit().Process.ExecId, "")
-	assert.Equal(t, ev.GetProcessExit().Process.Binary, "")
+	assert.Equal(t, "", ev.GetProcessExit().Process.ExecId)
+	assert.Equal(t, "", ev.GetProcessExit().Process.Binary)
 
 	// but should have a correct Pid
-	assert.Equal(t, ev.GetProcessExit().Process.Pid, &wrapperspb.UInt32Value{Value: currentPid})
+	assert.Equal(t, &wrapperspb.UInt32Value{Value: currentPid}, ev.GetProcessExit().Process.Pid)
 }
 
 func GrpcExecParentOutOfOrder[EXEC notify.Message, EXIT notify.Message](t *testing.T) {
@@ -628,7 +628,7 @@ func GrpcExecParentOutOfOrder[EXEC notify.Message, EXIT notify.Message](t *testi
 }
 
 func CheckCloneEvents(t *testing.T, events []*tetragon.GetEventsResponse, currentPid uint32, clonePid uint32) {
-	assert.Equal(t, len(events), 3)
+	assert.Equal(t, 3, len(events))
 
 	foundExitExecProcess := false
 	foundExitCloneProcess := false
@@ -638,8 +638,8 @@ func CheckCloneEvents(t *testing.T, events []*tetragon.GetEventsResponse, curren
 			assert.Equal(t, execEv.Process.Pid.Value, currentPid)
 		} else if ev.GetProcessExit() != nil {
 			exitEv := ev.GetProcessExit()
-			assert.NotEqual(t, exitEv.Process.ExecId, "") // ensure not empty
-			assert.NotEqual(t, exitEv.Process.Binary, "") // ensure not empty
+			assert.NotEqual(t, "", exitEv.Process.ExecId) // ensure not empty
+			assert.NotEqual(t, "", exitEv.Process.Binary) // ensure not empty
 
 			switch exitEv.Process.Pid.Value {
 			case currentPid:
@@ -755,7 +755,7 @@ func GrpcParentInOrder[EXEC notify.Message, EXIT notify.Message](t *testing.T) {
 		AllEvents = append(AllEvents, e)
 	}
 
-	assert.Equal(t, len(AllEvents), 4)
+	assert.Equal(t, 4, len(AllEvents))
 
 	parentExecEv := AllEvents[0].GetProcessExec()
 	currentExecEv := AllEvents[1].GetProcessExec()
@@ -793,7 +793,7 @@ func GrpcParentInOrder[EXEC notify.Message, EXIT notify.Message](t *testing.T) {
 }
 
 func CheckPodEvents(t *testing.T, events []*tetragon.GetEventsResponse) {
-	if !assert.Equal(t, 2, len(events)) {
+	if !assert.Len(t, events, 2) {
 		t.FailNow()
 	}
 
@@ -801,14 +801,14 @@ func CheckPodEvents(t *testing.T, events []*tetragon.GetEventsResponse) {
 
 	assert.NotNil(t, execEv)
 	assert.NotNil(t, execEv.Process.Pod)                                // has pod info
-	assert.Equal(t, execEv.Process.Pod.Namespace, "fake_pod_namespace") // correct pod
-	assert.NotEqual(t, execEv.Process.ExecId, "")                       // full process info
+	assert.Equal(t, "fake_pod_namespace", execEv.Process.Pod.Namespace) // correct pod
+	assert.NotEqual(t, "", execEv.Process.ExecId)                       // full process info
 	assert.NotNil(t, execEv.Parent)
 
 	assert.NotNil(t, exitEv)
 	assert.NotNil(t, exitEv.Process.Pod)                                // has pod info
-	assert.Equal(t, exitEv.Process.Pod.Namespace, "fake_pod_namespace") // correct pod
-	assert.NotEqual(t, exitEv.Process.ExecId, "")                       // full process info
+	assert.Equal(t, "fake_pod_namespace", exitEv.Process.Pod.Namespace) // correct pod
+	assert.NotEqual(t, "", exitEv.Process.ExecId)                       // full process info
 	assert.NotNil(t, exitEv.Parent)
 }
 
@@ -1007,7 +1007,7 @@ func GrpcExecPodInfoDelayedOutOfOrder[EXEC notify.Message, EXIT notify.Message](
 
 	time.Sleep(time.Millisecond * (5 * CacheTimerMs)) // wait for cache to do it's work (but less than eventcache.CacheStrikes iterations)
 
-	if !assert.Equal(t, 0, len(AllEvents)) { // here we should still not have any events as we don't have the podinfo yet
+	if !assert.Empty(t, AllEvents) { // here we should still not have any events as we don't have the podinfo yet
 		t.FailNow()
 	}
 
@@ -1052,7 +1052,7 @@ func GrpcExecPodInfoDelayedInOrder[EXEC notify.Message, EXIT notify.Message](t *
 
 	time.Sleep(time.Millisecond * (5 * CacheTimerMs)) // wait for cache to do it's work (but less than eventcache.CacheStrikes iterations)
 
-	if !assert.Equal(t, 0, len(AllEvents)) { // here we should still not have any events as we don't have the podinfo yet
+	if !assert.Empty(t, AllEvents) { // here we should still not have any events as we don't have the podinfo yet
 		t.FailNow()
 	}
 
@@ -1093,7 +1093,7 @@ func GrpcDelayedExecK8sOutOfOrder[EXEC notify.Message, EXIT notify.Message](t *t
 	fakeWatcher.AddPod(dummyPod) // setup some dummy pod to return
 
 	time.Sleep(time.Millisecond * (5 * CacheTimerMs)) // wait for cache to do it's work (but less than eventcache.CacheStrikes iterations)
-	if !assert.Equal(t, len(AllEvents), 0) {          // here we should still not have any events as we don't have the podinfo yet
+	if !assert.Empty(t, AllEvents) {                  // here we should still not have any events as we don't have the podinfo yet
 		t.FailNow()
 	}
 
@@ -1141,7 +1141,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 
 	dn.WaitNotifier(2)
 
-	assert.Equal(t, 2, len(AllEvents))
+	assert.Len(t, AllEvents, 2)
 
 	rootExecEv := AllEvents[0].GetProcessExec()
 	aExecEv := AllEvents[1].GetProcessExec()
@@ -1163,7 +1163,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 3, len(AllEvents))
+	assert.Len(t, AllEvents, 3)
 	bExecEv := AllEvents[2].GetProcessExec()
 	assert.NotNil(t, bExecEv)
 
@@ -1182,7 +1182,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 4, len(AllEvents))
+	assert.Len(t, AllEvents, 4)
 	cExecEv := AllEvents[3].GetProcessExec()
 	assert.NotNil(t, cExecEv)
 
@@ -1193,7 +1193,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 	assert.Equal(t, uint32(2), GetProcessRefcntFromCache(t, bPid, 21034975097238)) //        /usr/b    pid=3 exec_id=5 refCnt=2 [+2 from parent    | -1 from CleanupEvent]
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, cPid, 21034975100084)) //        /usr/b    pid=4 exec_id=6 refCnt=0 [+1 from clone     | -1 from CleanupEvent]
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, cPid, 21034975112851)) //exec    /usr/c    pid=4 exec_id=7 refCnt=1 [+1 from exec]
-	assert.Equal(t, 1, len(cExecEv.Ancestors))
+	assert.Len(t, cExecEv.Ancestors, 1)
 	assert.Equal(t, uint32(2), cExecEv.Ancestors[len(cExecEv.Ancestors)-1].Pid.Value)
 
 	if e := (*dExecMsg).HandleMessage(); e != nil {
@@ -1202,7 +1202,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 5, len(AllEvents))
+	assert.Len(t, AllEvents, 5)
 	dExecEv := AllEvents[4].GetProcessExec()
 	assert.NotNil(t, dExecEv)
 
@@ -1214,7 +1214,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, cPid, 21034975100084)) //        /usr/b    pid=4 exec_id=6 refCnt=0 []
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, cPid, 21034975112851)) //        /usr/c    pid=4 exec_id=7 refCnt=1 [+1 from parent    | -1 from CleanupEvent]
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, dPid, 21034975123672)) //exec    /usr/d    pid=4 exec_id=8 refCnt=1 [+1 from exec]
-	assert.Equal(t, 2, len(dExecEv.Ancestors))
+	assert.Len(t, dExecEv.Ancestors, 2)
 	assert.Equal(t, uint32(2), dExecEv.Ancestors[len(dExecEv.Ancestors)-1].Pid.Value)
 
 	if e := (*eExecMsg).HandleMessage(); e != nil {
@@ -1223,7 +1223,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 6, len(AllEvents))
+	assert.Len(t, AllEvents, 6)
 	eExecEv := AllEvents[5].GetProcessExec()
 	assert.NotNil(t, eExecEv)
 
@@ -1236,7 +1236,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, cPid, 21034975112851)) //        /usr/c    pid=4 exec_id=7 refCnt=1 [+1 from Ancestors | -1 from CleanupEvent]
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, dPid, 21034975123672)) //        /usr/d    pid=4 exec_id=8 refCnt=1 [+1 from parent    | -1 from CleanupEvent]
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, ePid, 21034975145167)) //exec    /usr/e    pid=4 exec_id=9 refCnt=1 [+1 from exec]
-	assert.Equal(t, 3, len(eExecEv.Ancestors))
+	assert.Len(t, eExecEv.Ancestors, 3)
 	assert.Equal(t, uint32(2), eExecEv.Ancestors[len(eExecEv.Ancestors)-1].Pid.Value)
 
 	if e := (*eExitMsg).HandleMessage(); e != nil {
@@ -1245,7 +1245,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 7, len(AllEvents))
+	assert.Len(t, AllEvents, 7)
 	eExitEv := AllEvents[6].GetProcessExit()
 	assert.NotNil(t, eExitEv)
 
@@ -1258,7 +1258,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, cPid, 21034975112851)) //        /usr/c    pid=4 exec_id=7 refCnt=0 [-1 from Ancestors]
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, dPid, 21034975123672)) //        /usr/d    pid=4 exec_id=8 refCnt=0 [-1 from parent]
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, ePid, 21034975145167)) //exit    /usr/e    pid=4 exec_id=9 refCnt=0 [-1 from exit]
-	assert.Equal(t, 3, len(eExitEv.Ancestors))
+	assert.Len(t, eExitEv.Ancestors, 3)
 	assert.Equal(t, uint32(2), eExitEv.Ancestors[len(eExitEv.Ancestors)-1].Pid.Value)
 
 	if e := (*bExitMsg).HandleMessage(); e != nil {
@@ -1267,7 +1267,7 @@ func GrpcExecAncestorsInOrder[EXEC notify.Message, CLONE notify.Message, EXIT no
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 8, len(AllEvents))
+	assert.Len(t, AllEvents, 8)
 	bExitEv := AllEvents[7].GetProcessExit()
 	assert.NotNil(t, bExitEv)
 
@@ -1314,7 +1314,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 
 	dn.WaitNotifier(2)
 
-	assert.Equal(t, 2, len(AllEvents))
+	assert.Len(t, AllEvents, 2)
 
 	rootExecEv := AllEvents[0].GetProcessExec()
 	aExecEv := AllEvents[1].GetProcessExec()
@@ -1336,7 +1336,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 3, len(AllEvents))
+	assert.Len(t, AllEvents, 3)
 	bExecEv := AllEvents[2].GetProcessExec()
 	assert.NotNil(t, bExecEv)
 
@@ -1355,7 +1355,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 4, len(AllEvents))
+	assert.Len(t, AllEvents, 4)
 	cExecEv := AllEvents[3].GetProcessExec()
 	assert.NotNil(t, cExecEv)
 
@@ -1366,7 +1366,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 	assert.Equal(t, uint32(2), GetProcessRefcntFromCache(t, bPid, 21034975097238)) //        /usr/b    pid=3 exec_id=5 refCnt=2 [+2 from parent    | -1 from CleanupEvent]
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, cPid, 21034975100084)) //        /usr/b    pid=4 exec_id=6 refCnt=0 [+1 from clone     | -1 from CleanupEvent]
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, cPid, 21034975112851)) //exec    /usr/c    pid=4 exec_id=7 refCnt=1 [+1 from exec]
-	assert.Equal(t, 1, len(cExecEv.Ancestors))
+	assert.Len(t, cExecEv.Ancestors, 1)
 	assert.Equal(t, uint32(2), cExecEv.Ancestors[len(cExecEv.Ancestors)-1].Pid.Value)
 
 	if e := (*bExitMsg).HandleMessage(); e != nil {
@@ -1375,7 +1375,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 5, len(AllEvents))
+	assert.Len(t, AllEvents, 5)
 	bExitEv := AllEvents[4].GetProcessExit()
 	assert.NotNil(t, bExitEv)
 
@@ -1392,7 +1392,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 6, len(AllEvents))
+	assert.Len(t, AllEvents, 6)
 	dExecEv := AllEvents[5].GetProcessExec()
 	assert.NotNil(t, dExecEv)
 
@@ -1404,7 +1404,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, cPid, 21034975100084)) //        /usr/b    pid=4 exec_id=6 refCnt=0 []
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, cPid, 21034975112851)) //        /usr/c    pid=4 exec_id=7 refCnt=1 [+1 from parent    | -1 from CleanupEvent]
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, dPid, 21034975123672)) //exec    /usr/d    pid=4 exec_id=8 refCnt=1 [+1 from exec]
-	assert.Equal(t, 2, len(dExecEv.Ancestors))
+	assert.Len(t, dExecEv.Ancestors, 2)
 	assert.Equal(t, uint32(2), dExecEv.Ancestors[len(dExecEv.Ancestors)-1].Pid.Value)
 
 	if e := (*eExecMsg).HandleMessage(); e != nil {
@@ -1413,7 +1413,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 7, len(AllEvents))
+	assert.Len(t, AllEvents, 7)
 	eExecEv := AllEvents[6].GetProcessExec()
 	assert.NotNil(t, eExecEv)
 
@@ -1426,7 +1426,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, cPid, 21034975112851)) //        /usr/c    pid=4 exec_id=7 refCnt=1 [+1 from Ancestors | -1 from CleanupEvent]
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, dPid, 21034975123672)) //        /usr/d    pid=4 exec_id=8 refCnt=1 [+1 from parent    | -1 from CleanupEvent]
 	assert.Equal(t, uint32(1), GetProcessRefcntFromCache(t, ePid, 21034975145167)) //exec    /usr/e    pid=4 exec_id=9 refCnt=1 [+1 from exec]
-	assert.Equal(t, 3, len(eExecEv.Ancestors))
+	assert.Len(t, eExecEv.Ancestors, 3)
 	assert.Equal(t, uint32(2), eExecEv.Ancestors[len(eExecEv.Ancestors)-1].Pid.Value)
 
 	if e := (*eExitMsg).HandleMessage(); e != nil {
@@ -1435,7 +1435,7 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 
 	dn.WaitNotifier(1)
 
-	assert.Equal(t, 8, len(AllEvents))
+	assert.Len(t, AllEvents, 8)
 	eExitEv := AllEvents[7].GetProcessExit()
 	assert.NotNil(t, eExitEv)
 
@@ -1448,6 +1448,6 @@ func GrpcExecAncestorsOutOfOrder[EXEC notify.Message, CLONE notify.Message, EXIT
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, cPid, 21034975112851)) //        /usr/c    pid=4 exec_id=7 refCnt=0 [-1 from Ancestors]
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, dPid, 21034975123672)) //        /usr/d    pid=4 exec_id=8 refCnt=0 [-1 from parent]
 	assert.Equal(t, uint32(0), GetProcessRefcntFromCache(t, ePid, 21034975145167)) //exit    /usr/e    pid=4 exec_id=9 refCnt=0 [-1 from exit]
-	assert.Equal(t, 3, len(eExitEv.Ancestors))
+	assert.Len(t, eExitEv.Ancestors, 3)
 	assert.Equal(t, uint32(2), eExitEv.Ancestors[len(eExitEv.Ancestors)-1].Pid.Value)
 }

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -407,7 +407,7 @@ func GetProcessRefcntFromCache(t *testing.T, Pid uint32, Ktime uint64) uint32 {
 }
 
 func GetEvents(t *testing.T, events []*tetragon.GetEventsResponse) (*tetragon.ProcessExec, *tetragon.ProcessExit) {
-	assert.Equal(t, 2, len(events))
+	assert.Len(t, events, 2)
 
 	var execEv *tetragon.ProcessExec
 	var exitEv *tetragon.ProcessExit
@@ -441,7 +441,7 @@ func CheckProcessEqual(t *testing.T, p1, p2 *tetragon.Process) {
 }
 
 func CheckExecEvents(t *testing.T, events []*tetragon.GetEventsResponse, parentPid uint32, currentPid uint32) {
-	assert.Equal(t, 4, len(events))
+	assert.Len(t, events, 4)
 
 	var execRootEv, execParentEv, execEv *tetragon.ProcessExec
 	var exitEv *tetragon.ProcessExit
@@ -584,13 +584,13 @@ func GrpcMissingExec[EXEC notify.Message, EXIT notify.Message](t *testing.T) {
 
 	dn.WaitNotifier(2)
 
-	assert.Equal(t, 1, len(AllEvents))
+	assert.Len(t, AllEvents, 1)
 	ev := AllEvents[0]
 	assert.NotNil(t, ev.GetProcessExit())
 
 	// this events misses process info
-	assert.Equal(t, "", ev.GetProcessExit().Process.ExecId)
-	assert.Equal(t, "", ev.GetProcessExit().Process.Binary)
+	assert.Empty(t, ev.GetProcessExit().Process.ExecId)
+	assert.Empty(t, ev.GetProcessExit().Process.Binary)
 
 	// but should have a correct Pid
 	assert.Equal(t, &wrapperspb.UInt32Value{Value: currentPid}, ev.GetProcessExit().Process.Pid)
@@ -628,7 +628,7 @@ func GrpcExecParentOutOfOrder[EXEC notify.Message, EXIT notify.Message](t *testi
 }
 
 func CheckCloneEvents(t *testing.T, events []*tetragon.GetEventsResponse, currentPid uint32, clonePid uint32) {
-	assert.Equal(t, 3, len(events))
+	assert.Len(t, events, 3)
 
 	foundExitExecProcess := false
 	foundExitCloneProcess := false
@@ -638,8 +638,8 @@ func CheckCloneEvents(t *testing.T, events []*tetragon.GetEventsResponse, curren
 			assert.Equal(t, execEv.Process.Pid.Value, currentPid)
 		} else if ev.GetProcessExit() != nil {
 			exitEv := ev.GetProcessExit()
-			assert.NotEqual(t, "", exitEv.Process.ExecId) // ensure not empty
-			assert.NotEqual(t, "", exitEv.Process.Binary) // ensure not empty
+			assert.NotEmpty(t, exitEv.Process.ExecId) // ensure not empty
+			assert.NotEmpty(t, exitEv.Process.Binary) // ensure not empty
 
 			switch exitEv.Process.Pid.Value {
 			case currentPid:
@@ -755,7 +755,7 @@ func GrpcParentInOrder[EXEC notify.Message, EXIT notify.Message](t *testing.T) {
 		AllEvents = append(AllEvents, e)
 	}
 
-	assert.Equal(t, 4, len(AllEvents))
+	assert.Len(t, AllEvents, 4)
 
 	parentExecEv := AllEvents[0].GetProcessExec()
 	currentExecEv := AllEvents[1].GetProcessExec()
@@ -802,13 +802,13 @@ func CheckPodEvents(t *testing.T, events []*tetragon.GetEventsResponse) {
 	assert.NotNil(t, execEv)
 	assert.NotNil(t, execEv.Process.Pod)                                // has pod info
 	assert.Equal(t, "fake_pod_namespace", execEv.Process.Pod.Namespace) // correct pod
-	assert.NotEqual(t, "", execEv.Process.ExecId)                       // full process info
+	assert.NotEmpty(t, execEv.Process.ExecId)                           // full process info
 	assert.NotNil(t, execEv.Parent)
 
 	assert.NotNil(t, exitEv)
 	assert.NotNil(t, exitEv.Process.Pod)                                // has pod info
 	assert.Equal(t, "fake_pod_namespace", exitEv.Process.Pod.Namespace) // correct pod
-	assert.NotEqual(t, "", exitEv.Process.ExecId)                       // full process info
+	assert.NotEmpty(t, exitEv.Process.ExecId)                           // full process info
 	assert.NotNil(t, exitEv.Parent)
 }
 

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/tetragon/pkg/rthooks"
 	"github.com/cilium/tetragon/pkg/watcher"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	corev1 "k8s.io/api/core/v1"
@@ -59,7 +60,7 @@ func TestProcessManager_getPodInfo(t *testing.T) {
 
 	pods := []interface{}{&podA}
 	err := process.InitCache(watcher.NewFakeK8sWatcher(pods), 10, defaults.DefaultProcessCacheGCInterval)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer process.FreeCache()
 	pod := process.GetPodInfo("container-id-not-found", "", "", 0)
 	assert.Nil(t, pod)
@@ -125,7 +126,7 @@ func TestProcessManager_getPodInfoMaybeExecProbe(t *testing.T) {
 	}
 	pods := []interface{}{&podA}
 	err := process.InitCache(watcher.NewFakeK8sWatcher(pods), 10, defaults.DefaultProcessCacheGCInterval)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer process.FreeCache()
 	pod := process.GetPodInfo("aaaaaaa", "/bin/command", "arg-a arg-b", 1234)
 	assert.Equal(t,
@@ -146,7 +147,7 @@ func TestProcessManager_getPodInfoMaybeExecProbe(t *testing.T) {
 
 func TestProcessManager_GetProcessExec(t *testing.T) {
 	err := process.InitCache(watcher.NewFakeK8sWatcher(nil), 10, defaults.DefaultProcessCacheGCInterval)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer process.FreeCache()
 	var wg sync.WaitGroup
 
@@ -157,7 +158,7 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 		&wg,
 		nil,
 		&rthooks.Runner{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	pi := &exec.MsgExecveEventUnix{
 		Unix: &processapi.MsgExecveEventUnix{
 			Msg: &processapi.MsgExecveEvent{

--- a/pkg/grpc/process_manager_test_linux.go
+++ b/pkg/grpc/process_manager_test_linux.go
@@ -13,18 +13,19 @@ import (
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/watcher"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProcessManager_GetProcessID(t *testing.T) {
-	assert.NoError(t, os.Setenv("NODE_NAME", "my-node"))
+	require.NoError(t, os.Setenv("NODE_NAME", "my-node"))
 	node.SetExportNodeName()
 
 	err := process.InitCache(watcher.NewFakeK8sWatcher([]interface{}{}), 10, defaults.DefaultProcessCacheGCInterval)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer process.FreeCache()
 	id := process.GetProcessID(1, 2)
 	decoded, err := base64.StdEncoding.DecodeString(id)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "my-node:2:1", string(decoded))
-	assert.NoError(t, os.Unsetenv("NODE_NAME"))
+	require.NoError(t, os.Unsetenv("NODE_NAME"))
 }

--- a/pkg/grpc/process_manager_test_windows.go
+++ b/pkg/grpc/process_manager_test_windows.go
@@ -13,18 +13,19 @@ import (
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/watcher"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProcessManager_GetProcessID(t *testing.T) {
-	assert.NoError(t, os.Setenv("NODE_NAME", "my-node"))
+	require.NoError(t, os.Setenv("NODE_NAME", "my-node"))
 	node.SetExportNodeName()
 
 	err := process.InitCache(watcher.NewFakeK8sWatcher([]interface{}{}), 10, defaults.DefaultProcessCacheGCInterval)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer process.FreeCache()
 	id := process.GetProcessID(1, 2)
 	decoded, err := base64.StdEncoding.DecodeString(id)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "1:1:1", string(decoded))
-	assert.NoError(t, os.Unsetenv("NODE_NAME"))
+	require.NoError(t, os.Unsetenv("NODE_NAME"))
 }

--- a/pkg/kernels/kernels_test.go
+++ b/pkg/kernels/kernels_test.go
@@ -44,6 +44,6 @@ func TestKernelStringToNumeric(t *testing.T) {
 
 func TestGetKernelVersion(t *testing.T) {
 	ver, verStr, err := GetKernelVersion("", "/proc")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, KernelStringToNumeric(verStr), ver)
 }

--- a/pkg/kernels/kernels_test.go
+++ b/pkg/kernels/kernels_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKernelStringToNumeric(t *testing.T) {
@@ -44,6 +45,6 @@ func TestKernelStringToNumeric(t *testing.T) {
 
 func TestGetKernelVersion(t *testing.T) {
 	ver, verStr, err := GetKernelVersion("", "/proc")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.EqualValues(t, KernelStringToNumeric(verStr), ver)
 }

--- a/pkg/ktime/ktime_windows_test.go
+++ b/pkg/ktime/ktime_windows_test.go
@@ -7,22 +7,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKtime(t *testing.T) {
 	time1, err := NanoTimeSince(0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Greater(t, time1.Milliseconds(), int64(0))
 	time2, err := NanoTimeSince(0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.GreaterOrEqual(t, time2, time1)
 }
 
 func TestBoottime(t *testing.T) {
 	time1, err := NanoTimeSince(0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ktime1, err := DecodeKtime(time1.Nanoseconds(), false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Greater(t, ktime1.UnixMilli(), int64(0))
 }
 

--- a/pkg/ktime/ktime_windows_test.go
+++ b/pkg/ktime/ktime_windows_test.go
@@ -13,7 +13,7 @@ import (
 func TestKtime(t *testing.T) {
 	time1, err := NanoTimeSince(0)
 	require.NoError(t, err)
-	assert.Greater(t, time1.Milliseconds(), int64(0))
+	assert.Positive(t, time1.Milliseconds())
 	time2, err := NanoTimeSince(0)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, time2, time1)
@@ -24,10 +24,10 @@ func TestBoottime(t *testing.T) {
 	require.NoError(t, err)
 	ktime1, err := DecodeKtime(time1.Nanoseconds(), false)
 	require.NoError(t, err)
-	assert.Greater(t, ktime1.UnixMilli(), int64(0))
+	assert.Positive(t, ktime1.UnixMilli())
 }
 
 func TestKernelTime(t *testing.T) {
 	uTime, _ := DecodeKtime(133918958189958838, false)
-	assert.Equal(t, uTime.Unix(), int64(1747422218))
+	assert.Equal(t, int64(1747422218), uTime.Unix())
 }

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -4,7 +4,6 @@
 package labels
 
 import (
-	"fmt"
 	"testing"
 
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -203,7 +202,7 @@ func TestCmp(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		require.Equal(t, tc.expected, Labels(tc.l1).Cmp(tc.l2), fmt.Sprintf("test: %+v", tc))
-		require.Equal(t, tc.expected, Labels(tc.l2).Cmp(tc.l1), fmt.Sprintf("reverse-test: %+v", tc))
+		require.Equal(t, tc.expected, Labels(tc.l1).Cmp(tc.l2), "test: %+v", tc)
+		require.Equal(t, tc.expected, Labels(tc.l2).Cmp(tc.l1), "reverse-test: %+v", tc)
 	}
 }

--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -38,14 +38,14 @@ type ManagerTestSuite struct {
 
 func (suite *ManagerTestSuite) SetupSuite() {
 	err := os.Setenv("NODE_NAME", nodeName)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	node.SetKubernetesNodeName()
 	useExistingCluster := true
 	suite.testEnv = &envtest.Environment{
 		UseExistingCluster: &useExistingCluster,
 	}
 	_, err = suite.testEnv.Start()
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	suite.manager = Get()
 	suite.manager.Start(context.Background())
 }
@@ -53,22 +53,22 @@ func (suite *ManagerTestSuite) SetupSuite() {
 func (suite *ManagerTestSuite) TestListNamespaces() {
 	// List namespaces.
 	namespaces, err := suite.manager.ListNamespaces()
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.NotEmpty(suite.T(), namespaces)
 
 	// Call GetNamespace on the first namespace in the list.
 	namespace, err := suite.manager.GetNamespace(namespaces[0].Name)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), namespaces[0].Name, namespace.Name)
 }
 
 func (suite *ManagerTestSuite) TestFindPod() {
 	var pods corev1.PodList
 	err := suite.manager.Manager.GetCache().List(context.Background(), &pods, client.InNamespace("kube-system"))
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.NotEmpty(suite.T(), pods.Items)
 	pod, err := suite.manager.FindPod(string(pods.Items[0].UID))
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), pods.Items[0].UID, pod.UID)
 }
 
@@ -109,7 +109,7 @@ func (suite *ManagerTestSuite) TestFindContainer() {
 
 	// Delete the pod.
 	err := k8sClient.Delete(context.Background(), pod)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.Eventually(suite.T(), func() bool {
 		err = k8sClient.Get(context.Background(), client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name}, &podFromClient)
 		return errors.IsNotFound(err)
@@ -126,20 +126,20 @@ func (suite *ManagerTestSuite) TestLocalPods() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	err := os.Setenv("NODE_NAME", "nonexistent-node")
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	node.SetKubernetesNodeName()
 	controllerManager, err := newControllerManager()
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	go func() {
-		assert.NoError(suite.T(), controllerManager.Manager.Start(ctx))
+		require.NoError(suite.T(), controllerManager.Manager.Start(ctx))
 	}()
 	controllerManager.Manager.GetCache().WaitForCacheSync(ctx)
 	pods := corev1.PodList{}
 	err = controllerManager.Manager.GetCache().List(context.Background(), &pods)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 	// Pod cache should be empty because the node name is set to a nonexistent node.
 	assert.Empty(suite.T(), pods.Items)
-	assert.NoError(suite.T(), os.Setenv("NODE_NAME", nodeName))
+	require.NoError(suite.T(), os.Setenv("NODE_NAME", nodeName))
 	node.SetKubernetesNodeName()
 }
 
@@ -156,7 +156,7 @@ func (suite *ManagerTestSuite) TestGetNode() {
 }
 
 func (suite *ManagerTestSuite) TearDownSuite() {
-	assert.NoError(suite.T(), suite.testEnv.Stop())
+	require.NoError(suite.T(), suite.testEnv.Stop())
 }
 
 func TestControllerSuite(t *testing.T) {

--- a/pkg/matchers/bytesmatcher/bytesmatcher_test.go
+++ b/pkg/matchers/bytesmatcher/bytesmatcher_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/cilium/tetragon/pkg/eventcheckertests/yamlhelpers"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBytesMatcherFullSmoke(t *testing.T) {
@@ -27,10 +27,10 @@ func TestBytesMatcherFullSmoke(t *testing.T) {
 	}
 
 	err := checker.Match(bytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(bytes[:3])
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBytesMatcherPrefixSmoke(t *testing.T) {
@@ -49,13 +49,13 @@ func TestBytesMatcherPrefixSmoke(t *testing.T) {
 	}
 
 	err := checker.Match(bytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(bytes[:3])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(bytes[:2])
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBytesMatcherSuffixSmoke(t *testing.T) {
@@ -74,13 +74,13 @@ func TestBytesMatcherSuffixSmoke(t *testing.T) {
 	}
 
 	err := checker.Match(bytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(bytes[3:])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(bytes[:3])
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestBytesMatcherContainsSmoke(t *testing.T) {
@@ -99,14 +99,14 @@ func TestBytesMatcherContainsSmoke(t *testing.T) {
 	}
 
 	err := checker.Match(bytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(bytes[:4])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(bytes[1:4])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(bytes[:3])
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/matchers/durationmatcher/durationmatcher_test.go
+++ b/pkg/matchers/durationmatcher/durationmatcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/eventcheckertests/yamlhelpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -26,12 +27,12 @@ func TestDurationMatcherFullSmoke(t *testing.T) {
 	// Exact match
 	toCheck := 2 * time.Second
 	err := checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Bad match
 	toCheck = 2 * time.Minute
 	err = checker.Match(durationpb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Make sure a flat duration is the same as a full matcher
 	yamlStr2 := `2s`
@@ -58,27 +59,27 @@ func TestDurationMatcherLessSmoke(t *testing.T) {
 	// Exact match
 	toCheck := 1*time.Minute + 30*time.Second
 	err := checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 1 second less
 	toCheck = 1*time.Minute + 29*time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 1 minute less
 	toCheck = 30 * time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 1 second over
 	toCheck = 1*time.Minute + 31*time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// 1 minute over
 	toCheck = 2*time.Minute + 30*time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestDurationMatcherGreaterSmoke(t *testing.T) {
@@ -95,27 +96,27 @@ func TestDurationMatcherGreaterSmoke(t *testing.T) {
 	// Exact match
 	toCheck := 1*time.Minute + 30*time.Second
 	err := checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 1 second greater
 	toCheck = 1*time.Minute + 31*time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 1 minute greater
 	toCheck = 2*time.Minute + 30*time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 1 second under
 	toCheck = 1*time.Minute + 29*time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// 1 minute under
 	toCheck = 30 * time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestDurationMatcherBetweenSmoke(t *testing.T) {
@@ -134,25 +135,25 @@ func TestDurationMatcherBetweenSmoke(t *testing.T) {
 	// Exact match on lower bound
 	toCheck := 1 * time.Minute
 	err := checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Exact match on upper bound
 	toCheck = 2 * time.Minute
 	err = checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// In between
 	toCheck = 1*time.Minute + 30*time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Under
 	toCheck = 59 * time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Over
 	toCheck = 2*time.Minute + 1*time.Second
 	err = checker.Match(durationpb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/matchers/stringmatcher/stringmatcher_test.go
+++ b/pkg/matchers/stringmatcher/stringmatcher_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cilium/tetragon/pkg/eventcheckertests/yamlhelpers"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringMatcherFullSmoke(t *testing.T) {
@@ -24,10 +24,10 @@ func TestStringMatcherFullSmoke(t *testing.T) {
 	}
 
 	err := checker.Match(str)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(str[:3])
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestStringMatcherPrefixSmoke(t *testing.T) {
@@ -44,13 +44,13 @@ func TestStringMatcherPrefixSmoke(t *testing.T) {
 	}
 
 	err := checker.Match(str)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(str[:3])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(str[2:])
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestStringMatcherSuffixSmoke(t *testing.T) {
@@ -67,13 +67,13 @@ func TestStringMatcherSuffixSmoke(t *testing.T) {
 	}
 
 	err := checker.Match(str)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(str[3:])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(str[:3])
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestStringMatcherContainsSmoke(t *testing.T) {
@@ -90,16 +90,16 @@ func TestStringMatcherContainsSmoke(t *testing.T) {
 	}
 
 	err := checker.Match(str)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(str[:4])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(str[1:4])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match(str[:3])
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestStringMatcherRegexSmoke(t *testing.T) {
@@ -114,17 +114,17 @@ func TestStringMatcherRegexSmoke(t *testing.T) {
 	}
 
 	err := checker.Match("foobarqux")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match("barqux")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match("bazbarqux")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = checker.Match("foobarqu")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = checker.Match("foobarquxxxxx")
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/matchers/timestampmatcher/timestampmatcher_test.go
+++ b/pkg/matchers/timestampmatcher/timestampmatcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/eventcheckertests/yamlhelpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -63,22 +64,22 @@ func TestTimestampMatcherDaySmoke(t *testing.T) {
 	// Right day, month, year
 	toCheck := time.Date(2022, 5, 9, 0, 0, 0, 0, time.UTC)
 	err := checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wrong day
 	toCheck = time.Date(2022, 5, 10, 20, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong month
 	toCheck = time.Date(2022, 6, 9, 20, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong year
 	toCheck = time.Date(2023, 5, 9, 20, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestTimestampMatcherHourSmoke(t *testing.T) {
@@ -95,27 +96,27 @@ func TestTimestampMatcherHourSmoke(t *testing.T) {
 	// Right day, month, year, hour
 	toCheck := time.Date(2022, 5, 9, 20, 0, 0, 0, time.UTC)
 	err := checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wrong hour
 	toCheck = time.Date(2022, 5, 9, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong day
 	toCheck = time.Date(2022, 5, 10, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong month
 	toCheck = time.Date(2022, 6, 9, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong year
 	toCheck = time.Date(2023, 5, 9, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestTimestampMatcherMinuteSmoke(t *testing.T) {
@@ -132,32 +133,32 @@ func TestTimestampMatcherMinuteSmoke(t *testing.T) {
 	// Right day, month, year, hour, minute
 	toCheck := time.Date(2022, 5, 9, 20, 29, 0, 0, time.UTC)
 	err := checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wrong minute
 	toCheck = time.Date(2022, 5, 9, 21, 30, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong hour
 	toCheck = time.Date(2022, 5, 9, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong day
 	toCheck = time.Date(2022, 5, 10, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong month
 	toCheck = time.Date(2022, 6, 9, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong year
 	toCheck = time.Date(2023, 5, 9, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestTimestampMatcherSecondSmoke(t *testing.T) {
@@ -174,37 +175,37 @@ func TestTimestampMatcherSecondSmoke(t *testing.T) {
 	// Right day, month, year, hour, minute, second
 	toCheck := time.Date(2022, 5, 9, 20, 29, 34, 0, time.UTC)
 	err := checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wrong second
 	toCheck = time.Date(2022, 5, 9, 21, 29, 35, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong minute
 	toCheck = time.Date(2022, 5, 9, 21, 30, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong hour
 	toCheck = time.Date(2022, 5, 9, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong day
 	toCheck = time.Date(2022, 5, 10, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong month
 	toCheck = time.Date(2022, 6, 9, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Wrong year
 	toCheck = time.Date(2023, 5, 9, 21, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestTimestampMatcherBeforeSmoke(t *testing.T) {
@@ -221,37 +222,37 @@ func TestTimestampMatcherBeforeSmoke(t *testing.T) {
 	// Equal
 	toCheck := time.Date(2022, 5, 9, 20, 29, 34, 0, time.UTC)
 	err := checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Second before
 	toCheck = time.Date(2022, 5, 9, 20, 29, 33, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// NS before
 	toCheck = time.Date(2022, 5, 9, 20, 29, 33, 137, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Year before
 	toCheck = time.Date(2021, 5, 9, 20, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Second after
 	toCheck = time.Date(2022, 5, 9, 20, 29, 35, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Year after
 	toCheck = time.Date(2023, 5, 9, 20, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// NS after
 	toCheck = time.Date(2022, 5, 9, 20, 29, 34, 137, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestTimestampMatcherAfterSmoke(t *testing.T) {
@@ -268,37 +269,37 @@ func TestTimestampMatcherAfterSmoke(t *testing.T) {
 	// Equal
 	toCheck := time.Date(2022, 5, 9, 20, 29, 34, 0, time.UTC)
 	err := checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Second before
 	toCheck = time.Date(2022, 5, 9, 20, 29, 33, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// NS before
 	toCheck = time.Date(2022, 5, 9, 20, 29, 33, 137, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Year before
 	toCheck = time.Date(2021, 5, 9, 20, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Second after
 	toCheck = time.Date(2022, 5, 9, 20, 29, 35, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Year after
 	toCheck = time.Date(2023, 5, 9, 20, 29, 34, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// NS after
 	toCheck = time.Date(2022, 5, 9, 20, 29, 34, 137, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestTimestampMatcherBetweenSmoke(t *testing.T) {
@@ -317,15 +318,15 @@ func TestTimestampMatcherBetweenSmoke(t *testing.T) {
 	// Inside
 	toCheck := time.Date(2022, 5, 9, 20, 29, 34, 0, time.UTC)
 	err := checker.Match(timestamppb.New(toCheck))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Before by 1s
 	toCheck = time.Date(2022, 5, 9, 20, 28, 59, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// After by 1s
 	toCheck = time.Date(2022, 5, 9, 20, 30, 1, 0, time.UTC)
 	err = checker.Match(timestamppb.New(toCheck))
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/metrics/eventmetrics/eventmetrics_test.go
+++ b/pkg/metrics/eventmetrics/eventmetrics_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleProcessedEvent(t *testing.T) {
-	assert.NoError(t, testutil.CollectAndCompare(EventsProcessed, strings.NewReader("")))
+	require.NoError(t, testutil.CollectAndCompare(EventsProcessed, strings.NewReader("")))
 	handleProcessedEvent(nil, nil)
 	// empty process
 	handleProcessedEvent(nil, &tetragon.GetEventsResponse{Event: &tetragon.GetEventsResponse_ProcessKprobe{ProcessKprobe: &tetragon.ProcessKprobe{}}})
@@ -79,13 +79,13 @@ tetragon_events_total{binary="binary_c",namespace="namespace_c",pod="pod_c",type
 tetragon_events_total{binary="binary_e",namespace="",pod="",type="PROCESS_EXIT",workload=""} 1
 tetragon_events_total{binary="binary_e",namespace="namespace_e",pod="pod_e",type="PROCESS_EXIT",workload="workload_e"} 1
 `)
-	assert.NoError(t, testutil.CollectAndCompare(EventsProcessed, expected))
+	require.NoError(t, testutil.CollectAndCompare(EventsProcessed, expected))
 }
 
 func TestHandleOriginalEvent(t *testing.T) {
 	handleOriginalEvent(nil)
 	handleOriginalEvent(&processapi.MsgExecveEventUnix{})
-	assert.NoError(t, testutil.CollectAndCompare(FlagCount, strings.NewReader("")))
+	require.NoError(t, testutil.CollectAndCompare(FlagCount, strings.NewReader("")))
 	handleOriginalEvent(&processapi.MsgExecveEventUnix{
 		Process: processapi.MsgProcess{
 			Flags: api.EventClone | api.EventExecve,
@@ -96,5 +96,5 @@ func TestHandleOriginalEvent(t *testing.T) {
 tetragon_flags_total{type="clone"} 1
 tetragon_flags_total{type="execve"} 1
 `)
-	assert.NoError(t, testutil.CollectAndCompare(FlagCount, expected))
+	require.NoError(t, testutil.CollectAndCompare(FlagCount, expected))
 }

--- a/pkg/metrics/filteredlabels_test.go
+++ b/pkg/metrics/filteredlabels_test.go
@@ -25,18 +25,18 @@ func TestProcessLabels(t *testing.T) {
 
 	// by default all labels should be enabled
 	processLabels := option.CreateProcessLabels(namespace, workload, pod, binary)
-	assert.Equal(t, processLabels.Values(), []string{namespace, workload, pod, binary})
+	assert.Equal(t, []string{namespace, workload, pod, binary}, processLabels.Values())
 
 	// disable workload and pod
 	option.Config.MetricsLabelFilter["workload"] = false
 	option.Config.MetricsLabelFilter["pod"] = false
 	processLabels = option.CreateProcessLabels(namespace, workload, pod, binary)
-	assert.Equal(t, processLabels.Values(), []string{namespace, "", "", binary})
+	assert.Equal(t, []string{namespace, "", "", binary}, processLabels.Values())
 
 	// delete binary (this shouldn't really happen, we set the values to false instead)
 	delete(option.Config.MetricsLabelFilter, "binary")
 	processLabels = option.CreateProcessLabels(namespace, workload, pod, binary)
-	assert.Equal(t, processLabels.Values(), []string{namespace, "", "", ""})
+	assert.Equal(t, []string{namespace, "", "", ""}, processLabels.Values())
 
 	// disable all
 	option.Config.MetricsLabelFilter = option.DefaultLabelFilter()
@@ -44,10 +44,10 @@ func TestProcessLabels(t *testing.T) {
 		option.Config.MetricsLabelFilter[l] = false
 	}
 	processLabels = option.CreateProcessLabels(namespace, workload, pod, binary)
-	assert.Equal(t, processLabels.Values(), []string{"", "", "", ""})
+	assert.Equal(t, []string{"", "", "", ""}, processLabels.Values())
 
 	// clear label filter (this shouldn't really happen, we set the values to false instead)
 	option.Config.MetricsLabelFilter = metrics.LabelFilter{}
 	processLabels = option.CreateProcessLabels(namespace, workload, pod, binary)
-	assert.Equal(t, processLabels.Values(), []string{"", "", "", ""})
+	assert.Equal(t, []string{"", "", "", ""}, processLabels.Values())
 }

--- a/pkg/metrics/policymetrics/policymetrics_test.go
+++ b/pkg/metrics/policymetrics/policymetrics_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,33 +54,33 @@ tetragon_tracingpolicy_loaded{state="load_error"} %d
 			Name: "pizza",
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Add three policies with the same name: one clusterwide, two namespaced
 	err = manager.AddTracingPolicy(context.TODO(), &tracingpolicy.GenericTracingPolicy{
 		Metadata: v1.ObjectMeta{
 			Name: "amazing-one",
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = manager.AddTracingPolicy(context.TODO(), &tracingpolicy.GenericTracingPolicyNamespaced{
 		Metadata: v1.ObjectMeta{
 			Name:      "amazing-one",
 			Namespace: "default",
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = manager.AddTracingPolicy(context.TODO(), &tracingpolicy.GenericTracingPolicyNamespaced{
 		Metadata: v1.ObjectMeta{
 			Name:      "amazing-one",
 			Namespace: "kube-system",
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = testutil.CollectAndCompare(collector, expectedMetrics(0, 4, 0, 0))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = manager.DisableTracingPolicy(context.TODO(), "pizza", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = testutil.CollectAndCompare(collector, expectedMetrics(1, 3, 0, 0))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/policyconf/test/mode_test.go
+++ b/pkg/policyconf/test/mode_test.go
@@ -93,7 +93,7 @@ func TestModeSigKill(t *testing.T) {
 			})
 		require.NoError(t, progErr)
 		require.Contains(t, progOut, "signal: killed")
-		require.Equal(t, cnt[1], 1, fmt.Sprintf("count=%v", cnt))
+		require.Equal(t, 1, cnt[1], fmt.Sprintf("count=%v", cnt))
 	}
 
 	checkMonitor := func() {
@@ -110,7 +110,7 @@ func TestModeSigKill(t *testing.T) {
 		require.NoError(t, progErr)
 		require.NotContains(t, progOut, "signal: killed")
 		require.Contains(t, progOut, "returned without an error")
-		require.Equal(t, cnt[1], 1, fmt.Sprintf("count=%v", cnt))
+		require.Equal(t, 1, cnt[1], fmt.Sprintf("count=%v", cnt))
 	}
 
 	// finally, we can do the test
@@ -190,14 +190,14 @@ func TestModeEnforcer(t *testing.T) {
 				return 0
 			})
 		require.NoError(t, cmdErr)
-		require.Equal(t, cnt[1], 1, fmt.Sprintf("count=%v", cnt))
+		require.Equal(t, 1, cnt[1], fmt.Sprintf("count=%v", cnt))
 		enfDump, enfDumpErr := stracing.DumpEnforcerMap(polName, polNamespace)
 		require.NoError(t, enfDumpErr)
 		require.Len(t, enfDump, 1)
 		require.Contains(t, cmdOut, "operation not permitted")
 		for key, val := range enfDump {
 			require.Equal(t, pid, int(key.PidTgid>>32))
-			require.Equal(t, val.Sig, int16(9))
+			require.Equal(t, int16(9), val.Sig)
 			break
 		}
 	}
@@ -219,11 +219,11 @@ func TestModeEnforcer(t *testing.T) {
 				return 0
 			})
 		require.NoError(t, cmdErr)
-		require.Equal(t, cnt[1], 1, fmt.Sprintf("count=%v", cnt))
+		require.Equal(t, 1, cnt[1], fmt.Sprintf("count=%v", cnt))
 		require.NotContains(t, cmdOut, "operation not permitted")
 		enfDump, enfDumpErr := stracing.DumpEnforcerMap(polName, polNamespace)
 		require.NoError(t, enfDumpErr)
-		require.Len(t, enfDump, 0)
+		require.Empty(t, enfDump)
 	}
 
 	// finally, we can do the test

--- a/pkg/policyconf/test/mode_test.go
+++ b/pkg/policyconf/test/mode_test.go
@@ -7,7 +7,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -93,7 +92,7 @@ func TestModeSigKill(t *testing.T) {
 			})
 		require.NoError(t, progErr)
 		require.Contains(t, progOut, "signal: killed")
-		require.Equal(t, 1, cnt[1], fmt.Sprintf("count=%v", cnt))
+		require.Equal(t, 1, cnt[1], "count=%v", cnt)
 	}
 
 	checkMonitor := func() {
@@ -110,7 +109,7 @@ func TestModeSigKill(t *testing.T) {
 		require.NoError(t, progErr)
 		require.NotContains(t, progOut, "signal: killed")
 		require.Contains(t, progOut, "returned without an error")
-		require.Equal(t, 1, cnt[1], fmt.Sprintf("count=%v", cnt))
+		require.Equal(t, 1, cnt[1], "count=%v", cnt)
 	}
 
 	// finally, we can do the test
@@ -190,7 +189,7 @@ func TestModeEnforcer(t *testing.T) {
 				return 0
 			})
 		require.NoError(t, cmdErr)
-		require.Equal(t, 1, cnt[1], fmt.Sprintf("count=%v", cnt))
+		require.Equal(t, 1, cnt[1], "count=%v", cnt)
 		enfDump, enfDumpErr := stracing.DumpEnforcerMap(polName, polNamespace)
 		require.NoError(t, enfDumpErr)
 		require.Len(t, enfDump, 1)
@@ -219,7 +218,7 @@ func TestModeEnforcer(t *testing.T) {
 				return 0
 			})
 		require.NoError(t, cmdErr)
-		require.Equal(t, 1, cnt[1], fmt.Sprintf("count=%v", cnt))
+		require.Equal(t, 1, cnt[1], "count=%v", cnt)
 		require.NotContains(t, cmdOut, "operation not permitted")
 		enfDump, enfDumpErr := stracing.DumpEnforcerMap(polName, polNamespace)
 		require.NoError(t, enfDumpErr)

--- a/pkg/policyfilter/error_test.go
+++ b/pkg/policyfilter/error_test.go
@@ -11,6 +11,6 @@ import (
 
 func TestErrorLabel(t *testing.T) {
 	var err error = &podNamespaceConflictError{PodID{}, "foo", "lala"}
-	require.Equal(t, "", ErrorLabel(nil))
+	require.Empty(t, ErrorLabel(nil))
 	require.Equal(t, "pod-namespace-conflict", ErrorLabel(err))
 }

--- a/pkg/policyfilter/k8s_test.go
+++ b/pkg/policyfilter/k8s_test.go
@@ -635,7 +635,7 @@ func testPreExistingPods(t *testing.T, st *state, ts *testState) {
 	}, nil)
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(ts.podsCgroupIDs(t, "web")))
+	require.Len(t, ts.podsCgroupIDs(t, "web"), 2)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
 			uint64(matchesWebID): ts.podsCgroupIDs(t, "web"),
@@ -671,8 +671,8 @@ func testContainersChange(t *testing.T, st *state, ts *testState) {
 		})
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(ts.podsCgroupIDs(t, "web")))
-	require.Equal(t, 1, len(ts.podsCgroupIDs(t, "db")))
+	require.Len(t, ts.podsCgroupIDs(t, "web"), 2)
+	require.Len(t, ts.podsCgroupIDs(t, "db"), 1)
 	require.Empty(t, ts.containersCgroupIDs(t, map[string][]string{"log": {}}))
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
@@ -682,8 +682,8 @@ func testContainersChange(t *testing.T, st *state, ts *testState) {
 
 	ts.updatePodContainers(t, "web", "web-c1", "web-c3", "web-c4")
 	ts.updatePodContainers(t, "db", "db-c2")
-	require.Equal(t, 3, len(ts.podsCgroupIDs(t, "web")))
-	require.Equal(t, 1, len(ts.podsCgroupIDs(t, "db")))
+	require.Len(t, ts.podsCgroupIDs(t, "web"), 3)
+	require.Len(t, ts.podsCgroupIDs(t, "db"), 1)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{

--- a/pkg/policyfilter/k8s_test.go
+++ b/pkg/policyfilter/k8s_test.go
@@ -635,7 +635,7 @@ func testPreExistingPods(t *testing.T, st *state, ts *testState) {
 	}, nil)
 	require.NoError(t, err)
 
-	require.Equal(t, len(ts.podsCgroupIDs(t, "web")), 2)
+	require.Equal(t, 2, len(ts.podsCgroupIDs(t, "web")))
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
 			uint64(matchesWebID): ts.podsCgroupIDs(t, "web"),
@@ -671,9 +671,9 @@ func testContainersChange(t *testing.T, st *state, ts *testState) {
 		})
 	require.NoError(t, err)
 
-	require.Equal(t, len(ts.podsCgroupIDs(t, "web")), 2)
-	require.Equal(t, len(ts.podsCgroupIDs(t, "db")), 1)
-	require.Equal(t, len(ts.containersCgroupIDs(t, map[string][]string{"log": {}})), 0)
+	require.Equal(t, 2, len(ts.podsCgroupIDs(t, "web")))
+	require.Equal(t, 1, len(ts.podsCgroupIDs(t, "db")))
+	require.Empty(t, ts.containersCgroupIDs(t, map[string][]string{"log": {}}))
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
 			uint64(policyID): ts.podsCgroupIDs(t, "web", "db"),
@@ -682,8 +682,8 @@ func testContainersChange(t *testing.T, st *state, ts *testState) {
 
 	ts.updatePodContainers(t, "web", "web-c1", "web-c3", "web-c4")
 	ts.updatePodContainers(t, "db", "db-c2")
-	require.Equal(t, len(ts.podsCgroupIDs(t, "web")), 3)
-	require.Equal(t, len(ts.podsCgroupIDs(t, "db")), 1)
+	require.Equal(t, 3, len(ts.podsCgroupIDs(t, "web")))
+	require.Equal(t, 1, len(ts.podsCgroupIDs(t, "db")))
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{

--- a/pkg/policyfilter/map_test.go
+++ b/pkg/policyfilter/map_test.go
@@ -33,8 +33,8 @@ func requirePfmEqualTo(t *testing.T, m PfMap, val map[uint64][]uint64) {
 
 	mapVals, err := m.readAll()
 	require.NoError(t, err)
-	require.EqualValues(t, checkVals, mapVals.Policy)
-	require.EqualValues(t, checkCgroupVals, mapVals.Cgroup)
+	require.Equal(t, checkVals, mapVals.Policy)
+	require.Equal(t, checkCgroupVals, mapVals.Cgroup)
 }
 
 // TestPfMapOps tests some simple map operations

--- a/pkg/policyfilter/state_test.go
+++ b/pkg/policyfilter/state_test.go
@@ -89,7 +89,7 @@ func TestState(t *testing.T) {
 	require.NoError(t, err)
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{})
 
-	require.Len(t, s.policies, 0)
+	require.Empty(t, s.policies)
 	require.Len(t, s.pods, 3)
 
 	err = s.DelPod(pod1)
@@ -100,6 +100,6 @@ func TestState(t *testing.T) {
 	require.NoError(t, err)
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{})
 
-	require.Len(t, s.policies, 0)
-	require.Len(t, s.pods, 0)
+	require.Empty(t, s.policies)
+	require.Empty(t, s.pods)
 }

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -35,7 +35,7 @@ func TestProcessCache(t *testing.T) {
 	assert.Equal(t, 1, cache.len())
 
 	result, err := cache.get(proc.process.ExecId)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, proc.process.ExecId, result.process.ExecId)
 	assert.Equal(t, proc.capabilities, result.capabilities)
 
@@ -43,5 +43,5 @@ func TestProcessCache(t *testing.T) {
 	assert.True(t, cache.remove(proc.process))
 	assert.Equal(t, 0, cache.len())
 	_, err = cache.get(proc.process.ExecId)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -32,7 +32,7 @@ func TestProcessCache(t *testing.T) {
 		},
 	}
 	cache.add(&proc)
-	assert.Equal(t, cache.len(), 1)
+	assert.Equal(t, 1, cache.len())
 
 	result, err := cache.get(proc.process.ExecId)
 	assert.NoError(t, err)
@@ -41,7 +41,7 @@ func TestProcessCache(t *testing.T) {
 
 	// remove the entry from cache.
 	assert.True(t, cache.remove(proc.process))
-	assert.Equal(t, cache.len(), 0)
+	assert.Equal(t, 0, cache.len())
 	_, err = cache.get(proc.process.ExecId)
 	assert.Error(t, err)
 }

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -40,11 +41,11 @@ func Test_rateLimitJSON(t *testing.T) {
 		Time:     timestamppb.New(time.Time{}),
 	}
 	b, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(ev)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ev2 := &tetragon.GetEventsResponse{}
 	err = ev2.UnmarshalJSON(b)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, ev, ev2)
 }

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -16,18 +16,20 @@ import (
 )
 
 func Test_getLimit(t *testing.T) {
-	assert.Equal(t, rate.Limit(0), getLimit(0, time.Minute))
-	assert.Equal(t, rate.Limit(0), getLimit(0, 0))
-	assert.Equal(t, rate.Limit(1), getLimit(60, time.Minute))
-	assert.Equal(t, rate.Limit(10.0/60), getLimit(10, time.Minute))
+	eps := 1e-9
+
+	assert.InDelta(t, float64(rate.Limit(0)), float64(getLimit(0, time.Minute)), eps)
+	assert.InDelta(t, float64(rate.Limit(0)), float64(getLimit(0, 0)), eps)
+	assert.InEpsilon(t, float64(rate.Limit(1)), float64(getLimit(60, time.Minute)), eps)
+	assert.InEpsilon(t, float64(rate.Limit(10.0/60)), float64(getLimit(10, time.Minute)), eps)
 	// 1/ms => 1000/second
-	assert.Equal(t, rate.Limit(1000), getLimit(1, time.Millisecond))
+	assert.InEpsilon(t, float64(rate.Limit(1000)), float64(getLimit(1, time.Millisecond)), eps)
 	// 3600/hour => 1/second
-	assert.Equal(t, rate.Limit(1), getLimit(60*60, time.Hour))
+	assert.InEpsilon(t, float64(rate.Limit(1)), float64(getLimit(60*60, time.Hour)), eps)
 
 	// interval<=0 => infinite rate limit (allow all events)
-	assert.Equal(t, rate.Inf, getLimit(1, 0))
-	assert.Equal(t, rate.Inf, getLimit(1, -1))
+	assert.InEpsilon(t, float64(rate.Inf), float64(getLimit(1, 0)), eps)
+	assert.InEpsilon(t, float64(rate.Inf), float64(getLimit(1, -1)), eps)
 }
 
 func Test_rateLimitJSON(t *testing.T) {

--- a/pkg/reader/caps/caps_test.go
+++ b/pkg/reader/caps/caps_test.go
@@ -12,16 +12,16 @@ import (
 
 func TestIsCapValid(t *testing.T) {
 	valid := isCapValid(constants.CAP_CHOWN)
-	assert.Equal(t, true, valid)
+	assert.True(t, valid)
 
 	valid = isCapValid(constants.CAP_CHOWN - 1)
-	assert.Equal(t, false, valid)
+	assert.False(t, valid)
 
 	valid = isCapValid(constants.CAP_LAST_CAP)
-	assert.Equal(t, true, valid)
+	assert.True(t, valid)
 
 	valid = isCapValid(constants.CAP_LAST_CAP + 1)
-	assert.Equal(t, false, valid)
+	assert.False(t, valid)
 }
 
 func TestGetCapability(t *testing.T) {
@@ -44,8 +44,8 @@ func TestGetCapability(t *testing.T) {
 }
 
 func TestCapsAreSubset(t *testing.T) {
-	assert.Equal(t, true, AreSubset(0x000001ffffffffff, 0x000001ffffffffff))
-	assert.Equal(t, true, AreSubset(0x000001fffffffffe, 0x000001ffffffffff))
-	assert.Equal(t, false, AreSubset(0x000001ffffffffff, 0x000001fffffffffe))
-	assert.Equal(t, true, AreSubset(0x0, 0x0))
+	assert.True(t, AreSubset(0x000001ffffffffff, 0x000001ffffffffff))
+	assert.True(t, AreSubset(0x000001fffffffffe, 0x000001ffffffffff))
+	assert.False(t, AreSubset(0x000001ffffffffff, 0x000001fffffffffe))
+	assert.True(t, AreSubset(0x0, 0x0))
 }

--- a/pkg/reader/caps/caps_test.go
+++ b/pkg/reader/caps/caps_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/constants"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsCapValid(t *testing.T) {
@@ -27,19 +28,19 @@ func TestIsCapValid(t *testing.T) {
 func TestGetCapability(t *testing.T) {
 	// Test our caps package if it was updated and contains the last CAP_LAST_CAP from upstream
 	str, err := GetCapability(constants.CAP_LAST_CAP)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, str)
 
 	str, err = GetCapability(constants.CAP_CHOWN)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "CAP_CHOWN", str)
 
 	str, err = GetCapability(constants.CAP_LAST_CAP + 1)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Empty(t, str)
 
 	str, err = GetCapability(constants.CAP_CHOWN - 1)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Empty(t, str)
 }
 

--- a/pkg/reader/node/node_test.go
+++ b/pkg/reader/node/node_test.go
@@ -10,18 +10,19 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetNodeNameForExport(t *testing.T) {
 	assert.NotEmpty(t, GetNodeNameForExport()) // we should get the hostname here
-	assert.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
+	require.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
 	SetExportNodeName()
 	assert.Equal(t, "from-node-name", GetNodeNameForExport())
-	assert.NoError(t, os.Setenv("HUBBLE_NODE_NAME", "from-hubble-node-name"))
+	require.NoError(t, os.Setenv("HUBBLE_NODE_NAME", "from-hubble-node-name"))
 	SetExportNodeName()
 	assert.Equal(t, "from-hubble-node-name", GetNodeNameForExport())
-	assert.NoError(t, os.Unsetenv("NODE_NAME"))
-	assert.NoError(t, os.Unsetenv("HUBBLE_NODE_NAME"))
+	require.NoError(t, os.Unsetenv("NODE_NAME"))
+	require.NoError(t, os.Unsetenv("HUBBLE_NODE_NAME"))
 }
 
 func TestSetCommonFields(t *testing.T) {
@@ -29,23 +30,23 @@ func TestSetCommonFields(t *testing.T) {
 	assert.Empty(t, ev.NodeName)
 	assert.Empty(t, ev.ClusterName)
 	nodeName := "my-node-name"
-	assert.NoError(t, os.Setenv("NODE_NAME", nodeName))
+	require.NoError(t, os.Setenv("NODE_NAME", nodeName))
 	SetExportNodeName()
 	option.Config.ClusterName = "my-cluster-name"
 	SetCommonFields(&ev)
 	assert.Equal(t, nodeName, ev.GetNodeName())
 	assert.Equal(t, option.Config.ClusterName, ev.GetClusterName())
-	assert.NoError(t, os.Unsetenv("NODE_NAME"))
+	require.NoError(t, os.Unsetenv("NODE_NAME"))
 }
 
 func TestGetKubernetesNodeName(t *testing.T) {
 	assert.NotEmpty(t, GetKubernetesNodeName()) // we should get the hostname here
-	assert.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
+	require.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
 	SetKubernetesNodeName()
 	assert.Equal(t, "from-node-name", GetKubernetesNodeName())
-	assert.NoError(t, os.Setenv("HUBBLE_NODE_NAME", "from-hubble-node-name"))
+	require.NoError(t, os.Setenv("HUBBLE_NODE_NAME", "from-hubble-node-name"))
 	SetKubernetesNodeName()
 	assert.Equal(t, "from-node-name", GetKubernetesNodeName())
-	assert.NoError(t, os.Unsetenv("NODE_NAME"))
-	assert.NoError(t, os.Unsetenv("HUBBLE_NODE_NAME"))
+	require.NoError(t, os.Unsetenv("NODE_NAME"))
+	require.NoError(t, os.Unsetenv("HUBBLE_NODE_NAME"))
 }

--- a/pkg/reader/node/node_test.go
+++ b/pkg/reader/node/node_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetNodeNameForExport(t *testing.T) {
-	assert.NotEqual(t, "", GetNodeNameForExport()) // we should get the hostname here
+	assert.NotEmpty(t, GetNodeNameForExport()) // we should get the hostname here
 	assert.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
 	SetExportNodeName()
 	assert.Equal(t, "from-node-name", GetNodeNameForExport())
@@ -39,7 +39,7 @@ func TestSetCommonFields(t *testing.T) {
 }
 
 func TestGetKubernetesNodeName(t *testing.T) {
-	assert.NotEqual(t, "", GetKubernetesNodeName()) // we should get the hostname here
+	assert.NotEmpty(t, GetKubernetesNodeName()) // we should get the hostname here
 	assert.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
 	SetKubernetesNodeName()
 	assert.Equal(t, "from-node-name", GetKubernetesNodeName())

--- a/pkg/reader/proc/proc_linux_test.go
+++ b/pkg/reader/proc/proc_linux_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetProcStatStrings(t *testing.T) {
@@ -28,7 +29,7 @@ func TestGetStatus(t *testing.T) {
 	self := filepath.Join(option.Config.ProcFS, "self")
 
 	status, err := GetStatus(self)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, status.Uids)
 	for i := range status.Uids {
 		assert.NotEmpty(t, status.Uids[i])
@@ -46,21 +47,21 @@ func TestGetPid1Status(t *testing.T) {
 	file.Close()
 
 	status, err := GetStatus(pid1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, status.Uids)
 
 	uids, err := status.GetUids()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint32(0), uids[0])
 	assert.Equal(t, uint32(0), uids[1])
 
 	gids, err := status.GetGids()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint32(0), gids[0])
 	assert.Equal(t, uint32(0), gids[1])
 
 	// PID 1 does not have a loginuid
 	loginuid, err := status.GetLoginUid()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint32(4294967295), loginuid)
 }

--- a/pkg/reader/proc/proc_linux_test.go
+++ b/pkg/reader/proc/proc_linux_test.go
@@ -15,13 +15,13 @@ import (
 func TestGetProcStatStrings(t *testing.T) {
 	stat := "206305 (zsh( )foo) S 206303 206305 206305 34821 206368 4194304 9687 4455 0 0 56 17 2 0 20 0 1 0 19321046 17514496 1866 18446744073709551615 94273300672512 94273301280581 140729040978832 0 0 0 2 3686400 134295555 1 0 0 17 3 0 0 0 0 0 94273301428976 94273301458280 94273325256704 140729040984354 140729040984358 140729040984358 140729040986095 0"
 	statStrings := getProcStatStrings(stat)
-	assert.Equal(t, statStrings[0], "206305", "Incorrect first field")
-	assert.Equal(t, statStrings[1], "(zsh( )foo)", "Incorrect comm field")
-	assert.Equal(t, statStrings[2], "S", "Incorrect third field")
-	assert.Equal(t, statStrings[3], "206303", "Incorrect fourth field")
-	assert.Equal(t, statStrings[50], "140729040986095", "Incorrect 51st field")
-	assert.Equal(t, statStrings[51], "0", "Incorrect 52nd field")
-	assert.Equal(t, len(statStrings), 52, "Incorrect number of entries")
+	assert.Equal(t, "206305", statStrings[0], "Incorrect first field")
+	assert.Equal(t, "(zsh( )foo)", statStrings[1], "Incorrect comm field")
+	assert.Equal(t, "S", statStrings[2], "Incorrect third field")
+	assert.Equal(t, "206303", statStrings[3], "Incorrect fourth field")
+	assert.Equal(t, "140729040986095", statStrings[50], "Incorrect 51st field")
+	assert.Equal(t, "0", statStrings[51], "Incorrect 52nd field")
+	assert.Equal(t, 52, len(statStrings), "Incorrect number of entries")
 }
 
 func TestGetStatus(t *testing.T) {

--- a/pkg/reader/proc/proc_linux_test.go
+++ b/pkg/reader/proc/proc_linux_test.go
@@ -22,7 +22,7 @@ func TestGetProcStatStrings(t *testing.T) {
 	assert.Equal(t, "206303", statStrings[3], "Incorrect fourth field")
 	assert.Equal(t, "140729040986095", statStrings[50], "Incorrect 51st field")
 	assert.Equal(t, "0", statStrings[51], "Incorrect 52nd field")
-	assert.Equal(t, 52, len(statStrings), "Incorrect number of entries")
+	assert.Len(t, statStrings, 52, "Incorrect number of entries")
 }
 
 func TestGetStatus(t *testing.T) {

--- a/pkg/reader/proc/proc_windows_test.go
+++ b/pkg/reader/proc/proc_windows_test.go
@@ -4,13 +4,12 @@
 package proc
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 	"testing"
 	"unsafe"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
 
@@ -18,7 +17,7 @@ func TestGetProcStatStrings(t *testing.T) {
 	pid := os.Getpid() // Get the current process's PID
 
 	status, err := GetStatus(uint32(pid))
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	t.Log("User = ", status.Uids)
 	t.Log("Group = ", status.Gids)
 	t.Log("LoginUId = ", status.LoginUid)
@@ -28,21 +27,21 @@ func TestFillLoginUid(t *testing.T) {
 	pid := os.Getpid() // Get the current process's PID
 
 	c, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	defer windows.CloseHandle(c)
 
 	var token syscall.Token
 	err = syscall.OpenProcessToken(syscall.Handle(c), syscall.TOKEN_QUERY, &token)
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	defer token.Close()
 	var logonSid *TokenGroups
 
 	ret, err := getTokenInfo(token, windows.TokenLogonSid, 32)
-	assert.Equal(t, err, nil)
+	require.NoError(t, err)
 	logonSid = (*TokenGroups)(ret)
 	tokenUser := (*syscall.SIDAndAttributes)(unsafe.Pointer(&logonSid.Groups[0]))
 	sid := (*syscall.SID)(unsafe.Pointer(&tokenUser.Sid))
 	str, err1 := sid.String()
-	assert.Equal(t, err1, nil)
-	fmt.Printf("SID = %s", str)
+	require.NoError(t, err1)
+	t.Logf("SID = %s", str)
 }

--- a/pkg/reader/userdb/userdb_linux_test.go
+++ b/pkg/reader/userdb/userdb_linux_test.go
@@ -7,21 +7,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUsersRecords(t *testing.T) {
 	name, err := UsersCache.lookupUser(0)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Empty(t, name)
 
 	UsersCache.addUser(0, "root")
 	name, err = UsersCache.lookupUser(0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "root", name)
 
 	name, err = UsersCache.LookupUser(2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	name2, err := UsersCache.lookupUser(2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, name, name2)
 }

--- a/pkg/reader/userdb/userdb_windows_test.go
+++ b/pkg/reader/userdb/userdb_windows_test.go
@@ -7,16 +7,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUsersRecords(t *testing.T) {
 	name, err := UsersCache.lookupUser(0)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Empty(t, name)
 
 	UsersCache.addUser(0, "root")
 	name, err = UsersCache.lookupUser(0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "root", name)
 
 	//ToDo: We need to convert a unix-style uid to a Windows style RID

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -797,7 +797,7 @@ func TestCgroupEventMkdirRmdir(t *testing.T) {
 	// Ensure that we received proper events
 	assert.True(t, mkdir)
 	assert.True(t, rmdir)
-	assert.NotZero(t, true, cgrpTrackingId)
+	assert.NotZero(t, cgrpTrackingId)
 
 	// Should be removed from the tracking map
 	_, err = cgrouptrackmap.LookupTrackingCgroup(cgrpMapPath, cgrpTrackingId)

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -338,7 +338,7 @@ func requireCgroupEventOpMkdir(t *testing.T, msg *grpcexec.MsgCgroupEventUnix, c
 	require.EqualValues(t, ops.CGROUP_NEW, msg.CgrpData.State)
 
 	looked, err := cgrouptrackmap.LookupTrackingCgroup(cgrpMapPath, msg.CgrpidTracker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if looked == nil {
 		t.Fatalf("Failed to find tracking cgroupID=%d in bpf-map=%s", msg.CgrpidTracker, cgrpMapPath)
 	}
@@ -348,7 +348,7 @@ func requireCgroupEventOpMkdir(t *testing.T, msg *grpcexec.MsgCgroupEventUnix, c
 
 func requireCgroupEventOpRmdir(t *testing.T, msg *grpcexec.MsgCgroupEventUnix, cgrpMapPath string) {
 	looked, err := cgrouptrackmap.LookupTrackingCgroup(cgrpMapPath, msg.CgrpidTracker)
-	assert.Error(t, err)
+	require.Error(t, err)
 	if looked != nil {
 		t.Fatalf("Failed found tracking cgroup with cgroupID=%d in bpf-map=%s", msg.CgrpidTracker, cgrpMapPath)
 	}

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -79,7 +79,7 @@ func Test_msgToExecveKubeUnix(t *testing.T) {
 	copy(event.Kube.Docker[:], gkeID)
 	kube = msgToExecveKubeUnix(&event, "", "")
 	assert.Equal(t, gkeID[:idLength], kube.Docker)
-	assert.Equal(t, idLength, len(kube.Docker))
+	assert.Len(t, kube.Docker, idLength)
 	event.Kube.Docker[0] = 0
 	kube = msgToExecveKubeUnix(&event, "", "")
 	assert.Empty(t, kube.Docker)
@@ -89,32 +89,32 @@ func Test_msgToExecveKubeUnix(t *testing.T) {
 	kube = msgToExecveKubeUnix(&event, "", "")
 	assert.Equal(t, id[80:80+idLength], kube.Docker)
 	assert.Equal(t, strings.Split(id, ":")[2][:idLength], kube.Docker)
-	assert.Equal(t, idLength, len(kube.Docker))
+	assert.Len(t, kube.Docker, idLength)
 
 	id = "kubepods-besteffort-pod13cb8437-00ed-40e4-99d8-e17193a58086.slice:cri-containerd:a5a6a3af5d51ad95b915ca948710b90a94abc279e84963b9d22a39f342ce67d9"
 	copy(event.Kube.Docker[:], id)
 	kube = msgToExecveKubeUnix(&event, "", "")
 	assert.Equal(t, id[81:81+idLength], kube.Docker)
 	assert.Equal(t, strings.Split(id, ":")[2][:idLength], kube.Docker)
-	assert.Equal(t, idLength, len(kube.Docker))
+	assert.Len(t, kube.Docker, idLength)
 
 	id = "cri-containerd-5694f82f44168cc048e014ae14d1b0c8ef673bec49f329dc169911ea638f63c2.scope"
 	copy(event.Kube.Docker[:], id)
 	kube = msgToExecveKubeUnix(&event, "", "")
 	assert.Equal(t, strings.Split(id, "-")[2][:idLength], kube.Docker)
-	assert.Equal(t, idLength, len(kube.Docker))
+	assert.Len(t, kube.Docker, idLength)
 
 	id = "libpod-01f3c60cfaadbb51e4d5947dd2ef0480d53551cbcee8f3ada8c3723b2bf03bf4"
 	copy(event.Kube.Docker[:], id)
 	kube = msgToExecveKubeUnix(&event, "", "")
 	assert.Equal(t, strings.Split(id, "-")[1][:idLength], kube.Docker)
-	assert.Equal(t, idLength, len(kube.Docker))
+	assert.Len(t, kube.Docker, idLength)
 
 	id = ":a5a6a3af5d51ad95b915ca948710b90a94abc279e84963b9d22a39f342ce67d9"
 	copy(event.Kube.Docker[:], id)
 	kube = msgToExecveKubeUnix(&event, "", "")
 	assert.Equal(t, strings.Split(id, ":")[1][:idLength], kube.Docker)
-	assert.Equal(t, idLength, len(kube.Docker))
+	assert.Len(t, kube.Docker, idLength)
 
 	// Empty event so we don't fail tests
 	for i := range processapi.DOCKER_ID_LENGTH {
@@ -828,10 +828,10 @@ func TestExecParse(t *testing.T) {
 
 		assert.Equal(t, string(filename), process.Filename)
 		assert.Equal(t, string(cwd), process.Args)
-		assert.Equal(t, empty, false)
+		assert.False(t, empty)
 
 		decArgs, decCwd := proc.ArgsDecoder(process.Args, process.Flags)
-		assert.Equal(t, "", decArgs)
+		assert.Empty(t, decArgs)
 		assert.Equal(t, string(cwd), decCwd)
 	}
 
@@ -863,11 +863,11 @@ func TestExecParse(t *testing.T) {
 		// execParse check
 		assert.Equal(t, string(filename), process.Filename)
 		assert.Equal(t, string(cwd), process.Args)
-		assert.Equal(t, empty, false)
+		assert.False(t, empty)
 
 		// ArgsDecoder check
 		decArgs, decCwd := proc.ArgsDecoder(process.Args, process.Flags)
-		assert.Equal(t, "", decArgs)
+		assert.Empty(t, decArgs)
 		assert.Equal(t, string(cwd), decCwd)
 	}
 
@@ -904,7 +904,7 @@ func TestExecParse(t *testing.T) {
 		// execParse check
 		assert.Equal(t, string(filename), process.Filename)
 		assert.Equal(t, string(args)+string(cwd), process.Args)
-		assert.Equal(t, empty, false)
+		assert.False(t, empty)
 
 		// ArgsDecoder check
 		decArgs, decCwd := proc.ArgsDecoder(process.Args, process.Flags)
@@ -949,7 +949,7 @@ func TestExecParse(t *testing.T) {
 		// execParse check
 		assert.Equal(t, string(filename), process.Filename)
 		assert.Equal(t, string(args)+string(cwd), process.Args)
-		assert.Equal(t, empty, false)
+		assert.False(t, empty)
 
 		// ArgsDecoder check
 		decArgs, decCwd := proc.ArgsDecoder(process.Args, process.Flags)
@@ -990,7 +990,7 @@ func TestExecParse(t *testing.T) {
 		// execParse check
 		assert.Equal(t, strutils.UTF8FromBPFBytes(filename), process.Filename)
 		assert.Equal(t, strutils.UTF8FromBPFBytes(args)+strutils.UTF8FromBPFBytes(cwd), process.Args)
-		assert.Equal(t, empty, false)
+		assert.False(t, empty)
 
 		// ArgsDecoder check
 		decArgs, decCwd := proc.ArgsDecoder(process.Args, process.Flags)

--- a/pkg/sensors/exec/exec_test.go
+++ b/pkg/sensors/exec/exec_test.go
@@ -845,7 +845,7 @@ func TestExecParse(t *testing.T) {
 		id := dataapi.DataEventId{Pid: 1, Time: 1}
 		desc := dataapi.DataEventDesc{Error: 0, Pad: 0, Leftover: 0, Size: uint32(len(filename[:])), Id: id}
 		err = observer.DataAdd(id, filename)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		exec.Flags = api.EventDataFilename
 		exec.Size = uint32(processapi.MSG_SIZEOF_EXECVE + binary.Size(desc) + len(cwd))

--- a/pkg/sensors/exec/procevents/proc_reader_test.go
+++ b/pkg/sensors/exec/procevents/proc_reader_test.go
@@ -21,7 +21,7 @@ func TestListRunningProcs(t *testing.T) {
 	procs, err := listRunningProcs("/proc")
 	require.NoError(t, err)
 	require.NotNil(t, procs)
-	require.NotEqual(t, 0, len(procs))
+	require.NotEmpty(t, procs)
 
 	for _, p := range procs {
 		require.NotZero(t, p.pid)
@@ -47,7 +47,7 @@ func TestInInitTreeProcfs(t *testing.T) {
 	procs, err := listRunningProcs("/proc")
 	require.NoError(t, err)
 	require.NotNil(t, procs)
-	require.NotEqual(t, 0, len(procs))
+	require.NotEmpty(t, procs)
 
 	inInitTree := make(map[uint32]struct{})
 	for _, p := range procs {

--- a/pkg/sensors/exec/procevents/proc_test.go
+++ b/pkg/sensors/exec/procevents/proc_test.go
@@ -20,7 +20,7 @@ func TestProcsContainerIdOffset(t *testing.T) {
 
 	s, i := ProcsContainerIdOffset(test1)
 	assert.Equal(t, s, test1, "Expect input == output")
-	assert.Equal(t, i, 0, "Expect zero offset")
+	assert.Equal(t, 0, i, "Expect zero offset")
 
 	s, i = ProcsContainerIdOffset(test2)
 	assert.Equal(t, test1, s, "Expect output is test1")
@@ -31,8 +31,8 @@ func TestProcsContainerIdOffset(t *testing.T) {
 	assert.Equal(t, offsetValue3, i, "Expect docker- offset")
 
 	s, i = ProcsContainerIdOffset("")
-	assert.Equal(t, s, "", "Expect output '' empty string")
-	assert.Equal(t, i, 0, "Expect ContainerId offset should be zero")
+	assert.Equal(t, "", s, "Expect output '' empty string")
+	assert.Equal(t, 0, i, "Expect ContainerId offset should be zero")
 }
 
 func TestProcsContainerId(t *testing.T) {
@@ -40,7 +40,7 @@ func TestProcsContainerId(t *testing.T) {
 
 	s, e := procsDockerId(myPid)
 	// This is not in a docker-cgroup so we have no info
-	assert.Equal(t, "", s, "No cgroup info here")
+	assert.Empty(t, s, "No cgroup info here")
 	assert.NoError(t, e)
 
 	// To further test we need a k8s environment unforunately. TBD
@@ -49,129 +49,129 @@ func TestProcsContainerId(t *testing.T) {
 func TestProcsFindContainerId(t *testing.T) {
 	p := "6:pids:/kubepods/besteffort/pod26ab26cd-6409-443f-a13c-fd6c231207c8/ae7a1981e064c217035e0b23979c8defd51c850d1af26fbcf148187e5b0da61c"
 	d, i := procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong")
-	assert.Equal(t, d, "ae7a1981e064c217035e0b23979c8de", "ContainerId wrong")
+	assert.Equal(t, 0, i, "ContainerId offset wrong")
+	assert.Equal(t, "ae7a1981e064c217035e0b23979c8de", d, "ContainerId wrong")
 
 	p = "4:pids:/kubepods/burstable/pod1399d9c7-c86f-4371-8568-07b3d32258a4/91f2457fb4c2b1356eefc7bace36532f5eb3d354804bb2cff787ea321320b5a5"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong")
-	assert.Equal(t, d, "91f2457fb4c2b1356eefc7bace36532", "ContainerId wrong")
+	assert.Equal(t, 0, i, "ContainerId offset wrong")
+	assert.Equal(t, "91f2457fb4c2b1356eefc7bace36532", d, "ContainerId wrong")
 
 	p = "4:pids:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podeb052b63_ea96_4728_ab4a_64ab3babccd7.slice/cri-containerd-5694f82f44168cc048e014ae14d1b0c8ef673bec49f329dc169911ea638f63c2.scope"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 15, "ContainerId offset wrong")
-	assert.Equal(t, d, "5694f82f44168cc048e014ae14d1b0c", "ContainerId wrong")
+	assert.Equal(t, 15, i, "ContainerId offset wrong")
+	assert.Equal(t, "5694f82f44168cc048e014ae14d1b0c", d, "ContainerId wrong")
 
 	p = "4:pids:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podeb052b63_ea96_4728_ab4a_64ab3babccd7.slice/docker-5694f82f44168cc048e014ae14d1b0c8ef673bec49f329dc169911ea638f63c2.scope"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 7, "ContainerId offset wrong")
-	assert.Equal(t, d, "5694f82f44168cc048e014ae14d1b0c", "ContainerId wrong")
+	assert.Equal(t, 7, i, "ContainerId offset wrong")
+	assert.Equal(t, "5694f82f44168cc048e014ae14d1b0c", d, "ContainerId wrong")
 
 	// A docker container directly using systemd driver as a cgroup driver
 	p = "0::/system.slice/docker-ee40841f79d52f66f4958c8a484bd2dfb453228874dcca1a3f2ec6e8420ec87c.scope"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 7, "ContainerId offset wrong")
-	assert.Equal(t, d, "ee40841f79d52f66f4958c8a484bd2d", "ContainerId wrong")
+	assert.Equal(t, 7, i, "ContainerId offset wrong")
+	assert.Equal(t, "ee40841f79d52f66f4958c8a484bd2d", d, "ContainerId wrong")
 
 	// A docker container using cgroupfs driver
 	p = "0::/docker/5aaf9eb7648eeb1459d86eaa0ace8bcfa93089642e5c3113a14250dae3238aaf"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong")
-	assert.Equal(t, d, "5aaf9eb7648eeb1459d86eaa0ace8bc", "ContainerId wrong")
+	assert.Equal(t, 0, i, "ContainerId offset wrong")
+	assert.Equal(t, "5aaf9eb7648eeb1459d86eaa0ace8bc", d, "ContainerId wrong")
 
 	// Podman directly using systemd driver as a cgroup manager under a user slice
 	p = "0::/user.slice/user-1000.slice/user@1000.service/user.slice/libpod-6fb480da903b96185cd497db694641d13534e2b80cf4cb738b6691677146adea.scope/container"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 7, "ContainerId offset wrong")
-	assert.Equal(t, d, "6fb480da903b96185cd497db694641d", "ContainerId wrong")
+	assert.Equal(t, 7, i, "ContainerId offset wrong")
+	assert.Equal(t, "6fb480da903b96185cd497db694641d", d, "ContainerId wrong")
 
 	// Podman container directly using systemd driver as a cgroup manager under root
 	p = "0::/machine.slice/libpod-89e89703fbd1e88b72d279d951ce389d3742874205196d73f96e0dcbc0da0659.scope/container"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 7, "ContainerId offset wrong")
-	assert.Equal(t, d, "89e89703fbd1e88b72d279d951ce389", "ContainerId wrong")
+	assert.Equal(t, 7, i, "ContainerId offset wrong")
+	assert.Equal(t, "89e89703fbd1e88b72d279d951ce389", d, "ContainerId wrong")
 
 	// Podman container directly using --cgroup-manager cgroupfs under root
 	p = "0::/libpod_parent/libpod-01f3c60cfaadbb51e4d5947dd2ef0480d53551cbcee8f3ada8c3723b2bf03bf4"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 7, "ContainerId offset wrong")
-	assert.Equal(t, d, "01f3c60cfaadbb51e4d5947dd2ef048", "ContainerId wrong")
+	assert.Equal(t, 7, i, "ContainerId offset wrong")
+	assert.Equal(t, "01f3c60cfaadbb51e4d5947dd2ef048", d, "ContainerId wrong")
 
 	// Podman directly using --cgroup-manager cgroupfs under root, this is the container monitor
 	p = "0::/libpod_parent/conmon"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong should be zero")
-	assert.Equal(t, d, "", "ContainerId wrong should return empty")
+	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
+	assert.Equal(t, "", d, "ContainerId wrong should return empty")
 
 	// Minikube with docker container and --extra-config=kubelet.cgroup-driver=systemd
 	p = "0::/system.slice/docker-1b3319ed9c1d4cca681f9c102da9b015555785b6240c4e4619f11b535cabdc07.scope/init.scope"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong should be zero")
-	assert.Equal(t, d, "", "ContainerId wrong should return empty")
+	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
+	assert.Equal(t, "", d, "ContainerId wrong should return empty")
 
 	p = "0::/system.slice/docker-1b3319ed9c1d4cca681f9c102da9b015555785b6240c4e4619f11b535cabdc07.scope/system.slice/containerd.service"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong should be zero")
-	assert.Equal(t, d, "", "ContainerId wrong should return empty")
+	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
+	assert.Equal(t, "", d, "ContainerId wrong should return empty")
 
 	p = "0::/system.slice/docker-1b3319ed9c1d4cca681f9c102da9b015555785b6240c4e4619f11b535cabdc07.scope/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podeb653d22_2525_47ca_9fc4_3762497ae1d2.slice/docker-84e9ffffe97fea4c5a0f01d401611cbafbf7e559fc6190ed74abfc2b25e889d4.scope"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 7, "ContainerId offset wrong")
-	assert.Equal(t, d, "84e9ffffe97fea4c5a0f01d401611cb", "ContainerId wrong")
+	assert.Equal(t, 7, i, "ContainerId offset wrong")
+	assert.Equal(t, "84e9ffffe97fea4c5a0f01d401611cb", d, "ContainerId wrong")
 
 	p = "0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podeb653d22_2525_47ca_9fc4_3762497ae1d2.slice/docker-84e9ffffe97fea4c5a0f01d401611cbafbf7e559fc6190ed74abfc2b25e889d4.scope"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 7, "ContainerId offset wrong")
-	assert.Equal(t, d, "84e9ffffe97fea4c5a0f01d401611cb", "ContainerId wrong")
+	assert.Equal(t, 7, i, "ContainerId offset wrong")
+	assert.Equal(t, "84e9ffffe97fea4c5a0f01d401611cb", d, "ContainerId wrong")
 
 	// Minikube with containerd runtime and cgroupfs
 	p = "0::/system.slice/docker-94acc75af8cf9c56e10676b0760ed424bec95dadc91f68f6564014686930200e.scope/kubepods/besteffort/pod13cb8437-00ed-40e4-99d8-e17193a58086/a5a6a3af5d51ad95b915ca948710b90a94abc279e84963b9d22a39f342ce67d9"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong")
-	assert.Equal(t, d, "a5a6a3af5d51ad95b915ca948710b90", "ContainerId wrong")
+	assert.Equal(t, 0, i, "ContainerId offset wrong")
+	assert.Equal(t, "a5a6a3af5d51ad95b915ca948710b90", d, "ContainerId wrong")
 
 	p = "0::/kubepods/besteffort/pod13cb8437-00ed-40e4-99d8-e17193a58086/a5a6a3af5d51ad95b915ca948710b90a94abc279e84963b9d22a39f342ce67d9"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong")
-	assert.Equal(t, d, "a5a6a3af5d51ad95b915ca948710b90", "ContainerId wrong")
+	assert.Equal(t, 0, i, "ContainerId offset wrong")
+	assert.Equal(t, "a5a6a3af5d51ad95b915ca948710b90", d, "ContainerId wrong")
 
 	// Kind: containerd service under a system slice which is under a docker container that is using systemd as cgroup manager
 	p = "0::/system.slice/docker-c1146e7ccca9ab4436abd69923c07d097b37b762ed21cc3f24584c2f84e77c57.scope/system.slice/containerd.service"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong should be zero")
-	assert.Equal(t, d, "", "ContainerId wrong should be empty")
+	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
+	assert.Equal(t, "", d, "ContainerId wrong should be empty")
 
 	// Kind: kubelet under a system slice which is under a docker container that is using systemd as cgroup manager
 	p = "0::/system.slice/docker-c1146e7ccca9ab4436abd69923c07d097b37b762ed21cc3f24584c2f84e77c57.scope/system.slice/kubelet.service"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong should be zero")
-	assert.Equal(t, d, "", "ContainerId wrong should be empty")
+	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
+	assert.Equal(t, "", d, "ContainerId wrong should be empty")
 
 	// Kind with a cgroup driver cgroupfs under /kubelet/ path
 	p = "0::/system.slice/docker-c1146e7ccca9ab4436abd69923c07d097b37b762ed21cc3f24584c2f84e77c57.scope/kubelet/kubepods/burstable/pod09a70ae9ccc491e651e5c773579b3490/b0e6aa50e847c3d3b1880e307ec7996040275c8063832cffc9274defce2cb655"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong")
-	assert.Equal(t, d, "b0e6aa50e847c3d3b1880e307ec7996", "ContainerId wrong")
+	assert.Equal(t, 0, i, "ContainerId offset wrong")
+	assert.Equal(t, "b0e6aa50e847c3d3b1880e307ec7996", d, "ContainerId wrong")
 
 	// Kind with a cgroup driver cgroupfs under /kubelet/ path
 	p = "0::/system.slice/docker-c1146e7ccca9ab4436abd69923c07d097b37b762ed21cc3f24584c2f84e77c57.scope/kubelet/kubepods/pod55db13a1-c151-4cdd-a48b-e002a2b1fb58/21e677e6fe95215ea48bcb5609c10e67ba8e76a7a3ea749af704e72260eb93fe"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 0, "ContainerId offset wrong")
-	assert.Equal(t, d, "21e677e6fe95215ea48bcb5609c10e6", "ContainerId wrong")
+	assert.Equal(t, 0, i, "ContainerId offset wrong")
+	assert.Equal(t, "21e677e6fe95215ea48bcb5609c10e6", d, "ContainerId wrong")
 
 	// Cgroupv1 Hierarchy with CgroupPath set
 	p = "4:pids:/podruntime.slice/containerd.service/kubepods-burstable-pod29349498_197c_4919_b13f_9a928e7d001b.slice:cri-containerd:0ca2b3cd20e5f55a2bbe8d4aa3f811cf7963b40f0542ad147054b0fcb60fc400"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 80, "ContainerId offset wrong")
-	assert.Equal(t, d, "0ca2b3cd20e5f55a2bbe8d4aa3f811c", "ContainerId wrong")
+	assert.Equal(t, 80, i, "ContainerId offset wrong")
+	assert.Equal(t, "0ca2b3cd20e5f55a2bbe8d4aa3f811c", d, "ContainerId wrong")
 
 	p = "11:pids:/actions_job/ec5fd62ba68d0b75a3cbdb7f7f78b526440b7969e22b2b362fb6f429ded42fdc"
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, i, 20, "ContainerId offset wrong")
-	assert.Equal(t, d, "ec5fd62ba68d0b75a3cbdb7f7f78b52", "ContainerId wrong")
+	assert.Equal(t, 20, i, "ContainerId offset wrong")
+	assert.Equal(t, "ec5fd62ba68d0b75a3cbdb7f7f78b52", d, "ContainerId wrong")
 
 	p = ""
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, d, "", "Expect output '' empty string")
-	assert.Equal(t, i, 0, "Expect ContainerId offset should be zero")
+	assert.Equal(t, "", d, "Expect output '' empty string")
+	assert.Equal(t, 0, i, "Expect ContainerId offset should be zero")
 }

--- a/pkg/sensors/exec/procevents/proc_test.go
+++ b/pkg/sensors/exec/procevents/proc_test.go
@@ -32,7 +32,7 @@ func TestProcsContainerIdOffset(t *testing.T) {
 	assert.Equal(t, offsetValue3, i, "Expect docker- offset")
 
 	s, i = ProcsContainerIdOffset("")
-	assert.Equal(t, "", s, "Expect output '' empty string")
+	assert.Empty(t, s, "Expect output '' empty string")
 	assert.Equal(t, 0, i, "Expect ContainerId offset should be zero")
 }
 
@@ -102,18 +102,18 @@ func TestProcsFindContainerId(t *testing.T) {
 	p = "0::/libpod_parent/conmon"
 	d, i = procsFindDockerId(p)
 	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
-	assert.Equal(t, "", d, "ContainerId wrong should return empty")
+	assert.Empty(t, d, "ContainerId wrong should return empty")
 
 	// Minikube with docker container and --extra-config=kubelet.cgroup-driver=systemd
 	p = "0::/system.slice/docker-1b3319ed9c1d4cca681f9c102da9b015555785b6240c4e4619f11b535cabdc07.scope/init.scope"
 	d, i = procsFindDockerId(p)
 	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
-	assert.Equal(t, "", d, "ContainerId wrong should return empty")
+	assert.Empty(t, d, "ContainerId wrong should return empty")
 
 	p = "0::/system.slice/docker-1b3319ed9c1d4cca681f9c102da9b015555785b6240c4e4619f11b535cabdc07.scope/system.slice/containerd.service"
 	d, i = procsFindDockerId(p)
 	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
-	assert.Equal(t, "", d, "ContainerId wrong should return empty")
+	assert.Empty(t, d, "ContainerId wrong should return empty")
 
 	p = "0::/system.slice/docker-1b3319ed9c1d4cca681f9c102da9b015555785b6240c4e4619f11b535cabdc07.scope/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podeb653d22_2525_47ca_9fc4_3762497ae1d2.slice/docker-84e9ffffe97fea4c5a0f01d401611cbafbf7e559fc6190ed74abfc2b25e889d4.scope"
 	d, i = procsFindDockerId(p)
@@ -140,13 +140,13 @@ func TestProcsFindContainerId(t *testing.T) {
 	p = "0::/system.slice/docker-c1146e7ccca9ab4436abd69923c07d097b37b762ed21cc3f24584c2f84e77c57.scope/system.slice/containerd.service"
 	d, i = procsFindDockerId(p)
 	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
-	assert.Equal(t, "", d, "ContainerId wrong should be empty")
+	assert.Empty(t, d, "ContainerId wrong should be empty")
 
 	// Kind: kubelet under a system slice which is under a docker container that is using systemd as cgroup manager
 	p = "0::/system.slice/docker-c1146e7ccca9ab4436abd69923c07d097b37b762ed21cc3f24584c2f84e77c57.scope/system.slice/kubelet.service"
 	d, i = procsFindDockerId(p)
 	assert.Equal(t, 0, i, "ContainerId offset wrong should be zero")
-	assert.Equal(t, "", d, "ContainerId wrong should be empty")
+	assert.Empty(t, d, "ContainerId wrong should be empty")
 
 	// Kind with a cgroup driver cgroupfs under /kubelet/ path
 	p = "0::/system.slice/docker-c1146e7ccca9ab4436abd69923c07d097b37b762ed21cc3f24584c2f84e77c57.scope/kubelet/kubepods/burstable/pod09a70ae9ccc491e651e5c773579b3490/b0e6aa50e847c3d3b1880e307ec7996040275c8063832cffc9274defce2cb655"
@@ -173,6 +173,6 @@ func TestProcsFindContainerId(t *testing.T) {
 
 	p = ""
 	d, i = procsFindDockerId(p)
-	assert.Equal(t, "", d, "Expect output '' empty string")
+	assert.Empty(t, d, "Expect output '' empty string")
 	assert.Equal(t, 0, i, "Expect ContainerId offset should be zero")
 }

--- a/pkg/sensors/exec/procevents/proc_test.go
+++ b/pkg/sensors/exec/procevents/proc_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProcsContainerIdOffset(t *testing.T) {
@@ -41,7 +42,7 @@ func TestProcsContainerId(t *testing.T) {
 	s, e := procsDockerId(myPid)
 	// This is not in a docker-cgroup so we have no info
 	assert.Empty(t, s, "No cgroup info here")
-	assert.NoError(t, e)
+	require.NoError(t, e)
 
 	// To further test we need a k8s environment unforunately. TBD
 }

--- a/pkg/sensors/exec/userinfo/userinfo_test.go
+++ b/pkg/sensors/exec/userinfo/userinfo_test.go
@@ -29,7 +29,7 @@ func TestAccountUnix(t *testing.T) {
 
 	name, err = getAccountUnix(0, &ns)
 	require.NoError(t, err)
-	require.Equal(t, name, "root")
+	require.Equal(t, "root", name)
 
 	ns.MntInum += 0x1000
 	name, err = getAccountUnix(1, &ns)

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -6,7 +6,7 @@ package sensors
 import (
 	"context"
 	"errors"
-	"sync"
+	"fmt"
 	"testing"
 	"time"
 
@@ -279,95 +279,118 @@ func TestPolicyListingWhileLoadUnload(t *testing.T) {
 	mgr, err := StartSensorManager("")
 	require.NoError(t, err)
 
-	checkPolicy := func(t *testing.T, statuses []*tetragon.TracingPolicyStatus, state tetragon.TracingPolicyState) {
-		require.Len(t, statuses, 1)
+	wrongPolicyErr := errors.New("wrong policy state")
+
+	checkPolicy := func(statuses []*tetragon.TracingPolicyStatus, state tetragon.TracingPolicyState) error {
+		if len(statuses) != 1 {
+			return fmt.Errorf("expected 1 policy, got %d", len(statuses))
+		}
 		pol := statuses[0]
-		require.Equal(t, pol.Name, polName)
-		require.Equal(t, pol.State, state)
+		if pol.Name != polName {
+			return fmt.Errorf("expected policy name %s, got %s", polName, pol.Name)
+		}
+		if pol.State != state {
+			return fmt.Errorf("%w: expected %v, got %v", wrongPolicyErr, state, pol.State)
+		}
+		return nil
 	}
 
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		// wait until at least one policy shows up, verify that it's in loading state and
-		// unblock the loading of the policy
+	verifyState := func(errCh chan error, state tetragon.TracingPolicyState) {
+		// wait until at least one policy shows up, verify that it's in loading/unloading state and
+		// unblock the loading/unloading of the policy
 		for {
 			l, err := mgr.ListTracingPolicies(ctx)
-			require.NoError(t, err)
+			if err != nil {
+				errCh <- fmt.Errorf("ListTracingPolicies error: %w", err)
+				return
+			}
 			if len(l.Policies) > 0 {
-				checkPolicy(t, l.Policies, tetragon.TracingPolicyState_TP_STATE_LOADING)
+				err := checkPolicy(l.Policies, state)
+				if err != nil && !errors.Is(err, wrongPolicyErr) {
+					errCh <- err
+					return
+				}
 				testSensor.unblock(t)
-				break
+				errCh <- nil
+				return
 			}
 			time.Sleep(1 * time.Millisecond)
 		}
-		wg.Done()
-	}()
+	}
+
+	errCh := make(chan error, 1)
+	go verifyState(errCh, tetragon.TracingPolicyState_TP_STATE_LOADING)
 
 	t.Log("adding policy")
 	policy := v1alpha1.TracingPolicy{}
 	policy.Name = polName
-	err = mgr.AddTracingPolicy(ctx, &policy)
-	require.NoError(t, err)
-	wg.Wait()
+	mgrErrCh := make(chan error, 1)
+	go func() {
+		mgrErrCh <- mgr.AddTracingPolicy(ctx, &policy)
+	}()
+
+	for range 2 {
+		select {
+		case err := <-mgrErrCh:
+			require.NoError(t, err)
+		case err := <-errCh:
+			require.NoError(t, err)
+		}
+	}
 
 	// check that policy is now enabled
 	l, err := mgr.ListTracingPolicies(ctx)
 	require.NoError(t, err)
-	checkPolicy(t, l.Policies, tetragon.TracingPolicyState_TP_STATE_ENABLED)
+	err = checkPolicy(l.Policies, tetragon.TracingPolicyState_TP_STATE_ENABLED)
+	require.NoError(t, err)
 
-	wg.Add(1)
-	go func() {
-		// wait until at least one policy shows up, verify that it's in unloading state and
-		// unblock the unloading of the policy
-		for {
-			l, err := mgr.ListTracingPolicies(ctx)
-			require.NoError(t, err)
-			require.Len(t, l.Policies, 1)
-			if l.Policies[0].State == tetragon.TracingPolicyState_TP_STATE_UNLOADING {
-				testSensor.unblock(t)
-				break
-			}
-			time.Sleep(1 * time.Millisecond)
-		}
-		wg.Done()
-	}()
+	errCh = make(chan error, 1)
+	go verifyState(errCh, tetragon.TracingPolicyState_TP_STATE_UNLOADING)
 
 	t.Log("disabling policy")
-	err = mgr.DisableTracingPolicy(ctx, polName, "")
-	require.NoError(t, err)
-	wg.Wait()
+	mgrErrCh = make(chan error, 1)
+	go func() {
+		mgrErrCh <- mgr.DisableTracingPolicy(ctx, polName, "")
+	}()
+
+	for range 2 {
+		select {
+		case err := <-mgrErrCh:
+			require.NoError(t, err)
+		case err := <-errCh:
+			require.NoError(t, err)
+		}
+	}
 
 	// check that policy is now disabled
 	l, err = mgr.ListTracingPolicies(ctx)
 	require.NoError(t, err)
-	checkPolicy(t, l.Policies, tetragon.TracingPolicyState_TP_STATE_DISABLED)
+	err = checkPolicy(l.Policies, tetragon.TracingPolicyState_TP_STATE_DISABLED)
+	require.NoError(t, err)
 
-	wg.Add(1)
-	go func() {
-		for {
-			l, err := mgr.ListTracingPolicies(ctx)
-			require.NoError(t, err)
-			require.Len(t, l.Policies, 1, "policies:", l.Policies)
-			if l.Policies[0].State == tetragon.TracingPolicyState_TP_STATE_LOADING {
-				testSensor.unblock(t)
-				break
-			}
-			time.Sleep(1000 * time.Millisecond)
-		}
-		wg.Done()
-	}()
+	errCh = make(chan error, 1)
+	go verifyState(errCh, tetragon.TracingPolicyState_TP_STATE_LOADING)
 
 	t.Log("re-enabling policy")
-	err = mgr.EnableTracingPolicy(ctx, polName, "")
-	require.NoError(t, err)
-	wg.Wait()
+	mgrErrCh = make(chan error, 1)
+	go func() {
+		mgrErrCh <- mgr.EnableTracingPolicy(ctx, polName, "")
+	}()
+
+	for range 2 {
+		select {
+		case err := <-mgrErrCh:
+			require.NoError(t, err)
+		case err := <-errCh:
+			require.NoError(t, err)
+		}
+	}
 
 	// check that policy is now diabled
 	l, err = mgr.ListTracingPolicies(ctx)
 	require.NoError(t, err)
-	checkPolicy(t, l.Policies, tetragon.TracingPolicyState_TP_STATE_ENABLED)
+	err = checkPolicy(l.Policies, tetragon.TracingPolicyState_TP_STATE_ENABLED)
+	require.NoError(t, err)
 
 	t.Log("deleting policy")
 	err = mgr.DeleteTracingPolicy(ctx, polName, "")

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -324,7 +324,7 @@ func TestPolicyListingWhileLoadUnload(t *testing.T) {
 		for {
 			l, err := mgr.ListTracingPolicies(ctx)
 			require.NoError(t, err)
-			require.Equal(t, 1, len(l.Policies))
+			require.Len(t, l.Policies, 1)
 			if l.Policies[0].State == tetragon.TracingPolicyState_TP_STATE_UNLOADING {
 				testSensor.unblock(t)
 				break
@@ -349,7 +349,7 @@ func TestPolicyListingWhileLoadUnload(t *testing.T) {
 		for {
 			l, err := mgr.ListTracingPolicies(ctx)
 			require.NoError(t, err)
-			require.Equal(t, 1, len(l.Policies), "policies:", l.Policies)
+			require.Len(t, l.Policies, 1, "policies:", l.Policies)
 			if l.Policies[0].State == tetragon.TracingPolicyState_TP_STATE_LOADING {
 				testSensor.unblock(t)
 				break

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -6,7 +6,6 @@ package sensors
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -96,7 +95,7 @@ func TestAddPolicySpecError(t *testing.T) {
 	require.NoError(t, err)
 	policy.Name = "test-policy"
 	err = mgr.AddTracingPolicy(ctx, &policy)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	t.Logf("got error (as expected): %s", err)
 	l, err := mgr.ListSensors(ctx)
 	require.NoError(t, err)
@@ -123,7 +122,7 @@ func TestAddPolicyLoadError(t *testing.T) {
 	require.NoError(t, err)
 	policy.Name = "test-policy"
 	addError := mgr.AddTracingPolicy(ctx, &policy)
-	require.NotNil(t, addError)
+	require.Error(t, addError)
 	t.Logf("got error (as expected): %s", addError)
 
 	l, err := mgr.ListTracingPolicies(ctx)
@@ -147,7 +146,7 @@ func TestPolicyFilterDisabled(t *testing.T) {
 	policyNamespace := ""
 	policy.Name = policyName
 	err = mgr.AddTracingPolicy(ctx, &policy)
-	require.NoError(t, err, fmt.Sprintf("Add tracing policy failed with error: %v", err))
+	require.NoError(t, err, "Add tracing policy failed with error: %v", err)
 	err = mgr.DeleteTracingPolicy(ctx, policyName, policyNamespace)
 	require.NoError(t, err)
 	err = mgr.AddTracingPolicy(ctx, &policy)
@@ -192,7 +191,7 @@ func TestPolicyStates(t *testing.T) {
 		require.NoError(t, err)
 		policy.Name = "test-policy"
 		addError := mgr.AddTracingPolicy(ctx, &policy)
-		require.NotNil(t, addError)
+		require.Error(t, addError)
 
 		l, err := mgr.ListTracingPolicies(ctx)
 		require.NoError(t, err)
@@ -247,7 +246,7 @@ func TestPolicyLoadErrorOverride(t *testing.T) {
 	require.NoError(t, err)
 	policy.Name = "test-policy"
 	addError := mgr.AddTracingPolicy(ctx, &policy)
-	require.NotNil(t, addError)
+	require.Error(t, addError)
 
 	l, err := mgr.ListTracingPolicies(ctx)
 	require.NoError(t, err)
@@ -281,7 +280,7 @@ func TestPolicyListingWhileLoadUnload(t *testing.T) {
 	require.NoError(t, err)
 
 	checkPolicy := func(t *testing.T, statuses []*tetragon.TracingPolicyStatus, state tetragon.TracingPolicyState) {
-		require.Equal(t, 1, len(statuses))
+		require.Len(t, statuses, 1)
 		pol := statuses[0]
 		require.Equal(t, pol.Name, polName)
 		require.Equal(t, pol.State, state)
@@ -325,7 +324,7 @@ func TestPolicyListingWhileLoadUnload(t *testing.T) {
 		for {
 			l, err := mgr.ListTracingPolicies(ctx)
 			require.NoError(t, err)
-			require.Equal(t, len(l.Policies), 1)
+			require.Equal(t, 1, len(l.Policies))
 			if l.Policies[0].State == tetragon.TracingPolicyState_TP_STATE_UNLOADING {
 				testSensor.unblock(t)
 				break
@@ -350,7 +349,7 @@ func TestPolicyListingWhileLoadUnload(t *testing.T) {
 		for {
 			l, err := mgr.ListTracingPolicies(ctx)
 			require.NoError(t, err)
-			require.Equal(t, len(l.Policies), 1, "policies:", l.Policies)
+			require.Equal(t, 1, len(l.Policies), "policies:", l.Policies)
 			if l.Policies[0].State == tetragon.TracingPolicyState_TP_STATE_LOADING {
 				testSensor.unblock(t)
 				break
@@ -375,7 +374,7 @@ func TestPolicyListingWhileLoadUnload(t *testing.T) {
 	require.NoError(t, err)
 	l, err = mgr.ListTracingPolicies(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(l.Policies))
+	require.Empty(t, l.Policies)
 }
 
 func TestPolicyKernelMemoryBytes(t *testing.T) {

--- a/pkg/sensors/test/sensors_test.go
+++ b/pkg/sensors/test/sensors_test.go
@@ -342,7 +342,7 @@ func TestMapUser(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
-		assert.Error(t, err)
+		require.Error(t, err)
 		if err == nil {
 			defer s1.Unload(true)
 		}
@@ -566,7 +566,7 @@ func TestCleanup(t *testing.T) {
 		for _, f := range files {
 			_, err := os.Stat(filepath.Join(bpf.MapPrefixPath(), f))
 			t.Logf("Removed checking path: '%s'\n", f)
-			assert.Error(t, err)
+			require.Error(t, err)
 		}
 	}
 
@@ -574,7 +574,7 @@ func TestCleanup(t *testing.T) {
 		for _, f := range files {
 			_, err := os.Stat(filepath.Join(bpf.MapPrefixPath(), f))
 			t.Logf("Exists checking path: '%s'\n", f)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 
@@ -639,7 +639,7 @@ func TestCleanup(t *testing.T) {
 		}
 
 		err = s1.Load(bpf.MapPrefixPath())
-		assert.Error(t, err)
+		require.Error(t, err)
 		if err == nil {
 			defer s1.Unload(true)
 		}

--- a/pkg/sensors/test/sensors_test.go
+++ b/pkg/sensors/test/sensors_test.go
@@ -195,8 +195,8 @@ func TestMapMultipleSensors(t *testing.T) {
 	s2.Load(bpf.MapPrefixPath())
 	defer s2.Unload(true)
 
-	assert.Equal(t, m11.PinPath, "m1")
-	assert.Equal(t, m12.PinPath, "policy/m2")
+	assert.Equal(t, "m1", m11.PinPath)
+	assert.Equal(t, "policy/m2", m12.PinPath)
 	assert.Equal(t, m11.PinPath, m21.PinPath)
 	assert.Equal(t, m12.PinPath, m22.PinPath)
 }

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -69,8 +69,6 @@ spec:
 	for _, arg := range failHook.Args {
 		_, _, err := resolveBTFArg(failHook.Call, arg, false)
 
-		if !assert.ErrorContains(t, err, "The maximum depth allowed is") {
-			t.Fatalf("The path %q must have len < %d", arg.Resolve, api.MaxBTFArgDepth)
-		}
+		require.ErrorContains(t, err, "The maximum depth allowed is", "The path %q must have len < %d", arg.Resolve, api.MaxBTFArgDepth)
 	}
 }

--- a/pkg/sensors/tracing/generickprobe_test.go
+++ b/pkg/sensors/tracing/generickprobe_test.go
@@ -156,7 +156,7 @@ func Test_DisableEnablePolicy_Kprobe(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = mgr.DeleteTracingPolicy(ctx, tcpConnectPolicyName, tcpConnectPolicyNamespace)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 
 		err = mgr.DisableSensor(ctx, tcpConnectPolicyName)
@@ -170,7 +170,7 @@ func Test_DisableEnablePolicy_Kprobe(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = mgr.DeleteTracingPolicy(ctx, tcpConnectPolicyName, tcpConnectPolicyNamespace)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 
 		err = mgr.DisableTracingPolicy(ctx, tcpConnectPolicyName, tcpConnectPolicyNamespace)
@@ -196,7 +196,7 @@ func Test_DisableEnablePolicy_KernelMemoryBytes(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err = mgr.DeleteTracingPolicy(ctx, tcpConnectPolicyName, tcpConnectPolicyNamespace)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	list, err := mgr.ListTracingPolicies(ctx)

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2888,7 +2888,7 @@ func TestKprobeOverrideMulti(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTemp failed: %s", err)
 	}
-	defer assert.NoError(t, link.Close())
+	defer require.NoError(t, link.Close())
 
 	// The test hooks on 4 syscalls and override 3 of them.
 	//
@@ -7672,7 +7672,7 @@ func TestKprobeDentryPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer assert.NoError(t, file_2.Close())
+	defer require.NoError(t, file_2.Close())
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()

--- a/pkg/sensors/tracing/kprobe_validation_test.go
+++ b/pkg/sensors/tracing/kprobe_validation_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/tetragon/pkg/config"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -357,10 +356,10 @@ spec:
  `
 
 	_, err := tracingpolicy.FromYAML(crd1)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, err = tracingpolicy.FromYAML(crd2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = tracingpolicy.FromYAML(crd3)
 	require.NoError(t, err)

--- a/pkg/sensors/tracing/message_test.go
+++ b/pkg/sensors/tracing/message_test.go
@@ -21,9 +21,9 @@ func TestGetPolicyMessage(t *testing.T) {
 
 	msg, err = getPolicyMessage("test")
 	require.NoError(t, err)
-	require.Equal(t, msg, "test")
+	require.Equal(t, "test", msg)
 
 	msg, err = getPolicyMessage(strings.Repeat("a", TpMaxMessageLen+1))
 	require.Equal(t, err, ErrMsgSyntaxLong)
-	require.Equal(t, TpMaxMessageLen, len(msg))
+	require.Len(t, msg, TpMaxMessageLen)
 }

--- a/pkg/sensors/tracing/syscall_list_test.go
+++ b/pkg/sensors/tracing/syscall_list_test.go
@@ -6,7 +6,6 @@
 package tracing
 
 import (
-	"fmt"
 	"runtime"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 
 func defABI(t *testing.T) string {
 	abi, err := syscallinfo.DefaultABI()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	return abi
 }
 
@@ -51,9 +50,9 @@ func TestParseSyscallValue(t *testing.T) {
 	for _, tc := range tcs {
 		abi, name, err := parseSyscallValue(SyscallVal(tc.val))
 		if tc.expError {
-			require.Error(t, err, fmt.Sprintf("tc: %+v", tc))
+			require.Error(t, err, "tc: %+v", tc)
 		} else {
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, tc.expABI, abi)
 			require.Equal(t, tc.expName, name)
 		}
@@ -82,7 +81,7 @@ func TestSyscallValSymbol(t *testing.T) {
 		if tc.symExpError {
 			require.Error(t, err)
 		} else {
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, tc.symExpVal, sym)
 		}
 	}

--- a/pkg/sensors/tracing/tags_test.go
+++ b/pkg/sensors/tracing/tags_test.go
@@ -22,7 +22,7 @@ func TestGetPolicyTags(t *testing.T) {
 	input = []string{"observability.filesystem"}
 	tags, err := getPolicyTags(input)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(tags))
+	require.Len(t, tags, 1)
 
 	input = []string{"observability.filesystem", "", "CVES"}
 	_, err = getPolicyTags(input)
@@ -31,7 +31,7 @@ func TestGetPolicyTags(t *testing.T) {
 	input = []string{"observability.filesystem", "CVES", "aa"}
 	tags, err = getPolicyTags(input)
 	require.NoError(t, err)
-	require.Equal(t, 3, len(tags))
+	require.Len(t, tags, 3)
 
 	input = []string{"01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16", "17"}
 	_, err = getPolicyTags(input)

--- a/pkg/testutils/progs/tester.go
+++ b/pkg/testutils/progs/tester.go
@@ -228,6 +228,6 @@ func (pt *Tester) AddToCgroup(t *testing.T, cgroupPath string) {
 	procs := filepath.Join(cgroupPath, "cgroup.procs")
 	pidStr := strconv.Itoa(pid)
 	err := os.WriteFile(procs, []byte(pidStr), 0644)
-	require.NoError(t, err, fmt.Sprintf("failed to add pid '%s' to %s", pidStr, procs))
+	require.NoError(t, err, "failed to add pid '%s' to %s", pidStr, procs)
 	// TODO: add check that cgroup is what we set
 }

--- a/pkg/testutils/progs/tester_test.go
+++ b/pkg/testutils/progs/tester_test.go
@@ -21,7 +21,7 @@ func TestPing(t *testing.T) {
 	err := pt.Ping()
 	require.NoError(t, err)
 	err = pt.Stop()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestExec(t *testing.T) {
@@ -32,7 +32,7 @@ func TestExec(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "cmd=\"/bin/echo hello\" returned without an error. Combined output was: \"hello\\n\"", out)
 	err = pt.Stop()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestSigkill(t *testing.T) {
@@ -44,5 +44,5 @@ func TestSigkill(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, out, "signal: killed")
 	err = pt.Stop()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/timer/timer_test.go
+++ b/pkg/timer/timer_test.go
@@ -21,14 +21,14 @@ func TestTimer(t *testing.T) {
 	timer1.Start(time.Duration(100) * time.Millisecond)
 	time.Sleep(time.Duration(550) * time.Millisecond)
 	timer1.Stop()
-	assert.Equal(count, 5, "Tests simple timer (100ms interval)")
+	assert.Equal(5, count, "Tests simple timer (100ms interval)")
 	timer1.Start(time.Duration(1000) * time.Millisecond)
 	time.Sleep(time.Duration(1500) * time.Millisecond)
-	assert.Equal(count, 6, "Tests simple timer (1000ms interval)")
+	assert.Equal(6, count, "Tests simple timer (1000ms interval)")
 	timer1.Start(time.Duration(200) * time.Millisecond)
 	time.Sleep(time.Duration(300) * time.Millisecond)
 	timer1.Stop()
-	assert.Equal(count, 7, "Tests restart of timer")
+	assert.Equal(7, count, "Tests restart of timer")
 }
 
 func Worker() {

--- a/pkg/tracingpolicy/generictracingpolicy_test.go
+++ b/pkg/tracingpolicy/generictracingpolicy_test.go
@@ -92,6 +92,6 @@ func TestYamlNamespaced(t *testing.T) {
 func TestEmptyTracingPolicy(t *testing.T) {
 	path := crdutils.CreateTempFile(t, "")
 	_, err := FromFile(path)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown CRD kind: ")
 }

--- a/pkg/tracingpolicy/yaml_test.go
+++ b/pkg/tracingpolicy/yaml_test.go
@@ -4,7 +4,6 @@
 package tracingpolicy
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"text/template"
@@ -100,8 +99,8 @@ func TestPolicyYAMLSetMode(t *testing.T) {
 		require.NoError(t, err)
 		out := outBld.String()
 		ret, err := PolicyYAMLSetMode([]byte(in), c.mode)
-		require.NoError(t, err, fmt.Sprintf("unexpected error test %q", c.desc))
-		require.Equal(t, out, string(ret), fmt.Sprintf("test %q failed", c.desc))
+		require.NoError(t, err, "unexpected error test %q", c.desc)
+		require.Equal(t, out, string(ret), "test %q failed", c.desc)
 	}
 
 }


### PR DESCRIPTION
Fun time!

This fixes many swapping between "expected" and "actual" values which should be nice for debugging and also encourage to use the correct methods (Len/Empty/etc) for more context on debugging. It also fixes a few issues and potential mistakes.