### PR TITLE
tester-progs: make clean should remove libs too

### DIFF
--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -44,6 +44,8 @@ PROGS = sigkill-tester \
 
 PROGS += $(PROGS_ARCH)
 
+LIBS = libuprobe.so
+
 all: $(PROGS)
 
 %: %.c
@@ -154,6 +156,6 @@ test-helper: FORCE
 
 .PHONY: clean
 clean:
-	rm -f $(PROGS)
+	rm -f $(PROGS) $(LIBS)
 
 FORCE:


### PR DESCRIPTION
I ran into a compilation issue due to an out-of-date libuprobe.so. "make clean" did not fix the issue because it left libuprobe.so.
