### PR TITLE
bugtool: Collect pprof CPU profile

### DIFF
--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -156,7 +156,7 @@ jobs:
       - name: Test Tetragon with a different tracing-policy-dir
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
-          timeout_seconds: 30
+          timeout_seconds: 60
           max_attempts: 5
           retry_wait_seconds: 5
           retry_on: error
@@ -165,7 +165,7 @@ jobs:
             sudo tetra status
             sudo grep "tetra" /var/log/tetragon/tetragon.log
             sudo tetra tracingpolicy list | grep bpf -
-            sudo tetra bugtool 2>&1 | grep "Successfully dumped gops pprof-heap" -
+            sudo tetra bugtool 2>&1 | grep "Successfully dumped gops pprof.*profile=heap" -
 
       - name: Uninstall Tetragon Tarball
         run: |


### PR DESCRIPTION
[ upstream commit 15f723f34673b48640033d887d0bf88c2038579c ]

Collect pprof CPU profile as a part of the bugtool output. This makes the bugtool command 30 seconds slower, but I think it's still worth it to always collect CPU profile. Having access to CPU profile is immensely valuable for troubleshooting performance issues, and we often end up manually running 'gops pprof-cpu' to collect it anyways.

Bump the timeout for "Test Tetragon with a different tracing-policy-dir" step in Packages e2e Tests from 30 seconds to 60 seconds. This step runs tetra bugtool command.