### PR TITLE
Remove duplicate from k8s definition

### DIFF
--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -428,7 +428,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -535,7 +535,7 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -668,7 +668,7 @@ A return argument to include in the trace output.
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -1738,7 +1738,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -2881,7 +2881,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -3953,7 +3953,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -4060,7 +4060,7 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -4167,7 +4167,7 @@ A return argument to include in the trace output.
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -5202,7 +5202,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -6518,7 +6518,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -6625,7 +6625,7 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -6758,7 +6758,7 @@ A return argument to include in the trace output.
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -7828,7 +7828,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -8971,7 +8971,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -10043,7 +10043,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -10150,7 +10150,7 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -10257,7 +10257,7 @@ A return argument to include in the trace output.
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>
@@ -11292,7 +11292,7 @@ Maximum of 16 Tags are supported.<br/>
         <td>
           Argument type.<br/>
           <br/>
-            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, size_t, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
+            <i>Enum</i>: auto, int, sint8, int8, uint8, sint16, int16, uint16, uint32, sint32, int32, ulong, uint64, size_t, long, sint64, int64, char_buf, char_iovec, skb, sock, sockaddr, socket, string, fd, file, filename, path, nop, bpf_attr, perf_event, bpf_map, user_namespace, capability, kiocb, iov_iter, cred, const_buf, load_info, module, syscall64, kernel_cap_t, cap_inheritable, cap_permitted, cap_effective, linux_binprm, data_loc, net_device, bpf_cmd, dentry, bpf_prog<br/>
             <i>Default</i>: auto<br/>
         </td>
         <td>true</td>

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -192,7 +192,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -307,7 +306,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -435,7 +433,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -1191,7 +1188,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -1984,7 +1980,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2721,7 +2716,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2836,7 +2830,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2972,7 +2965,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -3692,7 +3684,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -192,7 +192,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -307,7 +306,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -435,7 +433,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -1191,7 +1188,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -1984,7 +1980,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2721,7 +2716,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2836,7 +2830,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2972,7 +2965,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -3692,7 +3684,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -192,7 +192,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -307,7 +306,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -435,7 +433,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -1191,7 +1188,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -1984,7 +1980,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2721,7 +2716,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2836,7 +2830,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2972,7 +2965,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -3692,7 +3684,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -192,7 +192,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -307,7 +306,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -435,7 +433,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -1191,7 +1188,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -1984,7 +1980,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2721,7 +2716,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2836,7 +2830,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2972,7 +2965,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -3692,7 +3684,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -73,7 +73,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=auto;int;sint8;int8;uint8;sint16;int16;uint16;uint32;sint32;int32;ulong;uint64;size_t;long;sint64;int64;char_buf;char_iovec;size_t;skb;sock;sockaddr;socket;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;const_buf;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd;dentry;bpf_prog;
+	// +kubebuilder:validation:Enum=auto;int;sint8;int8;uint8;sint16;int16;uint16;uint32;sint32;int32;ulong;uint64;size_t;long;sint64;int64;char_buf;char_iovec;skb;sock;sockaddr;socket;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;const_buf;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd;dentry;bpf_prog;
 	// +kubebuilder:default=auto
 	// Argument type.
 	Type string `json:"type"`

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.4"
+const CustomResourceDefinitionSchemaVersion = "1.7.5"

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -192,7 +192,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -307,7 +306,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -435,7 +433,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -1191,7 +1188,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -1984,7 +1980,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2721,7 +2716,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2836,7 +2830,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2972,7 +2965,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -3692,7 +3684,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -192,7 +192,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -307,7 +306,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -435,7 +433,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -1191,7 +1188,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -1984,7 +1980,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2721,7 +2716,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2836,7 +2830,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr
@@ -2972,7 +2965,6 @@ spec:
                           - int64
                           - char_buf
                           - char_iovec
-                          - size_t
                           - skb
                           - sock
                           - sockaddr
@@ -3692,7 +3684,6 @@ spec:
                             - int64
                             - char_buf
                             - char_iovec
-                            - size_t
                             - skb
                             - sock
                             - sockaddr

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -73,7 +73,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=auto;int;sint8;int8;uint8;sint16;int16;uint16;uint32;sint32;int32;ulong;uint64;size_t;long;sint64;int64;char_buf;char_iovec;size_t;skb;sock;sockaddr;socket;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;const_buf;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd;dentry;bpf_prog;
+	// +kubebuilder:validation:Enum=auto;int;sint8;int8;uint8;sint16;int16;uint16;uint32;sint32;int32;ulong;uint64;size_t;long;sint64;int64;char_buf;char_iovec;skb;sock;sockaddr;socket;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;const_buf;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd;dentry;bpf_prog;
 	// +kubebuilder:default=auto
 	// Argument type.
 	Type string `json:"type"`

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.4"
+const CustomResourceDefinitionSchemaVersion = "1.7.5"


### PR DESCRIPTION
https://github.com/cilium/tetragon/commit/b8ba58bf1 adds size_t in the allowed types.

The issue is that size_t already exists and may breaks some kubeconform calls.
