### PR TITLE
tetragon: Enable TestTracepointLoadFormat on 6.1 and bpf-next

### DIFF
--- a/pkg/vmtests/skip.go
+++ b/pkg/vmtests/skip.go
@@ -18,7 +18,6 @@ type skipRule struct {
 // We should probably have this in a json file, but for now we keep it here
 var rules = []skipRule{
 	skipRule{TestNameRe: "pkg.sensors.tracing.TestLoader", KernelRe: "(6\\.6|6\\.1)"},
-	skipRule{TestNameRe: "pkg.tracepoint.TestTracepointLoadFormat", KernelRe: "(6\\.1|bpf-next)"},
 	skipRule{TestNameRe: "pkg.sensors.exec.TestProcessCacheInterval", KernelRe: ""},
 	skipRule{TestNameRe: "pkg.watcher.TestFastK8s", KernelRe: ""},
 }


### PR DESCRIPTION
The #1251 got fixed by following commits:
  40c3ad08208b ("Tracepoint: adapt a format test on task_newtask to arm64")
  e5399c54a53d ("Tracepoint tests: Fix comm signedness check")