### PR TITLE
lint: Ignore error check for cgroups.DiscoverSubSysIds call

### DIFF
--- a/pkg/sensors/config/confmap/confmap.go
+++ b/pkg/sensors/config/confmap/confmap.go
@@ -84,8 +84,7 @@ func UpdateTgRuntimeConf(mapDir string, nspid int) error {
 	}
 
 	// This must be called before probing cgroup configurations
-	err = cgroups.DiscoverSubSysIds()
-	if err != nil {
+	if err = cgroups.DiscoverSubSysIds(); err != nil { // nolint: staticcheck // DiscoverSubSysIds is always return non-nil error in windows
 		log.Warn("Detection of Cgroup Subsystem Controllers failed", "confmap-update", configMapName, logfields.Error, err)
 		log.Warn("Cgroup Subsystems IDs are unknown, advanced Cgroups tracking will be disabled", "confmap-update", configMapName)
 		return err

--- a/pkg/testutils/confmap.go
+++ b/pkg/testutils/confmap.go
@@ -21,8 +21,7 @@ func GetTgRuntimeConf() (*confmap.TetragonConfValue, error) {
 	}
 
 	// This must be called before probing cgroup configurations
-	err = cgroups.DiscoverSubSysIds()
-	if err != nil {
+	if err = cgroups.DiscoverSubSysIds(); err != nil { // nolint: staticcheck // DiscoverSubSysIds is always return non-nil error in windows
 		return nil, err
 	}
 


### PR DESCRIPTION
This is to fix the the below failure by ignoring the condition check.

Failure run https://github.com/cilium/tetragon/actions/runs/16615955129/job/47008554004?pr=3967

```
pkg/sensors/config/confmap/confmap.go:88:5  staticcheck  SA4023: this comparison is always true
...
pkg/testutils/confmap.go:25:5               staticcheck  SA4023: this comparison is always true
```

