### PR TITLE
fix(dev) lsm: Failed to load policy

### DIFF
--- a/bpf/cgroup/cgtracker.h
+++ b/bpf/cgroup/cgtracker.h
@@ -6,7 +6,7 @@
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 1);
+	__uint(max_entries, 16384);
 	__type(key, __u64); /* cgroup id */
 	__type(value, __u64); /* tracker cgroup id */
 } tg_cgtracker_map SEC(".maps");


### PR DESCRIPTION
Fixes [#7125](https://github.com/isovalent/hubble-fgs/issues/7125) 

## Summary

Fix BPF map size mismatch in `tg_cgtracker_map` that prevented LSM policies from loading.

## Problem Description

When attempting to load LSM-based TracingPolicies (e.g., CVE-2024-21626 protection policy), 
Tetragon fails with the following error:

```shell
level=warn msg="adding tracing policy failed" error="sensor generic_lsm from collection protection-policy-cve-2024-21626 failed to load: failed prog /var/lib/tetragon/bpf_generic_lsm_core_v612.o kern_version 396334 loadInstance: opening collection '/var/lib/tetragon/bpf_generic_lsm_core_v612.o' failed: using replacement map tg_cgtracker_map: MaxEntries: 16384 changed to 1: map spec is incompatible with existing map"
```

This prevents critical security policies from being enforced.

## Root Cause

The BPF map `tg_cgtracker_map` in [modules/tetragon-oss/bpf/cgroup/cgtracker.h](cci:7://file:///Users/ariosmon/Documents/github_isovalent/hubble-fgs/modules/tetragon-oss/bpf/cgroup/cgtracker.h:0:0-0:0) 
was defined with `max_entries: 1`, while the userspace Go code in 
[modules/tetragon-oss/pkg/cgtracker/cgtracker.go](cci:7://file:///Users/ariosmon/Documents/github_isovalent/hubble-fgs/modules/tetragon-oss/pkg/cgtracker/cgtracker.go:0:0-0:0) expects `max_entries: 16384` 
(defined as `MapEntries = 16 * 1024`).

This mismatch causes BPF program loading to fail when the kernel verifier detects 
that the map specification in the new BPF program doesn't match the existing 
pinned map.

**Relevant Code Context:**

Go expectation ([pkg/cgtracker/cgtracker.go](cci:7://file:///Users/ariosmon/Documents/github_isovalent/hubble-fgs/modules/tetragon-oss/pkg/cgtracker/cgtracker.go:0:0-0:0)):
```go
const (
    MapEntries  = 16 * 1024  // 16384
    MapName     = "tg_cgtracker_map"
    objFilename = "bpf_cgtracker.o"
)


BPF definition (BEFORE fix):

struct {
    __uint(type, BPF_MAP_TYPE_HASH);
    __uint(max_entries, 1);  // ❌ INCORRECT
    __type(key, __u64);
    __type(value, __u64);
} tg_cgtracker_map SEC(".maps");

Solution
Update 
modules/tetragon-oss/bpf/cgroup/cgtracker.h
 to match the Go code expectation:
 
 struct {
    __uint(type, BPF_MAP_TYPE_HASH);
    __uint(max_entries, 16384);  // ✅ CORRECT
    __type(key, __u64);
    __type(value, __u64);
} tg_cgtracker_map SEC(".maps");
```

## This ensures consistency between BPF and userspace expectations, allowing proper map creation and BPF program loading.

```shell
➜  hubble-fgs git:(lsm_Failed_to_load_policy) ✗ kubectl apply -f testdata/lsm-cgtracker-test.yaml
tracingpolicy.cilium.io/protection-policy-cve-2024-21626 created
```


