### PR TITLE
Restore upgrade notes in v1.5.0.md

### DIFF
--- a/contrib/upgrade-notes/v1.5.0.md
+++ b/contrib/upgrade-notes/v1.5.0.md
@@ -3,7 +3,18 @@
 Read the upgrade notes carefully before upgrading Tetragon.
 Depending on your setup, changes listed here might require a manual intervention.
 
-* TBD
+* Enabling ancestors for process events is now configured by a new `--enable-ancestors` flag.
+  The following flags are being deprecarted in this (1.5) and are scheduled for removal in the next (1.6):
+   * `--enable-process-ancestors`
+   * `--enable-process-kprobe-ancestors`
+   * `--enable-process-tracepoint-ancestors`
+   * `--enable-process-uprobe-ancestors`
+   * `--enable-process-lsm-ancestors`
+
+* The logging library used by Tetragon is migrated from `logrus` to `log/slog`.
+  This change is not expected to affect the end user, but it may require some adjustments in custom scripts or tools
+  that parse Tetragon logs.
+  * `level=warning` is now `level=warn`
 
 ### Agent Options
 
@@ -11,7 +22,12 @@ Depending on your setup, changes listed here might require a manual intervention
 
 ### Helm Values
 
-* TBD
+* The default value of metrics scrape interval in both agent and operator
+  ServiceMonitors (`tetragon.prometheus.serviceMonitor.scrapeInterval` and
+  `tetragonOperator.prometheus.serviceMonitor.scrapeInterval` values
+  respectively) is changed from 10s to 60s.
+
+* OciHookSetup section is removed after being deprecated in 1.2.
 
 ### TracingPolicy (k8s CRD)
 


### PR DESCRIPTION
Because of a rebase, I missed upgrade notes somehow.

Original upgrade notes are in https://github.com/cilium/tetragon/commit/f50fa70cca17b0574e0f6002707b8cb6a2f71f40
