### PR TITLE
renovate: Update the branch for breaking change check

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -13,6 +13,6 @@ GO ?= go
 CONTAINER_ENGINE ?= docker
 
 BUF ?= buf
-BUF_BREAKING_AGAINST_BRANCH ?= origin/main
+BUF_BREAKING_AGAINST_BRANCH ?= origin/v1.4
 # renovate: datasource=docker
 BUILDER_IMAGE=quay.io/cilium/cilium-builder:cd04ac813fb4763f840911c88beae99efc4aa457


### PR DESCRIPTION


<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

This is mainly for renovate post upgrade task. Renovate config is only available in main branch, and it's hard to pass respective branch for BUF_BREAKING_AGAINST_BRANCH, unlike in github action with (ref_name and base_ref).

https://github.com/cilium/tetragon/pull/4303#issuecomment-3497943244

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
renovate: Update the branch for breaking change check
```
