### PR TITLE
tetragon/windows: Support multiple programs from a single collection

### DIFF
--- a/pkg/sensors/program/loader_windows.go
+++ b/pkg/sensors/program/loader_windows.go
@@ -124,12 +124,15 @@ func doLoadProgram(
 	_ int,
 ) (*LoadedCollection, error) {
 
-	coll, err := ebpf.LoadCollection(load.Name)
+	coll, err := bpf.GetCollectionByPath(load.Name)
 	if err != nil {
-		logger.GetLogger().Warn(" Failed to load Native Windows Collection", logfields.Error, err)
-		return nil, err
+		coll, err = ebpf.LoadCollection(load.Name)
+		if err != nil {
+			logger.GetLogger().Warn(" Failed to load Native Windows Collection", logfields.Error, err)
+			return nil, err
+		}
+		bpf.SetCollection(load.Label, load.Name, coll)
 	}
-	bpf.SetCollection(load.Label, coll)
 
 	collMaps := map[ebpf.MapID]*ebpf.Map{}
 	// we need a mapping by ID
@@ -166,7 +169,6 @@ func doLoadProgram(
 
 	var prog *ebpf.Program
 	for _, p := range coll.Programs {
-
 		i, err := p.Info()
 		if i.Name == load.Label {
 			prog = p


### PR DESCRIPTION

### Description
This PR changes the way programs are loaded on Windows in order to support loading multiple programs from a single collection. Earlier implementation assumed one program per collection.
In Windows, a collection can be loaded only once per process. In that light, if a sensor had two programs from the same sys file, the loading of the second program would fail, as loading the collection second time around fails.

In the PR, we cache loaded collections by path and check the cache before loading a new collection. The second run will use the cached collection object and load the passed in program.
