### PR TITLE
fix: Force remove tetragon-clang container for the tetragon-bpf target in case it's still running.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,9 @@ tetragon-bpf-local:
 
 .PHONY: tetragon-bpf-container
 tetragon-bpf-container:
-	$(CONTAINER_ENGINE) rm tetragon-clang || true
+	$(CONTAINER_ENGINE) rm -f tetragon-clang || true
 	$(CONTAINER_ENGINE) run -v $(CURDIR):/tetragon:Z -u $$(id -u) -e BPF_TARGET_ARCH=$(BPF_TARGET_ARCH) --name tetragon-clang $(CLANG_IMAGE) make -C /tetragon/bpf -j$(JOBS) $(__BPF_DEBUG_FLAGS)
-	$(CONTAINER_ENGINE) rm tetragon-clang
+	$(CONTAINER_ENGINE) rm -f tetragon-clang
 
 .PHONY: tetragon-bench
 tetragon-bench: ## Compile tetragon-bench tool.


### PR DESCRIPTION
### Description
After `make clean`, I got an error when trying to rebuild the tetragon-bpf target:

```
acam@lima-default:~/src/hubble-fgs/modules/tetragon-oss$ make -j3 tetragon-bpf
docker rm tetragon-clang || true
Error response from daemon: cannot remove container "tetragon-clang": container is running: stop the container before removing or force remove
```

This PR contains a simple change to force-remove the tetragon-clang container if it's already running.
