### PR TITLE
fix(deps):  tg_cgtracker_map size in LSM generic probes

### DIFF
--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -19,6 +19,7 @@ import (
 	processapi "github.com/cilium/tetragon/pkg/api/processapi"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/cgtracker"
 	"github.com/cilium/tetragon/pkg/config"
 	gt "github.com/cilium/tetragon/pkg/generictypes"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
@@ -534,6 +535,10 @@ func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 	maps = append(maps, overrideTasksMapOutput)
 
 	maps = append(maps, polInfo.policyConfMap(load), polInfo.policyStatsMap(load))
+
+	if option.Config.EnableCgTrackerID {
+		maps = append(maps, program.MapUser(cgtracker.MapName, load))
+	}
 
 	logger.GetLogger().
 		Info(fmt.Sprintf("Added generic lsm sensor: %s -> %s", load.Name, load.Attach))


### PR DESCRIPTION
Fix tg_cgtracker_map size in LSM generic probes

### Description
LSM sensors were failing to load when `--enable-cgidmap` flag was enabled, with the error:

```shell
level=error msg="Failed to start tetragon" error="add TracingPolicy failed: failed to get sensors from (pol-lsm.yaml) parser policy: sensor generic_lsm from collection protection-policy-cve-2024-21626 failed to load: failed prog bpf/objs/bpf_generic_lsm_core_v61.o kern_version 393630 loadInstance: opening collection 'bpf/objs/bpf_generic_lsm_core_v61.o' failed: using replacement map tg_cgtracker_map: MaxEntries: 16384 changed to 1: map spec is incompatible with existing map"
```

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->


```release-note
Fix LSM sensor failing to load with --enable-cgidmap due to tg_cgtracker_map size mismatch
```
