### PR TITLE
confmap: use config.FindProgramFile()

### DIFF
--- a/pkg/sensors/config/confmap/confmap.go
+++ b/pkg/sensors/config/confmap/confmap.go
@@ -5,7 +5,6 @@ package confmap
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 
 	"github.com/cilium/ebpf"
@@ -45,7 +44,10 @@ var (
 // confmapSpec returns the spec for the configuration map
 func confmapSpec() (*ebpf.MapSpec, error) {
 	objName := config.ExecObj()
-	objPath := path.Join(option.Config.HubbleLib, objName)
+	objPath, err := config.FindProgramFile(objName)
+	if err != nil {
+		return nil, fmt.Errorf("loading spec for %s failed: %w", objPath, err)
+	}
 	spec, err := ebpf.LoadCollectionSpec(objPath)
 	if err != nil {
 		return nil, fmt.Errorf("loading spec for %s failed: %w", objPath, err)


### PR DESCRIPTION
Use config.FindProgramFile() to load the program, so that compressed .o files work as expected.

Fixes: c66c93870f9f ("tetragon: support loading compressed (gz) .o files")


