### PR TITLE
cel: Move heavy operations outside of loops

### DIFF
--- a/pkg/filters/cel_expression.go
+++ b/pkg/filters/cel_expression.go
@@ -42,8 +42,8 @@ func compile(env *cel.Env, expr string, celType *cel.Type) (*cel.Ast, error) {
 	return ast, nil
 }
 
-func EvalCEL(ctx context.Context, program cel.Program, event *tetragon.GetEventsResponse) (bool, error) {
-	out, _, err := program.ContextEval(ctx, helpers.ProcessEventMap(event))
+func EvalCEL(ctx context.Context, program cel.Program, eventMap map[string]any) (bool, error) {
+	out, _, err := program.ContextEval(ctx, eventMap)
 	if err != nil {
 		return false, fmt.Errorf("error running CEL program: %w", err)
 	}
@@ -76,8 +76,9 @@ func (c *CELExpressionFilter) filterByCELExpression(ctx context.Context, log log
 		if !ok {
 			return false
 		}
+		eventMap := helpers.ProcessEventMap(response)
 		for _, prg := range programs {
-			match, err := EvalCEL(ctx, prg, response)
+			match, err := EvalCEL(ctx, prg, eventMap)
 			if err != nil {
 				log.Error("EvalCEL Error", logfields.Error, err)
 				return false


### PR DESCRIPTION
Based on some profiling, it seems that the call of helpers.ProcessEventMap is a bit heavy in terms of CPU cycles.

This patch changes EvalCEL function to call that outside of the loops.