### PR TITLE
k8s: Add alias for getting k8s config

### DIFF
--- a/pkg/watcher/conf/conf.go
+++ b/pkg/watcher/conf/conf.go
@@ -10,9 +10,12 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 )
 
+// K8sConfig alias is mainly for testing and extension if required.
+var K8sConfig = k8sConfig
+
 // K8sConfig returns Kubernetes client configuration. If running in-cluster, the
 // second return value is true, otherwise false.
-func K8sConfig() (*rest.Config, bool, error) {
+func k8sConfig() (*rest.Config, bool, error) {
 	if option.Config.K8sKubeConfigPath != "" {
 		cfg, err := clientcmd.BuildConfigFromFlags("", option.Config.K8sKubeConfigPath)
 		return cfg, false, err


### PR DESCRIPTION
Similar to what controller-runtime is having (e.g. alias.go), this will help with testing and extension later. One of the use case is to support more auth methods to k8s.

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
Similar to what controller-runtime is having (e.g. alias.go), this will help with testing and extension later. One of the use case is to support more auth methods to k8s.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
k8s: Add alias for getting k8s config
```
