### PR TITLE
docs: add FAQ entry for kernel lockdown and improve warning message

### DIFF
--- a/pkg/reader/proc/proc_linux.go
+++ b/pkg/reader/proc/proc_linux.go
@@ -178,7 +178,7 @@ func LogCurrentSecurityContext() {
 			logLSM = true
 		}
 		if lockdown == "confidentiality" {
-			logger.GetLogger().Warn("Kernel Lockdown is in 'confidentiality' mode, Tetragon will fail to load BPF programs")
+			logger.GetLogger().Warn("Kernel Lockdown is in 'confidentiality' mode; Tetragon will fail to load BPF programs. See https://tetragon.io/docs/installation/faq/#kernel-lockdown for details.")
 		}
 	}
 


### PR DESCRIPTION
Implementation for https://github.com/cilium/tetragon/issues/2265 
### Description
Adds documentation for why Tetragon will fail with operation not permitted when loading BPF programs on some machines.


### FAQ Section Rendered
Here how the documentation looks https://deploy-preview-4381--tetragon.netlify.app/docs/installation/faq/#kernel-lockdown

### Debug message
Here the info message updated when the lockdown is set to confidential:

<img width="978" height="203" alt="Screenshot 2025-11-24 at 6 34 31 PM" src="https://github.com/user-attachments/assets/3969bd1f-8cca-44ba-a1b6-c3b9a2929541" />
