### PR TITLE
Backports/v1.6: tetragon: Limit sys_close events in test

### DIFF
--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -3336,9 +3336,17 @@ spec:
     syscall: true
     args:
     - index: 0
-      type: "int"
+      type: "fd"
     selectors:
-    - matchActions:
+    - matchArgs:
+      - index: 0
+        operator: "` + opStr + `"
+        values: `
+	for i := range vals {
+		configHook += fmt.Sprintf("\n        - \"%s\"", vals[i])
+	}
+	configHook += "\n"
+	configHook += `      matchActions:
       - action: UnfollowFD
         argFd: 0
         argName: 0


### PR DESCRIPTION
The TestKprobeMatchArgsFileEqual test (among others) uses the getMatchArgsFdCrd() function to generate a policy to track file descriptors and subsequent specific file actions happening to certain files. While the fd_install kprobe matches the file specifications provided, the sys_close kprobe (that unfollows the FD) does not. This results in vast amounts of sys_close events.

When using the perf ring buffer, this did not cause test failures. With the BPF ring buffer, the tests can flake, however. This is due to the additional volume of events processed in user space (due to the increased efficiency of the BPF ring buffer), delaying the test events' arrival, and causing the test to give up before the test events have been observed.

This commit adds the file specification to the sys_close selectors to reduce the number of additional events.

[Upstream PR: #4269]
