### PR TITLE
tools: Avoid picking protoc file randomly

### DIFF
--- a/tools/protoc-gen-go-tetragon/common/common.go
+++ b/tools/protoc-gen-go-tetragon/common/common.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+var TetragonProtoPackageName = "tetragon"
+
 // TetragonPackageName is the import path for the Tetragon package
 var TetragonPackageName = "github.com/cilium/tetragon"
 
@@ -365,4 +367,15 @@ func GetEnums(files []*protogen.File) ([]*protogen.Enum, error) {
 	}
 
 	return enumsCache, nil
+}
+
+// GetFirstTetragonFile returns the first file in the provided files that has a filename prefix
+// starting with TetragonProtoPackageName
+func GetFirstTetragonFile(files []*protogen.File) (*protogen.File, error) {
+	for _, file := range files {
+		if strings.HasPrefix(file.GeneratedFilenamePrefix, TetragonProtoPackageName) {
+			return file, nil
+		}
+	}
+	return nil, errors.New("no Tetragon file found in the provided files")
 }

--- a/tools/protoc-gen-go-tetragon/eventchecker/eventchecker.go
+++ b/tools/protoc-gen-go-tetragon/eventchecker/eventchecker.go
@@ -14,8 +14,12 @@ func Generate(gen *protogen.Plugin, files []*protogen.File) error {
 	// generated files will be in pkg tetragon so its not important
 	// from packaging side and any prefix will work fine we just pick
 	// the first file arbitrarily.
-	g := common.NewCodegenFile(gen, files[0], "eventchecker")
-	yaml := common.NewCodegenFile(gen, files[0], "eventchecker/yaml")
+	f, err := common.GetFirstTetragonFile(files)
+	if err != nil {
+		return err
+	}
+	g := common.NewCodegenFile(gen, f, "eventchecker")
+	yaml := common.NewCodegenFile(gen, f, "eventchecker/yaml")
 
 	if err := generateEventCheckerConf(yaml); err != nil {
 		return err

--- a/tools/protoc-gen-go-tetragon/helpers/helpers.go
+++ b/tools/protoc-gen-go-tetragon/helpers/helpers.go
@@ -298,8 +298,11 @@ func generateProcessEventMap(g *protogen.GeneratedFile, files []*protogen.File) 
 
 // Generate generates boilerplate helpers
 func Generate(gen *protogen.Plugin, files []*protogen.File) error {
-	// Pick arbitrary file to use for prefix of generated files, files[0] here.
-	g := common.NewCodegenFile(gen, files[0], "helpers")
+	f, err := common.GetFirstTetragonFile(files)
+	if err != nil {
+		return err
+	}
+	g := common.NewCodegenFile(gen, f, "helpers")
 
 	if err := generateResponseTypeString(g, files); err != nil {
 		return err

--- a/tools/protoc-gen-go-tetragon/types/types.go
+++ b/tools/protoc-gen-go-tetragon/types/types.go
@@ -11,7 +11,11 @@ import (
 )
 
 func Generate(gen *protogen.Plugin, files []*protogen.File) error {
-	g := common.NewFile(gen, files[0], "", filepath.Base(common.TetragonApiPackageName), "types")
+	f, err := common.GetFirstTetragonFile(files)
+	if err != nil {
+		return err
+	}
+	g := common.NewFile(gen, f, "", filepath.Base(common.TetragonApiPackageName), "types")
 
 	events, err := common.GetEvents(files)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
This is to make sure that we don't rely on import statement and generate the files in unintended directory.

For example, dummy import in bpf.proto, followed by `make codegen` will generate files into google/protobuf instead of `tetragon` dir

```diff
diff --git i/api/v1/tetragon/bpf.proto w/api/v1/tetragon/bpf.proto
index 486c4ed32..08629fac3 100644
--- i/api/v1/tetragon/bpf.proto
+++ w/api/v1/tetragon/bpf.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package tetragon;
 
+import "google/protobuf/duration.proto";
+
 option go_package = "github.com/cilium/tetragon/api/v1/tetragon";
 
 enum BpfCmd {
```

```bash
$  make protogen
... 
...
buf generate 
time="2025-06-12T03:27:25Z" level=info msg=google/protobuf/codegen/helpers/helpers.pb.go
time="2025-06-12T03:27:25Z" level=info msg=google/protobuf/codegen/eventchecker/eventchecker.pb.go
time="2025-06-12T03:27:25Z" level=info msg=google/protobuf/codegen/eventchecker/yaml/yaml.pb.go
time="2025-06-12T03:27:25Z" level=info msg=google/protobuf/types.pb.go
...

$ git status              
...
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        api/v1/google/
```

With this patch, I can see the generated files are in the correct directory

```
$ make protogen
...
time="2025-06-12T03:56:29Z" level=info msg=tetragon/codegen/helpers/helpers.pb.go
time="2025-06-12T03:56:29Z" level=info msg=tetragon/codegen/eventchecker/eventchecker.pb.go
time="2025-06-12T03:56:29Z" level=info msg=tetragon/codegen/eventchecker/yaml/yaml.pb.go
time="2025-06-12T03:56:29Z" level=info msg=tetragon/types.pb.go
...
```

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
tools: Avoid picking protoc file randomly
```
