### PR TITLE
k8s: Reduce RBAC permission for non-k8s deployment

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+
 	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/logger/logfields"
@@ -263,4 +264,9 @@ func K8SControlPlaneEnabled() bool {
 	// This is because the control plane is required to get the kubeconfig
 	// and other K8s related information.
 	return Config.EnableK8s || len(Config.K8sKubeConfigPath) > 0
+}
+
+func InClusterControlPlaneEnabled() bool {
+	// If K8s is enabled and no kubeconfig path is provided, we assume that the control plane is in-cluster.
+	return Config.EnableK8s && len(Config.K8sKubeConfigPath) == 0
 }

--- a/pkg/watcher/conf/conf.go
+++ b/pkg/watcher/conf/conf.go
@@ -10,9 +10,13 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 )
 
-func K8sConfig() (*rest.Config, error) {
+// K8sConfig returns Kubernetes client configuration. If running in-cluster, the
+// second return value is true, otherwise false.
+func K8sConfig() (*rest.Config, bool, error) {
 	if option.Config.K8sKubeConfigPath != "" {
-		return clientcmd.BuildConfigFromFlags("", option.Config.K8sKubeConfigPath)
+		cfg, err := clientcmd.BuildConfigFromFlags("", option.Config.K8sKubeConfigPath)
+		return cfg, false, err
 	}
-	return rest.InClusterConfig()
+	cfg, err := rest.InClusterConfig()
+	return cfg, true, err
 }


### PR DESCRIPTION
### Description

The below PR enables k8s cluster as control plane for non-k8s workload, however, the RBAC permission seems to be required unnecessarily for Pods, Nodes, and CRDs. This commit is to make sure that required RBAC is only limited to tetragon related resources

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: tetragon-vm
rules:
- apiGroups:
  - cilium.io
  resources:
  - podinfo
  - tracingpolicies
  - tracingpoliciesnamespaced
  verbs:
  - get
  - list
  - watch
```

Relates: #4011

### Testing

Testing was done with one dedicated Service account having only the above permission, and then run tetragon locally as per below

```shell
$ KUBECONFIG=./tetragon-vm.kubeconfig kg service
Error from server (Forbidden): services is forbidden: User "system:serviceaccount:default:tetragon-vm" cannot list resource "services" in API group "" in the namespace "default"

$ sudo ./tetragon --bpf-lib bpf/objs --k8s-kubeconfig-path ./roadmap/cp/tetragon-vm.kubeconfig 
level=info msg="Starting tetragon" version=v1.6.0-pre.0-101-g70dde2ffc
level=info msg="config settings" config="map[bpf-dir:tetragon bpf-lib:bpf/objs btf: cgroup-rate: cluster-name: config-dir: cpuprofile: cri-endpoint: data-cache-size:1024 debug:false disable-kprobe-multi:false enable-ancestors:[] enable-cgidmap:false enable-cgidmap-debug:false enable-cgtrackerid:true enable-compatibility-syscall64-size-type:false enable-cri:false enable-export-aggregation:false enable-k8s-api:false enable-msg-handling-latency:false enable-pid-set-filter:false enable-pod-annotations:false enable-pod-info:false enable-policy-filter:false enable-policy-filter-cgroup-map:false enable-policy-filter-debug:false enable-process-cred:false enable-process-ns:false enable-tracing-policy-crd:true event-cache-retries:15 event-cache-retry-delay:2 event-queue-size:10000 execve-map-entries:0 execve-map-size: export-aggregation-buffer-size:10000 export-aggregation-window-size:15s export-allowlist: export-denylist: export-file-compress:false export-file-max-backups:5 export-file-max-size-mb:10 export-file-perm:600 export-file-rotation-interval:0s export-filename: export-rate-limit:-1 expose-stack-addresses:false field-filters: force-large-progs:false force-small-progs:false generate-docs:false gops-address: health-server-address::6789 health-server-interval:10 k8s-kubeconfig-path:./roadmap/cp/tetragon-vm.kubeconfig keep-sensors-on-exit:false kernel: log-format:text log-level:info memprofile: metrics-label-filter:namespace,workload,pod,binary metrics-server: netns-dir:/var/run/docker/netns/ pprof-address: process-cache-gc-interval:30s process-cache-size:65536 procfs:/proc/ rb-queue-size:65535 rb-size:0 rb-size-total:0 redaction-filters: release-pinned-bpf:true server-address:localhost:54321 tracing-policy: tracing-policy-dir:/etc/tetragon/tetragon.tp.d username-metadata:disabled verbose:0]"
level=info msg="Tetragon current security context" SELinux=unconfined AppArmor=unconfined Smack="" Lockdown=none
level=info msg="Tetragon pid file creation succeeded" pid=731406 pidfile=/var/run/tetragon/tetragon.pid
level=warn msg="Unable to mount BPF filesystem" error="multiple mount points detected at /sys/fs/bpf"
level=info msg="BPF: successfully released pinned BPF programs and maps" bpf-dir=/sys/fs/bpf/tetragon
level=info msg="BTF discovery: default kernel btf file found" btf-file=/sys/kernel/btf/vmlinux
level=info msg="BPF detected features: override_return: true, buildid: true, kprobe_multi: false, uprobe_multi false, fmodret: true, fmodret_syscall: true, signal: true, large: true, link_pin: true, lsm: false, missed_stats_kprobe_multi: true, missed_stats_kprobe: true, batch_update: true, uprobe_refctroff: true"
level=info msg="Cgroup mode detection succeeded" cgroup.fs=/sys/fs/cgroup cgroup.mode="Unified mode (Cgroupv2)"
level=info msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/proc/1/root/sys/fs/cgroup cgroup.controllers="[cpuset cpu io memory hugetlb pids rdma misc]" cgroup.hierarchyID=0
level=info msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/sys/fs/cgroup/user.slice/user-501.slice/session-317.scope cgroup.controllers="[cpuset cpu io memory pids]" cgroup.hierarchyID=0
level=info msg="Cgroupv2 hierarchy validated successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/sys/fs/cgroup/user.slice/user-501.slice/session-317.scope
level=info msg="Deployment mode detection succeeded" cgroup.fs=/sys/fs/cgroup deployment.mode="systemd user session"
level=info msg="Updated TetragonConf map successfully" confmap-update=tg_conf_map deployment.mode="systemd user session" log.level=0 cgroup.fs.magic=Cgroupv2 cgroup.hierarchyID=0 NSPID=731406
level=info msg="Enabling Kubernetes API"
level=info msg="Configured redaction filters" redactionFilters=""
level=info msg="Exit probe on acct_process"
level=info msg="Set execve_map entries 32768" size=28M
level=info msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
level=info msg="Loading sensor" name=__base__
level=info msg="Loading kernel version 6.8.12"
level=info msg="Loaded sensor successfully" sensor=__base__
level=info msg="Available sensors" sensors=__base__
level=info msg="Registered sensors (policy-handlers)" policy-handlers="loader sensor, tracing, enforcer"
level=info msg="Registered probe types" types="execve, enforcer, generic_kprobe, generic_lsm, generic_tracepoint, generic_uprobe, generic_usdt, loader"
level=info msg="Creating new EventCache" retries=15 delay=2s
level=info msg="Starting process manager" enableK8s=false enableProcessCred=false enableProcessNs=false
level=info msg="Exporter configuration" enabled=false fileName=""
level=info msg="Successfully detected bpftool path" bpftool=/usr/sbin/bpftool
level=warn msg="failed to locate gops binary, on bugtool debugging ensure you have gops installed"
level=info msg="Enabling policy informers"
level=info msg="Starting gRPC health server" address=:6789 interval=10
level=info msg="Starting gRPC server" protocol=tcp address=localhost:54321
level=info msg="BPF: found active BPF resources" bpf-dir=/sys/fs/bpf/tetragon pinned-bpf="[__base__ execve_map execve_map_stats execve_map_update_data tcpmon_map tg_conf_map tg_errmetrics_map tg_execve_joined_info_map tg_execve_joined_info_map_stats tg_mbset_gen tg_mbset_map tg_stats_map]"
level=info msg="Read ProcFS /proc/ appended 310/370 entries"
level=info msg="Cgroup rate disabled (0/0s)"
level=info msg="Loading Tracing Policies from directory ignored, directory does not exist" tracing-policy-dir=/etc/tetragon/tetragon.tp.d
level=info msg="Perf ring buffer size (bytes)" percpu=68K total=884K
level=info msg="Perf ring buffer events queue size (events)" size=63K
level=info msg="Listening for events..."

// In another terminal
$ ka examples/tracingpolicy/bpf.yaml 
tracingpolicy.cilium.io/bpf created
$ ./tetra tracingpolicy list
ID   NAME   STATE     FILTERID   NAMESPACE   SENSORS          KERNELMEMORY   MODE
1    bpf    enabled   0          (global)    generic_kprobe   5.76 MB        enforce 
```

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
k8s: Reduce RBAC permission for non-k8s deployment
```
