### PR TITLE
tetragon/windows: Fix ancestor list

### DIFF
--- a/pkg/constants/constants_linux.go
+++ b/pkg/constants/constants_linux.go
@@ -63,4 +63,5 @@ const (
 	S_IFMT               = syscall.S_IFMT
 	DEFAULT_TEMP_DIR     = "/tmp"
 	INIT_PROC_ID         = 1
+	OLDEST_ANCESTOR_PID  = 2
 )

--- a/pkg/constants/constants_windows.go
+++ b/pkg/constants/constants_windows.go
@@ -25,6 +25,7 @@ const (
 	S_IFMT               = 0xf000
 	DEFAULT_TEMP_DIR     = ""
 	INIT_PROC_ID         = 0
+	OLDEST_ANCESTOR_PID  = 4
 )
 
 var (

--- a/pkg/pidfile/pid_alive_windows.go
+++ b/pkg/pidfile/pid_alive_windows.go
@@ -4,14 +4,40 @@
 package pidfile
 
 import (
-	"os"
 	"strconv"
+
+	"golang.org/x/sys/windows"
 )
+
+const (
+	INVALID_HANDLE_VALUE = windows.Handle(^uintptr(0))
+)
+
+func IsPidAliveByHandle(hProc windows.Handle) bool {
+	var exitCode uint32
+	err := windows.GetExitCodeProcess(hProc, &exitCode)
+	if err != nil {
+		return false // error occurred while querying process state
+	}
+	return exitCode == 259
+}
+func IsPidAlive(pid int32) bool {
+
+	if (pid == 4) || (pid == 0) {
+		return true // pid 0(kernel) and 4(system) are always alive
+	}
+	hProc, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if hProc == INVALID_HANDLE_VALUE {
+		return false // process does not exist
+	}
+	defer windows.CloseHandle(hProc)
+	if err != nil {
+		return false
+	}
+	return IsPidAliveByHandle(hProc)
+}
 
 func isPidAlive(pid string) bool {
 	int32pid, err := strconv.ParseInt(pid, 0, 32)
-	if err == nil {
-		_, err = os.FindProcess(int(int32pid))
-	}
-	return err == nil
+	return err == nil && IsPidAlive(int32(int32pid))
 }

--- a/pkg/pidfile/pid_alive_windows_test.go
+++ b/pkg/pidfile/pid_alive_windows_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package pidfile
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestIsPidAliveByHandle_CurrentProcess(t *testing.T) {
+	// Get current process ID
+	pid := os.Getpid()
+	// Open a handle to the current process
+	hProc, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		t.Fatalf("Failed to open process handle: %v", err)
+	}
+	defer windows.CloseHandle(hProc)
+
+	alive := IsPidAliveByHandle(hProc)
+	if !alive {
+		t.Errorf("Expected current process to be alive, got false")
+	}
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cilium/tetragon/pkg/constants"
 	"github.com/cilium/tetragon/pkg/fieldfilters"
 	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/metrics/errormetrics"
@@ -497,7 +498,7 @@ func GetAncestorProcessesInternal(execId string) ([]*ProcessInternal, error) {
 	}
 
 	// No need to include <kernel> process (PID 0)
-	for process.process.Pid.Value > 2 {
+	for process.process.Pid.Value > constants.OLDEST_ANCESTOR_PID {
 		if process, err = procCache.get(process.process.ParentExecId); err != nil {
 			logger.GetLogger().Debug("ancestor process not found in cache",
 				logfields.Error, err,


### PR DESCRIPTION
### Description
In Windows, the ancestor list algorithm was broken due to multiple issues.
- One, on Windows, the ancestor enumeration needs to stop at pid 4, not pid 1.
- Two, Windows has true orphan processes. Which means that if a parent is terminated, it's parent is not automatically pid 4. This PR makes an adjustment to insert pid 4 as parent of orphaned processes. 
- Three, parent may be dead but still exist in kernel, allowing OpenProcess to succeed, even if the process is orphaned. This PR adds a robust process alive check.
