### PR TITLE
add default setting to enable-ancestors(install/kubernetes/tetragon/t…

### DIFF
--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -14,7 +14,7 @@ data:
   debug: {{ .Values.tetragon.debug | quote }}
   enable-process-cred: {{ .Values.tetragon.enableProcessCred | quote }}
   enable-process-ns: {{ .Values.tetragon.enableProcessNs | quote }}
-  enable-ancestors: {{ .Values.tetragon.processAncestors.enabled }}
+  enable-ancestors: {{ .Values.tetragon.processAncestors.enabled | quote }}
   process-cache-size: {{ .Values.tetragon.processCacheSize | quote }}
 {{- if .Values.tetragon.exportFilename }}
   export-filename: {{ .Values.exportDirectory}}/{{ .Values.tetragon.exportFilename }}


### PR DESCRIPTION
…emplates/tetragon_configmap.yaml)

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->


### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
In this directory `install/kubernetes/tetragon/templates/tetragon_configmap.yaml`, `enable-ancestors` hasn't default value. so I add quote as default.

