### PR TITLE
tracingpolicy: respect syscall attribute in lists

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -426,7 +426,7 @@ func preValidateKprobe(
 	btfobj *btf.Spec,
 	lists []v1alpha1.ListSpec,
 ) (*kpValidateInfo, error) {
-	isSyscall := false
+	isSyscall := f.Syscall
 	var calls []string
 	// the f.Call is either defined as list:NAME
 	// or specifies directly the function
@@ -439,7 +439,9 @@ func preValidateKprobe(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get symbols from list '%s': %w", f.Call, err)
 		}
-		isSyscall = isSyscallListType(list.Type)
+		if isSyscallListType(list.Type) {
+			isSyscall = true
+		}
 	} else {
 		calls = []string{f.Call}
 		if f.Syscall {
@@ -451,7 +453,6 @@ func preValidateKprobe(
 			} else {
 				calls[0] = prefixedName
 			}
-			isSyscall = true
 		}
 	}
 


### PR DESCRIPTION
If we have a policy such as:

```
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
 name: "unload-module"
spec:
  lists:
    - name: "sys_delete_module" type: "generated_ftrace" pattern: "sys_delete_module" kprobes:
  - call: "list:sys_delete_module" syscall: true args:
      - index: 0  # module (user-space pointer, so unsafe) type: "string"
      - index: 1  # flags type: "uint32"
```

The "syscall: true" is not respected when generating the calls. This commit fixes this.

```release-note
tracinpolicy: respect syscall attribute in lists
```