### PR TITLE
procevents: fix in-init-tree

### DIFF
--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -82,7 +82,7 @@ func (p procs) pargs() []byte {
 	return proc.PrependPath(string(p.pexe), p.pcmdline)
 }
 
-func pushExecveEvents(p procs) {
+func pushExecveEvents(p procs, inInitTreeMap map[uint32]struct{}) {
 	var err error
 
 	/* If we can't fit this in the buffer lets trim some parts and
@@ -229,6 +229,10 @@ func pushExecveEvents(p procs) {
 		m.Unix.Process.Filename = filename
 		m.Unix.Process.Args = args
 
+		if _, ok := inInitTreeMap[m.Unix.Process.PID]; ok {
+			m.Unix.Process.Flags |= api.EventInInitTree
+		}
+
 		err := userinfo.MsgToExecveAccountUnix(m.Unix)
 		if err != nil {
 			logger.GetLogger().WithFields(logrus.Fields{
@@ -278,14 +282,14 @@ func procToKeyValue(p procs, inInitTree map[uint32]struct{}) (*execvemap.ExecveK
 }
 
 func pushEvents(ps []procs) {
-	writeExecveMap(ps)
+	inInitTreeMap := writeExecveMap(ps)
 
 	sort.Slice(ps, func(i, j int) bool {
 		return ps[i].ppid < ps[j].ppid
 	})
 	ps = append([]procs{procKernel()}, ps...)
 	for _, p := range ps {
-		pushExecveEvents(p)
+		pushExecveEvents(p, inInitTreeMap)
 	}
 }
 

--- a/pkg/sensors/exec/procevents/proc_reader_windows.go
+++ b/pkg/sensors/exec/procevents/proc_reader_windows.go
@@ -181,10 +181,11 @@ func getCWD(pid uint32) (string, uint32) {
 	return cwd, flags
 }
 
-func writeExecveMap(_ []procs) {
+func writeExecveMap(_ []procs) map[uint32]struct{} {
 	//ToDo: WIP
 	// Currently we do not share the infor gathered in usermode with execve map in kernel in Windows,
 	// This method is currently stubbed out but will be implemented
+	return make(map[uint32]struct{})
 }
 
 func getProcessParamsFromHandle64(handle windows.Handle) (RtlUserProcessParams64, error) {


### PR DESCRIPTION
8073fb2df erroneously removed the logic for handling inInitTree from proc events. Add that logic back here.

```release-note
Fix an issue where inInitTree was not properly accounting processes started before Tetragon.
```
