### PR TITLE
check-links: fix the periodic check issue creation

### DIFF
--- a/.github/workflows/check-links-cron.yaml
+++ b/.github/workflows/check-links-cron.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 # v2.6.1
         with:
           args: --config .github/lychee.toml --base https://tetragon.io docs/content README.md
+          fail: false
 
       # to avoid automated spam, try to find an existing open issue before opening a new one
       - name: Search for existing issue number
@@ -38,8 +39,8 @@ jobs:
           echo "issue_number=$issue_number" >> $GITHUB_OUTPUT
 
       - name: Create or update issue with report
-        if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+        if: steps.lychee.outputs.exit_code != 0
         with:
           title: ${{ env.ISSUE_NAME }}
           content-filepath: ./lychee/out.md
@@ -47,7 +48,7 @@ jobs:
           labels: automated-issue
 
       - name: Close automated issue
-        if: env.lychee_exit_code == 0 && steps.search-issue.outputs.issue_number != ''
+        if: steps.lychee.outputs.exit_code == 0 && steps.search-issue.outputs.issue_number != ''
         uses: peter-evans/close-issue@276d7966e389d888f011539a86c8920025ea0626 # v3.0.1
         with:
           issue-number: ${{ steps.search-issue.outputs.issue_number }}


### PR DESCRIPTION
For some reason (didn't investigate more) the workflow was broken and the issue was never created while it was failing for a long time recently. This should fix it.

Detected it thanks to https://github.com/cilium/tetragon/pull/4177 and fixed recent failures in https://github.com/cilium/tetragon/pull/4181

