### PR TITLE
workflows: run static checks on every PR without exceptions

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -11,9 +11,8 @@ on:
       - 'docs/**'
       - '**.md'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
+    # Until https://github.com/orgs/community/discussions/44490
+    # is not resolved, run on all paths, even "**.md".
 
 permissions:
   # For golangci/golangci-lint to have read access to pull request for `only-new-issues` option.


### PR DESCRIPTION
By enabling the required checks, we bumped into this issue[^1] on the GitHub side that has not been fixed. Briefly, GitHub allows you to filter if workflow should be triggered or not using path filters on PR. But if you do so, the required checks will not take this rule into account, thus you will end up with pending checks with "Expected — Waiting for status to be reported", that will never be triggered but still required.

The workaround recommended by GitHub is to skip the job as a skipped job is considered as successful by, for using example, an action like https://github.com/dorny/paths-filter. Since these static checks are not that expensive, let's run them on every PR.

[^1]: https://github.com/orgs/community/discussions/44490
