### PR TITLE
observer: deal with empty data in HandlePerfData

### DIFF
--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -43,6 +43,7 @@ type EventHandlerError int
 // TODO: Recognize different errors returned by individual handlers
 const (
 	HandlePerfUnknownOp EventHandlerError = iota
+	HandlePerfEmptyData
 	HandlePerfHandlerError
 )
 

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -87,6 +87,13 @@ func (e *HandlePerfError) Unwrap() error {
 // HandlePerfData returns the events from raw bytes
 // NB: It is made public so that it can be used in testing.
 func HandlePerfData(data []byte) (byte, []Event, *HandlePerfError) {
+	if len(data) == 0 {
+		return ops.MSG_OP_UNDEF, nil, &HandlePerfError{
+			kind:   errormetrics.HandlePerfEmptyData,
+			err:    errors.New("empty perf data"),
+			opcode: ops.MSG_OP_UNDEF,
+		}
+	}
 	op := data[0]
 	r := bytes.NewReader(data)
 	// These ops handlers are registered by RegisterEventHandlerAtInit().


### PR DESCRIPTION
Some tests were failing with a SIGSEGV because the data passed to HandlePerfData were empty. Add a check to avoid the SIGSEGV.