### PR TITLE
allow negative override values

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1099,7 +1099,7 @@ func ParseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, a
 		WriteSelectorUint32(&k.data, action.ArgName)
 	case ActionTypeOverride:
 		if k.isUprobe {
-			id, err := parseOverrideRegs(k, action.ArgRegs, uint64(action.ArgError))
+			id, err := parseOverrideRegs(k, action.ArgRegs, action.ArgError)
 			if err != nil {
 				return err
 			}

--- a/pkg/selectors/kernel_regs_amd64.go
+++ b/pkg/selectors/kernel_regs_amd64.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/tetragon/pkg/asm"
 )
 
-func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64) (uint32, error) {
+func parseOverrideRegs(k *KernelSelectorState, values []string, errValue int32) (uint32, error) {
 	if len(k.regs) > 0 {
 		return uint32(0xffffffff), errors.New("only single instance of regs action is allowed")
 	}

--- a/pkg/selectors/kernel_regs_arm64.go
+++ b/pkg/selectors/kernel_regs_arm64.go
@@ -7,6 +7,6 @@ package selectors
 
 import "errors"
 
-func parseOverrideRegs(_ *KernelSelectorState, _ []string, _ uint64) (uint32, error) {
+func parseOverrideRegs(_ *KernelSelectorState, _ []string, _ int32) (uint32, error) {
 	return uint32(0xffffffff), errors.New("register override is not supported")
 }


### PR DESCRIPTION
The user specified override value is stored as an int32 and then cast to
uint64. When the override value is negative, this casting creates a very
large number. Later when we parse this large constant, we try to store
it in a signed integer, which cannot accommodate a value this large.

Hence, write the override return value as a signed value when auto
generating the register overrides. This way, ParseAssignment will be
able to parse the negative integers.

I tested that negative override worked as expected.
