### PR TITLE
cleanup(pkg/sensors): use ebpf `MapSpec.Compatible()`.

### DIFF
--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -268,31 +268,8 @@ func (m *Map) LoadPinnedMap(path string) error {
 	return err
 }
 
-// MapSpec.Compatible will be exported in ebpf v0.9.3,
-// meanwhile steal that and make it our own ;-)
-func compatible(ms *ebpf.MapSpec, m *ebpf.Map) error {
-	switch {
-	case m.Type() != ms.Type:
-		return fmt.Errorf("expected type %v, got %v: %w", ms.Type, m.Type(), ebpf.ErrMapIncompatible)
-
-	case m.KeySize() != ms.KeySize:
-		return fmt.Errorf("expected key size %v, got %v: %w", ms.KeySize, m.KeySize(), ebpf.ErrMapIncompatible)
-
-	case m.ValueSize() != ms.ValueSize:
-		return fmt.Errorf("expected value size %v, got %v: %w", ms.ValueSize, m.ValueSize(), ebpf.ErrMapIncompatible)
-
-	case (ms.Type != ebpf.PerfEventArray || ms.MaxEntries != 0) &&
-		m.MaxEntries() != ms.MaxEntries:
-		return fmt.Errorf("expected max entries %v, got %v: %w", ms.MaxEntries, m.MaxEntries(), ebpf.ErrMapIncompatible)
-
-	case m.Flags() != ms.Flags:
-		return fmt.Errorf("expected flags %v, got %v: %w", ms.Flags, m.Flags(), ebpf.ErrMapIncompatible)
-	}
-	return nil
-}
-
 func (m *Map) IsCompatibleWith(spec *ebpf.MapSpec) error {
-	return compatible(spec, m.MapHandle)
+	return spec.Compatible(m.MapHandle)
 }
 
 func (m *Map) Close() error {
@@ -340,7 +317,7 @@ func LoadOrCreatePinnedMap(pinPath string, mapSpec *ebpf.MapSpec, create bool) (
 		if err != nil {
 			return nil, fmt.Errorf("loading pinned map from path '%s' failed: %w", pinPath, err)
 		}
-		if err := compatible(mapSpec, m); err != nil {
+		if err := mapSpec.Compatible(m); err != nil {
 			logger.GetLogger().Warn("incompatible map found", logfields.Error, err,
 				"path", pinPath,
 				"map-name", mapSpec.Name)


### PR DESCRIPTION


### Description
Drop our own `compatible()` implementation.

