### PR TITLE
policies: only warn once for stats and mode

### DIFF
--- a/pkg/policyconf/policyconf.go
+++ b/pkg/policyconf/policyconf.go
@@ -44,7 +44,7 @@ func ParseMode(s string) (Mode, error) {
 func ModeFromBPFMap(fname string) (Mode, error) {
 	m, err := ebpf.LoadPinnedMap(fname, &ebpf.LoadPinOptions{ReadOnly: true})
 	if err != nil {
-		return InvalidMode, err
+		return InvalidMode, fmt.Errorf("failed to open bpf map %s: %w", fname, err)
 	}
 	defer m.Close()
 

--- a/pkg/policystats/policystats.go
+++ b/pkg/policystats/policystats.go
@@ -4,6 +4,7 @@
 package policystats
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/cilium/ebpf"
@@ -38,14 +39,14 @@ type PolicyStats struct {
 func StatsFromBPFMap(fname string) (*PolicyStats, error) {
 	m, err := ebpf.LoadPinnedMap(fname, &ebpf.LoadPinOptions{ReadOnly: true})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open bpf map %s: %w", fname, err)
 	}
 	defer m.Close()
 
 	var ret PolicyStats
 	zero := uint32(0)
 	if err = m.Lookup(&zero, &ret); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("lookup failed: %w", err)
 	}
 	return &ret, nil
 }


### PR DESCRIPTION
If, for whatever, reason the bpf maps for stats and mode do not exist in the BPF filesystem, we issue a warning. In the cases where this happens, the warnings can get noisy. Introduce an atomic variable in every collection to only issue the warning once per poilcy.

