### PR TITLE
fix: reject NotifyEnforcer kprobe action without an Enforcer

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1497,6 +1497,18 @@ func HasFilter(selectors []v1alpha1.KProbeSelector, index uint32) bool {
 	return false
 }
 
+// HasNotifyEnforcerAction returns true if any selector in the KProbeSpec has a NotifyEnforcer action
+func HasNotifyEnforcerAction(kspec *v1alpha1.KProbeSpec) bool {
+	for _, s := range kspec.Selectors {
+		for _, action := range s.MatchActions {
+			if action.Action == "NotifyEnforcer" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // parseCapabilitiesMask create a capabilities mask
 func parseCapabilitiesMask(s string) (uint64, error) {
 	base := getBase(s)

--- a/pkg/sensors/tracing/policyhandler_linux.go
+++ b/pkg/sensors/tracing/policyhandler_linux.go
@@ -126,7 +126,7 @@ func (h policyHandler) PolicyHandler(
 			"policy", tracingpolicy.TpLongname(policy),
 			"sensor", name,
 		)
-		validateInfo, err := preValidateKprobes(log, spec.KProbes, spec.Lists)
+		validateInfo, err := preValidateKprobes(log, spec.KProbes, spec.Lists, spec.Enforcers)
 		if err != nil {
 			return nil, fmt.Errorf("validation failed: %w", err)
 		}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes #4007 

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
```

### Testing
This policy fails to load (it's missing `enforcers`):
```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "linux-ssh-key-config-deletion-detection"
  annotations:
    author: "Isovalent now part of Cisco"
spec:
  kprobes:
  - call: "security_path_unlink"
    syscall: false
    return: false
    tags: [ "attack.T1070.004", "attack.T1485", "attack.defense_evasion", "attack.impact" ]
    args:
    - index: 0
      type: "path"
    selectors:
    # System SSH keys/config files
    - matchArgs:
      - index: 0
        operator: "Prefix"
        values:
        - "/etc/ssh/ssh_host_"
        - "/etc/ssh/sshd_config"
        - "/etc/ssh/ssh_config"
      matchBinaries:
        - operator: "NotIn"
          values: ["/usr/bin/ssh-keygen", "/usr/sbin/sshd", "/usr/bin/dpkg"]
      matchActions:
      - action: NotifyEnforcer
 ```
 
Failure to load due to missing `enforcers`:
```
level=error msg="Failed to execute tetragon" error="policy handler 'tracing' failed loading policy 'linux-ssh-key-config-deletion-detection': NotifyEnforcer action specified, but spec contains no enforcers"
```

The same policy loads after adding a `enforcers`:
```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "linux-ssh-key-config-deletion-detection"
  annotations:
    author: "Isovalent now part of Cisco"
spec:
  enforcers:
    - calls:
      - security_path_unlink
  kprobes:
  - call: "security_path_unlink"
    syscall: false
    return: false
    tags: [ "attack.T1070.004", "attack.T1485", "attack.defense_evasion", "attack.impact" ]
    args:
    - index: 0
      type: "path"
    selectors:
    # System SSH keys/config files
    - matchArgs:
      - index: 0
        operator: "Prefix"
        values:
        - "/etc/ssh/ssh_host_"
        - "/etc/ssh/sshd_config"
        - "/etc/ssh/ssh_config"
      matchBinaries:
        - operator: "NotIn"
          values: ["/usr/bin/ssh-keygen", "/usr/sbin/sshd", "/usr/bin/dpkg"]
      matchActions:
      - action: NotifyEnforcer
```

Loaded successfully:

```
dave@cartman:~/src/github.com/cilium/tetragon$ sudo ./tetra tp list
ID   NAME                                      STATE     FILTERID   NAMESPACE   SENSORS                       KERNELMEMORY   MODE
1    linux-ssh-key-config-deletion-detection   enabled   0          (global)    __enforcer__,generic_kprobe   3.91 MB        enforce
```