### PR TITLE
renovate: sync helm chart version/appVersion update with image tag

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -251,6 +251,7 @@
       "matchFileNames": [
         "install/kubernetes/tetragon/values.yaml",
         "install/kubernetes/Makefile",
+        "install/kubernetes/tetragon/Chart.yaml"
       ],
       // Generate files for the Helm chart
       "postUpgradeTasks": {
@@ -548,6 +549,14 @@
       ],
       "matchStrings": [
         "\\/\\/ renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+CiliumVersion:\\s*\"(?<currentValue>.*?)\""
+      ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)Chart\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s*\\nversion:\\s*(?<currentValue>.*)",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s*\\nappVersion:\\s*(?<currentValue>.*)"
       ]
     },
   ]

--- a/install/kubernetes/tetragon/Chart.yaml
+++ b/install/kubernetes/tetragon/Chart.yaml
@@ -2,9 +2,11 @@ apiVersion: v2
 name: tetragon
 description: Helm chart for Tetragon
 type: application
+# renovate: datasource=docker depName=quay.io/cilium/tetragon
 version: 1.5.0
 icon: https://tetragon.io/images/tetragon-shield.png
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
+# renovate: datasource=docker depName=quay.io/cilium/tetragon
 appVersion: 1.5.0


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [  ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [. ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes #3941 

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
This PR ensures that the `version` and` appVersion` fields in Chart.yaml are kept in sync with the image tag from [quay.io/cilium/tetragon](https://quay.io/repository/cilium/tetragon?tab=tags&tag=latest).
A custom regex manager has been added in renovate.json, along with Renovate comments in Chart.yaml. These updates are grouped with changes to values.yaml, ensuring that all related Helm chart updates are applied together in a single Renovate PR.






