### PR TITLE
helm: Add a Role for tetragon service account

### DIFF
--- a/install/kubernetes/tetragon/templates/_extensions.tpl
+++ b/install/kubernetes/tetragon/templates/_extensions.tpl
@@ -10,6 +10,8 @@
 
 {{- define "clusterrole.extra" -}}{{- end }}
 
+{{- define "role.extra" -}}{{- end }}
+
 {{- define "operatorconfigmap.extra" -}}{{- end }}
 
 {{- define "operatorclusterrole.extra" -}}{{- end }}

--- a/install/kubernetes/tetragon/templates/_helpers.tpl
+++ b/install/kubernetes/tetragon/templates/_helpers.tpl
@@ -13,6 +13,10 @@ Resources names
 {{- include "tetragon.name" . }}
 {{- end }}
 
+{{- define "tetragon.role" -}}
+{{- include "tetragon.name" . }}
+{{- end }}
+
 {{- define "tetragon-operator.name" -}}
 {{- default (printf "%s-operator" .Release.Name) .Values.tetragonOperator.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/install/kubernetes/tetragon/templates/role.yaml
+++ b/install/kubernetes/tetragon/templates/role.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon.role" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon.labels" . | nindent 4 }}
+rules:
+  {{- include "role.extra" . | nindent 2 }}
+{{- end }}

--- a/install/kubernetes/tetragon/templates/rolebinding.yaml
+++ b/install/kubernetes/tetragon/templates/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.serviceAccount.create }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tetragon.role" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "tetragon.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tetragon.role" . }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "tetragon.serviceAccount" . }}
+{{- end }}


### PR DESCRIPTION
Add "tetragon" role and bind it to the tetragon service account. Define "role.extra" helper function to allow customizing the role by modifying _extensions.tpl.