### PR TITLE
vmtests: add kernel 6.12 to test matrix

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -71,6 +71,8 @@ jobs:
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
               - 'bpf-next-20251008.075427'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
+              - '6.12-20251021.054756'
+              # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
               - '6.6-20251008.075427'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
               - '6.1-20251008.075427'


### PR DESCRIPTION


<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes #4228

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Add kernel 6.12-20251021.054756 to Vmtests matrix.
