### PR TITLE
selectors: error on vals larger than supported

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -609,6 +609,12 @@ func capsStrToUint64(values []string) (uint64, error) {
 }
 
 func writeMatchValues(k *KernelSelectorState, values []string, ty, op uint32) error {
+	// NB: maxMatchValues should match MAX_MATCH_VALUES in bpf/process/types/basic.h
+	maxMatchValues := 4
+	if len(values) > maxMatchValues {
+		return fmt.Errorf("selector does not support more than %d values: consider using InMap or NotInMap operators", maxMatchValues)
+	}
+
 	for _, v := range values {
 		base := getBase(v)
 		switch ty {


### PR DESCRIPTION
The bpf implementations for selectors have a limit of 4 values:

```
   #define MAX_MATCH_VALUES 4

...

   filter_64ty_selector_val(struct selector_arg_filter *filter, char *args)
   {
   	__u64 *v = (__u64 *)&filter->value;
   	int i, j = 0;

   #pragma unroll
   	for (i = 0; i < MAX_MATCH_VALUES; i++) {

...

    filter_32ty_selector_val(struct selector_arg_filter *filter, char *args)
    {
    	__u32 *v = (__u32 *)&filter->value;
    	int i, j = 0;

    #pragma unroll
    	for (i = 0; i < MAX_MATCH_VALUES; i++) {
```

Current code just ignores the additional values.
Add a check to return an error in that case.

```release-note
tracingpolicy: return error on unsupported number of values 
```