### PR TITLE
tetragon: check event length in test ring handler

### DIFF
--- a/pkg/testutils/perfring/perfring.go
+++ b/pkg/testutils/perfring/perfring.go
@@ -125,15 +125,17 @@ func ProcessEvents(t *testing.T, ctx context.Context, eventFn EventFn, wgStarted
 				break
 			}
 
-			_, events, handlerErr := observer.HandlePerfData(record.RawSample)
-			if handlerErr != nil {
-				errChan <- fmt.Errorf("error handling perfring data: %w", handlerErr)
-				break
-			}
-			err = loopEvents(events, eventFn, complChecker)
-			if err != nil {
-				errChan <- fmt.Errorf("error loop event function returned: %w", err)
-				break
+			if len(record.RawSample) > 0 {
+				_, events, handlerErr := observer.HandlePerfData(record.RawSample)
+				if handlerErr != nil {
+					errChan <- fmt.Errorf("error handling perfring data: %w", handlerErr)
+					break
+				}
+				err = loopEvents(events, eventFn, complChecker)
+				if err != nil {
+					errChan <- fmt.Errorf("error loop event function returned: %w", err)
+					break
+				}
 			}
 
 			if complChecker.Done() {
@@ -161,15 +163,17 @@ func ProcessEvents(t *testing.T, ctx context.Context, eventFn EventFn, wgStarted
 					break
 				}
 
-				_, events, handlerErr := observer.HandlePerfData(record.RawSample)
-				if handlerErr != nil {
-					errChan <- fmt.Errorf("error handling ringbuf data: %w", handlerErr)
-					break
-				}
-				err = loopEvents(events, eventFn, complChecker)
-				if err != nil {
-					errChan <- fmt.Errorf("error loop event function returned: %w", err)
-					break
+				if len(record.RawSample) > 0 {
+					_, events, handlerErr := observer.HandlePerfData(record.RawSample)
+					if handlerErr != nil {
+						errChan <- fmt.Errorf("error handling ringbuf data: %w", handlerErr)
+						break
+					}
+					err = loopEvents(events, eventFn, complChecker)
+					if err != nil {
+						errChan <- fmt.Errorf("error loop event function returned: %w", err)
+						break
+					}
 				}
 
 				if complChecker.Done() {


### PR DESCRIPTION
The ring buffer servicing functions in pkg/testutils/perfring fail to check that the record.RawSample has length > 0, resulting in occasional panics in tests. The equivalent routines that run in normal use include the check so the panics only happen in tests. This commit adds the check to the test routines.
