### PR TITLE
docs: Clarify export filter scope (JSON vs gRPC)

### DIFF
--- a/docs/content/en/docs/concepts/events.md
+++ b/docs/content/en/docs/concepts/events.md
@@ -146,6 +146,15 @@ in cases where two filter configurations match on the same event.
 You can configure export filters using the provided helm options, command line
 flags, or environment variables.
 
+{{< caution >}}
+The `denylist` and `allowlist` filters mentioned above only apply to events
+exported as JSON files (e.g., through a configured `file` sink). These filters
+do not affect events streamed via the gRPC API, which are consumed by tools
+like the `tetra` CLI. You will still see unfiltered events when using the
+`tetra` CLI, even if those events would be filtered out by `denylist` or
+`allowlist` for JSON export.
+{{< /caution >}}
+
 ##### List of Process Event Filters
 
 The type for each filter attribute can be determined by referring to the 

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -90,7 +90,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.eventCacheRetries | int | `15` | Configure the number of retries in tetragon's event cache. |
 | tetragon.eventCacheRetryDelay | int | `2` | Configure the delay (in seconds) between retires in tetragon's event cache. |
 | tetragon.exportAllowList | string | `"{\"event_set\":[\"PROCESS_EXEC\", \"PROCESS_EXIT\", \"PROCESS_KPROBE\", \"PROCESS_UPROBE\", \"PROCESS_TRACEPOINT\", \"PROCESS_LSM\"]}"` | Allowlist for JSON export. For example, to export only process_connect events from the default namespace:  exportAllowList: |   {"namespace":["default"],"event_set":["PROCESS_EXEC"]} |
-| tetragon.exportDenyList | string | `"{\"health_check\":true}\n{\"namespace\":[\"\", \"cilium\", \"kube-system\"]}"` | Denylist for JSON export. For example, to exclude exec events that look similar to Kubernetes health checks and all the events from kube-system namespace and the host:  exportDenyList: |   {"health_check":true}   {"namespace":["kube-system",""]}  |
+| tetragon.exportDenyList | string | `"{\"health_check\":true}\n{\"namespace\":[\"\", \"cilium\", \"kube-system\"]}"` | Denylist for JSON export **(for file sinks only; does not filter gRPC output)**. For example, to exclude exec events that look similar to Kubernetes health checks and all the events from kube-system namespace and the host:  exportDenyList: |   {"health_check":true}   {"namespace":["kube-system",""]}  |
 | tetragon.exportFileCompress | bool | `false` | Compress rotated JSON export files. |
 | tetragon.exportFileMaxBackups | int | `5` | Number of rotated files to retain. |
 | tetragon.exportFileMaxSizeMB | int | `10` | Size in megabytes at which to rotate JSON export files. |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -72,7 +72,7 @@ Helm chart for Tetragon
 | tetragon.eventCacheRetries | int | `15` | Configure the number of retries in tetragon's event cache. |
 | tetragon.eventCacheRetryDelay | int | `2` | Configure the delay (in seconds) between retires in tetragon's event cache. |
 | tetragon.exportAllowList | string | `"{\"event_set\":[\"PROCESS_EXEC\", \"PROCESS_EXIT\", \"PROCESS_KPROBE\", \"PROCESS_UPROBE\", \"PROCESS_TRACEPOINT\", \"PROCESS_LSM\"]}"` | Allowlist for JSON export. For example, to export only process_connect events from the default namespace:  exportAllowList: |   {"namespace":["default"],"event_set":["PROCESS_EXEC"]} |
-| tetragon.exportDenyList | string | `"{\"health_check\":true}\n{\"namespace\":[\"\", \"cilium\", \"kube-system\"]}"` | Denylist for JSON export. For example, to exclude exec events that look similar to Kubernetes health checks and all the events from kube-system namespace and the host:  exportDenyList: |   {"health_check":true}   {"namespace":["kube-system",""]}  |
+| tetragon.exportDenyList | string | `"{\"health_check\":true}\n{\"namespace\":[\"\", \"cilium\", \"kube-system\"]}"` | Denylist for JSON export **(for file sinks only; does not filter gRPC output)**. For example, to exclude exec events that look similar to Kubernetes health checks and all the events from kube-system namespace and the host:  exportDenyList: |   {"health_check":true}   {"namespace":["kube-system",""]}  |
 | tetragon.exportFileCompress | bool | `false` | Compress rotated JSON export files. |
 | tetragon.exportFileMaxBackups | int | `5` | Number of rotated files to retain. |
 | tetragon.exportFileMaxSizeMB | int | `10` | Size in megabytes at which to rotate JSON export files. |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -82,7 +82,7 @@ tetragon:
   #   {"namespace":["default"],"event_set":["PROCESS_EXEC"]}
   exportAllowList: |-
     {"event_set":["PROCESS_EXEC", "PROCESS_EXIT", "PROCESS_KPROBE", "PROCESS_UPROBE", "PROCESS_TRACEPOINT", "PROCESS_LSM"]}
-  # -- Denylist for JSON export. For example, to exclude exec events that look similar to
+  # -- Denylist for JSON export **(for file sinks only; does not filter gRPC output)**. For example, to exclude exec events that look similar to
   # Kubernetes health checks and all the events from kube-system namespace and the host:
   #
   # exportDenyList: |


### PR DESCRIPTION
Fixes #3742

### Description
This PR clarifies the scope of `denylist` and `allowlist` export filters in the Tetragon documentation. Users were confused about why filtered events still appeared in `tetra` CLI output, not realizing these filters only apply to JSON file exports and not to gRPC streaming.

The changes add:
- A prominent caution note in `docs/content/en/docs/events.md` using the `{{< caution >}}` shortcode to clearly explain that export filters only affect JSON file sinks
- Concise inline notes in the Helm chart value tables in both `helm-chart.md` and `README.md` to indicate the filters are "for file sinks only"

These documentation updates will help users understand the intended behavior and avoid confusion when using the `tetra` CLI alongside export filters.

### Changelog
```release-note
docs: Clarify that export filters (denylist/allowlist) only apply to JSON file exports, not gRPC streaming
```
