### PR TITLE
tetragon: Add missing switch break to do_action

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -970,6 +970,7 @@ do_action(void *ctx, __u32 i, struct selector_action *actions, bool *post, bool 
 		break;
 	case ACTION_CLEANUP_ENFORCER_NOTIFICATION:
 		do_enforcer_cleanup();
+		break;
 	case ACTION_SET:
 		index = actions->act[++i];
 		value = actions->act[++i];


### PR DESCRIPTION
Adding missing switch break to do_action.

fixes: 31a9aef3e8eb ("tetragon: Add support for usdt set action")
