### PR TITLE
new(bpf): errmetrics improvements

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -4,3 +4,4 @@ bpf/include/vmlinux_generated_x86.h
 bpf/include/api.h
 bpf/libbpf/*
 bpf/lib/bpf_helpers.h
+bpf/tetragon/fileids.h

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ clean: cli-clean tarball-clean
 ##@ Build and install
 
 pkg/errmetrics/fileids.json: bpf/tetragon/fileids.h
-	go run ./cmd/bpf-fileids bpf/tetragon/fileids.h pkg/errmetrics/fileids.json
+	go run ./cmd/bpf-fileids pkg/errmetrics/fileids.json
 
 .PHONY: fileids
 fileids: pkg/errmetrics/fileids.json

--- a/bpf/cgroup/bpf_cgroup_mkdir.c
+++ b/bpf/cgroup/bpf_cgroup_mkdir.c
@@ -9,6 +9,7 @@
 #include "bpf_cgroup.h"
 #include "bpf_task.h"
 #include "bpf_cgroup_events.h"
+#include "bpf_errmetrics.h"
 
 char _license[] __attribute__((section(("license")), used)) = "GPL";
 #ifdef VMLINUX_KERNEL_VERSION
@@ -66,7 +67,7 @@ tg_tp_cgrp_mkdir(struct bpf_raw_tracepoint_args *ctx)
 		/* We track only for now cgroups that are at same or above tetragon
 		 * level (ancestors level)
 		 */
-		map_update_elem(&tg_cgrps_tracking_map, &cgrpid, cgrp_heap,
+		with_errmetrics(map_update_elem, &tg_cgrps_tracking_map, &cgrpid, cgrp_heap,
 				BPF_ANY);
 
 		/* We forward bpf events only under TraceLevel */

--- a/bpf/cgroup/bpf_cgtracker.c
+++ b/bpf/cgroup/bpf_cgtracker.c
@@ -61,7 +61,7 @@ tg_cgtracker_cgroup_mkdir(struct bpf_raw_tracepoint_args *ctx)
 		return 0;
 	cgid_tracker = map_lookup_elem(&tg_cgtracker_map, &cgid_parent);
 	if (cgid_tracker)
-		map_update_elem__errmetrics(&tg_cgtracker_map, &cgid, cgid_tracker, BPF_ANY);
+		with_errmetrics(map_update_elem, &tg_cgtracker_map, &cgid, cgid_tracker, BPF_ANY);
 
 	return 0;
 }

--- a/bpf/lib/bpf_errmetrics.h
+++ b/bpf/lib/bpf_errmetrics.h
@@ -53,13 +53,12 @@ errmetrics_update(__u16 error, __u8 file_id, __u16 line_nr, __u64 helper_id)
 		compile_time_error();                                                        \
 	} while (0)
 
-// To be used for bpf helpers that return a 0 -> OK, non-zero KO.
+// To be used for bpf helpers that on failure return <0 errno-style return code.
 #define with_errmetrics(bpf_helper, ...) ({                                   \
-	int err;                                                              \
-	__u16 fileid = get_fileid__(__FILE__);                                \
+	__u16 fileid = get_fileid__(__FILE_NAME__);                           \
 	if (!__builtin_constant_p(fileid) || !fileid)                         \
-		compile_error(__FILE__);                                      \
-	err = bpf_helper(__VA_ARGS__);                                        \
+		compile_error(__FILE_NAME__);                                 \
+	__auto_type err = bpf_helper(__VA_ARGS__);                            \
 	if (err)                                                              \
 		errmetrics_update(-err, fileid, __LINE__, (__u64)bpf_helper); \
 	err;                                                                  \

--- a/bpf/lib/bpf_errmetrics.h
+++ b/bpf/lib/bpf_errmetrics.h
@@ -51,13 +51,12 @@ errmetrics_update(__u16 error, __u8 file_id, __u16 line_nr)
 		compile_time_error();                                                        \
 	} while (0)
 
-#define map_update_elem__errmetrics(m, k, v, f) ({         \
+#define with_errmetrics(bpf_helper, ...) ({                \
 	int err;                                           \
 	__u16 fileid = get_fileid__(__FILE__);             \
-                                                           \
 	if (!__builtin_constant_p(fileid) || !fileid)      \
 		compile_error(__FILE__);                   \
-	err = map_update_elem(m, k, v, f);                 \
+	err = bpf_helper(__VA_ARGS__);                     \
 	if (err)                                           \
 		errmetrics_update(-err, fileid, __LINE__); \
 	err;                                               \

--- a/bpf/process/bpf_enforcer.h
+++ b/bpf/process/bpf_enforcer.h
@@ -6,6 +6,7 @@
 
 #include "vmlinux.h"
 #include "bpf_helpers.h"
+#include "bpf_errmetrics.h"
 
 /* information to track how an enforcer notify action was triggered */
 struct enforcer_act_info {
@@ -55,7 +56,7 @@ enforcer_update_missed_notifications(struct enforcer_missed_key *key)
 		return;
 	}
 
-	err = map_update_elem(&enforcer_missed_notifications, key, &one, BPF_NOEXIST);
+	err = with_errmetrics(map_update_elem, &enforcer_missed_notifications, key, &one, BPF_NOEXIST);
 	if (!err)
 		return;
 
@@ -103,7 +104,7 @@ FUNC_INLINE void do_enforcer_action(int error, int signal, struct enforcer_act_i
 		enforcer_update_missed_notifications(&missed_key);
 		*ptr = data;
 	} else {
-		map_update_elem(&enforcer_data, &id, &data, BPF_ANY);
+		with_errmetrics(map_update_elem, &enforcer_data, &id, &data, BPF_ANY);
 	}
 }
 

--- a/bpf/process/retprobe_map.h
+++ b/bpf/process/retprobe_map.h
@@ -5,6 +5,7 @@
 #define __RETPROBE_MAP_H__
 
 #include "bpf_tracing.h"
+#include "bpf_errmetrics.h"
 
 struct retprobe_key {
 	u64 id;
@@ -66,7 +67,7 @@ retprobe_map_set(__u64 id, __u64 tid, __u64 ktime, unsigned long ptr)
 		.tid = tid,
 	};
 
-	map_update_elem(&retprobe_map, &key, &info, BPF_ANY);
+	with_errmetrics(map_update_elem, &retprobe_map, &key, &info, BPF_ANY);
 }
 
 FUNC_INLINE void
@@ -83,7 +84,7 @@ retprobe_map_set_iovec(__u64 id, __u64 tid, __u64 ktime, unsigned long ptr,
 		.tid = tid,
 	};
 
-	map_update_elem(&retprobe_map, &key, &info, BPF_ANY);
+	with_errmetrics(map_update_elem, &retprobe_map, &key, &info, BPF_ANY);
 }
 
 /**

--- a/bpf/tetragon/fileids.h
+++ b/bpf/tetragon/fileids.h
@@ -5,4 +5,4 @@
 // inspired by cilium's bpf metrics. See: https://github.com/cilium/cilium/pull/30972
 // NB: keep this file simple: only single-line comments and fileid__ entries
 
-fileid__("cgroup/bpf_cgtracker.c", 112)
+fileid__("bpf_cgtracker.c", 112)

--- a/bpf/tetragon/fileids.h
+++ b/bpf/tetragon/fileids.h
@@ -6,3 +6,7 @@
 // NB: keep this file simple: only single-line comments and fileid__ entries
 
 fileid__("bpf_cgtracker.c", 112)
+fileid__("bpf_cgroup_mkdir.c", 113)
+fileid__("bpf_enforcer.h", 114)
+fileid__("bpf_alignchecker.c", 115)
+fileid__("retprobe_map.h", 116)

--- a/cmd/bpf-fileids/fileids.go
+++ b/cmd/bpf-fileids/fileids.go
@@ -3,14 +3,38 @@
 
 package main
 
+/*
+typedef struct {
+	const char *filename;
+	int id;
+}  fileid_t;
+
+const fileid_t *get_fileids() {
+    static fileid_t fileids[] = {
+#define fileid__(f, id)                  { f, id },
+#include "../../bpf/tetragon/fileids.h"
+#undef fileid__
+		{ NULL, -1 }
+	};
+	return fileids;
+}
+
+size_t get_fileids_len() {
+    const fileid_t *fileids = get_fileids();
+	size_t len = 0;
+	while (fileids[len].filename != NULL) {
+		len++;
+	}
+	return len;
+}
+*/
+import "C"
+
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
-	"regexp"
-	"strconv"
-	"strings"
+	"unsafe"
 )
 
 // json entry
@@ -19,52 +43,37 @@ type Entry struct {
 	Filename string `json:"filename"`
 }
 
-func initFileIDs(fname string) []Entry {
-	entryRe := regexp.MustCompile(`fileid__\("([^"]+)", *([0-9]+)\)`)
-	f, err := os.Open(fname)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error opening '%s': %v", fname, err)
+func loadFileIDs() []Entry {
+	fileidsLen := C.get_fileids_len()
+	cArrayPtr := C.get_fileids()
+	if cArrayPtr == nil {
+		fmt.Fprintf(os.Stderr, "Failed to allocate C array.")
 		os.Exit(1)
 	}
-	defer f.Close()
-
-	ret := []Entry{}
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "//") {
-			continue
-		}
-
-		m := entryRe.FindStringSubmatch(line)
-		if len(m) == 3 {
-			id, err := strconv.ParseInt(m[2], 0, 32)
-			if err != nil {
-				continue
-			}
-			ret = append(ret, Entry{int(id), m[1]})
-		}
-
+	goSlice := (*[1 << 30]C.fileid_t)(unsafe.Pointer(cArrayPtr))[:fileidsLen:fileidsLen]
+	var ret []Entry
+	for _, fileid := range goSlice {
+		id := int(fileid.id)
+		name := C.GoString(fileid.filename)
+		ret = append(ret, Entry{id, name})
 	}
-	// NB: no need to check scanner.Err()
 	return ret
 }
 
 func main() {
-	if len(os.Args) < 3 {
-		fmt.Fprintf(os.Stderr, "Usage: %s <fileids.h> <out.json>\n", os.Args[0])
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <out.json>\n", os.Args[0])
 		os.Exit(1)
 	}
 
-	fname := os.Args[1]
-	fileIDs := initFileIDs(fname)
+	fileIDs := loadFileIDs()
 	b, err := json.MarshalIndent(fileIDs, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error marshalling file ids: %v", err)
 		os.Exit(1)
 	}
 
-	outFname := os.Args[2]
+	outFname := os.Args[1]
 	err = os.WriteFile(outFname, b, 0622)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error writing file: %v", err)

--- a/pkg/errmetrics/fileids.json
+++ b/pkg/errmetrics/fileids.json
@@ -1,6 +1,6 @@
 [
   {
     "id": 112,
-    "filename": "cgroup/bpf_cgtracker.c"
+    "filename": "bpf_cgtracker.c"
   }
 ]

--- a/pkg/errmetrics/fileids.json
+++ b/pkg/errmetrics/fileids.json
@@ -2,5 +2,21 @@
   {
     "id": 112,
     "filename": "bpf_cgtracker.c"
+  },
+  {
+    "id": 113,
+    "filename": "bpf_cgroup_mkdir.c"
+  },
+  {
+    "id": 114,
+    "filename": "bpf_enforcer.h"
+  },
+  {
+    "id": 115,
+    "filename": "bpf_alignchecker.c"
+  },
+  {
+    "id": 116,
+    "filename": "retprobe_map.h"
   }
 ]


### PR DESCRIPTION
### Description

This PR improves bpf errmetrics intoduced in #3205.
It does so with multiple things (split by commit):
* added a generic `with_errmetrics` macro that supersedes `map_update_elem__errmetrics`
* expose bpf helper informations too in errmetrics
* use `__FILE_NAME__` macro instead of just `__FILE__`; this prevents issues with relative includes: prior to this, some files (eg: `bpf_process_event.h`) were also included with relative path (`../bpf_process_event.h`), and we would've been required to add them twice to the `fileids` with both paths. Now, we will only report the filename. We don't expect any name clash between bpf sources!
* the trick used to trigger a comp time error in `with_errmetrics` macro worked fine until we had multiple comp time errors in the same source file. At that point, the compiler complained about multiple `extern` function definition with different `error` attributes. I fixed it by appending a `__COUNTER__` to the end of the comp time error function name
* `bpf/tetragon/fileids.h` should not be formatted; added it to the ignore list
* expanded usage of `with_errmetrics` macro for `map_update_elem`
* updated `cmd/bpf-fileids` go command to leverage `cgo` instead of manually parsing the C header. Only downside: we are no more able to customize `fileids.h` path. I don't think that is needed at all since this command is mostly made to be automatically ran by makefile.
