### PR TITLE
RFC tetragon: Do not rate limit exit events

### DIFF
--- a/bpf/process/bpf_exit.h
+++ b/bpf/process/bpf_exit.h
@@ -69,14 +69,8 @@ FUNC_INLINE void event_exit_send(void *ctx, __u32 tgid)
 		probe_read(&exit->info.code, sizeof(exit->info.code),
 			   _(&task->exit_code));
 
-#ifndef __RHEL7_BPF_PROG
-		struct msg_k8s kube;
-
-		__event_get_cgroup_info(task, &kube);
-		if (cgroup_rate(ctx, &kube, exit->common.ktime))
-#endif
-			perf_event_output_metric(ctx, MSG_OP_EXIT, &tcpmon_map,
-						 BPF_F_CURRENT_CPU, exit, size);
+		perf_event_output_metric(ctx, MSG_OP_EXIT, &tcpmon_map,
+					 BPF_F_CURRENT_CPU, exit, size);
 	}
 	execve_map_delete(tgid);
 }

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -154,7 +154,7 @@ func CheckSensorLoad(sensors []*sensors.Sensor, sensorMaps []SensorMap, sensorPr
 		SensorMap{Name: "execve_map_stats", Progs: []uint{1, 2}},
 
 		// event_execve
-		SensorMap{Name: "tg_conf_map", Progs: []uint{0, 1, 2}},
+		SensorMap{Name: "tg_conf_map", Progs: []uint{0, 2}},
 
 		// event_wake_up_new_task
 		SensorMap{Name: "execve_val", Progs: []uint{2}},


### PR DESCRIPTION
As reported by Balasaheb we could pollute process cache by rate limiting exit events.

It makes more sense to let all possible exit events go through, because they won't eat much resources and eventually release process cache records.

Otherwise we could end up with hanging process cache records.

Reported-by: Balasaheb Salunke ...