### PR TITLE
e2e: Make uninstalling Tetragon optional

### DIFF
--- a/tests/e2e/flags/flags.go
+++ b/tests/e2e/flags/flags.go
@@ -29,7 +29,8 @@ var Opts = Flags{
 	KeepExportData: false,
 	InstallCilium:  true,
 	// renovate: datasource=go depName=github.com/cilium/cilium
-	CiliumVersion: "v1.17.4",
+	CiliumVersion:     "v1.17.4",
+	UninstallTetragon: true,
 }
 
 func init() {
@@ -91,6 +92,11 @@ func init() {
 		"tetragon.cilium-version",
 		Opts.CiliumVersion,
 		"Version of Cilium to install. Only makes sense if tetragon.install-cilium is true.")
+
+	flag.BoolVar(&Opts.UninstallTetragon,
+		"tetragon.uninstall-tetragon",
+		Opts.UninstallTetragon,
+		"Uninstall Tetragon after the test run.")
 }
 
 type Flags struct {
@@ -101,6 +107,8 @@ type Flags struct {
 	InstallCilium bool
 	// Version of Cilium to use
 	CiliumVersion string
+	// UninstallTetragon specifies whether Tetragon should be uninstalled after the test run.
+	UninstallTetragon bool
 }
 
 type HelmOptions struct {

--- a/tests/e2e/runners/runners.go
+++ b/tests/e2e/runners/runners.go
@@ -225,7 +225,7 @@ func (r *Runner) Init() *Runner {
 		return helpers.DumpInfo(ctx, config)
 	})
 
-	if r.uninstallTetragon != nil {
+	if r.uninstallTetragon != nil && flags.Opts.UninstallTetragon {
 		r.Finish(r.uninstallTetragon)
 	}
 


### PR DESCRIPTION
Add -tetragon.uninstall-tetragon flag to specify whether Tetragon is uninstalled after the test run. Sometimes I want to run E2E tests in a cluster with Tetragon already installed, and I want to keep Tetragon installed after the test run for debugging purpose like capturing sysdump and such.