### PR TITLE
install/kubernetes/tetragon: Helm chart add serviceAnnotations and serviceLabels

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -69,6 +69,8 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceAnnotations | object | `{}` |  |
+| serviceLabels | object | `{}` |  |
 | serviceLabelsOverride | object | `{}` |  |
 | tetragon.argsOverride | list | `[]` | Override the arguments. For advanced users only. |
 | tetragon.btf | string | `""` |  |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -51,6 +51,8 @@ Helm chart for Tetragon
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceAnnotations | object | `{}` |  |
+| serviceLabels | object | `{}` |  |
 | serviceLabelsOverride | object | `{}` |  |
 | tetragon.argsOverride | list | `[]` | Override the arguments. For advanced users only. |
 | tetragon.btf | string | `""` |  |

--- a/install/kubernetes/tetragon/templates/service.yaml
+++ b/install/kubernetes/tetragon/templates/service.yaml
@@ -3,11 +3,18 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- with .Values.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- with .Values.serviceLabelsOverride}}
     {{- toYaml . | nindent 4 }}
     {{- else }}
     {{- include "tetragon.labels" . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ include "tetragon.name" . }}
   namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -9,6 +9,7 @@ serviceAccount:
   annotations: {}
   name: ""
 podAnnotations: {}
+serviceAnnotations: {}
 podSecurityContext: {}
 nodeSelector: {}
 tolerations:
@@ -20,6 +21,7 @@ daemonSetAnnotations: {}
 extraVolumes: []
 updateStrategy: {}
 podLabels: {}
+serviceLabels: {}
 daemonSetLabelsOverride: {}
 selectorLabelsOverride: {}
 podLabelsOverride: {}


### PR DESCRIPTION
charts: add serviceAnnotations and serviceLabels for additive Service metadata management

Tetragon Helm chart currently exposes only serviceLabelsOverride which forces full replacement of the Service labels and makes day to day label management error prone.

This patch fixes this by adding:

A new values key serviceLabels as an empty map in values.yaml to allow appending labels without losing chart defaults.

A new values key serviceAnnotations as an empty map in values.yaml to allow appending annotations without losing chart defaults.

Service template logic that preserves compatibility. If serviceLabels is set it is merged with existing chart labels or serviceLabelsOverride to produce the final label set. If serviceAnnotations is set it is merged with existing chart annotations to produce the final annotations set.

Example values:
```
serviceLabels: {}
# serviceLabels:
# k8s-app: tetragon

serviceAnnotations: {}
# serviceAnnotations:
# prometheus.io/port: "2112"
# prometheus.io/scrape: "true"
```

As a secondary note, these additive fields can simplify label based selection in systems such as Prometheus.