### PR TITLE
refactor: Rename functions in the node package

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -426,7 +426,7 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 		if err != nil {
 			log.WithError(err).Warn("Failed to get local Kubernetes node info. node_labels field will be empty")
 		} else {
-			node.SetKubernetesNodeLabels(k8sNode.Labels)
+			node.SetNodeLabels(k8sNode.Labels)
 		}
 	} else {
 		log.Info("Disabling Kubernetes API")

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -67,10 +67,10 @@ func newControllerManager() (*ControllerManager, error) {
 	cacheOptions := cmCache.Options{
 		ByObject: map[client.Object]cmCache.ByObject{
 			&corev1.Pod{}: {
-				Field: fields.OneTermEqualSelector("spec.nodeName", node.GetKubernetesNodeName()),
+				Field: fields.OneTermEqualSelector("spec.nodeName", node.GetNodeName()),
 			},
 			&corev1.Node{}: {
-				Field: fields.SelectorFromSet(fields.Set{"metadata.name": node.GetKubernetesNodeName()}),
+				Field: fields.SelectorFromSet(fields.Set{"metadata.name": node.GetNodeName()}),
 			},
 		},
 	}
@@ -111,7 +111,7 @@ func (cm *ControllerManager) GetNamespace(name string) (*corev1.Namespace, error
 
 func (cm *ControllerManager) GetNode() (*corev1.Node, error) {
 	k8sNode := corev1.Node{}
-	if err := cm.Manager.GetCache().Get(context.Background(), types.NamespacedName{Name: node.GetKubernetesNodeName()}, &k8sNode); err != nil {
+	if err := cm.Manager.GetCache().Get(context.Background(), types.NamespacedName{Name: node.GetNodeName()}, &k8sNode); err != nil {
 		return nil, err
 	}
 	return &k8sNode, nil

--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -39,7 +39,7 @@ type ManagerTestSuite struct {
 func (suite *ManagerTestSuite) SetupSuite() {
 	err := os.Setenv("NODE_NAME", nodeName)
 	require.NoError(suite.T(), err)
-	node.SetKubernetesNodeName()
+	node.SetNodeName()
 	useExistingCluster := true
 	suite.testEnv = &envtest.Environment{
 		UseExistingCluster: &useExistingCluster,
@@ -127,7 +127,7 @@ func (suite *ManagerTestSuite) TestLocalPods() {
 	defer cancel()
 	err := os.Setenv("NODE_NAME", "nonexistent-node")
 	require.NoError(suite.T(), err)
-	node.SetKubernetesNodeName()
+	node.SetNodeName()
 	controllerManager, err := newControllerManager()
 	require.NoError(suite.T(), err)
 	go func() {
@@ -140,7 +140,7 @@ func (suite *ManagerTestSuite) TestLocalPods() {
 	// Pod cache should be empty because the node name is set to a nonexistent node.
 	assert.Empty(suite.T(), pods.Items)
 	require.NoError(suite.T(), os.Setenv("NODE_NAME", nodeName))
-	node.SetKubernetesNodeName()
+	node.SetNodeName()
 }
 
 func (suite *ManagerTestSuite) TestGetNode() {

--- a/pkg/reader/node/node.go
+++ b/pkg/reader/node/node.go
@@ -17,14 +17,14 @@ const (
 )
 
 var (
-	kubernetesNodeName   string
-	exportNodeName       string
-	kubernetesNodeLabels = map[string]string{}
+	nodeName       string
+	exportNodeName string
+	nodeLabels     = map[string]string{}
 )
 
 func init() {
 	SetExportNodeName()
-	SetKubernetesNodeName()
+	SetNodeName()
 }
 
 // SetExportNodeName initializes the exportNodeName variable. It's defined separately from
@@ -43,24 +43,24 @@ func SetExportNodeName() {
 	}
 }
 
-// SetKubernetesNodeName initializes the kubernetesNodeName variable. It's defined separately from
+// SetNodeName initializes the nodeName variable. It's defined separately from
 // init() so that it can be called from unit tests.
-func SetKubernetesNodeName() {
+func SetNodeName() {
 	var err error
-	if kubernetesNodeName = os.Getenv(nodeNameEnvVar); kubernetesNodeName != "" {
+	if nodeName = os.Getenv(nodeNameEnvVar); nodeName != "" {
 		return
 	}
-	if kubernetesNodeName = os.Getenv(hubbleNodeNameEnvVar); kubernetesNodeName != "" {
+	if nodeName = os.Getenv(hubbleNodeNameEnvVar); nodeName != "" {
 		return
 	}
-	kubernetesNodeName, err = os.Hostname()
+	nodeName, err = os.Hostname()
 	if err != nil {
 		logger.GetLogger().WithError(err).Warn("failed to retrieve hostname")
 	}
 }
 
-func SetKubernetesNodeLabels(labels map[string]string) {
-	kubernetesNodeLabels = labels
+func SetNodeLabels(labels map[string]string) {
+	nodeLabels = labels
 }
 
 // GetNodeNameForExport returns node name string for JSON export. It uses the HUBBLE_NODE_NAME
@@ -70,20 +70,20 @@ func GetNodeNameForExport() string {
 	return exportNodeName
 }
 
-// GetKubernetesNodeName returns node name string for the given node in Kubernetes. It uses the NODE_NAME
+// GetNodeName returns node name string for the given node in Kubernetes. It uses the NODE_NAME
 // env variable by default, and falls back to HUBBLE_NODE_NAME if the former is missing. If both
 // are missing, it will use the host name reported by the kernel. This value is used when watching for
 // pods running on the node in Kubernetes.
 //
 // NOTE: This is different from the Export equivalent for cases where nodes in kubernetes are named different
 // from the desired node name in the JSON export.
-func GetKubernetesNodeName() string {
-	return kubernetesNodeName
+func GetNodeName() string {
+	return nodeName
 }
 
 // SetCommonFields set fields that are common in all the events.
 func SetCommonFields(ev *tetragon.GetEventsResponse) {
 	ev.NodeName = exportNodeName
 	ev.ClusterName = option.Config.ClusterName
-	ev.NodeLabels = kubernetesNodeLabels
+	ev.NodeLabels = nodeLabels
 }

--- a/pkg/reader/node/node_test.go
+++ b/pkg/reader/node/node_test.go
@@ -40,13 +40,13 @@ func TestSetCommonFields(t *testing.T) {
 }
 
 func TestGetKubernetesNodeName(t *testing.T) {
-	assert.NotEmpty(t, GetKubernetesNodeName()) // we should get the hostname here
+	assert.NotEmpty(t, GetNodeName()) // we should get the hostname here
 	require.NoError(t, os.Setenv("NODE_NAME", "from-node-name"))
-	SetKubernetesNodeName()
-	assert.Equal(t, "from-node-name", GetKubernetesNodeName())
+	SetNodeName()
+	assert.Equal(t, "from-node-name", GetNodeName())
 	require.NoError(t, os.Setenv("HUBBLE_NODE_NAME", "from-hubble-node-name"))
-	SetKubernetesNodeName()
-	assert.Equal(t, "from-node-name", GetKubernetesNodeName())
+	SetNodeName()
+	assert.Equal(t, "from-node-name", GetNodeName())
 	require.NoError(t, os.Unsetenv("NODE_NAME"))
 	require.NoError(t, os.Unsetenv("HUBBLE_NODE_NAME"))
 }


### PR DESCRIPTION
- Rename GetKubernetesNodeName() to GetNodeName()
- Rename SetKubernetesNodeName() to SetNodeName()
- Rename SetKubernetesNodeLabels() to SetNodeLabels()

One could imagine node name / labels might come from other sources outside Kubernetes in the future.