### PR TITLE
helm: Handle tetragon.enabled value properly

### DIFF
--- a/install/kubernetes/tetragon/templates/daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tetragon.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -56,9 +57,7 @@ spec:
 {{- if eq .Values.export.mode "stdout" }}
       {{- include "container.export.stdout" . | nindent 6 -}}
 {{- end }}
-{{- if .Values.tetragon.enabled }}
       {{- include "container.tetragon" . | nindent 6 -}}
-{{- end }}
       {{- include "containers.extra" . | nindent 6 -}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -84,7 +83,6 @@ spec:
         hostPath:
           path: {{ .Values.exportDirectory }}
           type: DirectoryOrCreate
-{{- if .Values.tetragon.enabled }}
       - name: tetragon-config
         configMap:
           name: {{ include "tetragon.configMapName" . }}
@@ -102,7 +100,6 @@ spec:
           path: {{ quote .Values.tetragon.cri.socketHostPath }}
           type: Socket
 {{- end }}
-{{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -115,4 +112,5 @@ spec:
 {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/install/kubernetes/tetragon/templates/service.yaml
+++ b/install/kubernetes/tetragon/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tetragon.prometheus.enabled -}}
+{{- if and .Values.tetragon.enabled .Values.tetragon.prometheus.enabled -}}
 ---
 apiVersion: v1
 kind: Service

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tetragon.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -89,3 +90,4 @@ data:
   enable-cgidmap: {{ .Values.tetragon.cgidmap.enabled | quote }}
   enable-pod-annotations: {{ .Values.tetragon.podAnnotations.enabled | default "false" | quote }}
   use-perf-ring-buffer: {{ .Values.tetragon.usePerfRingBuffer | default "false" | quote }}
+{{- end }}


### PR DESCRIPTION
[ upstream commit e3a065383068f05455d4af835efd56f73baf66ea ]

Don't create Tetragon daemonset/configmap/service if tetragon.enabled is set to false. This allows users to manage CRDs using Tetragon Helm chart without running Tetragon agent/operator by setting crds.installMethod to "helm" and disabling everything else. For example:

    % helm template tetragon ./install/kubernetes/tetragon \
      --set crds.installMethod=helm \
      --set tetragon.enabled=false \
      --set tetragonOperator.enabled=false \
      --set serviceAccount.create=false