### PR TITLE
install/kubernetes/tetragon: Helm chart add serviceAnnotations and serviceLabels

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -85,6 +85,8 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceAnnotations | object | `{}` |  |
+| serviceLabels | object | `{}` |  |
 | serviceLabelsOverride | object | `{}` |  |
 | tetragon.argsOverride | list | `[]` | Override the arguments. For advanced users only. |
 | tetragon.btf | string | `""` |  |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -67,6 +67,8 @@ Helm chart for Tetragon
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceAnnotations | object | `{}` |  |
+| serviceLabels | object | `{}` |  |
 | serviceLabelsOverride | object | `{}` |  |
 | tetragon.argsOverride | list | `[]` | Override the arguments. For advanced users only. |
 | tetragon.btf | string | `""` |  |

--- a/install/kubernetes/tetragon/templates/service.yaml
+++ b/install/kubernetes/tetragon/templates/service.yaml
@@ -3,11 +3,18 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- with .Values.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- with .Values.serviceLabelsOverride}}
     {{- toYaml . | nindent 4 }}
     {{- else }}
     {{- include "tetragon.labels" . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ include "tetragon.name" . }}
   namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -9,6 +9,7 @@ serviceAccount:
   annotations: {}
   name: ""
 podAnnotations: {}
+serviceAnnotations: {}
 podSecurityContext: {}
 nodeSelector: {}
 tolerations:
@@ -20,6 +21,7 @@ daemonSetAnnotations: {}
 extraVolumes: []
 updateStrategy: {}
 podLabels: {}
+serviceLabels: {}
 daemonSetLabelsOverride: {}
 selectorLabelsOverride: {}
 podLabelsOverride: {}


### PR DESCRIPTION
charts: add serviceAnnotations and serviceLabels for additive Service metadata management

Tetragon Helm chart currently exposes only serviceLabelsOverride which forces full replacement of the Service labels and makes day to day label management error prone.

This patch fixes this by adding:

A new values key serviceLabels as an empty map in values.yaml to allow appending labels without losing chart defaults.

A new values key serviceAnnotations as an empty map in values.yaml to allow appending annotations without losing chart defaults.

Service template logic that preserves compatibility. If serviceLabels is set it is merged with existing chart labels or serviceLabelsOverride to produce the final label set. If serviceAnnotations is set it is merged with existing chart annotations to produce the final annotations set.

Example values:
```
serviceLabels: {}
# serviceLabels:
#   k8s-app: tetragon

serviceAnnotations: {}
# serviceAnnotations:
#  prometheus.io/port: "2112"
#  prometheus.io/scrape: "true"
```

As a secondary note, these additive fields can simplify label based selection in systems such as Prometheus.

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->