### PR TITLE
docs(assets/scss): Remove useless horizontal scrollbar

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -1,3 +1,4 @@
+@import "body";
 @import "button";
 @import "community-banner";
 @import "home";

--- a/docs/assets/scss/body.scss
+++ b/docs/assets/scss/body.scss
@@ -1,0 +1,3 @@
+body {
+  overflow-x: hidden;
+}


### PR DESCRIPTION
### Description
Added `overflow-x: hidden;` style to the `body` element to remove the useless horizontal scrollbar.

Before patch:
<img width="1920" height="933" alt="image" src="https://github.com/user-attachments/assets/d44daf65-3162-447a-bd77-90cdd315a730" />

After patch:
<img width="1920" height="933" alt="image" src="https://github.com/user-attachments/assets/71150bde-3ad9-40d8-a125-c42c170e2eb3" />
