### PR TITLE
install/kubernetes/tetragon: Helm chart add serviceLabels

### DIFF
--- a/install/kubernetes/tetragon/templates/service.yaml
+++ b/install/kubernetes/tetragon/templates/service.yaml
@@ -23,5 +23,8 @@ spec:
     {{- else }}
     {{- include "tetragon.labels" . | nindent 4 }}
     {{- end }}
+    {{- with .Values.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   type: ClusterIP
 {{- end }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -20,6 +20,7 @@ daemonSetAnnotations: {}
 extraVolumes: []
 updateStrategy: {}
 podLabels: {}
+serviceLabels: {}
 daemonSetLabelsOverride: {}
 selectorLabelsOverride: {}
 podLabelsOverride: {}


### PR DESCRIPTION
charts: add serviceLabels for additive Service label management

Tetragon Helm chart currently exposes only serviceLabelsOverride which forces full replacement of the Service labels and makes day to day label management error prone.

This patch fixes this by adding:

A new values key serviceLabels as an empty map in values.yaml to allow appending labels without losing chart defaults. Example:

```
serviceLabels: {}
# serviceLabels:
#   team: sre
#   owner: platform
```

Service template logic that preserves compatibility. If serviceLabels is set it is merged with existing chart labels or serviceLabelsOverride to produce the final label set. additional serviceLabels can simplify label based integration such as Prometheus.

Signed-off-by: Lyon <yieon1230@gmail.com>