### PR TITLE
e2e: Don't install Cilium

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -118,7 +118,7 @@ jobs:
         GHA_OS: ${{matrix.os}}
       run: |
         cd go/src/github.com/cilium/tetragon
-        make e2e-test E2E_TESTS=${{matrix.package.f}} E2E_BUILD_IMAGES=0 E2E_AGENT=${{ needs.prepare.outputs.agentImage }} E2E_OPERATOR=${{ needs.prepare.outputs.operatorImage }} EXTRA_TESTFLAGS="-cluster-name=${{ env.clusterName }} -args -v=4"
+        make e2e-test E2E_TESTS=${{matrix.package.f}} E2E_BUILD_IMAGES=0 E2E_AGENT=${{ needs.prepare.outputs.agentImage }} E2E_OPERATOR=${{ needs.prepare.outputs.operatorImage }} EXTRA_TESTFLAGS="-cluster-name=${{ env.clusterName }} -args -v=4 -tetragon.install-cilium=false"
 
     - name: Upload Tetragon Logs
       if: failure() || cancelled()


### PR DESCRIPTION
E2E tests don't rely on Cilium.