### PR TITLE
k8s: Enable k8s control plane for non-k8s deployment

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -401,7 +401,7 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 	// waiting for metadata.
 	var controllerManager *manager.ControllerManager
 	var podAccessor watcher.PodAccessor
-	if option.Config.EnableK8s {
+	if option.K8SControlPlaneEnabled() {
 		log.Info("Enabling Kubernetes API")
 		// Start controller-runtime manager.
 		controllerManager = manager.Get()
@@ -502,7 +502,7 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 	// Initialize a k8s watcher used to manage policies. This should happen
 	// after the sensors are loaded, otherwise existing policies will fail to
 	// load on the first attempt.
-	if option.Config.EnableK8s && option.Config.EnableTracingPolicyCRD {
+	if option.K8SControlPlaneEnabled() && option.Config.EnableTracingPolicyCRD {
 		// add informers for all resources
 		log.Info("Enabling policy informers")
 		err := crdwatcher.AddTracingPolicyInformer(ctx, controllerManager, observer.GetSensorManager())

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -23,6 +23,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/watcher/conf"
+
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/podhooks"
@@ -77,7 +79,12 @@ func newControllerManager() (*ControllerManager, error) {
 	}
 	metricsOptions := metricsserver.Options{BindAddress: "0"}
 	controllerOptions := ctrl.Options{Scheme: scheme, Cache: cacheOptions, Metrics: metricsOptions}
-	controllerManager, err := ctrl.NewManager(ctrl.GetConfigOrDie(), controllerOptions)
+	cfg, err := conf.K8sConfig()
+	if err != nil {
+		logger.GetLogger().Warn("Unable to get Kubernetes config, using default controller-runtime config", logfields.Error, err)
+		cfg = ctrl.GetConfigOrDie()
+	}
+	controllerManager, err := ctrl.NewManager(cfg, controllerOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -257,3 +257,10 @@ func ReadConfigDir(path string) error {
 
 	return nil
 }
+
+func K8SControlPlaneEnabled() bool {
+	// If K8s is enabled, we assume that the control plane is enabled.
+	// This is because the control plane is required to get the kubeconfig
+	// and other K8s related information.
+	return Config.EnableK8s || len(Config.K8sKubeConfigPath) > 0
+}

--- a/pkg/watcher/crdwatcher/tracingpolicy.go
+++ b/pkg/watcher/crdwatcher/tracingpolicy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger/logfields"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/manager"
 	"github.com/cilium/tetragon/pkg/sensors"


### PR DESCRIPTION
### Description
This commit is to enable non-k8s tetragon deployment to have k8s control plane i.e. tracing policy can be synced to the tetragon agent. A valid k8s config is required.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
k8s: Enable k8s control plane for non-k8s deployment
```

----
### Testing

Testing was done locally by just running one kind cluster with tetragon installed, and then apply one TracingPolicy. 

```
$ sudo ./tetragon --bpf-lib bpf/objs --k8s-kubeconfig-path /home/tammach/.kube/config
level=info msg="Starting tetragon" version=v1.6.0-pre.0-67-g154c87ce7
level=info msg="Tetragon current security context" SELinux=unconfined AppArmor=unconfined Smack="" Lockdown=none
level=info msg="Tetragon pid file creation succeeded" pid=3668931 pidfile=/var/run/tetragon/tetragon.pid
level=info msg="BPF: successfully released pinned BPF programs and maps" bpf-dir=/sys/fs/bpf/tetragon
level=info msg="BTF discovery: default kernel btf file found" btf-file=/sys/kernel/btf/vmlinux
level=info msg="BPF detected features: override_return: true, buildid: true, kprobe_multi: true, uprobe_multi true, fmodret: true, fmodret_syscall: true, signal: true, large: true, link_pin: true, lsm: false, missed_stats_kprobe_multi: true, missed_stats_kprobe: true, batch_update: true, uprobe_refctroff: false"
level=info msg="Cgroup mode detection succeeded" cgroup.fs=/sys/fs/cgroup cgroup.mode="Unified mode (Cgroupv2)"
level=info msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/proc/1/root/sys/fs/cgroup cgroup.controllers="[cpuset cpu io memory hugetlb pids rdma misc]" cgroup.hierarchyID=0
level=info msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/sys/fs/cgroup/user.slice/user-1000.slice/session-24.scope cgroup.controllers="[memory pids]" cgroup.hierarchyID=0
level=info msg="Cgroupv2 hierarchy validated successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/sys/fs/cgroup/user.slice/user-1000.slice/session-24.scope
level=info msg="Deployment mode detection succeeded" cgroup.fs=/sys/fs/cgroup deployment.mode="systemd user session"
level=info msg="Updated TetragonConf map successfully" confmap-update=tg_conf_map deployment.mode="systemd user session" log.level=0 cgroup.fs.magic=Cgroupv2 cgroup.hierarchyID=0 NSPID=3668931
level=info msg="Enabling Kubernetes API"
level=info msg="registering policyfilter pod handlers"
level=info msg="Waiting for required CRDs" crds="map[tracingpolicies.cilium.io:{} tracingpoliciesnamespaced.cilium.io:{}]"
level=info msg="Found CRD" crd=tracingpolicies.cilium.io
level=info msg="Found CRD" crd=tracingpoliciesnamespaced.cilium.io
level=info msg="Found all the required CRDs"
level=warn msg="Failed to get local Kubernetes node info. node_labels field will be empty" error="Node \"tower\" not found"
level=info msg="Configured redaction filters" redactionFilters=""
...

# In another terminal to check if the existing policies are sync to non-k8s tetragon
$ ./tetra tracingpolicy list                            
ID   NAME   STATE     FILTERID   NAMESPACE   SENSORS          KERNELMEMORY   MODE
1    bpf    enabled   0          (global)    generic_kprobe   7.76 MB        enforce 
```