### PR TITLE
PoC: Templated Policies for Reduced Memory and eBPF Program Count

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -35,6 +35,10 @@ generic_start_process_filter(void *ctx, struct bpf_map_def *calls)
 		return 0;
 	if (!policy_filter_check(config->policy_id))
 		return 0;
+	// todo: this should replace the policy filter check above
+	if (config->cgroup_filter && !get_policy_from_cgroup())
+		return 0;
+	// bpf_printk("passed the check on the cgroup");
 	msg->func_id = config->func_id;
 	msg->retprobe_id = 0;
 

--- a/bpf/process/string_maps.h
+++ b/bpf/process/string_maps.h
@@ -91,6 +91,39 @@ DEFINE_ARRAY_OF_STRING_MAPS(9)
 DEFINE_ARRAY_OF_STRING_MAPS(10)
 #endif
 
+#define POLICY_STR_OUTER_MAX_ENTRIES 1
+#define POLICY_STR_INNER_MAX_ENTRIES 1
+
+#define DEFINE_POLICY_STR_HASH_OF_MAPS(N)                                               \
+	struct {                                                                    \
+		__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);                            \
+		__uint(max_entries, POLICY_STR_OUTER_MAX_ENTRIES);                 \
+		__uint(map_flags, BPF_F_NO_PREALLOC);                               \
+		__type(key, __u32);                                                 \
+		__array(                                                            \
+			values, struct {                                            \
+				__uint(type, BPF_MAP_TYPE_HASH);                    \
+				__uint(max_entries, POLICY_STR_INNER_MAX_ENTRIES); \
+				__type(key, __u8[STRING_MAPS_SIZE_##N]);            \
+				__type(value, __u8);                                \
+			});                                                         \
+	} pol_str_maps_##N SEC(".maps");
+
+DEFINE_POLICY_STR_HASH_OF_MAPS(0)
+DEFINE_POLICY_STR_HASH_OF_MAPS(1)
+DEFINE_POLICY_STR_HASH_OF_MAPS(2)
+DEFINE_POLICY_STR_HASH_OF_MAPS(3)
+DEFINE_POLICY_STR_HASH_OF_MAPS(4)
+DEFINE_POLICY_STR_HASH_OF_MAPS(5)
+DEFINE_POLICY_STR_HASH_OF_MAPS(6)
+DEFINE_POLICY_STR_HASH_OF_MAPS(7)
+
+#ifdef __V511_BPF_PROG
+DEFINE_POLICY_STR_HASH_OF_MAPS(8)
+DEFINE_POLICY_STR_HASH_OF_MAPS(9)
+DEFINE_POLICY_STR_HASH_OF_MAPS(10)
+#endif
+
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -648,7 +648,7 @@ type EventConfig struct {
 	ArgReturnAction int32                                            `align:"argreturnaction"`
 	PolicyID        uint32                                           `align:"policy_id"`
 	Flags           uint32                                           `align:"flags"`
-	Pad             uint32                                           `align:"pad"`
+	CgroupFilter    uint32                                           `align:"cgroup_filter"`
 	BTFArg          [EventConfigMaxArgs][MaxBTFArgDepth]ConfigBTFArg `align:"btf_arg"`
 	UsdtArg         [EventConfigMaxUsdtArgs]ConfigUsdtArg            `align:"usdt_arg"`
 }

--- a/pkg/policyfilter/base_policy.go
+++ b/pkg/policyfilter/base_policy.go
@@ -1,0 +1,68 @@
+package policyfilter
+
+import (
+	"github.com/cilium/tetragon/pkg/labels"
+)
+
+type basePolicy struct {
+	id                PolicyID
+	namespace         string
+	containerSelector labels.Selector
+	podSelector       labels.Selector
+}
+
+func (b *basePolicy) setID(polID PolicyID) {
+	b.id = polID
+}
+
+func (b *basePolicy) setFilters(namespace string, podSelector labels.Selector, containerSelector labels.Selector) {
+	b.namespace = namespace
+	b.podSelector = podSelector
+	b.containerSelector = containerSelector
+}
+
+func (b *basePolicy) getID() PolicyID {
+	return b.id
+}
+
+func (b *basePolicy) podInfoMatches(pod *podInfo) bool {
+	if pod == nil {
+		return false
+	}
+	return b.podMatches(pod.namespace, pod.labels)
+}
+
+func (b *basePolicy) podMatches(podNs string, podLabels labels.Labels) bool {
+	if b.namespace != "" && podNs != b.namespace {
+		return false
+	}
+	podLabels1 := make(labels.Labels)
+	if podLabels != nil {
+		podLabels1 = podLabels
+	}
+	if _, ok := podLabels1[labels.K8sPodNamespace]; !ok {
+		podLabels1[labels.K8sPodNamespace] = podNs
+	}
+	return b.podSelector.Match(podLabels1)
+}
+
+func (b *basePolicy) containerMatches(container *containerInfo) bool {
+	if container == nil {
+		return false
+	}
+	filter := labels.Labels{
+		"name": container.name,
+		"repo": container.repo,
+	}
+	return b.containerSelector.Match(filter)
+}
+
+func (b *basePolicy) matchingContainersCgroupIDs(containers []containerInfo) []CgroupID {
+	var ids []CgroupID
+	for i := range containers {
+		if b.containerMatches(&containers[i]) {
+			ids = append(ids, containers[i].cgID)
+		}
+	}
+	return ids
+}

--- a/pkg/policyfilter/binding_policy.go
+++ b/pkg/policyfilter/binding_policy.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package policyfilter
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/ebpf"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+type bindingPolicy struct {
+	basePolicy
+	template *tracingPolicyTemplate
+}
+
+func (m *state) getTemplateForPolicy(refPolID PolicyID) (*tracingPolicyTemplate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	index := m.findTracingPolicyTemplate(refPolID)
+	if index == -1 {
+		return nil, fmt.Errorf("template with id %d does not exist", refPolID)
+	}
+	return m.tracingPolicyTemplates[index], nil
+}
+
+func (m *state) AddTracingPolicyBinding(polID PolicyID, refPolID PolicyID, namespace string, podLabelSelector *slimv1.LabelSelector,
+	containerLabelSelector *slimv1.LabelSelector) error {
+	m.log.Info("state: add tracing policy binding", "policy_id", polID)
+	template, err := m.getTemplateForPolicy(refPolID)
+	if err != nil {
+		return err
+	}
+	policy := &bindingPolicy{
+		template: template,
+	}
+	policy.setID(polID)
+	return m.addPolicyCommon(policy, namespace, podLabelSelector, containerLabelSelector)
+}
+
+func (m *state) DeleteTracingPolicyBinding(polID PolicyID) error {
+	m.log.Info("state: delete tracing policy binding", "policy_id", polID)
+	return m.delPolicyCommon(polID)
+}
+
+func (pol *bindingPolicy) addCgroupIDs(log *slog.Logger, ids []CgroupID) error {
+	var err error
+	cgroupToPolicy := pol.template.cgroupToPolicy
+	if cgroupToPolicy == nil {
+		return fmt.Errorf("workload map is nil for bindingPolicy with id %d", pol.getID())
+	}
+
+	// Cleanup of the maps if something goes wrong
+	defer func() {
+		if err == nil {
+			return
+		}
+
+		for _, id := range ids {
+			err = cgroupToPolicy.Delete(id)
+			if err != nil && errors.Is(err, ebpf.ErrKeyNotExist) {
+				log.Warn("failed to rollback cgroup map after error", "cgroup_id", id, "policy_id", pol.getID(), "error", err)
+			}
+		}
+	}()
+
+	for _, id := range ids {
+		err = cgroupToPolicy.Update(id, pol.getID(), ebpf.UpdateNoExist)
+		if err == nil {
+			log.Info("state: add cgroup to cgroup map", "cgroup_id", id, "policy_id", pol.getID())
+			continue
+		}
+
+		if errors.Is(err, ebpf.ErrKeyExist) {
+			log.Warn("key already exists for cgroup", "cgroup_id", id, ". Overriding with policy_id", pol.getID())
+			err = cgroupToPolicy.Update(id, pol.getID(), 0)
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to insert (cgroup_id=%d, policy_id=%d) into workload map: %w", id, pol.getID(), err)
+		}
+	}
+	return nil
+}
+
+func (pol *bindingPolicy) AddInitialCgroupIDs(state *state, ids []CgroupID) error {
+	return pol.addCgroupIDs(state.log, ids)
+}
+
+func (pol *bindingPolicy) AddCgroupIDs(log *slog.Logger, ids []CgroupID) error {
+	return pol.addCgroupIDs(log, ids)
+}
+
+func (pol *bindingPolicy) DelCgroupIDs(log *slog.Logger, ids []CgroupID) error {
+	cgroupToPolicy := pol.template.cgroupToPolicy
+	if cgroupToPolicy == nil {
+		return fmt.Errorf("workload map is nil for bindingPolicy with id %d", pol.getID())
+	}
+
+	for _, id := range ids {
+		err := cgroupToPolicy.Delete(id)
+		log.Info("state: remove cgroup from cgroup map", "cgroup_id", id, "policy_id", pol.getID())
+
+		if err != nil && errors.Is(err, ebpf.ErrKeyNotExist) {
+			log.Warn("failed to remove entry from cgroup map", "cgroup_id", id, "policy_id", pol.getID(), "error", err)
+		}
+	}
+	return nil
+}
+
+func (pol *bindingPolicy) Close(log *slog.Logger) {
+	var cgroupID uint64
+	var policyID uint32
+	currPolicyID := pol.getID()
+	workloadIterator := pol.template.cgroupToPolicy.Iterate()
+	for workloadIterator.Next(&cgroupID, &policyID) {
+		if PolicyID(policyID) == currPolicyID {
+			log.Info("state: delete cgroupID from cgroup map during close iteration", "cgroup_id", cgroupID, "policy_id", currPolicyID)
+			if err := pol.template.cgroupToPolicy.Delete(cgroupID); err != nil {
+				log.Warn("failed to delete cgroupID from cgroup map during bindingPolicy Close", "cgroup_id", cgroupID, "policy_id", currPolicyID, "error", err)
+			}
+		}
+	}
+
+	if err := workloadIterator.Err(); err != nil {
+		log.Warn("failed to iterate over cgroup map during close iteration", "error", err)
+	}
+	log.Info("state: deleted cgroupIDs from cgroup map during close iteration", "policy_id", currPolicyID)
+}

--- a/pkg/policyfilter/disabled.go
+++ b/pkg/policyfilter/disabled.go
@@ -9,6 +9,7 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/cilium/ebpf"
 	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/tetragon/pkg/labels"
 	"github.com/cilium/tetragon/pkg/podhelpers"
@@ -21,16 +22,37 @@ func DisabledState() State {
 type disabled struct {
 }
 
-func (s *disabled) AddPolicy(polID PolicyID, namespace string, podSelector *slimv1.LabelSelector,
-	containerSelector *slimv1.LabelSelector) error {
+func disabledError() error {
 	return errors.New("policyfilter is disabled")
 }
 
-func (s *disabled) DelPolicy(polID PolicyID) error {
+func (s *disabled) AddGenericPolicy(polID PolicyID, namespace string, podSelector *slimv1.LabelSelector,
+	containerSelector *slimv1.LabelSelector) error {
+	return disabledError()
+}
+
+func (s *disabled) AddTracingPolicyBinding(polID PolicyID, refPolID PolicyID, namespace string, podLabelSelector *slimv1.LabelSelector,
+	containerLabelSelector *slimv1.LabelSelector) error {
+	return disabledError()
+}
+
+func (s *disabled) DeleteGenericPolicy(polID PolicyID) error {
 	if polID == NoFilterPolicyID {
 		return nil
 	}
-	return errors.New("policyfilter is disabled")
+	return disabledError()
+}
+
+func (s *disabled) DeleteTracingPolicyBinding(polID PolicyID) error {
+	return disabledError()
+}
+
+func (s *disabled) AddTracingPolicyTemplate(polID PolicyID, cgroupToPolicy *ebpf.Map) error {
+	return disabledError()
+}
+
+func (s *disabled) DeleteTracingPolicyTemplate(polID PolicyID) error {
+	return disabledError()
 }
 
 func (s *disabled) AddPodContainer(podID PodID, namespace, workload, kind string, podLabels labels.Labels,

--- a/pkg/policyfilter/generic_policy.go
+++ b/pkg/policyfilter/generic_policy.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package policyfilter
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/ebpf"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+type genericPolicy struct {
+	basePolicy
+	// polMap is the (inner) policy map for this policy
+	polMap polMap
+}
+
+// AddGenericPolicy adds a generic policy
+func (m *state) AddGenericPolicy(polID PolicyID, namespace string, podLabelSelector *slimv1.LabelSelector,
+	containerLabelSelector *slimv1.LabelSelector) error {
+	policy := &genericPolicy{}
+	policy.setID(polID)
+	return m.addPolicyCommon(policy, namespace, podLabelSelector, containerLabelSelector)
+}
+
+func (m *state) DeleteGenericPolicy(polID PolicyID) error {
+	if polID == NoFilterPolicyID {
+		// we do nothing
+		return nil
+	}
+
+	m.mu.Lock()
+	// delete entry in policy outerMap
+	if err := m.pfMap.policyMap.Delete(polID); err != nil && err != ebpf.ErrKeyNotExist {
+		m.log.Warn("failed to remove policy from external map", "policy-id", polID)
+	}
+	// delete entry in cgroup map
+	if err := m.pfMap.deletePolicyIDInCgroupMap(polID); err != nil && err != ebpf.ErrKeyNotExist {
+		m.log.Warn("failed to remove policy from cgroup map", "policy-id", polID)
+	}
+	m.mu.Unlock()
+
+	return m.delPolicyCommon(polID)
+}
+
+func (pol *genericPolicy) AddInitialCgroupIDs(state *state, ids []CgroupID) error {
+	var err error
+	pol.polMap, err = state.pfMap.newPolicyMap(pol.getID(), ids)
+	return err
+}
+
+func (pol *genericPolicy) AddCgroupIDs(_ *slog.Logger, ids []CgroupID) error {
+	if err := pol.polMap.addCgroupIDs(ids); err != nil {
+		return fmt.Errorf("failed to update policy map. error: %w", err)
+	}
+	if err := pol.polMap.addPolicyIDs(pol.id, ids); err != nil {
+		return fmt.Errorf("failed to update cgroup map. error: %w", err)
+	}
+	return nil
+
+}
+
+func (pol *genericPolicy) DelCgroupIDs(_ *slog.Logger, ids []CgroupID) error {
+	return pol.polMap.delCgroupIDs(pol.id, ids)
+}
+
+func (pol *genericPolicy) Close(_ *slog.Logger) {
+	pol.polMap.Inner.Close()
+}

--- a/pkg/policyfilter/k8s_test.go
+++ b/pkg/policyfilter/k8s_test.go
@@ -343,9 +343,9 @@ func (ts *testState) containersCgroupIDs(t *testing.T, podContainerMap map[strin
 }
 
 func testNamespacePods(t *testing.T, st *state, ts *testState) {
-	err := st.AddPolicy(PolicyID(1), "ns1", nil, nil)
+	err := st.AddGenericPolicy(PolicyID(1), "ns1", nil, nil)
 	require.NoError(t, err)
-	err = st.AddPolicy(PolicyID(2), "ns2", nil, nil)
+	err = st.AddGenericPolicy(PolicyID(2), "ns2", nil, nil)
 	require.NoError(t, err)
 
 	emptyLabels := labels.Labels{}
@@ -380,7 +380,7 @@ func testNamespacePods(t *testing.T, st *state, ts *testState) {
 		},
 	)
 
-	err = st.DelPolicy(PolicyID(2))
+	err = st.DeleteGenericPolicy(PolicyID(2))
 	require.NoError(t, err)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
@@ -388,7 +388,7 @@ func testNamespacePods(t *testing.T, st *state, ts *testState) {
 		},
 	)
 
-	err = st.DelPolicy(PolicyID(1))
+	err = st.DeleteGenericPolicy(PolicyID(1))
 	require.NoError(t, err)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{},
@@ -406,9 +406,9 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 	matchesAllID := uint32(1)
 	matchesWebID := uint32(2)
 	matchesAppsID := uint32(3)
-	err := st.AddPolicy(PolicyID(matchesAllID), "", nil, nil)
+	err := st.AddGenericPolicy(PolicyID(matchesAllID), "", nil, nil)
 	require.NoError(t, err)
-	err = st.AddPolicy(PolicyID(matchesWebID), "", &slimv1.LabelSelector{
+	err = st.AddGenericPolicy(PolicyID(matchesWebID), "", &slimv1.LabelSelector{
 		MatchExpressions: []slimv1.LabelSelectorRequirement{{
 			Key:      "app",
 			Operator: slimv1.LabelSelectorOpIn,
@@ -416,7 +416,7 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 		}},
 	}, nil)
 	require.NoError(t, err)
-	err = st.AddPolicy(PolicyID(matchesAppsID), "", &slimv1.LabelSelector{
+	err = st.AddGenericPolicy(PolicyID(matchesAppsID), "", &slimv1.LabelSelector{
 		MatchExpressions: []slimv1.LabelSelectorRequirement{{
 			Key:      "app",
 			Operator: slimv1.LabelSelectorOpExists,
@@ -469,7 +469,7 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 		},
 	)
 
-	err = st.DelPolicy(PolicyID(matchesAllID))
+	err = st.DeleteGenericPolicy(PolicyID(matchesAllID))
 	require.NoError(t, err)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
@@ -481,9 +481,9 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 
 	ts.deletePod(t, "web")
 	ts.deletePod(t, "db")
-	err = st.DelPolicy(PolicyID(matchesAppsID))
+	err = st.DeleteGenericPolicy(PolicyID(matchesAppsID))
 	require.NoError(t, err)
-	err = st.DelPolicy(PolicyID(matchesWebID))
+	err = st.DeleteGenericPolicy(PolicyID(matchesWebID))
 	require.NoError(t, err)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
@@ -496,9 +496,9 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 	matchesAllContainers := uint32(1)
 	matchesWebContainers := uint32(2)
 	matchesNotInitContainers := uint32(3)
-	err := st.AddPolicy(PolicyID(matchesAllContainers), "", nil, nil)
+	err := st.AddGenericPolicy(PolicyID(matchesAllContainers), "", nil, nil)
 	require.NoError(t, err)
-	err = st.AddPolicy(PolicyID(matchesWebContainers), "", nil,
+	err = st.AddGenericPolicy(PolicyID(matchesWebContainers), "", nil,
 		&slimv1.LabelSelector{
 			MatchExpressions: []slimv1.LabelSelectorRequirement{{
 				Key:      "name",
@@ -507,7 +507,7 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 			}},
 		})
 	require.NoError(t, err)
-	err = st.AddPolicy(PolicyID(matchesNotInitContainers), "", &slimv1.LabelSelector{
+	err = st.AddGenericPolicy(PolicyID(matchesNotInitContainers), "", &slimv1.LabelSelector{
 		MatchExpressions: []slimv1.LabelSelectorRequirement{{
 			Key:      "app",
 			Operator: slimv1.LabelSelectorOpIn,
@@ -591,7 +591,7 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 		},
 	)
 
-	err = st.DelPolicy(PolicyID(matchesAllContainers))
+	err = st.DeleteGenericPolicy(PolicyID(matchesAllContainers))
 	require.NoError(t, err)
 	ts.deletePod(t, "log")
 	ts.waitForCallbacks(t)
@@ -609,9 +609,9 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 
 	ts.deletePod(t, "web")
 	ts.deletePod(t, "db")
-	err = st.DelPolicy(PolicyID(matchesNotInitContainers))
+	err = st.DeleteGenericPolicy(PolicyID(matchesNotInitContainers))
 	require.NoError(t, err)
-	err = st.DelPolicy(PolicyID(matchesWebContainers))
+	err = st.DeleteGenericPolicy(PolicyID(matchesWebContainers))
 	require.NoError(t, err)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
@@ -627,7 +627,7 @@ func testPreExistingPods(t *testing.T, st *state, ts *testState) {
 
 	// create policy
 	matchesWebID := uint32(2)
-	err := st.AddPolicy(PolicyID(matchesWebID), "", &slimv1.LabelSelector{
+	err := st.AddGenericPolicy(PolicyID(matchesWebID), "", &slimv1.LabelSelector{
 		MatchExpressions: []slimv1.LabelSelectorRequirement{{
 			Key:      "app",
 			Operator: slimv1.LabelSelectorOpIn,
@@ -645,7 +645,7 @@ func testPreExistingPods(t *testing.T, st *state, ts *testState) {
 
 	ts.deletePod(t, "web")
 	ts.deletePod(t, "db")
-	err = st.DelPolicy(PolicyID(matchesWebID))
+	err = st.DeleteGenericPolicy(PolicyID(matchesWebID))
 	require.NoError(t, err)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
@@ -661,7 +661,7 @@ func testContainersChange(t *testing.T, st *state, ts *testState) {
 
 	// create policy
 	policyID := uint32(2)
-	err := st.AddPolicy(PolicyID(policyID), "", &slimv1.LabelSelector{},
+	err := st.AddGenericPolicy(PolicyID(policyID), "", &slimv1.LabelSelector{},
 		&slimv1.LabelSelector{
 			MatchExpressions: []slimv1.LabelSelectorRequirement{
 				{
@@ -695,7 +695,7 @@ func testContainersChange(t *testing.T, st *state, ts *testState) {
 	ts.deletePod(t, "web")
 	ts.deletePod(t, "db")
 	ts.deletePod(t, "log")
-	err = st.DelPolicy(PolicyID(policyID))
+	err = st.DeleteGenericPolicy(PolicyID(policyID))
 	require.NoError(t, err)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,

--- a/pkg/policyfilter/policy.go
+++ b/pkg/policyfilter/policy.go
@@ -1,0 +1,24 @@
+package policyfilter
+
+import (
+	"log/slog"
+
+	"github.com/cilium/tetragon/pkg/labels"
+)
+
+type policy interface {
+	// base methods
+	getID() PolicyID
+	setID(polID PolicyID)
+	setFilters(namespace string, podSelector labels.Selector, containerSelector labels.Selector)
+	podInfoMatches(*podInfo) bool
+	podMatches(string, labels.Labels) bool
+	containerMatches(*containerInfo) bool
+	matchingContainersCgroupIDs([]containerInfo) []CgroupID
+
+	// Implementation specific methods
+	AddInitialCgroupIDs(state *state, ids []CgroupID) error
+	AddCgroupIDs(log *slog.Logger, ids []CgroupID) error
+	DelCgroupIDs(log *slog.Logger, ids []CgroupID) error
+	Close(log *slog.Logger)
+}

--- a/pkg/policyfilter/state_test.go
+++ b/pkg/policyfilter/state_test.go
@@ -21,11 +21,11 @@ func TestState(t *testing.T) {
 	}
 	defer s.Close()
 
-	err = s.AddPolicy(PolicyID(1), "ns1", nil, nil)
+	err = s.AddGenericPolicy(PolicyID(1), "ns1", nil, nil)
 	require.NoError(t, err)
-	err = s.AddPolicy(PolicyID(2), "ns2", nil, nil)
+	err = s.AddGenericPolicy(PolicyID(2), "ns2", nil, nil)
 	require.NoError(t, err)
-	err = s.AddPolicy(PolicyID(3), "ns3", nil, nil)
+	err = s.AddGenericPolicy(PolicyID(3), "ns3", nil, nil)
 	require.NoError(t, err)
 
 	pod1 := PodID(uuid.New())
@@ -67,14 +67,14 @@ func TestState(t *testing.T) {
 		3: {3001, 3002, 3003},
 	})
 
-	err = s.DelPolicy(PolicyID(1))
+	err = s.DeleteGenericPolicy(PolicyID(1))
 	require.NoError(t, err)
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
 		2: {2001, 2002},
 		3: {3001, 3002, 3003},
 	})
 
-	err = s.DelPolicy(PolicyID(2))
+	err = s.DeleteGenericPolicy(PolicyID(2))
 	require.NoError(t, err)
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
 		3: {3001, 3002, 3003},
@@ -86,7 +86,7 @@ func TestState(t *testing.T) {
 		3: {3001},
 	})
 
-	err = s.DelPolicy(PolicyID(3))
+	err = s.DeleteGenericPolicy(PolicyID(3))
 	require.NoError(t, err)
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{})
 

--- a/pkg/policyfilter/template_info.go
+++ b/pkg/policyfilter/template_info.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package policyfilter
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+)
+
+type tracingPolicyTemplate struct {
+	id             PolicyID
+	cgroupToPolicy *ebpf.Map
+}
+
+func (m *state) findTracingPolicyTemplate(polID PolicyID) int32 {
+	for i, info := range m.tracingPolicyTemplates {
+		if info.id == polID {
+			return int32(i)
+		}
+	}
+	return -1
+}
+
+func (m *state) AddTracingPolicyTemplate(polID PolicyID, cgroupToPolicy *ebpf.Map) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.log.Info("state: add tracing policy template", "template_id", polID)
+
+	if m.findTracingPolicyTemplate(polID) != -1 {
+		return fmt.Errorf("template with id %d already exists: not adding new one", polID)
+	}
+
+	info := &tracingPolicyTemplate{
+		id:             polID,
+		cgroupToPolicy: cgroupToPolicy,
+	}
+
+	m.tracingPolicyTemplates = append(m.tracingPolicyTemplates, info)
+	return nil
+}
+
+func (m *state) DeleteTracingPolicyTemplate(polID PolicyID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.log.Info("state: delete tracing policy template", "template_id", polID)
+	index := m.findTracingPolicyTemplate(polID)
+	if index == -1 {
+		return fmt.Errorf("template with id %d does not exist: not deleting", polID)
+	}
+
+	for i := range m.pods {
+		pod := &m.pods[i]
+		pod.delCachedPolicy(polID)
+	}
+
+	// delete all policies associated with this tracingPolicyTemplate
+	for i := range m.policies {
+		pol, ok := m.policies[i].(*bindingPolicy)
+		if !ok {
+			continue
+		}
+		if pol.template.id != polID {
+			continue
+		}
+
+		// For each policy we need to remove the associated pods cached policy
+		for i := range m.pods {
+			pod := &m.pods[i]
+			pod.delCachedPolicy(pol.getID())
+		}
+
+		m.log.Warn("state: delete policy because its parent template was deleted", "policy_id", pol.getID(), "template_id", polID)
+		// we don't need to iterate over the ebpf maps to clean the cgroup in this case since we are deleting the whole policy
+		m.policies = append(m.policies[:i], m.policies[i+1:]...)
+	}
+
+	m.tracingPolicyTemplates = append(m.tracingPolicyTemplates[:index], m.tracingPolicyTemplates[index+1:]...)
+	return nil
+}

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -703,14 +703,13 @@ func writeMatchValues(k *KernelSelectorState, values []string, ty, op uint32) er
 	return nil
 }
 
-func writeMatchStrings(k *KernelSelectorState, values []string, ty uint32) error {
-	maps := k.createStringMaps()
-
+func ConvertValuesToMaps(values []string, ty uint32) (SelectorStringMaps, error) {
+	maps := createStringMaps()
 	for _, v := range values {
 		trimNulSuffix := ty == gt.GenericStringType
 		value, size, err := ArgStringSelectorValue(v, trimNulSuffix)
 		if err != nil {
-			return fmt.Errorf("MatchArgs value %s invalid: %w", v, err)
+			return maps, fmt.Errorf("value %s invalid: %w", v, err)
 		}
 		numSubMaps := StringMapsNumSubMaps
 		if !kernels.MinKernelVersion("5.11") {
@@ -728,6 +727,14 @@ func writeMatchStrings(k *KernelSelectorState, values []string, ty uint32) error
 				break
 			}
 		}
+	}
+	return maps, nil
+}
+
+func writeMatchStrings(k *KernelSelectorState, values []string, ty uint32) error {
+	maps, err := ConvertValuesToMaps(values, ty)
+	if err != nil {
+		return err
 	}
 	// write the map ids into the selector
 	mapDetails := k.insertStringMaps(maps)
@@ -882,6 +889,34 @@ func ParseMatchData(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1a
 	return parseMatchArg(k, arg, sig, ty)
 }
 
+const templateValue = "*"
+
+func checkTemplateValueIsValid(arg *v1alpha1.ArgSelector, op uint32, ty uint32) error {
+	switch op {
+	case SelectorOpEQ, SelectorOpNEQ:
+	default:
+		return fmt.Errorf("operator %s not supported with template value", selectorOpStringTable[op])
+	}
+
+	switch ty {
+	case gt.GenericFdType, gt.GenericFileType, gt.GenericPathType, gt.GenericStringType, gt.GenericCharBuffer, gt.GenericLinuxBinprmType, gt.GenericDataLoc, gt.GenericNetDev:
+	default:
+		return fmt.Errorf("type %s not supported with template value", gt.GenericTypeString(int(ty)))
+	}
+	return nil
+}
+
+func isTemplateValue(arg *v1alpha1.ArgSelector) bool {
+	if len(arg.Values) != 1 {
+		return false
+	}
+
+	if arg.Values[0] != templateValue {
+		return false
+	}
+	return true
+}
+
 func parseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1alpha1.KProbeArg, ty uint32) error {
 	op, err := SelectorOp(arg.Operator)
 	if err != nil {
@@ -894,6 +929,19 @@ func parseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 	WriteSelectorUint32(&k.data, op)
 	moff := AdvanceSelectorLength(&k.data)
 	WriteSelectorUint32(&k.data, ty)
+
+	// just for now until we decide a UX
+	if isTemplateValue(arg) {
+		if err := checkTemplateValueIsValid(arg, op, ty); err != nil {
+			return fmt.Errorf("template value error: %w", err)
+		}
+
+		// we don't populate the selector in case of a template because values will be populated at runtime
+		// the selector length is always 8 in this case (selector_len + type)
+		WriteSelectorLength(&k.data, moff)
+		return nil
+	}
+
 	switch op {
 	case SelectorOpInRange, SelectorOpNotInRange:
 		err := writeMatchValuesRange(k, arg.Values, ty)

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -472,7 +472,7 @@ func TestParseMatchArg(t *testing.T) {
 	expected1 := []byte{
 		0x00, 0x00, 0x00, 0x00, // Index == 0
 		0x03, 0x00, 0x00, 0x00, // operator == equal
-		52, 0x00, 0x00, 0x00, // length == 32
+		52, 0x00, 0x00, 0x00, // length == 52
 		0x06, 0x00, 0x00, 0x00, // value type == string
 		0x00, 0x00, 0x00, 0x00, // map ID for strings <25
 		0xff, 0xff, 0xff, 0xff, // map ID for strings 25-48
@@ -603,6 +603,26 @@ func TestParseMatchArg(t *testing.T) {
 		if err := ParseMatchArgs(ks, arg12, []v1alpha1.ArgSelector{}, sig, []v1alpha1.KProbeArg{}); err != nil || bytes.Equal(expected3, d.e[0:d.off]) == false {
 			t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected3, d.e[0:d.off], arg3)
 		}
+	}
+}
+
+func TestParseMatchArgForEach(t *testing.T) {
+	sig := []v1alpha1.KProbeArg{
+		v1alpha1.KProbeArg{Index: 1, Type: "linux_binprm", SizeArgIndex: 0, ReturnCopy: false},
+	}
+
+	arg1 := &v1alpha1.ArgSelector{Index: 1, Operator: "Equal", Values: []string{templateValue}}
+	k := NewKernelSelectorState(nil, nil, false)
+	d := &k.data
+
+	expected1 := []byte{
+		0x00, 0x00, 0x00, 0x00, // Index == 0
+		0x03, 0x00, 0x00, 0x00, // operator == equal
+		8, 0x00, 0x00, 0x00, // length == 8
+		0x25, 0x00, 0x00, 0x00, // value type == linux_binprm
+	}
+	if err := ParseMatchArg(k, arg1, sig); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
+		t.Errorf("parseMatchArg: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected1, d.e[0:d.off], arg1)
 	}
 }
 

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -434,7 +434,7 @@ func (k *KernelSelectorState) insertAddr6Map(addr6map map[KernelLPMTrie6]struct{
 	return uint32(mapid)
 }
 
-func (k *KernelSelectorState) createStringMaps() SelectorStringMaps {
+func createStringMaps() SelectorStringMaps {
 	return SelectorStringMaps{
 		{},
 		{},

--- a/pkg/sensors/handler.go
+++ b/pkg/sensors/handler.go
@@ -6,11 +6,17 @@ package sensors
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
+	"github.com/cilium/ebpf"
 	"github.com/cilium/tetragon/api/v1/tetragon"
-	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/tetragon/pkg/bpf"
+	gt "github.com/cilium/tetragon/pkg/generictypes"
+	"github.com/cilium/tetragon/pkg/kernels"
+	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/policyfilter"
+	"github.com/cilium/tetragon/pkg/selectors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
 
@@ -74,38 +80,199 @@ func SensorsFromPolicy(tp tracingpolicy.TracingPolicy, filterID policyfilter.Pol
 //	policyfilter.PolicyID(tpID), nil if filtering is needed and policyfilter has been successfully set up
 //	_, err if an error occurred
 func (h *handler) updatePolicyFilter(tp tracingpolicy.TracingPolicy, tpID uint64) (policyfilter.PolicyID, error) {
-	var namespace string
-	if tpNs, ok := tp.(tracingpolicy.TracingPolicyNamespaced); ok {
-		namespace = tpNs.TpNamespace()
-	}
+	namespace, podSelector, containerSelector := getNamespaceAndSelectors(tp)
 
-	var podSelector *slimv1.LabelSelector
-	if ps := tp.TpSpec().PodSelector; ps != nil {
-		if len(ps.MatchLabels)+len(ps.MatchExpressions) > 0 {
-			podSelector = ps
-		}
-	}
-
-	var containerSelector *slimv1.LabelSelector
-	if ps := tp.TpSpec().ContainerSelector; ps != nil {
-		if len(ps.MatchLabels)+len(ps.MatchExpressions) > 0 {
-			containerSelector = ps
-		}
-	}
-
-	// we do not call AddPolicy unless filtering is actually needed. This
+	// we do not call AddGenericPolicy unless filtering is actually needed. This
 	// means that if policyfilter is disabled
 	// (option.Config.EnablePolicyFilter is false) then loading the policy
 	// will only fail if filtering is required.
 	if namespace == "" && podSelector == nil && containerSelector == nil {
+		// if this is a policy template we will return here because we validated the policy ahead of time
 		return policyfilter.NoFilterID, nil
 	}
 
 	filterID := policyfilter.PolicyID(tpID)
-	if err := h.pfState.AddPolicy(filterID, namespace, podSelector, containerSelector); err != nil {
+	if err := h.pfState.AddGenericPolicy(filterID, namespace, podSelector, containerSelector); err != nil {
 		return policyfilter.NoFilterID, err
 	}
 	return filterID, nil
+}
+
+func (h *handler) addTracingPolicyBinding(currCol *collection) error {
+	var err error
+	defer func() {
+		if err != nil {
+			currCol.err = err
+			currCol.state = LoadErrorState
+		} else {
+			currCol.state = EnabledState
+		}
+	}()
+
+	namespace, podSelector, containerSelector := getNamespaceAndSelectors(currCol.tracingpolicy)
+	if namespace == "" && podSelector == nil && containerSelector == nil {
+		return errors.New("we should have at least a pod or container selector for binding policies")
+	}
+
+	spec := currCol.tracingpolicy.TpSpec()
+
+	// Get the referenced policy name
+	refPolicyName := getRefPolicyFromOptions(spec.Options)
+	// default format is name only
+	namespaceRefPol := "" // if not namespaced the namespace should be ""
+	nameRefPol := refPolicyName
+	parts := strings.Split(refPolicyName, "/")
+	if len(parts) == 2 {
+		// if namespaced this is in namespace/name format
+		namespaceRefPol = parts[0]
+		nameRefPol = parts[1]
+	}
+
+	ck := collectionKey{nameRefPol, namespaceRefPol}
+
+	refCol, exists := h.collections.c[ck]
+	if !exists {
+		return fmt.Errorf("referenced policy %s does not exist", ck)
+	}
+
+	// todo: today we don't support enable/disable of binding policies
+	if refCol.state != EnabledState {
+		return fmt.Errorf("referenced policy %s is not enabled", ck)
+	}
+
+	if refCol.templateState == nil {
+		return fmt.Errorf("referenced policy %s does not have template state", ck)
+	}
+
+	// Get values from the policy
+	// comma separated list of values
+	valuesList := getValuesFromOptions(spec.Options)
+	values := strings.Split(valuesList, ",")
+
+	// Create the workload map before populating the cgroup->policy map
+	subMaps, err := selectors.ConvertValuesToMaps(values, refCol.templateState.ArgType)
+	if err != nil {
+		return fmt.Errorf("failed to convert values to maps: %w", err)
+	}
+
+	policyID := policyfilter.PolicyID(currCol.tracingpolicyID)
+	stringMaps := refCol.templateState.PolicyStringMaps
+	preKernelVersion5_9 := !kernels.MinKernelVersion("5.9")
+	preKernelVersion5_11 := !kernels.MinKernelVersion("5.11")
+
+	for i := range subMaps {
+		// if the subMap is empty we skip it
+		if len(subMaps[i]) == 0 {
+			continue
+		}
+
+		mapKeySize := selectors.StringMapsSizes[i]
+		if i == 7 && preKernelVersion5_11 {
+			mapKeySize = selectors.StringMapSize7a
+		}
+
+		name := fmt.Sprintf("p_%d_str_map_%d", policyID, i)
+		innerSpec := &ebpf.MapSpec{
+			Name:       name,
+			Type:       ebpf.Hash,
+			KeySize:    uint32(mapKeySize),
+			ValueSize:  uint32(1),
+			MaxEntries: uint32(len(subMaps[i])),
+		}
+
+		if preKernelVersion5_9 {
+			innerSpec.Flags = uint32(bpf.BPF_F_NO_PREALLOC)
+			innerSpec.MaxEntries = uint32(200)
+		}
+
+		inner, err := ebpf.NewMap(innerSpec)
+		if err != nil {
+			return fmt.Errorf("failed to create inner_map: %w", err)
+		}
+
+		// update values
+		// todo: ideally we should rollback if any of these fail
+		one := uint8(1)
+		for rawVal := range subMaps[i] {
+			val := rawVal[:mapKeySize]
+			err := inner.Update(val, one, 0)
+			if err != nil {
+				return fmt.Errorf("failed to insert value into %s: %w", name, err)
+			}
+		}
+
+		err = stringMaps[i].Update(policyID, uint32(inner.FD()), ebpf.UpdateNoExist)
+		if err != nil && errors.Is(err, ebpf.ErrKeyExist) {
+			logger.GetLogger().Warn("inner policy map entry already exists, retrying update", "map", name, "policyID", policyID)
+			err = stringMaps[i].Update(policyID, uint32(inner.FD()), 0)
+		}
+		inner.Close()
+		if err != nil {
+			return fmt.Errorf("failed to insert inner policy (id=%d) map: %w", policyID, err)
+		}
+		logger.GetLogger().Info("handler: add new inner map inside policy str", "name", name)
+	}
+
+	err = h.pfState.AddTracingPolicyBinding(policyID, policyfilter.PolicyID(refCol.tracingpolicyID), namespace, podSelector, containerSelector)
+	if err != nil {
+		// cleanup of the maps
+		for i := range subMaps {
+			err = stringMaps[i].Delete(policyID)
+			if err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+				logger.GetLogger().Warn("map entry doesn't exist, retrying update", "map", stringMaps[i].String(), "policyID", policyID)
+			}
+		}
+		return fmt.Errorf("failed to add for-each-cgroup-values policy to policyfilter: %w", err)
+	}
+
+	currCol.refCollection = refCol
+	logger.GetLogger().Info("handler: add tracing policy binding to template", "name", currCol.name, "policy_id", currCol.tracingpolicyID, "template_id", refCol.tracingpolicyID)
+	return nil
+}
+
+func (h *handler) addTracingPolicyTemplate(col *collection) error {
+	if len(col.sensors) == 0 {
+		return errors.New("template policy requires at least one sensor")
+	}
+
+	// all sensors should have the maps we need since are shared across sensors, so we use the first one for simplicity
+	sensor := col.sensors[0]
+
+	// Get the cgroup to policy map handle
+	cgroupMapHandle := sensor.GetCgroupToPolicyMapHandle()
+	if cgroupMapHandle == nil {
+		return errors.New("template policy requires a cgroup to policy map")
+	}
+
+	// Get the policy string maps
+	policyStringMaps := sensor.GetPolicyStringMapHandles()
+	if len(policyStringMaps) == 0 {
+		return errors.New("template policy requires policy string maps")
+	}
+
+	// We will need the type when populating the maps for the template
+	argTypeString := getArgTypeFromOptions(col.tracingpolicy.TpSpec().Options)
+	if argTypeString == "" {
+		return errors.New("template policy requires arg type option")
+	}
+	argType := gt.GenericTypeFromString(argTypeString)
+	if argType == gt.GenericInvalidType {
+		return fmt.Errorf("invalid arg type string: %s", argTypeString)
+	}
+
+	// Populate the state of the collection
+	col.templateState = &TemplateState{
+		ArgType:          uint32(argType),
+		PolicyStringMaps: policyStringMaps,
+	}
+
+	// we can use the tracingpolicyID as identifier since it is unique in the policyFilter state
+	if err := h.pfState.AddTracingPolicyTemplate(policyfilter.PolicyID(col.tracingpolicyID), cgroupMapHandle); err != nil {
+		return err
+	}
+
+	logger.GetLogger().Info("handler: add tracing policy template", "name", col.name, "namespace", "template_id", col.tracingpolicyID)
+	return nil
 }
 
 func (h *handler) addTracingPolicy(op *tracingPolicyAdd) error {
@@ -125,6 +292,10 @@ func (h *handler) addTracingPolicy(op *tracingPolicyAdd) error {
 		tracingpolicyID: uint64(tpID),
 	}
 	collections[op.ck] = &col
+
+	if isTracingPolicyBinding(op.tp.TpSpec().Options) {
+		return h.addTracingPolicyBinding(&col)
+	}
 
 	// update policy filter state before loading the sensors of the policy.
 	//
@@ -163,7 +334,50 @@ func (h *handler) addTracingPolicy(op *tracingPolicyAdd) error {
 		col.state = LoadErrorState
 		return err
 	}
+
+	if IsTracingPolicyTemplate(op.tp.TpSpec().Options) {
+		if err = h.addTracingPolicyTemplate(&col); err != nil {
+			col.err = err
+			col.state = LoadErrorState
+			return err
+		}
+	}
+
 	col.state = EnabledState
+	return nil
+}
+
+func (h *handler) deleteTracingPolicyBinding(col *collection) error {
+	if col.refCollection == nil {
+		return errors.New("deleteTracingPolicyBinding called on a non-binding policy")
+	}
+
+	logger.GetLogger().Info("handler: delete tracing policy binding for template", "name", col.name, "policy_id", col.tracingpolicyID, "template_id", col.refCollection.tracingpolicyID)
+
+	// first remove the mapping cgroup -> policy
+	if err := h.pfState.DeleteTracingPolicyBinding(policyfilter.PolicyID(col.tracingpolicyID)); err != nil {
+		return err
+	}
+
+	// We need to remove the entries in the string maps
+	maps := col.refCollection.templateState.PolicyStringMaps
+	for i := range maps {
+		logger.GetLogger().Info("handler: delete entry in the policy string map", "map_name", maps[i].String(), "map_id", i, "policy_id", col.tracingpolicyID)
+		err := maps[i].Delete(policyfilter.PolicyID(col.tracingpolicyID))
+		if err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+			logger.GetLogger().Warn("cannot delete map entry", "map", maps[i].String(), "policyID", col.tracingpolicyID, "error", err)
+		}
+	}
+	return nil
+}
+
+func (h *handler) deleteTracingPolicyTemplate(col *collection) error {
+	logger.GetLogger().Info("handler: delete tracing policy template", "name", col.name, "id", col.tracingpolicyID)
+
+	// first we need to disable the cgroup -> policy population from the pods in the policyfilter state
+	if err := h.pfState.DeleteTracingPolicyTemplate(policyfilter.PolicyID(col.tracingpolicyID)); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -175,15 +389,43 @@ func (h *handler) deleteTracingPolicy(op *tracingPolicyDelete) error {
 		h.collections.mu.Unlock()
 		return fmt.Errorf("tracing policy %s does not exist", op.ck)
 	}
+
+	if col.isCollectionBinding() {
+		if err := h.deleteTracingPolicyBinding(col); err != nil {
+			h.collections.mu.Unlock()
+			return fmt.Errorf("failed to delete tracing policy binding %s: %w", op.ck, err)
+		}
+	}
+
+	if col.isCollectionTemplate() {
+		if err := h.deleteTracingPolicyTemplate(col); err != nil {
+			h.collections.mu.Unlock()
+			return fmt.Errorf("failed to delete tracing policy binding %s: %w", op.ck, err)
+		}
+
+		// remove all the collections associated with this template
+		for k, c := range collections {
+			if !c.isCollectionBinding() {
+				continue
+			}
+			if c.refCollection.tracingpolicyID != col.tracingpolicyID {
+				continue
+			}
+			delete(collections, k)
+		}
+	}
+
 	delete(collections, op.ck)
 	// we have removed the collection, so unlock the map so that the lister can quickly view
 	// that the collection is gone
 	h.collections.mu.Unlock()
 
+	// this has no effect for tracing bindings
 	col.destroy(true)
 
+	// this has no effect for tracing bindings and templates
 	filterID := policyfilter.PolicyID(col.policyfilterID)
-	err := h.pfState.DelPolicy(filterID)
+	err := h.pfState.DeleteGenericPolicy(filterID)
 	if err != nil {
 		return fmt.Errorf("failed to remove from policyfilter: %w", err)
 	}

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -120,6 +120,12 @@ type TracingPolicy interface {
 // NB: if tp implements tracingpolicy.TracingPolicyNamespaced, it will be
 // treated as a namespaced policy
 func (h *Manager) AddTracingPolicy(ctx context.Context, tp tracingpolicy.TracingPolicy) error {
+	// Here we validate the tracing policy before adding it
+	err := validateTracingPolicy(tp)
+	if err != nil {
+		return err
+	}
+
 	var namespace string
 	if tpNs, ok := tp.(tracingpolicy.TracingPolicyNamespaced); ok {
 		namespace = tpNs.TpNamespace()

--- a/pkg/sensors/tracing_policy_helpers.go
+++ b/pkg/sensors/tracing_policy_helpers.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package sensors
+
+import (
+	"errors"
+
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/tetragon/pkg/tracingpolicy"
+)
+
+func getNamespaceAndSelectors(tp tracingpolicy.TracingPolicy) (string, *slimv1.LabelSelector, *slimv1.LabelSelector) {
+	var namespace string
+	if tpNs, ok := tp.(tracingpolicy.TracingPolicyNamespaced); ok {
+		namespace = tpNs.TpNamespace()
+	}
+
+	var podSelector *slimv1.LabelSelector
+	if ps := tp.TpSpec().PodSelector; ps != nil {
+		if len(ps.MatchLabels)+len(ps.MatchExpressions) > 0 {
+			podSelector = ps
+		}
+	}
+
+	var containerSelector *slimv1.LabelSelector
+	if ps := tp.TpSpec().ContainerSelector; ps != nil {
+		if len(ps.MatchLabels)+len(ps.MatchExpressions) > 0 {
+			containerSelector = ps
+		}
+	}
+	return namespace, podSelector, containerSelector
+}
+
+func validateTracingPolicy(tp tracingpolicy.TracingPolicy) error {
+	tpSpec := tp.TpSpec()
+	if tpSpec == nil {
+		return errors.New("tracing policy spec is nil")
+	}
+
+	/////////////////////////
+	// Validate if the tracing policy has bindings
+	/////////////////////////
+	hasBindings := IsTracingPolicyTemplate(tpSpec.Options)
+	if !hasBindings {
+		return nil
+	}
+
+	// if the tracing policy has bindings it cannot have podSelector/containerSelector/namespace, because it is considered "a template".
+	// The selectors will be applied when we deploy the TracingPolicyBinding CRs
+	// This is just a basic validation we implement here to avoid falling in the global policyfilter case.
+	namespace, podSelector, containerSelector := getNamespaceAndSelectors(tp)
+	if namespace != "" || podSelector != nil || containerSelector != nil {
+		return errors.New("podSelector, containerSelector or namespace cannot be used in a tracing policy template with bindings")
+	}
+	return nil
+}
+
+func getRefPolicyFromOptions(opts []v1alpha1.OptionSpec) string {
+	for _, opt := range opts {
+		if opt.Name == "policy-template-ref" {
+			return opt.Value
+		}
+	}
+	return ""
+}
+
+func getValuesFromOptions(opts []v1alpha1.OptionSpec) string {
+	for _, opt := range opts {
+		if opt.Name == "values" {
+			return opt.Value
+		}
+	}
+	return ""
+}
+
+func getBinidingFromOptions(opts []v1alpha1.OptionSpec) string {
+	for _, opt := range opts {
+		if opt.Name == "binding" {
+			return opt.Value
+		}
+	}
+	return ""
+}
+
+func getArgTypeFromOptions(opts []v1alpha1.OptionSpec) string {
+	for _, opt := range opts {
+		if opt.Name == "arg-type" {
+			return opt.Value
+		}
+	}
+	return ""
+}
+
+func isTracingPolicyBinding(opts []v1alpha1.OptionSpec) bool {
+	return getRefPolicyFromOptions(opts) != "" && getBinidingFromOptions(opts) != "" && getValuesFromOptions(opts) != ""
+}
+
+func IsTracingPolicyTemplate(opts []v1alpha1.OptionSpec) bool {
+	return getBinidingFromOptions(opts) != "" && getArgTypeFromOptions(opts) != ""
+}

--- a/pkg/testutils/policyfilter/policyfilter.go
+++ b/pkg/testutils/policyfilter/policyfilter.go
@@ -8,6 +8,7 @@ import (
 
 	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 
+	"github.com/cilium/ebpf"
 	"github.com/cilium/tetragon/pkg/labels"
 	"github.com/cilium/tetragon/pkg/podhelpers"
 	"github.com/cilium/tetragon/pkg/policyfilter"
@@ -15,16 +16,33 @@ import (
 
 // DummyPF implements policyfilter.State.
 // It's very similar to the disabled state, with the difference that it doesn't
-// return an error on AddPolicy and DelPolicy. It can be used in tests where
+// return an error on AddGenericPolicy and DeleteGenericPolicy. It can be used in tests where
 // a namespaced policy must be loaded, but the policyfilter doesn't matter.
 type DummyPF struct{}
 
-func (s *DummyPF) AddPolicy(_ policyfilter.PolicyID, _ string, _ *slimv1.LabelSelector,
+func (s *DummyPF) AddGenericPolicy(_ policyfilter.PolicyID, _ string, _ *slimv1.LabelSelector,
 	_ *slimv1.LabelSelector) error {
 	return nil
 }
 
-func (s *DummyPF) DelPolicy(_ policyfilter.PolicyID) error {
+func (s *DummyPF) AddTracingPolicyBinding(polID policyfilter.PolicyID, refPolID policyfilter.PolicyID, namespace string, podLabelSelector *slimv1.LabelSelector,
+	containerLabelSelector *slimv1.LabelSelector) error {
+	return nil
+}
+
+func (s *DummyPF) DeleteGenericPolicy(_ policyfilter.PolicyID) error {
+	return nil
+}
+
+func (s *DummyPF) DeleteTracingPolicyBinding(polID policyfilter.PolicyID) error {
+	return nil
+}
+
+func (s *DummyPF) AddTracingPolicyTemplate(polID policyfilter.PolicyID, cgroupToPolicy *ebpf.Map) error {
+	return nil
+}
+
+func (s *DummyPF) DeleteTracingPolicyTemplate(polID policyfilter.PolicyID) error {
 	return nil
 }
 

--- a/poc/README.md
+++ b/poc/README.md
@@ -1,0 +1,41 @@
+# Run the POC
+
+From the tetragon root directory, run:
+
+```bash
+make kind-setup
+# now tetragon should be running in kind
+
+# deploy a simple app with the right deployment label
+kubectl apply -f ./poc/test/app.yaml
+
+# Create the template
+kubectl apply -f ./poc/test/template.yaml
+
+# Create the binding for the above app deployment
+kubectl apply -f ./poc/test/binding1.yaml
+
+# Tetragon in one terminal
+kubectl exec -ti -n tetragon ds/tetragon -c tetragon -- tetra getevents -o compact --pods app-1
+
+# Enter the app pod
+kubectl exec -ti deploy/app-1 -- bash
+```
+
+Now inside the app pod we should receive a notification only when the binary `/usr/bin/nmap` is executed, this is what we defined in the binding1 above.
+Running `/usr/bin/nmap` should produce the following output:
+
+```txt
+❓ syscall default/app-1-ffd9b9b9b-47wjw /bin/bash security_bprm_creds_for_exec     
+🚀 process default/app-1-ffd9b9b9b-47wjw /usr/bin/nmap                    
+💥 exit    default/app-1-ffd9b9b9b-47wjw /usr/bin/nmap  255  
+```
+
+## Cleanup
+
+```bash
+kubectl delete -f ./poc/test/binding1.yaml
+kubectl delete -f ./poc/test/template.yaml
+kubectl delete -f ./poc/test/app.yaml
+make kind-down
+```

--- a/poc/test/app.yaml
+++ b/poc/test/app.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-1
+  labels:
+    app: "my-deployment-1"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-deployment-1
+  template:
+    metadata:
+      labels:
+        app: my-deployment-1
+    spec:
+      containers:
+      - name: netshoot-1
+        image: andreater/netshoot:v1
+        command: ["sleep", "10d"]

--- a/poc/test/binding1.yaml
+++ b/poc/test/binding1.yaml
@@ -1,0 +1,15 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "block-process-template-values-1"
+spec:
+  podSelector:
+    matchLabels:
+      app: "my-deployment-1"
+  options:
+  - name: binding
+    value: "targetExecPaths"
+  - name: values
+    value: "/usr/bin/nmap"
+  - name: policy-template-ref
+    value: "block-process-template"

--- a/poc/test/template.yaml
+++ b/poc/test/template.yaml
@@ -1,0 +1,24 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "block-process-template"
+spec:
+  kprobes:
+  - call: "security_bprm_creds_for_exec"
+    syscall: false
+    args:
+    - index: 0
+      type: "linux_binprm"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+        - "*"
+  options:
+  - name: disable-kprobe-multi
+    value: "1"
+  - name: binding
+    value: "targetExecPaths"
+  - name: arg-type
+    value: "linux_binprm"


### PR DESCRIPTION
This PR introduces a Proof of Concept to address the issues discussed in <https://github.com/cilium/tetragon/issues/4191>.  
This approach attempts to solve the two main problems described in the issue:

1. Decrease memory usage for each policy.  
2. Instead of deploying a new program for each policy, deploy a unique eBPF program that can be shared by multiple policies.

The primary use case is deploying a distinct policy for each K8s workload where the sensors and filters are identical, but the specific values being enforced (e.g., a list of binaries) differ for each workload.

> [!WARNING]
> * This PR is intended to demonstrate a potential design and start a discussion. It is not intended for a code review.  
> * Only the significant parts of the logic needed to explain the concept have been implemented. It is not a complete, functioning solution.
> * Tests, comprehensive comments, and validation checks are entirely missing.  
> * The `poc/` directory in this branch contains sample YAML files and a README.md to help test and understand this approach.

## **Ideal Design Explanation**

Let's start from the ideal solution we have in mind, and then let's see how this is translated into the POC.  
The proposed solution is based on two core concepts: **"Templates"** and **"Bindings"**.

### Template

A "template" is a `TracingPolicy` that specifies variables which can be populated at runtime, rather than being hardcoded at load time. Selectors within the policy reference these variables by name.

```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "block-process-template"
spec:
  variables:
  - name: "targetExecPaths"
    type: "linux_binprm" # this could be used for extra validation but it's probably not strictly necessary
  kprobes:
  - call: "security_bprm_creds_for_exec"
    syscall: false
    args:
    - index: 0
      type: "linux_binprm"
    selectors:
    - matchArgs:
      - index: 0
        operator: "Equal"
        valuesFromVariable: "targetExecPaths"
```

When a template policy is deployed, it loads the necessary eBPF programs and maps, but it has no runtime effect because it lacks concrete values for its comparisons.

### Binding

A "binding" is a new resource (e.g., `TracingPolicyBinding`) that provides concrete values for a template's variables and applies them to specific workloads.

```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicyBinding
metadata:
  name: "block-process-template-values-1"
spec:
  policyTemplateRef:
    name: "block-process-template"
  podSelector:
    matchLabels:
      app: "my-app-1"
  bindings:
  - name: "targetExecPaths"
    values:
    - "/usr/bin/true"
    - "/usr/bin/ls"
```

The policy logic becomes active only when a `TracingPolicyBinding` is deployed. This action populates the template's eBPF maps with the specified values for the cgroups matching the podSelector.

## **POC Implementation**

To minimize changes for this POC, we reuse the existing `TracingPolicy` resource and its `OptionSpec` to simulate both templates and bindings.  
**Template:** A template is defined as a TracingPolicy using these options:  
  
```yaml
  - name: binding # Ideally "variable", but "binding" is used in the POC
    value: "targetExecPaths"
  - name: arg-type
    value: "linux_binprm"
```

**Binding:**  A binding is also a TracingPolicy (which would ideally be a TracingPolicyBinding) that references the template and provides values. This POC currently supports only one binding.

```yaml
apiVersion: cilium.io/v1alpha1  
kind: TracingPolicy  
metadata:  
  name: "block-process-template-values-1"  
spec:  
  podSelector:  
    matchLabels:  
      app: "my-deployment-1"  
  options:  
  - name: binding  
    value: "targetExecPaths"  
  - name: values  
    value: "/usr/bin/nmap"  
  - name: policy-template-ref  
    value: "block-process-template"
```

### Details

* When the template `TracingPolicy` is deployed, the eBPF programs and maps are loaded.  
* A new `BPF_MAP_TYPE_HASH`, `cg_to_policy_map` is introduced. It stores a mapping from `cgroupid-> policy_id`. This allows us to look up a policy ID from a cgroupid, which is the reverse of the current `policy_filter_cgroup_maps` (a `BPF_MAP_TYPE_HASH_OF_MAPS`).  
* When a "binding" TracingPolicy is deployed:  
  * It is assigned a new `policy_id`.  
  * For all cgroups matching its podSelector, an entry (`cgroupid->policy_id`) is added to the `cg_to_policy_map`.  
  * The binding's main job is to populate this map, thereby activating the template's logic for the targeted cgroups.  
  * To store the values from the binding, new `BPF_MAP_TYPE_HASH_OF_MAPS` are used: `pol_str_maps_*`. This implementation is very specific to string/charbuf/filename types and the eq/neq operators, but the concept can be extended to other types/operators, more on this later.
  * These maps are keyed by the `policy_id` (obtained from `cg_to_policy_map`).
  * The value is a hash set of strings (the values from the binding), using the same 11-map-size-bucket technique as the existing `string_maps_*`.

> [!NOTE]
> A `cgroup_id` can only be associated with one `policy_id` (binding) at a time. A new binding for the same cgroup should either be rejected or overwrite the existing one. For example, binding `cgroup1` to both `policy_1` (values: `/bin/ls`) and `policy_5` (values: `/bin/cat`) simultaneously is not logical.

### Current Limitations & Hacks

* The value-matching logic is currently limited to:  
  * matchArgs / matchData filters  
  * String / charbuf / filename types  
  * eq / neq operators  
* Extending this to other types/operators would require different eBPF maps/approaches. We think that we could also have a v1 with only some operators/types supported but the design of the API and eBPF program should be flexible enough to allow future extensions without breaking changes.
* Same thing for multiple bindings per template, currently only one binding is supported but the design should be extensible to support multiple bindings without API changes. I'm not sure multi-binding support would be really needed in practice for this reason i would avoid complicating the code too much until we have a real use case for it.
* A hack is used to signal the eBPF program to use the new `pol_str_maps_*` instead of a hardcoded value: we set `vallen=8` in the `selector_arg_filter`. I've to admit i've not verified this approach too much since i think this is not a sustainable solution but just works for the POC.

## Summary & Goals

This design provides a path toward achieving the two goals of the issue:

1. **Single eBPF Program:** A single, shared eBPF program can serve `n` policies (e.g., 512-1024 or more), as they all reference the same template. This drastically reduces the number of eBPF programs loaded in the kernel.
2. **Low Memory Overhead:** The memory increase for each new policy (binding) is minimal. It's limited to new entries in `cg_to_policy_map` and the `pol_str_maps_*` (likely a few KB per policy, assuming non-massive value lists).
