### PR TITLE
tetragon/windows: Case insensitive Windows Paths for processes

### DIFF
--- a/pkg/sensors/exec/args_windows.go
+++ b/pkg/sensors/exec/args_windows.go
@@ -37,17 +37,12 @@ func getArgsFromPID(PID uint32) (string, string, error) {
 		}
 	}
 	var wideCmd [2048]uint16
-	err := cmdMap.Lookup(PID, &wideCmd)
-	if err == nil {
-		cmdMap.Delete(PID)
-	}
+	cmdMap.Lookup(PID, &wideCmd)
 	strCmd := windows.UTF16ToString(wideCmd[:])
 
 	var wideImagePath [1024]byte
-	err = imageMap.Lookup(PID, &wideImagePath)
-	if err == nil {
-		imageMap.Delete(PID)
-	}
+	imageMap.Lookup(PID, &wideImagePath)
+
 	var s = (*uint16)(unsafe.Pointer(&wideImagePath[0]))
 	strImagePath := windows.UTF16PtrToString(s)
 


### PR DESCRIPTION


### Description
This PR changes the windows process_monitor bpf program to report lowercase path and command-line to facilitate easier path comparison. This also changes the existing processes enumeration to report paths in lowercase
This also writes back the paths of existing processes into image_map and command_map.


### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note

Tetragon on Windows now reports Windows process image_paths in lowercase only
```
