### PR TITLE
fix(pkg/sensors): use correct name for multiUprobePinPath

### DIFF
--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -544,7 +544,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 }
 
 func multiUprobePinPath(sensorPath string) string {
-	return sensors.PathJoin(sensorPath, "multi_kprobe")
+	return sensors.PathJoin(sensorPath, "multi_uprobe")
 }
 
 func createMultiUprobeSensor(sensorPath string, multiIDs []idtable.EntryID, policyName string, hasSleepableOffload bool) ([]*program.Program, []*program.Map, error) {


### PR DESCRIPTION
Extracted from #4193

### Changelog

```release-note
fix(pkg/sensors): use correct name for multiUprobePinPath
```
