### PR TITLE
tetragon: Fix k8s validation of ArgSelector fields

### DIFF
--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -962,16 +962,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -985,6 +975,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1166,16 +1166,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -1189,6 +1179,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1482,16 +1482,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -1505,6 +1495,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1973,16 +1973,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -1996,6 +1986,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2177,16 +2177,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -2200,6 +2190,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2493,16 +2493,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -2516,6 +2506,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3057,16 +3057,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -3080,6 +3070,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3261,16 +3261,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -3284,6 +3274,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3577,16 +3577,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -3600,6 +3590,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4033,16 +4033,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -4056,6 +4046,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4237,16 +4237,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -4260,6 +4250,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4553,16 +4553,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -4576,6 +4566,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5002,16 +5002,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -5025,6 +5015,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5206,16 +5206,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -5229,6 +5219,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5522,16 +5522,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -5545,6 +5535,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6481,16 +6481,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -6504,6 +6494,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6685,16 +6685,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -6708,6 +6698,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7001,16 +7001,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -7024,6 +7014,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7492,16 +7492,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -7515,6 +7505,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7696,16 +7696,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -7719,6 +7709,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8012,16 +8012,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -8035,6 +8025,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8576,16 +8576,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -8599,6 +8589,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8780,16 +8780,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -8803,6 +8793,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9096,16 +9096,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -9119,6 +9109,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9552,16 +9552,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -9575,6 +9565,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9756,16 +9756,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -9779,6 +9769,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10072,16 +10072,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -10095,6 +10085,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10521,16 +10521,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -10544,6 +10534,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10725,16 +10725,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -10748,6 +10738,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -11041,16 +11041,6 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>index</b></td>
-        <td>integer</td>
-        <td>
-          Position of the argument (in function prototype) to apply fhe filter to.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>operator</b></td>
         <td>enum</td>
         <td>
@@ -11064,6 +11054,16 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]integer</td>
         <td>
           Position of the operator arguments (in spec file) to apply fhe filter to.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>index</b></td>
+        <td>integer</td>
+        <td>
+          Position of the argument (in function prototype) to apply fhe filter to.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -592,7 +592,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -751,7 +750,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -992,7 +990,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1313,7 +1310,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1472,7 +1468,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1713,7 +1708,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2070,7 +2064,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2229,7 +2222,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2470,7 +2462,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2771,7 +2762,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2930,7 +2920,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3171,7 +3160,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3467,7 +3455,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3626,7 +3613,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3867,7 +3853,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -592,7 +592,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -751,7 +750,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -992,7 +990,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1313,7 +1310,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1472,7 +1468,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1713,7 +1708,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2070,7 +2064,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2229,7 +2222,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2470,7 +2462,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2771,7 +2762,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2930,7 +2920,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3171,7 +3160,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3467,7 +3455,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3626,7 +3613,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3867,7 +3853,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -592,7 +592,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -751,7 +750,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -992,7 +990,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1313,7 +1310,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1472,7 +1468,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1713,7 +1708,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2070,7 +2064,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2229,7 +2222,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2470,7 +2462,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2771,7 +2762,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2930,7 +2920,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3171,7 +3160,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3467,7 +3455,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3626,7 +3613,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3867,7 +3853,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -592,7 +592,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -751,7 +750,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -992,7 +990,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1313,7 +1310,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1472,7 +1468,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1713,7 +1708,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2070,7 +2064,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2229,7 +2222,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2470,7 +2462,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2771,7 +2762,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2930,7 +2920,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3171,7 +3160,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3467,7 +3455,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3626,7 +3613,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3867,7 +3853,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -212,9 +212,11 @@ type PIDSelector struct {
 }
 
 type ArgSelector struct {
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument (in function prototype) to apply fhe filter to.
 	Index uint32 `json:"index"`
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:items:Minimum=0
 	// Position of the operator arguments (in spec file) to apply fhe filter to.
 	Args []uint32 `json:"args,omitempty"`

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.6.4"
+const CustomResourceDefinitionSchemaVersion = "1.6.5"

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -592,7 +592,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -751,7 +750,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -992,7 +990,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1313,7 +1310,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1472,7 +1468,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1713,7 +1708,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2070,7 +2064,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2229,7 +2222,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2470,7 +2462,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2771,7 +2762,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2930,7 +2920,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3171,7 +3160,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3467,7 +3455,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3626,7 +3613,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3867,7 +3853,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -592,7 +592,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -751,7 +750,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -992,7 +990,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1313,7 +1310,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1472,7 +1468,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -1713,7 +1708,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2070,7 +2064,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2229,7 +2222,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2470,7 +2462,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2771,7 +2762,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -2930,7 +2920,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3171,7 +3160,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3467,7 +3455,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3626,7 +3613,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array
@@ -3867,7 +3853,6 @@ spec:
                                     type: string
                                   type: array
                               required:
-                              - index
                               - operator
                               type: object
                             type: array

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -212,9 +212,11 @@ type PIDSelector struct {
 }
 
 type ArgSelector struct {
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument (in function prototype) to apply fhe filter to.
 	Index uint32 `json:"index"`
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:items:Minimum=0
 	// Position of the operator arguments (in spec file) to apply fhe filter to.
 	Args []uint32 `json:"args,omitempty"`

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.6.4"
+const CustomResourceDefinitionSchemaVersion = "1.6.5"


### PR DESCRIPTION
Make ArgSelector::index/Args optional for k8s, so we can load policies through k8s validation.
