### PR TITLE
new: retprobes events cache size option

### DIFF
--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -226,6 +226,9 @@ options:
       default_value: "true"
       usage: |
         Release all pinned BPF programs and maps in Tetragon BPF directory. Enabled by default. Set to false to disable
+    - name: retprobes-cache-size
+      default_value: "4096"
+      usage: Set {k,u}retprobes events cache maximum size
     - name: server-address
       default_value: localhost:54321
       usage: |

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -56,6 +56,9 @@ const (
 
 	// defaults for the process cache
 	DefaultProcessCacheGCInterval = 30 * time.Second
+
+	// defaults for the {k,u}retprobes lru cache
+	DefaultRetprobesCacheSize = 4096
 )
 
 var (

--- a/pkg/defaults/defaults_windows.go
+++ b/pkg/defaults/defaults_windows.go
@@ -48,4 +48,7 @@ const (
 
 	// defaults for the process cache
 	DefaultProcessCacheGCInterval = 30 * time.Second
+
+	// defaults for the {k,u}retprobes lru cache
+	DefaultRetprobesCacheSize = 4096
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -128,6 +128,8 @@ type config struct {
 
 	ExecveMapEntries int
 	ExecveMapSize    string
+
+	RetprobesCacheSize int
 }
 
 var (
@@ -146,10 +148,13 @@ var (
 		// Enable all metrics labels by default
 		MetricsLabelFilter: DefaultLabelFilter(),
 
-		// set default valus for the event cache
+		// set default values for the event cache
 		// mainly used in the case of testing
 		EventCacheNumRetries: defaults.DefaultEventCacheNumRetries,
 		EventCacheRetryDelay: defaults.DefaultEventCacheRetryDelay,
+
+		// Set default value for {k,u}retprobes lru events cache
+		RetprobesCacheSize: defaults.DefaultRetprobesCacheSize,
 	}
 )
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -133,6 +133,8 @@ const (
 
 	KeyExecveMapEntries = "execve-map-entries"
 	KeyExecveMapSize    = "execve-map-size"
+
+	KeyRetprobesCacheSize = "retprobes-cache-size"
 )
 
 type UsernameMetadaCode int
@@ -285,6 +287,8 @@ func ReadAndSetFlags() error {
 
 	Config.ExecveMapEntries = viper.GetInt(KeyExecveMapEntries)
 	Config.ExecveMapSize = viper.GetString(KeyExecveMapSize)
+
+	Config.RetprobesCacheSize = viper.GetInt(KeyRetprobesCacheSize)
 	return nil
 }
 
@@ -477,4 +481,6 @@ func AddFlags(flags *pflag.FlagSet) {
 
 	flags.Int(KeyExecveMapEntries, 0, "Set entries for execve_map table (default 32768)")
 	flags.String(KeyExecveMapSize, "", "Set size for execve_map table (allows K/M/G suffix)")
+
+	flags.Int(KeyRetprobesCacheSize, defaults.DefaultRetprobesCacheSize, "Set {k,u}retprobes events cache maximum size")
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -981,7 +981,7 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 		}
 	}
 
-	kprobeEntry.pendingEvents, err = lru.New[pendingEventKey, pendingEvent[*tracing.MsgGenericKprobeUnix]](4096)
+	kprobeEntry.pendingEvents, err = lru.New[pendingEventKey, pendingEvent[*tracing.MsgGenericKprobeUnix]](option.Config.RetprobesCacheSize)
 	if err != nil {
 		return errFn(err)
 	}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -649,7 +649,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 			pendingEvents:     nil,
 		}
 
-		uprobeEntry.pendingEvents, err = lru.New[pendingEventKey, pendingEvent[*tracing.MsgGenericUprobeUnix]](4096)
+		uprobeEntry.pendingEvents, err = lru.New[pendingEventKey, pendingEvent[*tracing.MsgGenericUprobeUnix]](option.Config.RetprobesCacheSize)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

In #4193 we noticed that the default size for the lru cache used by kretprobes and uretprobes is very large (4096).
This PR moves the default to 64, and adds an option key to set it to a desired value.

Context: https://github.com/cilium/tetragon/pull/4193#discussion_r2470185219

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
new: retprobes events cache size option
```
