### PR TITLE
pkg/sensors: configure has.rateLimit per policy

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -267,7 +267,6 @@ func createMultiKprobeSensor(polInfo *policyInfo, multiIDs []idtable.EntryID, ha
 		gk.data = data
 
 		has.stackTrace = has.stackTrace || gk.hasStackTrace
-		has.rateLimit = has.rateLimit || gk.hasRatelimit
 		has.override = has.override || gk.hasOverride
 	}
 
@@ -585,6 +584,7 @@ func hasMapsSetup(spec *v1alpha1.TracingPolicySpec) hasMaps {
 	for _, kprobe := range spec.KProbes {
 		has.fdInstall = has.fdInstall || selectorsHaveFDInstall(kprobe.Selectors)
 		has.enforcer = has.enforcer || len(spec.Enforcers) != 0
+		has.rateLimit = has.rateLimit || selectorsHaveRateLimit(kprobe.Selectors)
 
 		// check for early break
 		if has.fdInstall && has.enforcer {
@@ -1098,7 +1098,6 @@ func createSingleKprobeSensor(polInfo *policyInfo, ids []idtable.EntryID, has ha
 
 		// setup per kprobe map config
 		has.stackTrace = gk.hasStackTrace
-		has.rateLimit = gk.hasRatelimit
 		has.override = gk.hasOverride
 
 		progs, maps = createKprobeSensorFromEntry(polInfo, gk, progs, maps, has)


### PR DESCRIPTION
Fixes 3251.

The ratelimit_map seems to be scoped per policy but the has.rateLimit detection at kprobe sensor creation was scoped per kprobe. Thus if you enabled the rateLimit feature only on one kprobe, you ended up with an error that the second sensor could not load because the size was set to one while the first sensor already loaded a resized map.

This is a common mistake and we already have examples on how we load and resize the per kprobe, and per policy maps.

Full details to reproduce this, load this policy:

	kprobes:
	  - call: "__sys_setuid" message: "Privileged operation setuid to root" syscall: false args:
	    - index: 0 type: "int" selectors:
	    - matchArgs:
	      - index: 0 operator: "Equal" values:
		- "0" matchActions: - action: Post rateLimit: "1m"
	  - call: "__sys_setgid" message: "Privileged operation setgid to root" syscall: false args:
	    - index: 0 type: "int" selectors:
	    - matchArgs:
	      - index: 0 operator: "Equal" values:
		- "0" matchActions: - action: Post # rateLimit: "1m"

It should failed to load with:
	time="2024-12-23T03:59:09Z" level=warning msg="adding tracing policy failed" error="sensor generic_kprobe from collection privileges-raise failed to load: failed prog /var/lib/tetragon/bpf_generic_kprobe_v511.o kern_version 331663 loadInstance: opening collection '/var/lib/tetragon/bpf_generic_kprobe_v511.o' failed: using replacement map ratelimit_map: MaxEntries: 1 changed to 32768: map spec is incompatible with existing map

```release-note
tracingpolicies: fixes load sensor failure when mixing rate limited and non rate limited kprobes.
```
