### PR TITLE
Fix a typo in kubectl in the runtime hook documentation

### DIFF
--- a/docs/content/en/docs/installation/runtime-hooks.md
+++ b/docs/content/en/docs/installation/runtime-hooks.md
@@ -197,7 +197,7 @@ helm install \
 {{< /tabpane >}}
 
 ```shel
-kubecl -n kube-system get pods | grep tetragon
+kubectl -n kube-system get pods | grep tetragon
 ```
 
 With output similar to:


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes <!-- #issue-number -->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Line 200 fixed broken type kubecl to kubectl

