### PR TITLE
tetragon: Add macros for atomic instructions

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -9,6 +9,7 @@
 #include "bpf_cred.h"
 #include "bpf_d_path.h"
 #include "../process/string_maps.h"
+#include "api.h"
 
 /* Applying 'packed' attribute to structs causes clang to write to the
  * members byte-by-byte, as offsets may not be aligned. This is bad for
@@ -593,22 +594,22 @@ perf_event_output_update_error_metric(u8 msg_op, long err)
 	if (valp) {
 		switch (err) {
 		case -2: // ENOENT
-			__sync_fetch_and_add(&valp->sent_failed[msg_op][SENT_FAILED_ENOENT], 1);
+			lock_add(&valp->sent_failed[msg_op][SENT_FAILED_ENOENT], 1);
 			break;
 		case -7: // E2BIG
-			__sync_fetch_and_add(&valp->sent_failed[msg_op][SENT_FAILED_E2BIG], 1);
+			lock_add(&valp->sent_failed[msg_op][SENT_FAILED_E2BIG], 1);
 			break;
 		case -16: // EBUSY
-			__sync_fetch_and_add(&valp->sent_failed[msg_op][SENT_FAILED_EBUSY], 1);
+			lock_add(&valp->sent_failed[msg_op][SENT_FAILED_EBUSY], 1);
 			break;
 		case -22: // EINVAL
-			__sync_fetch_and_add(&valp->sent_failed[msg_op][SENT_FAILED_EINVAL], 1);
+			lock_add(&valp->sent_failed[msg_op][SENT_FAILED_EINVAL], 1);
 			break;
 		case -28: // ENOSPC
-			__sync_fetch_and_add(&valp->sent_failed[msg_op][SENT_FAILED_ENOSPC], 1);
+			lock_add(&valp->sent_failed[msg_op][SENT_FAILED_ENOSPC], 1);
 			break;
 		default:
-			__sync_fetch_and_add(&valp->sent_failed[msg_op][SENT_FAILED_UNKNOWN], 1);
+			lock_add(&valp->sent_failed[msg_op][SENT_FAILED_UNKNOWN], 1);
 		}
 	}
 }

--- a/bpf/process/bpf_enforcer.h
+++ b/bpf/process/bpf_enforcer.h
@@ -51,7 +51,7 @@ enforcer_update_missed_notifications(struct enforcer_missed_key *key)
 	__u32 *counter = map_lookup_elem(&enforcer_missed_notifications, key), one = 1;
 
 	if (counter) {
-		__sync_fetch_and_add(counter, one);
+		lock_add(counter, one);
 		return;
 	}
 
@@ -64,7 +64,7 @@ enforcer_update_missed_notifications(struct enforcer_missed_key *key)
 	 */
 	counter = map_lookup_elem(&enforcer_missed_notifications, key);
 	if (counter) {
-		__sync_fetch_and_add(counter, one);
+		lock_add(counter, one);
 	}
 }
 

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -278,11 +278,7 @@ void update_mb_bitset(struct binary *bin)
 		/* ->mb_bitset is used to track matchBinary matches to children (followChildren), so
 		 * here we propagate the parent value to the child.
 		 */
-#ifdef __V511_BPF_PROG
-		__sync_fetch_and_or(&bin->mb_bitset, parent->bin.mb_bitset);
-#else
-		bin->mb_bitset |= parent->bin.mb_bitset;
-#endif
+		lock_or(&bin->mb_bitset, parent->bin.mb_bitset);
 	}
 
 	/* check the map and see if the binary path matches a binary
@@ -290,11 +286,7 @@ void update_mb_bitset(struct binary *bin)
 	 */
 	bitsetp = map_lookup_elem(&tg_mbset_map, bin->path);
 	if (bitsetp)
-#ifdef __V511_BPF_PROG
-		__sync_fetch_and_or(&bin->mb_bitset, *bitsetp);
-#else
-		bin->mb_bitset |= *bitsetp;
-#endif
+		lock_or(&bin->mb_bitset, *bitsetp);
 }
 
 /**

--- a/bpf/process/bpf_execve_map_update.c
+++ b/bpf/process/bpf_execve_map_update.c
@@ -44,7 +44,7 @@ __execve_map_update(struct update_data *data)
 		pid = data->pids[idx];
 		curr = execve_map_get_noinit(pid);
 		if (curr)
-			__sync_fetch_and_and(&curr->bin.mb_bitset, ~(1 << data->bit));
+			lock_and(&curr->bin.mb_bitset, ~(1 << data->bit));
 	}
 	bpf_iter_num_destroy(&it);
 }
@@ -65,11 +65,7 @@ __execve_map_update(struct update_data *data)
 		pid = data->pids[idx];
 		curr = execve_map_get_noinit(pid);
 		if (curr)
-#ifdef __V511_BPF_PROG
-			__sync_fetch_and_and(&curr->bin.mb_bitset, ~(1 << data->bit));
-#else
-			curr->bin.mb_bitset &= ~(1 << data->bit);
-#endif
+			lock_and(&curr->bin.mb_bitset, ~(1 << data->bit));
 	}
 }
 #else


### PR DESCRIPTION
And restrict them based on architecture and kernel version,
because as Tam reported, recent changes break compilation on arm.
