### PR TITLE
docs: Clarify event output in Network Monitoring guide

### DIFF
--- a/docs/content/en/docs/getting-started/network.md
+++ b/docs/content/en/docs/getting-started/network.md
@@ -97,12 +97,13 @@ The output should be similar to:
 Ship landed
 ```
 
-And as expected no new events:
+You will observe that no new `connect` events are generated for in-cluster traffic.  
+However, `process` and `exit` events for the `curl` command will still be reported  
+due to active execution monitoring.
 
 ```
-🚀 process default/xwing /usr/bin/curl https://ebpf.io/applications/#tetragon
-🔌 connect default/xwing /usr/bin/curl tcp 10.32.0.19:33978 -> 104.198.14.52:443
-💥 exit    default/xwing /usr/bin/curl https://ebpf.io/applications/#tetragon 60
+🚀 process default/xwing /usr/bin/curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing 
+💥 exit    default/xwing /usr/bin/curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing 0 
 ```
 
 Finally, delete the applied TracingPolicy with:


### PR DESCRIPTION
Fixes #2687

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
This PR updates the Network Monitoring documentation to clarify that while no new connect events are generated, process and exit events are still reported for in-cluster curl connections.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section -->

```release-note
Docs: Correct Network Monitoring event details
