### PR TITLE
pkg/sensors: reduce socktrack map memory footprint

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -2049,7 +2049,7 @@ struct socket_owner {
 // socktrack_map maintains a mapping of sock to pid_tgid
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
-	__uint(max_entries, 32000);
+	__uint(max_entries, 1); // will be resized by agent when needed
 	__type(key, __u64);
 	__type(value, struct socket_owner);
 } socktrack_map SEC(".maps");

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1673,6 +1673,33 @@ func HasStackTrace(selectors []v1alpha1.KProbeSelector) bool {
 	return false
 }
 
+func HasSockTrack(spec *v1alpha1.KProbeSpec) bool {
+	// Check ReturnArgAction
+	if spec.ReturnArgAction != "" {
+		if a := ActionTypeFromString(spec.ReturnArgAction); a == ActionTypeTrackSock ||
+			a == ActionTypeUntrackSock {
+			return true
+		}
+	}
+
+	// Check selectors MatchActions and MatchReturnActions
+	for _, selector := range spec.Selectors {
+		for _, matchAction := range selector.MatchActions {
+			if a := ActionTypeFromString(matchAction.Action); a == ActionTypeTrackSock ||
+				a == ActionTypeUntrackSock {
+				return true
+			}
+		}
+		for _, matchReturnAction := range selector.MatchReturnActions {
+			if a := ActionTypeFromString(matchReturnAction.Action); a == ActionTypeTrackSock ||
+				a == ActionTypeUntrackSock {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // parseCapabilitiesMask create a capabilities mask
 func parseCapabilitiesMask(s string) (uint64, error) {
 	mask, err := strconv.ParseUint(s, 0, 64)

--- a/pkg/sensors/tracing/consts.go
+++ b/pkg/sensors/tracing/consts.go
@@ -17,4 +17,5 @@ const (
 	enforcerMapMaxEntries      = 32768
 	overrideMapMaxEntries      = 32768
 	sleepableOffloadMaxEntries = 32768
+	socktrackMapMaxEntries     = 32000
 )

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -319,6 +319,9 @@ func createMultiKprobeSensor(polInfo *policyInfo, multiIDs []idtable.EntryID, ha
 
 	if config.EnableLargeProgs() {
 		socktrack := program.MapBuilderSensor("socktrack_map", load)
+		if has.sockTrack {
+			socktrack.SetMaxEntries(socktrackMapMaxEntries)
+		}
 		maps = append(maps, socktrack)
 	}
 
@@ -382,6 +385,9 @@ func createMultiKprobeSensor(polInfo *policyInfo, multiIDs []idtable.EntryID, ha
 		maps = append(maps, fdinstall)
 
 		socktrack := program.MapBuilderSensor("socktrack_map", loadret)
+		if has.sockTrack {
+			socktrack.SetMaxEntries(socktrackMapMaxEntries)
+		}
 		maps = append(maps, socktrack)
 
 		tailCalls := program.MapBuilderSensor("retkprobe_calls", loadret)
@@ -574,6 +580,7 @@ type hasMaps struct {
 	fdInstall  bool
 	enforcer   bool
 	override   bool
+	sockTrack  bool
 }
 
 // hasMapsSetup setups the has maps for the per policy maps. The per kprobe maps
@@ -584,6 +591,7 @@ func hasMapsSetup(spec *v1alpha1.TracingPolicySpec) hasMaps {
 		has.fdInstall = has.fdInstall || selectors.HasFDInstall(kprobe.Selectors)
 		has.enforcer = has.enforcer || len(spec.Enforcers) != 0
 		has.rateLimit = has.rateLimit || selectors.HasRateLimit(kprobe.Selectors)
+		has.sockTrack = has.sockTrack || selectors.HasSockTrack(&kprobe)
 	}
 	return has
 }
@@ -1041,6 +1049,9 @@ func createKprobeSensorFromEntry(polInfo *policyInfo, kprobeEntry *genericKprobe
 
 	if config.EnableLargeProgs() {
 		socktrack := program.MapBuilderSensor("socktrack_map", load)
+		if has.sockTrack {
+			socktrack.SetMaxEntries(socktrackMapMaxEntries)
+		}
 		maps = append(maps, socktrack)
 	}
 
@@ -1112,6 +1123,9 @@ func createKprobeSensorFromEntry(polInfo *policyInfo, kprobeEntry *genericKprobe
 
 		if config.EnableLargeProgs() {
 			socktrack := program.MapBuilderSensor("socktrack_map", loadret)
+			if has.sockTrack {
+				socktrack.SetMaxEntries(socktrackMapMaxEntries)
+			}
 			maps = append(maps, socktrack)
 		}
 	}


### PR DESCRIPTION
Resize the socktrack_map if needed to save memory. Prevent ~2.8MB unnecessary per-policy memory allocation when socktrack_map is unused.

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes <!-- #issue-number -->
#4210 
### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Currently the `socktrack_map` consumes **2.8 MB** memory even when it’s not being used:
```
2198: lru_hash  name socktrack_map  flags 0x0
	key 8B  value 16B  max_entries 32000  memlock 2829312B
	btf_id 2308
	pids tetragon(509601)
```

This commit will prevent unnecessary per-policy memory allocation when socktrack_map is unused.
```
2506: lru_hash  name socktrack_map  flags 0x0
	key 8B  value 16B  max_entries 1  memlock 1112B
	btf_id 2633
	pids tetragon(519618)
```