### PR TITLE
tetragon: Add fentry sensor

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -44,7 +44,8 @@ PROCESS += bpf_execve_event_v310.o bpf_exit_v310.o bpf_fork_v310.o
 PROCESS += bpf_execve_event.o bpf_fork.o bpf_exit.o bpf_execve_bprm_commit_creds.o
 # generic probes
 PROCESS += bpf_generic_kprobe.o bpf_generic_retkprobe.o bpf_generic_tracepoint.o \
-	   bpf_generic_uprobe.o bpf_generic_retuprobe.o bpf_generic_rawtp.o bpf_generic_usdt.o
+	   bpf_generic_uprobe.o bpf_generic_retuprobe.o bpf_generic_rawtp.o bpf_generic_usdt.o \
+	   bpf_generic_fentry.o
 
 # lsm
 PROCESS += bpf_generic_lsm_core.o bpf_generic_lsm_output.o
@@ -58,7 +59,8 @@ PROCESS += bpf_generic_kprobe_v53.o bpf_generic_retkprobe_v53.o \
 	   bpf_generic_tracepoint_v53.o \
 	   bpf_generic_uprobe_v53.o bpf_generic_retuprobe_v53.o \
 	   bpf_generic_rawtp_v53.o \
-	   bpf_generic_usdt_v53.o
+	   bpf_generic_usdt_v53.o \
+	   bpf_generic_fentry_v53.o
 
 # v5.11
 # base sensor
@@ -73,7 +75,8 @@ PROCESS += bpf_generic_kprobe_v511.o bpf_generic_retkprobe_v511.o \
 	   bpf_multi_uprobe_v511.o bpf_multi_retuprobe_v511.o \
 	   bpf_generic_rawtp_v511.o \
 	   bpf_generic_usdt_v511.o \
-	   bpf_multi_usdt_v511.o
+	   bpf_multi_usdt_v511.o \
+	   bpf_generic_fentry_v511.o
 
 # lsm
 PROCESS += bpf_generic_lsm_core_v511.o bpf_generic_lsm_output_v511.o \
@@ -90,7 +93,8 @@ PROCESS += bpf_generic_kprobe_v61.o bpf_generic_retkprobe_v61.o \
 	   bpf_multi_uprobe_v61.o bpf_multi_retuprobe_v61.o \
 	   bpf_generic_rawtp_v61.o \
 	   bpf_generic_usdt_v61.o \
-	   bpf_multi_usdt_v61.o
+	   bpf_multi_usdt_v61.o \
+	   bpf_generic_fentry_v61.o
 
 # lsm
 PROCESS += bpf_generic_lsm_core_v61.o bpf_generic_lsm_output_v61.o \

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -45,7 +45,7 @@ PROCESS += bpf_execve_event.o bpf_fork.o bpf_exit.o bpf_execve_bprm_commit_creds
 # generic probes
 PROCESS += bpf_generic_kprobe.o bpf_generic_retkprobe.o bpf_generic_tracepoint.o \
 	   bpf_generic_uprobe.o bpf_generic_retuprobe.o bpf_generic_rawtp.o bpf_generic_usdt.o \
-	   bpf_generic_fentry.o
+	   bpf_generic_fentry.o bpf_generic_fexit.o
 
 # lsm
 PROCESS += bpf_generic_lsm_core.o bpf_generic_lsm_output.o
@@ -60,7 +60,8 @@ PROCESS += bpf_generic_kprobe_v53.o bpf_generic_retkprobe_v53.o \
 	   bpf_generic_uprobe_v53.o bpf_generic_retuprobe_v53.o \
 	   bpf_generic_rawtp_v53.o \
 	   bpf_generic_usdt_v53.o \
-	   bpf_generic_fentry_v53.o
+	   bpf_generic_fentry_v53.o \
+	   bpf_generic_fexit_v53.o
 
 # v5.11
 # base sensor
@@ -76,7 +77,8 @@ PROCESS += bpf_generic_kprobe_v511.o bpf_generic_retkprobe_v511.o \
 	   bpf_generic_rawtp_v511.o \
 	   bpf_generic_usdt_v511.o \
 	   bpf_multi_usdt_v511.o \
-	   bpf_generic_fentry_v511.o
+	   bpf_generic_fentry_v511.o \
+	   bpf_generic_fexit_v511.o
 
 # lsm
 PROCESS += bpf_generic_lsm_core_v511.o bpf_generic_lsm_output_v511.o \
@@ -94,7 +96,8 @@ PROCESS += bpf_generic_kprobe_v61.o bpf_generic_retkprobe_v61.o \
 	   bpf_generic_rawtp_v61.o \
 	   bpf_generic_usdt_v61.o \
 	   bpf_multi_usdt_v61.o \
-	   bpf_generic_fentry_v61.o
+	   bpf_generic_fentry_v61.o \
+	   bpf_generic_fexit_v61.o
 
 # lsm
 PROCESS += bpf_generic_lsm_core_v61.o bpf_generic_lsm_output_v61.o \

--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -279,6 +279,11 @@ static long BPF_FUNC(ima_inode_hash, struct inode *inode, void *dst, uint32_t si
 
 static int BPF_FUNC(seq_write, struct seq_file *m, const void *data, uint32_t len);
 
+/* Tracing */
+static int BPF_FUNC(get_func_arg, void *ctx, __u32 n, __u64 *value);
+static int BPF_FUNC(get_func_ret, void *ctx, __u64 *value);
+static long BPF_FUNC(get_func_ip, void *ctx);
+
 /** LLVM built-ins, mem*() routines work for constant size */
 
 #ifndef memset

--- a/bpf/lib/policy_stats.h
+++ b/bpf/lib/policy_stats.h
@@ -15,7 +15,8 @@
 	defined(GENERIC_KRETPROBE) ||  \
 	defined(ALIGNCHECKER) ||       \
 	defined(GENERIC_URETPROBE) ||  \
-	defined(GENERIC_FENTRY)
+	defined(GENERIC_FENTRY) ||     \
+	defined(GENERIC_FEXIT)
 #define HAS_POLICY_STATS
 #endif
 

--- a/bpf/lib/policy_stats.h
+++ b/bpf/lib/policy_stats.h
@@ -6,7 +6,16 @@
 
 #include "policy_conf.h"
 
-#if defined(GENERIC_KPROBE) || defined(GENERIC_TRACEPOINT) || defined(GENERIC_LSM) || defined(GENERIC_RAWTP) || defined(GENERIC_UPROBE) || defined(GENERIC_USDT) || defined(GENERIC_KRETPROBE) || defined(ALIGNCHECKER) || defined(GENERIC_URETPROBE)
+#if defined(GENERIC_KPROBE) ||         \
+	defined(GENERIC_TRACEPOINT) || \
+	defined(GENERIC_LSM) ||        \
+	defined(GENERIC_RAWTP) ||      \
+	defined(GENERIC_UPROBE) ||     \
+	defined(GENERIC_USDT) ||       \
+	defined(GENERIC_KRETPROBE) ||  \
+	defined(ALIGNCHECKER) ||       \
+	defined(GENERIC_URETPROBE) ||  \
+	defined(GENERIC_FENTRY)
 #define HAS_POLICY_STATS
 #endif
 

--- a/bpf/process/bpf_generic_fentry.c
+++ b/bpf/process/bpf_generic_fentry.c
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "vmlinux.h"
+#include "api.h"
+
+#define GENERIC_FENTRY
+
+#include "compiler.h"
+#include "bpf_event.h"
+#include "bpf_task.h"
+#include "retprobe_map.h"
+#include "types/operations.h"
+#include "types/basic.h"
+#include "policy_filter.h"
+
+char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
+
+int generic_fentry_setup_event(void *ctx);
+int generic_fentry_process_event(void *ctx);
+int generic_fentry_process_filter(void *ctx);
+int generic_fentry_filter_arg(void *ctx);
+int generic_fentry_actions(void *ctx);
+int generic_fentry_output(void *ctx);
+int generic_fentry_path(void *ctx);
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(max_entries, 13);
+	__type(key, __u32);
+	__array(values, int(void *));
+} fentry_calls SEC(".maps") = {
+	.values = {
+		[TAIL_CALL_SETUP] = (void *)&generic_fentry_setup_event,
+		[TAIL_CALL_PROCESS] = (void *)&generic_fentry_process_event,
+		[TAIL_CALL_FILTER] = (void *)&generic_fentry_process_filter,
+		[TAIL_CALL_ARGS] = (void *)&generic_fentry_filter_arg,
+		[TAIL_CALL_ACTIONS] = (void *)&generic_fentry_actions,
+		[TAIL_CALL_SEND] = (void *)&generic_fentry_output,
+#ifndef __V61_BPF_PROG
+		[TAIL_CALL_PATH] = (void *)&generic_fentry_path,
+#endif
+	},
+};
+
+#include "generic_maps.h"
+#include "generic_calls.h"
+
+#define SECTION_ENTRY "fentry/generic_fentry"
+#define SECTION_TAIL  "fentry/generic_fentry_tail"
+
+__attribute__((section((SECTION_ENTRY)), used)) int
+generic_fentry_event(struct pt_regs *ctx)
+{
+	return generic_start_process_filter(ctx, (struct bpf_map_def *)&fentry_calls);
+}
+
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fentry_setup_event(void *ctx)
+{
+	return generic_process_event_and_setup(ctx, (struct bpf_map_def *)&fentry_calls);
+}
+
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fentry_process_event(void *ctx)
+{
+	return generic_process_event(ctx, (struct bpf_map_def *)&fentry_calls, __READ_ARG_ALL);
+}
+
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fentry_process_filter(void *ctx)
+{
+	int ret;
+
+	ret = generic_process_filter();
+	if (ret == PFILTER_CONTINUE)
+		tail_call(ctx, &fentry_calls, TAIL_CALL_FILTER);
+	else if (ret == PFILTER_ACCEPT)
+		tail_call(ctx, &fentry_calls, TAIL_CALL_SETUP);
+	/* If filter does not accept drop it. Ideally we would
+	 * log error codes for later review, TBD.
+	 */
+	return PFILTER_REJECT;
+}
+
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fentry_filter_arg(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&fentry_calls, true, __FILTER_ARG_ALL);
+}
+
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fentry_actions(void *ctx)
+{
+	generic_actions(ctx, (struct bpf_map_def *)&fentry_calls);
+	return 0;
+}
+
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fentry_output(void *ctx)
+{
+	return generic_output(ctx, MSG_OP_GENERIC_KPROBE);
+}
+
+#ifndef __V61_BPF_PROG
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fentry_path(void *ctx)
+{
+	return generic_path(ctx, (struct bpf_map_def *)&fentry_calls);
+}
+#endif

--- a/bpf/process/bpf_generic_fexit.c
+++ b/bpf/process/bpf_generic_fexit.c
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "vmlinux.h"
+#include "api.h"
+
+#define GENERIC_FEXIT
+
+#include "compiler.h"
+#include "bpf_tracing.h"
+#include "bpf_event.h"
+#include "bpf_task.h"
+#include "retprobe_map.h"
+#include "types/basic.h"
+
+#define MAX_FILENAME 8096
+
+char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
+
+int generic_fexit_filter_arg(void *ctx);
+int generic_fexit_actions(void *ctx);
+int generic_fexit_output(void *ctx);
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(max_entries, 6);
+	__type(key, __u32);
+	__array(values, int(struct pt_regs *));
+} fexit_calls SEC(".maps") = {
+	.values = {
+		[TAIL_CALL_ARGS] = (void *)&generic_fexit_filter_arg,
+		[TAIL_CALL_ACTIONS] = (void *)&generic_fexit_actions,
+		[TAIL_CALL_SEND] = (void *)&generic_fexit_output,
+	},
+};
+
+#include "generic_maps.h"
+#include "generic_calls.h"
+
+#define SECTION_ENTRY "fexit/generic_fexit"
+#define SECTION_TAIL  "fexit/generic_fexit_tail"
+
+__attribute__((section(SECTION_ENTRY), used)) int
+generic_fexit_event(void *ctx)
+{
+	__u64 ret;
+
+	get_func_ret(ctx, &ret);
+	generic_retprobe(ctx, (struct bpf_map_def *)&fexit_calls, ret);
+	return 0;
+}
+
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fexit_filter_arg(void *ctx)
+{
+	generic_filter_arg(ctx, (struct bpf_map_def *)&fexit_calls, false, __FILTER_ARG_ALL);
+	return 0;
+}
+
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fexit_actions(void *ctx)
+{
+	generic_actions(ctx, (struct bpf_map_def *)&fexit_calls);
+	return 0;
+}
+
+__attribute__((section(SECTION_TAIL), used)) int
+generic_fexit_output(void *ctx)
+{
+	generic_output(ctx, MSG_OP_GENERIC_KPROBE);
+	return 0;
+}

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -748,6 +748,37 @@ generic_process_event_and_setup(struct pt_regs *ctx, struct bpf_map_def *tailcal
 		retprobe_map_set(e->func_id, e->retprobe_id, e->common.ktime, 1);
 #endif
 
+#ifdef GENERIC_FENTRY
+	struct bpf_raw_tracepoint_args *raw_args = (struct bpf_raw_tracepoint_args *)ctx;
+
+	if (config->syscall) {
+		struct pt_regs *_ctx = (struct pt_regs *)BPF_CORE_READ(raw_args, args[0]);
+
+		if (!_ctx)
+			return 0;
+		e->a0 = PT_REGS_PARM1_CORE_SYSCALL(_ctx);
+		e->a1 = PT_REGS_PARM2_CORE_SYSCALL(_ctx);
+		e->a2 = PT_REGS_PARM3_CORE_SYSCALL(_ctx);
+		e->a3 = PT_REGS_PARM4_CORE_SYSCALL(_ctx);
+		e->a4 = PT_REGS_PARM5_CORE_SYSCALL(_ctx);
+	} else {
+		e->a0 = BPF_CORE_READ(raw_args, args[0]);
+		e->a1 = BPF_CORE_READ(raw_args, args[1]);
+		e->a2 = BPF_CORE_READ(raw_args, args[2]);
+		e->a3 = BPF_CORE_READ(raw_args, args[3]);
+		e->a4 = BPF_CORE_READ(raw_args, args[4]);
+	}
+
+	generic_process_init(e, MSG_OP_GENERIC_KPROBE);
+
+	e->retprobe_id = retprobe_map_get_key(ctx);
+
+	/* If return arg is needed mark retprobe */
+	ty = config->argreturn;
+	if (ty > 0)
+		retprobe_map_set(e->func_id, e->retprobe_id, e->common.ktime, 1);
+#endif
+
 #ifdef GENERIC_LSM
 	struct bpf_raw_tracepoint_args *raw_args = (struct bpf_raw_tracepoint_args *)ctx;
 

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -1163,7 +1163,7 @@ generic_output(void *ctx, u8 op)
 		return 0;
 
 /* We don't need this data in return kprobe event */
-#if !defined(GENERIC_KRETPROBE) && !defined(GENERIC_URETPROBE)
+#if !defined(GENERIC_KRETPROBE) && !defined(GENERIC_URETPROBE) && !defined(GENERIC_FEXIT)
 #ifdef __NS_CHANGES_FILTER
 	/* update the namespaces if we matched a change on that */
 	if (e->sel.match_ns) {
@@ -1238,7 +1238,7 @@ FUNC_INLINE int generic_retprobe(void *ctx, struct bpf_map_def *calls, unsigned 
 	do_copy = config->argreturncopy;
 	if (ty_arg) {
 		size += read_arg(ctx, 0, ty_arg, size, ret, 0, __READ_ARG_ALL);
-#if defined(__LARGE_BPF_PROG) && defined(GENERIC_KRETPROBE)
+#if defined(__LARGE_BPF_PROG) && (defined(GENERIC_KRETPROBE) || defined(GENERIC_FEXIT))
 		struct socket_owner owner;
 
 		switch (config->argreturnaction) {
@@ -1277,7 +1277,7 @@ FUNC_INLINE int generic_retprobe(void *ctx, struct bpf_map_def *calls, unsigned 
 
 	/* Complete message header and send */
 	enter = event_find_curr(&ppid, &walker);
-#ifdef GENERIC_KRETPROBE
+#if defined(GENERIC_KRETPROBE) || defined(GENERIC_FEXIT)
 	e->common.op = MSG_OP_GENERIC_KPROBE;
 #else
 	e->common.op = MSG_OP_GENERIC_UPROBE;

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -67,6 +67,12 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 			continue
 		}
 
+		// Can't load fentry/fexit objects without loader setup
+		if strings.HasPrefix(fileName, "bpf_generic_fentry") ||
+			strings.HasPrefix(fileName, "bpf_generic_fexit") {
+			continue
+		}
+
 		// Skip v6.1 objects check for kernel < 6.1
 		if strings.HasSuffix(fileName, "61.o") && !kernels.MinKernelVersion("6.1") {
 			continue

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -117,6 +117,13 @@ Currently, only the "name" field is supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindex">fentries</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of fentry specs.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#tracingpolicyspeckprobesindex">kprobes</a></b></td>
         <td>[]object</td>
         <td>
@@ -298,6 +305,1366 @@ merge patch.<br/>
           Calls where enforcer is executed in<br/>
         </td>
         <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index]
+<sup><sup>[↩ Parent](#tracingpolicyspec)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>call</b></td>
+        <td>string</td>
+        <td>
+          Name of the function to apply the kprobe spec to.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexargsindex">args</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of function arguments to include in the trace output.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexdataindex">data</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of data to include in the trace output.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexignore">ignore</a></b></td>
+        <td>object</td>
+        <td>
+          Conditions for ignoring this kprobe<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>message</b></td>
+        <td>string</td>
+        <td>
+          A short message of 256 characters max that will be included
+in the event output to inform users what is going on.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>return</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether to collect return value of the traced function.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexreturnarg">returnArg</a></b></td>
+        <td>object</td>
+        <td>
+          A return argument to include in the trace output.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnArgAction</b></td>
+        <td>string</td>
+        <td>
+          An action to perform on the return argument.
+Available actions are: Post;TrackSock;UntrackSock<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindex">selectors</a></b></td>
+        <td>[]object</td>
+        <td>
+          Selectors to apply before producing trace output. Selectors are ORed and short-circuited.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>syscall</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether the traced function is a syscall.<br/>
+          <br/>
+            <i>Default</i>: true<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>tags</b></td>
+        <td>[]string</td>
+        <td>
+          Tags to categorize the event, will be include in the event output.
+Maximum of 16 Tags are supported.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].args[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Argument type.<br/>
+          <br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Default</i>: auto<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>btfType</b></td>
+        <td>string</td>
+        <td>
+          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+type.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>label</b></td>
+        <td>string</td>
+        <td>
+          Label to output in the JSON<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>maxData</b></td>
+        <td>boolean</td>
+        <td>
+          Read maximum possible data (currently 327360). This field is only used
+for char_buff data. When this value is false (default), the bpf program
+will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+supports fetching up to 327360 bytes if this flag is turned on<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>resolve</b></td>
+        <td>string</td>
+        <td>
+          Resolve the path to a specific attribute<br/>
+          <br/>
+            <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnCopy</b></td>
+        <td>boolean</td>
+        <td>
+          This field is used only for char_buf and char_iovec types. It indicates
+that this argument should be read later (when the kretprobe for the
+symbol is triggered) because it might not be populated when the kprobe
+is triggered at the entrance of the function. For example, a buffer
+supplied to read(2) won't have content until kretprobe is triggered.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>sizeArgIndex</b></td>
+        <td>integer</td>
+        <td>
+          Specifies the position of the corresponding size argument for this argument.
+This field is used only for char_buf and char_iovec types.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>source</b></td>
+        <td>string</td>
+        <td>
+          Source of the data, if missing the default if function arguments<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].data[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Argument type.<br/>
+          <br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Default</i>: auto<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>btfType</b></td>
+        <td>string</td>
+        <td>
+          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+type.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>label</b></td>
+        <td>string</td>
+        <td>
+          Label to output in the JSON<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>maxData</b></td>
+        <td>boolean</td>
+        <td>
+          Read maximum possible data (currently 327360). This field is only used
+for char_buff data. When this value is false (default), the bpf program
+will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+supports fetching up to 327360 bytes if this flag is turned on<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>resolve</b></td>
+        <td>string</td>
+        <td>
+          Resolve the path to a specific attribute<br/>
+          <br/>
+            <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnCopy</b></td>
+        <td>boolean</td>
+        <td>
+          This field is used only for char_buf and char_iovec types. It indicates
+that this argument should be read later (when the kretprobe for the
+symbol is triggered) because it might not be populated when the kprobe
+is triggered at the entrance of the function. For example, a buffer
+supplied to read(2) won't have content until kretprobe is triggered.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>sizeArgIndex</b></td>
+        <td>integer</td>
+        <td>
+          Specifies the position of the corresponding size argument for this argument.
+This field is used only for char_buf and char_iovec types.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>source</b></td>
+        <td>string</td>
+        <td>
+          Source of the data, if missing the default if function arguments<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].ignore
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindex)</sup></sup>
+
+
+Conditions for ignoring this kprobe
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>callNotFound</b></td>
+        <td>boolean</td>
+        <td>
+          Ignores calls that are not present in the system<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].returnArg
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindex)</sup></sup>
+
+
+A return argument to include in the trace output.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Argument type.<br/>
+          <br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Default</i>: auto<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>btfType</b></td>
+        <td>string</td>
+        <td>
+          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+type.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>label</b></td>
+        <td>string</td>
+        <td>
+          Label to output in the JSON<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>maxData</b></td>
+        <td>boolean</td>
+        <td>
+          Read maximum possible data (currently 327360). This field is only used
+for char_buff data. When this value is false (default), the bpf program
+will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+supports fetching up to 327360 bytes if this flag is turned on<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>resolve</b></td>
+        <td>string</td>
+        <td>
+          Resolve the path to a specific attribute<br/>
+          <br/>
+            <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnCopy</b></td>
+        <td>boolean</td>
+        <td>
+          This field is used only for char_buf and char_iovec types. It indicates
+that this argument should be read later (when the kretprobe for the
+symbol is triggered) because it might not be populated when the kprobe
+is triggered at the entrance of the function. For example, a buffer
+supplied to read(2) won't have content until kretprobe is triggered.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>sizeArgIndex</b></td>
+        <td>integer</td>
+        <td>
+          Specifies the position of the corresponding size argument for this argument.
+This field is used only for char_buf and char_iovec types.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>source</b></td>
+        <td>string</td>
+        <td>
+          Source of the data, if missing the default if function arguments<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindex)</sup></sup>
+
+
+KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+results of MatchPIDs and MatchArgs are ANDed.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>macros</b></td>
+        <td>[]string</td>
+        <td>
+          A list of macros names, defined in spec.selectorsMacros.
+Filters specified in macros will be appended to corresponding filters of the selector.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchactionsindex">matchActions</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of actions to execute when this selector matches<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchargsindex">matchArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchbinariesindex">matchBinaries</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of binary exec name filters.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchcapabilitiesindex">matchCapabilities</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of capabilities and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchcapabilitychangesindex">matchCapabilityChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for capabilities changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchdataindex">matchData</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchData are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchnamespacechangesindex">matchNamespaceChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for namespace changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchnamespacesindex">matchNamespaces</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of namespaces and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchpidsindex">matchPIDs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of process ID filters. MatchPIDs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchparentbinariesindex">matchParentBinaries</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of process parent exec name filters.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchreturnactionsindex">matchReturnActions</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of actions to execute when MatchReturnArgs selector matches<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspecfentriesindexselectorsindexmatchreturnargsindex">matchReturnArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchActions[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>action</b></td>
+        <td>enum</td>
+        <td>
+          Action to execute.
+NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+be removed in version 1.5.<br/>
+          <br/>
+            <i>Enum</i>: Post, FollowFD, UnfollowFD, Sigkill, CopyFD, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>argError</b></td>
+        <td>integer</td>
+        <td>
+          error value for override action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFd</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the fd for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFqdn</b></td>
+        <td>string</td>
+        <td>
+          A FQDN to lookup for the dnsLookup action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argIndex</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the set action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argName</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the filename for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argRegs</b></td>
+        <td>[]string</td>
+        <td>
+          An arg value for the regs action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSig</b></td>
+        <td>integer</td>
+        <td>
+          A signal number for signal action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSock</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the sock for trackSock and untrackSock actions<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argUrl</b></td>
+        <td>string</td>
+        <td>
+          A URL for the getUrl action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argValue</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the set action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>imaHash</b></td>
+        <td>boolean</td>
+        <td>
+          Enable collection of file hashes from integrity subsystem.
+Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>kernelStackTrace</b></td>
+        <td>boolean</td>
+        <td>
+          Enable kernel stack trace export. Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>rateLimit</b></td>
+        <td>string</td>
+        <td>
+          A time period within which repeated messages will not be posted. Can be
+specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+or hours ('h' suffix). Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>rateLimitScope</b></td>
+        <td>string</td>
+        <td>
+          The scope of the provided rate limit argument. Can be "thread" (default),
+"process" (all threads for the same process), or "global". If "thread" is
+selected then rate limiting applies per thread; if "process" is selected
+then rate limiting applies per process; if "global" is selected then rate
+limiting applies regardless of which process or thread caused the action.
+Only valid with the post action and with a rateLimit specified.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>userStackTrace</b></td>
+        <td>boolean</td>
+        <td>
+          Enable user stack trace export. Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, NotPrefix, Postfix, NotPostfix, GreaterThan, LessThan, GT, LT, Mask, SPort, NotSPort, SPortPriv, NotSportPriv, DPort, NotDPort, DPortPriv, NotDPortPriv, SAddr, NotSAddr, DAddr, NotDAddr, Protocol, Family, State, InMap, NotInMap, CapabilitiesGained, InRange, NotInRange, SubString, SubStringIgnCase, CelExpr, FileType, NotFileType<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>args</b></td>
+        <td>[]integer</td>
+        <td>
+          Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchBinaries[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn, Prefix, NotPrefix, Postfix, NotPostfix<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>followChildren</b></td>
+        <td>boolean</td>
+        <td>
+          In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchCapabilities[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchCapabilityChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchData[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, NotPrefix, Postfix, NotPostfix, GreaterThan, LessThan, GT, LT, Mask, SPort, NotSPort, SPortPriv, NotSportPriv, DPort, NotDPort, DPortPriv, NotDPortPriv, SAddr, NotSAddr, DAddr, NotDAddr, Protocol, Family, State, InMap, NotInMap, CapabilitiesGained, InRange, NotInRange, SubString, SubStringIgnCase, CelExpr, FileType, NotFileType<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>args</b></td>
+        <td>[]integer</td>
+        <td>
+          Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchNamespaceChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace types (e.g., Mnt, Pid) to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchNamespaces[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>namespace</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector name.<br/>
+          <br/>
+            <i>Enum</i>: Uts, Ipc, Mnt, Pid, PidForChildren, Net, Time, TimeForChildren, Cgroup, User<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace IDs (or host_ns for host namespace) of namespaces to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchPIDs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          PID selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]integer</td>
+        <td>
+          Process IDs to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>followForks</b></td>
+        <td>boolean</td>
+        <td>
+          Matches any descendant processes of the matching PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>isNamespacePID</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether PIDs are namespace PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchParentBinaries[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn, Prefix, NotPrefix, Postfix, NotPostfix<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>followChildren</b></td>
+        <td>boolean</td>
+        <td>
+          In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchReturnActions[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>action</b></td>
+        <td>enum</td>
+        <td>
+          Action to execute.
+NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+be removed in version 1.5.<br/>
+          <br/>
+            <i>Enum</i>: Post, FollowFD, UnfollowFD, Sigkill, CopyFD, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>argError</b></td>
+        <td>integer</td>
+        <td>
+          error value for override action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFd</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the fd for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFqdn</b></td>
+        <td>string</td>
+        <td>
+          A FQDN to lookup for the dnsLookup action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argIndex</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the set action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argName</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the filename for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argRegs</b></td>
+        <td>[]string</td>
+        <td>
+          An arg value for the regs action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSig</b></td>
+        <td>integer</td>
+        <td>
+          A signal number for signal action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSock</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the sock for trackSock and untrackSock actions<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argUrl</b></td>
+        <td>string</td>
+        <td>
+          A URL for the getUrl action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argValue</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the set action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>imaHash</b></td>
+        <td>boolean</td>
+        <td>
+          Enable collection of file hashes from integrity subsystem.
+Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>kernelStackTrace</b></td>
+        <td>boolean</td>
+        <td>
+          Enable kernel stack trace export. Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>rateLimit</b></td>
+        <td>string</td>
+        <td>
+          A time period within which repeated messages will not be posted. Can be
+specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+or hours ('h' suffix). Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>rateLimitScope</b></td>
+        <td>string</td>
+        <td>
+          The scope of the provided rate limit argument. Can be "thread" (default),
+"process" (all threads for the same process), or "global". If "thread" is
+selected then rate limiting applies per thread; if "process" is selected
+then rate limiting applies per process; if "global" is selected then rate
+limiting applies regardless of which process or thread caused the action.
+Only valid with the post action and with a rateLimit specified.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>userStackTrace</b></td>
+        <td>boolean</td>
+        <td>
+          Enable user stack trace export. Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.fentries[index].selectors[index].matchReturnArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicyspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, NotPrefix, Postfix, NotPostfix, GreaterThan, LessThan, GT, LT, Mask, SPort, NotSPort, SPortPriv, NotSportPriv, DPort, NotDPort, DPortPriv, NotDPortPriv, SAddr, NotSAddr, DAddr, NotDAddr, Protocol, Family, State, InMap, NotInMap, CapabilitiesGained, InRange, NotInRange, SubString, SubStringIgnCase, CelExpr, FileType, NotFileType<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>args</b></td>
+        <td>[]integer</td>
+        <td>
+          Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -7420,6 +8787,13 @@ Currently, only the "name" field is supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindex">fentries</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of fentry specs.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#tracingpolicynamespacedspeckprobesindex">kprobes</a></b></td>
         <td>[]object</td>
         <td>
@@ -7601,6 +8975,1366 @@ merge patch.<br/>
           Calls where enforcer is executed in<br/>
         </td>
         <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspec)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>call</b></td>
+        <td>string</td>
+        <td>
+          Name of the function to apply the kprobe spec to.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexargsindex">args</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of function arguments to include in the trace output.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexdataindex">data</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of data to include in the trace output.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexignore">ignore</a></b></td>
+        <td>object</td>
+        <td>
+          Conditions for ignoring this kprobe<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>message</b></td>
+        <td>string</td>
+        <td>
+          A short message of 256 characters max that will be included
+in the event output to inform users what is going on.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>return</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether to collect return value of the traced function.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexreturnarg">returnArg</a></b></td>
+        <td>object</td>
+        <td>
+          A return argument to include in the trace output.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnArgAction</b></td>
+        <td>string</td>
+        <td>
+          An action to perform on the return argument.
+Available actions are: Post;TrackSock;UntrackSock<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindex">selectors</a></b></td>
+        <td>[]object</td>
+        <td>
+          Selectors to apply before producing trace output. Selectors are ORed and short-circuited.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>syscall</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether the traced function is a syscall.<br/>
+          <br/>
+            <i>Default</i>: true<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>tags</b></td>
+        <td>[]string</td>
+        <td>
+          Tags to categorize the event, will be include in the event output.
+Maximum of 16 Tags are supported.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].args[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Argument type.<br/>
+          <br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Default</i>: auto<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>btfType</b></td>
+        <td>string</td>
+        <td>
+          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+type.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>label</b></td>
+        <td>string</td>
+        <td>
+          Label to output in the JSON<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>maxData</b></td>
+        <td>boolean</td>
+        <td>
+          Read maximum possible data (currently 327360). This field is only used
+for char_buff data. When this value is false (default), the bpf program
+will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+supports fetching up to 327360 bytes if this flag is turned on<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>resolve</b></td>
+        <td>string</td>
+        <td>
+          Resolve the path to a specific attribute<br/>
+          <br/>
+            <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnCopy</b></td>
+        <td>boolean</td>
+        <td>
+          This field is used only for char_buf and char_iovec types. It indicates
+that this argument should be read later (when the kretprobe for the
+symbol is triggered) because it might not be populated when the kprobe
+is triggered at the entrance of the function. For example, a buffer
+supplied to read(2) won't have content until kretprobe is triggered.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>sizeArgIndex</b></td>
+        <td>integer</td>
+        <td>
+          Specifies the position of the corresponding size argument for this argument.
+This field is used only for char_buf and char_iovec types.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>source</b></td>
+        <td>string</td>
+        <td>
+          Source of the data, if missing the default if function arguments<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].data[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Argument type.<br/>
+          <br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Default</i>: auto<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>btfType</b></td>
+        <td>string</td>
+        <td>
+          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+type.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>label</b></td>
+        <td>string</td>
+        <td>
+          Label to output in the JSON<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>maxData</b></td>
+        <td>boolean</td>
+        <td>
+          Read maximum possible data (currently 327360). This field is only used
+for char_buff data. When this value is false (default), the bpf program
+will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+supports fetching up to 327360 bytes if this flag is turned on<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>resolve</b></td>
+        <td>string</td>
+        <td>
+          Resolve the path to a specific attribute<br/>
+          <br/>
+            <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnCopy</b></td>
+        <td>boolean</td>
+        <td>
+          This field is used only for char_buf and char_iovec types. It indicates
+that this argument should be read later (when the kretprobe for the
+symbol is triggered) because it might not be populated when the kprobe
+is triggered at the entrance of the function. For example, a buffer
+supplied to read(2) won't have content until kretprobe is triggered.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>sizeArgIndex</b></td>
+        <td>integer</td>
+        <td>
+          Specifies the position of the corresponding size argument for this argument.
+This field is used only for char_buf and char_iovec types.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>source</b></td>
+        <td>string</td>
+        <td>
+          Source of the data, if missing the default if function arguments<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].ignore
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindex)</sup></sup>
+
+
+Conditions for ignoring this kprobe
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>callNotFound</b></td>
+        <td>boolean</td>
+        <td>
+          Ignores calls that are not present in the system<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].returnArg
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindex)</sup></sup>
+
+
+A return argument to include in the trace output.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Argument type.<br/>
+          <br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Default</i>: auto<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>btfType</b></td>
+        <td>string</td>
+        <td>
+          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+type.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>label</b></td>
+        <td>string</td>
+        <td>
+          Label to output in the JSON<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>maxData</b></td>
+        <td>boolean</td>
+        <td>
+          Read maximum possible data (currently 327360). This field is only used
+for char_buff data. When this value is false (default), the bpf program
+will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+supports fetching up to 327360 bytes if this flag is turned on<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>resolve</b></td>
+        <td>string</td>
+        <td>
+          Resolve the path to a specific attribute<br/>
+          <br/>
+            <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>returnCopy</b></td>
+        <td>boolean</td>
+        <td>
+          This field is used only for char_buf and char_iovec types. It indicates
+that this argument should be read later (when the kretprobe for the
+symbol is triggered) because it might not be populated when the kprobe
+is triggered at the entrance of the function. For example, a buffer
+supplied to read(2) won't have content until kretprobe is triggered.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>sizeArgIndex</b></td>
+        <td>integer</td>
+        <td>
+          Specifies the position of the corresponding size argument for this argument.
+This field is used only for char_buf and char_iovec types.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>source</b></td>
+        <td>string</td>
+        <td>
+          Source of the data, if missing the default if function arguments<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindex)</sup></sup>
+
+
+KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+results of MatchPIDs and MatchArgs are ANDed.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>macros</b></td>
+        <td>[]string</td>
+        <td>
+          A list of macros names, defined in spec.selectorsMacros.
+Filters specified in macros will be appended to corresponding filters of the selector.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchactionsindex">matchActions</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of actions to execute when this selector matches<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchargsindex">matchArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchbinariesindex">matchBinaries</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of binary exec name filters.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchcapabilitiesindex">matchCapabilities</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of capabilities and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchcapabilitychangesindex">matchCapabilityChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for capabilities changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchdataindex">matchData</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchData are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchnamespacechangesindex">matchNamespaceChanges</a></b></td>
+        <td>[]object</td>
+        <td>
+          IDs for namespace changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchnamespacesindex">matchNamespaces</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of namespaces and IDs<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchpidsindex">matchPIDs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of process ID filters. MatchPIDs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchparentbinariesindex">matchParentBinaries</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of process parent exec name filters.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchreturnactionsindex">matchReturnActions</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of actions to execute when MatchReturnArgs selector matches<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspecfentriesindexselectorsindexmatchreturnargsindex">matchReturnArgs</a></b></td>
+        <td>[]object</td>
+        <td>
+          A list of argument filters. MatchArgs are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchActions[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>action</b></td>
+        <td>enum</td>
+        <td>
+          Action to execute.
+NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+be removed in version 1.5.<br/>
+          <br/>
+            <i>Enum</i>: Post, FollowFD, UnfollowFD, Sigkill, CopyFD, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>argError</b></td>
+        <td>integer</td>
+        <td>
+          error value for override action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFd</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the fd for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFqdn</b></td>
+        <td>string</td>
+        <td>
+          A FQDN to lookup for the dnsLookup action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argIndex</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the set action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argName</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the filename for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argRegs</b></td>
+        <td>[]string</td>
+        <td>
+          An arg value for the regs action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSig</b></td>
+        <td>integer</td>
+        <td>
+          A signal number for signal action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSock</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the sock for trackSock and untrackSock actions<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argUrl</b></td>
+        <td>string</td>
+        <td>
+          A URL for the getUrl action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argValue</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the set action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>imaHash</b></td>
+        <td>boolean</td>
+        <td>
+          Enable collection of file hashes from integrity subsystem.
+Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>kernelStackTrace</b></td>
+        <td>boolean</td>
+        <td>
+          Enable kernel stack trace export. Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>rateLimit</b></td>
+        <td>string</td>
+        <td>
+          A time period within which repeated messages will not be posted. Can be
+specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+or hours ('h' suffix). Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>rateLimitScope</b></td>
+        <td>string</td>
+        <td>
+          The scope of the provided rate limit argument. Can be "thread" (default),
+"process" (all threads for the same process), or "global". If "thread" is
+selected then rate limiting applies per thread; if "process" is selected
+then rate limiting applies per process; if "global" is selected then rate
+limiting applies regardless of which process or thread caused the action.
+Only valid with the post action and with a rateLimit specified.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>userStackTrace</b></td>
+        <td>boolean</td>
+        <td>
+          Enable user stack trace export. Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, NotPrefix, Postfix, NotPostfix, GreaterThan, LessThan, GT, LT, Mask, SPort, NotSPort, SPortPriv, NotSportPriv, DPort, NotDPort, DPortPriv, NotDPortPriv, SAddr, NotSAddr, DAddr, NotDAddr, Protocol, Family, State, InMap, NotInMap, CapabilitiesGained, InRange, NotInRange, SubString, SubStringIgnCase, CelExpr, FileType, NotFileType<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>args</b></td>
+        <td>[]integer</td>
+        <td>
+          Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchBinaries[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn, Prefix, NotPrefix, Postfix, NotPostfix<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>followChildren</b></td>
+        <td>boolean</td>
+        <td>
+          In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchCapabilities[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchCapabilityChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Capabilities to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>isNamespaceCapability</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether these caps are namespace caps.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          Type of capabilities<br/>
+          <br/>
+            <i>Enum</i>: Effective, Inheritable, Permitted<br/>
+            <i>Default</i>: Effective<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchData[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, NotPrefix, Postfix, NotPostfix, GreaterThan, LessThan, GT, LT, Mask, SPort, NotSPort, SPortPriv, NotSportPriv, DPort, NotDPort, DPortPriv, NotDPortPriv, SAddr, NotSAddr, DAddr, NotDAddr, Protocol, Family, State, InMap, NotInMap, CapabilitiesGained, InRange, NotInRange, SubString, SubStringIgnCase, CelExpr, FileType, NotFileType<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>args</b></td>
+        <td>[]integer</td>
+        <td>
+          Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchNamespaceChanges[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace types (e.g., Mnt, Pid) to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchNamespaces[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>namespace</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector name.<br/>
+          <br/>
+            <i>Enum</i>: Uts, Ipc, Mnt, Pid, PidForChildren, Net, Time, TimeForChildren, Cgroup, User<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Namespace selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Namespace IDs (or host_ns for host namespace) of namespaces to match.<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchPIDs[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          PID selector operator.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]integer</td>
+        <td>
+          Process IDs to match.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>followForks</b></td>
+        <td>boolean</td>
+        <td>
+          Matches any descendant processes of the matching PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>isNamespacePID</b></td>
+        <td>boolean</td>
+        <td>
+          Indicates whether PIDs are namespace PIDs.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchParentBinaries[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn, Prefix, NotPrefix, Postfix, NotPostfix<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>followChildren</b></td>
+        <td>boolean</td>
+        <td>
+          In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchReturnActions[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>action</b></td>
+        <td>enum</td>
+        <td>
+          Action to execute.
+NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+be removed in version 1.5.<br/>
+          <br/>
+            <i>Enum</i>: Post, FollowFD, UnfollowFD, Sigkill, CopyFD, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>argError</b></td>
+        <td>integer</td>
+        <td>
+          error value for override action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFd</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the fd for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argFqdn</b></td>
+        <td>string</td>
+        <td>
+          A FQDN to lookup for the dnsLookup action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argIndex</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the set action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argName</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the filename for fdInstall action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argRegs</b></td>
+        <td>[]string</td>
+        <td>
+          An arg value for the regs action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSig</b></td>
+        <td>integer</td>
+        <td>
+          A signal number for signal action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argSock</b></td>
+        <td>integer</td>
+        <td>
+          An arg index for the sock for trackSock and untrackSock actions<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argUrl</b></td>
+        <td>string</td>
+        <td>
+          A URL for the getUrl action<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argValue</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the set action<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>imaHash</b></td>
+        <td>boolean</td>
+        <td>
+          Enable collection of file hashes from integrity subsystem.
+Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>kernelStackTrace</b></td>
+        <td>boolean</td>
+        <td>
+          Enable kernel stack trace export. Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>rateLimit</b></td>
+        <td>string</td>
+        <td>
+          A time period within which repeated messages will not be posted. Can be
+specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+or hours ('h' suffix). Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>rateLimitScope</b></td>
+        <td>string</td>
+        <td>
+          The scope of the provided rate limit argument. Can be "thread" (default),
+"process" (all threads for the same process), or "global". If "thread" is
+selected then rate limiting applies per thread; if "process" is selected
+then rate limiting applies per process; if "global" is selected then rate
+limiting applies regardless of which process or thread caused the action.
+Only valid with the post action and with a rateLimit specified.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>userStackTrace</b></td>
+        <td>boolean</td>
+        <td>
+          Enable user stack trace export. Only valid with the post action.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.fentries[index].selectors[index].matchReturnArgs[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspecfentriesindexselectorsindex)</sup></sup>
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          Filter operation.<br/>
+          <br/>
+            <i>Enum</i>: Equal, NotEqual, Prefix, NotPrefix, Postfix, NotPostfix, GreaterThan, LessThan, GT, LT, Mask, SPort, NotSPort, SPortPriv, NotSportPriv, DPort, NotDPort, DPortPriv, NotDPortPriv, SAddr, NotSAddr, DAddr, NotDAddr, Protocol, Family, State, InMap, NotInMap, CapabilitiesGained, InRange, NotInRange, SubString, SubStringIgnCase, CelExpr, FileType, NotFileType<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>args</b></td>
+        <td>[]integer</td>
+        <td>
+          Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          Value to compare the argument against.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -114,6 +114,1021 @@ spec:
                   - calls
                   type: object
                 type: array
+              fentries:
+                description: A list of fentry specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return argument.
+                        Available actions are: Post;TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -114,6 +114,1021 @@ spec:
                   - calls
                   type: object
                 type: array
+              fentries:
+                description: A list of fentry specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return argument.
+                        Available actions are: Post;TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -57,6 +57,7 @@ var (
 	uprobeRegsChange       Feature
 	kfuncs                 FeatureKfuncs
 	mixBpfAndTailCalls     Feature
+	getFuncRetHelper       Feature
 )
 
 func HasOverrideHelper() bool {
@@ -69,6 +70,10 @@ func HasSignalHelper() bool {
 
 func HasProbeWriteUserHelper() bool {
 	return features.HaveProgramHelper(ebpf.Kprobe, asm.FnProbeWriteUser) == nil
+}
+
+func HasFentryProgram() bool {
+	return features.HaveProgramType(ebpf.Tracing) == nil
 }
 
 func detectKprobeMulti() bool {
@@ -569,6 +574,32 @@ func detectUprobeRegsChange() bool {
 	return true
 }
 
+func detectGetFuncRetHelper() bool {
+	sysGetcpu, err := arch.AddSyscallPrefix("sys_getcpu")
+	if err != nil {
+		return false
+	}
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name:       "probe_get_func_ret",
+		Type:       ebpf.Tracing,
+		AttachType: ebpf.AttachTraceFExit,
+		Instructions: asm.Instructions{
+			asm.Mov.Reg(asm.R2, asm.R10),
+			asm.Add.Imm(asm.R2, -8),
+			asm.FnGetFuncRet.Call(),
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License:  "GPL",
+		AttachTo: sysGetcpu,
+	})
+	if err != nil {
+		return false
+	}
+	prog.Close()
+	return true
+}
+
 func detectUprobeRegsChangeOnce() {
 	uprobeRegsChange.init.Do(func() {
 		uprobeRegsChange.detected = detectUprobeRegsChange()
@@ -682,6 +713,17 @@ func DetectMixBpfAndTailCalls() bool {
 	return mixBpfAndTailCalls.detected
 }
 
+func detectGetFuncRetHelperOnce() {
+	getFuncRetHelper.init.Do(func() {
+		getFuncRetHelper.detected = detectGetFuncRetHelper()
+	})
+}
+
+func HasGetFuncRetHelper() bool {
+	detectGetFuncRetHelperOnce()
+	return getFuncRetHelper.detected
+}
+
 func LogFeatures() string {
 	// once we have detected all features, flush the BTF spec
 	// we cache all values so calling again a Has* function will
@@ -730,4 +772,6 @@ var FeatureProbes = []FeatureProbe{
 	{ProbeWriteUserProbe, HasProbeWriteUserHelper},
 	{UprobeRegsChangeProbe, HasUprobeRegsChange},
 	{MixBPFAndTailCallsProbe, DetectMixBpfAndTailCalls},
+	{Fentry, HasFentryProgram},
+	{GetFuncRet, HasGetFuncRetHelper},
 }

--- a/pkg/bpf/probes.go
+++ b/pkg/bpf/probes.go
@@ -22,4 +22,6 @@ const (
 	ProbeWriteUserProbe         = "probe_write_user"
 	UprobeRegsChangeProbe       = "uprobe_regs_change"
 	MixBPFAndTailCallsProbe     = "mix_bpf_and_tail_calls"
+	Fentry                      = "fentry"
+	GetFuncRet                  = "get_func_ret"
 )

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -77,6 +77,17 @@ func GenericKprobeObjs(multi bool) (string, string) {
 	return "bpf_generic_kprobe.o", "bpf_generic_retkprobe.o"
 }
 
+func GenericTracingObjs() (string, string) {
+	if EnableV61Progs() {
+		return "bpf_generic_fentry_v61.o", "bpf_generic_fexit_v61.o"
+	} else if kernels.MinKernelVersion("5.11") {
+		return "bpf_generic_fentry_v511.o", "bpf_generic_fexit_v511.o"
+	} else if EnableLargeProgs() {
+		return "bpf_generic_fentry_v53.o", "bpf_generic_fexit_v53.o"
+	}
+	return "bpf_generic_fentry.o", "bpf_generic_fexit.o"
+}
+
 // GenericUprobeObjs returns the generic uprobe and generic uretprobe objects
 func GenericUprobeObjs(multi bool) (string, string) {
 	if multi {

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -114,6 +114,1021 @@ spec:
                   - calls
                   type: object
                 type: array
+              fentries:
+                description: A list of fentry specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return argument.
+                        Available actions are: Post;TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -114,6 +114,1021 @@ spec:
                   - calls
                   type: object
                 type: array
+              fentries:
+                description: A list of fentry specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return argument.
+                        Available actions are: Post;TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -92,6 +92,9 @@ type TracingPolicySpec struct {
 	// +kubebuilder:validation:Optional
 	// A list of usdt specs.
 	Usdts []UsdtSpec `json:"usdts,omitempty"`
+	// +kubebuilder:validation:Optional
+	// A list of fentry specs.
+	Fentries []KProbeSpec `json:"fentries,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// PodSelector selects pods that this policy applies to

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.11"
+const CustomResourceDefinitionSchemaVersion = "1.7.12"

--- a/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
@@ -732,6 +732,13 @@ func (in *TracingPolicySpec) DeepCopyInto(out *TracingPolicySpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Fentries != nil {
+		in, out := &in.Fentries, &out.Fentries
+		*out = make([]KProbeSpec, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.PodSelector != nil {
 		in, out := &in.PodSelector, &out.PodSelector
 		*out = new(v1.LabelSelector)

--- a/pkg/sensors/program/loader_linux.go
+++ b/pkg/sensors/program/loader_linux.go
@@ -498,6 +498,19 @@ func uprobeAttach(load *Program, bpfDir string,
 	return un, err
 }
 
+func TracingOpen(load *Program) OpenFunc {
+	return func(coll *ebpf.CollectionSpec) error {
+		data, ok := load.AttachData.(*TracingAttachData)
+		if !ok {
+			return nil
+		}
+		for _, spec := range coll.Programs {
+			spec.AttachTo = data.AttachTo
+		}
+		return nil
+	}
+}
+
 func TracingAttach(load *Program, bpfDir string) AttachFunc {
 	return func(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
@@ -753,6 +766,7 @@ func LoadFmodRetProgram(bpfDir string, load *Program, maps []*Map, progName stri
 func LoadTracingProgram(bpfDir string, load *Program, maps []*Map, verbose int) error {
 	opts := &LoadOpts{
 		Attach: TracingAttach(load, bpfDir),
+		Open:   TracingOpen(load),
 		Maps:   maps,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)

--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -74,6 +74,10 @@ type MapLoad struct {
 	Load func(m *ebpf.Map, pinPathPrefix string) error
 }
 
+type TracingAttachData struct {
+	AttachTo string
+}
+
 type MultiKprobeAttachData struct {
 	Symbols   []string
 	Cookies   []uint64

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -265,3 +265,8 @@ func TestFentryMatchArgsFdPostfix(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchArgsFdPostfix(t, true)
 }
+
+func TestFentryMatchArgsFdPrefix(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchArgsFdPrefix(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -270,3 +270,8 @@ func TestFentryMatchArgsFdPrefix(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchArgsFdPrefix(t, true)
 }
+
+func TestFentrytMatchArgsFileMonitoringPrefix(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchArgsFileMonitoringPrefix(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -494,3 +494,8 @@ func TestFentryFileTypeFilterNotRegular(t *testing.T) {
 	checkFentry(t)
 	testKprobeFileTypeFilterNotRegular(t, true)
 }
+
+func TestFentryFileTypeFilterSocket(t *testing.T) {
+	checkFentry(t)
+	testKprobeFileTypeFilterSocket(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -220,3 +220,8 @@ func TestFentryMultipleMountPathFiltered(t *testing.T) {
 	checkFentry(t)
 	testMultipleMountPathFiltered(t, true)
 }
+
+func TestFentryArgValues(t *testing.T) {
+	checkFentry(t)
+	testKprobeArgValues(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -225,3 +225,18 @@ func TestFentryArgValues(t *testing.T) {
 	checkFentry(t)
 	testKprobeArgValues(t, true)
 }
+
+func TestFentry_char_iovec(t *testing.T) {
+	checkFentry(t)
+	testKprobe_char_iovec(t, true)
+}
+
+func TestFentry_char_iovec_overflow(t *testing.T) {
+	checkFentry(t)
+	testKprobe_char_iovec_overflow(t, true)
+}
+
+func TestFentry_char_iovec_returnCopy(t *testing.T) {
+	checkFentry(t)
+	testKprobe_char_iovec_returnCopy(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -459,3 +459,13 @@ func TestFentryResolveCurrent(t *testing.T) {
 	checkFentry(t)
 	testKprobeResolveCurrent(t, true)
 }
+
+func TestFentryRangeIn(t *testing.T) {
+	checkFentry(t)
+	testKprobeRangeOp(t, true, true)
+}
+
+func TestFentryRangeNotIn(t *testing.T) {
+	checkFentry(t)
+	testKprobeRangeOp(t, false, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -305,3 +305,8 @@ func TestFentryMatchBinariesEarlyExec(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchBinariesEarlyExec(t, true)
 }
+
+func TestFentryMatchBinariesPrefixMatchArgs(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchBinariesPrefixMatchArgs(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -285,3 +285,8 @@ func TestFentryMatchParentBinaries(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchParentBinaries(t, true)
 }
+
+func TestFentryMatchBinaries(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchBinaries(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -389,3 +389,8 @@ func TestFentryProcessSetCap(t *testing.T) {
 func TestFentryMissedProgStatsKprobeMulti(t *testing.T) {
 	t.Skip("TODO")
 }
+
+func TestFentryBpfCmd(t *testing.T) {
+	checkFentry(t)
+	testKprobeBpfCmd(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -6,6 +6,7 @@
 package tracing
 
 import (
+	"syscall"
 	"testing"
 
 	"github.com/cilium/tetragon/pkg/config"
@@ -73,4 +74,129 @@ func TestFentryObjectReadReturn(t *testing.T) {
 func TestFentryObjectReturnCopy(t *testing.T) {
 	checkFentry(t)
 	testKprobeObjectReturnCopy(t, true)
+}
+
+func TestFentryObjectMultiValueOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectMultiValueOpen(t, true)
+}
+
+func TestFentryObjectMultiValueOpenMount(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectMultiValueOpenMount(t, true)
+}
+
+func TestFentryObjectFilterOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterOpen(t, true)
+}
+
+func TestFentryObjectMultiValueFilterOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectMultiValueFilterOpen(t, true)
+}
+
+func TestFentryObjectFilterPrefixOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterPrefixOpen(t, true)
+}
+
+func TestFentryObjectFilterPrefixOpenSuperLong(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterPrefixOpenSuperLong(t, true)
+}
+
+func TestFentryObjectFilterPrefixOpenMount(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterPrefixOpenMount(t, true)
+}
+
+func TestFentryObjectFilterPrefixExactOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterPrefixExactOpen(t, true)
+}
+
+func TestFentryObjectFilterPrefixExactOpenMount(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterPrefixExactOpenMount(t, true)
+}
+
+func TestFentryObjectFilterPrefixSubdirOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterPrefixSubdirOpen(t, true)
+}
+
+func TestFentryObjectFilterPrefixSubdirOpenMount(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterPrefixSubdirOpenMount(t, true)
+}
+
+func TestFentryObjectFilterPrefixMissOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterPrefixMissOpen(t, true)
+}
+
+func TestFentryObjectPostfixOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectPostfixOpen(t, false, true)
+}
+
+func TestFentryObjectPostfixOpenWithNull(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectPostfixOpen(t, true, true)
+}
+
+func TestFentryObjectPostfixOpenSuperLong(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectPostfixOpenSuperLong(t, true)
+}
+
+func TestFentryObjectFilterModeOpenMatchDec(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterModeOpenMatch(t, "%d", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_TRUNC, true)
+}
+
+func TestFentryObjectFilterModeOpenMatchHex(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterModeOpenMatch(t, "0x%x", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_RDWR, true)
+}
+
+func TestFentryObjectFilterModeOpenMatchOct(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterModeOpenMatch(t, "0%o", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_CLOEXEC, true)
+}
+
+func TestFentryObjectFilterModeOpenFail(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilterModeOpenFail(t, true)
+}
+
+func TestFentryObjectFilenameOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFilenameOpen(t, true)
+}
+
+func TestFentryObjectReturnFilenameOpen(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectReturnFilenameOpen(t, true)
+}
+
+func TestFentryObjectFileWrite(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFileWrite(t, true)
+}
+
+func TestFentryObjectFileWriteFiltered(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFileWriteFiltered(t, true)
+}
+
+func TestFentryObjectFileWriteMount(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFileWriteMount(t, true)
+}
+
+func TestFentryObjectFileWriteMountFiltered(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectFileWriteMountFiltered(t, true)
 }

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -365,3 +365,8 @@ func TestFentryKernelStackTrace(t *testing.T) {
 	checkFentry(t)
 	testKprobeKernelStackTrace(t, true)
 }
+
+func TestFentryUserStackTrace(t *testing.T) {
+	checkFentry(t)
+	testKprobeUserStackTrace(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -419,3 +419,8 @@ func TestFentryResolvePid(t *testing.T) {
 	checkFentry(t)
 	testKprobeResolvePid(t, true)
 }
+
+func TestFentryArgsReverse(t *testing.T) {
+	checkFentry(t)
+	testKprobeArgsReverse(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -479,3 +479,8 @@ func TestFentryGTFail(t *testing.T) {
 	checkFentry(t)
 	testKprobeGT(t, 0xfffef, true, true)
 }
+
+func TestFentryFileTypeFilterRegular(t *testing.T) {
+	checkFentry(t)
+	testKprobeFileTypeFilterRegular(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -345,3 +345,8 @@ func TestFentryListSyscallDupsRange(t *testing.T) {
 	checkFentry(t)
 	testKprobeListSyscallDupsRange(t, true)
 }
+
+func TestFentryKernelModuleCallsStability(t *testing.T) {
+	checkFentry(t)
+	testTraceKernelModuleCallsStability(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -275,3 +275,8 @@ func TestFentrytMatchArgsFileMonitoringPrefix(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchArgsFileMonitoringPrefix(t, true)
 }
+
+func TestFentryMatchArgsNonPrefix(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchArgsNonPrefix(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -370,3 +370,8 @@ func TestFentryUserStackTrace(t *testing.T) {
 	checkFentry(t)
 	testKprobeUserStackTrace(t, true)
 }
+
+func TestFentryMultiMatcArgs(t *testing.T) {
+	checkFentry(t)
+	testKprobeMultiMatcArgs(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -439,3 +439,8 @@ func TestFentryArgsMulti(t *testing.T) {
 	checkFentry(t)
 	testKprobeArgsMulti(t, true)
 }
+
+func TestFentryArgsMultiResolve(t *testing.T) {
+	checkFentry(t)
+	testKprobeArgsMultiResolve(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -484,3 +484,8 @@ func TestFentryFileTypeFilterRegular(t *testing.T) {
 	checkFentry(t)
 	testKprobeFileTypeFilterRegular(t, true)
 }
+
+func TestFentryFileTypeFilterPipe(t *testing.T) {
+	checkFentry(t)
+	testKprobeFileTypeFilterPipe(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -380,3 +380,8 @@ func TestFentryArgs(t *testing.T) {
 	checkFentry(t)
 	testKprobeArgs(t, true)
 }
+
+func TestFentryProcessSetCap(t *testing.T) {
+	checkFentry(t)
+	testProcessSetCap(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -469,3 +469,13 @@ func TestFentryRangeNotIn(t *testing.T) {
 	checkFentry(t)
 	testKprobeRangeOp(t, false, true)
 }
+
+func TestFentryGTOk(t *testing.T) {
+	checkFentry(t)
+	testKprobeGT(t, 0xffff1, false, true)
+}
+
+func TestFentryGTFail(t *testing.T) {
+	checkFentry(t)
+	testKprobeGT(t, 0xfffef, true, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -429,3 +429,8 @@ func TestFentryResolveSecondArg(t *testing.T) {
 	checkFentry(t)
 	testKprobeResolveSecondArg(t, true)
 }
+
+func TestFentryIgnore(t *testing.T) {
+	checkFentry(t)
+	testKprobeIgnore(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -315,3 +315,18 @@ func TestFentryBpfAttr(t *testing.T) {
 	checkFentry(t)
 	testKprobeBpfAttr(t, true)
 }
+
+func TestFentryWriteMaxDataTrunc(t *testing.T) {
+	checkFentry(t)
+	testKprobeWriteMaxDataTrunc(t, true)
+}
+
+func TestFentryWriteMaxData(t *testing.T) {
+	checkFentry(t)
+	testKprobeWriteMaxData(t, true)
+}
+
+func TestFentryWriteMaxDataFull(t *testing.T) {
+	checkFentry(t)
+	testKprobeWriteMaxDataFull(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -360,3 +360,8 @@ func TestFentryTraceKernelModule(t *testing.T) {
 	checkFentry(t)
 	testTraceKernelModule(t, true)
 }
+
+func TestFentryKernelStackTrace(t *testing.T) {
+	checkFentry(t)
+	testKprobeKernelStackTrace(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -434,3 +434,8 @@ func TestFentryIgnore(t *testing.T) {
 	checkFentry(t)
 	testKprobeIgnore(t, true)
 }
+
+func TestFentryArgsMulti(t *testing.T) {
+	checkFentry(t)
+	testKprobeArgsMulti(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -399,3 +399,8 @@ func TestFentryMultiSymbolInstancesOk(t *testing.T) {
 	checkFentry(t)
 	testKprobeMultiSymbolInstancesOk(t, true)
 }
+
+func TestFentryLongPath(t *testing.T) {
+	checkFentry(t)
+	testLongPath(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -350,3 +350,8 @@ func TestFentryKernelModuleCallsStability(t *testing.T) {
 	checkFentry(t)
 	testTraceKernelModuleCallsStability(t, true)
 }
+
+func TestFentryLinuxBinprmExtractPath(t *testing.T) {
+	checkFentry(t)
+	testLinuxBinprmExtractPath(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -29,3 +29,28 @@ func TestFentryLseek(t *testing.T) {
 		"Hook": "fentries",
 	})
 }
+
+func TestFentryObjectWriteReadHostNs(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectWriteReadHostNs(t, true)
+}
+
+func TestFentryObjectWriteRead(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectWriteRead(t, true)
+}
+
+func TestFentryObjectWriteCapsNotIn(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectWriteCapsNotIn(t, true)
+}
+
+func TestFentryObjectWriteReadNsOnly(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectWriteReadNsOnly(t, true)
+}
+
+func TestFentryObjectWriteReadPidOnly(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectWriteReadPidOnly(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -340,3 +340,8 @@ func TestFentryRateLimit(t *testing.T) {
 	checkFentry(t)
 	testKprobeRateLimit(t, true, true)
 }
+
+func TestFentryListSyscallDupsRange(t *testing.T) {
+	checkFentry(t)
+	testKprobeListSyscallDupsRange(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -414,3 +414,8 @@ func TestFentryDentryPath(t *testing.T) {
 	checkFentry(t)
 	testKprobeDentryPath(t, true)
 }
+
+func TestFentryResolvePid(t *testing.T) {
+	checkFentry(t)
+	testKprobeResolvePid(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -509,3 +509,8 @@ func TestFentryFileTypeFilterMultiple(t *testing.T) {
 	checkFentry(t)
 	testKprobeFileTypeFilterMultiple(t, true)
 }
+
+func TestFentryNotEqualMultipleValues(t *testing.T) {
+	checkFentry(t)
+	testKprobeNotEqualMultipleValues(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -310,3 +310,8 @@ func TestFentryMatchBinariesPrefixMatchArgs(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchBinariesPrefixMatchArgs(t, true)
 }
+
+func TestFentryBpfAttr(t *testing.T) {
+	checkFentry(t)
+	testKprobeBpfAttr(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -250,3 +250,8 @@ func TestFentryMatchArgsFilePostfix(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchArgsFilePostfix(t, true)
 }
+
+func TestFentryMatchArgsFilePrefix(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchArgsFilePrefix(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -394,3 +394,8 @@ func TestFentryBpfCmd(t *testing.T) {
 	checkFentry(t)
 	testKprobeBpfCmd(t, true)
 }
+
+func TestFentryMultiSymbolInstancesOk(t *testing.T) {
+	checkFentry(t)
+	testKprobeMultiSymbolInstancesOk(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -444,3 +444,8 @@ func TestFentryArgsMultiResolve(t *testing.T) {
 	checkFentry(t)
 	testKprobeArgsMultiResolve(t, true)
 }
+
+func TestFentryArgsFilter(t *testing.T) {
+	checkFentry(t)
+	testKprobeArgsFilter(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -409,3 +409,8 @@ func TestFentryMaxPath(t *testing.T) {
 	checkFentry(t)
 	testMaxPath(t, true)
 }
+
+func TestFentryDentryPath(t *testing.T) {
+	checkFentry(t)
+	testKprobeDentryPath(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -375,3 +375,8 @@ func TestFentryMultiMatcArgs(t *testing.T) {
 	checkFentry(t)
 	testKprobeMultiMatcArgs(t, true)
 }
+
+func TestFentryArgs(t *testing.T) {
+	checkFentry(t)
+	testKprobeArgs(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -404,3 +404,8 @@ func TestFentryLongPath(t *testing.T) {
 	checkFentry(t)
 	testLongPath(t, true)
 }
+
+func TestFentryMaxPath(t *testing.T) {
+	checkFentry(t)
+	testMaxPath(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -355,3 +355,8 @@ func TestFentryLinuxBinprmExtractPath(t *testing.T) {
 	checkFentry(t)
 	testLinuxBinprmExtractPath(t, true)
 }
+
+func TestFentryTraceKernelModule(t *testing.T) {
+	checkFentry(t)
+	testTraceKernelModule(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -300,3 +300,8 @@ func TestFentryMatchBinariesPerfring(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchBinariesPerfring(t, true)
 }
+
+func TestFentryMatchBinariesEarlyExec(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchBinariesEarlyExec(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -240,3 +240,8 @@ func TestFentry_char_iovec_returnCopy(t *testing.T) {
 	checkFentry(t)
 	testKprobe_char_iovec_returnCopy(t, true)
 }
+
+func TestFentryMatchArgsFileEqual(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchArgsFileEqual(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -454,3 +454,8 @@ func TestFentryCapabilitiesGained(t *testing.T) {
 	checkFentry(t)
 	testCapabilitiesGained(t, true)
 }
+
+func TestFentryResolveCurrent(t *testing.T) {
+	checkFentry(t)
+	testKprobeResolveCurrent(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -200,3 +200,23 @@ func TestFentryObjectFileWriteMountFiltered(t *testing.T) {
 	checkFentry(t)
 	testKprobeObjectFileWriteMountFiltered(t, true)
 }
+
+func TestFentryMultipleMountsFiltered(t *testing.T) {
+	checkFentry(t)
+	testMultipleMountsFiltered(t, true)
+}
+
+func TestFentryMultiplePathComponents(t *testing.T) {
+	checkFentry(t)
+	testMultiplePathComponents(t, true)
+}
+
+func TestFentryMultipleMountPath(t *testing.T) {
+	checkFentry(t)
+	testMultipleMountPath(t, true)
+}
+
+func TestFentryMultipleMountPathFiltered(t *testing.T) {
+	checkFentry(t)
+	testMultipleMountPathFiltered(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -504,3 +504,8 @@ func TestFentryFileTypeFilterNotPipe(t *testing.T) {
 	checkFentry(t)
 	testKprobeFileTypeFilterNotPipe(t, true)
 }
+
+func TestFentryFileTypeFilterMultiple(t *testing.T) {
+	checkFentry(t)
+	testKprobeFileTypeFilterMultiple(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -255,3 +255,8 @@ func TestFentryMatchArgsFilePrefix(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchArgsFilePrefix(t, true)
 }
+
+func TestFentryMatchArgsFdEqual(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchArgsFdEqual(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -280,3 +280,8 @@ func TestFentryMatchArgsNonPrefix(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchArgsNonPrefix(t, true)
 }
+
+func TestFentryMatchParentBinaries(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchParentBinaries(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package tracing
+
+import (
+	"testing"
+
+	"github.com/cilium/tetragon/pkg/config"
+)
+
+func checkFentry(t *testing.T) {
+	if !config.EnableV61Progs() {
+		t.Skip("fentry requires at least 6.1 kernel")
+	}
+}
+
+func TestFentryObjectLoad(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectLoad(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -424,3 +424,8 @@ func TestFentryArgsReverse(t *testing.T) {
 	checkFentry(t)
 	testKprobeArgsReverse(t, true)
 }
+
+func TestFentryResolveSecondArg(t *testing.T) {
+	checkFentry(t)
+	testKprobeResolveSecondArg(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -330,3 +330,13 @@ func TestFentryWriteMaxDataFull(t *testing.T) {
 	checkFentry(t)
 	testKprobeWriteMaxDataFull(t, true)
 }
+
+func TestFentryNoRateLimit(t *testing.T) {
+	checkFentry(t)
+	testKprobeRateLimit(t, false, true)
+}
+
+func TestFentryRateLimit(t *testing.T) {
+	checkFentry(t)
+	testKprobeRateLimit(t, true, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -449,3 +449,8 @@ func TestFentryArgsFilter(t *testing.T) {
 	checkFentry(t)
 	testKprobeArgsFilter(t, true)
 }
+
+func TestFentryCapabilitiesGained(t *testing.T) {
+	checkFentry(t)
+	testCapabilitiesGained(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -489,3 +489,8 @@ func TestFentryFileTypeFilterPipe(t *testing.T) {
 	checkFentry(t)
 	testKprobeFileTypeFilterPipe(t, true)
 }
+
+func TestFentryFileTypeFilterNotRegular(t *testing.T) {
+	checkFentry(t)
+	testKprobeFileTypeFilterNotRegular(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -260,3 +260,8 @@ func TestFentryMatchArgsFdEqual(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchArgsFdEqual(t, true)
 }
+
+func TestFentryMatchArgsFdPostfix(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchArgsFdPostfix(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -385,3 +385,7 @@ func TestFentryProcessSetCap(t *testing.T) {
 	checkFentry(t)
 	testProcessSetCap(t, true)
 }
+
+func TestFentryMissedProgStatsKprobeMulti(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cilium/tetragon/pkg/config"
+	"github.com/cilium/tetragon/pkg/testutils/policytest"
 )
 
 func checkFentry(t *testing.T) {
@@ -20,4 +21,11 @@ func checkFentry(t *testing.T) {
 func TestFentryObjectLoad(t *testing.T) {
 	checkFentry(t)
 	testKprobeObjectLoad(t, true)
+}
+
+func TestFentryLseek(t *testing.T) {
+	checkFentry(t)
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-lseek", map[string]any{
+		"Hook": "fentries",
+	})
 }

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -54,3 +54,23 @@ func TestFentryObjectWriteReadPidOnly(t *testing.T) {
 	checkFentry(t)
 	testKprobeObjectWriteReadPidOnly(t, true)
 }
+
+func TestFentryObjectRead(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectRead(t, true)
+}
+
+func TestFentryObjectReadIdxMismatch(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectReadIdxMismatch(t, true)
+}
+
+func TestFentryObjectReadReturn(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectReadReturn(t, true)
+}
+
+func TestFentryObjectReturnCopy(t *testing.T) {
+	checkFentry(t)
+	testKprobeObjectReturnCopy(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -290,3 +290,8 @@ func TestFentryMatchBinaries(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchBinaries(t, true)
 }
+
+func TestFentryMatchBinariesLargePath(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchBinariesLargePath(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -499,3 +499,8 @@ func TestFentryFileTypeFilterSocket(t *testing.T) {
 	checkFentry(t)
 	testKprobeFileTypeFilterSocket(t, true)
 }
+
+func TestFentryFileTypeFilterNotPipe(t *testing.T) {
+	checkFentry(t)
+	testKprobeFileTypeFilterNotPipe(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -295,3 +295,8 @@ func TestFentryMatchBinariesLargePath(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchBinariesLargePath(t, true)
 }
+
+func TestFentryMatchBinariesPerfring(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchBinariesPerfring(t, true)
+}

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -245,3 +245,8 @@ func TestFentryMatchArgsFileEqual(t *testing.T) {
 	checkFentry(t)
 	testKprobeMatchArgsFileEqual(t, true)
 }
+
+func TestFentryMatchArgsFilePostfix(t *testing.T) {
+	checkFentry(t)
+	testKprobeMatchArgsFilePostfix(t, true)
+}

--- a/pkg/sensors/tracing/genericfentry.go
+++ b/pkg/sensors/tracing/genericfentry.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package tracing
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cilium/tetragon/pkg/idtable"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/selectors"
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+)
+
+type observerFentrySensor struct {
+	name string
+}
+
+func init() {
+	fentry := &observerFentrySensor{
+		name: "fentrry sensor",
+	}
+	sensors.RegisterProbeType("generic_fentry", fentry)
+}
+
+func createGenericFentrySensor(
+	spec *v1alpha1.TracingPolicySpec,
+	name string,
+	polInfo *policyInfo,
+	valInfo []*kpValidateInfo,
+) (*sensors.Sensor, error) {
+
+	// TODO support enforcement ;-)
+	for _, fentry := range spec.Fentries {
+		if selectors.HasEnforcementAction(fentry.Selectors) {
+			return nil, errors.New("enforcement is not supported for fentry yet")
+		}
+	}
+
+	return createGenericKprobeSensor(spec, name, polInfo, valInfo, fentry)
+}
+
+func (k *observerFentrySensor) LoadProbe(args sensors.LoadProbeArgs) error {
+	return loadGenericFentrySensor(args.BPFDir, args.Load, args.Maps, args.Verbose)
+}
+
+func loadGenericFentrySensor(bpfDir string, load *program.Program, maps []*program.Map, verbose int) error {
+	if id, ok := load.LoaderData.(idtable.EntryID); ok {
+		return loadSingleKprobeSensor(id, bpfDir, load, maps, verbose, true)
+	}
+	return fmt.Errorf("invalid loadData type: expecting idtable.EntryID and got: %T (%v)",
+		load.LoaderData, load.LoaderData)
+}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -528,6 +528,7 @@ type hasMaps struct {
 	override   bool
 	sockTrack  bool
 	selector   bool
+	fentry     bool
 }
 
 // hasMapsSetup setups the has maps for the per policy maps. The per kprobe maps
@@ -966,15 +967,41 @@ func createKprobeSensorFromEntry(polInfo *policyInfo, kprobeEntry *genericKprobe
 		pinProg = fmt.Sprintf("%s:%d", kprobeEntry.funcName, kprobeEntry.instance)
 	}
 
-	load := program.Builder(
-		path.Join(option.Config.HubbleLib, loadProgName),
-		kprobeEntry.funcName,
-		"kprobe/generic_kprobe",
-		pinProg,
-		"generic_kprobe").
-		SetLoaderData(kprobeEntry.tableId).
-		SetPolicy(kprobeEntry.policyName)
+	var load *program.Program
+
+	if has.fentry {
+		data := &program.TracingAttachData{
+			AttachTo: kprobeEntry.funcName,
+		}
+
+		loadProgName, loadProgRetName = config.GenericTracingObjs()
+
+		load = program.Builder(
+			path.Join(option.Config.HubbleLib, loadProgName),
+			kprobeEntry.funcName,
+			"fentry/generic_fentry",
+			pinProg,
+			"generic_fentry").
+			SetAttachData(data)
+
+		tailCalls := program.MapBuilderProgram("fentry_calls", load)
+		maps = append(maps, tailCalls)
+	} else {
+		load = program.Builder(
+			path.Join(option.Config.HubbleLib, loadProgName),
+			kprobeEntry.funcName,
+			"kprobe/generic_kprobe",
+			pinProg,
+			"generic_kprobe")
+
+		tailCalls := program.MapBuilderProgram("kprobe_calls", load)
+		maps = append(maps, tailCalls)
+	}
+
+	load.SetPolicy(kprobeEntry.policyName)
+	load.SetLoaderData(kprobeEntry.tableId)
 	load.Override = kprobeEntry.hasOverride
+
 	if load.Override {
 		load.OverrideFmodRet = isSecurityFunc && bpf.HasModifyReturn()
 	}
@@ -988,9 +1015,6 @@ func createKprobeSensorFromEntry(polInfo *policyInfo, kprobeEntry *genericKprobe
 
 	configMap := program.MapBuilderProgram("config_map", load)
 	maps = append(maps, configMap)
-
-	tailCalls := program.MapBuilderProgram("kprobe_calls", load)
-	maps = append(maps, tailCalls)
 
 	filterMap := program.MapBuilderProgram("filter_map", load)
 	maps = append(maps, filterMap)
@@ -1061,15 +1085,40 @@ func createKprobeSensorFromEntry(polInfo *policyInfo, kprobeEntry *genericKprobe
 		if kprobeEntry.instance != 0 {
 			pinRetProg = sensors.PathJoin(fmt.Sprintf("%s_return:%d", kprobeEntry.funcName, kprobeEntry.instance))
 		}
-		loadret := program.Builder(
-			path.Join(option.Config.HubbleLib, loadProgRetName),
-			kprobeEntry.funcName,
-			"kprobe/generic_retkprobe",
-			pinRetProg,
-			"generic_kprobe").
-			SetRetProbe(true).
-			SetLoaderData(kprobeEntry.tableId).
-			SetPolicy(kprobeEntry.policyName)
+
+		var loadret *program.Program
+
+		if has.fentry {
+			data := &program.TracingAttachData{
+				AttachTo: kprobeEntry.funcName,
+			}
+
+			loadret = program.Builder(
+				path.Join(option.Config.HubbleLib, loadProgRetName),
+				kprobeEntry.funcName,
+				"fexit/generic_fexit",
+				pinRetProg,
+				"generic_fentry").
+				SetAttachData(data)
+
+			tailCalls := program.MapBuilderProgram("fexit_calls", loadret)
+			maps = append(maps, tailCalls)
+		} else {
+			loadret = program.Builder(
+				path.Join(option.Config.HubbleLib, loadProgRetName),
+				kprobeEntry.funcName,
+				"kprobe/generic_retkprobe",
+				pinRetProg,
+				"generic_kprobe")
+
+			tailCalls := program.MapBuilderProgram("retkprobe_calls", loadret)
+			maps = append(maps, tailCalls)
+		}
+
+		loadret.SetRetProbe(true)
+		loadret.SetLoaderData(kprobeEntry.tableId)
+		loadret.SetPolicy(kprobeEntry.policyName)
+
 		progs = append(progs, loadret)
 
 		retProbe := program.MapBuilderSensor("retprobe_map", loadret)
@@ -1077,9 +1126,6 @@ func createKprobeSensorFromEntry(polInfo *policyInfo, kprobeEntry *genericKprobe
 
 		retConfigMap := program.MapBuilderProgram("config_map", loadret)
 		maps = append(maps, retConfigMap)
-
-		tailCalls := program.MapBuilderProgram("retkprobe_calls", loadret)
-		maps = append(maps, tailCalls)
 
 		filterMap := program.MapBuilderProgram("filter_map", loadret)
 		maps = append(maps, filterMap)

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -533,9 +533,9 @@ type hasMaps struct {
 
 // hasMapsSetup setups the has maps for the per policy maps. The per kprobe maps
 // are setup later in createSingleKprobeSensor or createMultiKprobeSensor.
-func hasMapsSetup(spec *v1alpha1.TracingPolicySpec) hasMaps {
-	has := hasMaps{}
-	for _, kprobe := range spec.KProbes {
+func hasMapsSetup(spec *v1alpha1.TracingPolicySpec, kprobes []v1alpha1.KProbeSpec, fentry bool) hasMaps {
+	has := hasMaps{fentry: fentry}
+	for _, kprobe := range kprobes {
 		has.fdInstall = has.fdInstall || selectors.HasFDInstall(kprobe.Selectors)
 		has.enforcer = has.enforcer || len(spec.Enforcers) != 0
 		has.rateLimit = has.rateLimit || selectors.HasRateLimit(kprobe.Selectors)
@@ -550,11 +550,23 @@ func isArm() bool {
 	return runtime.GOARCH == "arm64"
 }
 
+type attachType int
+
+const (
+	kprobe attachType = iota
+	fentry
+)
+
+func isFentry(typ attachType) bool {
+	return typ == fentry
+}
+
 func createGenericKprobeSensor(
 	spec *v1alpha1.TracingPolicySpec,
 	name string,
 	polInfo *policyInfo,
 	valInfo []*kpValidateInfo,
+	typ attachType,
 ) (*sensors.Sensor, error) {
 	var progs []*program.Program
 	var maps []*program.Map
@@ -562,10 +574,17 @@ func createGenericKprobeSensor(
 	var useMulti bool
 	var selMaps *selectors.KernelSelectorMaps
 	var celExprs *selectors.CelExprFunctions
+	var kprobes []v1alpha1.KProbeSpec
 
-	kprobes := spec.KProbes
+	fentry := isFentry(typ)
 
-	has := hasMapsSetup(spec)
+	if fentry {
+		kprobes = spec.Fentries
+	} else {
+		kprobes = spec.KProbes
+	}
+
+	has := hasMapsSetup(spec, kprobes, fentry)
 
 	// use multi kprobe only if:
 	// - it's not disabled by spec option
@@ -576,6 +595,10 @@ func createGenericKprobeSensor(
 
 		// arm does not override on top of kprobe.multi
 		if isArm() && (has.enforcer || has.override) {
+			useMulti = false
+		}
+		// there's no multi support yet
+		if fentry {
 			useMulti = false
 		}
 	}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -618,7 +618,7 @@ func createGenericKprobeSensor(
 			}
 			dups[sym] = instance
 
-			id, err := addKprobe(sym, instance, &kprobes[i], &in)
+			id, err := addKprobe(sym, instance, &kprobes[i], &in, has)
 			if err != nil {
 				return nil, err
 			}
@@ -685,7 +685,7 @@ func initEventConfig() *api.EventConfig {
 // addKprobe will, amongst other things, create a generic kprobe entry and add
 // it to the genericKprobeTable. The caller should make sure that this entry is
 // properly removed on kprobe removal.
-func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKprobeIn) (id idtable.EntryID, err error) {
+func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKprobeIn, has hasMaps) (id idtable.EntryID, err error) {
 	var argSigPrinters []argPrinter
 	var argReturnPrinters []argPrinter
 	var setRetprobe bool
@@ -949,7 +949,8 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 	eventConfig.FuncId = uint32(kprobeEntry.tableId.ID)
 
 	logger.GetLogger().
-		Info("Added kprobe", "return", setRetprobe, "function", kprobeEntry.funcName, "override", kprobeEntry.hasOverride)
+		Info("Added kprobe", "return", setRetprobe, "function", kprobeEntry.funcName,
+			"override", kprobeEntry.hasOverride, "enforcer", has.enforcer)
 
 	return kprobeEntry.tableId, nil
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -1188,7 +1188,9 @@ func getMapLoad(load *program.Program, kprobeEntry *genericKprobe, index uint32)
 	return selectorsMaploads(state, index)
 }
 
-func loadSingleKprobeSensor(id idtable.EntryID, bpfDir string, load *program.Program, maps []*program.Map, verbose int) error {
+func loadSingleKprobeSensor(id idtable.EntryID, bpfDir string, load *program.Program, maps []*program.Map,
+	verbose int, fentry bool) error {
+
 	gk, err := genericKprobeTableGet(id)
 	if err != nil {
 		return err
@@ -1214,10 +1216,14 @@ func loadSingleKprobeSensor(id idtable.EntryID, bpfDir string, load *program.Pro
 	}
 	load.MapLoad = append(load.MapLoad, config)
 
-	if err := program.LoadKprobeProgram(bpfDir, load, maps, verbose); err == nil {
-		logger.GetLogger().Info(fmt.Sprintf("Loaded generic kprobe program: %s -> %s", load.Name, load.Attach))
+	if fentry {
+		if err = program.LoadTracingProgram(bpfDir, load, maps, verbose); err == nil {
+			logger.GetLogger().Info(fmt.Sprintf("Loaded generic fentry program: %s -> %s", load.Name, load.Attach))
+		}
 	} else {
-		return err
+		if err = program.LoadKprobeProgram(bpfDir, load, maps, verbose); err == nil {
+			logger.GetLogger().Info(fmt.Sprintf("Loaded generic kprobe program: %s -> %s", load.Name, load.Attach))
+		}
 	}
 
 	return err
@@ -1274,9 +1280,9 @@ func loadMultiKprobeSensor(ids []idtable.EntryID, bpfDir string, load *program.P
 	return nil
 }
 
-func loadGenericKprobeSensor(bpfDir string, load *program.Program, maps []*program.Map, verbose int) error {
+func loadGenericKprobeSensor(bpfDir string, load *program.Program, maps []*program.Map, verbose int, fentry bool) error {
 	if id, ok := load.LoaderData.(idtable.EntryID); ok {
-		return loadSingleKprobeSensor(id, bpfDir, load, maps, verbose)
+		return loadSingleKprobeSensor(id, bpfDir, load, maps, verbose, fentry)
 	}
 	if ids, ok := load.LoaderData.([]idtable.EntryID); ok {
 		return loadMultiKprobeSensor(ids, bpfDir, load, maps, verbose)
@@ -1527,5 +1533,5 @@ func retprobeMergeEvents[T evArgsRetriever](unix T, pendingEvents *lru.Cache[pen
 }
 
 func (k *observerKprobeSensor) LoadProbe(args sensors.LoadProbeArgs) error {
-	return loadGenericKprobeSensor(args.BPFDir, args.Load, args.Maps, args.Verbose)
+	return loadGenericKprobeSensor(args.BPFDir, args.Load, args.Maps, args.Verbose, false)
 }

--- a/pkg/sensors/tracing/generickprobe_test.go
+++ b/pkg/sensors/tracing/generickprobe_test.go
@@ -100,7 +100,7 @@ func Test_SensorDestroyHook(t *testing.T) {
 	// contained in one sensor.
 	policyInfo, err := newPolicyInfoFromSpec("", "test_policy", policyfilter.NoFilterID, spec, nil)
 	require.NoError(t, err)
-	sensor, err := createGenericKprobeSensor(spec, "test_sensor", policyInfo, simpleValidateInfo(spec.KProbes))
+	sensor, err := createGenericKprobeSensor(spec, "test_sensor", policyInfo, simpleValidateInfo(spec.KProbes), kprobe)
 	if err != nil {
 		t.Errorf("createGenericKprobeSensor err expected: nil, got: %s", err)
 	}

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3888,14 +3888,14 @@ spec:
 	return configHook.String()
 }
 
-func TestKprobeMatchArgsFileMonitoringPrefix(t *testing.T) {
+func testKprobeMatchArgsFileMonitoringPrefix(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, getMatchArgsFileFIMCrd([]string{"/etc/"}))
+	createCrdFileFlag(t, getMatchArgsFileFIMCrd([]string{"/etc/"}), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -3920,6 +3920,10 @@ func TestKprobeMatchArgsFileMonitoringPrefix(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeMatchArgsFileMonitoringPrefix(t *testing.T) {
+	testKprobeMatchArgsFileMonitoringPrefix(t, false)
 }
 
 func TestKprobeMatchArgsNonPrefix(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7741,7 +7741,7 @@ func TestKprobeRangeNotIn(t *testing.T) {
 	testKprobeRangeOp(t, false, false)
 }
 
-func testKprobeGT(t *testing.T, value uint64, fail bool) {
+func testKprobeGT(t *testing.T, value uint64, fail, fentry bool) {
 
 	if !config.EnableLargeProgs() {
 		t.Skipf("Skipping test since it needs kernel >= 5.3")
@@ -7773,7 +7773,7 @@ spec:
         - "0xffff0"
 `
 
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -7801,11 +7801,11 @@ spec:
 }
 
 func TestKprobeGTOk(t *testing.T) {
-	testKprobeGT(t, 0xffff1, false)
+	testKprobeGT(t, 0xffff1, false, false)
 }
 
 func TestKprobeGTFail(t *testing.T) {
-	testKprobeGT(t, 0xfffef, true)
+	testKprobeGT(t, 0xfffef, true, false)
 }
 
 func TestKprobeFileTypeFilterRegular(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4051,14 +4051,14 @@ func createParentsChecker(parent, binary string) *ec.ProcessKprobeChecker {
 	return kpChecker
 }
 
-func matchParentBinariesTest(t *testing.T, operator string, values []string, kpChecker *ec.ProcessKprobeChecker, newProcess bool) {
+func matchParentBinariesTest(t *testing.T, operator string, values []string, kpChecker *ec.ProcessKprobeChecker, newProcess, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, getMatchParentBinariesCrd(operator, values))
+	createCrdFileFlag(t, getMatchParentBinariesCrd(operator, values), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -4092,7 +4092,7 @@ func matchParentBinariesTest(t *testing.T, operator string, values []string, kpC
 
 const skipMatchParentBinaries = "kernels without large progs do not support matchParentBinaries selector"
 
-func TestKprobeMatchParentBinaries(t *testing.T) {
+func testKprobeMatchParentBinaries(t *testing.T, fentry bool) {
 	if !config.EnableLargeProgs() {
 		t.Skip(skipMatchParentBinaries)
 	}
@@ -4193,9 +4193,13 @@ func TestKprobeMatchParentBinaries(t *testing.T) {
 	option.Config.ParentsMapEnabled = true
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			matchParentBinariesTest(t, test.operator, test.values, createParentsChecker(test.expectedParent, test.binary), test.parentCreatesNewProcess)
+			matchParentBinariesTest(t, test.operator, test.values, createParentsChecker(test.expectedParent, test.binary), test.parentCreatesNewProcess, fentry)
 		})
 	}
+}
+
+func TestKprobeMatchParentBinaries(t *testing.T) {
+	testKprobeMatchParentBinaries(t, false)
 }
 
 func getMatchBinariesCrd(opStr string, vals []string) string {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7466,7 +7466,7 @@ func TestKprobeArgsFilter(t *testing.T) {
 	testKprobeArgsFilter(t, false)
 }
 
-func TestCapabilitiesGained(t *testing.T) {
+func testCapabilitiesGained(t *testing.T, fentry bool) {
 	testutils.CaptureLog(t, logger.GetLogger())
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
@@ -7506,6 +7506,11 @@ func TestCapabilitiesGained(t *testing.T) {
 		}},
 	}
 
+	if fentry {
+		spec.Fentries = spec.KProbes
+		spec.KProbes = []v1alpha1.KProbeSpec{}
+	}
+
 	loadGenericSensorTest(t, spec)
 	t0 := time.Now()
 	loadElapsed := time.Since(t0)
@@ -7543,6 +7548,10 @@ func TestCapabilitiesGained(t *testing.T) {
 
 	perfring.RunTest(t, ctx, ops, eventFn)
 	require.Equal(t, 1, countEvents, "expected single event")
+}
+
+func TestCapabilitiesGained(t *testing.T) {
+	testCapabilitiesGained(t, false)
 }
 
 func TestKprobeResolveCurrent(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6196,7 +6196,7 @@ func TestKprobeArgs(t *testing.T) {
 }
 
 // Detect changing capabilities
-func TestProcessSetCap(t *testing.T) {
+func testProcessSetCap(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -6239,7 +6239,7 @@ spec:
         - "0"
 `
 
-	createCrdFile(t, tracingPolicy)
+	createCrdFileFlag(t, tracingPolicy, fentry)
 
 	fullSet := caps.GetCapsFullSet()
 	firstChange := fullSet&0xffffffff00000000 | uint64(0xffdfffff)  // Removes CAP_SYS_ADMIN
@@ -6321,6 +6321,10 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpCheckers1, kpCheckers2)
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestProcessSetCap(t *testing.T) {
+	testProcessSetCap(t, false)
 }
 
 func TestMissedProgStatsKprobeMulti(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7366,7 +7366,7 @@ func TestKprobeArgsMultiResolve(t *testing.T) {
 	testKprobeArgsMultiResolve(t, false)
 }
 
-func TestKprobeArgsFilter(t *testing.T) {
+func testKprobeArgsFilter(t *testing.T, fentry bool) {
 	if !config.EnableLargeProgs() {
 		t.Skip("Older kernels do not support more than 1 selector argument")
 	}
@@ -7435,7 +7435,7 @@ spec:
         - "0"
 `
 
-	createCrdFile(t, lseekConfigHook_)
+	createCrdFileFlag(t, lseekConfigHook_, fentry)
 
 	kpChecker := ec.NewProcessKprobeChecker("lseek-checker").
 		WithFunctionName(sm.Suffix("sys_lseek")).
@@ -7460,6 +7460,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(kpChecker))
 	require.NoError(t, err)
+}
+
+func TestKprobeArgsFilter(t *testing.T) {
+	testKprobeArgsFilter(t, false)
 }
 
 func TestCapabilitiesGained(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7048,7 +7048,7 @@ func TestKprobeResolvePid(t *testing.T) {
 	testKprobeResolvePid(t, false)
 }
 
-func TestKprobeArgsReverse(t *testing.T) {
+func testKprobeArgsReverse(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -7086,7 +7086,7 @@ spec:
         values:
         - ` + pidStr
 
-	createCrdFile(t, lseekConfigHook_)
+	createCrdFileFlag(t, lseekConfigHook_, fentry)
 
 	kpChecker := ec.NewProcessKprobeChecker("lseek-checker").
 		WithFunctionName(sm.Suffix("sys_lseek")).
@@ -7109,6 +7109,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(kpChecker))
 	require.NoError(t, err)
+}
+
+func TestKprobeArgsReverse(t *testing.T) {
+	testKprobeArgsReverse(t, false)
 }
 
 func TestKprobeResolveSecondArg(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6886,7 +6886,7 @@ func TestMaxPath(t *testing.T) {
 	testMaxPath(t, false)
 }
 
-func TestKprobeDentryPath(t *testing.T) {
+func testKprobeDentryPath(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -6946,7 +6946,7 @@ spec:
         values:
         - "` + check1 + `"
 `
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	t.Logf("Removing file 1 %s, check %s\n", file1.Name(), check1)
 	t.Logf("Removing file 2 %s, check %s\n", file2.Name(), check2)
@@ -6984,6 +6984,10 @@ spec:
 	// ... but not for file_2 (check_2).
 	err = jsonchecker.JsonTestCheckExpect(t, getChecker(check2), true)
 	require.NoError(t, err)
+}
+
+func TestKprobeDentryPath(t *testing.T) {
+	testKprobeDentryPath(t, false)
 }
 
 func TestKprobeResolvePid(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7304,7 +7304,7 @@ func TestKprobeArgsMulti(t *testing.T) {
 	testKprobeArgsMulti(t, false)
 }
 
-func TestKprobeArgsMultiResolve(t *testing.T) {
+func testKprobeArgsMultiResolve(t *testing.T, fentry bool) {
 	if !kernels.MinKernelVersion("5.4") {
 		t.Skip("Test requires kernel 5.4+")
 	}
@@ -7332,7 +7332,7 @@ spec:
       resolve: "mm.owner.mm.owner.pid"
 `
 
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -7360,6 +7360,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeArgsMultiResolve(t *testing.T) {
+	testKprobeArgsMultiResolve(t, false)
 }
 
 func TestKprobeArgsFilter(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4988,14 +4988,14 @@ spec:
 	t.Logf("got error (as expected): %s", err)
 }
 
-func testMaxData(t *testing.T, data []byte, checker *ec.UnorderedEventChecker, configHook string, fd int) {
+func testMaxData(t *testing.T, data []byte, checker *ec.UnorderedEventChecker, configHook string, fd int, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, configHook)
+	createCrdFileFlag(t, configHook, fentry)
 
 	option.Config.RBSize = 1024 * 1024
 
@@ -5012,7 +5012,7 @@ func testMaxData(t *testing.T, data []byte, checker *ec.UnorderedEventChecker, c
 	require.NoError(t, err)
 }
 
-func TestKprobeWriteMaxDataTrunc(t *testing.T) {
+func testKprobeWriteMaxDataTrunc(t *testing.T, fentry bool) {
 	if !kernels.MinKernelVersion("5.3.0") {
 		t.Skip("TestCopyFd requires at least 5.3.0 version")
 	}
@@ -5072,10 +5072,14 @@ spec:
 				ec.NewKprobeArgumentChecker().WithSizeArg(uint64(len(data))),
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
-	testMaxData(t, data, checker, writeHook, fd2)
+	testMaxData(t, data, checker, writeHook, fd2, fentry)
 }
 
-func TestKprobeWriteMaxData(t *testing.T) {
+func TestKprobeWriteMaxDataTrunc(t *testing.T) {
+	testKprobeWriteMaxDataTrunc(t, false)
+}
+
+func testKprobeWriteMaxData(t *testing.T, fentry bool) {
 	if !kernels.MinKernelVersion("5.3.0") {
 		t.Skip("TestCopyFd requires at least 5.3.0 version")
 	}
@@ -5131,10 +5135,14 @@ spec:
 				ec.NewKprobeArgumentChecker().WithSizeArg(uint64(len(data))),
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
-	testMaxData(t, data, checker, writeHook, fd2)
+	testMaxData(t, data, checker, writeHook, fd2, fentry)
 }
 
-func TestKprobeWriteMaxDataFull(t *testing.T) {
+func TestKprobeWriteMaxData(t *testing.T) {
+	testKprobeWriteMaxData(t, false)
+}
+
+func testKprobeWriteMaxDataFull(t *testing.T, fentry bool) {
 	if !kernels.MinKernelVersion("5.3.0") {
 		t.Skip("TestCopyFd requires at least 5.3.0 version")
 	}
@@ -5191,7 +5199,11 @@ spec:
 				ec.NewKprobeArgumentChecker().WithSizeArg(uint64(len(data))),
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
-	testMaxData(t, data, checker, writeHook, fd2)
+	testMaxData(t, data, checker, writeHook, fd2, fentry)
+}
+
+func TestKprobeWriteMaxDataFull(t *testing.T) {
+	testKprobeWriteMaxDataFull(t, false)
 }
 
 func testKprobeRateLimit(t *testing.T, rateLimit bool) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4373,7 +4373,7 @@ func TestKprobeMatchBinariesLargePath(t *testing.T) {
 
 // matchBinariesPerfringTest checks that the matchBinaries do correctly
 // filter the events i.e. it checks that no other events appear.
-func matchBinariesPerfringTest(t *testing.T, operator string, values []string) {
+func matchBinariesPerfringTest(t *testing.T, operator string, values []string, fentry bool) {
 	testutils.CaptureLog(t, logger.GetLogger())
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
@@ -4408,6 +4408,11 @@ func matchBinariesPerfringTest(t *testing.T, operator string, values []string) {
 				},
 			},
 		},
+	}
+
+	if fentry {
+		matchBinariesTracingPolicy.Spec.Fentries = matchBinariesTracingPolicy.Spec.KProbes
+		matchBinariesTracingPolicy.Spec.KProbes = []v1alpha1.KProbeSpec{}
 	}
 
 	err := sm.Manager.AddTracingPolicy(ctx, &matchBinariesTracingPolicy)
@@ -4454,22 +4459,26 @@ func matchBinariesPerfringTest(t *testing.T, operator string, values []string) {
 	}
 }
 
-func TestKprobeMatchBinariesPerfring(t *testing.T) {
+func testKprobeMatchBinariesPerfring(t *testing.T, fentry bool) {
 	t.Run("In", func(t *testing.T) {
-		matchBinariesPerfringTest(t, "In", []string{"/usr/bin/tail"})
+		matchBinariesPerfringTest(t, "In", []string{"/usr/bin/tail"}, fentry)
 	})
 	t.Run("Prefix", func(t *testing.T) {
 		if !config.EnableLargeProgs() {
 			t.Skip(skipMatchBinaries)
 		}
-		matchBinariesPerfringTest(t, "Prefix", []string{"/usr/bin/t"})
+		matchBinariesPerfringTest(t, "Prefix", []string{"/usr/bin/t"}, fentry)
 	})
 	t.Run("Postfix", func(t *testing.T) {
 		if !config.EnableLargeProgs() {
 			t.Skip(skipMatchBinaries)
 		}
-		matchBinariesPerfringTest(t, "Postfix", []string{"tail"})
+		matchBinariesPerfringTest(t, "Postfix", []string{"tail"}, fentry)
 	})
+}
+
+func TestKprobeMatchBinariesPerfring(t *testing.T) {
+	testKprobeMatchBinariesPerfring(t, false)
 }
 
 // TestKprobeMatchBinariesEarlyExec checks that the matchBinaries can filter

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5340,7 +5340,7 @@ func TestKprobeRateLimit(t *testing.T) {
 	testKprobeRateLimit(t, true, false)
 }
 
-func TestKprobeListSyscallDupsRange(t *testing.T) {
+func testKprobeListSyscallDupsRange(t *testing.T, fentry bool) {
 	if !kernels.MinKernelVersion("5.3.0") {
 		t.Skip("TestCopyFd requires at least 5.3.0 version")
 	}
@@ -5389,7 +5389,11 @@ spec:
 		checker.AddChecks(kpCheckerDup)
 	}
 
-	testListSyscallsDupsRange(t, checker, configHook)
+	testListSyscallsDupsRange(t, checker, configHook, fentry)
+}
+
+func TestKprobeListSyscallDupsRange(t *testing.T) {
+	testKprobeListSyscallDupsRange(t, false)
 }
 
 // This just tests if the hooks that we are using in our

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7808,7 +7808,7 @@ func TestKprobeGTFail(t *testing.T) {
 	testKprobeGT(t, 0xfffef, true, false)
 }
 
-func TestKprobeFileTypeFilterRegular(t *testing.T) {
+func testKprobeFileTypeFilterRegular(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -7849,7 +7849,7 @@ spec:
         - "reg"
 `
 
-	createCrdFile(t, fileTypeHook)
+	createCrdFileFlag(t, fileTypeHook, fentry)
 
 	kpChecker := ec.NewProcessKprobeChecker("filetype-regular-checker").
 		WithFunctionName(sm.Full("vfs_write")).
@@ -7873,6 +7873,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeFileTypeFilterRegular(t *testing.T) {
+	testKprobeFileTypeFilterRegular(t, false)
 }
 
 func TestKprobeFileTypeFilterPipe(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6020,7 +6020,7 @@ func trigger(t *testing.T) {
 	}
 }
 
-func TestKprobeArgs(t *testing.T) {
+func testKprobeArgs(t *testing.T, fentry bool) {
 	_, err := ftrace.ReadAvailFuncs("^bpf_fentry_test1$")
 	if err != nil {
 		t.Skip("Skipping test: could not find bpf_fentry_test1")
@@ -6124,7 +6124,7 @@ spec:
         - ` + pidStr + `
 `
 
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -6189,6 +6189,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeArgs(t *testing.T) {
+	testKprobeArgs(t, false)
 }
 
 // Detect changing capabilities

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6610,7 +6610,7 @@ func TestLongPath(t *testing.T) {
 	testLongPath(t, false)
 }
 
-func TestMaxPath(t *testing.T) {
+func testMaxPath(t *testing.T, fentry bool) {
 	// depending on temp dir, this should generate a path of ~1500 chars
 	// we can increase this to reach ~4000 for kernel supporting more than 11 dentry walk
 	tmp := t.TempDir()
@@ -6667,7 +6667,7 @@ spec:
     - index: 1
       type: "file"`
 
-		createCrdFile(t, spec)
+		createCrdFileFlag(t, spec, fentry)
 
 		kprobeCheck := ec.NewProcessKprobeChecker("file").
 			WithFunctionName(sm.Full("fd_install")).
@@ -6766,7 +6766,7 @@ spec:
 				))
 		}
 
-		createCrdFile(t, spec)
+		createCrdFileFlag(t, spec, fentry)
 
 		obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 		if err != nil {
@@ -6849,7 +6849,7 @@ spec:
     - index: 1
       type: "dentry"`
 
-		createCrdFile(t, hook)
+		createCrdFileFlag(t, hook, fentry)
 
 		t.Logf("Removing file %s, check %s\n", pathRemoved, pathRemovedCheck)
 
@@ -6880,6 +6880,10 @@ spec:
 		err = jsonchecker.JsonTestCheck(t, checker)
 		require.NoError(t, err)
 	})
+}
+
+func TestMaxPath(t *testing.T) {
+	testMaxPath(t, false)
 }
 
 func TestKprobeDentryPath(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3814,7 +3814,7 @@ func TestKprobeMatchArgsFdPostfix(t *testing.T) {
 	testKprobeMatchArgsFdPostfix(t, false)
 }
 
-func TestKprobeMatchArgsFdPrefix(t *testing.T) {
+func testKprobeMatchArgsFdPrefix(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -3830,7 +3830,7 @@ func TestKprobeMatchArgsFdPrefix(t *testing.T) {
 		argVals[3] = "/etc/s"
 	}
 
-	createCrdFile(t, getMatchArgsFdCrd("Prefix", argVals[:]))
+	createCrdFileFlag(t, getMatchArgsFdCrd("Prefix", argVals[:]), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -3855,6 +3855,10 @@ func TestKprobeMatchArgsFdPrefix(t *testing.T) {
 		}
 	}
 	require.NoError(t, err)
+}
+
+func TestKprobeMatchArgsFdPrefix(t *testing.T) {
+	testKprobeMatchArgsFdPrefix(t, false)
 }
 
 func getMatchArgsFileFIMCrd(vals []string) string {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4240,14 +4240,14 @@ func createBinariesChecker(binary, filename string) *ec.ProcessKprobeChecker {
 	return kpChecker
 }
 
-func matchBinariesTest(t *testing.T, operator string, values []string, kpChecker *ec.ProcessKprobeChecker) {
+func matchBinariesTest(t *testing.T, operator string, values []string, kpChecker *ec.ProcessKprobeChecker, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, getMatchBinariesCrd(operator, values))
+	createCrdFileFlag(t, getMatchBinariesCrd(operator, values), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -4271,37 +4271,41 @@ func matchBinariesTest(t *testing.T, operator string, values []string, kpChecker
 
 const skipMatchBinaries = "kernels without large progs do not support matchBinaries Prefix/NotPrefix/Postfix/NotPostfix"
 
-func TestKprobeMatchBinaries(t *testing.T) {
+func testKprobeMatchBinaries(t *testing.T, fentry bool) {
 	t.Run("In", func(t *testing.T) {
-		matchBinariesTest(t, "In", []string{"/usr/bin/tail"}, createBinariesChecker("/usr/bin/tail", "/etc/passwd"))
+		matchBinariesTest(t, "In", []string{"/usr/bin/tail"}, createBinariesChecker("/usr/bin/tail", "/etc/passwd"), fentry)
 	})
 	t.Run("NotIn", func(t *testing.T) {
-		matchBinariesTest(t, "NotIn", []string{"/usr/bin/tail"}, createBinariesChecker("/usr/bin/head", "/etc/passwd"))
+		matchBinariesTest(t, "NotIn", []string{"/usr/bin/tail"}, createBinariesChecker("/usr/bin/head", "/etc/passwd"), fentry)
 	})
 	t.Run("Prefix", func(t *testing.T) {
 		if !config.EnableLargeProgs() {
 			t.Skip(skipMatchBinaries)
 		}
-		matchBinariesTest(t, "Prefix", []string{"/usr/bin/t"}, createBinariesChecker("/usr/bin/tail", "/etc/passwd"))
+		matchBinariesTest(t, "Prefix", []string{"/usr/bin/t"}, createBinariesChecker("/usr/bin/tail", "/etc/passwd"), fentry)
 	})
 	t.Run("NotPrefix", func(t *testing.T) {
 		if !config.EnableLargeProgs() {
 			t.Skip(skipMatchBinaries)
 		}
-		matchBinariesTest(t, "NotPrefix", []string{"/usr/bin/t"}, createBinariesChecker("/usr/bin/head", "/etc/passwd"))
+		matchBinariesTest(t, "NotPrefix", []string{"/usr/bin/t"}, createBinariesChecker("/usr/bin/head", "/etc/passwd"), fentry)
 	})
 	t.Run("Postfix", func(t *testing.T) {
 		if !config.EnableLargeProgs() {
 			t.Skip(skipMatchBinaries)
 		}
-		matchBinariesTest(t, "Postfix", []string{"bin/tail"}, createBinariesChecker("/usr/bin/tail", "/etc/passwd"))
+		matchBinariesTest(t, "Postfix", []string{"bin/tail"}, createBinariesChecker("/usr/bin/tail", "/etc/passwd"), fentry)
 	})
 	t.Run("NotPostfix", func(t *testing.T) {
 		if !config.EnableLargeProgs() {
 			t.Skip(skipMatchBinaries)
 		}
-		matchBinariesTest(t, "NotPostfix", []string{"bin/tail"}, createBinariesChecker("/usr/bin/head", "/etc/passwd"))
+		matchBinariesTest(t, "NotPostfix", []string{"bin/tail"}, createBinariesChecker("/usr/bin/head", "/etc/passwd"), fentry)
 	})
+}
+
+func TestKprobeMatchBinaries(t *testing.T) {
+	testKprobeMatchBinaries(t, false)
 }
 
 func matchBinariesLargePathTest(t *testing.T, operator string, values []string, binary string) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5873,7 +5873,7 @@ func TestKprobeUserStackTrace(t *testing.T) {
 	testKprobeUserStackTrace(t, false)
 }
 
-func TestKprobeMultiMatcArgs(t *testing.T) {
+func testKprobeMultiMatcArgs(t *testing.T, fentry bool) {
 	if !config.EnableLargeProgs() {
 		t.Skip("Older kernels do not support matchArgs for more than one arguments")
 	}
@@ -5943,7 +5943,7 @@ spec:
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, tracingPolicy)
+	createCrdFileFlag(t, tracingPolicy, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -5983,6 +5983,10 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kpCheckersRead, kpCheckersMmap)
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeMultiMatcArgs(t *testing.T) {
+	testKprobeMultiMatcArgs(t, false)
 }
 
 func trigger(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3734,7 +3734,7 @@ func TestKprobeMatchArgsFilePrefix(t *testing.T) {
 	testKprobeMatchArgsFilePrefix(t, false)
 }
 
-func TestKprobeMatchArgsFdEqual(t *testing.T) {
+func testKprobeMatchArgsFdEqual(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -3750,7 +3750,7 @@ func TestKprobeMatchArgsFdEqual(t *testing.T) {
 		argVals[3] = "/etc/shadow"
 	}
 
-	createCrdFile(t, getMatchArgsFdCrd("Equal", argVals[:]))
+	createCrdFileFlag(t, getMatchArgsFdCrd("Equal", argVals[:]), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -3768,6 +3768,10 @@ func TestKprobeMatchArgsFdEqual(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeMatchArgsFdEqual(t *testing.T) {
+	testKprobeMatchArgsFdEqual(t, false)
 }
 
 func TestKprobeMatchArgsFdPostfix(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7229,7 +7229,7 @@ func TestKprobeIgnore(t *testing.T) {
 	testKprobeIgnore(t, false)
 }
 
-func TestKprobeArgsMulti(t *testing.T) {
+func testKprobeArgsMulti(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -7273,7 +7273,7 @@ spec:
         values:
         - ` + pidStr
 
-	createCrdFile(t, lseekConfigHook_)
+	createCrdFileFlag(t, lseekConfigHook_, fentry)
 
 	kpChecker := ec.NewProcessKprobeChecker("lseek-checker").
 		WithFunctionName(sm.Suffix("sys_lseek")).
@@ -7298,6 +7298,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(kpChecker))
 	require.NoError(t, err)
+}
+
+func TestKprobeArgsMulti(t *testing.T) {
+	testKprobeArgsMulti(t, false)
 }
 
 func TestKprobeArgsMultiResolve(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6531,7 +6531,7 @@ func TestKprobeMultiSymbolInstancesOk(t *testing.T) {
 
 // TestLongPath could be split into a test checking for long args from kprobe
 // events and a test checking for long cwd
-func TestLongPath(t *testing.T) {
+func testLongPath(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -6564,7 +6564,7 @@ spec:
     - index: 1
       type: "file"`
 
-	createCrdFile(t, fdinstallHook)
+	createCrdFileFlag(t, fdinstallHook, fentry)
 
 	kprobeLongFileArgChecker := ec.NewProcessKprobeChecker("longFile").
 		WithFunctionName(sm.Full("fd_install")).
@@ -6604,6 +6604,10 @@ spec:
 	checker := ec.NewUnorderedEventChecker(kprobeLongFileArgChecker, processLongCWDChecker)
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestLongPath(t *testing.T) {
+	testLongPath(t, false)
 }
 
 func TestMaxPath(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2181,7 +2181,7 @@ func TestKprobeObjectFileWriteMountFiltered(t *testing.T) {
 	testKprobeObjectFileWriteMountFiltered(t, false)
 }
 
-func corePathTest(t *testing.T, filePath string, readHook string, writeChecker ec.MultiEventChecker) {
+func corePathTest(t *testing.T, filePath string, readHook string, writeChecker ec.MultiEventChecker, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -2196,7 +2196,7 @@ func corePathTest(t *testing.T, filePath string, readHook string, writeChecker e
 	}
 	syscall.Close(fd)
 
-	createCrdFile(t, readHook)
+	createCrdFileFlag(t, readHook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -2219,7 +2219,7 @@ func corePathTest(t *testing.T, filePath string, readHook string, writeChecker e
 	require.NoError(t, err)
 }
 
-func testMultipleMountsFiltered(t *testing.T, readHook string) {
+func testMultipleMountsFilteredRun(t *testing.T, readHook string, fentry bool) {
 	var pathStack []string
 
 	// let's create /tmp2/tmp3/tmp4/tmp5 where each dir is a mount point
@@ -2255,10 +2255,10 @@ func testMultipleMountsFiltered(t *testing.T, readHook string) {
 
 	writeChecker := getWriteChecker(t, "/tmp2/tmp3/tmp4/tmp5/testfile", "")
 
-	corePathTest(t, filePath, readHook, writeChecker)
+	corePathTest(t, filePath, readHook, writeChecker, fentry)
 }
 
-func testMultiplePathComponentsFiltered(t *testing.T, readHook string) {
+func testMultiplePathComponentsFiltered(t *testing.T, readHook string, fentry bool) {
 	path := "/tmp"
 
 	// let's create /tmp/0/.. 32*8 where each dir is a directory
@@ -2282,10 +2282,10 @@ func testMultiplePathComponentsFiltered(t *testing.T, readHook string) {
 	if config.EnableLargeProgs() {
 		writeChecker = getWriteChecker(t, filePath, "")
 	}
-	corePathTest(t, filePath, readHook, writeChecker)
+	corePathTest(t, filePath, readHook, writeChecker, fentry)
 }
 
-func testMultipleMountPathFiltered(t *testing.T, readHook string) {
+func testMultipleMountPathFilteredRun(t *testing.T, readHook string, fentry bool) {
 	var pathStack []string
 	var dirStack []string
 	path := "/"
@@ -2342,34 +2342,50 @@ func testMultipleMountPathFiltered(t *testing.T, readHook string) {
 
 	filePath := path + "/testfile"
 	writeChecker := getWriteChecker(t, "/tmp2/tmp3/tmp4/tmp5/0/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/testfile", "")
-	corePathTest(t, filePath, readHook, writeChecker)
+	corePathTest(t, filePath, readHook, writeChecker, fentry)
 }
 
-func TestMultipleMountsFiltered(t *testing.T) {
+func testMultipleMountsFiltered(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	readHook := testKprobeObjectFileWriteFilteredHook(pidStr, "/tmp2/tmp3/tmp4/tmp5")
-	testMultipleMountsFiltered(t, readHook)
+	testMultipleMountsFilteredRun(t, readHook, fentry)
 }
 
-func TestMultiplePathComponents(t *testing.T) {
+func TestKprobeMultipleMountsFiltered(t *testing.T) {
+	testMultipleMountsFiltered(t, false)
+}
+
+func testMultiplePathComponents(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	readHook := testKprobeObjectFileWriteHook(pidStr)
-	testMultiplePathComponentsFiltered(t, readHook)
+	testMultiplePathComponentsFiltered(t, readHook, fentry)
 }
 
-func TestMultipleMountPath(t *testing.T) {
+func TestKprobeMultiplePathComponents(t *testing.T) {
+	testMultiplePathComponents(t, false)
+}
+
+func testMultipleMountPath(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	readHook := testKprobeObjectFileWriteHook(pidStr)
-	testMultipleMountPathFiltered(t, readHook)
+	testMultipleMountPathFilteredRun(t, readHook, fentry)
 }
 
-func TestMultipleMountPathFiltered(t *testing.T) {
+func TestKprobeMultipleMountPath(t *testing.T) {
+	testMultipleMountPath(t, false)
+}
+
+func testMultipleMountPathFiltered(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	readHook := testKprobeObjectFileWriteFilteredHook(pidStr, "/7/8/9/10/11/12/13/14/15/16")
 	if config.EnableLargeProgs() {
 		readHook = testKprobeObjectFileWriteFilteredHook(pidStr, "/tmp2/tmp3/tmp4/tmp5/0/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16")
 	}
-	testMultipleMountPathFiltered(t, readHook)
+	testMultipleMountPathFilteredRun(t, readHook, fentry)
+}
+
+func TestKprobeMultipleMountPathFiltered(t *testing.T) {
+	testMultipleMountPathFiltered(t, false)
 }
 
 func TestKprobeArgValues(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4720,7 +4720,7 @@ spec:
 	return s.Destroy(true)
 }
 
-func TestKprobeBpfAttr(t *testing.T) {
+func testKprobeBpfAttr(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -4739,7 +4739,7 @@ spec:
    - index: 1
      type: "bpf_attr"
 `
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -4767,6 +4767,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeBpfAttr(t *testing.T) {
+	testKprobeBpfAttr(t, false)
 }
 
 func TestLoadKprobeSensor(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -704,7 +704,8 @@ func testKprobeObjectFiltered(t *testing.T,
 	mntPath string,
 	expectFailure bool,
 	mode int,
-	perm uint32) {
+	perm uint32,
+	fentry bool) {
 
 	if useMount == true {
 		if err := syscall.Mount("tmpfs", mntPath, "tmpfs", 0, ""); err != nil {
@@ -734,7 +735,7 @@ func testKprobeObjectFiltered(t *testing.T,
 	}
 	syscall.Close(fd)
 
-	createCrdFile(t, readHook)
+	createCrdFileFlag(t, readHook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -802,28 +803,28 @@ func TestKprobeObjectOpen(t *testing.T) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectOpenHook(pidStr, dir, false)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770, false)
 }
 
 func TestKprobeObjectOpenWithNull(t *testing.T) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectOpenHook(pidStr, dir, true)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770, false)
 }
 
 func TestKprobeObjectOpenMount(t *testing.T) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectOpenHook(pidStr, dir, false)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770, false)
 }
 
 func TestKprobeObjectOpenMountWithNull(t *testing.T) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectOpenHook(pidStr, dir, true)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770, false)
 }
 
 func testKprobeStringMatch(t *testing.T,
@@ -1139,21 +1140,29 @@ func testKprobeObjectMultiValueOpenHook(pidStr string, path string) string {
   `
 }
 
-func TestKprobeObjectMultiValueOpen(t *testing.T) {
+func testKprobeObjectMultiValueOpen(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectMultiValueOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectMultiValueOpen(t *testing.T) {
+	testKprobeObjectMultiValueOpen(t, false)
+}
+
+func testKprobeObjectMultiValueOpenMount(t *testing.T, fentry bool) {
+	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
+	dir := t.TempDir()
+	readHook := testKprobeObjectMultiValueOpenHook(pidStr, dir)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770, fentry)
 }
 
 func TestKprobeObjectMultiValueOpenMount(t *testing.T) {
-	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
-	dir := t.TempDir()
-	readHook := testKprobeObjectMultiValueOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectMultiValueOpenMount(t, false)
 }
 
-func TestKprobeObjectFilterOpen(t *testing.T) {
+func testKprobeObjectFilterOpen(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := `
@@ -1185,10 +1194,14 @@ spec:
         values:
         - "` + dir + `/foofile"
 `
-	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770, fentry)
 }
 
-func TestKprobeObjectMultiValueFilterOpen(t *testing.T) {
+func TestKprobeObjectFilterOpen(t *testing.T) {
+	testKprobeObjectFilterOpen(t, false)
+}
+
+func testKprobeObjectMultiValueFilterOpen(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := `
@@ -1221,7 +1234,11 @@ spec:
         - "` + dir + `/foo"
         - "` + dir + `/bar"
 `
-	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectMultiValueFilterOpen(t *testing.T) {
+	testKprobeObjectMultiValueFilterOpen(t, false)
 }
 
 func testKprobeObjectFilterPrefixOpenHook(pidStr string, path string) string {
@@ -1256,14 +1273,18 @@ func testKprobeObjectFilterPrefixOpenHook(pidStr string, path string) string {
   `
 }
 
-func TestKprobeObjectFilterPrefixOpen(t *testing.T) {
+func testKprobeObjectFilterPrefixOpen(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770, fentry)
 }
 
-func TestKprobeObjectFilterPrefixOpenSuperLong(t *testing.T) {
+func TestKprobeObjectFilterPrefixOpen(t *testing.T) {
+	testKprobeObjectFilterPrefixOpen(t, false)
+}
+
+func testKprobeObjectFilterPrefixOpenSuperLong(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixOpenHook(pidStr, dir)
@@ -1279,14 +1300,22 @@ func TestKprobeObjectFilterPrefixOpenSuperLong(t *testing.T) {
 		t.Logf("Mkdir %s failed: %s\n", longDir, err)
 		t.Skip()
 	}
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, longDir), false, longDir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, longDir), false, longDir, false, syscall.O_RDWR, 0x770, fentry)
 }
 
-func TestKprobeObjectFilterPrefixOpenMount(t *testing.T) {
+func TestKprobeObjectFilterPrefixOpenSuperLong(t *testing.T) {
+	testKprobeObjectFilterPrefixOpenSuperLong(t, false)
+}
+
+func testKprobeObjectFilterPrefixOpenMount(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectFilterPrefixOpenMount(t *testing.T) {
+	testKprobeObjectFilterPrefixOpenMount(t, false)
 }
 
 func testKprobeObjectFilterPrefixExactOpenHook(pidStr string, path string) string {
@@ -1321,18 +1350,26 @@ func testKprobeObjectFilterPrefixExactOpenHook(pidStr string, path string) strin
   `
 }
 
-func TestKprobeObjectFilterPrefixExactOpen(t *testing.T) {
+func testKprobeObjectFilterPrefixExactOpen(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixExactOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectFilterPrefixExactOpen(t *testing.T) {
+	testKprobeObjectFilterPrefixExactOpen(t, false)
+}
+
+func testKprobeObjectFilterPrefixExactOpenMount(t *testing.T, fentry bool) {
+	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
+	dir := t.TempDir()
+	readHook := testKprobeObjectFilterPrefixExactOpenHook(pidStr, dir)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770, fentry)
 }
 
 func TestKprobeObjectFilterPrefixExactOpenMount(t *testing.T) {
-	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
-	dir := t.TempDir()
-	readHook := testKprobeObjectFilterPrefixExactOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFilterPrefixExactOpenMount(t, false)
 }
 
 func testKprobeObjectFilterPrefixSubdirOpenHook(pidStr string, path string) string {
@@ -1367,21 +1404,29 @@ func testKprobeObjectFilterPrefixSubdirOpenHook(pidStr string, path string) stri
   `
 }
 
-func TestKprobeObjectFilterPrefixSubdirOpen(t *testing.T) {
+func testKprobeObjectFilterPrefixSubdirOpen(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFilterPrefixSubdirOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectFilterPrefixSubdirOpen(t *testing.T) {
+	testKprobeObjectFilterPrefixSubdirOpen(t, false)
+}
+
+func testKprobeObjectFilterPrefixSubdirOpenMount(t *testing.T, fentry bool) {
+	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
+	dir := t.TempDir()
+	readHook := testKprobeObjectFilterPrefixSubdirOpenHook(pidStr, dir)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770, fentry)
 }
 
 func TestKprobeObjectFilterPrefixSubdirOpenMount(t *testing.T) {
-	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
-	dir := t.TempDir()
-	readHook := testKprobeObjectFilterPrefixSubdirOpenHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), true, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFilterPrefixSubdirOpenMount(t, false)
 }
 
-func TestKprobeObjectFilterPrefixMissOpen(t *testing.T) {
+func testKprobeObjectFilterPrefixMissOpen(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := `
@@ -1413,7 +1458,11 @@ spec:
         values:
         - "/foo/"
 `
-	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectFilterPrefixMissOpen(t *testing.T) {
+	testKprobeObjectFilterPrefixMissOpen(t, false)
 }
 
 // String matches should not require the '\0' null character on the end.
@@ -1426,7 +1475,7 @@ func testKprobeObjectPostfixOpenFileName(withNull bool) string {
 	return `testfile`
 }
 
-func testKprobeObjectPostfixOpen(t *testing.T, withNull bool) {
+func testKprobeObjectPostfixOpen(t *testing.T, withNull, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := `
@@ -1458,18 +1507,18 @@ spec:
         values:
         - "` + testKprobeObjectPostfixOpenFileName(withNull) + `"
 `
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, dir), false, dir, false, syscall.O_RDWR, 0x770, fentry)
 }
 
 func TestKprobeObjectPostfixOpen(t *testing.T) {
-	testKprobeObjectPostfixOpen(t, false)
+	testKprobeObjectPostfixOpen(t, false, false)
 }
 
 func TestKprobeObjectPostfixOpenWithNull(t *testing.T) {
-	testKprobeObjectPostfixOpen(t, true)
+	testKprobeObjectPostfixOpen(t, true, false)
 }
 
-func TestKprobeObjectPostfixOpenSuperLong(t *testing.T) {
+func testKprobeObjectPostfixOpenSuperLong(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := `
@@ -1510,7 +1559,11 @@ spec:
 		t.Skip()
 	}
 
-	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, longDir), false, longDir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getOpenatChecker(t, longDir), false, longDir, false, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectPostfixOpenSuperLong(t *testing.T) {
+	testKprobeObjectPostfixOpenSuperLong(t, false)
 }
 
 func testKprobeObjectFilterModeOpenHook(pidStr string, mode int, valueFmt string) string {
@@ -1547,7 +1600,7 @@ func testKprobeObjectFilterModeOpenHook(pidStr string, mode int, valueFmt string
   `
 }
 
-func testKprobeObjectFilterModeOpenMatch(t *testing.T, valueFmt string, modeCreate, modeCheck int) {
+func testKprobeObjectFilterModeOpenMatch(t *testing.T, valueFmt string, modeCreate, modeCheck int, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 
 	checker := func(dir string) *ec.UnorderedEventChecker {
@@ -1566,26 +1619,30 @@ func testKprobeObjectFilterModeOpenMatch(t *testing.T, valueFmt string, modeCrea
 
 	dir := t.TempDir()
 	openHook := testKprobeObjectFilterModeOpenHook(pidStr, modeCheck, valueFmt)
-	testKprobeObjectFiltered(t, openHook, checker(dir), false, dir, false, modeCreate, 0x770)
+	testKprobeObjectFiltered(t, openHook, checker(dir), false, dir, false, modeCreate, 0x770, fentry)
 }
 
 func TestKprobeObjectFilterModeOpenMatchDec(t *testing.T) {
-	testKprobeObjectFilterModeOpenMatch(t, "%d", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_TRUNC)
+	testKprobeObjectFilterModeOpenMatch(t, "%d", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_TRUNC, false)
 }
 
 func TestKprobeObjectFilterModeOpenMatchHex(t *testing.T) {
-	testKprobeObjectFilterModeOpenMatch(t, "0x%x", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_RDWR)
+	testKprobeObjectFilterModeOpenMatch(t, "0x%x", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_RDWR, false)
 }
 
 func TestKprobeObjectFilterModeOpenMatchOct(t *testing.T) {
-	testKprobeObjectFilterModeOpenMatch(t, "0%o", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_CLOEXEC)
+	testKprobeObjectFilterModeOpenMatch(t, "0%o", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_CLOEXEC, false)
 }
 
-func TestKprobeObjectFilterModeOpenFail(t *testing.T) {
+func testKprobeObjectFilterModeOpenFail(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	openHook := testKprobeObjectFilterModeOpenHook(pidStr, syscall.O_TRUNC, "%d")
-	testKprobeObjectFiltered(t, openHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, openHook, getAnyChecker(), false, dir, true, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectFilterModeOpenFail(t *testing.T) {
+	testKprobeObjectFilterModeOpenFail(t, false)
 }
 
 func testKprobeObjectFilterReturnValueGTHook(pidStr, path string) string {
@@ -1898,7 +1955,7 @@ func getFilpOpenChecker(dir string, funcName string) ec.MultiEventChecker {
 	return ec.NewUnorderedEventChecker(kpChecker)
 }
 
-func TestKprobeObjectFilenameOpen(t *testing.T) {
+func testKprobeObjectFilenameOpen(t *testing.T, fentry bool) {
 	funcName := getFilpOpenFunc(t)
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
@@ -1924,10 +1981,10 @@ spec:
         values:
         - ` + pidStr + `
      `
-	testKprobeObjectFiltered(t, readHook, getFilpOpenChecker(dir, funcName), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getFilpOpenChecker(dir, funcName), false, dir, false, syscall.O_RDWR, 0x770, fentry)
 }
 
-func TestKprobeObjectReturnFilenameOpen(t *testing.T) {
+func testKprobeObjectReturnFilenameOpen(t *testing.T, fentry bool) {
 	funcName := getFilpOpenFunc(t)
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
@@ -1956,7 +2013,11 @@ spec:
         values:
         - ` + pidStr + `
      `
-	testKprobeObjectFiltered(t, readHook, getFilpOpenChecker(dir, funcName), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getFilpOpenChecker(dir, funcName), false, dir, false, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectReturnFilenameOpen(t *testing.T) {
+	testKprobeObjectReturnFilenameOpen(t, false)
 }
 
 func testKprobeObjectFileWriteHook(pidStr string) string {
@@ -2076,32 +2137,48 @@ func getWriteChecker(t *testing.T, path, flags string) ec.MultiEventChecker {
 	return ec.NewUnorderedEventChecker(kpChecker)
 }
 
-func TestKprobeObjectFileWrite(t *testing.T) {
+func testKprobeObjectFileWrite(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFileWriteHook(pidStr)
-	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), false, dir, false, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectFileWrite(t *testing.T) {
+	testKprobeObjectFileWrite(t, false)
+}
+
+func testKprobeObjectFileWriteFiltered(t *testing.T, fentry bool) {
+	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
+	dir := t.TempDir()
+	readHook := testKprobeObjectFileWriteFilteredHook(pidStr, dir)
+	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), false, dir, false, syscall.O_RDWR, 0x770, fentry)
 }
 
 func TestKprobeObjectFileWriteFiltered(t *testing.T) {
-	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
-	dir := t.TempDir()
-	readHook := testKprobeObjectFileWriteFilteredHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), false, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFileWriteFiltered(t, false)
 }
 
-func TestKprobeObjectFileWriteMount(t *testing.T) {
+func testKprobeObjectFileWriteMount(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFileWriteHook(pidStr)
-	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), true, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), true, dir, false, syscall.O_RDWR, 0x770, fentry)
 }
 
-func TestKprobeObjectFileWriteMountFiltered(t *testing.T) {
+func TestKprobeObjectFileWriteMount(t *testing.T) {
+	testKprobeObjectFileWriteMount(t, false)
+}
+
+func testKprobeObjectFileWriteMountFiltered(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	dir := t.TempDir()
 	readHook := testKprobeObjectFileWriteFilteredHook(pidStr, dir)
-	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), true, dir, false, syscall.O_RDWR, 0x770)
+	testKprobeObjectFiltered(t, readHook, getWriteChecker(t, filepath.Join(dir, "testfile"), ""), true, dir, false, syscall.O_RDWR, 0x770, fentry)
+}
+
+func TestKprobeObjectFileWriteMountFiltered(t *testing.T) {
+	testKprobeObjectFileWriteMountFiltered(t, false)
 }
 
 func corePathTest(t *testing.T, filePath string, readHook string, writeChecker ec.MultiEventChecker) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -163,14 +163,14 @@ func getTestKprobeObjectWRChecker(t *testing.T) ec.MultiEventChecker {
 	return ec.NewUnorderedEventChecker(kpChecker)
 }
 
-func runKprobeObjectWriteRead(t *testing.T, writeReadHook string) {
+func runKprobeObjectWriteRead(t *testing.T, writeReadHook string, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, writeReadHook)
+	createCrdFileFlag(t, writeReadHook, fentry)
 
 	checker := getTestKprobeObjectWRChecker(t)
 
@@ -187,7 +187,7 @@ func runKprobeObjectWriteRead(t *testing.T, writeReadHook string) {
 	require.NoError(t, err)
 }
 
-func TestKprobeObjectWriteReadHostNs(t *testing.T) {
+func testKprobeObjectWriteReadHostNs(t *testing.T, fentry bool) {
 	// if we run inside a container it will not match the host namespace
 	nsOp := "NotIn"
 	if _, err := os.Stat("/.dockerenv"); errors.Is(err, os.ErrNotExist) {
@@ -235,10 +235,14 @@ spec:
         values:
         - "1"
 `
-	runKprobeObjectWriteRead(t, writeReadHook)
+	runKprobeObjectWriteRead(t, writeReadHook, fentry)
 }
 
-func TestKprobeObjectWriteRead(t *testing.T) {
+func TestKprobeObjectWriteReadHostNs(t *testing.T) {
+	testKprobeObjectWriteReadHostNs(t, false)
+}
+
+func testKprobeObjectWriteRead(t *testing.T, fentry bool) {
 	myPid := observertesthelper.GetMyPid()
 	pidStr := strconv.Itoa(int(myPid))
 	mntns, err := namespace.GetPidNsInode(myPid, "mnt")
@@ -287,10 +291,14 @@ spec:
         values:
         - "1"
 `
-	runKprobeObjectWriteRead(t, writeReadHook)
+	runKprobeObjectWriteRead(t, writeReadHook, fentry)
 }
 
-func TestKprobeObjectWriteCapsNotIn(t *testing.T) {
+func TestKprobeObjectWriteRead(t *testing.T) {
+	testKprobeObjectWriteRead(t, false)
+}
+
+func testKprobeObjectWriteCapsNotIn(t *testing.T, fentry bool) {
 	writeReadHook := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -321,10 +329,14 @@ spec:
         values:
         - "1"
 `
-	runKprobeObjectWriteRead(t, writeReadHook)
+	runKprobeObjectWriteRead(t, writeReadHook, fentry)
 }
 
-func TestKprobeObjectWriteReadNsOnly(t *testing.T) {
+func TestKprobeObjectWriteCapsNotIn(t *testing.T) {
+	testKprobeObjectWriteCapsNotIn(t, false)
+}
+
+func testKprobeObjectWriteReadNsOnly(t *testing.T, fentry bool) {
 	myPid := observertesthelper.GetMyPid()
 	mntns, err := namespace.GetPidNsInode(myPid, "mnt")
 	require.NoError(t, err)
@@ -366,10 +378,14 @@ spec:
         values:
         - "1"
 `
-	runKprobeObjectWriteRead(t, writeReadHook)
+	runKprobeObjectWriteRead(t, writeReadHook, fentry)
 }
 
-func TestKprobeObjectWriteReadPidOnly(t *testing.T) {
+func TestKprobeObjectWriteReadNsOnly(t *testing.T) {
+	testKprobeObjectWriteReadNsOnly(t, false)
+}
+
+func testKprobeObjectWriteReadPidOnly(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	writeReadHook := `
 apiVersion: cilium.io/v1alpha1
@@ -402,7 +418,11 @@ spec:
         values:
         - "1"
 `
-	runKprobeObjectWriteRead(t, writeReadHook)
+	runKprobeObjectWriteRead(t, writeReadHook, fentry)
+}
+
+func TestKprobeObjectWriteReadPidOnly(t *testing.T) {
+	testKprobeObjectWriteReadPidOnly(t, false)
 }
 
 func createTestFile(t *testing.T) (int, int, string) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3926,7 +3926,7 @@ func TestKprobeMatchArgsFileMonitoringPrefix(t *testing.T) {
 	testKprobeMatchArgsFileMonitoringPrefix(t, false)
 }
 
-func TestKprobeMatchArgsNonPrefix(t *testing.T) {
+func testKprobeMatchArgsNonPrefix(t *testing.T, fentry bool) {
 	if !config.EnableLargeProgs() {
 		t.Skip()
 	}
@@ -3963,7 +3963,7 @@ spec:
         - "/etc/passwd"
         - "/etc/group"`
 
-	createCrdFile(t, configHook)
+	createCrdFileFlag(t, configHook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -4011,6 +4011,10 @@ spec:
 	errChecker := ec.NewUnorderedEventChecker(kpErrCheckers...)
 	err = jsonchecker.JsonTestCheckExpect(t, errChecker, true)
 	require.NoError(t, err)
+}
+
+func TestKprobeMatchArgsNonPrefix(t *testing.T) {
+	testKprobeMatchArgsNonPrefix(t, false)
 }
 
 func getMatchParentBinariesCrd(opStr string, vals []string) string {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4308,7 +4308,7 @@ func TestKprobeMatchBinaries(t *testing.T) {
 	testKprobeMatchBinaries(t, false)
 }
 
-func matchBinariesLargePathTest(t *testing.T, operator string, values []string, binary string) {
+func matchBinariesLargePathTest(t *testing.T, operator string, values []string, binary string, fentry bool) {
 
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
@@ -4316,7 +4316,7 @@ func matchBinariesLargePathTest(t *testing.T, operator string, values []string, 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, getMatchBinariesCrd(operator, values))
+	createCrdFileFlag(t, getMatchBinariesCrd(operator, values), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -4336,7 +4336,7 @@ func matchBinariesLargePathTest(t *testing.T, operator string, values []string, 
 	require.NoError(t, err)
 
 }
-func TestKprobeMatchBinariesLargePath(t *testing.T) {
+func testKprobeMatchBinariesLargePath(t *testing.T, fentry bool) {
 	if !config.EnableLargeProgs() {
 		t.Skip()
 	}
@@ -4360,11 +4360,15 @@ func TestKprobeMatchBinariesLargePath(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Prefix", func(t *testing.T) {
-		matchBinariesLargePathTest(t, "Prefix", []string{tmpDir}, targetBinLargePath)
+		matchBinariesLargePathTest(t, "Prefix", []string{tmpDir}, targetBinLargePath, fentry)
 	})
 	t.Run("Postfix", func(t *testing.T) {
-		matchBinariesLargePathTest(t, "Postfix", []string{"/true"}, targetBinLargePath)
+		matchBinariesLargePathTest(t, "Postfix", []string{"/true"}, targetBinLargePath, fentry)
 	})
+}
+
+func TestKprobeMatchBinariesLargePath(t *testing.T) {
+	testKprobeMatchBinariesLargePath(t, false)
 }
 
 // matchBinariesPerfringTest checks that the matchBinaries do correctly

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7879,7 +7879,7 @@ func TestKprobeFileTypeFilterRegular(t *testing.T) {
 	testKprobeFileTypeFilterRegular(t, false)
 }
 
-func TestKprobeFileTypeFilterPipe(t *testing.T) {
+func testKprobeFileTypeFilterPipe(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -7913,7 +7913,7 @@ spec:
         - "pipe"
 `
 
-	createCrdFile(t, fileTypeHook)
+	createCrdFileFlag(t, fileTypeHook, fentry)
 
 	kpChecker := ec.NewProcessKprobeChecker("filetype-pipe-checker").
 		WithFunctionName(sm.Full("vfs_write")).
@@ -7942,6 +7942,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeFileTypeFilterPipe(t *testing.T) {
+	testKprobeFileTypeFilterPipe(t, false)
 }
 
 func TestKprobeFileTypeFilterNotRegular(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -8028,7 +8028,7 @@ func TestKprobeFileTypeFilterNotRegular(t *testing.T) {
 	testKprobeFileTypeFilterNotRegular(t, false)
 }
 
-func TestKprobeFileTypeFilterSocket(t *testing.T) {
+func testKprobeFileTypeFilterSocket(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -8062,7 +8062,7 @@ spec:
         - "socket"
 `
 
-	createCrdFile(t, fileTypeHook)
+	createCrdFileFlag(t, fileTypeHook, fentry)
 
 	kpChecker := ec.NewProcessKprobeChecker("filetype-socket-checker").
 		WithFunctionName(sm.Full("vfs_write")).
@@ -8113,6 +8113,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeFileTypeFilterSocket(t *testing.T) {
+	testKprobeFileTypeFilterSocket(t, false)
 }
 
 func TestKprobeFileTypeFilterNotPipe(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -8287,7 +8287,7 @@ func TestKprobeFileTypeFilterMultiple(t *testing.T) {
 	testKprobeFileTypeFilterMultiple(t, false)
 }
 
-func TestKprobeNotEqualMultipleValues(t *testing.T) {
+func testKprobeNotEqualMultipleValues(t *testing.T, fentry bool) {
 	if !kernels.MinKernelVersion("5.0") {
 		t.Skip("Test fails on older kernels (like 4.19) due to missing BTF resolution for f_inode.i_sb.s_magic")
 	}
@@ -8326,7 +8326,7 @@ spec:
         values:
         - curl
 `
-	createCrdFile(t, tracingPolicy)
+	createCrdFileFlag(t, tracingPolicy, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -8343,4 +8343,8 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(kpChecker))
 	require.NoError(t, err)
+}
+
+func TestKprobeNotEqualMultipleValues(t *testing.T) {
+	testKprobeNotEqualMultipleValues(t, false)
 }

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -443,14 +443,14 @@ func createTestFile(t *testing.T) (int, int, string) {
 	return fd, fd2, strconv.Itoa(fd2)
 }
 
-func runKprobeObjectRead(t *testing.T, readHook string, checker ec.MultiEventChecker, fd, fd2 int) {
+func runKprobeObjectRead(t *testing.T, readHook string, checker ec.MultiEventChecker, fd, fd2 int, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, readHook)
+	createCrdFileFlag(t, readHook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -476,7 +476,7 @@ func runKprobeObjectRead(t *testing.T, readHook string, checker ec.MultiEventChe
 	require.NoError(t, err)
 }
 
-func TestKprobeObjectRead(t *testing.T) {
+func testKprobeObjectRead(t *testing.T, fentry bool) {
 	fd, fd2, fdString := createTestFile(t)
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	readHook := `
@@ -519,56 +519,64 @@ spec:
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	runKprobeObjectRead(t, readHook, checker, fd, fd2)
+	runKprobeObjectRead(t, readHook, checker, fd, fd2, fentry)
+}
+
+func TestKprobeObjectRead(t *testing.T) {
+	testKprobeObjectRead(t, false)
+}
+
+func testKprobeObjectReadIdxMismatch(t *testing.T, fentry bool) {
+	fd, fd2, fdString := createTestFile(t)
+	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
+	readHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "sys-read"
+spec:
+  kprobes:
+  - call: "sys_read"
+    syscall: true
+    args:
+    - index: 1
+      type: "char_buf"
+      returnCopy: true
+    - index: 2
+      type: "size_t"
+    - index: 0
+      type: "int"
+    selectors:
+    - matchPIDs:
+      - operator: In
+        followForks: true
+        values:
+        - ` + pidStr + `
+      matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "` + fdString + `"`
+
+	kpChecker := ec.NewProcessKprobeChecker("").
+		WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_read"))).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithBytesArg(bc.Full([]byte("hello world"))),
+				ec.NewKprobeArgumentChecker().WithSizeArg(100),
+				ec.NewKprobeArgumentChecker().WithIntArg(int32(fd2)),
+			))
+	checker := ec.NewUnorderedEventChecker(kpChecker)
+
+	runKprobeObjectRead(t, readHook, checker, fd, fd2, fentry)
 }
 
 func TestKprobeObjectReadIdxMismatch(t *testing.T) {
-	fd, fd2, fdString := createTestFile(t)
-	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
-	readHook := `
-apiVersion: cilium.io/v1alpha1
-kind: TracingPolicy
-metadata:
-  name: "sys-read"
-spec:
-  kprobes:
-  - call: "sys_read"
-    syscall: true
-    args:
-    - index: 1
-      type: "char_buf"
-      returnCopy: true
-    - index: 2
-      type: "size_t"
-    - index: 0
-      type: "int"
-    selectors:
-    - matchPIDs:
-      - operator: In
-        followForks: true
-        values:
-        - ` + pidStr + `
-      matchArgs:
-      - index: 0
-        operator: "Equal"
-        values:
-        - "` + fdString + `"`
-
-	kpChecker := ec.NewProcessKprobeChecker("").
-		WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_read"))).
-		WithArgs(ec.NewKprobeArgumentListMatcher().
-			WithOperator(lc.Ordered).
-			WithValues(
-				ec.NewKprobeArgumentChecker().WithBytesArg(bc.Full([]byte("hello world"))),
-				ec.NewKprobeArgumentChecker().WithSizeArg(100),
-				ec.NewKprobeArgumentChecker().WithIntArg(int32(fd2)),
-			))
-	checker := ec.NewUnorderedEventChecker(kpChecker)
-
-	runKprobeObjectRead(t, readHook, checker, fd, fd2)
+	testKprobeObjectReadIdxMismatch(t, false)
 }
 
-func TestKprobeObjectReadReturn(t *testing.T) {
+func testKprobeObjectReadReturn(t *testing.T, fentry bool) {
 	fd, fd2, fdString := createTestFile(t)
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	readHook := `
@@ -616,13 +624,17 @@ spec:
 		WithReturn(ec.NewKprobeArgumentChecker().WithSizeArg(11))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	runKprobeObjectRead(t, readHook, checker, fd, fd2)
+	runKprobeObjectRead(t, readHook, checker, fd, fd2, fentry)
+}
+
+func TestKprobeObjectReadReturn(t *testing.T) {
+	testKprobeObjectReadReturn(t, false)
 }
 
 // Differently from other tests using returnCopy,
 // this one skips index 0 element to avoid future regressions
 // like https://github.com/cilium/tetragon/issues/4488.
-func TestKprobeObjectReturnCopy(t *testing.T) {
+func testKprobeObjectReturnCopy(t *testing.T, fentry bool) {
 	fd, fd2, _ := createTestFile(t)
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	readHook := `
@@ -658,7 +670,11 @@ spec:
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	runKprobeObjectRead(t, readHook, checker, fd, fd2)
+	runKprobeObjectRead(t, readHook, checker, fd, fd2, fentry)
+}
+
+func TestKprobeObjectReturnCopy(t *testing.T) {
+	testKprobeObjectReturnCopy(t, false)
 }
 
 // sys_openat trace

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7648,7 +7648,7 @@ func TestKprobeResolveCurrent(t *testing.T) {
 	testKprobeResolveCurrent(t, false)
 }
 
-func testKprobeRangeOp(t *testing.T, in bool) {
+func testKprobeRangeOp(t *testing.T, in, fentry bool) {
 
 	if !config.EnableLargeProgs() {
 		t.Skipf("Skipping test since it needs kernel >= 5.3")
@@ -7687,7 +7687,7 @@ spec:
         - 0xffffe:0xfffff
 `
 
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -7734,11 +7734,11 @@ spec:
 }
 
 func TestKprobeRangeIn(t *testing.T) {
-	testKprobeRangeOp(t, true)
+	testKprobeRangeOp(t, true, false)
 }
 
 func TestKprobeRangeNotIn(t *testing.T) {
-	testKprobeRangeOp(t, false)
+	testKprobeRangeOp(t, false, false)
 }
 
 func testKprobeGT(t *testing.T, value uint64, fail bool) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4565,10 +4565,10 @@ func TestKprobeMatchBinariesEarlyExec(t *testing.T) {
 	testKprobeMatchBinariesEarlyExec(t, false)
 }
 
-// TestKprobeMatchBinariesPrefixMatchArgs makes sure that the prefix of
+// testKprobeMatchBinariesPrefixMatchArgs makes sure that the prefix of
 // matchBinaries works well with the prefix of matchArgs since its reusing some
 // of its machinery.
-func TestKprobeMatchBinariesPrefixMatchArgs(t *testing.T) {
+func testKprobeMatchBinariesPrefixMatchArgs(t *testing.T, fentry bool) {
 	if !config.EnableLargeProgs() {
 		t.Skip(skipMatchBinaries)
 	}
@@ -4623,6 +4623,11 @@ func TestKprobeMatchBinariesPrefixMatchArgs(t *testing.T) {
 		},
 	}
 
+	if fentry {
+		matchBinariesTracingPolicy.Spec.Fentries = matchBinariesTracingPolicy.Spec.KProbes
+		matchBinariesTracingPolicy.Spec.KProbes = []v1alpha1.KProbeSpec{}
+	}
+
 	err := sm.Manager.AddTracingPolicy(ctx, &matchBinariesTracingPolicy)
 	if assert.NoError(t, err) {
 		t.Cleanup(func() {
@@ -4675,6 +4680,10 @@ func TestKprobeMatchBinariesPrefixMatchArgs(t *testing.T) {
 	if !tailEventExist {
 		t.Error("kprobe event triggered by /usr/bin/tail should be present, unfiltered by the matchBinaries selector")
 	}
+}
+
+func TestKprobeMatchBinariesPrefixMatchArgs(t *testing.T) {
+	testKprobeMatchBinariesPrefixMatchArgs(t, false)
 }
 
 func loadTestCrd() error {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6461,7 +6461,7 @@ func TestKprobeBpfCmd(t *testing.T) {
 	testKprobeBpfCmd(t, false)
 }
 
-func TestKprobeMultiSymbolInstancesOk(t *testing.T) {
+func testKprobeMultiSymbolInstancesOk(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -6502,7 +6502,7 @@ spec:
     syscall: true
     tags: [ "prctl_8888" ]
 `
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -6523,6 +6523,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeMultiSymbolInstancesOk(t *testing.T) {
+	testKprobeMultiSymbolInstancesOk(t, false)
 }
 
 // TestLongPath could be split into a test checking for long args from kprobe

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5534,7 +5534,7 @@ func TestLinuxBinprmExtractPath(t *testing.T) {
 }
 
 // Test module loading/unloading on Ubuntu
-func TestTraceKernelModule(t *testing.T) {
+func testTraceKernelModule(t *testing.T, fentry bool) {
 	_, err := ftrace.ReadAvailFuncs("^find_module_sections$")
 	if err != nil {
 		t.Skip("Skipping test: could not find find_module_sections")
@@ -5610,7 +5610,7 @@ spec:
 		t.Skip("Skipping test: could not determin if this is an Ubuntu machine")
 	}
 
-	createCrdFile(t, hookFull)
+	createCrdFileFlag(t, hookFull, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -5695,6 +5695,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestTraceKernelModule(t *testing.T) {
+	testTraceKernelModule(t, false)
 }
 
 func TestKprobeKernelStackTrace(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -8119,7 +8119,7 @@ func TestKprobeFileTypeFilterSocket(t *testing.T) {
 	testKprobeFileTypeFilterSocket(t, false)
 }
 
-func TestKprobeFileTypeFilterNotPipe(t *testing.T) {
+func testKprobeFileTypeFilterNotPipe(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -8160,7 +8160,7 @@ spec:
         - "pipe"
 `
 
-	createCrdFile(t, fileTypeHook)
+	createCrdFileFlag(t, fileTypeHook, fentry)
 
 	kpChecker := ec.NewProcessKprobeChecker("filetype-notpipe-checker").
 		WithFunctionName(sm.Full("vfs_write")).
@@ -8193,6 +8193,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeFileTypeFilterNotPipe(t *testing.T) {
+	testKprobeFileTypeFilterNotPipe(t, false)
 }
 
 func TestKprobeFileTypeFilterMultiple(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3774,7 +3774,7 @@ func TestKprobeMatchArgsFdEqual(t *testing.T) {
 	testKprobeMatchArgsFdEqual(t, false)
 }
 
-func TestKprobeMatchArgsFdPostfix(t *testing.T) {
+func testKprobeMatchArgsFdPostfix(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -3790,7 +3790,7 @@ func TestKprobeMatchArgsFdPostfix(t *testing.T) {
 		argVals[3] = "shadow"
 	}
 
-	createCrdFile(t, getMatchArgsFdCrd("Postfix", argVals[:]))
+	createCrdFileFlag(t, getMatchArgsFdCrd("Postfix", argVals[:]), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -3808,6 +3808,10 @@ func TestKprobeMatchArgsFdPostfix(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeMatchArgsFdPostfix(t *testing.T) {
+	testKprobeMatchArgsFdPostfix(t, false)
 }
 
 func TestKprobeMatchArgsFdPrefix(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2388,7 +2388,7 @@ func TestKprobeMultipleMountPathFiltered(t *testing.T) {
 	testMultipleMountPathFiltered(t, false)
 }
 
-func TestKprobeArgValues(t *testing.T) {
+func testKprobeArgValues(t *testing.T, fentry bool) {
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 	readHook := `
 apiVersion: cilium.io/v1alpha1
@@ -2443,7 +2443,7 @@ spec:
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, readHook)
+	createCrdFileFlag(t, readHook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -2476,6 +2476,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeArgValues(t *testing.T) {
+	testKprobeArgValues(t, false)
 }
 
 // override

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6990,7 +6990,7 @@ func TestKprobeDentryPath(t *testing.T) {
 	testKprobeDentryPath(t, false)
 }
 
-func TestKprobeResolvePid(t *testing.T) {
+func testKprobeResolvePid(t *testing.T, fentry bool) {
 	if !kernels.MinKernelVersion("5.4") {
 		t.Skip("Test requires kernel 5.4+")
 	}
@@ -7015,7 +7015,7 @@ spec:
       resolve: "mm.owner.pid"
 `
 
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -7042,6 +7042,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeResolvePid(t *testing.T) {
+	testKprobeResolvePid(t, false)
 }
 
 func TestKprobeArgsReverse(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5431,7 +5431,7 @@ func TestTraceKernelModuleCallsStability(t *testing.T) {
 	testTraceKernelModuleCallsStability(t, false)
 }
 
-func TestLinuxBinprmExtractPath(t *testing.T) {
+func testLinuxBinprmExtractPath(t *testing.T, fentry bool) {
 	if !config.EnableLargeProgs() {
 		t.Skip("Older kernels do not support matchArgs with linux_binprm")
 	}
@@ -5485,6 +5485,11 @@ func TestLinuxBinprmExtractPath(t *testing.T) {
 		},
 	}
 
+	if fentry {
+		bprmTracingPolicy.TpSpec().Fentries = bprmTracingPolicy.TpSpec().KProbes
+		bprmTracingPolicy.TpSpec().KProbes = []v1alpha1.KProbeSpec{}
+	}
+
 	err := sm.Manager.AddTracingPolicy(ctx, &bprmTracingPolicy)
 	if assert.NoError(t, err) {
 		t.Cleanup(func() {
@@ -5522,6 +5527,10 @@ func TestLinuxBinprmExtractPath(t *testing.T) {
 	if !wantedEventExist {
 		t.Error("kprobe event triggered by /usr/bin/id should be present, unfiltered by the matchArgs selector")
 	}
+}
+
+func TestLinuxBinprmExtractPath(t *testing.T) {
+	testLinuxBinprmExtractPath(t, false)
 }
 
 // Test module loading/unloading on Ubuntu

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3207,14 +3207,14 @@ spec:
 }
 
 func runKprobeCharIovec(t *testing.T, configHook string,
-	checker *ec.UnorderedEventChecker, fdw, fdr int, buffer []byte) {
+	checker *ec.UnorderedEventChecker, fdw, fdr int, buffer []byte, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, configHook)
+	createCrdFileFlag(t, configHook, fentry)
 
 	b := base.GetInitialSensorTest(t)
 	obs, err := observertesthelper.GetDefaultObserverWithWatchers(t, ctx, b, observertesthelper.WithConfig(testConfigFile), observertesthelper.WithLib(tus.Conf().TetragonLib), observertesthelper.WithMyPid())
@@ -3252,7 +3252,7 @@ func runKprobeCharIovec(t *testing.T, configHook string,
 	require.NoError(t, err)
 }
 
-func TestKprobe_char_iovec(t *testing.T) {
+func testKprobe_char_iovec(t *testing.T, fentry bool) {
 	fdw, fdr, _ := createTestFile(t)
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 
@@ -3303,10 +3303,14 @@ spec:
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	runKprobeCharIovec(t, configHook, checker, fdw, fdr, buffer)
+	runKprobeCharIovec(t, configHook, checker, fdw, fdr, buffer, fentry)
 }
 
-func TestKprobe_char_iovec_overflow(t *testing.T) {
+func TestKprobe_char_iovec(t *testing.T) {
+	testKprobe_char_iovec(t, false)
+}
+
+func testKprobe_char_iovec_overflow(t *testing.T, fentry bool) {
 	fdw, fdr, _ := createTestFile(t)
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 
@@ -3357,10 +3361,14 @@ spec:
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	runKprobeCharIovec(t, configHook, checker, fdw, fdr, buffer)
+	runKprobeCharIovec(t, configHook, checker, fdw, fdr, buffer, fentry)
 }
 
-func TestKprobe_char_iovec_returnCopy(t *testing.T) {
+func TestKprobe_char_iovec_overflow(t *testing.T) {
+	testKprobe_char_iovec_overflow(t, false)
+}
+
+func testKprobe_char_iovec_returnCopy(t *testing.T, fentry bool) {
 	fdw, fdr, _ := createTestFile(t)
 	pidStr := strconv.Itoa(int(observertesthelper.GetMyPid()))
 
@@ -3412,7 +3420,11 @@ spec:
 			))
 	checker := ec.NewUnorderedEventChecker(kpChecker)
 
-	runKprobeCharIovec(t, configHook, checker, fdw, fdr, buffer)
+	runKprobeCharIovec(t, configHook, checker, fdw, fdr, buffer, fentry)
+}
+
+func TestKprobe_char_iovec_returnCopy(t *testing.T) {
+	testKprobe_char_iovec_returnCopy(t, false)
 }
 
 func getMatchArgsFileCrd(opStr string, vals []string) string {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -92,7 +92,7 @@ var (
 	}
 )
 
-func TestKprobeObjectLoad(t *testing.T) {
+func testKprobeObjectLoad(t *testing.T, fentry bool) {
 	writeReadHook := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -124,7 +124,7 @@ spec:
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, writeReadHook)
+	createCrdFileFlag(t, writeReadHook, fentry)
 
 	_, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -132,6 +132,10 @@ spec:
 	}
 	initialSensor := base.GetInitialSensorTest(t)
 	initialSensor.Load(bpf.MapPrefixPath())
+}
+
+func TestKprobeObjectLoad(t *testing.T) {
+	testKprobeObjectLoad(t, false)
 }
 
 // NB: This is similar to TestKprobeObjectWriteRead, but it's a bit easier to
@@ -3431,12 +3435,19 @@ func createReadChecker(t *testing.T, filename string) *ec.ProcessKprobeChecker {
 	return kpChecker
 }
 
-func createCrdFile(t *testing.T, readHook string) {
+func createCrdFileFlag(t *testing.T, readHook string, fentry bool) {
+	if fentry {
+		readHook = strings.ReplaceAll(readHook, "kprobes:", "fentries:")
+	}
 	readConfigHook := []byte(readHook)
 	err := os.WriteFile(testConfigFile, readConfigHook, 0644)
 	if err != nil {
 		t.Fatalf("writeFile(%s): err %s", testConfigFile, err)
 	}
+}
+
+func createCrdFile(t *testing.T, readHook string) {
+	createCrdFileFlag(t, readHook, false)
 }
 
 func getNumValues() int {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5701,7 +5701,7 @@ func TestTraceKernelModule(t *testing.T) {
 	testTraceKernelModule(t, false)
 }
 
-func TestKprobeKernelStackTrace(t *testing.T) {
+func testKprobeKernelStackTrace(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -5729,7 +5729,7 @@ spec: ` + disableKprobeMulti + `
         - action: Post
           kernelStackTrace: true`
 
-	createCrdFile(t, tracingPolicy)
+	createCrdFileFlag(t, tracingPolicy, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -5788,6 +5788,11 @@ spec: ` + disableKprobeMulti + `
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
 }
+
+func TestKprobeKernelStackTrace(t *testing.T) {
+	testKprobeKernelStackTrace(t, false)
+}
+
 func TestKprobeUserStackTrace(t *testing.T) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3602,7 +3602,7 @@ func getNumValues() int {
 	return 2
 }
 
-func TestKprobeMatchArgsFileEqual(t *testing.T) {
+func testKprobeMatchArgsFileEqual(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -3618,7 +3618,7 @@ func TestKprobeMatchArgsFileEqual(t *testing.T) {
 		argVals[3] = "/etc/shadow"
 	}
 
-	createCrdFile(t, getMatchArgsFileCrd("Equal", argVals[:]))
+	createCrdFileFlag(t, getMatchArgsFileCrd("Equal", argVals[:]), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -3640,6 +3640,10 @@ func TestKprobeMatchArgsFileEqual(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeMatchArgsFileEqual(t *testing.T) {
+	testKprobeMatchArgsFileEqual(t, false)
 }
 
 func TestKprobeMatchArgsFilePostfix(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6393,7 +6393,7 @@ tetragon_missed_prog_probes_total{attach="wake_up_new_task",policy="__base__"} 0
 
 }
 
-func TestKprobeBpfCmd(t *testing.T) {
+func testKprobeBpfCmd(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -6412,7 +6412,7 @@ spec:
    - index: 0
      type: "bpf_cmd"
 `
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -6455,6 +6455,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeBpfCmd(t *testing.T) {
+	testKprobeBpfCmd(t, false)
 }
 
 func TestKprobeMultiSymbolInstancesOk(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4483,7 +4483,7 @@ func TestKprobeMatchBinariesPerfring(t *testing.T) {
 
 // TestKprobeMatchBinariesEarlyExec checks that the matchBinaries can filter
 // events triggered by process started before Tetragon.
-func TestKprobeMatchBinariesEarlyExec(t *testing.T) {
+func testKprobeMatchBinariesEarlyExec(t *testing.T, fentry bool) {
 	testutils.CaptureLog(t, logger.GetLogger())
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
@@ -4534,6 +4534,11 @@ func TestKprobeMatchBinariesEarlyExec(t *testing.T) {
 		},
 	}
 
+	if fentry {
+		matchBinariesTracingPolicy.Spec.Fentries = matchBinariesTracingPolicy.Spec.KProbes
+		matchBinariesTracingPolicy.Spec.KProbes = []v1alpha1.KProbeSpec{}
+	}
+
 	err = sm.Manager.AddTracingPolicy(ctx, &matchBinariesTracingPolicy)
 	if assert.NoError(t, err) {
 		t.Cleanup(func() {
@@ -4554,6 +4559,10 @@ func TestKprobeMatchBinariesEarlyExec(t *testing.T) {
 		}
 	}
 	t.Error("events triggered by process executed before Tetragon should not be ignored because of matchBinaries")
+}
+
+func TestKprobeMatchBinariesEarlyExec(t *testing.T) {
+	testKprobeMatchBinariesEarlyExec(t, false)
 }
 
 // TestKprobeMatchBinariesPrefixMatchArgs makes sure that the prefix of

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7554,7 +7554,7 @@ func TestCapabilitiesGained(t *testing.T) {
 	testCapabilitiesGained(t, false)
 }
 
-func TestKprobeResolveCurrent(t *testing.T) {
+func testKprobeResolveCurrent(t *testing.T, fentry bool) {
 	if !kernels.MinKernelVersion("5.4") {
 		t.Skip("Test requires kernel 5.4+")
 	}
@@ -7611,7 +7611,7 @@ spec:
         - "` + strconv.Itoa(pid) + `"
 `
 
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -7642,6 +7642,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeResolveCurrent(t *testing.T) {
+	testKprobeResolveCurrent(t, false)
 }
 
 func testKprobeRangeOp(t *testing.T, in bool) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5398,7 +5398,7 @@ func TestKprobeListSyscallDupsRange(t *testing.T) {
 
 // This just tests if the hooks that we are using in our
 // trace kernel module examples are stable enough
-func TestTraceKernelModuleCallsStability(t *testing.T) {
+func testTraceKernelModuleCallsStability(t *testing.T, fentry bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
@@ -5419,12 +5419,16 @@ spec:
     - index: 0
       type: "module"
 `
-	createCrdFile(t, hookFull)
+	createCrdFileFlag(t, hookFull, fentry)
 
 	_, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
+}
+
+func TestTraceKernelModuleCallsStability(t *testing.T) {
+	testTraceKernelModuleCallsStability(t, false)
 }
 
 func TestLinuxBinprmExtractPath(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3690,7 +3690,7 @@ func TestKprobeMatchArgsFilePostfix(t *testing.T) {
 	testKprobeMatchArgsFilePostfix(t, false)
 }
 
-func TestKprobeMatchArgsFilePrefix(t *testing.T) {
+func testKprobeMatchArgsFilePrefix(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -3706,7 +3706,7 @@ func TestKprobeMatchArgsFilePrefix(t *testing.T) {
 		argVals[3] = "/etc/s"
 	}
 
-	createCrdFile(t, getMatchArgsFileCrd("Prefix", argVals[:]))
+	createCrdFileFlag(t, getMatchArgsFileCrd("Prefix", argVals[:]), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -3728,6 +3728,10 @@ func TestKprobeMatchArgsFilePrefix(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeMatchArgsFilePrefix(t *testing.T) {
+	testKprobeMatchArgsFilePrefix(t, false)
 }
 
 func TestKprobeMatchArgsFdEqual(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5206,7 +5206,7 @@ func TestKprobeWriteMaxDataFull(t *testing.T) {
 	testKprobeWriteMaxDataFull(t, false)
 }
 
-func testKprobeRateLimit(t *testing.T, rateLimit bool) {
+func testKprobeRateLimit(t *testing.T, rateLimit, fentry bool) {
 	testutils.CaptureLog(t, logger.GetLogger())
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
@@ -5260,6 +5260,11 @@ spec:
 	tp, err := tracingpolicy.FromYAML(hook)
 	if err != nil {
 		t.Fatalf("failed to decode yaml: %s", err)
+	}
+
+	if fentry {
+		tp.TpSpec().Fentries = tp.TpSpec().KProbes
+		tp.TpSpec().KProbes = []v1alpha1.KProbeSpec{}
 	}
 
 	err = sm.Manager.AddTracingPolicy(ctx, tp)
@@ -5324,7 +5329,7 @@ func TestKprobeNoRateLimit(t *testing.T) {
 		t.Skip("Test requires kernel 5.4")
 	}
 
-	testKprobeRateLimit(t, false)
+	testKprobeRateLimit(t, false, false)
 }
 
 func TestKprobeRateLimit(t *testing.T) {
@@ -5332,7 +5337,7 @@ func TestKprobeRateLimit(t *testing.T) {
 		t.Skip("Test requires kernel 5.4")
 	}
 
-	testKprobeRateLimit(t, true)
+	testKprobeRateLimit(t, true, false)
 }
 
 func TestKprobeListSyscallDupsRange(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3646,7 +3646,7 @@ func TestKprobeMatchArgsFileEqual(t *testing.T) {
 	testKprobeMatchArgsFileEqual(t, false)
 }
 
-func TestKprobeMatchArgsFilePostfix(t *testing.T) {
+func testKprobeMatchArgsFilePostfix(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -3662,7 +3662,7 @@ func TestKprobeMatchArgsFilePostfix(t *testing.T) {
 		argVals[3] = "shadow"
 	}
 
-	createCrdFile(t, getMatchArgsFileCrd("Postfix", argVals[:]))
+	createCrdFileFlag(t, getMatchArgsFileCrd("Postfix", argVals[:]), fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -3684,6 +3684,10 @@ func TestKprobeMatchArgsFilePostfix(t *testing.T) {
 	checker := ec.NewUnorderedEventChecker(kpCheckers...)
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeMatchArgsFilePostfix(t *testing.T) {
+	testKprobeMatchArgsFilePostfix(t, false)
 }
 
 func TestKprobeMatchArgsFilePrefix(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7948,7 +7948,7 @@ func TestKprobeFileTypeFilterPipe(t *testing.T) {
 	testKprobeFileTypeFilterPipe(t, false)
 }
 
-func TestKprobeFileTypeFilterNotRegular(t *testing.T) {
+func testKprobeFileTypeFilterNotRegular(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -7989,7 +7989,7 @@ spec:
         - "reg"
 `
 
-	createCrdFile(t, fileTypeHook)
+	createCrdFileFlag(t, fileTypeHook, fentry)
 
 	kpChecker := ec.NewProcessKprobeChecker("filetype-notreg-checker").
 		WithFunctionName(sm.Full("vfs_write")).
@@ -8022,6 +8022,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeFileTypeFilterNotRegular(t *testing.T) {
+	testKprobeFileTypeFilterNotRegular(t, false)
 }
 
 func TestKprobeFileTypeFilterSocket(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -8199,7 +8199,7 @@ func TestKprobeFileTypeFilterNotPipe(t *testing.T) {
 	testKprobeFileTypeFilterNotPipe(t, false)
 }
 
-func TestKprobeFileTypeFilterMultiple(t *testing.T) {
+func testKprobeFileTypeFilterMultiple(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -8241,7 +8241,7 @@ spec:
         - "pipe"
 `
 
-	createCrdFile(t, fileTypeHook)
+	createCrdFileFlag(t, fileTypeHook, fentry)
 
 	kpCheckerReg := ec.NewProcessKprobeChecker("filetype-multi-checker-reg").
 		WithFunctionName(sm.Full("vfs_write")).
@@ -8281,6 +8281,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeFileTypeFilterMultiple(t *testing.T) {
+	testKprobeFileTypeFilterMultiple(t, false)
 }
 
 func TestKprobeNotEqualMultipleValues(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7172,7 +7172,7 @@ func TestKprobeResolveSecondArg(t *testing.T) {
 	testKprobeResolveSecondArg(t, false)
 }
 
-func TestKprobeIgnore(t *testing.T) {
+func testKprobeIgnore(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -7207,7 +7207,7 @@ spec:
         values:
         - ` + pidStr
 
-	createCrdFile(t, lseekConfigHook_)
+	createCrdFileFlag(t, lseekConfigHook_, fentry)
 
 	kpChecker := ec.NewProcessKprobeChecker("lseek-checker").
 		WithFunctionName(sm.Suffix("sys_lseek"))
@@ -7223,6 +7223,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(kpChecker))
 	require.NoError(t, err)
+}
+
+func TestKprobeIgnore(t *testing.T) {
+	testKprobeIgnore(t, false)
 }
 
 func TestKprobeArgsMulti(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -7115,7 +7115,7 @@ func TestKprobeArgsReverse(t *testing.T) {
 	testKprobeArgsReverse(t, false)
 }
 
-func TestKprobeResolveSecondArg(t *testing.T) {
+func testKprobeResolveSecondArg(t *testing.T, fentry bool) {
 	if !kernels.MinKernelVersion("5.4") {
 		t.Skip("Test requires kernel 5.4+")
 	}
@@ -7140,7 +7140,7 @@ spec:
       resolve: "sa_family"
 `
 
-	createCrdFile(t, hook)
+	createCrdFileFlag(t, hook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
 	if err != nil {
@@ -7166,6 +7166,10 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestKprobeResolveSecondArg(t *testing.T) {
+	testKprobeResolveSecondArg(t, false)
 }
 
 func TestKprobeIgnore(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5793,7 +5793,7 @@ func TestKprobeKernelStackTrace(t *testing.T) {
 	testKprobeKernelStackTrace(t, false)
 }
 
-func TestKprobeUserStackTrace(t *testing.T) {
+func testKprobeUserStackTrace(t *testing.T, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -5824,7 +5824,7 @@ spec: ` + disableKprobeMulti + `
       - action: Post
         userStackTrace: true`
 
-	createCrdFile(t, tracingPolicy)
+	createCrdFileFlag(t, tracingPolicy, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -5867,6 +5867,10 @@ spec: ` + disableKprobeMulti + `
 	testCmd.Process.Kill()
 
 	require.NoError(t, err)
+}
+
+func TestKprobeUserStackTrace(t *testing.T) {
+	testKprobeUserStackTrace(t, false)
 }
 
 func TestKprobeMultiMatcArgs(t *testing.T) {

--- a/pkg/sensors/tracing/policyhandler_linux.go
+++ b/pkg/sensors/tracing/policyhandler_linux.go
@@ -163,6 +163,9 @@ func (h policyHandler) PolicyHandler(
 	if len(spec.Usdts) > 0 {
 		sections++
 	}
+	if len(spec.Fentries) > 0 {
+		sections++
+	}
 	if sections > 1 {
 		return nil, errors.New("tracing policies with multiple sections of kprobes, tracepoints, lsm hooks, uprobes or usdts are currently not supported")
 	}
@@ -172,13 +175,25 @@ func (h policyHandler) PolicyHandler(
 		return nil, fmt.Errorf("failed to parse options: %w", err)
 	}
 
-	if len(spec.KProbes) > 0 {
-		name := "generic_kprobe"
+	if len(spec.KProbes) > 0 || len(spec.Fentries) > 0 {
+		var kprobes []v1alpha1.KProbeSpec
+		var name string
+
+		fentry := len(spec.Fentries) > 0
+
+		if fentry {
+			name = "generic_fentry"
+			kprobes = spec.Fentries
+		} else {
+			name = "generic_kprobe"
+			kprobes = spec.KProbes
+		}
+
 		log := logger.GetLogger().With(
 			"policy", tracingpolicy.TpLongname(policy),
 			"sensor", name,
 		)
-		validateInfo, err := preValidateKprobes(log, spec.KProbes, spec.Lists, spec.Enforcers)
+		validateInfo, err := preValidateKprobes(log, kprobes, spec.Lists, spec.Enforcers)
 		if err != nil {
 			return nil, fmt.Errorf("validation failed: %w", err)
 		}
@@ -187,7 +202,10 @@ func (h policyHandler) PolicyHandler(
 		if allKprobesIgnored(validateInfo) {
 			return nil, nil
 		}
-		return createGenericKprobeSensor(spec, name, polInfo, validateInfo)
+		if fentry {
+			return createGenericFentrySensor(spec, name, polInfo, validateInfo)
+		}
+		return createGenericKprobeSensor(spec, name, polInfo, validateInfo, kprobe)
 	}
 	if len(spec.Tracepoints) > 0 {
 		return createGenericTracepointSensor(spec, "generic_tracepoint", polInfo)

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -875,14 +875,14 @@ func TestUInt16Tracepoint(t *testing.T) {
 	require.Equal(t, 3, count, "expected three events: one for each of 7777, 7779 and 7780")
 }
 
-func testListSyscallsDupsRange(t *testing.T, checker *ec.UnorderedEventChecker, configHook string) {
+func testListSyscallsDupsRange(t *testing.T, checker *ec.UnorderedEventChecker, configHook string, fentry bool) {
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
-	createCrdFile(t, configHook)
+	createCrdFileFlag(t, configHook, fentry)
 
 	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
 	if err != nil {
@@ -959,7 +959,7 @@ spec:
 		checker.AddChecks(tpCheckerDup)
 	}
 
-	testListSyscallsDupsRange(t, checker, configHook)
+	testListSyscallsDupsRange(t, checker, configHook, false)
 }
 
 func TestTracepointResolve(t *testing.T) {

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -114,6 +114,1021 @@ spec:
                   - calls
                   type: object
                 type: array
+              fentries:
+                description: A list of fentry specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return argument.
+                        Available actions are: Post;TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -114,6 +114,1021 @@ spec:
                   - calls
                   type: object
                 type: array
+              fentries:
+                description: A list of fentry specs.
+                items:
+                  properties:
+                    args:
+                      description: A list of function arguments to include in the
+                        trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    call:
+                      description: Name of the function to apply the kprobe spec to.
+                      type: string
+                    data:
+                      description: A list of data to include in the trace output.
+                      items:
+                        properties:
+                          btfType:
+                            description: |-
+                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                              type.
+                            type: string
+                          index:
+                            description: Position of the argument.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          label:
+                            description: Label to output in the JSON
+                            type: string
+                          maxData:
+                            default: false
+                            description: |-
+                              Read maximum possible data (currently 327360). This field is only used
+                              for char_buff data. When this value is false (default), the bpf program
+                              will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                              supports fetching up to 327360 bytes if this flag is turned on
+                            type: boolean
+                          resolve:
+                            default: ""
+                            description: Resolve the path to a specific attribute
+                            type: string
+                          returnCopy:
+                            default: false
+                            description: |-
+                              This field is used only for char_buf and char_iovec types. It indicates
+                              that this argument should be read later (when the kretprobe for the
+                              symbol is triggered) because it might not be populated when the kprobe
+                              is triggered at the entrance of the function. For example, a buffer
+                              supplied to read(2) won't have content until kretprobe is triggered.
+                            type: boolean
+                          sizeArgIndex:
+                            description: |-
+                              Specifies the position of the corresponding size argument for this argument.
+                              This field is used only for char_buf and char_iovec types.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          source:
+                            description: Source of the data, if missing the default
+                              if function arguments
+                            type: string
+                          type:
+                            default: auto
+                            description: Argument type.
+                            enum:
+                            - auto
+                            - int
+                            - sint8
+                            - int8
+                            - uint8
+                            - sint16
+                            - int16
+                            - uint16
+                            - uint32
+                            - sint32
+                            - int32
+                            - ulong
+                            - uint64
+                            - size_t
+                            - long
+                            - sint64
+                            - int64
+                            - char_buf
+                            - char_iovec
+                            - skb
+                            - sock
+                            - sockaddr
+                            - socket
+                            - string
+                            - fd
+                            - file
+                            - filename
+                            - path
+                            - nop
+                            - bpf_attr
+                            - perf_event
+                            - bpf_map
+                            - user_namespace
+                            - capability
+                            - kiocb
+                            - iov_iter
+                            - cred
+                            - const_buf
+                            - load_info
+                            - module
+                            - syscall64
+                            - kernel_cap_t
+                            - cap_inheritable
+                            - cap_permitted
+                            - cap_effective
+                            - linux_binprm
+                            - data_loc
+                            - net_device
+                            - bpf_cmd
+                            - dentry
+                            - bpf_prog
+                            type: string
+                        required:
+                        - index
+                        - type
+                        type: object
+                      type: array
+                    ignore:
+                      description: Conditions for ignoring this kprobe
+                      properties:
+                        callNotFound:
+                          description: Ignores calls that are not present in the system
+                          type: boolean
+                      type: object
+                    message:
+                      description: |-
+                        A short message of 256 characters max that will be included
+                        in the event output to inform users what is going on.
+                      type: string
+                    return:
+                      default: false
+                      description: Indicates whether to collect return value of the
+                        traced function.
+                      type: boolean
+                    returnArg:
+                      description: A return argument to include in the trace output.
+                      properties:
+                        btfType:
+                          description: |-
+                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
+                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
+                            type.
+                          type: string
+                        index:
+                          description: Position of the argument.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        label:
+                          description: Label to output in the JSON
+                          type: string
+                        maxData:
+                          default: false
+                          description: |-
+                            Read maximum possible data (currently 327360). This field is only used
+                            for char_buff data. When this value is false (default), the bpf program
+                            will fetch at most 4096 bytes. In later kernels (>=5.4) tetragon
+                            supports fetching up to 327360 bytes if this flag is turned on
+                          type: boolean
+                        resolve:
+                          default: ""
+                          description: Resolve the path to a specific attribute
+                          type: string
+                        returnCopy:
+                          default: false
+                          description: |-
+                            This field is used only for char_buf and char_iovec types. It indicates
+                            that this argument should be read later (when the kretprobe for the
+                            symbol is triggered) because it might not be populated when the kprobe
+                            is triggered at the entrance of the function. For example, a buffer
+                            supplied to read(2) won't have content until kretprobe is triggered.
+                          type: boolean
+                        sizeArgIndex:
+                          description: |-
+                            Specifies the position of the corresponding size argument for this argument.
+                            This field is used only for char_buf and char_iovec types.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        source:
+                          description: Source of the data, if missing the default
+                            if function arguments
+                          type: string
+                        type:
+                          default: auto
+                          description: Argument type.
+                          enum:
+                          - auto
+                          - int
+                          - sint8
+                          - int8
+                          - uint8
+                          - sint16
+                          - int16
+                          - uint16
+                          - uint32
+                          - sint32
+                          - int32
+                          - ulong
+                          - uint64
+                          - size_t
+                          - long
+                          - sint64
+                          - int64
+                          - char_buf
+                          - char_iovec
+                          - skb
+                          - sock
+                          - sockaddr
+                          - socket
+                          - string
+                          - fd
+                          - file
+                          - filename
+                          - path
+                          - nop
+                          - bpf_attr
+                          - perf_event
+                          - bpf_map
+                          - user_namespace
+                          - capability
+                          - kiocb
+                          - iov_iter
+                          - cred
+                          - const_buf
+                          - load_info
+                          - module
+                          - syscall64
+                          - kernel_cap_t
+                          - cap_inheritable
+                          - cap_permitted
+                          - cap_effective
+                          - linux_binprm
+                          - data_loc
+                          - net_device
+                          - bpf_cmd
+                          - dentry
+                          - bpf_prog
+                          type: string
+                      required:
+                      - index
+                      - type
+                      type: object
+                    returnArgAction:
+                      description: |-
+                        An action to perform on the return argument.
+                        Available actions are: Post;TrackSock;UntrackSock
+                      type: string
+                    selectors:
+                      description: Selectors to apply before producing trace output.
+                        Selectors are ORed and short-circuited.
+                      items:
+                        description: |-
+                          KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The
+                          results of MatchPIDs and MatchArgs are ANDed.
+                        properties:
+                          macros:
+                            description: |-
+                              A list of macros names, defined in spec.selectorsMacros.
+                              Filters specified in macros will be appended to corresponding filters of the selector.
+                            items:
+                              type: string
+                            type: array
+                          matchActions:
+                            description: A list of actions to execute when this selector
+                              matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchBinaries:
+                            description: A list of binary exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilities:
+                            description: A list of capabilities and IDs
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchCapabilityChanges:
+                            description: IDs for capabilities changes
+                            items:
+                              properties:
+                                isNamespaceCapability:
+                                  default: false
+                                  description: Indicates whether these caps are namespace
+                                    caps.
+                                  type: boolean
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                type:
+                                  default: Effective
+                                  description: Type of capabilities
+                                  enum:
+                                  - Effective
+                                  - Inheritable
+                                  - Permitted
+                                  type: string
+                                values:
+                                  description: Capabilities to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchData:
+                            description: A list of argument filters. MatchData are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                          matchNamespaceChanges:
+                            description: IDs for namespace changes
+                            items:
+                              properties:
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace types (e.g., Mnt, Pid) to
+                                    match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchNamespaces:
+                            description: A list of namespaces and IDs
+                            items:
+                              properties:
+                                namespace:
+                                  description: Namespace selector name.
+                                  enum:
+                                  - Uts
+                                  - Ipc
+                                  - Mnt
+                                  - Pid
+                                  - PidForChildren
+                                  - Net
+                                  - Time
+                                  - TimeForChildren
+                                  - Cgroup
+                                  - User
+                                  type: string
+                                operator:
+                                  description: Namespace selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Namespace IDs (or host_ns for host
+                                    namespace) of namespaces to match.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - namespace
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchPIDs:
+                            description: A list of process ID filters. MatchPIDs are
+                              ANDed.
+                            items:
+                              properties:
+                                followForks:
+                                  default: false
+                                  description: Matches any descendant processes of
+                                    the matching PIDs.
+                                  type: boolean
+                                isNamespacePID:
+                                  default: false
+                                  description: Indicates whether PIDs are namespace
+                                    PIDs.
+                                  type: boolean
+                                operator:
+                                  description: PID selector operator.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  type: string
+                                values:
+                                  description: Process IDs to match.
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchParentBinaries:
+                            description: A list of process parent exec name filters.
+                            items:
+                              properties:
+                                followChildren:
+                                  default: false
+                                  description: In addition to binaries, match children
+                                    processes of specified binaries.
+                                  type: boolean
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              - values
+                              type: object
+                            type: array
+                          matchReturnActions:
+                            description: A list of actions to execute when MatchReturnArgs
+                              selector matches
+                            items:
+                              properties:
+                                action:
+                                  description: |-
+                                    Action to execute.
+                                    NOTE: actions FollowFD, UnfollowFD, and CopyFD are marked as deprecated and planned to
+                                    be removed in version 1.5.
+                                  enum:
+                                  - Post
+                                  - FollowFD
+                                  - UnfollowFD
+                                  - Sigkill
+                                  - CopyFD
+                                  - Override
+                                  - GetUrl
+                                  - DnsLookup
+                                  - NoPost
+                                  - Signal
+                                  - TrackSock
+                                  - UntrackSock
+                                  - NotifyEnforcer
+                                  - CleanupEnforcerNotification
+                                  - Set
+                                  type: string
+                                argError:
+                                  description: error value for override action
+                                  format: int32
+                                  type: integer
+                                argFd:
+                                  description: An arg index for the fd for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argFqdn:
+                                  description: A FQDN to lookup for the dnsLookup
+                                    action
+                                  type: string
+                                argIndex:
+                                  description: An arg index for the set action
+                                  format: int32
+                                  type: integer
+                                argName:
+                                  description: An arg index for the filename for fdInstall
+                                    action
+                                  format: int32
+                                  type: integer
+                                argRegs:
+                                  description: An arg value for the regs action
+                                  items:
+                                    type: string
+                                  type: array
+                                argSig:
+                                  description: A signal number for signal action
+                                  format: int32
+                                  type: integer
+                                argSock:
+                                  description: An arg index for the sock for trackSock
+                                    and untrackSock actions
+                                  format: int32
+                                  type: integer
+                                argUrl:
+                                  description: A URL for the getUrl action
+                                  type: string
+                                argValue:
+                                  description: An arg value for the set action
+                                  format: int32
+                                  type: integer
+                                imaHash:
+                                  description: |-
+                                    Enable collection of file hashes from integrity subsystem.
+                                    Only valid with the post action.
+                                  type: boolean
+                                kernelStackTrace:
+                                  description: Enable kernel stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                                rateLimit:
+                                  description: |-
+                                    A time period within which repeated messages will not be posted. Can be
+                                    specified in seconds (default or with 's' suffix), minutes ('m' suffix)
+                                    or hours ('h' suffix). Only valid with the post action.
+                                  type: string
+                                rateLimitScope:
+                                  description: |-
+                                    The scope of the provided rate limit argument. Can be "thread" (default),
+                                    "process" (all threads for the same process), or "global". If "thread" is
+                                    selected then rate limiting applies per thread; if "process" is selected
+                                    then rate limiting applies per process; if "global" is selected then rate
+                                    limiting applies regardless of which process or thread caused the action.
+                                    Only valid with the post action and with a rateLimit specified.
+                                  type: string
+                                userStackTrace:
+                                  description: Enable user stack trace export. Only
+                                    valid with the post action.
+                                  type: boolean
+                              required:
+                              - action
+                              type: object
+                            type: array
+                          matchReturnArgs:
+                            description: A list of argument filters. MatchArgs are
+                              ANDed.
+                            items:
+                              properties:
+                                args:
+                                  description: Position of the operator arguments
+                                    (in spec file) to apply fhe filter to.
+                                  items:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  type: array
+                                index:
+                                  description: Position of the argument (in function
+                                    prototype) to apply fhe filter to.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                                operator:
+                                  description: Filter operation.
+                                  enum:
+                                  - Equal
+                                  - NotEqual
+                                  - Prefix
+                                  - NotPrefix
+                                  - Postfix
+                                  - NotPostfix
+                                  - GreaterThan
+                                  - LessThan
+                                  - GT
+                                  - LT
+                                  - Mask
+                                  - SPort
+                                  - NotSPort
+                                  - SPortPriv
+                                  - NotSportPriv
+                                  - DPort
+                                  - NotDPort
+                                  - DPortPriv
+                                  - NotDPortPriv
+                                  - SAddr
+                                  - NotSAddr
+                                  - DAddr
+                                  - NotDAddr
+                                  - Protocol
+                                  - Family
+                                  - State
+                                  - InMap
+                                  - NotInMap
+                                  - CapabilitiesGained
+                                  - InRange
+                                  - NotInRange
+                                  - SubString
+                                  - SubStringIgnCase
+                                  - CelExpr
+                                  - FileType
+                                  - NotFileType
+                                  type: string
+                                values:
+                                  description: Value to compare the argument against.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    syscall:
+                      default: true
+                      description: Indicates whether the traced function is a syscall.
+                      type: boolean
+                    tags:
+                      description: |-
+                        Tags to categorize the event, will be include in the event output.
+                        Maximum of 16 Tags are supported.
+                      items:
+                        type: string
+                      maxItems: 16
+                      type: array
+                  required:
+                  - call
+                  type: object
+                type: array
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -92,6 +92,9 @@ type TracingPolicySpec struct {
 	// +kubebuilder:validation:Optional
 	// A list of usdt specs.
 	Usdts []UsdtSpec `json:"usdts,omitempty"`
+	// +kubebuilder:validation:Optional
+	// A list of fentry specs.
+	Fentries []KProbeSpec `json:"fentries,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// PodSelector selects pods that this policy applies to

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.11"
+const CustomResourceDefinitionSchemaVersion = "1.7.12"

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
@@ -732,6 +732,13 @@ func (in *TracingPolicySpec) DeepCopyInto(out *TracingPolicySpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Fentries != nil {
+		in, out := &in.Fentries, &out.Fentries
+		*out = make([]KProbeSpec, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.PodSelector != nil {
 		in, out := &in.PodSelector, &out.PodSelector
 		*out = new(v1.LabelSelector)


### PR DESCRIPTION
Adding support for fentry sensor. The configuration mirrors kprobes at the moment, except for enforcement, which will come later.