### PR TITLE
fix(bpf): force explicit switch case fallthrough

### DIFF
--- a/bpf/Makefile.defs
+++ b/bpf/Makefile.defs
@@ -23,7 +23,7 @@ ERRMETRICS_DIR = $(ROOT_DIR)errmetrics/
 DEPS = $(patsubst %,$(IDIR)/%,$(_DEPS))
 
 FLAGS := -I$(ROOT_DIR) \
-	 -Wall -Werror \
+	 -Wall -Werror -Wimplicit-fallthrough \
 	 -Wno-address-of-packed-member -Wno-compare-distinct-pointer-types -Wno-unknown-warning-option \
 	 -O2
 

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -601,6 +601,7 @@ event_output_update_error_metric(u8 msg_op, long err)
 			break;
 		default:
 			lock_add(&valp->sent_failed[msg_op][SENT_FAILED_UNKNOWN], 1);
+			break;
 		}
 	}
 }

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -926,6 +926,7 @@ do_action(void *ctx, __u32 i, struct selector_action *actions, bool *post, bool 
 		break;
 	case ACTION_SIGNAL:
 		signal = actions->act[++i];
+		fallthrough;
 	case ACTION_SIGKILL:
 		if (enforce_mode) {
 			do_action_signal(signal);

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1757,6 +1757,7 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
 		case fd_ty:
 			/* Advance args past fd */
 			args += 4;
+			fallthrough;
 		case file_ty:
 		case path_ty:
 		case dentry_type:
@@ -1790,7 +1791,7 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
 				pass = !!((cap_old ^ cap_new) & cap_new);
 				break;
 			}
-			/* falltrough */
+			fallthrough;
 #endif
 		case syscall64_type:
 		case s64_ty:


### PR DESCRIPTION
Added `-Wimplicit-fallthrough` clang flag to enforce it.

### Description

### Changelog

```release-note
fix(bpf): force explicit switch case fallthrough
```
