### PR TITLE
e2e: Capture Tetragon state on failure

### DIFF
--- a/tests/e2e/helpers/dumpinfo.go
+++ b/tests/e2e/helpers/dumpinfo.go
@@ -112,19 +112,19 @@ func DumpInfo(ctx context.Context, cfg *envconf.Config) (context.Context, error)
 	return ctx, nil
 }
 
-func CreateExportDir(ctx context.Context, t *testing.T) (context.Context, error) {
+func CreateExportDir(ctx context.Context, name string) (context.Context, error) {
 	dir, err := GetExportDir(ctx)
 	if err == nil {
-		klog.V(2).InfoS("export dir already exists, skipping creation", "test", t.Name(), "dir", dir)
+		klog.V(2).InfoS("export dir already exists, skipping creation", "name", name, "dir", dir)
 		return ctx, nil
 	}
 
-	dir, err = os.MkdirTemp("", fmt.Sprintf("tetragon.e2e.%s.*", t.Name()))
+	dir, err = os.MkdirTemp("", fmt.Sprintf("tetragon.e2e.%s.*", name))
 	if err != nil {
 		return ctx, err
 	}
 
-	klog.InfoS("created export dir for test", "test", t.Name(), "dir", dir)
+	klog.InfoS("created export dir", "name", name, "dir", dir)
 
 	return context.WithValue(ctx, state.ExportDir, dir), nil
 }

--- a/tests/e2e/state/state.go
+++ b/tests/e2e/state/state.go
@@ -29,6 +29,4 @@ var (
 	ExportDir = Key{slug: "ExportDir"}
 	// Key for storing the cluster name
 	ClusterName = Key{slug: "ClusterName"}
-	// Key for storing test failure
-	TestFailure = Key{slug: "TestFailure"}
 )

--- a/tests/e2e/tests/labels/labels_test.go
+++ b/tests/e2e/tests/labels/labels_test.go
@@ -102,9 +102,6 @@ func TestLabelsDemoApp(t *testing.T) {
 		t.Skip("Skipping, see: ://github.com/cilium/tetragon/issues/3060")
 	}
 
-	// Must be called at the beginning of every test
-	runner.SetupExport(t)
-
 	labelsChecker := labelsEventChecker().WithEventLimit(5000).WithTimeLimit(5 * time.Minute)
 
 	// This starts labelsChecker and uses it to run event checks.

--- a/tests/e2e/tests/policyfilter/policyfilter_test.go
+++ b/tests/e2e/tests/policyfilter/policyfilter_test.go
@@ -83,8 +83,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestNamespacedPolicy(t *testing.T) {
-	runner.SetupExport(t)
-
 	checker := nsChecker().WithTimeLimit(30 * time.Second).WithEventLimit(20)
 
 	runEventChecker := features.New("Run Event Checks").
@@ -214,8 +212,6 @@ func (nsc *namespaceChecker) FinalCheck(_ *logrus.Logger) error {
 }
 
 func TestPodLabelFilters(t *testing.T) {
-	runner.SetupExport(t)
-
 	checker := podlblChecker().WithTimeLimit(30 * time.Second).WithEventLimit(20)
 
 	runEventChecker := features.New("Run Event Checks").
@@ -376,8 +372,6 @@ func (plc *podLabelChecker) FinalCheck(_ *logrus.Logger) error {
 }
 
 func testContainerFieldFilters(t *testing.T, checker *checker.RPCChecker, policy, policyName, pod string) {
-	runner.SetupExport(t)
-
 	runEventChecker := features.New("Run Event Checks").
 		Assess("Run Event Checks", checker.CheckWithFilters(
 			30*time.Second,

--- a/tests/e2e/tests/skeleton/skeleton_test.go
+++ b/tests/e2e/tests/skeleton/skeleton_test.go
@@ -86,9 +86,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestSkeletonBasic(t *testing.T) {
-	// Must be called at the beginning of every test
-	runner.SetupExport(t)
-
 	// Grab the minimum kernel version in all cluster nodes and define an RPC checker with it
 	kversion := helpers.GetMinKernelVersion(t, runner.Environment)
 	// Create an curl event checker with a limit or 10 events or 30 seconds, whichever comes first


### PR DESCRIPTION
fix e2e to call helpers.DumpInfo on setup / test failure. probably easier to review commit by commit. 

- test failure example: https://github.com/cilium/tetragon/actions/runs/15545804930?pr=3812
- setup failure example: https://github.com/cilium/tetragon/actions/runs/15545584308?pr=3812