### PR TITLE
fix: Resolve error message typo in TestHelperMain().

### DIFF
--- a/pkg/testutils/progs/tester.go
+++ b/pkg/testutils/progs/tester.go
@@ -97,7 +97,7 @@ func TestHelperMain() {
 				uintptr(unsafe.Pointer(&node)),
 				0,
 			)
-			fmt.Fprintf(os.Stdout, "getpcu returned: err:%v\n", err)
+			fmt.Fprintf(os.Stdout, "getcpu returned: err:%v\n", err)
 
 		case cmd == "exit":
 			fmt.Fprintf(os.Stderr, "Exiting...\n")


### PR DESCRIPTION
### Description
`s/getpcu/getcpu/`

Signed-off-by: Aaron Campbell <acam@cisco.com>
