### PR TITLE
renovate: Allow go 1.24 for v1.3 branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -307,18 +307,6 @@
       ]
     },
     {
-      // update go patch for 1.23 for stable branches
-      "enabled": true,
-      "matchPackageNames": [
-        "go",
-        "docker.io/library/golang"
-      ],
-      "allowedVersions": "/^1\\.23\\.[0-9]+-?(alpine)?$/",
-      "matchBaseBranches": [
-        "v1.3",
-      ]
-    },
-    {
       // update go patch for 1.24 for stable branches
       "enabled": true,
       "matchPackageNames": [
@@ -327,6 +315,7 @@
       ],
       "allowedVersions": "/^1\\.24\\.[0-9]+-?(alpine)?$/",
       "matchBaseBranches": [
+        "v1.3",
         "v1.4",
         "v1.5",
       ]


### PR DESCRIPTION
### Description

Go 1.23 is EOL after go 1.25 is released.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
renovate: Allow go 1.24 for v1.3 branch
```
