### PR TITLE
btf: Use user-provided KernelTypes if the btfSpec is nil

### DIFF
--- a/pkg/sensors/program/loader_linux.go
+++ b/pkg/sensors/program/loader_linux.go
@@ -879,13 +879,21 @@ func doLoadProgram(
 
 	var opts ebpf.CollectionOptions
 	if btfSpec != nil {
+		// we have a BTF in a non-normal location let's use that in the first try
 		opts.Programs.KernelTypes = btfSpec
+	} else if load.KernelTypes != nil {
+		// here we have the nornal BTF file (i.e. /sys/kernel/btf/vmlinux) and we can
+		// check if the user provided any custom BTF (i.e. containing kmod data) and use
+		// that instead
+		opts.Programs.KernelTypes = load.KernelTypes
 	}
 
 	opts.MapReplacements = pinnedMaps
 
 	coll, err := ebpf.NewCollectionWithOptions(spec, opts)
-	if err != nil && load.KernelTypes != nil {
+	if err != nil && btfSpec != nil && load.KernelTypes != nil {
+		// here we have tried using btfSpec and failed now let's
+		// try to use the user-provided load.KernelTypes
 		opts.Programs.KernelTypes = load.KernelTypes
 		coll, err = ebpf.NewCollectionWithOptions(spec, opts)
 	}


### PR DESCRIPTION
Currently, we check if btfSpec (BTF in non-normal location) is not nil and use that. If this fails to load, we then try to use user-provided load.KernelTypes. This has the issue that if we use the normal BTF file and the user also  provided load.KernelTypes. we tried that after a failed attempt which may result in missing features in loaded programs.

This patch fixes that issue by trying to load the user-provided load.KernelTypes in the first place if we use the BTF in the common location (i.e. /sys/kernel/btf/vmlinux).