### PR TITLE
tetragon: Fix struct perf_event_info_type layout

### DIFF
--- a/bpf/process/types/perfevent.h
+++ b/bpf/process/types/perfevent.h
@@ -8,9 +8,10 @@
 
 struct perf_event_info_type {
 	char kprobe_func[KSYM_NAME_LEN];
-	__u32 type;
 	__u64 config;
 	__u64 probe_offset;
+	__u32 type;
+	__u32 pad;
 };
 
 #endif

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -525,9 +525,10 @@ func (m MsgGenericKprobeArgBpfAttr) IsReturnArg() bool {
 
 type MsgGenericKprobePerfEvent struct {
 	KprobeFunc  [KSYM_NAME_LEN]byte
-	Type        uint32
 	Config      uint64
 	ProbeOffset uint64
+	Type        uint32
+	Pad         uint32
 }
 
 type MsgGenericKprobeArgPerfEvent struct {


### PR DESCRIPTION
We have a hole in perf_event_info_type which results in wrong number in its go counterpart MsgGenericKprobePerfEvent which is aligned differently.

Make sure the C object does not have any holes.

Fixes: https://github.com/cilium/tetragon/issues/4119