### PR TITLE
helm: Quote tetragon.processAncestors.enabled

### DIFF
--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -14,7 +14,7 @@ data:
   debug: {{ .Values.tetragon.debug | quote }}
   enable-process-cred: {{ .Values.tetragon.enableProcessCred | quote }}
   enable-process-ns: {{ .Values.tetragon.enableProcessNs | quote }}
-  enable-ancestors: {{ .Values.tetragon.processAncestors.enabled }}
+  enable-ancestors: {{ .Values.tetragon.processAncestors.enabled | quote }}
   process-cache-size: {{ .Values.tetragon.processCacheSize | quote }}
 {{- if .Values.tetragon.exportFilename }}
   export-filename: {{ .Values.exportDirectory}}/{{ .Values.tetragon.exportFilename }}


### PR DESCRIPTION
Kubernetes removes configmap entries if the value is null. Some GitOps systems (ArgoCD in my case) consider the configmap out of sync because the desired manifest contains:

    enable-ancestors:

but the realized configmap doesn't contain this entry. Quote the Helm value tetragon.processAncestors.enabled so that the entry gets rendered as:

    enable-ancestors: ""

instead so that Kubernetes does not remove the entry from the configmap.