### PR TITLE
tetragon: send slices to the events queue

### DIFF
--- a/pkg/observer/observer_linux.go
+++ b/pkg/observer/observer_linux.go
@@ -98,7 +98,7 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 
 	// We spawn go routine to read and process perf events,
 	// connected with main app through eventsQueue channel.
-	eventsQueue := make(chan *[]byte, k.getRBQueueSize())
+	eventsQueue := make(chan []byte, k.getRBQueueSize())
 
 	// Listeners are ready and about to start reading from perf reader, tell
 	// user everything is ready.
@@ -122,7 +122,7 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 			} else {
 				if len(record.RawSample) > 0 {
 					select {
-					case eventsQueue <- &record.RawSample:
+					case eventsQueue <- record.RawSample:
 					default:
 						// eventsQueue channel is full, drop the event
 						queueLost.Inc()
@@ -154,7 +154,7 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 				} else {
 					if len(record.RawSample) > 0 {
 						select {
-						case eventsQueue <- &record.RawSample:
+						case eventsQueue <- record.RawSample:
 						default:
 							// eventsQueue channel is full, drop the event
 							queueLost.Inc()
@@ -173,7 +173,7 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 		for {
 			select {
 			case eventRawSample := <-eventsQueue:
-				k.receiveEvent(*eventRawSample)
+				k.receiveEvent(eventRawSample)
 				queueReceived.Inc()
 			case <-stopCtx.Done():
 				k.log.Info("Listening for events completed.", logfields.Error, stopCtx.Err())


### PR DESCRIPTION
When reading the ring buffers, we check the length of the byte slice is greater than 0, and then send a reference to it to the events queue channel. Sometimes on retrieval, the byte slice has a length of 0.

This commit attempts to resolve this by sending the byte slice to the events queue channel instead, on the assumption that this will make tracking the backing array easier for golang, so it shouldn't invalidate it before we use it.
