### PR TITLE
tetragon/windows: add uid to exec events in Windows

### DIFF
--- a/bpf/windows/process_monitor.c
+++ b/bpf/windows/process_monitor.c
@@ -125,6 +125,7 @@ int ProcessMonitor(process_md_t *ctx)
 		process_create_info.parent_process_id = ctx->parent_process_id;
 		process_create_info.creating_process_id = ctx->creating_process_id;
 		process_create_info.creating_thread_id = ctx->creating_thread_id;
+		process_create_info.user_luid = bpf_get_current_logon_id(ctx);
 		process_create_info.creation_time = ctx->creation_time;
 
 		void *buffer = get_scratch_space();

--- a/pkg/api/processapi/processapi_windows.go
+++ b/pkg/api/processapi/processapi_windows.go
@@ -9,6 +9,7 @@ type MsgCreateProcessEvent struct {
 	ParentProcessID   uint32
 	CreatingProcessID uint32
 	CreatingThreadID  uint32
+	UserLUID          uint64
 	CreationTime      uint64
 }
 

--- a/pkg/reader/proc/proc_windows.go
+++ b/pkg/reader/proc/proc_windows.go
@@ -6,6 +6,7 @@ package proc
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -19,6 +20,19 @@ type TokenGroups struct {
 	Groups     []syscall.SIDAndAttributes
 }
 
+type TokenStatistics struct {
+	TokenId            windows.LUID
+	AuthenticationId   windows.LUID
+	ExpirationTime     int64
+	TokenType          uint32
+	ImpersonationLevel uint32
+	DynamicCharged     uint32
+	DynamicAvailable   uint32
+	GroupCount         uint32
+	PrivilegeCount     uint32
+	ModifiedId         windows.LUID
+}
+
 func getIDFromSID(str_sid string) (string, error) {
 	tokens := strings.Split(str_sid, "-")
 	if len(tokens) <= 1 {
@@ -27,24 +41,40 @@ func getIDFromSID(str_sid string) (string, error) {
 	return tokens[len(tokens)-1], nil
 }
 
+func getStrLuidFromToken(token windows.Token) (string, error) {
+
+	var size uint32
+	err := windows.GetTokenInformation(token, windows.TokenStatistics, nil, 0, &size)
+	if err != syscall.ERROR_INSUFFICIENT_BUFFER {
+		return "", fmt.Errorf("GetTokenInformation (size query) failed: %v\n", err)
+	}
+
+	// Allocate buffer and retrieve TokenStatistics
+	buffer := make([]byte, size)
+	err = windows.GetTokenInformation(token, windows.TokenStatistics, &buffer[0], size, &size)
+	if err != nil {
+		return "", fmt.Errorf("GetTokenInformation (size query) failed: %v\n", err)
+	}
+
+	// Cast buffer to TOKEN_STATISTICS
+	stats := (*TokenStatistics)(unsafe.Pointer(&buffer[0]))
+
+	luid := *(*uint64)(unsafe.Pointer(&stats.AuthenticationId))
+	strLUID := strconv.FormatUint(luid, 10)
+	return strLUID, nil
+
+}
+
 // fillStatus returns the content of /proc/pid/status as Status
 func fillStatus(hProc windows.Handle, status *Status) error {
-	var token syscall.Token
-	err := syscall.OpenProcessToken(syscall.Handle(hProc), syscall.TOKEN_QUERY, &token)
+	var token windows.Token
+	err := windows.OpenProcessToken(hProc, windows.TOKEN_QUERY, &token)
 	if err != nil {
 		return err
 	}
 
 	defer token.Close()
-	tokenUser, err := token.GetTokenUser()
-	if err != nil {
-		return err
-	}
-	sid_string, err := tokenUser.User.Sid.String()
-	if err != nil {
-		return err
-	}
-	str_uid, err := getIDFromSID(sid_string)
+	str_uid, err := getStrLuidFromToken(token)
 	if err != nil {
 		return err
 	}
@@ -53,7 +83,7 @@ func fillStatus(hProc windows.Handle, status *Status) error {
 	if err != nil {
 		return err
 	}
-	str_groupid, err := tokenGroup.PrimaryGroup.String()
+	str_groupid := tokenGroup.PrimaryGroup.String()
 	if err != nil {
 		return err
 	}

--- a/pkg/sensors/exec/exec_windows.go
+++ b/pkg/sensors/exec/exec_windows.go
@@ -28,6 +28,7 @@ func msgToExecveUnix(m *processapi.MsgCreateProcessEvent) *exec.MsgExecveEventUn
 		PID:   m.ProcessID,
 		TID:   m.ProcessID,
 		NSPID: 0,
+		UID:   uint32(m.UserLUID),
 		Flags: 1,
 		Size:  0,
 		Ktime: m.CreationTime,


### PR DESCRIPTION
### Description
This commit consumes the changes made in process_monitor.c program to send the  user's login id as a part of exec event. 
This id is also enumerated for existing processes during enumeration when tetragon starts.

This uid is a unique Login Identifier extracted from user's token, and is same as Token AuthenticationId field of TOKEN_STATISTICS structure, available when token is queried with TokenStatistics information class.

This Authetication Id can be used to retrieve back the token, sid, user name etc. fields using the win32 API LsaGetLogonSessionData()

Since the Login ID as a uint64 is unique per user, and is different between privileged and non-privileged sessions of the same user, it seems to be  a good proxy for uid field in exec event.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```Exec events in Windows are now reported with uid to identify user launching the process. 
```
