### PR TITLE
[backport/v1.4] selectors: Ignore empty matchBinaries

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1216,6 +1216,11 @@ func ParseMatchBinary(k *KernelSelectorState, b *v1alpha1.BinarySelector, selIdx
 		return fmt.Errorf("matchBinary error: %w", err)
 	}
 
+	// ignore matchBinaries selectors with no values
+	if len(b.Values) == 0 {
+		return nil
+	}
+
 	// prepare the selector options
 	sel := MatchBinariesSelectorOptions{}
 	sel.Op = op


### PR DESCRIPTION
[upstream commit: 996d40f0907c17a9e914bd23911b01f03a11ed1d]

When tried to use the following tracing policy:
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "lsm"
spec:
  lsmhooks:
  - hook: "bprm_check_security" args:
      - index: 0 type: "linux_binprm" selectors:
    - matchArgs:
        - index: 0 operator: "Postfix" values: - "/true" matchBinaries:
        - operator: NotIn values: []

I didn't get any events when running /usr/bin/true.

Removing the empty matchBinaries fixes that issue.

In order to fix that, this patch ignores empty (i.e. no values) matchBinaries selectors.