### PR TITLE
linters/staticcheck: fix underscore in names

### DIFF
--- a/cmd/tetra/stacktracetree/stacktracetree.go
+++ b/cmd/tetra/stacktracetree/stacktracetree.go
@@ -46,20 +46,20 @@ func sttPrint(ctx context.Context, client tetragon.FineGuidanceSensorsClient, st
 
 	// NB: leave this here, in case we want to add a json option at some point
 	if false {
-		res_json, err := json.Marshal(res)
+		resJSON, err := json.Marshal(res)
 		if err != nil {
 			fmt.Printf("error marshaling stt %s: %s\n", stt, err)
 			return
 		}
-		fmt.Printf("%s\n", string(res_json))
+		fmt.Printf("%s\n", string(resJSON))
 	}
 
 	sttPrintNodeTree(res.Root, 0)
 }
 
 func sttPrintNodeTree(node *tetragon.StackTraceNode, level int) {
-	indent_space := "    "
-	indent := strings.Repeat(indent_space, level)
+	identSpace := "    "
+	indent := strings.Repeat(identSpace, level)
 	fmt.Printf("%s0x%x (%s) count:%d\n", indent, node.Address.Address, node.Address.Symbol, node.Count)
 
 	nchildren := len(node.Children)
@@ -70,7 +70,7 @@ func sttPrintNodeTree(node *tetragon.StackTraceNode, level int) {
 	// This is a leaf, so we also print label counters
 	if nchildren == 0 {
 		for _, label := range node.Labels {
-			fmt.Printf("%s%s%s count:%d\n", indent, indent_space, label.Key, label.Count)
+			fmt.Printf("%s%s%s count:%d\n", indent, identSpace, label.Key, label.Count)
 		}
 	}
 }

--- a/cmd/tetragon/main_linux.go
+++ b/cmd/tetragon/main_linux.go
@@ -29,8 +29,8 @@ func checkProcFS() {
 	checkprocfs.Check()
 }
 
-func initCachedBTF(lib, btf_string string) error {
-	return btf.InitCachedBTF(lib, btf_string)
+func initCachedBTF(lib, btfString string) error {
+	return btf.InitCachedBTF(lib, btfString)
 }
 
 func checkStructAlignments() error {

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -89,10 +89,10 @@ type MsgCommon struct {
 	// Flags is used to:
 	//  - distinguish between an entry and a return kprobe event
 	//  - indicate if a stack trace id was passed in the event
-	Flags  uint8
-	Pad_v2 [2]uint8
-	Size   uint32
-	Ktime  uint64
+	Flags uint8
+	PadV2 [2]uint8
+	Size  uint32
+	Ktime uint64
 }
 
 type MsgK8s struct {
@@ -159,7 +159,7 @@ type Binary struct {
 	Reversed   uint32
 	Path       [BINARY_PATH_MAX_LEN]byte
 	End        [STRING_POSTFIX_MAX_LENGTH]byte
-	End_r      [STRING_POSTFIX_MAX_LENGTH]byte
+	EndR       [STRING_POSTFIX_MAX_LENGTH]byte
 	Args       [MAX_ARG_LENGTH]byte
 	MBSet      uint64
 	MBGen      uint64

--- a/pkg/arch/arch.go
+++ b/pkg/arch/arch.go
@@ -13,10 +13,10 @@ import (
 var supportedArchPrefix = map[string]string{"amd64": "__x64_", "arm64": "__arm64_", "i386": "__ia32_"}
 
 func addSyscallPrefix(symbol string, arch string) (string, error) {
-	for prefix_arch, prefix := range supportedArchPrefix {
+	for prefixArch, prefix := range supportedArchPrefix {
 		if strings.HasPrefix(symbol, prefix) {
 			// check that the prefix found is the correct one
-			if prefix_arch != arch {
+			if prefixArch != arch {
 				return "", fmt.Errorf("expecting %s and got %s", supportedArchPrefix[arch], prefix)
 			}
 			return symbol, nil

--- a/pkg/bpf/ringbuf_windows.go
+++ b/pkg/bpf/ringbuf_windows.go
@@ -65,9 +65,9 @@ type operationMapAsyncQueryReply struct {
 }
 
 type RingBufferRecord struct {
-	length      uint32
-	page_offset uint32
-	data        [1]uint8
+	length     uint32
+	pageOffset uint32
+	data       [1]uint8
 }
 
 type MsgCommon struct {
@@ -75,10 +75,10 @@ type MsgCommon struct {
 	// Flags is used to:
 	//  - distinguish between an entry and a return kprobe event
 	//  - indicate if a stack trace id was passed in the event
-	Flags  uint8
-	Pad_v2 [2]uint8
-	Size   uint32
-	Ktime  uint64
+	Flags uint8
+	PadV2 [2]uint8
+	Size  uint32
+	Ktime uint64
 }
 
 type ProcessInfo struct {
@@ -306,11 +306,11 @@ func EbpfRingBufferNextRecord(buffer []byte, bufferLength, consumer, producer ui
 	return (*RingBufferRecord)(unsafe.Pointer(&buffer[consumer%bufferLength]))
 }
 
-func (reader *WindowsRingBufReader) Init(fd int, ring_buffer_size int) error {
+func (reader *WindowsRingBufReader) Init(fd int, ringBufferSize int) error {
 	if fd <= 0 {
 		return errors.New("invalid fd provided")
 	}
-	reader.ringBufferSize = uint64(ring_buffer_size)
+	reader.ringBufferSize = uint64(ringBufferSize)
 	handle, err := EbpfGetHandleFromFD(fd)
 	if err != nil {
 		return fmt.Errorf("cannot get handle from fd: %w", err)
@@ -330,7 +330,7 @@ func (reader *WindowsRingBufReader) Init(fd int, ring_buffer_size int) error {
 		return fmt.Errorf("failed to do device io control: %w", err)
 	}
 	var buffer = uintptr(reply.bufferAddress)
-	reader.byteBuf = unsafe.Slice((*byte)(unsafe.Pointer(buffer)), ring_buffer_size)
+	reader.byteBuf = unsafe.Slice((*byte)(unsafe.Pointer(buffer)), ringBufferSize)
 
 	reader.currRequest.header.length = uint16(unsafe.Sizeof(reader.currRequest))
 	reader.currRequest.header.id = EBPF_OP_MAP_ASYNC_QUERY

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -108,7 +108,7 @@ func TestCgroupNameFromCStr(t *testing.T) {
 // Ensure that Cgroupv1 controllers discovery fails if no 'cpuset' and no 'memory'
 func TestParseCgroupSubSysIdsWithoutMemoryCpuset(t *testing.T) {
 	testDir := t.TempDir()
-	invalid_cgroupv1_controllers :=
+	invalidCgroupv1Controllers :=
 		`
 #subsys_name	hierarchy	num_cgroups	enabled
 cpu	6	78	1
@@ -118,7 +118,7 @@ perf_event	8	2	1
 `
 
 	file := filepath.Join(testDir, "testfile")
-	err := os.WriteFile(file, []byte(invalid_cgroupv1_controllers), 0644)
+	err := os.WriteFile(file, []byte(invalidCgroupv1Controllers), 0644)
 	require.NoError(t, err)
 
 	err = parseCgroupv1SubSysIds(file)
@@ -169,10 +169,10 @@ misc	10	1	1
 
 func TestCheckCgroupv2Controllers(t *testing.T) {
 	testDir := t.TempDir()
-	empty_controllers := ""
+	emptyControllers := ""
 
 	file := filepath.Join(testDir, "cgroup.controllers")
-	err := os.WriteFile(file, []byte(empty_controllers), 0644)
+	err := os.WriteFile(file, []byte(emptyControllers), 0644)
 	require.NoError(t, err)
 
 	err = checkCgroupv2Controllers(testDir)

--- a/pkg/constants/constants_linux.go
+++ b/pkg/constants/constants_linux.go
@@ -27,7 +27,7 @@ const (
 	AF_X25               = unix.AF_X25
 	AF_INET6             = unix.AF_INET6
 	AF_ROSE              = unix.AF_ROSE
-	AF_DECnet            = unix.AF_DECnet
+	AF_DECnet            = unix.AF_DECnet //nolint:staticcheck
 	AF_NETBEUI           = unix.AF_NETBEUI
 	AF_SECURITY          = unix.AF_SECURITY
 	AF_KEY               = unix.AF_KEY

--- a/pkg/encoder/encoder.go
+++ b/pkg/encoder/encoder.go
@@ -466,8 +466,8 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 			event := p.Colorer.Blue.Sprintf("🐝 %-7s", "perf_event_alloc")
 			attr := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil {
-				p_event := kprobe.Args[0].GetPerfEventArg()
-				attr = p.Colorer.Cyan.Sprintf("%s %s", p_event.Type, p_event.KprobeFunc)
+				pEvent := kprobe.Args[0].GetPerfEventArg()
+				attr = p.Colorer.Cyan.Sprintf("%s %s", pEvent.Type, pEvent.KprobeFunc)
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, attr), caps), nil
 		case "security_bpf_map_alloc":

--- a/pkg/filters/caps.go
+++ b/pkg/filters/caps.go
@@ -68,7 +68,7 @@ func filterByCaps(filter *tetragon.CapFilter) (FilterFunc, error) {
 
 type CapsFilter struct{}
 
-func ensure_single_set_defined(filter *tetragon.CapFilterSet) error {
+func ensureSingleSetDefined(filter *tetragon.CapFilterSet) error {
 	if filter == nil {
 		return nil
 	}
@@ -97,13 +97,13 @@ func (f *CapsFilter) OnBuildFilter(_ context.Context, ff *tetragon.Filter) ([]Fi
 			return nil, errors.New("capabilities are not enabled in process events, cannot configure capability filter")
 		}
 
-		if err := ensure_single_set_defined(ff.Capabilities.Permitted); err != nil {
+		if err := ensureSingleSetDefined(ff.Capabilities.Permitted); err != nil {
 			return nil, err
 		}
-		if err := ensure_single_set_defined(ff.Capabilities.Effective); err != nil {
+		if err := ensureSingleSetDefined(ff.Capabilities.Effective); err != nil {
 			return nil, err
 		}
-		if err := ensure_single_set_defined(ff.Capabilities.Inheritable); err != nil {
+		if err := ensureSingleSetDefined(ff.Capabilities.Inheritable); err != nil {
 			return nil, err
 		}
 

--- a/pkg/grpc/exec/exec_test_helper.go
+++ b/pkg/grpc/exec/exec_test_helper.go
@@ -123,11 +123,11 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 	rootEv := tetragonAPI.MsgExecveEventUnix{
 		Msg: &tetragonAPI.MsgExecveEvent{
 			Common: tetragonAPI.MsgCommon{
-				Op:     5,
-				Flags:  0,
-				Pad_v2: [2]uint8{0, 0},
-				Size:   326,
-				Ktime:  0,
+				Op:    5,
+				Flags: 0,
+				PadV2: [2]uint8{0, 0},
+				Size:  326,
+				Ktime: 0,
 			},
 			Kube: tetragonAPI.MsgK8s{
 				Cgrpid: 0,
@@ -162,11 +162,11 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 	parentEv := tetragonAPI.MsgExecveEventUnix{
 		Msg: &tetragonAPI.MsgExecveEvent{
 			Common: tetragonAPI.MsgCommon{
-				Op:     5,
-				Flags:  0,
-				Pad_v2: [2]uint8{0, 0},
-				Size:   326,
-				Ktime:  21034975106173,
+				Op:    5,
+				Flags: 0,
+				PadV2: [2]uint8{0, 0},
+				Size:  326,
+				Ktime: 21034975106173,
 			},
 			Kube: tetragonAPI.MsgK8s{
 				Cgrpid: 0,
@@ -201,11 +201,11 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 	execEv := tetragonAPI.MsgExecveEventUnix{
 		Msg: &tetragonAPI.MsgExecveEvent{
 			Common: tetragonAPI.MsgCommon{
-				Op:     5,
-				Flags:  0,
-				Pad_v2: [2]uint8{0, 0},
-				Size:   326,
-				Ktime:  21034975106173,
+				Op:    5,
+				Flags: 0,
+				PadV2: [2]uint8{0, 0},
+				Size:  326,
+				Ktime: 21034975106173,
 			},
 			Kube: tetragonAPI.MsgK8s{
 				Cgrpid: 0,
@@ -238,11 +238,11 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 
 	exitEv := tetragonAPI.MsgExitEvent{
 		Common: tetragonAPI.MsgCommon{
-			Op:     7,
-			Flags:  0,
-			Pad_v2: [2]uint8{0, 0},
-			Size:   40,
-			Ktime:  21034976281104,
+			Op:    7,
+			Flags: 0,
+			PadV2: [2]uint8{0, 0},
+			Size:  40,
+			Ktime: 21034976281104,
 		},
 		ProcessKey: tetragonAPI.MsgExecveKey{
 			Pid:   Pid,
@@ -264,11 +264,11 @@ func CreateEvents[EXEC notify.Message, EXIT notify.Message](Pid uint32, Ktime ui
 func CreateCloneEvents[CLONE notify.Message, EXIT notify.Message](Pid uint32, Ktime uint64, ParentPid uint32, ParentKtime uint64) (*CLONE, *EXIT) {
 	cloneEv := tetragonAPI.MsgCloneEvent{
 		Common: tetragonAPI.MsgCommon{
-			Op:     23,
-			Flags:  0,
-			Pad_v2: [2]uint8{0, 0},
-			Size:   326,
-			Ktime:  21034975126173,
+			Op:    23,
+			Flags: 0,
+			PadV2: [2]uint8{0, 0},
+			Size:  326,
+			Ktime: 21034975126173,
 		},
 		Parent: tetragonAPI.MsgExecveKey{
 			Pid:   ParentPid,
@@ -286,11 +286,11 @@ func CreateCloneEvents[CLONE notify.Message, EXIT notify.Message](Pid uint32, Kt
 
 	exitEv := tetragonAPI.MsgExitEvent{
 		Common: tetragonAPI.MsgCommon{
-			Op:     7,
-			Flags:  0,
-			Pad_v2: [2]uint8{0, 0},
-			Size:   40,
-			Ktime:  21034976291104,
+			Op:    7,
+			Flags: 0,
+			PadV2: [2]uint8{0, 0},
+			Size:  40,
+			Ktime: 21034976291104,
 		},
 		ProcessKey: tetragonAPI.MsgExecveKey{
 			Pid:   Pid,
@@ -321,11 +321,11 @@ func CreateAncestorEvents[EXEC notify.Message, EXIT notify.Message](
 	execEv := tetragonAPI.MsgExecveEventUnix{
 		Msg: &tetragonAPI.MsgExecveEvent{
 			Common: tetragonAPI.MsgCommon{
-				Op:     5,
-				Flags:  0,
-				Pad_v2: [2]uint8{0, 0},
-				Size:   326,
-				Ktime:  Ktime + 1200000,
+				Op:    5,
+				Flags: 0,
+				PadV2: [2]uint8{0, 0},
+				Size:  326,
+				Ktime: Ktime + 1200000,
 			},
 			Kube: tetragonAPI.MsgK8s{
 				Cgrpid: 0,
@@ -363,11 +363,11 @@ func CreateAncestorEvents[EXEC notify.Message, EXIT notify.Message](
 
 	exitEv := tetragonAPI.MsgExitEvent{
 		Common: tetragonAPI.MsgCommon{
-			Op:     7,
-			Flags:  0,
-			Pad_v2: [2]uint8{0, 0},
-			Size:   40,
-			Ktime:  Ktime + 20000000,
+			Op:    7,
+			Flags: 0,
+			PadV2: [2]uint8{0, 0},
+			Size:  40,
+			Ktime: Ktime + 20000000,
 		},
 		ProcessKey: tetragonAPI.MsgExecveKey{
 			Pid:   Pid,

--- a/pkg/grpc/process_manager_test_linux.go
+++ b/pkg/grpc/process_manager_test_linux.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProcessManager_GetProcessID(t *testing.T) {
+func TestProcessManagerGetProcessID(t *testing.T) {
 	require.NoError(t, os.Setenv("NODE_NAME", "my-node"))
 	node.SetExportNodeName()
 

--- a/pkg/grpc/process_manager_test_windows.go
+++ b/pkg/grpc/process_manager_test_windows.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProcessManager_GetProcessID(t *testing.T) {
+func TestProcessManagerGetProcessID(t *testing.T) {
 	require.NoError(t, os.Setenv("NODE_NAME", "my-node"))
 	node.SetExportNodeName()
 

--- a/pkg/reader/caps/caps.go
+++ b/pkg/reader/caps/caps.go
@@ -23,8 +23,8 @@ import (
 
 var (
 	// Set default last capability based on upstream unix go library
-	cap_last_cap = int32(constants.CAP_LAST_CAP)
-	lastCapOnce  sync.Once
+	capLastCap  = int32(constants.CAP_LAST_CAP)
+	lastCapOnce sync.Once
 )
 
 // GetLastCap() Returns unix.CAP_LAST_CAP unless the kernel
@@ -33,19 +33,19 @@ func GetLastCap() int32 {
 	lastCapOnce.Do(func() {
 		d, err := os.ReadFile(filepath.Join(option.Config.ProcFS, "/sys/kernel/cap_last_cap"))
 		if err != nil {
-			logger.GetLogger().Warn(fmt.Sprintf("Could not read kernel cap_last_cap, using default '%d' as cap_last_cap", cap_last_cap), logfields.Error, err)
+			logger.GetLogger().Warn(fmt.Sprintf("Could not read kernel cap_last_cap, using default '%d' as cap_last_cap", capLastCap), logfields.Error, err)
 		}
 		val, err := strconv.ParseInt(strings.TrimRight(string(d), "\n"), 10, 32)
 		if err != nil {
-			logger.GetLogger().Warn(fmt.Sprintf("Could not parse cap_last_cap, using default '%d' as cap_last_cap", cap_last_cap), logfields.Error, err)
+			logger.GetLogger().Warn(fmt.Sprintf("Could not parse cap_last_cap, using default '%d' as cap_last_cap", capLastCap), logfields.Error, err)
 			return
 		}
 		// just silence some CodeQL
 		if val >= 0 && val < constants.CAP_LAST_CAP {
-			cap_last_cap = int32(val)
+			capLastCap = int32(val)
 		}
 	})
-	return cap_last_cap
+	return capLastCap
 }
 
 func isCapValid(capInt int32) bool {

--- a/pkg/reader/namespace/namespace_linux.go
+++ b/pkg/reader/namespace/namespace_linux.go
@@ -94,58 +94,58 @@ func GetCurrentNamespace() *tetragon.Namespaces {
 	if err != nil {
 		return nil
 	}
-	self_ns := make(map[string]uint32)
+	selfNS := make(map[string]uint32)
 	for i := range listNamespaces {
 		ino, err := GetSelfNsInode(listNamespaces[i])
 		if err != nil {
 			logger.GetLogger().Warn("Failed to read current namespace", logfields.Error, err)
 			continue
 		}
-		self_ns[listNamespaces[i]] = ino
+		selfNS[listNamespaces[i]] = ino
 	}
 
 	retVal := &tetragon.Namespaces{
 		Uts: &tetragon.Namespace{
-			Inum:   self_ns["uts"],
-			IsHost: hostNs.Uts.Inum == self_ns["uts"],
+			Inum:   selfNS["uts"],
+			IsHost: hostNs.Uts.Inum == selfNS["uts"],
 		},
 		Ipc: &tetragon.Namespace{
-			Inum:   self_ns["ipc"],
-			IsHost: hostNs.Ipc.Inum == self_ns["ipc"],
+			Inum:   selfNS["ipc"],
+			IsHost: hostNs.Ipc.Inum == selfNS["ipc"],
 		},
 		Mnt: &tetragon.Namespace{
-			Inum:   self_ns["mnt"],
-			IsHost: hostNs.Mnt.Inum == self_ns["mnt"],
+			Inum:   selfNS["mnt"],
+			IsHost: hostNs.Mnt.Inum == selfNS["mnt"],
 		},
 		Pid: &tetragon.Namespace{
-			Inum:   self_ns["pid"],
-			IsHost: hostNs.Pid.Inum == self_ns["pid"],
+			Inum:   selfNS["pid"],
+			IsHost: hostNs.Pid.Inum == selfNS["pid"],
 		},
 		PidForChildren: &tetragon.Namespace{
-			Inum:   self_ns["pid_for_children"],
-			IsHost: hostNs.PidForChildren.Inum == self_ns["pid_for_children"],
+			Inum:   selfNS["pid_for_children"],
+			IsHost: hostNs.PidForChildren.Inum == selfNS["pid_for_children"],
 		},
 		Net: &tetragon.Namespace{
-			Inum:   self_ns["net"],
-			IsHost: hostNs.Net.Inum == self_ns["net"],
+			Inum:   selfNS["net"],
+			IsHost: hostNs.Net.Inum == selfNS["net"],
 		},
 		Time: &tetragon.Namespace{
-			Inum: self_ns["time"],
+			Inum: selfNS["time"],
 			// Check first if this kernel supports time namespace
-			IsHost: hostNs.Time.Inum != 0 && hostNs.Time.Inum == self_ns["time"],
+			IsHost: hostNs.Time.Inum != 0 && hostNs.Time.Inum == selfNS["time"],
 		},
 		TimeForChildren: &tetragon.Namespace{
-			Inum: self_ns["time_for_children"],
+			Inum: selfNS["time_for_children"],
 			// Check first if this kernel supports time namespace
-			IsHost: hostNs.TimeForChildren.Inum != 0 && hostNs.TimeForChildren.Inum == self_ns["time_for_children"],
+			IsHost: hostNs.TimeForChildren.Inum != 0 && hostNs.TimeForChildren.Inum == selfNS["time_for_children"],
 		},
 		Cgroup: &tetragon.Namespace{
-			Inum:   self_ns["cgroup"],
-			IsHost: hostNs.Cgroup.Inum == self_ns["cgroup"],
+			Inum:   selfNS["cgroup"],
+			IsHost: hostNs.Cgroup.Inum == selfNS["cgroup"],
 		},
 		User: &tetragon.Namespace{
-			Inum:   self_ns["user"],
-			IsHost: hostNs.User.Inum == self_ns["user"],
+			Inum:   selfNS["user"],
+			IsHost: hostNs.User.Inum == selfNS["user"],
 		},
 	}
 

--- a/pkg/reader/proc/proc_windows.go
+++ b/pkg/reader/proc/proc_windows.go
@@ -33,10 +33,10 @@ type TokenStatistics struct {
 	ModifiedId         windows.LUID
 }
 
-func getIDFromSID(str_sid string) (string, error) {
-	tokens := strings.Split(str_sid, "-")
+func getIDFromSID(strSID string) (string, error) {
+	tokens := strings.Split(strSID, "-")
 	if len(tokens) <= 1 {
-		return "", fmt.Errorf("could no parse SID %s", str_sid)
+		return "", fmt.Errorf("could no parse SID %s", strSID)
 	}
 	return tokens[len(tokens)-1], nil
 }
@@ -74,24 +74,24 @@ func fillStatus(hProc windows.Handle, status *Status) error {
 	}
 
 	defer token.Close()
-	str_uid, err := getStrLuidFromToken(token)
+	strUID, err := getStrLuidFromToken(token)
 	if err != nil {
 		return err
 	}
-	status.Uids = []string{str_uid, str_uid, str_uid, str_uid}
+	status.Uids = []string{strUID, strUID, strUID, strUID}
 	tokenGroup, err := token.GetTokenPrimaryGroup()
 	if err != nil {
 		return err
 	}
-	str_groupid := tokenGroup.PrimaryGroup.String()
+	strGroupID := tokenGroup.PrimaryGroup.String()
 	if err != nil {
 		return err
 	}
-	str_gid, err := getIDFromSID(str_groupid)
+	strGID, err := getIDFromSID(strGroupID)
 	if err != nil {
 		return err
 	}
-	status.Gids = []string{str_gid, str_gid, str_gid, str_gid}
+	status.Gids = []string{strGID, strGID, strGID, strGID}
 	return nil
 }
 
@@ -136,11 +136,11 @@ func fillLoginUid(hProc windows.Handle, status *Status) error {
 	if err != nil {
 		return err
 	}
-	str_sid, err := getIDFromSID(sid)
+	strSID, err := getIDFromSID(sid)
 	if err != nil {
 		return err
 	}
-	status.LoginUid = str_sid
+	status.LoginUid = strSID
 	return nil
 }
 

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -911,12 +911,12 @@ func ParseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 }
 
 func ParseMatchArgs(k *KernelSelectorState, args []v1alpha1.ArgSelector, sig []v1alpha1.KProbeArg) error {
-	max_args := 1
+	maxArgs := 1
 	if config.EnableLargeProgs() {
-		max_args = 5 // we support up 5 argument filters under matchArgs with kernels >= 5.3, otherwise 1 argument
+		maxArgs = 5 // we support up 5 argument filters under matchArgs with kernels >= 5.3, otherwise 1 argument
 	}
-	if len(args) > max_args {
-		return fmt.Errorf("parseMatchArgs: supports up to %d filters (%d provided)", max_args, len(args))
+	if len(args) > maxArgs {
+		return fmt.Errorf("parseMatchArgs: supports up to %d filters (%d provided)", maxArgs, len(args))
 	}
 	actionOffset := GetCurrentOffset(&k.data)
 	loff := AdvanceSelectorLength(&k.data)
@@ -1134,12 +1134,12 @@ func ParseMatchNamespace(k *KernelSelectorState, action *v1alpha1.NamespaceSelec
 }
 
 func ParseMatchNamespaces(k *KernelSelectorState, actions []v1alpha1.NamespaceSelector) error {
-	max_nactions := 4 // 4 should match the value of the NUM_NS_FILTERS_SMALL in pfilter.h
+	maxNActions := 4 // 4 should match the value of the NUM_NS_FILTERS_SMALL in pfilter.h
 	if config.EnableLargeProgs() {
-		max_nactions = 10 // 10 should match the value of ns_max_types in hubble_msg.h
+		maxNActions = 10 // 10 should match the value of ns_max_types in hubble_msg.h
 	}
-	if len(actions) > max_nactions {
-		return fmt.Errorf("matchNamespace supports up to %d filters (current number of filters is %d)", max_nactions, len(actions))
+	if len(actions) > maxNActions {
+		return fmt.Errorf("matchNamespace supports up to %d filters (current number of filters is %d)", maxNActions, len(actions))
 	}
 	loff := AdvanceSelectorLength(&k.data)
 	// maybe write the number of namespace matches

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -632,22 +632,22 @@ func TestMultipleSelectorsExample(t *testing.T) {
 }
 
 func TestInitKernelSelectors(t *testing.T) {
-	expected_header := []byte{
+	expectedHeader := []byte{
 		// spec header
 		0x01, 0x00, 0x00, 0x00, // single selector
 
 		0x04, 0x00, 0x00, 0x00, // selector offset list
 	}
 
-	expected_selsize_small := []byte{
+	expectedSelsizeSmall := []byte{
 		0x18, 0x01, 0x00, 0x00, // size = pids + args + actions + namespaces + capabilities  + 4
 	}
 
-	expected_selsize_large := []byte{
+	expectedSelsizeLarge := []byte{
 		0x4c, 0x01, 0x00, 0x00, // size = pids + args + actions + namespaces + namespacesChanges + capabilities + capabilityChanges + 4
 	}
 
-	expected_filters := []byte{
+	expectedFilters := []byte{
 		// pid header
 		56, 0x00, 0x00, 0x00, // size = sizeof(pid2) + sizeof(pid1) + 4
 
@@ -701,7 +701,7 @@ func TestInitKernelSelectors(t *testing.T) {
 		0x00, 0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, // Values (uint64)
 	}
 
-	expected_changes_empty := []byte{
+	expectedChangesEmpty := []byte{
 		// namespace changes header
 		0x04, 0x00, 0x00, 0x00,
 
@@ -709,7 +709,7 @@ func TestInitKernelSelectors(t *testing.T) {
 		0x04, 0x00, 0x00, 0x00,
 	}
 
-	expected_changes := []byte{
+	expectedChanges := []byte{
 		// namespace changes header
 		12, 0x00, 0x00, 0x00, // size = sizeof(nc1) + sizeof(nc2) + 4
 
@@ -727,7 +727,7 @@ func TestInitKernelSelectors(t *testing.T) {
 		0x00, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, // Values (uint64)
 	}
 
-	expected_last_large := []byte{
+	expectedLastLarge := []byte{
 		// arg header
 		108, 0x00, 0x00, 0x00, // size = sizeof(arg2) + sizeof(arg1) + 24
 		24, 0x00, 0x00, 0x00, // arg[0] offset
@@ -774,7 +774,7 @@ func TestInitKernelSelectors(t *testing.T) {
 		0x01, 0x00, 0x00, 0x00, // arg index of string filename
 	}
 
-	expected_last_small := []byte{
+	expectedLastSmall := []byte{
 		// arg header
 		84, 0x00, 0x00, 0x00, // size = sizeof(arg1) + 24
 		24, 0x00, 0x00, 0x00, // arg[0] offset
@@ -813,17 +813,17 @@ func TestInitKernelSelectors(t *testing.T) {
 		0x01, 0x00, 0x00, 0x00, // arg index of string filename
 	}
 
-	expected := expected_header
+	expected := expectedHeader
 	if config.EnableLargeProgs() {
-		expected = append(expected, expected_selsize_large...)
-		expected = append(expected, expected_filters...)
-		expected = append(expected, expected_changes...)
-		expected = append(expected, expected_last_large...)
+		expected = append(expected, expectedSelsizeLarge...)
+		expected = append(expected, expectedFilters...)
+		expected = append(expected, expectedChanges...)
+		expected = append(expected, expectedLastLarge...)
 	} else {
-		expected = append(expected, expected_selsize_small...)
-		expected = append(expected, expected_filters...)
-		expected = append(expected, expected_changes_empty...)
-		expected = append(expected, expected_last_small...)
+		expected = append(expected, expectedSelsizeSmall...)
+		expected = append(expected, expectedFilters...)
+		expected = append(expected, expectedChangesEmpty...)
+		expected = append(expected, expectedLastSmall...)
 	}
 
 	pid1 := &v1alpha1.PIDSelector{Operator: "In", Values: []uint32{1, 2, 3}, IsNamespacePID: true, FollowForks: true}

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -131,14 +131,14 @@ func setupSensor() {
 	// exit program function
 	ks, err := ksyms.KernelSymbols()
 	if err == nil {
-		has_acct_process := ks.IsAvailable("acct_process")
-		has_disassociate_ctty := ks.IsAvailable("disassociate_ctty")
+		hasAcctProcess := ks.IsAvailable("acct_process")
+		hasDisassociateCtty := ks.IsAvailable("disassociate_ctty")
 
 		/* Preffer acct_process over disassociate_ctty */
-		if has_acct_process {
+		if hasAcctProcess {
 			Exit.Attach = "acct_process"
 			Exit.Label = "kprobe/acct_process"
-		} else if has_disassociate_ctty {
+		} else if hasDisassociateCtty {
 			Exit.Attach = "disassociate_ctty"
 			Exit.Label = "kprobe/disassociate_ctty"
 		} else {

--- a/pkg/sensors/exec/args_windows.go
+++ b/pkg/sensors/exec/args_windows.go
@@ -14,38 +14,38 @@ import (
 )
 
 var (
-	cmd_map   *ebpf.Map
-	image_map *ebpf.Map
+	cmdMap   *ebpf.Map
+	imageMap *ebpf.Map
 )
 
 func getArgsFromPID(PID uint32) (string, string, error) {
 
-	if (cmd_map == nil) || (image_map == nil) {
+	if (cmdMap == nil) || (imageMap == nil) {
 		coll, _ := bpf.GetCollection("ProcessMonitor")
 		if coll == nil {
 			return "", "", errors.New("exec Preloaded collection is nil")
 		}
 		var ok bool
-		cmd_map, ok = coll.Maps["command_map"]
+		cmdMap, ok = coll.Maps["command_map"]
 		if !ok {
 			return "", "", errors.New("commad_map not found or not pinned")
 		}
-		image_map, ok = coll.Maps["process_map"]
+		imageMap, ok = coll.Maps["process_map"]
 		if !ok {
 			return "", "", errors.New("commad_map not found or not pinned")
 		}
 	}
 	var wideCmd [2048]uint16
-	err := cmd_map.Lookup(PID, &wideCmd)
+	err := cmdMap.Lookup(PID, &wideCmd)
 	if err == nil {
-		cmd_map.Delete(PID)
+		cmdMap.Delete(PID)
 	}
 	strCmd := windows.UTF16ToString(wideCmd[:])
 
 	var wideImagePath [1024]byte
-	err = image_map.Lookup(PID, &wideImagePath)
+	err = imageMap.Lookup(PID, &wideImagePath)
 	if err == nil {
-		image_map.Delete(PID)
+		imageMap.Delete(PID)
 	}
 	var s = (*uint16)(unsafe.Pointer(&wideImagePath[0]))
 	strImagePath := windows.UTF16PtrToString(s)

--- a/pkg/sensors/exec/exec_linux.go
+++ b/pkg/sensors/exec/exec_linux.go
@@ -36,7 +36,7 @@ func msgToExecveUnix(m *processapi.MsgExecveEvent) *exec.MsgExecveEventUnix {
 	return unix
 }
 
-func msgToExecveKubeUnix(m *processapi.MsgExecveEvent, exec_id string, filename string) processapi.MsgK8sUnix {
+func msgToExecveKubeUnix(m *processapi.MsgExecveEvent, execID string, filename string) processapi.MsgK8sUnix {
 	kube := processapi.MsgK8sUnix{
 		Cgrpid:        m.Kube.Cgrpid,
 		CgrpTrackerID: m.Kube.CgrpTrackerID,
@@ -60,19 +60,19 @@ func msgToExecveKubeUnix(m *processapi.MsgExecveEvent, exec_id string, filename 
 				"cgroup.id", m.Kube.Cgrpid,
 				"cgroup.name", cgroup,
 				"docker", kube.Docker,
-				"process.exec_id", exec_id,
+				"process.exec_id", execID,
 				"process.binary", filename)
 		} else {
 			logger.Trace(logger.GetLogger(), "process_exec: no container ID due to cgroup name not being a compatible ID, ignoring.",
 				"cgroup.id", m.Kube.Cgrpid,
 				"cgroup.name", cgroup,
-				"process.exec_id", exec_id,
+				"process.exec_id", execID,
 				"process.binary", filename)
 		}
 	} else {
 		logger.Trace(logger.GetLogger(), "process_exec: no container ID due to cgroup name being empty, ignoring.",
 			"cgroup.id", m.Kube.Cgrpid,
-			"process.exec_id", exec_id,
+			"process.exec_id", execID,
 			"process.binary", filename)
 	}
 

--- a/pkg/sensors/exec/procevents/proc_reader.go
+++ b/pkg/sensors/exec/procevents/proc_reader.go
@@ -39,38 +39,38 @@ func stringToUTF8(s []byte) []byte {
 }
 
 type procs struct {
-	psize                uint32
-	ppid                 uint32
-	pnspid               uint32
-	pflags               uint32
-	pktime               uint64
-	pcmdline             []byte
-	pexe                 []byte
-	size                 uint32
-	uids                 []uint32
-	gids                 []uint32
-	pid                  uint32
-	tid                  uint32
-	nspid                uint32
-	auid                 uint32
-	flags                uint32
-	ktime                uint64
-	cmdline              []byte
-	exe                  []byte
-	effective            uint64
-	inheritable          uint64
-	permitted            uint64
-	uts_ns               uint32
-	ipc_ns               uint32
-	mnt_ns               uint32
-	pid_ns               uint32
-	pid_for_children_ns  uint32
-	net_ns               uint32
-	time_ns              uint32
-	time_for_children_ns uint32
-	cgroup_ns            uint32
-	user_ns              uint32
-	kernel_thread        bool
+	psize             uint32
+	ppid              uint32
+	pnspid            uint32
+	pflags            uint32
+	pktime            uint64
+	pcmdline          []byte
+	pexe              []byte
+	size              uint32
+	uids              []uint32
+	gids              []uint32
+	pid               uint32
+	tid               uint32
+	nspid             uint32
+	auid              uint32
+	flags             uint32
+	ktime             uint64
+	cmdline           []byte
+	exe               []byte
+	effective         uint64
+	inheritable       uint64
+	permitted         uint64
+	utsNs             uint32
+	ipcNs             uint32
+	mntNs             uint32
+	pidNs             uint32
+	pidForChildrenNs  uint32
+	netNs             uint32
+	timeNs            uint32
+	timeForChildrenNs uint32
+	cgroupNs          uint32
+	userNs            uint32
+	kernelThread      bool
 }
 
 func (p procs) args() []byte {
@@ -88,8 +88,8 @@ func pushExecveEvents(p procs, inInitTreeMap map[uint32]struct{}) {
 	/* If we can't fit this in the buffer lets trim some parts and
 	 * make it fit.
 	 */
-	raw_args := p.args()
-	raw_pargs := p.pargs()
+	rawArgs := p.args()
+	rawPargs := p.pargs()
 
 	if p.size+p.psize > processapi.MSG_SIZEOF_BUFFER {
 		var deduct uint32
@@ -113,19 +113,19 @@ func pushExecveEvents(p procs, inInitTreeMap map[uint32]struct{}) {
 		}
 
 		for range need {
-			if len(raw_pargs) > len(raw_args) {
+			if len(rawPargs) > len(rawArgs) {
 				p.pflags |= api.EventTruncArgs
-				raw_pargs = raw_pargs[:len(raw_pargs)-1]
+				rawPargs = rawPargs[:len(rawPargs)-1]
 				p.psize--
 			} else {
 				p.flags |= api.EventTruncArgs
-				raw_args = raw_args[:len(raw_args)-1]
+				rawArgs = rawArgs[:len(rawArgs)-1]
 				p.size--
 			}
 		}
 	}
 
-	args, filename := procsFilename(raw_args)
+	args, filename := procsFilename(rawArgs)
 	cwd, flags := getCWD(p.pid)
 	if (flags & api.EventRootCWD) == 0 {
 		args = args + " " + cwd
@@ -133,12 +133,12 @@ func pushExecveEvents(p procs, inInitTreeMap map[uint32]struct{}) {
 
 	// If this is a kernel thread, we use its filename as process name
 	// similarly to what ps reports.
-	if p.kernel_thread {
+	if p.kernelThread {
 		filename = fmt.Sprintf("[%s]", filename)
 		args = ""
 	}
 
-	if p.kernel_thread {
+	if p.kernelThread {
 		m := exec.MsgKThreadInitUnix{}
 		m.Unix = &processapi.MsgExecveEventUnix{}
 		m.Unix.Msg = &processapi.MsgExecveEvent{}
@@ -200,16 +200,16 @@ func pushExecveEvents(p procs, inInitTreeMap map[uint32]struct{}) {
 			Inheritable: p.inheritable,
 		}
 
-		m.Unix.Msg.Namespaces.UtsInum = p.uts_ns
-		m.Unix.Msg.Namespaces.IpcInum = p.ipc_ns
-		m.Unix.Msg.Namespaces.MntInum = p.mnt_ns
-		m.Unix.Msg.Namespaces.PidInum = p.pid_ns
-		m.Unix.Msg.Namespaces.PidChildInum = p.pid_for_children_ns
-		m.Unix.Msg.Namespaces.NetInum = p.net_ns
-		m.Unix.Msg.Namespaces.TimeInum = p.time_ns
-		m.Unix.Msg.Namespaces.TimeChildInum = p.time_for_children_ns
-		m.Unix.Msg.Namespaces.CgroupInum = p.cgroup_ns
-		m.Unix.Msg.Namespaces.UserInum = p.user_ns
+		m.Unix.Msg.Namespaces.UtsInum = p.utsNs
+		m.Unix.Msg.Namespaces.IpcInum = p.ipcNs
+		m.Unix.Msg.Namespaces.MntInum = p.mntNs
+		m.Unix.Msg.Namespaces.PidInum = p.pidNs
+		m.Unix.Msg.Namespaces.PidChildInum = p.pidForChildrenNs
+		m.Unix.Msg.Namespaces.NetInum = p.netNs
+		m.Unix.Msg.Namespaces.TimeInum = p.timeNs
+		m.Unix.Msg.Namespaces.TimeChildInum = p.timeForChildrenNs
+		m.Unix.Msg.Namespaces.CgroupInum = p.cgroupNs
+		m.Unix.Msg.Namespaces.UserInum = p.userNs
 
 		m.Unix.Process.Size = p.size
 		m.Unix.Process.PID = p.pid
@@ -259,16 +259,16 @@ func procToKeyValue(p procs, inInitTree map[uint32]struct{}) (*execvemap.ExecveK
 	v.Capabilities.Permitted = p.permitted
 	v.Capabilities.Effective = p.effective
 	v.Capabilities.Inheritable = p.inheritable
-	v.Namespaces.UtsInum = p.uts_ns
-	v.Namespaces.IpcInum = p.ipc_ns
-	v.Namespaces.MntInum = p.mnt_ns
-	v.Namespaces.PidInum = p.pid_ns
-	v.Namespaces.PidChildInum = p.pid_for_children_ns
-	v.Namespaces.NetInum = p.net_ns
-	v.Namespaces.TimeInum = p.time_ns
-	v.Namespaces.TimeChildInum = p.time_for_children_ns
-	v.Namespaces.CgroupInum = p.cgroup_ns
-	v.Namespaces.UserInum = p.user_ns
+	v.Namespaces.UtsInum = p.utsNs
+	v.Namespaces.IpcInum = p.ipcNs
+	v.Namespaces.MntInum = p.mntNs
+	v.Namespaces.PidInum = p.pidNs
+	v.Namespaces.PidChildInum = p.pidForChildrenNs
+	v.Namespaces.NetInum = p.netNs
+	v.Namespaces.TimeInum = p.timeNs
+	v.Namespaces.TimeChildInum = p.timeForChildrenNs
+	v.Namespaces.CgroupInum = p.cgroupNs
+	v.Namespaces.UserInum = p.userNs
 	pathLength := copy(v.Binary.Path[:], p.exe)
 	v.Binary.PathLength = int32(pathLength)
 

--- a/pkg/sensors/exec/procevents/proc_reader_linux.go
+++ b/pkg/sensors/exec/procevents/proc_reader_linux.go
@@ -234,49 +234,49 @@ func listRunningProcs(procPath string) ([]procs, error) {
 
 		nspid, permitted, effective, inheritable := caps.GetPIDCaps(filepath.Join(procPath, d.Name(), "status"))
 
-		uts_ns, err := namespace.GetPidNsInode(uint32(pid), "uts")
+		utsNs, err := namespace.GetPidNsInode(uint32(pid), "uts")
 		if err != nil {
 			logger.GetLogger().Warn("Reading uts namespace failed", logfields.Error, err)
 		}
-		ipc_ns, err := namespace.GetPidNsInode(uint32(pid), "ipc")
+		ipcNs, err := namespace.GetPidNsInode(uint32(pid), "ipc")
 		if err != nil {
 			logger.GetLogger().Warn("Reading ipc namespace failed", logfields.Error, err)
 		}
-		mnt_ns, err := namespace.GetPidNsInode(uint32(pid), "mnt")
+		mntNs, err := namespace.GetPidNsInode(uint32(pid), "mnt")
 		if err != nil {
 			logger.GetLogger().Warn("Reading mnt namespace failed", logfields.Error, err)
 		}
-		pid_ns, err := namespace.GetPidNsInode(uint32(pid), "pid")
+		pidNs, err := namespace.GetPidNsInode(uint32(pid), "pid")
 		if err != nil {
 			logger.GetLogger().Warn("Reading pid namespace failed", logfields.Error, err)
 		}
-		pid_for_children_ns, err := namespace.GetPidNsInode(uint32(pid), "pid_for_children")
+		pidForChildrenNs, err := namespace.GetPidNsInode(uint32(pid), "pid_for_children")
 		if err != nil && !pidForChildrenWarned {
 			logger.GetLogger().Warn("Reading pid_for_children namespace failed", logfields.Error, err)
 			pidForChildrenWarned = true
 		}
-		net_ns, err := namespace.GetPidNsInode(uint32(pid), "net")
+		netNs, err := namespace.GetPidNsInode(uint32(pid), "net")
 		if err != nil {
 			logger.GetLogger().Warn("Reading net namespace failed", logfields.Error, err)
 		}
-		time_ns := uint32(0)
-		time_for_children_ns := uint32(0)
+		timeNs := uint32(0)
+		timeForChildrenNs := uint32(0)
 		if namespace.TimeNsSupport {
-			time_ns, err = namespace.GetPidNsInode(uint32(pid), "time")
+			timeNs, err = namespace.GetPidNsInode(uint32(pid), "time")
 			if err != nil {
 				logger.GetLogger().Warn("Reading time namespace failed", logfields.Error, err)
 			}
-			time_for_children_ns, err = namespace.GetPidNsInode(uint32(pid), "time_for_children")
+			timeForChildrenNs, err = namespace.GetPidNsInode(uint32(pid), "time_for_children")
 			if err != nil {
 				logger.GetLogger().Warn("Reading time_for_children namespace failed", logfields.Error, err)
 			}
 		}
-		cgroup_ns, err := namespace.GetPidNsInode(uint32(pid), "cgroup")
+		cgroupNs, err := namespace.GetPidNsInode(uint32(pid), "cgroup")
 		if err != nil && !cgroupNsWarned {
 			logger.GetLogger().Warn("Reading cgroup namespace failed", logfields.Error, err)
 			cgroupNsWarned = true
 		}
-		user_ns, err := namespace.GetPidNsInode(uint32(pid), "user")
+		userNs, err := namespace.GetPidNsInode(uint32(pid), "user")
 		if err != nil {
 			logger.GetLogger().Warn("Reading user namespace failed", logfields.Error, err)
 		}
@@ -354,36 +354,36 @@ func listRunningProcs(procPath string) ([]procs, error) {
 		}
 
 		p := procs{
-			ppid:                 uint32(_ppid),
-			pnspid:               pnspid,
-			pexe:                 stringToUTF8([]byte(pexecPath)),
-			pcmdline:             stringToUTF8(pcmdline),
-			pflags:               api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
-			pktime:               pktime,
-			uids:                 uids,
-			gids:                 gids,
-			auid:                 auid,
-			pid:                  uint32(pid),
-			tid:                  uint32(pid), // Read dir does not return threads and we only track tgid
-			nspid:                nspid,
-			exe:                  stringToUTF8([]byte(execPath)),
-			cmdline:              stringToUTF8(cmdline),
-			flags:                api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
-			ktime:                ktime,
-			permitted:            permitted,
-			effective:            effective,
-			inheritable:          inheritable,
-			uts_ns:               uts_ns,
-			ipc_ns:               ipc_ns,
-			mnt_ns:               mnt_ns,
-			pid_ns:               pid_ns,
-			pid_for_children_ns:  pid_for_children_ns,
-			net_ns:               net_ns,
-			time_ns:              time_ns,
-			time_for_children_ns: time_for_children_ns,
-			cgroup_ns:            cgroup_ns,
-			user_ns:              user_ns,
-			kernel_thread:        kernelThread,
+			ppid:              uint32(_ppid),
+			pnspid:            pnspid,
+			pexe:              stringToUTF8([]byte(pexecPath)),
+			pcmdline:          stringToUTF8(pcmdline),
+			pflags:            api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
+			pktime:            pktime,
+			uids:              uids,
+			gids:              gids,
+			auid:              auid,
+			pid:               uint32(pid),
+			tid:               uint32(pid), // Read dir does not return threads and we only track tgid
+			nspid:             nspid,
+			exe:               stringToUTF8([]byte(execPath)),
+			cmdline:           stringToUTF8(cmdline),
+			flags:             api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
+			ktime:             ktime,
+			permitted:         permitted,
+			effective:         effective,
+			inheritable:       inheritable,
+			utsNs:             utsNs,
+			ipcNs:             ipcNs,
+			mntNs:             mntNs,
+			pidNs:             pidNs,
+			pidForChildrenNs:  pidForChildrenNs,
+			netNs:             netNs,
+			timeNs:            timeNs,
+			timeForChildrenNs: timeForChildrenNs,
+			cgroupNs:          cgroupNs,
+			userNs:            userNs,
+			kernelThread:      kernelThread,
 		}
 
 		p.size = uint32(processapi.MSG_SIZEOF_EXECVE + len(p.args()) + processapi.MSG_SIZEOF_CWD)

--- a/pkg/sensors/exec/procevents/proc_reader_windows.go
+++ b/pkg/sensors/exec/procevents/proc_reader_windows.go
@@ -87,20 +87,20 @@ var (
 	bootTimeEpoch                    = GetBootTimeInWindowsEpoch()
 
 	system = procs{
-		ppid:          4,
-		pnspid:        0,
-		pexe:          stringToUTF8([]byte("<kernel>")),
-		pcmdline:      stringToUTF8([]byte("<kernel>")),
-		pflags:        api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
-		pktime:        bootTimeEpoch,
-		pid:           4,
-		tid:           4,
-		nspid:         0,
-		exe:           stringToUTF8([]byte("system")),
-		cmdline:       stringToUTF8([]byte("system")),
-		flags:         api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
-		ktime:         bootTimeEpoch,
-		kernel_thread: true,
+		ppid:         4,
+		pnspid:       0,
+		pexe:         stringToUTF8([]byte("<kernel>")),
+		pcmdline:     stringToUTF8([]byte("<kernel>")),
+		pflags:       api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
+		pktime:       bootTimeEpoch,
+		pid:          4,
+		tid:          4,
+		nspid:        0,
+		exe:          stringToUTF8([]byte("system")),
+		cmdline:      stringToUTF8([]byte("system")),
+		flags:        api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
+		ktime:        bootTimeEpoch,
+		kernelThread: true,
 	}
 	processorArch uint
 )
@@ -506,15 +506,14 @@ func NewProcess(procEntry windows.ProcessEntry32) (procs, error) {
 	// found using GetTokenInformation with TokenPrivileges, and converted o string using LookupPrivilegeName.
 	// They are best expressed as an array of strings, and don't fit in current structure.
 	var permitted, effective, inheritable uint64
-	var nspid, uts_ns, ipc_ns, mnt_ns, pid_ns, pid_for_children_ns uint32
+	var nsPID, utsNs, ipcNs, mntNs, pidNs, pidForChildrenNs uint32
 
-	var net_ns, time_ns uint32
-	var time_for_children_ns uint32
-	var cgroup_ns, user_ns uint32
+	var netNs, timeNs uint32
+	var timeForChildrenNs uint32
 
-	pcmdline = "system"
-	pexecPath = "system"
-	pktime = bootTimeEpoch
+	var cgroupNs, userNs uint32
+	pcmdline = ""
+	pktime = 0
 	var pnspid uint32
 	if ppid != 0 {
 		hPProc, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ|windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(ppid))
@@ -545,36 +544,36 @@ func NewProcess(procEntry windows.ProcessEntry32) (procs, error) {
 	}
 
 	p := procs{
-		ppid:                 uint32(ppid),
-		pnspid:               pnspid,
-		pexe:                 stringToUTF8([]byte(pexecPath)),
-		pcmdline:             stringToUTF8([]byte(pcmdline)),
-		pflags:               api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
-		pktime:               pktime,
-		uids:                 uids,
-		gids:                 gids,
-		auid:                 auid,
-		pid:                  uint32(pid),
-		tid:                  uint32(pid), // Read dir does not return threads and we only track tgid
-		nspid:                nspid,
-		exe:                  stringToUTF8([]byte(execPath)),
-		cmdline:              stringToUTF8([]byte(cmdline)),
-		flags:                api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
-		ktime:                ktime,
-		permitted:            permitted,
-		effective:            effective,
-		inheritable:          inheritable,
-		uts_ns:               uts_ns,
-		ipc_ns:               ipc_ns,
-		mnt_ns:               mnt_ns,
-		pid_ns:               pid_ns,
-		pid_for_children_ns:  pid_for_children_ns,
-		net_ns:               net_ns,
-		time_ns:              time_ns,
-		time_for_children_ns: time_for_children_ns,
-		cgroup_ns:            cgroup_ns,
-		user_ns:              user_ns,
-		kernel_thread:        false,
+		ppid:              uint32(ppid),
+		pnspid:            pnspid,
+		pexe:              stringToUTF8([]byte(pexecPath)),
+		pcmdline:          stringToUTF8([]byte(pcmdline)),
+		pflags:            api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
+		pktime:            pktime,
+		uids:              uids,
+		gids:              gids,
+		auid:              auid,
+		pid:               uint32(pid),
+		tid:               uint32(pid), // Read dir does not return threads and we only track tgid
+		nspid:             nsPID,
+		exe:               stringToUTF8([]byte(execPath)),
+		cmdline:           stringToUTF8([]byte(cmdline)),
+		flags:             api.EventProcFS | api.EventNeedsCWD | api.EventNeedsAUID,
+		ktime:             ktime,
+		permitted:         permitted,
+		effective:         effective,
+		inheritable:       inheritable,
+		utsNs:             utsNs,
+		ipcNs:             ipcNs,
+		mntNs:             mntNs,
+		pidNs:             pidNs,
+		pidForChildrenNs:  pidForChildrenNs,
+		netNs:             netNs,
+		timeNs:            timeNs,
+		timeForChildrenNs: timeForChildrenNs,
+		cgroupNs:          cgroupNs,
+		userNs:            userNs,
+		kernelThread:      false,
 	}
 
 	p.size = uint32(processapi.MSG_SIZEOF_EXECVE + len(p.args()) + processapi.MSG_SIZEOF_CWD)

--- a/pkg/sensors/tracing/args_linux.go
+++ b/pkg/sensors/tracing/args_linux.go
@@ -601,7 +601,7 @@ func parseString(r io.Reader) (string, error) {
 }
 
 func ReadArgBytes(r *bytes.Reader, index int, hasMaxData bool) (*api.MsgGenericKprobeArgBytes, error) {
-	var bytes, bytes_rd, hasDataEvents int32
+	var bytes, bytesRd, hasDataEvents int32
 	var arg api.MsgGenericKprobeArgBytes
 
 	if hasMaxData {
@@ -642,14 +642,14 @@ func ReadArgBytes(r *bytes.Reader, index int, hasMaxData bool) (*api.MsgGenericK
 		return &arg, nil
 	}
 	arg.OrigSize = uint64(bytes)
-	if err := binary.Read(r, binary.LittleEndian, &bytes_rd); err != nil {
+	if err := binary.Read(r, binary.LittleEndian, &bytesRd); err != nil {
 		return nil, fmt.Errorf("failed to read size for buffer argument: %w", err)
 	}
 
-	if bytes_rd > 0 {
-		arg.Value = make([]byte, bytes_rd)
+	if bytesRd > 0 {
+		arg.Value = make([]byte, bytesRd)
 		if err := binary.Read(r, binary.LittleEndian, &arg.Value); err != nil {
-			return nil, fmt.Errorf("failed to read buffer (size: %d): %w", bytes_rd, err)
+			return nil, fmt.Errorf("failed to read buffer (size: %d): %w", bytesRd, err)
 		}
 	}
 

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -217,15 +217,15 @@ func filterMaps(load *program.Program, kprobeEntry *genericKprobe) []*program.Ma
 		numSubMaps = selectors.StringMapsNumSubMapsSmall
 	}
 
-	for string_map_index := range numSubMaps {
-		stringFilterMap[string_map_index] = program.MapBuilderProgram(fmt.Sprintf("string_maps_%d", string_map_index), load)
+	for stringMapIndex := range numSubMaps {
+		stringFilterMap[stringMapIndex] = program.MapBuilderProgram(fmt.Sprintf("string_maps_%d", stringMapIndex), load)
 		if state != nil && !kernels.MinKernelVersion("5.9") {
 			// Versions before 5.9 do not allow inner maps to have different sizes.
 			// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
-			maxEntries := state.StringMapsMaxEntries(string_map_index)
-			stringFilterMap[string_map_index].SetInnerMaxEntries(maxEntries)
+			maxEntries := state.StringMapsMaxEntries(stringMapIndex)
+			stringFilterMap[stringMapIndex].SetInnerMaxEntries(maxEntries)
 		}
-		maps = append(maps, stringFilterMap[string_map_index])
+		maps = append(maps, stringFilterMap[stringMapIndex])
 	}
 
 	stringPrefixFilterMaps := program.MapBuilderProgram("string_prefix_maps", load)
@@ -1134,7 +1134,7 @@ func loadSingleKprobeSensor(id idtable.EntryID, bpfDir string, load *program.Pro
 }
 
 func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir string, load *program.Program, maps []*program.Map, verbose int) error {
-	bin_buf := make([]bytes.Buffer, len(ids))
+	binBuf := make([]bytes.Buffer, len(ids))
 
 	data := &program.MultiKprobeAttachData{}
 
@@ -1146,11 +1146,11 @@ func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir string, load *program.P
 
 		load.MapLoad = append(load.MapLoad, getMapLoad(load, gk, uint32(index))...)
 
-		binary.Write(&bin_buf[index], binary.LittleEndian, gk.loadArgs.config)
+		binary.Write(&binBuf[index], binary.LittleEndian, gk.loadArgs.config)
 		config := &program.MapLoad{
 			Name: "config_map",
 			Load: func(m *ebpf.Map, _ string) error {
-				return m.Update(uint32(index), bin_buf[index].Bytes()[:], ebpf.UpdateAny)
+				return m.Update(uint32(index), binBuf[index].Bytes()[:], ebpf.UpdateAny)
 			},
 		}
 		load.MapLoad = append(load.MapLoad, config)

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -567,15 +567,15 @@ func filterMapsForLsm(load *program.Program, lsmEntry *genericLsm) []*program.Ma
 		numSubMaps = selectors.StringMapsNumSubMapsSmall
 	}
 
-	for string_map_index := range numSubMaps {
-		stringFilterMap[string_map_index] = program.MapBuilderProgram(fmt.Sprintf("string_maps_%d", string_map_index), load)
+	for stringMapIndex := range numSubMaps {
+		stringFilterMap[stringMapIndex] = program.MapBuilderProgram(fmt.Sprintf("string_maps_%d", stringMapIndex), load)
 		if !kernels.MinKernelVersion("5.9") {
 			// Versions before 5.9 do not allow inner maps to have different sizes.
 			// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
-			maxEntries := lsmEntry.selectors.StringMapsMaxEntries(string_map_index)
-			stringFilterMap[string_map_index].SetInnerMaxEntries(maxEntries)
+			maxEntries := lsmEntry.selectors.StringMapsMaxEntries(stringMapIndex)
+			stringFilterMap[stringMapIndex].SetInnerMaxEntries(maxEntries)
 		}
-		maps = append(maps, stringFilterMap[string_map_index])
+		maps = append(maps, stringFilterMap[stringMapIndex])
 	}
 
 	stringPrefixFilterMaps := program.MapBuilderProgram("string_prefix_maps", load)

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -574,12 +574,12 @@ func createGenericTracepointSensor(
 		if !kernels.MinKernelVersion("5.11") {
 			numSubMaps = selectors.StringMapsNumSubMapsSmall
 		}
-		for string_map_index := range numSubMaps {
-			stringFilterMap := program.MapBuilderProgram(fmt.Sprintf("string_maps_%d", string_map_index), prog0)
+		for stringMapIndex := range numSubMaps {
+			stringFilterMap := program.MapBuilderProgram(fmt.Sprintf("string_maps_%d", stringMapIndex), prog0)
 			if !kernels.MinKernelVersion("5.9") {
 				// Versions before 5.9 do not allow inner maps to have different sizes.
 				// See: https://lore.kernel.org/bpf/20200828011800.1970018-1-kafai@fb.com/
-				maxEntries := tp.selectors.StringMapsMaxEntries(string_map_index)
+				maxEntries := tp.selectors.StringMapsMaxEntries(stringMapIndex)
 				stringFilterMap.SetInnerMaxEntries(maxEntries)
 			}
 			maps = append(maps, stringFilterMap)

--- a/pkg/sensors/tracing/kprobe_amd64_test.go
+++ b/pkg/sensors/tracing/kprobe_amd64_test.go
@@ -99,18 +99,18 @@ spec:
 
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	io_delay := 0x80
+	ioDelay := 0x80
 	// probe IO_DELAY to trigger a CAP_SYS_RAWIO check, this is for x86
-	err = syscall.Ioperm(io_delay, 1, 1)
+	err = syscall.Ioperm(ioDelay, 1, 1)
 	if err != nil {
-		t.Logf("Failed to ioperm(0x%02x): %v\n", io_delay, err)
+		t.Logf("Failed to ioperm(0x%02x): %v\n", ioDelay, err)
 		t.Fatal()
 	}
 
-	t.Logf("ioperm() enabling 0x%02x succeeded", io_delay)
+	t.Logf("ioperm() enabling 0x%02x succeeded", ioDelay)
 
 	// disable port
-	syscall.Ioperm(io_delay, 1, 0)
+	syscall.Ioperm(ioDelay, 1, 0)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3063,7 +3063,7 @@ spec:
 	runKprobeOverrideMulti(t, multiHook, checker, file.Name(), link.Name(), syscall.EPERM, syscall.ENOENT, syscall.ESRCH)
 }
 
-func runKprobe_char_iovec(t *testing.T, configHook string,
+func runKprobeCharIovec(t *testing.T, configHook string,
 	checker *ec.UnorderedEventChecker, fdw, fdr int, buffer []byte) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
@@ -3164,7 +3164,7 @@ spec:
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	runKprobe_char_iovec(t, configHook, checker, fdw, fdr, buffer)
+	runKprobeCharIovec(t, configHook, checker, fdw, fdr, buffer)
 }
 
 func TestKprobe_char_iovec_overflow(t *testing.T) {
@@ -3218,7 +3218,7 @@ spec:
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	runKprobe_char_iovec(t, configHook, checker, fdw, fdr, buffer)
+	runKprobeCharIovec(t, configHook, checker, fdw, fdr, buffer)
 }
 
 func TestKprobe_char_iovec_returnCopy(t *testing.T) {
@@ -3273,7 +3273,7 @@ spec:
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	runKprobe_char_iovec(t, configHook, checker, fdw, fdr, buffer)
+	runKprobeCharIovec(t, configHook, checker, fdw, fdr, buffer)
 }
 
 func getMatchArgsFileCrd(opStr string, vals []string) string {
@@ -5282,9 +5282,9 @@ spec:
 	}
 	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()
-	test_cmd := exec.Command(testUserStacktrace)
+	testCmd := exec.Command(testUserStacktrace)
 
-	if err := test_cmd.Start(); err != nil {
+	if err := testCmd.Start(); err != nil {
 		t.Fatalf("failed to run %s: %s", testUserStacktrace, err)
 	}
 
@@ -5314,7 +5314,7 @@ spec:
 	err = jsonchecker.JsonTestCheck(t, checker)
 
 	// Kill test because of endless loop in the test for stable stack trace extraction
-	test_cmd.Process.Kill()
+	testCmd.Process.Kill()
 
 	require.NoError(t, err)
 }
@@ -5944,12 +5944,12 @@ spec:
 	syscall.Syscall(syscall.SYS_PRCTL, 8888, 0, 0)
 	syscall.Syscall(syscall.SYS_PRCTL, 9999, 0, 0)
 
-	kp_8888 := ec.NewProcessKprobeChecker("").
+	kp8888 := ec.NewProcessKprobeChecker("").
 		WithTags(ec.NewStringListMatcher().WithValues(sm.Full("prctl_8888")))
-	kp_9999 := ec.NewProcessKprobeChecker("").
+	kp9999 := ec.NewProcessKprobeChecker("").
 		WithTags(ec.NewStringListMatcher().WithValues(sm.Full("prctl_9999")))
 
-	checker := ec.NewUnorderedEventChecker(kp_8888, kp_9999)
+	checker := ec.NewUnorderedEventChecker(kp8888, kp9999)
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
@@ -6263,17 +6263,17 @@ func TestKprobeDentryPath(t *testing.T) {
 	// The we make sure we get proper expected path value in the event
 	// and that there's no event for dentry-unlink-2 file removal.
 
-	file_1, err := os.CreateTemp(t.TempDir(), "dentry-unlink-1")
+	file1, err := os.CreateTemp(t.TempDir(), "dentry-unlink-1")
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer require.NoError(t, file_1.Close())
+	defer require.NoError(t, file1.Close())
 
-	file_2, err := os.CreateTemp(t.TempDir(), "dentry-unlink-2")
+	file2, err := os.CreateTemp(t.TempDir(), "dentry-unlink-2")
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
-	defer require.NoError(t, file_2.Close())
+	defer require.NoError(t, file2.Close())
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
@@ -6286,12 +6286,12 @@ func TestKprobeDentryPath(t *testing.T) {
 	// We can extract dentry type until first mount point,
 	// so let's detect that and find final path portion for
 	// checking.
-	check_1 := file_1.Name()
-	check_2 := file_2.Name()
+	check1 := file1.Name()
+	check2 := file2.Name()
 	for _, info := range infos {
-		if len(info.MountPoint) > 1 && strings.HasPrefix(file_1.Name(), info.MountPoint) {
-			check_1 = check_1[len(info.MountPoint):]
-			check_2 = check_2[len(info.MountPoint):]
+		if len(info.MountPoint) > 1 && strings.HasPrefix(file1.Name(), info.MountPoint) {
+			check1 = check1[len(info.MountPoint):]
+			check2 = check2[len(info.MountPoint):]
 			break
 		}
 	}
@@ -6312,12 +6312,12 @@ spec:
       - index: 1
         operator: "Postfix"
         values:
-        - "` + check_1 + `"
+        - "` + check1 + `"
 `
 	createCrdFile(t, hook)
 
-	t.Logf("Removing file 1 %s, check %s\n", file_1.Name(), check_1)
-	t.Logf("Removing file 2 %s, check %s\n", file_2.Name(), check_2)
+	t.Logf("Removing file 1 %s, check %s\n", file1.Name(), check1)
+	t.Logf("Removing file 2 %s, check %s\n", file2.Name(), check2)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -6326,8 +6326,8 @@ spec:
 	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 	readyWG.Wait()
 
-	syscall.Unlink(file_1.Name())
-	syscall.Unlink(file_2.Name())
+	syscall.Unlink(file1.Name())
+	syscall.Unlink(file2.Name())
 
 	getChecker := func(check string) *ec.UnorderedEventChecker {
 		kpChecker := ec.NewProcessKprobeChecker("").
@@ -6346,11 +6346,11 @@ spec:
 	}
 
 	// We filter for file_1 (check_1) so we should get event for that
-	err = jsonchecker.JsonTestCheck(t, getChecker(check_1))
+	err = jsonchecker.JsonTestCheck(t, getChecker(check1))
 	require.NoError(t, err)
 
 	// ... but not for file_2 (check_2).
-	err = jsonchecker.JsonTestCheck(t, getChecker(check_2))
+	err = jsonchecker.JsonTestCheck(t, getChecker(check2))
 	require.Error(t, err)
 }
 

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -226,9 +226,9 @@ func TestGenericTracepointPidFilterLseek(t *testing.T) {
 }
 
 func TestGenericTracepointArgFilterLseek(t *testing.T) {
-	fd_u := int32(100)
+	fdU := int32(100)
 	fd := 100
-	whence_u := uint64(whenceBogusValue)
+	whenceU := uint64(whenceBogusValue)
 	whenceStr := strconv.Itoa(whenceBogusValue)
 	whence := whenceBogusValue
 
@@ -271,7 +271,7 @@ func TestGenericTracepointArgFilterLseek(t *testing.T) {
 			return fmt.Errorf("unexpected first arg: %s", event.Args[0])
 		}
 		xwhence := arg0.SizeArg
-		if xwhence != whence_u {
+		if xwhence != whenceU {
 			return fmt.Errorf("unexpected arg val. got:%d expecting:%d", xwhence, whence)
 		}
 		arg1, ok := event.Args[1].GetArg().(*tetragon.KprobeArgument_IntArg)
@@ -279,7 +279,7 @@ func TestGenericTracepointArgFilterLseek(t *testing.T) {
 			return fmt.Errorf("unexpected first arg: %s", event.Args[1])
 		}
 		xfd := arg1.IntArg
-		if xfd != fd_u {
+		if xfd != fdU {
 			return fmt.Errorf("unexpected arg val. got:%d expecting:%d", xfd, fd)
 		}
 		return nil

--- a/pkg/stacktracetree/stacktracetree.go
+++ b/pkg/stacktracetree/stacktracetree.go
@@ -131,8 +131,8 @@ func (n *SttNode) addChildren(nodes []*SttNode) {
 }
 
 func (n *SttNode) printNode(level int) {
-	indent_space := "    "
-	indent := strings.Repeat(indent_space, level)
+	indentSpace := "    "
+	indent := strings.Repeat(indentSpace, level)
 	fmt.Printf("%s0x%x (%s) count:%d\n", indent, n.Addr, n.Symbol, n.Count)
 
 	nchildren := len(n.Children)
@@ -142,8 +142,8 @@ func (n *SttNode) printNode(level int) {
 
 	// This is a leaf, so we also print label counters
 	if nchildren == 0 {
-		for lbl, lbl_count := range n.Labels {
-			fmt.Printf("%s%s%s count:%d\n", indent, indent_space, lbl, lbl_count)
+		for lbl, lblCount := range n.Labels {
+			fmt.Printf("%s%s%s count:%d\n", indent, indentSpace, lbl, lblCount)
 		}
 	}
 }

--- a/pkg/tracepoint/fieldtype.go
+++ b/pkg/tracepoint/fieldtype.go
@@ -187,8 +187,8 @@ func parseField(s string) (*Field, error) {
 			return nil, &ParseError{r: "could not parse array structure"}
 		}
 		substrings := strings.Split(name, "[")
-		size_s := strings.TrimSuffix(substrings[1], "]")
-		size, err = strconv.ParseUint(size_s, 10, 32)
+		sizeS := strings.TrimSuffix(substrings[1], "]")
+		size, err = strconv.ParseUint(sizeS, 10, 32)
 		if err != nil {
 			return nil, &ParseError{r: fmt.Sprintf("failed to parse size: %s", err)}
 		}

--- a/tests/e2e/tests/policyfilter/policyfilter_test.go
+++ b/tests/e2e/tests/policyfilter/policyfilter_test.go
@@ -245,7 +245,7 @@ func TestPodLabelFilters(t *testing.T) {
 		Assess("Wait for Checker", checker.Wait(30*time.Second)).
 		Assess("Start pods", func(ctx context.Context, _ *testing.T, c *envconf.Config) context.Context {
 			var err error
-			for _, pod := range []string{ubuntuPod_l1, ubuntuPod_l2} {
+			for _, pod := range []string{ubuntuPodL1, ubuntuPodL2} {
 				ctx, err = helpers.LoadCRDString(podlblNamespace, pod, true)(ctx, c)
 				if err != nil {
 					klog.ErrorS(err, "failed to load pod")
@@ -285,7 +285,7 @@ spec:
       type: "int64"
 `
 
-const ubuntuPod_l1 = `
+const ubuntuPodL1 = `
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -308,7 +308,7 @@ spec:
         args: ["-c", "while sleep 1; do cat /etc/hostname; done"]
 `
 
-const ubuntuPod_l2 = `
+const ubuntuPodL2 = `
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -458,7 +458,7 @@ spec:
       type: "int64"
 `
 
-const ubuntuPod_l3 = `
+const ubuntuPodL3 = `
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -530,7 +530,7 @@ func (cfc *containerFieldNameChecker) FinalCheck(_ *slog.Logger) error {
 
 func TestContainerFieldNameFilters(t *testing.T) {
 	checker := containerSelectorNameChecker().WithTimeLimit(30 * time.Second).WithEventLimit(20)
-	testContainerFieldFilters(t, checker, containerSelectorNamePolicy, "ubuntu-container-syscalls", ubuntuPod_l3)
+	testContainerFieldFilters(t, checker, containerSelectorNamePolicy, "ubuntu-container-syscalls", ubuntuPodL3)
 }
 
 const containerSelectorRepoPolicy = `
@@ -553,7 +553,7 @@ spec:
       type: "int64"
 `
 
-const ubuntuPod_l4 = `
+const ubuntuPodL4 = `
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -625,5 +625,5 @@ func (cfc *containerFieldRepoChecker) FinalCheck(_ *slog.Logger) error {
 
 func TestContainerFieldRepoFilters(t *testing.T) {
 	checker := containerSelectorRepoChecker().WithTimeLimit(30 * time.Second).WithEventLimit(20)
-	testContainerFieldFilters(t, checker, containerSelectorRepoPolicy, "debian-container-syscalls", ubuntuPod_l4)
+	testContainerFieldFilters(t, checker, containerSelectorRepoPolicy, "debian-container-syscalls", ubuntuPodL4)
 }

--- a/tools/protoc-gen-go-tetragon/common/common.go
+++ b/tools/protoc-gen-go-tetragon/common/common.go
@@ -306,11 +306,11 @@ func GetFields(files []*protogen.File) ([]*protogen.Message, error) {
 // getFieldsForMessage recursively looks up all the fields for a given message
 func getFieldsForMessage(msg *protogen.Message) []*protogen.Field {
 	seen := make(map[string]struct{})
-	return __getFieldsForMessage(msg, seen)
+	return getFieldsForMessageRec(msg, seen)
 }
 
-// __getFieldsForMessage is the underlying recusion logic of getFieldsForMessage
-func __getFieldsForMessage(msg *protogen.Message, seen map[string]struct{}) []*protogen.Field {
+// getFieldsForMessageRec is the underlying recusion logic of getFieldsForMessage
+func getFieldsForMessageRec(msg *protogen.Message, seen map[string]struct{}) []*protogen.Field {
 	var fields []*protogen.Field
 
 	for _, field := range msg.Fields {
@@ -323,7 +323,7 @@ func __getFieldsForMessage(msg *protogen.Message, seen map[string]struct{}) []*p
 		}
 		seen[fieldType] = struct{}{}
 		fields = append(fields, field)
-		fields = append(fields, __getFieldsForMessage(field.Message, seen)...)
+		fields = append(fields, getFieldsForMessageRec(field.Message, seen)...)
 	}
 
 	return fields


### PR DESCRIPTION
This a cherry-pick from the abandoned https://github.com/cilium/tetragon/pull/3850.

Let's not impose too much restriction on naming but not using underscore is a pretty big convention in Golang.

Fixes:
```
	cmd/tetra/stacktracetree/stacktracetree.go:49:3          staticcheck  ST1003: should not use underscores in Go names; var res_json should be resJSON
	cmd/tetra/stacktracetree/stacktracetree.go:61:2          staticcheck  ST1003: should not use underscores in Go names; var indent_space should be indentSpace
	cmd/tetragon/main_linux.go:32:25                         staticcheck  ST1003: should not use underscores in Go names; func parameter btf_string should be btfString
	pkg/api/processapi/processapi.go:93:2                    staticcheck  ST1003: should not use underscores in Go names; struct field Pad_v2 should be PadV2
	pkg/api/processapi/processapi.go:162:2                   staticcheck  ST1003: should not use underscores in Go names; struct field End_r should be EndR
	pkg/arch/arch.go:16:6                                    staticcheck  ST1003: should not use underscores in Go names; range var prefix_arch should be prefixArch
	pkg/cgroups/cgroups_test.go:111:2                        staticcheck  ST1003: should not use underscores in Go names; var invalid_cgroupv1_controllers should be invalidCgroupv1Controllers
	pkg/cgroups/cgroups_test.go:172:2                        staticcheck  ST1003: should not use underscores in Go names; var empty_controllers should be emptyControllers
	pkg/constants/constants_linux.go:30:2                    staticcheck  ST1003: should not use underscores in Go names; const AF_DECnet should be AFDECnet
	pkg/encoder/encoder.go:469:5                             staticcheck  ST1003: should not use underscores in Go names; var p_event should be pEvent
	pkg/filters/caps.go:71:6                                 staticcheck  ST1003: should not use underscores in Go names; func ensure_single_set_defined should be ensureSingleSetDefined
	pkg/grpc/process_manager_test_linux.go:19:6              staticcheck  ST1003: should not use underscores in Go names; func TestProcessManager_GetProcessID should be TestProcessManagerGetProcessID
	pkg/reader/caps/caps.go:26:2                             staticcheck  ST1003: should not use underscores in Go names; var cap_last_cap should be capLastCap
	pkg/reader/namespace/namespace_linux.go:97:2             staticcheck  ST1003: should not use underscores in Go names; var self_ns should be selfNs
	pkg/selectors/kernel.go:842:2                            staticcheck  ST1003: should not use underscores in Go names; var max_args should be maxArgs
	pkg/selectors/kernel.go:1065:2                           staticcheck  ST1003: should not use underscores in Go names; var max_nactions should be maxNactions
	pkg/selectors/kernel_test.go:634:2                       staticcheck  ST1003: should not use underscores in Go names; var expected_header should be expectedHeader
	pkg/selectors/kernel_test.go:641:2                       staticcheck  ST1003: should not use underscores in Go names; var expected_selsize_small should be expectedSelsizeSmall
	pkg/selectors/kernel_test.go:645:2                       staticcheck  ST1003: should not use underscores in Go names; var expected_selsize_large should be expectedSelsizeLarge
	pkg/selectors/kernel_test.go:649:2                       staticcheck  ST1003: should not use underscores in Go names; var expected_filters should be expectedFilters
	pkg/selectors/kernel_test.go:703:2                       staticcheck  ST1003: should not use underscores in Go names; var expected_changes_empty should be expectedChangesEmpty
	pkg/selectors/kernel_test.go:711:2                       staticcheck  ST1003: should not use underscores in Go names; var expected_changes should be expectedChanges
	pkg/selectors/kernel_test.go:729:2                       staticcheck  ST1003: should not use underscores in Go names; var expected_last_large should be expectedLastLarge
	pkg/selectors/kernel_test.go:776:2                       staticcheck  ST1003: should not use underscores in Go names; var expected_last_small should be expectedLastSmall
	pkg/sensors/base/base.go:123:3                           staticcheck  ST1003: should not use underscores in Go names; var has_acct_process should be hasAcctProcess
	pkg/sensors/base/base.go:124:3                           staticcheck  ST1003: should not use underscores in Go names; var has_disassociate_ctty should be hasDisassociateCtty
	pkg/sensors/exec/exec_linux.go:39:56                     staticcheck  ST1003: should not use underscores in Go names; func parameter exec_id should be execID
	pkg/sensors/exec/procevents/proc_reader.go:63:2          staticcheck  ST1003: should not use underscores in Go names; struct field uts_ns should be utsNs
	pkg/sensors/exec/procevents/proc_reader.go:64:2          staticcheck  ST1003: should not use underscores in Go names; struct field ipc_ns should be ipcNs
	pkg/sensors/exec/procevents/proc_reader.go:65:2          staticcheck  ST1003: should not use underscores in Go names; struct field mnt_ns should be mntNs
	pkg/sensors/exec/procevents/proc_reader.go:66:2          staticcheck  ST1003: should not use underscores in Go names; struct field pid_ns should be pidNs
	pkg/sensors/exec/procevents/proc_reader.go:67:2          staticcheck  ST1003: should not use underscores in Go names; struct field pid_for_children_ns should be pidForChildrenNs
	pkg/sensors/exec/procevents/proc_reader.go:68:2          staticcheck  ST1003: should not use underscores in Go names; struct field net_ns should be netNs
	pkg/sensors/exec/procevents/proc_reader.go:69:2          staticcheck  ST1003: should not use underscores in Go names; struct field time_ns should be timeNs
	pkg/sensors/exec/procevents/proc_reader.go:70:2          staticcheck  ST1003: should not use underscores in Go names; struct field time_for_children_ns should be timeForChildrenNs
	pkg/sensors/exec/procevents/proc_reader.go:71:2          staticcheck  ST1003: should not use underscores in Go names; struct field cgroup_ns should be cgroupNs
	pkg/sensors/exec/procevents/proc_reader.go:72:2          staticcheck  ST1003: should not use underscores in Go names; struct field user_ns should be userNs
	pkg/sensors/exec/procevents/proc_reader.go:73:2          staticcheck  ST1003: should not use underscores in Go names; struct field kernel_thread should be kernelThread
	pkg/sensors/exec/procevents/proc_reader.go:91:2          staticcheck  ST1003: should not use underscores in Go names; var raw_args should be rawArgs
	pkg/sensors/exec/procevents/proc_reader.go:92:2          staticcheck  ST1003: should not use underscores in Go names; var raw_pargs should be rawPargs
	pkg/sensors/exec/procevents/proc_reader_linux.go:257:3   staticcheck  ST1003: should not use underscores in Go names; var uts_ns should be utsNs
	pkg/sensors/exec/procevents/proc_reader_linux.go:261:3   staticcheck  ST1003: should not use underscores in Go names; var ipc_ns should be ipcNs
	pkg/sensors/exec/procevents/proc_reader_linux.go:265:3   staticcheck  ST1003: should not use underscores in Go names; var mnt_ns should be mntNs
	pkg/sensors/exec/procevents/proc_reader_linux.go:269:3   staticcheck  ST1003: should not use underscores in Go names; var pid_ns should be pidNs
	pkg/sensors/exec/procevents/proc_reader_linux.go:273:3   staticcheck  ST1003: should not use underscores in Go names; var pid_for_children_ns should be pidForChildrenNs
	pkg/sensors/exec/procevents/proc_reader_linux.go:278:3   staticcheck  ST1003: should not use underscores in Go names; var net_ns should be netNs
	pkg/sensors/exec/procevents/proc_reader_linux.go:282:3   staticcheck  ST1003: should not use underscores in Go names; var time_ns should be timeNs
	pkg/sensors/exec/procevents/proc_reader_linux.go:283:3   staticcheck  ST1003: should not use underscores in Go names; var time_for_children_ns should be timeForChildrenNs
	pkg/sensors/exec/procevents/proc_reader_linux.go:294:3   staticcheck  ST1003: should not use underscores in Go names; var cgroup_ns should be cgroupNs
	pkg/sensors/exec/procevents/proc_reader_linux.go:299:3   staticcheck  ST1003: should not use underscores in Go names; var user_ns should be userNs
	pkg/sensors/tracing/args_linux.go:604:13                 staticcheck  ST1003: should not use underscores in Go names; var bytes_rd should be bytesRd
	pkg/sensors/tracing/generickprobe.go:221:6               staticcheck  ST1003: should not use underscores in Go names; range var string_map_index should be stringMapIndex
	pkg/sensors/tracing/generickprobe.go:1145:2              staticcheck  ST1003: should not use underscores in Go names; var bin_buf should be binBuf
	pkg/sensors/tracing/genericlsm.go:584:6                  staticcheck  ST1003: should not use underscores in Go names; range var string_map_index should be stringMapIndex
	pkg/sensors/tracing/generictracepoint.go:598:7           staticcheck  ST1003: should not use underscores in Go names; range var string_map_index should be stringMapIndex
	pkg/sensors/tracing/kprobe_test.go:3065:6                staticcheck  ST1003: should not use underscores in Go names; func runKprobe_char_iovec should be runKprobeCharIovec
	pkg/sensors/tracing/kprobe_test.go:5284:2                staticcheck  ST1003: should not use underscores in Go names; var test_cmd should be testCmd
	pkg/sensors/tracing/kprobe_test.go:5945:2                staticcheck  ST1003: should not use underscores in Go names; var kp_8888 should be kp8888
	pkg/sensors/tracing/kprobe_test.go:5947:2                staticcheck  ST1003: should not use underscores in Go names; var kp_9999 should be kp9999
	pkg/sensors/tracing/kprobe_test.go:6264:2                staticcheck  ST1003: should not use underscores in Go names; var file_1 should be file1
	pkg/sensors/tracing/kprobe_test.go:6270:2                staticcheck  ST1003: should not use underscores in Go names; var file_2 should be file2
	pkg/sensors/tracing/kprobe_test.go:6287:2                staticcheck  ST1003: should not use underscores in Go names; var check_1 should be check1
	pkg/sensors/tracing/kprobe_test.go:6288:2                staticcheck  ST1003: should not use underscores in Go names; var check_2 should be check2
	pkg/sensors/tracing/tracepoint_test.go:229:2             staticcheck  ST1003: should not use underscores in Go names; var fd_u should be fdU
	pkg/sensors/tracing/tracepoint_test.go:231:2             staticcheck  ST1003: should not use underscores in Go names; var whence_u should be whenceU
	pkg/stacktracetree/stacktracetree.go:134:2               staticcheck  ST1003: should not use underscores in Go names; var indent_space should be indentSpace
	pkg/stacktracetree/stacktracetree.go:145:12              staticcheck  ST1003: should not use underscores in Go names; range var lbl_count should be lblCount
	pkg/tracepoint/fieldtype.go:190:3                        staticcheck  ST1003: should not use underscores in Go names; var size_s should be sizeS
	tests/e2e/tests/policyfilter/policyfilter_test.go:288:7  staticcheck  ST1003: should not use underscores in Go names; const ubuntuPod_l1 should be ubuntuPodL1
	tests/e2e/tests/policyfilter/policyfilter_test.go:311:7  staticcheck  ST1003: should not use underscores in Go names; const ubuntuPod_l2 should be ubuntuPodL2
	tests/e2e/tests/policyfilter/policyfilter_test.go:461:7  staticcheck  ST1003: should not use underscores in Go names; const ubuntuPod_l3 should be ubuntuPodL3
	tests/e2e/tests/policyfilter/policyfilter_test.go:556:7  staticcheck  ST1003: should not use underscores in Go names; const ubuntuPod_l4 should be ubuntuPodL4
	tools/protoc-gen-go-tetragon/common/common.go:313:6      staticcheck  ST1003: should not use underscores in Go names; func __getFieldsForMessage should be _GetFieldsForMessage
	73 issues:
	* staticcheck: 73
```

