### PR TITLE
tetragon: Forgotten leftover for v6.12 variant

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -63,7 +63,7 @@ struct bpf_map_def {
 #define DEBUG(__fmt, ...)
 #endif
 
-#ifdef __V611_BPF_PROG
+#ifdef __V612_BPF_PROG
 #define __arg_ctx      __attribute__((btf_decl_tag("arg:ctx")))
 #define __arg_nonnull  __attribute((btf_decl_tag("arg:nonnull")))
 #define __arg_nullable __attribute((btf_decl_tag("arg:nullable")))
@@ -75,6 +75,6 @@ struct bpf_map_def {
 #define __arg_nullable
 #define __arg_trusted
 #define __arg_arena
-#endif // __V611_BPF_PROG
+#endif // __V612_BPF_PROG
 
 #endif // _MSG_COMMON__


### PR DESCRIPTION
We need to enable __arg_* macros for 6.12 as well.

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes <!-- #issue-number -->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
```
