### PR TITLE
bug: Avoid overwritten slogLeveler

### DIFF
--- a/pkg/logger/slog.go
+++ b/pkg/logger/slog.go
@@ -51,9 +51,10 @@ var slogLeveler = func() *slog.LevelVar {
 // phase.
 func initializeSlog(logOpts LogOptions, useStdout bool) {
 	opts := *slogHandlerOpts
-	opts.Level = logOpts.GetLogLevel()
+	lv := logOpts.GetLogLevel()
+	SetLogLevel(lv)
 
-	if opts.Level == slog.LevelDebug {
+	if lv == slog.LevelDebug {
 		opts.AddSource = true
 	}
 


### PR DESCRIPTION
This commit is to use SetLogLevel func to set the log level, instead of overwrite opts.Lelvel, which overwrites slogLeveler function i.e. we can't change the log level later during runtime.

Fixes: 09226dd9116da81b29ddede896f7827f7a1a62af

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

```release-note
bug: Avoid overwritten slogLeveler
```
