### PR TITLE
chore(ci): always use `actions/setup-go` after repo clone.

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -100,8 +100,6 @@ jobs:
   build_windows:
     runs-on: windows-latest
     timeout-minutes: 40
-    strategy:
-      fail-fast: false
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -103,18 +103,17 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        path: go/src/github.com/cilium/tetragon/
+
     - name: Install Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         # renovate: datasource=golang-version depName=go
         go-version: '1.25.0'
 
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        path: go/src/github.com/cilium/tetragon/
-
-    
     - name: Run go tests
       working-directory: ${{ github.workspace }}\go\src\github.com\cilium\tetragon
       run: |

--- a/.github/workflows/windows-build-smoke-test.yml
+++ b/.github/workflows/windows-build-smoke-test.yml
@@ -145,7 +145,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24.2'
+          # renovate: datasource=golang-version depName=go
+          go-version: '1.25.0'
       
       - name: Build and Zip tetragon Windows binaries
         working-directory: ${{ github.workspace }}\go\src\github.com\cilium\tetragon

--- a/.github/workflows/windows-build-smoke-test.yml
+++ b/.github/workflows/windows-build-smoke-test.yml
@@ -137,15 +137,15 @@ jobs:
         run: mkdir D:\temp
         shell: pwsh
 
-      - name: Install Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: '1.24.2'
-
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: go/src/github.com/cilium/tetragon/
+
+      - name: Install Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: '1.24.2'
       
       - name: Build and Zip tetragon Windows binaries
         working-directory: ${{ github.workspace }}\go\src\github.com\cilium\tetragon


### PR DESCRIPTION
Extracted from #4052 

### Description

Make sure to always use actions/setup-go after repo checkout.

