### PR TITLE
fix(pkg/sensors): account for sleepableOffloadMap in multi uprobe

### DIFF
--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -578,7 +578,7 @@ func createMultiUprobeSensor(sensorPath string, multiIDs []idtable.EntryID, poli
 		regsMap := program.MapBuilderProgram("regs_map", load)
 		sleepableOffloadMap := program.MapBuilderProgram("sleepable_offload", load)
 		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
-		maps = append(maps, regsMap)
+		maps = append(maps, regsMap, sleepableOffloadMap)
 	}
 
 	filterMap.SetMaxEntries(len(multiIDs))


### PR DESCRIPTION
Extracted from #4193 

### Description

This was a leftover from https://github.com/cilium/tetragon/pull/4173

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
fix(pkg/sensors): account for sleepableOffloadMap in multi uprobe
```
