### PR TITLE
[v1.3] Makefile: add `gen-docs-references` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,6 +488,9 @@ help: ## Display this help, based on https://www.thapaliya.com/en/writings/well-
 docs: ## Preview documentation website.
 	$(MAKE) -C docs
 
+.PHONY: gen-docs-references
+gen-docs-references: generate-flags metrics-docs ## Convenience alias to generate all docs references.
+
 .PHONY: version
 version: ## Print Tetragon version.
 	@echo $(VERSION)


### PR DESCRIPTION
[ inspired by upstream commit c60411a ("Makefile: tidy docs section and add generate-references target") ]

This is because the renovate config from main needs this target.
