### PR TITLE
Pr/t0x01/usdt ancestors

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -119,7 +119,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.pprof.address | string | `"localhost"` | The address at which to expose pprof. |
 | tetragon.pprof.enabled | bool | `false` | Whether to enable exposing pprof server. |
 | tetragon.pprof.port | int | `6060` | The port at which to expose pprof. |
-| tetragon.processAncestors.enabled | string | `""` | Comma-separated list of process event types to enable ancestors for. Supported event types are: base, kprobe, tracepoint, uprobe, lsm. Unknown event types will be ignored. Type "base" is required by all other supported event types for correct reference counting. Set it to "" to disable ancestors completely. |
+| tetragon.processAncestors.enabled | string | `""` | Comma-separated list of process event types to enable ancestors for. Supported event types are: base, kprobe, tracepoint, uprobe, lsm, usdt. Unknown event types will be ignored. Type "base" is required by all other supported event types for correct reference counting. Set it to "" to disable ancestors completely. |
 | tetragon.processCacheGCInterval | string | `"30s"` | Configure the interval (suffixed with s for seconds, m for minutes, etc) for the process cache garbage collector. |
 | tetragon.processCacheSize | int | `65536` | Tetragon puts processes in an LRU cache. The cache is used to find ancestors for subsequently exec'ed processes. |
 | tetragon.prometheus.address | string | `""` | The address at which to expose metrics. Set it to "" to expose on all available interfaces. |

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -35,7 +35,7 @@ options:
     - name: enable-ancestors
       default_value: '[]'
       usage: |
-        Comma-separated list of process event types to enable ancestors for. Supported event types are: base, kprobe, tracepoint, uprobe, lsm. Unknown event types will be ignored. Type 'base' enables ancestors for process_exec and process_exit events and is required by all other supported event types for correct reference counting. An empty string disables ancestors completely
+        Comma-separated list of process event types to enable ancestors for. Supported event types are: base, kprobe, tracepoint, uprobe, lsm, usdt. Unknown event types will be ignored. Type 'base' enables ancestors for process_exec and process_exit events and is required by all other supported event types for correct reference counting. An empty string disables ancestors completely
     - name: enable-cgidmap
       default_value: "false"
       usage: enable pod resolution via cgroup ids

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -101,7 +101,7 @@ Helm chart for Tetragon
 | tetragon.pprof.address | string | `"localhost"` | The address at which to expose pprof. |
 | tetragon.pprof.enabled | bool | `false` | Whether to enable exposing pprof server. |
 | tetragon.pprof.port | int | `6060` | The port at which to expose pprof. |
-| tetragon.processAncestors.enabled | string | `""` | Comma-separated list of process event types to enable ancestors for. Supported event types are: base, kprobe, tracepoint, uprobe, lsm. Unknown event types will be ignored. Type "base" is required by all other supported event types for correct reference counting. Set it to "" to disable ancestors completely. |
+| tetragon.processAncestors.enabled | string | `""` | Comma-separated list of process event types to enable ancestors for. Supported event types are: base, kprobe, tracepoint, uprobe, lsm, usdt. Unknown event types will be ignored. Type "base" is required by all other supported event types for correct reference counting. Set it to "" to disable ancestors completely. |
 | tetragon.processCacheGCInterval | string | `"30s"` | Configure the interval (suffixed with s for seconds, m for minutes, etc) for the process cache garbage collector. |
 | tetragon.processCacheSize | int | `65536` | Tetragon puts processes in an LRU cache. The cache is used to find ancestors for subsequently exec'ed processes. |
 | tetragon.prometheus.address | string | `""` | The address at which to expose metrics. Set it to "" to expose on all available interfaces. |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -151,7 +151,7 @@ tetragon:
   enableProcessNs: false
   processAncestors:
     # -- Comma-separated list of process event types to enable ancestors for.
-    # Supported event types are: base, kprobe, tracepoint, uprobe, lsm. Unknown event types will be ignored.
+    # Supported event types are: base, kprobe, tracepoint, uprobe, lsm, usdt. Unknown event types will be ignored.
     # Type "base" is required by all other supported event types for correct reference counting.
     # Set it to "" to disable ancestors completely.
     enabled: ""

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -220,6 +220,7 @@ func CheckAncestorsEnabled(types []tetragon.EventType) error {
 			tetragon.EventType_PROCESS_TRACEPOINT,
 			tetragon.EventType_PROCESS_UPROBE,
 			tetragon.EventType_PROCESS_LSM,
+			tetragon.EventType_PROCESS_USDT,
 		}
 	}
 

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -928,8 +928,8 @@ func GetProcessUsdt(event *MsgGenericUsdtUnix) *tetragon.ProcessUsdt {
 
 	proc, parent, tetragonProcess, tetragonParent := getProcessParent(&event.Msg.ProcessKey, event.Msg.Common.Flags)
 
-	// Set the ancestors only if --enable-process-uprobe-ancestors flag is set.
-	if option.Config.EnableProcessUprobeAncestors && proc.NeededAncestors() {
+	// Set the ancestors only if --enable-ancestors flag includes 'usdt'.
+	if option.Config.EnableProcessUsdtAncestors && proc.NeededAncestors() {
 		ancestors, _ = process.GetAncestorProcessesInternal(tetragonProcess.ParentExecId)
 		for _, ancestor := range ancestors {
 			tetragonAncestors = append(tetragonAncestors, ancestor.UnsafeGetProcess())
@@ -961,7 +961,7 @@ func GetProcessUsdt(event *MsgGenericUsdtUnix) *tetragon.ProcessUsdt {
 	if ec := eventcache.Get(); ec != nil && !isUnknown(tetragonProcess) &&
 		(ec.Needed(tetragonProcess) ||
 			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent)) ||
-			(option.Config.EnableProcessUprobeAncestors && ec.NeededAncestors(parent, ancestors))) {
+			(option.Config.EnableProcessUsdtAncestors && ec.NeededAncestors(parent, ancestors))) {
 		ec.Add(nil, tetragonEvent, event.Msg.Common.Ktime, event.Msg.ProcessKey.Ktime, event)
 		return nil
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -36,6 +36,7 @@ type config struct {
 	EnableProcessTracepointAncestors bool
 	EnableProcessUprobeAncestors     bool
 	EnableProcessLsmAncestors        bool
+	EnableProcessUsdtAncestors       bool
 
 	EnableProcessNs   bool
 	EnableProcessCred bool
@@ -167,6 +168,8 @@ func AncestorsEnabled(eventType tetragon.EventType) bool {
 		return Config.EnableProcessUprobeAncestors
 	case tetragon.EventType_PROCESS_LSM:
 		return Config.EnableProcessLsmAncestors
+	case tetragon.EventType_PROCESS_USDT:
+		return Config.EnableProcessUsdtAncestors
 	default:
 		return false
 	}

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -187,6 +187,7 @@ func ReadAndSetFlags() error {
 		Config.EnableProcessTracepointAncestors = slices.Contains(enableAncestors, "tracepoint")
 		Config.EnableProcessUprobeAncestors = slices.Contains(enableAncestors, "uprobe")
 		Config.EnableProcessLsmAncestors = slices.Contains(enableAncestors, "lsm")
+		Config.EnableProcessUsdtAncestors = slices.Contains(enableAncestors, "usdt")
 	}
 
 	Config.GopsAddr = viper.GetString(KeyGopsAddr)
@@ -377,7 +378,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Bool(KeyEnableProcessNs, false, "Enable namespace information in process_exec and process_kprobe events")
 	flags.Uint(KeyEventQueueSize, 10000, "Set the size of the internal event queue.")
 	flags.Bool(KeyEnablePodAnnotations, false, "Add pod annotations field to events.")
-	flags.StringSlice(KeyEnableAncestors, []string{}, "Comma-separated list of process event types to enable ancestors for. Supported event types are: base, kprobe, tracepoint, uprobe, lsm. Unknown event types will be ignored. Type 'base' enables ancestors for process_exec and process_exit events and is required by all other supported event types for correct reference counting. An empty string disables ancestors completely")
+	flags.StringSlice(KeyEnableAncestors, []string{}, "Comma-separated list of process event types to enable ancestors for. Supported event types are: base, kprobe, tracepoint, uprobe, lsm, usdt. Unknown event types will be ignored. Type 'base' enables ancestors for process_exec and process_exit events and is required by all other supported event types for correct reference counting. An empty string disables ancestors completely")
 
 	// Tracing policy file
 	flags.String(KeyTracingPolicy, "", "Tracing policy file to load at startup")


### PR DESCRIPTION
A small configuration change for full ancestors support in USDT events. A follow-up to a PR 3943 [comment](https://github.com/cilium/tetragon/pull/3943#issuecomment-3155628730).
