### PR TITLE
fix: detectUprobeRefCtrOffsetOnce init logic

### DIFF
--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -498,7 +498,7 @@ func detectUprobeRefCtrOffset() bool {
 }
 
 func detectUprobeRefCtrOffsetOnce() {
-	batchUpdate.init.Do(func() {
+	uprobeRefCtrOffset.init.Do(func() {
 		uprobeRefCtrOffset.detected = detectUprobeRefCtrOffset()
 	})
 }


### PR DESCRIPTION
Fix the issue where the detectUprobeRefCtrOffsetOnce function never executes its initialization logic due to incorrectly using an initialization variable from batchUpdate.