### PR TITLE
policy_stats: use the map only for policy sensors

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -603,8 +603,6 @@ FUNC_INLINE void
 perf_event_output_metric(void *ctx, u8 msg_op, void *map, u64 flags, void *data, u64 size)
 {
 	long err;
-	u32 zero = 0;
-	struct policy_stats *pstats;
 
 	err = perf_event_output(ctx, map, flags, data, size);
 	if (err < 0) {
@@ -612,9 +610,7 @@ perf_event_output_metric(void *ctx, u8 msg_op, void *map, u64 flags, void *data,
 		return;
 	}
 
-	pstats = map_lookup_elem(&policy_stats, &zero);
-	if (pstats)
-		lock_add(&pstats->act_cnt[POLICY_POST], 1);
+	policy_stats_update(POLICY_POST);
 }
 
 /**

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -4,11 +4,11 @@
 #include "vmlinux.h"
 #include "api.h"
 
+#define GENERIC_TRACEPOINT
+
 #include "compiler.h"
 #include "bpf_event.h"
 #include "bpf_task.h"
-
-#define GENERIC_TRACEPOINT
 
 #include "retprobe_map.h"
 #include "types/operations.h"

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -764,7 +764,6 @@ do_action(void *ctx, __u32 i, struct selector_action *actions, bool *post, bool 
 	int argi __maybe_unused;
 	int err = 0;
 	int zero = 0;
-	struct policy_stats *pstats;
 	u32 polacct;
 
 	e = map_lookup_elem(&process_call_heap, &zero);
@@ -870,9 +869,7 @@ do_action(void *ctx, __u32 i, struct selector_action *actions, bool *post, bool 
 	}
 
 	if (polacct != POLICY_INVALID_ACT_) {
-		pstats = map_lookup_elem(&policy_stats, &zero);
-		if (pstats)
-			lock_add(&pstats->act_cnt[polacct], 1);
+		policy_stats_update(polacct);
 	}
 
 	if (!err) {


### PR DESCRIPTION
perf_event_output_metric is defined in lib/process.h that is included from the code in the base sensor as well.

As a result, some programs from the exec sensor end up having private copies of the policy_stats map, which is just waster memory. Add some ifdefs to only enable the policy_stats map for the tracing (generic) sensors.

Fixes: b0e50ee7f3a1 ("bpf: policy stats")

