### PR TITLE
new(pkg/sensors): add a `ListCollections` method on sensors Manager.

### DIFF
--- a/pkg/sensors/collection.go
+++ b/pkg/sensors/collection.go
@@ -11,6 +11,8 @@ import (
 
 	"go.uber.org/multierr"
 
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/policyconf"
@@ -60,6 +62,18 @@ func (ck *collectionKey) String() string {
 		return fmt.Sprintf("%s/%s", ck.namespace, ck.name)
 	}
 	return ck.name
+}
+
+// Exposed via ListCollections()
+type Collection struct {
+	Name              string
+	TracingpolicyName string
+	TracingpolicySpec *v1alpha1.TracingPolicySpec
+	TracingpolicyMode tetragon.TracingPolicyMode
+	TracingpolicyID   uint64
+	PolicyfilterID    uint64
+	State             TracingPolicyState
+	Err               string
 }
 
 // collection is a collection of sensors

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -219,6 +219,13 @@ func (h *Manager) LogSensorsAndProbes(ctx context.Context) {
 	log.Info("Registered probe types", "types", strings.Join(names, ", "))
 }
 
+// ListCollections is not exposed via grpc;
+// can be used internally to access the list of Collection
+// (deep copied to avoid sync issues).
+func (h *Manager) ListCollections(_ context.Context, policiesOnly bool) []*Collection {
+	return h.handler.listCollections(policiesOnly)
+}
+
 // Manager handles dynamic sensor management, such as adding / removing sensors
 // at runtime.
 type Manager struct {


### PR DESCRIPTION
### Description
While not exposed via grpc, it can be used internally to access the list of Collection (deep copied to avoid sync issues).
