### PR TITLE
feat(helm): add icon section on Chart.yaml file

### DIFF
--- a/install/kubernetes/tetragon/Chart.yaml
+++ b/install/kubernetes/tetragon/Chart.yaml
@@ -3,6 +3,7 @@ name: tetragon
 description: Helm chart for Tetragon
 type: application
 version: 1.4.0
+icon: https://tetragon.io/images/tetragon-shield.png
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.


### PR DESCRIPTION
Hello, 🖖 

This PR adds icon section on chart.yaml file to make the CI happy with a green status 🟢 

Fixes : N/A

### Description

Currently, CI is issuing a warning about the helm linter because it wants to see the icon section in the Chart.yaml file.

My PR suggests adding the section to make the CI happy 👍 

Without icon section :

```
@HujinoKun ➜ /workspaces/tetragon (helm/add-icon-section-on-chart-file) $ make -C install/kubernetes lint
make: Entering directory '/workspaces/tetragon/install/kubernetes'
docker run --rm -u 1000:1000 -v /workspaces/tetragon/install/kubernetes/tetragon:/apps -v /workspaces/tetragon/install/kubernetes/helm_lint_values_override.yaml:/helm_lint_values_override.yaml docker.io/alpine/helm:3.18.3@sha256:afb4ca77e37c03fbf8009cbe29e5c014cfb2e5b1d4afff59c1b38bcd77e03845 lint . --with-subcharts
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
make: Leaving directory '/workspaces/tetragon/install/kubernetes'
```

With icon section :

```
@HujinoKun ➜ /workspaces/tetragon (helm/add-icon-section-on-chart-file) $ make -C install/kubernetes lint
make: Entering directory '/workspaces/tetragon/install/kubernetes'
docker run --rm -u 1000:1000 -v /workspaces/tetragon/install/kubernetes/tetragon:/apps -v /workspaces/tetragon/install/kubernetes/helm_lint_values_override.yaml:/helm_lint_values_override.yaml docker.io/alpine/helm:3.18.3@sha256:afb4ca77e37c03fbf8009cbe29e5c014cfb2e5b1d4afff59c1b38bcd77e03845 lint . --with-subcharts
Unable to find image 'alpine/helm:3.18.3@sha256:afb4ca77e37c03fbf8009cbe29e5c014cfb2e5b1d4afff59c1b38bcd77e03845' locally
docker.io/alpine/helm@sha256:afb4ca77e37c03fbf8009cbe29e5c014cfb2e5b1d4afff59c1b38bcd77e03845: Pulling from alpine/helm
fe07684b16b8: Pull complete 
843ac2081151: Pull complete 
e4b4f3eb08f8: Pull complete 
Digest: sha256:afb4ca77e37c03fbf8009cbe29e5c014cfb2e5b1d4afff59c1b38bcd77e03845
Status: Downloaded newer image for alpine/helm@sha256:afb4ca77e37c03fbf8009cbe29e5c014cfb2e5b1d4afff59c1b38bcd77e03845
==> Linting .
1 chart(s) linted, 0 chart(s) failed
make: Leaving directory '/workspaces/tetragon/install/kubernetes'
```
