### PR TITLE
pkg/crdutils: fix standalone custom resources validation

### DIFF
--- a/examples/tracingpolicy/security-socket-connect-block-others.yaml
+++ b/examples/tracingpolicy/security-socket-connect-block-others.yaml
@@ -31,7 +31,7 @@ spec:
       - index: 1
         operator: "SPort"
         values:
-        - 80
+        - "80"
       matchBinaries:
       - operator: "In"
         values:

--- a/examples/tracingpolicy/tcp-listen.yaml
+++ b/examples/tracingpolicy/tcp-listen.yaml
@@ -21,8 +21,8 @@ spec:
       - index: 1
         operator: "Equal"
         values:
-        - 2
-        - 10
+        - "2"
+        - "10"
       matchActions:
       - action: "NoPost"
   - call: "__sk_free"
@@ -35,8 +35,8 @@ spec:
       - index: 0
         operator: "Family"
         values:
-        - 2
-        - 10
+        - "2"
+        - "10"
       matchActions:
       - action: "UntrackSock"
         argSock: 0
@@ -51,5 +51,5 @@ spec:
       - index: 0
         operator: "SPort"
         values:
-        - 1337
-        - 31337
+        - "1337"
+        - "31337"

--- a/pkg/crdutils/crdutils.go
+++ b/pkg/crdutils/crdutils.go
@@ -105,7 +105,7 @@ func (c *CRDContext[P]) Validate(obj CRDObject, unstr *unstructured.Unstructured
 	)
 
 	// validate spec
-	validationResult := c.validator.Validate(obj)
+	validationResult := c.validator.Validate(unstr.Object)
 	// validate lists
 	listErrs := structurallisttype.ValidateListSetsAndMaps(
 		nil,

--- a/pkg/crdutils/crdutils_test.go
+++ b/pkg/crdutils/crdutils_test.go
@@ -232,7 +232,7 @@ spec:
         - namespace: Pid
           operator: In
           values:
-          - 4026532024
+          - "4026532024"
         matchNamespaceChanges:
         - operator: In
           values:

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -615,16 +615,6 @@ func writeMatchAddrsInMap(k *KernelSelectorState, values []string) error {
 	return nil
 }
 
-func getBase(v string) int {
-	if strings.HasPrefix(v, "0x") {
-		return 16
-	}
-	if strings.HasPrefix(v, "0") {
-		return 8
-	}
-	return 10
-}
-
 func parseAddr(v string) ([]byte, uint32, error) {
 	if strings.Contains(v, "/") {
 		ipAddr, ipNet, err := net.ParseCIDR(v)
@@ -669,29 +659,28 @@ func writeMatchValues(k *KernelSelectorState, values []string, ty, op uint32) er
 	}
 
 	for _, v := range values {
-		base := getBase(v)
 		switch ty {
 
 		case gt.GenericIntType, gt.GenericS32Type, gt.GenericSizeType:
-			i, err := strconv.ParseInt(v, base, 32)
+			i, err := strconv.ParseInt(v, 0, 32)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
 			}
 			WriteSelectorInt32(&k.data, int32(i))
 		case gt.GenericU32Type:
-			i, err := strconv.ParseUint(v, base, 32)
+			i, err := strconv.ParseUint(v, 0, 32)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
 			}
 			WriteSelectorUint32(&k.data, uint32(i))
 		case gt.GenericS64Type, gt.GenericSyscall64:
-			i, err := strconv.ParseInt(v, base, 64)
+			i, err := strconv.ParseInt(v, 0, 64)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
 			}
 			WriteSelectorInt64(&k.data, int64(i))
 		case gt.GenericU64Type:
-			i, err := strconv.ParseUint(v, base, 64)
+			i, err := strconv.ParseUint(v, 0, 64)
 			if err != nil {
 				return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
 			}
@@ -1650,8 +1639,7 @@ func HasStackTrace(selectors []v1alpha1.KProbeSelector) bool {
 
 // parseCapabilitiesMask create a capabilities mask
 func parseCapabilitiesMask(s string) (uint64, error) {
-	base := getBase(s)
-	mask, err := strconv.ParseUint(s, base, 64)
+	mask, err := strconv.ParseUint(s, 0, 64)
 	if err == nil {
 		return mask, nil
 	}

--- a/pkg/sensors/tracing/enforcer_test.go
+++ b/pkg/sensors/tracing/enforcer_test.go
@@ -567,7 +567,7 @@ spec:
       - index: 1
         operator: "Equal"
         values:
-        - 0xffff
+        - "0xffff"
       matchBinaries:
       - operator: "In"
         values:
@@ -609,7 +609,7 @@ spec:
       - index: 1
         operator: "Equal"
         values:
-        - 0xfffe
+        - "0xfffe"
       matchBinaries:
       - operator: "In"
         values:
@@ -621,14 +621,10 @@ spec:
 `
 
 	policy1, err := tracingpolicy.FromYAML(policyYAML1)
-	if err != nil {
-		t.Errorf("FromYAML policyYAML1 error %s", err)
-	}
+	require.NoError(t, err, "FromYAML policyYAML1 error")
 
 	policy2, err := tracingpolicy.FromYAML(policyYAML2)
-	if err != nil {
-		t.Errorf("FromYAML policyYAML2 error %s", err)
-	}
+	require.NoError(t, err, "FromYAML policyYAML2 error")
 
 	if err := observer.InitDataCache(1024); err != nil {
 		t.Fatalf("observertesthelper.InitDataCache: %s", err)

--- a/pkg/sensors/tracing/kprobe_amd64_test.go
+++ b/pkg/sensors/tracing/kprobe_amd64_test.go
@@ -143,7 +143,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - 9999
+        - "9999"
 `
 
 	// The test hooks sys_dup[23] syscalls through the list and

--- a/pkg/sensors/tracing/kprobe_net_test.go
+++ b/pkg/sensors/tracing/kprobe_net_test.go
@@ -843,7 +843,7 @@ spec:
       - index: 1
         operator: "Equal"
         values:
-        - 1
+        - "1"
 `
 	hookPart := `apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy

--- a/pkg/sensors/tracing/kprobe_process_credentials_test.go
+++ b/pkg/sensors/tracing/kprobe_process_credentials_test.go
@@ -411,6 +411,7 @@ spec:
       type: "file"
     data:
     - type: "int"
+      index: 0
       source: "current_task"
       resolve: "cred.uid.val"
     selectors:
@@ -520,6 +521,7 @@ spec:
       type: "file"
     data:
     - type: "int"
+      index: 0
       source: "current_task"
       resolve: "cred.uid.val"
     selectors:
@@ -630,9 +632,11 @@ spec:
       type: "file"
     data:
     - type: "int"
+      index: 0
       source: "current_task"
       resolve: "cred.uid.val"
     - type: "int"
+      index: 1
       source: "current_task"
       resolve: "cred.euid.val"
     selectors:
@@ -745,9 +749,11 @@ spec:
       type: "file"
     data:
     - type: "int"
+      index: 0
       source: "current_task"
       resolve: "cred.uid.val"
     - type: "int"
+      index: 1
       source: "current_task"
       resolve: "cred.euid.val"
     selectors:

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -1479,7 +1479,7 @@ func testKprobeObjectFilterModeOpenHook(pidStr string, mode int, valueFmt string
         - index: 2
           operator: "Mask"
           values:
-          - ` + fmt.Sprintf(valueFmt, mode) + `
+          - "` + fmt.Sprintf(valueFmt, mode) + `"
   `
 }
 
@@ -1514,7 +1514,7 @@ func TestKprobeObjectFilterModeOpenMatchHex(t *testing.T) {
 }
 
 func TestKprobeObjectFilterModeOpenMatchOct(t *testing.T) {
-	testKprobeObjectFilterModeOpenMatch(t, "0%d", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_CLOEXEC)
+	testKprobeObjectFilterModeOpenMatch(t, "0%o", syscall.O_RDWR|syscall.O_TRUNC|syscall.O_CLOEXEC, syscall.O_CLOEXEC)
 }
 
 func TestKprobeObjectFilterModeOpenFail(t *testing.T) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -1560,7 +1560,7 @@ func testKprobeObjectFilterReturnValueGTHook(pidStr, path string) string {
         - index: 0
           operator: "GT"
           values:
-          - 0
+          - "0"
   `
 }
 
@@ -1600,7 +1600,7 @@ func testKprobeObjectFilterReturnValueLTHook(pidStr, path string) string {
         - index: 0
           operator: "LT"
           values:
-          - 0
+          - "0"
   `
 }
 

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -322,7 +322,7 @@ spec:
       - namespace: Mnt
         operator: In
         values:
-        - ` + mntNsStr + `
+        - "` + mntNsStr + `"
       matchCapabilities:
       - type: Permitted
         operator: In
@@ -401,7 +401,7 @@ spec:
       - namespace: Mnt
         operator: In
         values:
-        - ` + mntNsStr + `
+        - "` + mntNsStr + `"
       matchCapabilities:
       - type: Permitted
         operator: In
@@ -538,7 +538,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + fdString
+        - "` + fdString + `"`
 
 	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_read"))).
@@ -588,7 +588,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + fdString
+        - "` + fdString + `"`
 
 	kpChecker := ec.NewProcessKprobeChecker("").
 		WithFunctionName(sm.Full(arch.AddSyscallPrefixTestHelper(t, "sys_read"))).
@@ -1782,7 +1782,7 @@ spec:
       - index: 0
         operator: Equal
         values:
-        - 1
+        - "1"
 `
 	writeConfigHook := []byte(writeReadHook)
 	err := os.WriteFile(testConfigFile, writeConfigHook, 0644)

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6961,9 +6961,11 @@ spec:
       resolve: "mm.owner.pid"
     data:
     - type: "string"
+      index: 0
       source: "current_task"
       resolve: "comm"
     - type: "int"
+      index: 1
       source: "current_task"
       resolve: "mm.owner.pid"
     selectors:
@@ -6976,13 +6978,13 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + comm_1 + `
-        - ` + comm_2 + `
+        - "` + comm_1 + `"
+        - "` + comm_2 + `"
       - args:
         - 1
         operator: "Equal"
         values:
-        - ` + strconv.Itoa(pid) + `
+        - "` + strconv.Itoa(pid) + `"
 `
 
 	createCrdFile(t, hook)

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3146,7 +3146,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + strconv.Itoa(fdw)
+        - "` + strconv.Itoa(fdw) + `"`
 
 	size := 4094
 	buffer := make([]byte, size)
@@ -3200,7 +3200,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + strconv.Itoa(fdw)
+        - "` + strconv.Itoa(fdw) + `"`
 
 	size := 5000
 	buffer := make([]byte, size)
@@ -3255,7 +3255,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + strconv.Itoa(fdr)
+        - "` + strconv.Itoa(fdr) + `"`
 
 	size := 4000
 	buffer := make([]byte, size)
@@ -4610,7 +4610,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + fdString + `
+        - "` + fdString + `"
 `
 
 	data := make([]byte, 6000)
@@ -4674,7 +4674,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + fdString + `
+        - "` + fdString + `"
 `
 
 	data := make([]byte, 6000)
@@ -4733,7 +4733,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + fdString + `
+        - "` + fdString + `"
 `
 
 	// 10 times 32736 buffer is the max now
@@ -6971,7 +6971,7 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - ` + strconv.Itoa(pid) + `
+        - "` + strconv.Itoa(pid) + `"
     - matchData:
       - index: 0
         operator: "Equal"

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4897,7 +4897,6 @@ kind: TracingPolicy
 metadata:
   name: "sys-write"
 spec:
-  lists:
   kprobes:
   - call: "sys_dup"
     syscall: true

--- a/pkg/sensors/tracing/kprobe_validation_test.go
+++ b/pkg/sensors/tracing/kprobe_validation_test.go
@@ -276,7 +276,7 @@ spec:
       - index: 0
         operator: "LT"
         values:
-        - 0
+        - "0"
 `
 
 	err := checkCrd(t, crd)
@@ -307,7 +307,7 @@ spec:
       - index: 0
         operator: "GT"
         values:
-        - 0
+        - "0"
 `
 
 	err := checkCrd(t, crd)

--- a/pkg/sensors/tracing/tracepoint_amd64_test.go
+++ b/pkg/sensors/tracing/tracepoint_amd64_test.go
@@ -94,7 +94,7 @@ spec:
       - index: 1
         operator: "Equal"
         values:
-        - 9999
+        - "9999"
 `
 
 	// The test hooks raw tracepoint and uses InMap operator with list

--- a/pkg/sensors/tracing/usdt_amd64_test.go
+++ b/pkg/sensors/tracing/usdt_amd64_test.go
@@ -227,15 +227,15 @@ spec:
       - index: 0
         operator: "Equal"
         values:
-        - 1
+        - "1"
       - index: 1
         operator: "Equal"
         values:
-        - 42
+        - "42"
       - index: 2
         operator: "Equal"
         values:
-        - 0xdeadbeef
+        - "0xdeadbeef"
       matchActions:
       - action: Sigkill
 `

--- a/testdata/specs/sigkill.yaml.tmpl
+++ b/testdata/specs/sigkill.yaml.tmpl
@@ -20,6 +20,6 @@ spec:
       - index: 2
         operator: Equal
         values:
-        - 5555 # magic value, see also sigkill-tester
+        - "5555" # magic value, see also sigkill-tester
       matchActions:
       - action: Sigkill

--- a/testdata/specs/sigkill_return.yaml.tmpl
+++ b/testdata/specs/sigkill_return.yaml.tmpl
@@ -24,7 +24,7 @@ spec:
       - index: 2
         operator: Equal
         values:
-        - 5555 # magic value, see also sigkill-tester
+        - "5555" # magic value, see also sigkill-tester
       matchReturnArgs:
       - index: 0
         operator: "Equal"

--- a/testdata/specs/sigkill_tracepoint.yaml.tmpl
+++ b/testdata/specs/sigkill_tracepoint.yaml.tmpl
@@ -21,6 +21,6 @@ spec:
       - index: 7
         operator: Equal
         values:
-        - 5555 # magic value, see also sigkill-tester
+        - "5555" # magic value, see also sigkill-tester
       matchActions:
       - action: Sigkill


### PR DESCRIPTION
This fixes commit 29b76c402b68 ("Refactor CRD defaulting and validation as generic") that was enhancing commit a9c9a0bd83a8 ("pkg/tracingpolicy: add k8s validation for meta and spec").

I think it's a typo that was introduced because when do the validation of the object, we give the function two versions of that object, cr that is typed and was created by yaml.UnmarshalStrict the JSON object with K8s default, and unstr that is the unstructured object version of what was passed as input, but with K8s default. We need these two objects to do the validation respectively on the ObjectMeta and the Spec.

When Unmarshaling the JSON object to the GenericTracingPolicy (or others) types, all fields are set to their Golang defaults (!) in addition to the K8s default that were already applied. So some missing fields, that were defaulted by the K8s default were injected in the process and thus only partial validation was done.
