### PR TITLE
new(pkg/sensors): expose `GetPolicyTags` helper.

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -784,7 +784,7 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 		logger.GetLogger().Warn(fmt.Sprintf("TracingPolicy 'message' field too long, truncated to %d characters", TpMaxMessageLen), "policy-name", in.policyName)
 	}
 
-	tagsField, err := getPolicyTags(f.Tags)
+	tagsField, err := GetPolicyTags(f.Tags)
 	if err != nil {
 		return errFn(fmt.Errorf("error: '%w'", err))
 	}

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -234,7 +234,7 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 		logger.GetLogger().Warn(fmt.Sprintf("TracingPolicy 'message' field too long, truncated to %d characters", TpMaxMessageLen), "policy-name", in.policyName)
 	}
 
-	tagsField, err := getPolicyTags(f.Tags)
+	tagsField, err := GetPolicyTags(f.Tags)
 	if err != nil {
 		return errFn(fmt.Errorf("error: '%w'", err))
 	}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -384,7 +384,7 @@ func createGenericTracepoint(
 		logger.GetLogger().Warn(fmt.Sprintf("TracingPolicy 'message' field too long, truncated to %d characters", TpMaxMessageLen), "policy-name", polInfo.name)
 	}
 
-	tagsField, err := getPolicyTags(conf.Tags)
+	tagsField, err := GetPolicyTags(conf.Tags)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -531,7 +531,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 		argReturnPrinters []argPrinter
 	)
 
-	tagsField, err := getPolicyTags(spec.Tags)
+	tagsField, err := GetPolicyTags(spec.Tags)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -246,7 +246,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID) ([]i
 		return nil, err
 	}
 
-	tagsField, err := getPolicyTags(spec.Tags)
+	tagsField, err := GetPolicyTags(spec.Tags)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sensors/tracing/tags.go
+++ b/pkg/sensors/tracing/tags.go
@@ -33,10 +33,10 @@ func escapeTag(tag string) (string, error) {
 	return escapedTag[1 : len(escapedTag)-1], nil
 }
 
-// getPolicyTags() Validates and escapes the passed tags.
+// GetPolicyTags() Validates and escapes the passed tags.
 // Returns: On success the validated tags of max length TpMaxTags
 // On failures an error is set.
-func getPolicyTags(tags []string) ([]string, error) {
+func GetPolicyTags(tags []string) ([]string, error) {
 	if len(tags) == 0 {
 		return nil, nil
 	} else if len(tags) > TpMaxTags {

--- a/pkg/sensors/tracing/tags_test.go
+++ b/pkg/sensors/tracing/tags_test.go
@@ -11,29 +11,29 @@ import (
 
 func TestGetPolicyTags(t *testing.T) {
 	input := []string{""}
-	_, err := getPolicyTags(input)
+	_, err := GetPolicyTags(input)
 	require.Error(t, err)
 
 	// short tag
 	input = []string{"a"}
-	_, err = getPolicyTags(input)
+	_, err = GetPolicyTags(input)
 	require.Error(t, err)
 
 	input = []string{"observability.filesystem"}
-	tags, err := getPolicyTags(input)
+	tags, err := GetPolicyTags(input)
 	require.NoError(t, err)
 	require.Len(t, tags, 1)
 
 	input = []string{"observability.filesystem", "", "CVES"}
-	_, err = getPolicyTags(input)
+	_, err = GetPolicyTags(input)
 	require.Error(t, err)
 
 	input = []string{"observability.filesystem", "CVES", "aa"}
-	tags, err = getPolicyTags(input)
+	tags, err = GetPolicyTags(input)
 	require.NoError(t, err)
 	require.Len(t, tags, 3)
 
 	input = []string{"01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16", "17"}
-	_, err = getPolicyTags(input)
+	_, err = GetPolicyTags(input)
 	require.Error(t, err)
 }


### PR DESCRIPTION

### Description

`GetPolicyTags` might be useful to validate tags of any policy kind.

### Changelog

```release-note
new(pkg/sensors): expose `GetPolicyTags` helper.
```
