### PR TITLE
docs: add instruction to cleanup getting started network policy

### DIFF
--- a/docs/content/en/docs/getting-started/network.md
+++ b/docs/content/en/docs/getting-started/network.md
@@ -105,6 +105,12 @@ And as expected no new events:
 💥 exit    default/xwing /usr/bin/curl https://ebpf.io/applications/#tetragon 60
 ```
 
+Finally, delete the applied TracingPolicy with:
+
+```shell
+envsubst < network_egress_cluster.yaml | kubectl delete -f -
+```
+
 ## Monitoring Docker or bare metal network access
 
 This example also works easily for local Docker users. However, since Docker


### PR DESCRIPTION
Fixes #2724

Users were confused that the next step, enforcement, wasn't working until they found out that the tutorial didn't told them to remove the previous policy that was still applied.

Suggested-by: SimonB <simonb@kaizo.org>