### PR TITLE
Add tests for enforce/monitor mode

### DIFF
--- a/pkg/testutils/policystats/stats.go
+++ b/pkg/testutils/policystats/stats.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package policystats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ps "github.com/cilium/tetragon/pkg/policystats"
+	"github.com/cilium/tetragon/pkg/tracingpolicy"
+)
+
+// ExpectedPolicyActions describes the expected delta for each policy action counter
+// between two snapshots.
+type ExpectedPolicyActions struct {
+	Post, Signal, MonitorSignal,
+	Override, MonitorOverride,
+	NotifyEnforcer, MonitorNotifyEnforcer uint64
+}
+
+// Checker holds a check function that verifies that policy statistics
+// counters changed by the expected deltas.
+type Checker struct {
+	Check func()
+}
+
+// NewChecker captures a snapshot of policy statistics for the given tracing
+// policy and returns a Checker whose Check method asserts that the stats
+// counters changed by the expected deltas.
+//
+// Typical usage in tests:
+//
+//	checker := NewChecker(<*T>, <TracingPolicy>, ExpectedPolicyActions{
+//		Post:   1,
+//		Signal: 1,
+//	})
+//	// run operations that should trigger the policy actions above
+//	checker.Check()
+func NewChecker(t *testing.T, tp tracingpolicy.TracingPolicy, expected ExpectedPolicyActions) Checker {
+	before, err := ps.GetPolicyStats(tp)
+	require.NoError(t, err)
+
+	return Checker{
+		Check: func() {
+			after, err := ps.GetPolicyStats(tp)
+			require.NoError(t, err)
+
+			require.Equal(
+				t,
+				before.ActionsCount[ps.PolicyPost]+expected.Post,
+				after.ActionsCount[ps.PolicyPost],
+				"PolicyPost delta mismatch: before=%d after=%d expectedDelta=%d",
+				before.ActionsCount[ps.PolicyPost],
+				after.ActionsCount[ps.PolicyPost],
+				expected.Post,
+			)
+			require.Equal(
+				t,
+				before.ActionsCount[ps.PolicySignal]+expected.Signal,
+				after.ActionsCount[ps.PolicySignal],
+				"PolicySignal delta mismatch: before=%d after=%d expectedDelta=%d",
+				before.ActionsCount[ps.PolicySignal],
+				after.ActionsCount[ps.PolicySignal],
+				expected.Signal,
+			)
+			require.Equal(
+				t,
+				before.ActionsCount[ps.PolicyMonitorSignal]+expected.MonitorSignal,
+				after.ActionsCount[ps.PolicyMonitorSignal],
+				"PolicyMonitorSignal delta mismatch: before=%d after=%d expectedDelta=%d",
+				before.ActionsCount[ps.PolicyMonitorSignal],
+				after.ActionsCount[ps.PolicyMonitorSignal],
+				expected.MonitorSignal,
+			)
+			require.Equal(
+				t,
+				before.ActionsCount[ps.PolicyOverride]+expected.Override,
+				after.ActionsCount[ps.PolicyOverride],
+				"PolicyOverride delta mismatch: before=%d after=%d expectedDelta=%d",
+				before.ActionsCount[ps.PolicyOverride],
+				after.ActionsCount[ps.PolicyOverride],
+				expected.Override,
+			)
+			require.Equal(
+				t,
+				before.ActionsCount[ps.PolicyMonitorOverride]+expected.MonitorOverride,
+				after.ActionsCount[ps.PolicyMonitorOverride],
+				"PolicyMonitorOverride delta mismatch: before=%d after=%d expectedDelta=%d",
+				before.ActionsCount[ps.PolicyMonitorOverride],
+				after.ActionsCount[ps.PolicyMonitorOverride],
+				expected.MonitorOverride,
+			)
+			require.Equal(
+				t,
+				before.ActionsCount[ps.PolicyNotifyEnforcer]+expected.NotifyEnforcer,
+				after.ActionsCount[ps.PolicyNotifyEnforcer],
+				"PolicyNotifyEnforcer delta mismatch: before=%d after=%d expectedDelta=%d",
+				before.ActionsCount[ps.PolicyNotifyEnforcer],
+				after.ActionsCount[ps.PolicyNotifyEnforcer],
+				expected.NotifyEnforcer,
+			)
+			require.Equal(
+				t,
+				before.ActionsCount[ps.PolicyMonitorNotifyEnforcer]+expected.MonitorNotifyEnforcer,
+				after.ActionsCount[ps.PolicyMonitorNotifyEnforcer],
+				"PolicyMonitorNotifyEnforcer delta mismatch: before=%d after=%d expectedDelta=%d",
+				before.ActionsCount[ps.PolicyMonitorNotifyEnforcer],
+				after.ActionsCount[ps.PolicyMonitorNotifyEnforcer],
+				expected.MonitorNotifyEnforcer,
+			)
+		},
+	}
+}


### PR DESCRIPTION

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes #4212 add tests for enforce/monitor mode

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Add validation of policy statistics counters in mode tests to verify that policy actions are correctly tracked. The tests now check that the appropriate action counters (PolicyPost, PolicySignal, PolicyOverride, etc.) are incremented as expected for both enforce and monitor modes.

Note: I intentionally updated the existing policyconf tests instead of adding new ones. Adding separate tests would duplicate the same flow as the first two tests and further slow down the already heavy test suite, so I extended those tests to cover the new behavior and stats instead.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Increase test coverage for policyconf mode handling and policy stats (tests only).
```

Testing:
- Ran the policyconf tests locally; they all passed.
- The extended verbose console output for the updated tests in pkg/policyconf/test/mode_test.go is attached below for reference.
<details>
  <summary>Show extended test output</summary>

  ```text
  make -C "contrib/tester-progs"
make[1]: Entering directory '/Users/sglushko/src/tetragon/contrib/tester-progs'
go build -o lseek-pipe ./go/lseek-pipe
go build -o getcpu ./go/getcpu
go build -o user-stacktrace ./go/user-stacktrace
go build -o test-helper ./go/test-helper
make[1]: Leaving directory '/Users/sglushko/src/tetragon/contrib/tester-progs'
nerdctl rm -f tetragon-clang || true
ERRO[0000] 1 errors:
no such container: tetragon-clang  
nerdctl run -v /Users/sglushko/src/tetragon:/tetragon:Z -u $(id -u) -e BPF_TARGET_ARCH=arm64 --name tetragon-clang quay.io/cilium/clang:b97f5b3d5c38da62fb009f21a53cd42aefd54a2f@sha256:e1c8ed0acd2e24ed05377f2861d8174af28e09bef3bbc79649c8eba165207df0 make -C /tetragon/bpf -j4 
WARN[0000] unsupported volume option "Z"                
make: Entering directory '/tetragon/bpf'
make: Nothing to be done for 'all'.
make: Leaving directory '/tetragon/bpf'
nerdctl rm -f tetragon-clang
tetragon-clang
go test -exec "sudo" -p 1 -parallel 1  -gcflags= -timeout 20m -failfast -cover ./pkg/policyconf/test -v
level=info msg="BTF discovery: default kernel btf file found" btf-file=/sys/kernel/btf/vmlinux
=== RUN   TestModeSigKill
    logcapture.go:24: time=2025-12-10T08:17:43.040Z level=INFO msg="Enabling policy filtering"
    logcapture.go:24: time=2025-12-10T08:17:43.051Z level=INFO msg="Cgroup mode detection succeeded" cgroup.fs=/sys/fs/cgroup cgroup.mode="Unified mode (Cgroupv2)"
    logcapture.go:24: time=2025-12-10T08:17:43.051Z level=INFO msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/proc/1/root/sys/fs/cgroup cgroup.controllers="[cpuset cpu io memory hugetlb pids rdma misc dmem]" cgroup.hierarchyID=0
    logcapture.go:24: time=2025-12-10T08:17:43.051Z level=INFO msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/sys/fs/cgroup/user.slice/user-501.slice/session-4.scope cgroup.controllers="[cpuset cpu io memory pids]" cgroup.hierarchyID=0
    logcapture.go:24: time=2025-12-10T08:17:43.051Z level=INFO msg="Cgroupv2 hierarchy validated successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/sys/fs/cgroup/user.slice/user-501.slice/session-4.scope
    logcapture.go:24: time=2025-12-10T08:17:43.051Z level=INFO msg="Deployment mode detection succeeded" cgroup.fs=/sys/fs/cgroup deployment.mode="systemd user session"
level=info msg="Updated TetragonConf map successfully" confmap-update=tg_conf_map deployment.mode="systemd user session" log.level=0 cgroup.fs.magic=Cgroupv2 cgroup.hierarchyID=0 NSPID=113542
    logcapture.go:24: time=2025-12-10T08:17:43.202Z level=INFO msg="Exit probe on acct_process"
    logcapture.go:24: time=2025-12-10T08:17:43.202Z level=INFO msg="Set execve_map entries 32768" size=28M
    logcapture.go:24: time=2025-12-10T08:17:43.203Z level=INFO msg="BPF ring buffer size (bytes)" total=256K
    logcapture.go:24: time=2025-12-10T08:17:43.204Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:43.204Z level=INFO msg="Loading sensor" name=__base__
    logcapture.go:24: time=2025-12-10T08:17:43.204Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:43.334Z level=INFO msg="Loaded sensor successfully" sensor=__base__
    logcapture.go:24: time=2025-12-10T08:17:43.339Z level=WARN msg="Reading uts namespace failed" error="namespace '/proc/1775/ns/uts' readlink /proc/1775/ns/uts: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:43.339Z level=WARN msg="Reading ipc namespace failed" error="namespace '/proc/1775/ns/ipc' readlink /proc/1775/ns/ipc: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:43.339Z level=WARN msg="Reading mnt namespace failed" error="namespace '/proc/1775/ns/mnt' readlink /proc/1775/ns/mnt: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:43.339Z level=WARN msg="Reading pid_for_children namespace failed" error="namespace '/proc/1775/ns/pid_for_children' readlink /proc/1775/ns/pid_for_children: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:43.339Z level=WARN msg="Reading net namespace failed" error="namespace '/proc/1775/ns/net' readlink /proc/1775/ns/net: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:43.339Z level=WARN msg="Reading cgroup namespace failed" error="namespace '/proc/1775/ns/cgroup' readlink /proc/1775/ns/cgroup: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:43.347Z level=INFO msg="Read ProcFS /proc appended 157/218 entries"
    logcapture.go:24: time=2025-12-10T08:17:43.348Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:43.348Z level=INFO msg="Loading sensor" name=test-sensor-1
    logcapture.go:24: time=2025-12-10T08:17:43.348Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:43.380Z level=INFO msg="Loaded sensor successfully" sensor=test-sensor-1
    logcapture.go:24: time=2025-12-10T08:17:43.380Z level=INFO msg="Enabling policy filtering"
    cgroup_fs.go:24: '/sys/fs/cgroup' is cgroup v2
    pftester.go:77: cgroup path:/sys/fs/cgroup/test-TestModeSigKill-2844027287 id:36497
    logcapture.go:24: time=2025-12-10T08:17:43.587Z level=INFO msg="Added kprobe" return=true function=__arm64_sys_getcpu override=false
    logcapture.go:24: time=2025-12-10T08:17:43.587Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:43.587Z level=INFO msg="Loading sensor" name=generic_kprobe
    logcapture.go:24: time=2025-12-10T08:17:43.587Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:44.013Z level=INFO msg="Loaded generic kprobe sensor: /Users/sglushko/src/tetragon/bpf/objs/bpf_multi_kprobe_v612.o -> kprobe_multi (1 functions)"
    logcapture.go:24: time=2025-12-10T08:17:44.281Z level=INFO msg="Loaded generic kprobe sensor: /Users/sglushko/src/tetragon/bpf/objs/bpf_multi_retkprobe_v612.o -> 1 retkprobes"
    logcapture.go:24: time=2025-12-10T08:17:44.281Z level=INFO msg="Loaded sensor successfully" sensor=generic_kprobe
    mode_test.go:80: prog:/Users/sglushko/src/tetragon/contrib/tester-progs/getcpu out:"cmd=\"/Users/sglushko/src/tetragon/contrib/tester-progs/getcpu\" returned an error \"signal: killed\"" err:<nil>
    mode_test.go:80: prog:/Users/sglushko/src/tetragon/contrib/tester-progs/getcpu out:"cmd=\"/Users/sglushko/src/tetragon/contrib/tester-progs/getcpu\" returned without an error. Combined output was: \"\"" err:<nil>
    mode_test.go:80: prog:/Users/sglushko/src/tetragon/contrib/tester-progs/getcpu out:"cmd=\"/Users/sglushko/src/tetragon/contrib/tester-progs/getcpu\" returned an error \"signal: killed\"" err:<nil>
    logcapture.go:24: time=2025-12-10T08:17:44.294Z level=INFO msg="Unloading sensor generic_kprobe"
    logcapture.go:24: time=2025-12-10T08:17:44.294Z level=INFO msg="Sensor unloaded" sensor=generic_kprobe maps-error=[]
    logcapture.go:24: time=2025-12-10T08:17:44.303Z level=INFO msg="Unloading sensor test-sensor-1"
    logcapture.go:24: time=2025-12-10T08:17:44.303Z level=INFO msg="Sensor unloaded" sensor=test-sensor-1 maps-error=[]
    logcapture.go:24: time=2025-12-10T08:17:44.303Z level=INFO msg="Unloading sensor __base__"
    logcapture.go:24: time=2025-12-10T08:17:44.303Z level=INFO msg="Sensor unloaded" sensor=__base__ maps-error=[]
    base.go:202: cleanup: unloading base sensor
    logcapture.go:24: time=2025-12-10T08:17:44.303Z level=INFO msg="Unloading sensor __base__"
--- PASS: TestModeSigKill (1.26s)
=== RUN   TestModeEnforcer
    logcapture.go:24: time=2025-12-10T08:17:44.303Z level=INFO msg="Enabling policy filtering"
    logcapture.go:24: time=2025-12-10T08:17:44.312Z level=INFO msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/proc/1/root/sys/fs/cgroup cgroup.controllers="[cpuset cpu io memory hugetlb pids rdma misc dmem]" cgroup.hierarchyID=0
    logcapture.go:24: time=2025-12-10T08:17:44.312Z level=INFO msg="Deployment mode detection succeeded" cgroup.fs=/sys/fs/cgroup deployment.mode="systemd user session"
level=info msg="Updated TetragonConf map successfully" confmap-update=tg_conf_map deployment.mode="systemd user session" log.level=0 cgroup.fs.magic=Cgroupv2 cgroup.hierarchyID=0 NSPID=113542
    logcapture.go:24: time=2025-12-10T08:17:44.459Z level=INFO msg="Exit probe on acct_process"
    logcapture.go:24: time=2025-12-10T08:17:44.459Z level=INFO msg="Set execve_map entries 32768" size=28M
    logcapture.go:24: time=2025-12-10T08:17:44.459Z level=INFO msg="BPF ring buffer size (bytes)" total=256K
    logcapture.go:24: time=2025-12-10T08:17:44.459Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:44.459Z level=INFO msg="Loading sensor" name=__base__
    logcapture.go:24: time=2025-12-10T08:17:44.459Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:44.566Z level=INFO msg="Loaded sensor successfully" sensor=__base__
    logcapture.go:24: time=2025-12-10T08:17:44.570Z level=WARN msg="Reading uts namespace failed" error="namespace '/proc/113551/ns/uts' readlink /proc/113551/ns/uts: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.570Z level=WARN msg="Reading ipc namespace failed" error="namespace '/proc/113551/ns/ipc' readlink /proc/113551/ns/ipc: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.570Z level=WARN msg="Reading mnt namespace failed" error="namespace '/proc/113551/ns/mnt' readlink /proc/113551/ns/mnt: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.570Z level=WARN msg="Reading pid_for_children namespace failed" error="namespace '/proc/113551/ns/pid_for_children' readlink /proc/113551/ns/pid_for_children: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.570Z level=WARN msg="Reading net namespace failed" error="namespace '/proc/113551/ns/net' readlink /proc/113551/ns/net: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.570Z level=WARN msg="Reading cgroup namespace failed" error="namespace '/proc/113551/ns/cgroup' readlink /proc/113551/ns/cgroup: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.571Z level=WARN msg="Reading uts namespace failed" error="namespace '/proc/1775/ns/uts' readlink /proc/1775/ns/uts: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.571Z level=WARN msg="Reading ipc namespace failed" error="namespace '/proc/1775/ns/ipc' readlink /proc/1775/ns/ipc: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.571Z level=WARN msg="Reading mnt namespace failed" error="namespace '/proc/1775/ns/mnt' readlink /proc/1775/ns/mnt: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.571Z level=WARN msg="Reading net namespace failed" error="namespace '/proc/1775/ns/net' readlink /proc/1775/ns/net: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:44.580Z level=INFO msg="Read ProcFS /proc appended 158/219 entries"
    logcapture.go:24: time=2025-12-10T08:17:44.581Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:44.581Z level=INFO msg="Loading sensor" name=test-sensor-2
    logcapture.go:24: time=2025-12-10T08:17:44.581Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:44.614Z level=INFO msg="Loaded sensor successfully" sensor=test-sensor-2
    cgroup_fs.go:24: '/sys/fs/cgroup' is cgroup v2
    pftester.go:77: cgroup path:/sys/fs/cgroup/test-TestModeEnforcer-3881541676 id:36597
    logcapture.go:24: time=2025-12-10T08:17:44.817Z level=INFO msg="Added kprobe" return=true function=__arm64_sys_getcpu override=true
    logcapture.go:24: time=2025-12-10T08:17:44.817Z level=INFO msg="Added generic kprobe sensor: /Users/sglushko/src/tetragon/bpf/objs/bpf_generic_kprobe_v612.o -> __arm64_sys_getcpu" override=true
    logcapture.go:24: time=2025-12-10T08:17:44.817Z level=INFO msg="enforcer: using override return (multi-kprobe: false)"
    logcapture.go:24: time=2025-12-10T08:17:44.817Z level=INFO msg="Added enforcer sensor 'tp-test'"
    logcapture.go:24: time=2025-12-10T08:17:44.817Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:44.817Z level=INFO msg="Loading sensor" name=__enforcer__
    logcapture.go:24: time=2025-12-10T08:17:44.817Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:44.820Z level=INFO msg="Loaded enforcer sensor: 1 syscalls: [__arm64_sys_lseek]"
    logcapture.go:24: time=2025-12-10T08:17:44.820Z level=INFO msg="Loaded sensor successfully" sensor=__enforcer__
    logcapture.go:24: time=2025-12-10T08:17:44.820Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:44.820Z level=INFO msg="Loading sensor" name=generic_kprobe
    logcapture.go:24: time=2025-12-10T08:17:44.820Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:45.228Z level=INFO msg="Loaded generic kprobe program: /Users/sglushko/src/tetragon/bpf/objs/bpf_generic_kprobe_v612.o -> __arm64_sys_getcpu"
    logcapture.go:24: time=2025-12-10T08:17:45.496Z level=INFO msg="Loaded generic kprobe program: /Users/sglushko/src/tetragon/bpf/objs/bpf_generic_retkprobe_v612.o -> __arm64_sys_getcpu"
    logcapture.go:24: time=2025-12-10T08:17:45.496Z level=INFO msg="Loaded sensor successfully" sensor=generic_kprobe
    mode_test.go:208: command getcpu out:"getcpu returned: err:operation not permitted" err:<nil>
    mode_test.go:208: command getcpu out:"getcpu returned: err:errno 0" err:<nil>
    mode_test.go:208: command getcpu out:"getcpu returned: err:operation not permitted" err:<nil>
    logcapture.go:24: time=2025-12-10T08:17:45.509Z level=INFO msg="Unloading sensor __enforcer__"
    logcapture.go:24: time=2025-12-10T08:17:45.509Z level=INFO msg="Sensor unloaded" sensor=__enforcer__ maps-error=[]
    logcapture.go:24: time=2025-12-10T08:17:45.509Z level=INFO msg="Cleaned up enforcer sensor 'tp-test'"
    logcapture.go:24: time=2025-12-10T08:17:45.509Z level=INFO msg="Unloading sensor generic_kprobe"
    logcapture.go:24: time=2025-12-10T08:17:45.509Z level=INFO msg="Sensor unloaded" sensor=generic_kprobe maps-error=[]
    logcapture.go:24: time=2025-12-10T08:17:45.527Z level=INFO msg="Unloading sensor test-sensor-2"
    logcapture.go:24: time=2025-12-10T08:17:45.527Z level=INFO msg="Sensor unloaded" sensor=test-sensor-2 maps-error=[]
    logcapture.go:24: time=2025-12-10T08:17:45.527Z level=INFO msg="Unloading sensor __base__"
    logcapture.go:24: time=2025-12-10T08:17:45.527Z level=INFO msg="Sensor unloaded" sensor=__base__ maps-error=[]
    base.go:202: cleanup: unloading base sensor
    logcapture.go:24: time=2025-12-10T08:17:45.527Z level=INFO msg="Unloading sensor __base__"
--- PASS: TestModeEnforcer (1.22s)
=== RUN   TestModeMonitorOnly
    logcapture.go:24: time=2025-12-10T08:17:45.527Z level=INFO msg="Enabling policy filtering"
    logcapture.go:24: time=2025-12-10T08:17:45.536Z level=INFO msg="Cgroupv2 supported controllers detected successfully" cgroup.fs=/sys/fs/cgroup cgroup.path=/proc/1/root/sys/fs/cgroup cgroup.controllers="[cpuset cpu io memory hugetlb pids rdma misc dmem]" cgroup.hierarchyID=0
    logcapture.go:24: time=2025-12-10T08:17:45.536Z level=INFO msg="Deployment mode detection succeeded" cgroup.fs=/sys/fs/cgroup deployment.mode="systemd user session"
level=info msg="Updated TetragonConf map successfully" confmap-update=tg_conf_map deployment.mode="systemd user session" log.level=0 cgroup.fs.magic=Cgroupv2 cgroup.hierarchyID=0 NSPID=113542
    logcapture.go:24: time=2025-12-10T08:17:45.687Z level=INFO msg="Exit probe on acct_process"
    logcapture.go:24: time=2025-12-10T08:17:45.687Z level=INFO msg="Set execve_map entries 32768" size=28M
    logcapture.go:24: time=2025-12-10T08:17:45.687Z level=INFO msg="BPF ring buffer size (bytes)" total=256K
    logcapture.go:24: time=2025-12-10T08:17:45.687Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:45.687Z level=INFO msg="Loading sensor" name=__base__
    logcapture.go:24: time=2025-12-10T08:17:45.688Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:45.877Z level=INFO msg="Loaded sensor successfully" sensor=__base__
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading uts namespace failed" error="namespace '/proc/113551/ns/uts' readlink /proc/113551/ns/uts: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading ipc namespace failed" error="namespace '/proc/113551/ns/ipc' readlink /proc/113551/ns/ipc: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading mnt namespace failed" error="namespace '/proc/113551/ns/mnt' readlink /proc/113551/ns/mnt: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading pid_for_children namespace failed" error="namespace '/proc/113551/ns/pid_for_children' readlink /proc/113551/ns/pid_for_children: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading net namespace failed" error="namespace '/proc/113551/ns/net' readlink /proc/113551/ns/net: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading cgroup namespace failed" error="namespace '/proc/113551/ns/cgroup' readlink /proc/113551/ns/cgroup: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading uts namespace failed" error="namespace '/proc/113577/ns/uts' readlink /proc/113577/ns/uts: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading ipc namespace failed" error="namespace '/proc/113577/ns/ipc' readlink /proc/113577/ns/ipc: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading mnt namespace failed" error="namespace '/proc/113577/ns/mnt' readlink /proc/113577/ns/mnt: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.880Z level=WARN msg="Reading net namespace failed" error="namespace '/proc/113577/ns/net' readlink /proc/113577/ns/net: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.882Z level=WARN msg="Reading uts namespace failed" error="namespace '/proc/1775/ns/uts' readlink /proc/1775/ns/uts: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.882Z level=WARN msg="Reading ipc namespace failed" error="namespace '/proc/1775/ns/ipc' readlink /proc/1775/ns/ipc: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.882Z level=WARN msg="Reading mnt namespace failed" error="namespace '/proc/1775/ns/mnt' readlink /proc/1775/ns/mnt: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.882Z level=WARN msg="Reading net namespace failed" error="namespace '/proc/1775/ns/net' readlink /proc/1775/ns/net: no such file or directory"
    logcapture.go:24: time=2025-12-10T08:17:45.890Z level=INFO msg="Read ProcFS /proc appended 160/221 entries"
    logcapture.go:24: time=2025-12-10T08:17:45.891Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:45.891Z level=INFO msg="Loading sensor" name=test-sensor-3
    logcapture.go:24: time=2025-12-10T08:17:45.891Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:45.923Z level=INFO msg="Loaded sensor successfully" sensor=test-sensor-3
    cgroup_fs.go:24: '/sys/fs/cgroup' is cgroup v2
    pftester.go:77: cgroup path:/sys/fs/cgroup/test-TestModeMonitorOnly-2808010204 id:36697
    logcapture.go:24: time=2025-12-10T08:17:46.114Z level=INFO msg="Added kprobe" return=true function=__arm64_sys_getcpu override=false
    logcapture.go:24: time=2025-12-10T08:17:46.114Z level=INFO msg="BTF file: using metadata file" metadata=/sys/kernel/btf/vmlinux
    logcapture.go:24: time=2025-12-10T08:17:46.114Z level=INFO msg="Loading sensor" name=generic_kprobe
    logcapture.go:24: time=2025-12-10T08:17:46.114Z level=INFO msg="Loading kernel version 6.17.1"
    logcapture.go:24: time=2025-12-10T08:17:46.511Z level=INFO msg="Loaded generic kprobe sensor: /Users/sglushko/src/tetragon/bpf/objs/bpf_multi_kprobe_v612.o -> kprobe_multi (1 functions)"
    logcapture.go:24: time=2025-12-10T08:17:46.770Z level=INFO msg="Loaded generic kprobe sensor: /Users/sglushko/src/tetragon/bpf/objs/bpf_multi_retkprobe_v612.o -> 1 retkprobes"
    logcapture.go:24: time=2025-12-10T08:17:46.770Z level=INFO msg="Loaded sensor successfully" sensor=generic_kprobe
    logcapture.go:24: time=2025-12-10T08:17:46.779Z level=INFO msg="Unloading sensor generic_kprobe"
    logcapture.go:24: time=2025-12-10T08:17:46.779Z level=INFO msg="Sensor unloaded" sensor=generic_kprobe maps-error=[]
    logcapture.go:24: time=2025-12-10T08:17:46.793Z level=INFO msg="Unloading sensor test-sensor-3"
    logcapture.go:24: time=2025-12-10T08:17:46.793Z level=INFO msg="Sensor unloaded" sensor=test-sensor-3 maps-error=[]
    logcapture.go:24: time=2025-12-10T08:17:46.793Z level=INFO msg="Unloading sensor __base__"
    logcapture.go:24: time=2025-12-10T08:17:46.793Z level=INFO msg="Sensor unloaded" sensor=__base__ maps-error=[]
    base.go:202: cleanup: unloading base sensor
    logcapture.go:24: time=2025-12-10T08:17:46.793Z level=INFO msg="Unloading sensor __base__"
--- PASS: TestModeMonitorOnly (1.27s)
PASS
coverage: [no statements]
ok      github.com/cilium/tetragon/pkg/policyconf/test  3.807s  coverage: [no statements]
  ```

</details>