### PR TITLE
fix: always close the bpf link in `detectKprobeMulti` before returning

### DIFF
--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -76,8 +76,12 @@ func detectKprobeMulti() bool {
 	syms := []string{"vprintk"}
 	opts := link.KprobeMultiOptions{Symbols: syms}
 
-	_, err = link.KprobeMulti(prog, opts)
-	return err == nil
+	link, err := link.KprobeMulti(prog, opts)
+	if err != nil {
+		return false
+	}
+	link.Close()
+	return true
 }
 
 func HasKprobeMulti() bool {


### PR DESCRIPTION
### Description

This PR ensures we always close the bpf link in `detectKprobeMulti` before returning

