### PR TITLE
workflows: fix release image display digest step

### DIFF
--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Release Build ${{ matrix.name }}
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         id: docker_build_release
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           provenance: false
           context: .


### PR DESCRIPTION
Docker build push action thought it was a good idea to add a build summary and uploading artifacts that can't be downloaded via the GitHub actions/download-artifact so we need to adapt each of our workflows.

See https://github.com/docker/build-push-action?tab=readme-ov-file#summaries and https://github.com/actions/toolkit/pull/1874.