### PR TITLE
tetragon: Allow override if one of override healpr or fmod_ret suppor…

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -454,8 +454,8 @@ func preValidateKprobe(
 	}
 
 	if selectors.HasOverride(f) {
-		if !bpf.HasOverrideHelper() {
-			return nil, errors.New("error override action not supported, bpf_override_return helper not available")
+		if !bpf.HasOverrideHelper() && !bpf.HasModifyReturn() {
+			return nil, errors.New("error override action not supported, bpf_override_return helper and fmodret are not available")
 		}
 		if !f.Syscall {
 			for idx := range calls {


### PR DESCRIPTION
…t is available

Currently we won't validate kprobe with override action when the kernel is not compiled with CONFIG_BPF_KPROBE_OVERRIDE. But we can still do override with fmod_ret program if it's available.

Fixes: https://github.com/cilium/tetragon/issues/4157
Reported-by: Shang-Wen Wang <sam.wang@suse.com>