### PR TITLE
k8s: Add retry support for ControllerManager

### DIFF
--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -168,6 +168,10 @@ options:
       shorthand: h
       default_value: "false"
       usage: help for tetragon
+    - name: k8s-controlplane-retry
+      default_value: "1"
+      usage: |
+        Number of attempts for Kubernetes control plane connection (negative for infinite, zero is invalid, positive for max attempts)
     - name: k8s-kubeconfig-path
       usage: Absolute path of the kubernetes kubeconfig file
     - name: keep-sensors-on-exit

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -40,10 +40,11 @@ type config struct {
 	EnableProcessLsmAncestors        bool
 	EnableProcessUsdtAncestors       bool
 
-	EnableProcessNs   bool
-	EnableProcessCred bool
-	EnableK8s         bool
-	K8sKubeConfigPath string
+	EnableProcessNs      bool
+	EnableProcessCred    bool
+	EnableK8s            bool
+	K8sKubeConfigPath    string
+	K8sControlPlaneRetry int
 
 	DisableKprobeMulti bool
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -40,8 +40,9 @@ const (
 	KeyLogLevel  = "log-level"
 	KeyLogFormat = "log-format"
 
-	KeyEnableK8sAPI      = "enable-k8s-api"
-	KeyK8sKubeConfigPath = "k8s-kubeconfig-path"
+	KeyEnableK8sAPI         = "enable-k8s-api"
+	KeyK8sKubeConfigPath    = "k8s-kubeconfig-path"
+	KeyK8sControlPlaneRetry = "k8s-controlplane-retry"
 
 	KeyEnablePodAnnotations = "enable-pod-annotations"
 
@@ -163,6 +164,7 @@ func ReadAndSetFlags() error {
 	Config.EnableProcessNs = viper.GetBool(KeyEnableProcessNs)
 	Config.EnableK8s = viper.GetBool(KeyEnableK8sAPI)
 	Config.K8sKubeConfigPath = viper.GetString(KeyK8sKubeConfigPath)
+	Config.K8sControlPlaneRetry = viper.GetInt(KeyK8sControlPlaneRetry)
 
 	Config.DisableKprobeMulti = viper.GetBool(KeyDisableKprobeMulti)
 
@@ -371,6 +373,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.String(KeyLogFormat, "text", "Set log format")
 	flags.Bool(KeyEnableK8sAPI, false, "Access Kubernetes API to associate Tetragon events with Kubernetes pods")
 	flags.String(KeyK8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
+	flags.Int(KeyK8sControlPlaneRetry, 1, "Number of attempts for Kubernetes control plane connection (negative for infinite, zero is invalid, positive for max attempts)")
 	flags.String(KeyMetricsServer, "", "Metrics server address (e.g. ':2112'). Disabled by default")
 	flags.String(KeyMetricsLabelFilter, "namespace,workload,pod,binary", "Comma-separated list of enabled metrics labels. Unknown labels will be ignored.")
 	flags.String(KeyServerAddress, "localhost:54321", "gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock'). An empty address disables the gRPC server")

--- a/pkg/watcher/conf/conf.go
+++ b/pkg/watcher/conf/conf.go
@@ -13,6 +13,9 @@ import (
 // K8sConfig alias is mainly for testing and extension if required.
 var K8sConfig = k8sConfig
 
+// K8sConfigRetry alias is for clients to override the retry default, if required
+var K8sConfigRetry = k8sConfigRetry
+
 // K8sConfig returns Kubernetes client configuration. If running in-cluster, the
 // second return value is true, otherwise false.
 func k8sConfig() (*rest.Config, bool, error) {
@@ -22,4 +25,12 @@ func k8sConfig() (*rest.Config, bool, error) {
 	}
 	cfg, err := rest.InClusterConfig()
 	return cfg, true, err
+}
+
+// k8sConfigRetry returns the number of attempts configured for the Kubernetes control plane.
+// It retrieves this value from the global option.Config.K8sControlPlaneRetry setting.
+// Negative values indicate infinite retries, zero is invalid, and positive values specify the maximum number of attempts.
+// Default behavior is 1 attempt.
+func k8sConfigRetry() (retryAttempts int) {
+	return option.Config.K8sControlPlaneRetry
 }


### PR DESCRIPTION
### Changelog
```Support ControllerManager retry logic.
```

### Description
Problem:
  ControllerManager lacks support for retry. The retry option is required for projects where the on-prem controller can be delayed to come up.
Solution:
- Added retry support for ControllerManager. 
- The retry logic uses expontential backoff to avoid hammering the API Server.
- The retry logic uses Jitter, and logs retry attempt with time duration.
- Default for RetryCount is 1, where 1 means no retries,  just one execution of the connection attempt.
- Default for backoff is retry.DefaultBackoff

- This PR ensures the backward compatability for client's retry of ControllerManager is 1.
With this implementation, the Client's can set their desired values using the k8sConfigRetry alias to override.

Testing
1. Default behavior
```
hyperadmin@simulator:~/tetragon$ sudo ./tetragon --bpf-lib bpf/objs --k8s-kubeconfig-path /home/hyperadmin/tetragon/config --enable-application-model
level=info msg="Starting tetragon" version=71ec615fc
level=info msg="config settings" config="map[bpf-dir:tetragon bpf-lib:bpf/objs btf: cgroup-rate: cluster-name: config-dir: cpuprofile: cri-endpoint: data-cache-size:1024 debug:false disable-kprobe-multi:false enable-ancestors:[] enable-cgidmap:false enable-cgidmap-debug:false enable-cgtrackerid:true enable-compatibility-syscall64-size-type:false enable-cri:false enable-export-aggregation:false enable-k8s-api:false enable-msg-handling-latency:false enable-pid-set-filter:false enable-pod-annotations:false enable-pod-info:false enable-policy-filter:false enable-policy-filter-cgroup-map:false enable-policy-filter-debug:false enable-process-cred:false enable-process-ns:false enable-tracing-policy-crd:true event-cache-retries:15 event-cache-retry-delay:2 event-queue-size:10000 execve-map-entries:0 execve-map-size: export-aggregation-buffer-size:10000 export-aggregation-window-size:15s export-allowlist: export-denylist: export-file-compress:false export-file-max-backups:5 export-file-max-size-mb:10 export-file-perm:600 export-file-rotation-interval:0s export-filename: export-rate-limit:-1 expose-stack-addresses:false field-filters: force-large-progs:false force-small-progs:false generate-docs:false gops-address: health-server-address::6789 health-server-interval:10 k8s-kubeconfig-path:/home/hyperadmin/tetragon/config keep-sensors-on-exit:false kernel: log-format:text log-level:info memprofile: metrics-label-filter:namespace,workload,pod,binary metrics-server: netns-dir:/var/run/docker/netns/ pprof-address: process-cache-gc-interval:30s process-cache-size:65536 procfs:/proc/ rb-queue-size:65535 rb-size:0 rb-size-total:0 redaction-filters: release-pinned-bpf:true server-address:localhost:54321 tracing-policy: tracing-policy-dir:/etc/tetragon/tetragon.tp.d username-metadata:disabled verbose:0]"
level=info msg="Tetragon current security context" SELinux=unconfined AppArmor=unconfined Smack="" Lockdown=none
level=info msg="Tetragon pid file creation succeeded" pid=344077 pidfile=/var/run/tetragon/tetragon.pid
level=info msg="BPF: successfully released pinned BPF programs and maps" bpf-dir=/sys/fs/bpf/tetragon
level=info msg="BTF discovery: default kernel btf file found" btf-file=/sys/kernel/btf/vmlinux
level=info msg="BPF detected features: override_return: true, buildid: true, kprobe_multi: true, uprobe_multi true, fmodret: true, fmodret_syscall: true, signal: true, large: true, link_pin: true, lsm: false, missed_stats_kprobe_multi: true, missed_stats_kprobe: true, batch_update: true, uprobe_refctroff: true, audit_loginuid: true"
level=info msg="Cgroup mode detection succeeded" cgroup.fs=/sys/fs/cgroup cgroup.mode="Unified mode (Cgroupv2)"
level=info msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/proc/1/root/sys/fs/cgroup cgroup.controllers="[cpuset cpu io memory hugetlb pids rdma misc]" cgroup.hierarchyID=0
level=info msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/sys/fs/cgroup/user.slice/user-1001.slice/session-1175.scope cgroup.controllers="[memory pids]" cgroup.hierarchyID=0
level=info msg="Cgroupv2 hierarchy validated successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/sys/fs/cgroup/user.slice/user-1001.slice/session-1175.scope
level=info msg="Deployment mode detection succeeded" cgroup.fs=/sys/fs/cgroup deployment.mode="systemd user session"
level=info msg="Updated TetragonConf map successfully" confmap-update=tg_conf_map deployment.mode="systemd user session" log.level=0 cgroup.fs.magic=Cgroupv2 cgroup.hierarchyID=0 NSPID=344077
level=info msg="Enabling Kubernetes API"
level=info msg="created controller manager" attempts=1 duration=248.54994ms
level=info msg="Configured redaction filters" redactionFilters=""
```

2. With --k8s-controlplane-retry 1
```
hyperadmin@simulator:~/tetragon$ sudo ./tetragon --bpf-lib bpf/objs --k8s-kubeconfig-path /home/hyperadmin/tetragon/config --k8s-controlplane-retry 1
level=info msg="Starting tetragon" version=71ec615fc
...
level=info msg="Enabling Kubernetes API"
level=info msg="created controller manager" attempts=1 duration=249.152782ms
level=info msg="Configured redaction filters" redactionFilters=""
...
```

3. With --k8s-controlplane-retry 2
```
hyperadmin@simulator:~/tetragon$ sudo ./tetragon --bpf-lib bpf/objs --k8s-kubeconfig-path /home/hyperadmin/tetragon/config --k8s-controlplane-retry 2
...
level=info msg="Enabling Kubernetes API"
level=info msg="created controller manager" attempts=1 duration=250.076563ms
level=info msg="Configured redaction filters" redactionFilters=""
...
```

4. --k8s-controlplane-retry 0
```
hyperadmin@simulator:~/tetragon$ sudo ./tetragon --bpf-lib bpf/objs --k8s-kubeconfig-path /home/hyperadmin/tetragon/config --k8s-controlplane-retry 0
...
level=info msg="Enabling Kubernetes API"
level=info msg="retryCount is zero, which is invalid. Defaulting to 1"
level=info msg="created controller manager" attempts=1 duration=249.37557ms
```

5 With infinite retries, set to -1,  --k8s-controlplane-retry -1
```
hyperadmin@simulator:~/tetragon$ sudo ./tetragon --bpf-lib bpf/objs --k8s-kubeconfig-path /home/hyperadmin/tetragon/config --k8s-controlplane-retry -1
level=info msg="Enabling Kubernetes API"
level=info msg="created controller manager" attempts=1 duration=247.925219ms
level=info msg="Configured redaction filters" redactionFilters=""
...
```