### PR TITLE
fix(bpf/process): fix some missing `break` statements.

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -970,10 +970,12 @@ do_action(void *ctx, __u32 i, struct selector_action *actions, bool *post, bool 
 		break;
 	case ACTION_CLEANUP_ENFORCER_NOTIFICATION:
 		do_enforcer_cleanup();
+		break;
 	case ACTION_SET:
 		index = actions->act[++i];
 		value = actions->act[++i];
 		do_set_action(ctx, e, index, value);
+		break;
 	default:
 		break;
 	}
@@ -1181,6 +1183,7 @@ FUNC_INLINE int generic_retkprobe(void *ctx, struct bpf_map_def *calls, unsigned
 		break;
 	case char_iovec:
 		size += __copy_char_iovec(size, info.ptr, info.cnt, ret, e);
+		break;
 	default:
 		break;
 	}

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1263,6 +1263,7 @@ filter_64ty_selector_val(struct selector_arg_filter *filter, char *args)
 		case op_filter_mask:
 			if (*(u64 *)args & w)
 				return 1;
+			break;
 		default:
 			break;
 		}
@@ -1434,6 +1435,7 @@ filter_32ty_selector_val(struct selector_arg_filter *filter, char *args)
 		case op_filter_mask:
 			if (*(u32 *)args & w)
 				return 1;
+			break;
 		default:
 			break;
 		}


### PR DESCRIPTION
Not a real fix since the `default` case would cover us, still it is error prone.