### PR TITLE
[backport/v1.6] Add umode_t in validation

### DIFF
--- a/pkg/btf/validation.go
+++ b/pkg/btf/validation.go
@@ -281,7 +281,7 @@ func typesCompatible(specTy string, kernelTy string) bool {
 		}
 	case "uint16":
 		switch kernelTy {
-		case "u16", "short unsigned int":
+		case "u16", "short unsigned int", "umode_t":
 			return true
 		}
 	case "uint8":


### PR DESCRIPTION
[upstream commit https://github.com/cilium/tetragon/commit/43204714dab35745a0a2c9ae2f3b67c32c073ef6]

Definition of umode_t is:
typedef unsigned short umode_t;

From https://elixir.bootlin.com/linux/v6.17.7/source/include/linux/types.h#L24