### PR TITLE
bpf: uprobes: remove stale comment

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -715,7 +715,6 @@ generic_process_event_and_setup(struct pt_regs *ctx, struct bpf_map_def *tailcal
 #endif
 
 #ifdef GENERIC_UPROBE
-	/* no arguments for uprobes for now */
 	e->a0 = PT_REGS_PARM1_CORE(ctx);
 	e->a1 = PT_REGS_PARM2_CORE(ctx);
 	e->a2 = PT_REGS_PARM3_CORE(ctx);


### PR DESCRIPTION
Comment was introduced in d1d6c20fe9 but arguments parsing was added in 84855ae3aa.