### PR TITLE
pkg/asm: fuzz Assignment func parsing strings

### DIFF
--- a/pkg/asm/assignment_amd64_test.go
+++ b/pkg/asm/assignment_amd64_test.go
@@ -12,6 +12,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func FuzzAssignment(f *testing.F) {
+	f.Add("rax=1")
+	f.Add("rbp=128%rax")
+	f.Add("rbp=0x20(%rsp)")
+	f.Add("rsp=-1372(%rbp)")
+	f.Fuzz(func(t *testing.T, exp string) {
+		ass, err := ParseAssignment(exp)
+		if err != nil && ass != nil {
+			t.Errorf("ass:%v, err:%v", ass, err)
+		}
+	})
+}
+
 func TestAssignment(t *testing.T) {
 	var (
 		ass *Assignment


### PR DESCRIPTION
This function is a good candidate for a little fuzzing test, it seems that it's fine for now and does not crash quickly, I just run the fuzzer for a minute and it didn't found anything.

	$ go test -fuzz FuzzAssignment ./pkg/asm
	fuzz: elapsed: 0s, gathering baseline coverage: 0/4 completed
	fuzz: elapsed: 0s, gathering baseline coverage: 4/4 completed, now fuzzing with 16 workers
	fuzz: elapsed: 3s, execs: 344912 (114957/sec), new interesting: 127 (total: 131)
	fuzz: elapsed: 6s, execs: 653268 (102778/sec), new interesting: 140 (total: 144)
	fuzz: elapsed: 9s, execs: 881934 (76219/sec), new interesting: 152 (total: 156)
	fuzz: elapsed: 12s, execs: 1136876 (84972/sec), new interesting: 162 (total: 166)
	fuzz: elapsed: 15s, execs: 1392002 (85058/sec), new interesting: 167 (total: 171)
	fuzz: elapsed: 18s, execs: 1603344 (70440/sec), new interesting: 170 (total: 174)
	fuzz: elapsed: 21s, execs: 1807887 (68188/sec), new interesting: 172 (total: 176)
	fuzz: elapsed: 24s, execs: 2003307 (65110/sec), new interesting: 172 (total: 176)
	fuzz: elapsed: 27s, execs: 2198554 (65089/sec), new interesting: 174 (total: 178)
	fuzz: elapsed: 30s, execs: 2532384 (111316/sec), new interesting: 177 (total: 181)
	fuzz: elapsed: 33s, execs: 2747540 (71720/sec), new interesting: 179 (total: 183)
	fuzz: elapsed: 36s, execs: 2962609 (71676/sec), new interesting: 180 (total: 184)
	fuzz: elapsed: 39s, execs: 3095150 (44179/sec), new interesting: 180 (total: 184)
	fuzz: elapsed: 42s, execs: 3270395 (58423/sec), new interesting: 180 (total: 184)
	fuzz: elapsed: 45s, execs: 3404022 (44545/sec), new interesting: 182 (total: 186)
	fuzz: elapsed: 48s, execs: 3531282 (42424/sec), new interesting: 183 (total: 187)
	fuzz: elapsed: 51s, execs: 3632989 (33894/sec), new interesting: 183 (total: 187)
	fuzz: elapsed: 54s, execs: 3747458 (38120/sec), new interesting: 183 (total: 187)
	fuzz: elapsed: 57s, execs: 3847757 (33433/sec), new interesting: 183 (total: 187)
	fuzz: elapsed: 1m0s, execs: 3941115 (31148/sec), new interesting: 183 (total: 187)
	^Cfuzz: elapsed: 1m1s, execs: 3973386 (42041/sec), new interesting: 183 (total: 187)
	PASS
	ok      github.com/cilium/tetragon/pkg/asm      60.797s
