### PR TITLE
cleanup: remove old build constraint syntax

### DIFF
--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build linux
-// +build linux
 
 package bpf
 

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build !windows
-// +build !windows
 
 package btf
 

--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build !windows
-// +build !windows
 
 package btf
 

--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build !windows
-// +build !windows
 
 package btf
 

--- a/pkg/btf/validation_test.go
+++ b/pkg/btf/validation_test.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build !windows
-// +build !windows
 
 package btf
 

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build linux
-// +build linux
 
 package cgroups
 

--- a/pkg/elf/usdt_args_amd64.go
+++ b/pkg/elf/usdt_args_amd64.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build amd64 && linux
-// +build amd64,linux
 
 package elf
 

--- a/pkg/elf/usdt_args_amd64_test.go
+++ b/pkg/elf/usdt_args_amd64_test.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build amd64 && linux
-// +build amd64,linux
 
 package elf
 

--- a/pkg/k8s/tools/tools.go
+++ b/pkg/k8s/tools/tools.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Cilium
 
 //go:build tools
-// +build tools
 
 package tools
 

--- a/pkg/lock/lock_fast.go
+++ b/pkg/lock/lock_fast.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Cilium
 
 //go:build !lockdebug
-// +build !lockdebug
 
 package lock
 

--- a/pkg/sensors/tracing/genericuprobe_cgo.go
+++ b/pkg/sensors/tracing/genericuprobe_cgo.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build linux
-// +build linux
 
 package tracing
 

--- a/pkg/sensors/tracing/kprobe_amd64_test.go
+++ b/pkg/sensors/tracing/kprobe_amd64_test.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build amd64 && linux
-// +build amd64,linux
 
 package tracing
 

--- a/pkg/sensors/tracing/tracepoint_amd64_test.go
+++ b/pkg/sensors/tracing/tracepoint_amd64_test.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build amd64 && linux
-// +build amd64,linux
 
 package tracing
 

--- a/pkg/sensors/tracing/usdt_amd64_test.go
+++ b/pkg/sensors/tracing/usdt_amd64_test.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Tetragon
 
 //go:build amd64 && linux
-// +build amd64,linux
 
 package tracing
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -2,7 +2,6 @@
 // Copyright Authors of Cilium
 
 //go:build tools
-// +build tools
 
 package tools
 


### PR DESCRIPTION
searched them with
```
git grep -F "+build" ":(exclude)*vendor*"
```