### PR TITLE
deps: remove direct gopkg.in/yaml.v2 dep

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,14 @@ linters:
             recommendations:
             - sync/atomic
             reason: Go 1.19+ supports atomic types, see https://go.dev/doc/go1.19#atomic_types
+        - gopkg.in/yaml.v2:
+            recommendations:
+            - "sigs.k8s.io/yaml"
+            reason: This project is unmaintained.
+        - gopkg.in/yaml.v3:
+            recommendations:
+            - "sigs.k8s.io/yaml"
+            reason: This project is unmaintained.
   exclusions:
     generated: lax
     presets:

--- a/cmd/tetragon/conf_test.go
+++ b/cmd/tetragon/conf_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 type confInput struct {

--- a/go.mod
+++ b/go.mod
@@ -45,8 +45,6 @@ require (
 	golang.org/x/time v0.12.0
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.6
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.3
 	k8s.io/apiextensions-apiserver v0.33.3
 	k8s.io/apimachinery v0.33.3
@@ -150,6 +148,8 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.33.3 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect


### PR DESCRIPTION
The project is unmaintained, and we regularly use the k8s package elsewhere, let's use it everywhere.

This will auto-close https://github.com/cilium/tetragon/pull/3436.
