### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/windows-build-smoke-test.yml
+++ b/.github/workflows/windows-build-smoke-test.yml
@@ -33,6 +33,30 @@ jobs:
         with:
           path: go/src/github.com/cilium/tetragon/
       
+
+      - name: Cache chocolatey packages
+        if: steps.skip_check.outputs.should_skip != 'true'
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        env:
+          cache-name: cache-choco-packages
+        with:
+          path: C:\ProgramData\chocolatey
+          key: ${{ runner.os }}-choco-llvm-18.1.8
+
+      - name: Install LLVM 18.1.8
+        if: steps.skip_check.outputs.should_skip != 'true'
+        run: |
+          # Install LLVM 18.1.8 to ensure consistent version across runners
+          try {
+            choco install llvm --version=18.1.8 --allow-downgrade --force -y
+            # Add installed LLVM to PATH first so it takes precedence
+            echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            Write-Host "Successfully installed LLVM 18.1.8"
+          } catch {
+            Write-Warning "Failed to install LLVM 18.1.8 via chocolatey: $($_.Exception.Message)"
+            Write-Host "Continuing with pre-installed LLVM version"
+          }
+
       - name: Set MSVC Environment Variables
         shell: cmd
         run: |


### PR DESCRIPTION
### Description
GH workers changed llvm version to 20.0 which caused verification failures in compiled bpf programs. This PR fixes that by force installing llvm 18.1.8 on GH worker
