### PR TITLE
fix(tests): Adjust skeleton test timeouts to reduce flakyness

### DIFF
--- a/tests/e2e/tests/skeleton/skeleton_test.go
+++ b/tests/e2e/tests/skeleton/skeleton_test.go
@@ -87,8 +87,8 @@ func TestMain(m *testing.M) {
 func TestSkeletonBasic(t *testing.T) {
 	// Grab the minimum kernel version in all cluster nodes and define an RPC checker with it
 	kversion := helpers.GetMinKernelVersion(t, runner.Environment)
-	// Create an curl event checker with a limit or 10 events or 30 seconds, whichever comes first
-	curlChecker := curlEventChecker(kversion).WithEventLimit(100).WithTimeLimit(30 * time.Second)
+	// Create an curl event checker with a limit or 200 events or 120 seconds, whichever comes first
+	curlChecker := curlEventChecker(kversion).WithEventLimit(200).WithTimeLimit(120 * time.Second)
 
 	metricsChecker := metricschecker.NewMetricsChecker("skeletonMetricsChecker")
 
@@ -103,8 +103,8 @@ func TestSkeletonBasic(t *testing.T) {
 
 	// This feature waits for curlChecker to start then runs a custom workload.
 	runWorkload := features.New("Run Workload").
-		/* Wait up to 30 seconds for the event checker to start before continuing */
-		Assess("Wait for Checker", curlChecker.Wait(30*time.Second)).
+		/* Wait up to 60 seconds for the event checker to start before continuing */
+		Assess("Wait for Checker", curlChecker.Wait(60*time.Second)).
 		/* Run the workload */
 		Assess("Run Workload", func(ctx context.Context, _ *testing.T, c *envconf.Config) context.Context {
 			ctx, err := helpers.LoadCRDString(namespace, curlPod, true)(ctx, c)


### PR DESCRIPTION
Increase the curl event checker time limit from 30 to 60 seconds and change the curl container imagePullPolicy from Always to IfNotPresent.

Tested several times:
```shiell
--- PASS: TestSkeletonBasic (15.05s)
    --- PASS: TestSkeletonBasic/Get_Minimum_Kernel_Version (0.00s)
        --- PASS: TestSkeletonBasic/Get_Minimum_Kernel_Version/Lookup_Kernel_Version (0.00s)
    --- PASS: TestSkeletonBasic/Run_Event_Checks (2.98s)
        --- PASS: TestSkeletonBasic/Run_Event_Checks/Run_Event_Checks (2.98s)
    --- PASS: TestSkeletonBasic/Run_Workload (15.05s)
        --- PASS: TestSkeletonBasic/Run_Workload/Wait_for_Checker (0.00s)
        --- PASS: TestSkeletonBasic/Run_Workload/Run_Workload (10.02s)
        --- PASS: TestSkeletonBasic/Run_Workload/Run_Metrics_Checks (0.02s)
        --- PASS: TestSkeletonBasic/Run_Workload/Uninstall_policy (5.01s)
```

Found several pipelines failing due to timeout issue so I increased them. The execution time should not be affected when the network is working properly, the current change just add additional changes to make the tests work