### PR TITLE
helm: Add 'containers.extra' helper function

### DIFF
--- a/install/kubernetes/tetragon/templates/_extensions.tpl
+++ b/install/kubernetes/tetragon/templates/_extensions.tpl
@@ -6,6 +6,8 @@
 
 {{- define "initcontainers.extra" -}}{{- end }}
 
+{{- define "containers.extra" -}}{{- end }}
+
 {{- define "clusterrole.extra" -}}{{- end }}
 
 {{- define "operatorconfigmap.extra" -}}{{- end }}

--- a/install/kubernetes/tetragon/templates/daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
 {{- if .Values.tetragon.enabled }}
       {{- include "container.tetragon" . | nindent 6 -}}
 {{- end }}
+      {{- include "containers.extra" . | nindent 6 -}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Similar to initcontainers.extra function, containers.extra allows you to add extra containers to Tetragon daemonset.