### PR TITLE
Helm chart: add support for export.stdout.envFromSecrets to inject environment variables from Kubernetes secrets

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -32,7 +32,10 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | daemonSetLabelsOverride | object | `{}` |  |
 | dnsPolicy | string | `"Default"` | DNS policy for Tetragon pods.  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | enabled | bool | `true` |  |
-| export | object | `{"filenames":["tetragon.log"],"mode":"stdout","resources":{},"securityContext":{},"stdout":{"argsOverride":[],"commandOverride":[],"enabledArgs":true,"enabledCommand":true,"extraEnv":[],"extraVolumeMounts":[],"image":{"override":null,"repository":"quay.io/cilium/hubble-export-stdout","tag":"v1.1.0"}}}` | Tetragon events export settings |
+| export | object | `{"filenames":["tetragon.log"],"mode":"stdout","resources":{},"securityContext":{},"stdout":{"argsOverride":[],"commandOverride":[],"enabledArgs":true,"enabledCommand":true,"envFromSecrets":[],"extraEnv":[],"extraEnvFrom":[],"extraVolumeMounts":[],"image":{"override":null,"repository":"quay.io/cilium/hubble-export-stdout","tag":"v1.1.0"}}}` | Tetragon events export settings |
+| export.stdout.envFromSecrets | list | `[]` | A simplified way to add secret references to envFrom. Can be specified either as a string (just the secret name) or as an object with additional parameters. Example: envFromSecrets:   - my-simple-secret   - name: my-optional-secret     optional: true |
+| export.stdout.extraEnv | list | `[]` | Extra environment variables to add to the export-stdout container. Example: extraEnv:   - name: FOO     value: bar   - name: SECRET_KEY     valueFrom:       secretKeyRef:         name: my-secret         key: secret-key |
+| export.stdout.extraEnvFrom | list | `[]` | Extra envFrom sources to add to the export-stdout container. This allows adding any type of envFrom source (configMapRef, secretRef, etc.). Example: extraEnvFrom:   - configMapRef:       name: my-config-map   - secretRef:       name: my-secret       optional: true |
 | exportDirectory | string | `"/var/run/cilium/tetragon"` | Directory to put Tetragon JSON export files. |
 | extraConfigmapMounts | list | `[]` |  |
 | extraHostPathMounts | list | `[]` |  |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -14,7 +14,10 @@ Helm chart for Tetragon
 | daemonSetLabelsOverride | object | `{}` |  |
 | dnsPolicy | string | `"Default"` | DNS policy for Tetragon pods.  https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | enabled | bool | `true` |  |
-| export | object | `{"filenames":["tetragon.log"],"mode":"stdout","resources":{},"securityContext":{},"stdout":{"argsOverride":[],"commandOverride":[],"enabledArgs":true,"enabledCommand":true,"extraEnv":[],"extraVolumeMounts":[],"image":{"override":null,"repository":"quay.io/cilium/hubble-export-stdout","tag":"v1.1.0"}}}` | Tetragon events export settings |
+| export | object | `{"filenames":["tetragon.log"],"mode":"stdout","resources":{},"securityContext":{},"stdout":{"argsOverride":[],"commandOverride":[],"enabledArgs":true,"enabledCommand":true,"envFromSecrets":[],"extraEnv":[],"extraEnvFrom":[],"extraVolumeMounts":[],"image":{"override":null,"repository":"quay.io/cilium/hubble-export-stdout","tag":"v1.1.0"}}}` | Tetragon events export settings |
+| export.stdout.envFromSecrets | list | `[]` | A simplified way to add secret references to envFrom. Can be specified either as a string (just the secret name) or as an object with additional parameters. Example: envFromSecrets:   - my-simple-secret   - name: my-optional-secret     optional: true |
+| export.stdout.extraEnv | list | `[]` | Extra environment variables to add to the export-stdout container. Example: extraEnv:   - name: FOO     value: bar   - name: SECRET_KEY     valueFrom:       secretKeyRef:         name: my-secret         key: secret-key |
+| export.stdout.extraEnvFrom | list | `[]` | Extra envFrom sources to add to the export-stdout container. This allows adding any type of envFrom source (configMapRef, secretRef, etc.). Example: extraEnvFrom:   - configMapRef:       name: my-config-map   - secretRef:       name: my-secret       optional: true |
 | exportDirectory | string | `"/var/run/cilium/tetragon"` | Directory to put Tetragon JSON export files. |
 | extraConfigmapMounts | list | `[]` |  |
 | extraHostPathMounts | list | `[]` |  |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -356,10 +356,37 @@ export:
     - tetragon.log
   # stdout specific exporter settings
   stdout:
-    extraEnv: []
+    # -- Extra environment variables to add to the export-stdout container.
+    # Example:
     # extraEnv:
-    #   - name: foo
+    #   - name: FOO
     #     value: bar
+    #   - name: SECRET_KEY
+    #     valueFrom:
+    #       secretKeyRef:
+    #         name: my-secret
+    #         key: secret-key
+    extraEnv: []
+    
+    # -- Extra envFrom sources to add to the export-stdout container.
+    # This allows adding any type of envFrom source (configMapRef, secretRef, etc.).
+    # Example:
+    # extraEnvFrom:
+    #   - configMapRef:
+    #       name: my-config-map
+    #   - secretRef:
+    #       name: my-secret
+    #       optional: true
+    extraEnvFrom: []
+    
+    # -- A simplified way to add secret references to envFrom.
+    # Can be specified either as a string (just the secret name) or as an object with additional parameters.
+    # Example:
+    # envFromSecrets:
+    #   - my-simple-secret
+    #   - name: my-optional-secret
+    #     optional: true
+    envFromSecrets: []
 
     # * When enabledCommand=true and commandOverride is not set, the command inserted will be hubble-export-stdout.
     #   This supports the default for the current deployment instructions to deploy stdout-export sidecar container.


### PR DESCRIPTION
This PR extends the Helm chart for Tetragon by adding support for envFromSecrets in the export.stdout template. This allows injecting environment variables from Kubernetes secrets using the envFrom field.

The implementation checks for the presence of .Values.export.stdout.envFromSecrets, and if present, renders the corresponding envFrom entries as secretRef definitions. This is useful when multiple environment variables need to be sourced from secrets without specifying each variable explicitly.

This change is backward-compatible and does not affect existing configurations that do not use envFromSecrets.