### PR TITLE
metrics: Add debug metric for non-critical errors

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -94,6 +94,14 @@ The number of data events by type. For internal use only.
 | ----- | ------ |
 | `event` | `Added, Appended, Bad, Matched, NotMatched, Received` |
 
+### `tetragon_debug_events_total`
+
+The total number of Tetragon debug events. For internal use only.
+
+| label | values |
+| ----- | ------ |
+| `type ` | `process_metadata_username_ignored_not_in_host_namespaces` |
+
 ### `tetragon_enforcer_missed_notifications_total`
 
 The number of missed notifications by the enforcer.
@@ -110,7 +118,7 @@ The total number of Tetragon errors. For internal use only.
 
 | label | values |
 | ----- | ------ |
-| `type ` | `event_finalize_process_info_failed, process_metadata_username_failed, process_metadata_username_ignored_not_in_host_namespaces, process_pid_tid_mismatch` |
+| `type ` | `event_finalize_process_info_failed, process_metadata_username_failed, process_pid_tid_mismatch` |
 
 ### `tetragon_event_cache_entries`
 

--- a/pkg/metrics/errormetrics/debugmetrics.go
+++ b/pkg/metrics/errormetrics/debugmetrics.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package errormetrics
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/metrics/consts"
+)
+
+type DebugType int
+
+const (
+	// The username resolution was skipped since the process is not in host
+	// namespaces.
+	ProcessMetadataUsernameIgnoredNotInHost DebugType = iota
+)
+
+var debugTypeLabelValues = map[DebugType]string{
+	ProcessMetadataUsernameIgnoredNotInHost: "process_metadata_username_ignored_not_in_host_namespaces",
+}
+
+func (e DebugType) String() string {
+	return debugTypeLabelValues[e]
+}
+
+var (
+	// Constrained label for debug type
+	debugTypeLabel = metrics.ConstrainedLabel{
+		Name:   "type",
+		Values: slices.Collect(maps.Values(debugTypeLabelValues)),
+	}
+
+	DebugTotal = metrics.MustNewCounter(
+		metrics.NewOpts(
+			consts.MetricsNamespace, "", "debug_events_total",
+			"The total number of Tetragon debug events. For internal use only.",
+			nil, []metrics.ConstrainedLabel{debugTypeLabel}, nil,
+		),
+		nil,
+	)
+)
+
+// Get a new handle on a DebugTotal metric for a DebugType
+func GetDebugTotal(er DebugType) prometheus.Counter {
+	return DebugTotal.WithLabelValues(er.String())
+}
+
+// Increment a DebugTotal for a DebugType
+func DebugTotalInc(er DebugType) {
+	GetDebugTotal(er).Inc()
+}

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -24,16 +24,12 @@ const (
 	EventFinalizeProcessInfoFailed
 	// Failed to resolve Process uid to username
 	ProcessMetadataUsernameFailed
-	// The username resolution was skipped since the process is not in host
-	// namespaces.
-	ProcessMetadataUsernameIgnoredNotInHost
 )
 
 var errorTypeLabelValues = map[ErrorType]string{
-	ProcessPidTidMismatch:                   "process_pid_tid_mismatch",
-	EventFinalizeProcessInfoFailed:          "event_finalize_process_info_failed",
-	ProcessMetadataUsernameFailed:           "process_metadata_username_failed",
-	ProcessMetadataUsernameIgnoredNotInHost: "process_metadata_username_ignored_not_in_host_namespaces",
+	ProcessPidTidMismatch:          "process_pid_tid_mismatch",
+	EventFinalizeProcessInfoFailed: "event_finalize_process_info_failed",
+	ProcessMetadataUsernameFailed:  "process_metadata_username_failed",
 }
 
 func (e ErrorType) String() string {
@@ -106,6 +102,7 @@ var (
 func RegisterMetrics(group metrics.Group) {
 	group.MustRegister(ErrorTotal)
 	group.MustRegister(HandlerErrors)
+	group.MustRegister(DebugTotal)
 }
 
 func InitMetrics() {
@@ -121,6 +118,10 @@ func InitMetrics() {
 	// NB: We initialize only ops.MSG_OP_UNDEF here, but unknown_opcode can occur for any opcode
 	// that is not explicitly handled.
 	GetHandlerErrors(ops.MSG_OP_UNDEF, HandlePerfUnknownOp).Add(0)
+
+	for er := range debugTypeLabelValues {
+		GetDebugTotal(er).Add(0)
+	}
 }
 
 // Get a new handle on an ErrorTotal metric for an ErrorType

--- a/pkg/sensors/exec/userinfo/userinfo.go
+++ b/pkg/sensors/exec/userinfo/userinfo.go
@@ -42,7 +42,7 @@ func MsgToExecveAccountUnix(unix *processapi.MsgExecveEventUnix) error {
 		}
 
 		if errors.Is(err, ErrNotInHostNs) {
-			errormetrics.ErrorTotalInc(errormetrics.ProcessMetadataUsernameIgnoredNotInHost)
+			errormetrics.DebugTotalInc(errormetrics.ProcessMetadataUsernameIgnoredNotInHost)
 		} else {
 			errormetrics.ErrorTotalInc(errormetrics.ProcessMetadataUsernameFailed)
 		}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Part of #2785 
>  Stop reporting non-errors (as in: no action needed) as errors. Define separate metrics for "casual fails" if needed.

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Adds `tetragon_debug_events_total` metric for non-critical errors to reduce noise in `tetragon_errors_total`. (see commit)

Example Output:
```
# HELP tetragon_debug_events_total The total number of Tetragon debug events. For internal use only.
# TYPE tetragon_debug_events_total counter
tetragon_debug_events_total{type="process_metadata_username_ignored_not_in_host_namespaces"} 1
```

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Added tetragon_debug_events_total metric to separate non-critical issues from actual errors.
```
