### PR TITLE
fix(pkg/sensors): fixed `ret{k,u}probe_calls` map builder invocation.

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -391,7 +391,7 @@ func createMultiKprobeSensor(polInfo *policyInfo, multiIDs []idtable.EntryID, ha
 		}
 		maps = append(maps, socktrack)
 
-		tailCalls := program.MapBuilderSensor("retkprobe_calls", loadret)
+		tailCalls := program.MapBuilderProgram("retkprobe_calls", loadret)
 		maps = append(maps, tailCalls)
 
 		retConfigMap.SetMaxEntries(len(multiRetIDs))

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -828,7 +828,7 @@ func createMultiUprobeSensor(sensorPath string, multiIDs []idtable.EntryID, poli
 		retFilterMap := program.MapBuilderProgram("filter_map", loadret)
 		maps = append(maps, retFilterMap)
 
-		retTailCalls := program.MapBuilderSensor("retuprobe_calls", loadret)
+		retTailCalls := program.MapBuilderProgram("retuprobe_calls", loadret)
 		maps = append(maps, retTailCalls)
 		retConfigMap.SetMaxEntries(len(multiRetIDs))
 		retFilterMap.SetMaxEntries(len(multiRetIDs))


### PR DESCRIPTION
### Description
We should be using `MapBuilderProgram` instead of `MapBuilderSensor` for multi sensors too, just like we do for single sensors.

### Changelog

```release-note
fix(pkg/sensors): fixed `ret{k,u}probe_calls` map builder invocation.
```
