### PR TITLE
metrics: migrate Prometheus metrics to pkg/metrics helpers

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -42,6 +42,14 @@ Build information about tetragon
 | `time ` | `2022-05-13T15:54:45Z` |
 | `version` | `v1.2.0` |
 
+### `tetragon_cgroup_rate_total`
+
+The total number of Tetragon cgroup rate counters. For internal use only.
+
+| label | values |
+| ----- | ------ |
+| `type ` | `check, delete, delete_fail, lookup_fail, process, throttle_start, throttle_stop, update_fail` |
+
 ### `tetragon_cri_cgidmap_resolutions_errors_total`
 
 number of cgroup id map (cgidmap) CRI resolutions that failed
@@ -164,7 +172,7 @@ The total number of Tetragon flags. For internal use only.
 
 | label | values |
 | ----- | ------ |
-| `type ` | `clone, dataArgs, dataFilename, errorArgs, errorCWD, errorCgroupID, errorCgroupName, errorCgroupSubsys, errorCgroupSubsysCgrp, errorCgroups, errorFilename, errorPathResolutionCwd, execve, inInitTree, miss, nocwd, procFS, rootcwd, truncArgs` |
+| `type ` | `clone, dataArgs, dataFilename, errorArgs, errorCWD, errorCgroupID, errorCgroupName, errorCgroupSubsys, errorCgroupSubsysCgrp, errorCgroups, errorFilename, errorPathResolutionCwd, execve, inInitTree, miss, nocwd, procFS, rootcwd, truncArgs, unknown` |
 
 ### `tetragon_generic_kprobe_merge_errors_total`
 

--- a/pkg/bench/summary.go
+++ b/pkg/bench/summary.go
@@ -84,8 +84,8 @@ func (s *Summary) PrettyPrint() {
 			getCounterValue(observer.RingbufLost),
 			getCounterValue(observer.RingbufErrors))
 
-		mergePushed := getCounterValue(kprobemetrics.MergePushed)
-		mergeOkTotal := getCounterValue(kprobemetrics.MergeOkTotal)
+		mergePushed := getCounterValue(kprobemetrics.MergePushed.WithLabelValues())
+		mergeOkTotal := getCounterValue(kprobemetrics.MergeOkTotal.WithLabelValues())
 		fmt.Printf("Merged events:      pushed=%d, ok=%d, errors=%d\n",
 			mergePushed, mergeOkTotal, mergePushed-mergeOkTotal)
 	}

--- a/pkg/grpc/tracing/stats.go
+++ b/pkg/grpc/tracing/stats.go
@@ -4,19 +4,22 @@
 package tracing
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	"maps"
+	"slices"
 
 	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 )
 
 var (
-	LoaderStats = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:   consts.MetricsNamespace,
-		Name:        "process_loader_stats",
-		Help:        "Process Loader event statistics. For internal use only.",
-		ConstLabels: nil,
-	}, []string{"count"})
+	LoaderStats = metrics.MustNewCounter(
+		metrics.NewOpts(
+			consts.MetricsNamespace, "", "process_loader_stats",
+			"Process Loader event statistics. For internal use only.",
+			nil, []metrics.ConstrainedLabel{{Name: "count", Values: slices.Collect(maps.Values(LoaderTypeStrings))}}, nil,
+		),
+		nil,
+	)
 )
 
 func RegisterMetrics(group metrics.Group) {

--- a/pkg/metrics/cgroupratemetrics/cgroupratemetrics.go
+++ b/pkg/metrics/cgroupratemetrics/cgroupratemetrics.go
@@ -4,6 +4,9 @@
 package cgroupratemetrics
 
 import (
+	"maps"
+	"slices"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/tetragon/pkg/metrics"
@@ -39,12 +42,14 @@ func (e CgroupRateType) String() string {
 }
 
 var (
-	CgroupRateTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:   consts.MetricsNamespace,
-		Name:        "cgroup_rate_total",
-		Help:        "The total number of Tetragon cgroup rate counters. For internal use only.",
-		ConstLabels: nil,
-	}, []string{"type"})
+	CgroupRateTotal = metrics.MustNewCounter(
+		metrics.NewOpts(
+			consts.MetricsNamespace, "", "cgroup_rate_total",
+			"The total number of Tetragon cgroup rate counters. For internal use only.",
+			nil, []metrics.ConstrainedLabel{{Name: "type", Values: slices.Collect(maps.Values(totalLabelValues))}}, nil,
+		),
+		nil,
+	)
 )
 
 func RegisterMetrics(group metrics.Group) {

--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -14,20 +14,44 @@ import (
 )
 
 var (
-	MsgOpsCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace:   consts.MetricsNamespace,
-		Name:        "msg_op_total",
-		Help:        "The total number of times we encounter a given message opcode. For internal use only.",
-		ConstLabels: nil,
-	}, []string{"msg_op"})
+	MsgOpsCount = metrics.MustNewCounter(
+		metrics.NewOpts(
+			consts.MetricsNamespace, "", "msg_op_total",
+			"The total number of times we encounter a given message opcode. For internal use only.",
+			nil, []metrics.ConstrainedLabel{{Name: "msg_op", Values: func() []string {
+				res := make([]string, 0, len(ops.OpCodeStrings))
+				for opcode := range ops.OpCodeStrings {
+					// Exclude MSG_OP_UNDEF (0) as it's not a valid operational opcode - only used for error tracking.
+					// Also exclude MSG_OP_TEST as it's only used for testing purposes.
+					if opcode != ops.MSG_OP_UNDEF && opcode != ops.MSG_OP_TEST {
+						res = append(res, strconv.Itoa(int(int32(opcode))))
+					}
+				}
+				return res
+			}()}}, nil,
+		),
+		nil,
+	)
 
-	LatencyStats = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:   consts.MetricsNamespace,
-		Name:        "handling_latency",
-		Help:        "The latency of handling messages in us.",
-		Buckets:     []float64{50, 100, 500, 1000, 10000, 100000}, // 50us, 100us, 500us, 1ms, 10ms, 100ms
-		ConstLabels: nil,
-	}, []string{"op"})
+	LatencyStats = metrics.MustNewHistogram(
+		metrics.HistogramOpts{
+			Opts: metrics.NewOpts(
+				consts.MetricsNamespace, "", "handling_latency",
+				"The latency of handling messages in us.",
+				nil, []metrics.ConstrainedLabel{{Name: "op", Values: func() []string {
+					res := make([]string, 0, len(ops.OpCodeStrings))
+					for opcode := range ops.OpCodeStrings {
+						if opcode != ops.MSG_OP_UNDEF && opcode != ops.MSG_OP_TEST {
+							res = append(res, strconv.Itoa(int(int32(opcode))))
+						}
+					}
+					return res
+				}()}}, nil,
+			),
+			Buckets: []float64{50, 100, 500, 1000, 10000, 100000}, // 50us, 100us, 500us, 1ms, 10ms, 100ms
+		},
+		nil,
+	)
 )
 
 func RegisterMetrics(group metrics.Group) {

--- a/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
+++ b/pkg/metrics/policyfiltermetrics/policyfiltermetrics.go
@@ -7,8 +7,6 @@ import (
 	"maps"
 	"slices"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/consts"
 )
@@ -91,19 +89,17 @@ var (
 		nil, []metrics.ConstrainedLabel{subsysLabel, operationLabel, errorLabel}, nil,
 	), nil)
 
-	PolicyFilterHookContainerNameMissingMetrics = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:   consts.MetricsNamespace,
-		Name:        "policyfilter_hook_container_name_missing_total",
-		Help:        "The total number of operations when the container name was missing in the OCI hook",
-		ConstLabels: nil,
-	})
+	PolicyFilterHookContainerNameMissingMetrics = metrics.MustNewCounter(metrics.NewOpts(
+		consts.MetricsNamespace, "", "policyfilter_hook_container_name_missing_total",
+		"The total number of operations when the container name was missing in the OCI hook",
+		nil, nil, nil,
+	), nil)
 
-	PolicyFilterHookContainerImageMissingMetrics = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:   consts.MetricsNamespace,
-		Name:        "policyfilter_hook_container_image_missing_total",
-		Help:        "The total number of operations when the container image was missing in the OCI hook",
-		ConstLabels: nil,
-	})
+	PolicyFilterHookContainerImageMissingMetrics = metrics.MustNewCounter(metrics.NewOpts(
+		consts.MetricsNamespace, "", "policyfilter_hook_container_image_missing_total",
+		"The total number of operations when the container image was missing in the OCI hook",
+		nil, nil, nil,
+	), nil)
 )
 
 func RegisterMetrics(group metrics.Group) {
@@ -115,9 +111,9 @@ func OpInc(subsys Subsys, op Operation, err string) {
 }
 
 func ContNameMissInc() {
-	PolicyFilterHookContainerNameMissingMetrics.Inc()
+	PolicyFilterHookContainerNameMissingMetrics.WithLabelValues().Inc()
 }
 
 func ContImageMissInc() {
-	PolicyFilterHookContainerImageMissingMetrics.Inc()
+	PolicyFilterHookContainerImageMissingMetrics.WithLabelValues().Inc()
 }

--- a/pkg/metrics/syscallmetrics/syscallmetrics.go
+++ b/pkg/metrics/syscallmetrics/syscallmetrics.go
@@ -13,12 +13,14 @@ import (
 )
 
 var (
-	syscallStats = metrics.MustNewGranularCounter[metrics.ProcessLabels](prometheus.CounterOpts{
-		Namespace:   consts.MetricsNamespace,
-		Name:        "syscalls_total",
-		Help:        "System calls observed.",
-		ConstLabels: nil,
-	}, []string{"syscall"})
+	syscallStats = metrics.MustNewGranularCounterWithInit[metrics.ProcessLabels](
+		metrics.NewOpts(
+			consts.MetricsNamespace, "", "syscalls_total",
+			"System calls observed.",
+			nil, nil, []metrics.UnconstrainedLabel{{Name: "syscall", ExampleValue: consts.ExampleSyscallLabel}},
+		),
+		nil,
+	)
 )
 
 func InitMetrics(registry *prometheus.Registry) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -95,7 +95,7 @@ func (l *getEventsListener) Notify(res *tetragon.GetEventsResponse) {
 	case l.events <- res:
 	default:
 		// events channel is full: drop the event so that we do not block everything
-		eventmetrics.NotifyOverflowedEvents.Inc()
+		eventmetrics.NotifyOverflowedEvents.WithLabelValues().Inc()
 	}
 }
 


### PR DESCRIPTION


<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes #2798

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
This PR migrates Prometheus metrics to use pkg/metrics helpers.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Migrated metrics to use pkg/metrics helpers 
```
