### PR TITLE
tetragon: split process event tail call

### DIFF
--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -323,4 +323,10 @@ static int BPF_FUNC(seq_write, struct seq_file *m, const void *data, uint32_t le
 # define lock_and(ptr, val)	(*(ptr) &= val)
 #endif
 
+enum {
+	__READ_ARG_1,
+	__READ_ARG_2,
+	__READ_ARG_ALL,
+};
+
 #endif /* __BPF_API__ */

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -18,6 +18,7 @@ char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
 
 int generic_kprobe_setup_event(void *ctx);
 int generic_kprobe_process_event(void *ctx);
+int generic_kprobe_process_event_2(void *ctx);
 int generic_kprobe_process_filter(void *ctx);
 int generic_kprobe_filter_arg(void *ctx);
 int generic_kprobe_actions(void *ctx);
@@ -39,6 +40,9 @@ struct {
 		[TAIL_CALL_SEND] = (void *)&generic_kprobe_output,
 #ifndef __V61_BPF_PROG
 		[TAIL_CALL_PATH] = (void *)&generic_kprobe_path,
+#endif
+#ifndef __LARGE_BPF_PROG
+		[TAIL_CALL_PROCESS_2] = (void *)&generic_kprobe_process_event_2,
 #endif
 	},
 };
@@ -91,11 +95,25 @@ generic_kprobe_setup_event(void *ctx)
 	return generic_process_event_and_setup(ctx, (struct bpf_map_def *)&kprobe_calls);
 }
 
+#ifdef __LARGE_BPF_PROG
 __attribute__((section(COMMON), used)) int
 generic_kprobe_process_event(void *ctx)
 {
-	return generic_process_event(ctx, (struct bpf_map_def *)&kprobe_calls);
+	return generic_process_event(ctx, (struct bpf_map_def *)&kprobe_calls, __READ_ARG_ALL);
 }
+#else
+__attribute__((section(COMMON), used)) int
+generic_kprobe_process_event(void *ctx)
+{
+	return generic_process_event(ctx, (struct bpf_map_def *)&kprobe_calls, __READ_ARG_1);
+}
+
+__attribute__((section(COMMON), used)) int
+generic_kprobe_process_event_2(void *ctx)
+{
+	return generic_process_event(ctx, (struct bpf_map_def *)&kprobe_calls, __READ_ARG_2);
+}
+#endif
 
 __attribute__((section(COMMON), used)) int
 generic_kprobe_process_filter(void *ctx)

--- a/bpf/process/bpf_generic_lsm_core.c
+++ b/bpf/process/bpf_generic_lsm_core.c
@@ -63,7 +63,7 @@ generic_lsm_setup_event(void *ctx)
 __attribute__((section("lsm"), used)) int
 generic_lsm_process_event(void *ctx)
 {
-	return generic_process_event(ctx, (struct bpf_map_def *)&lsm_calls);
+	return generic_process_event(ctx, (struct bpf_map_def *)&lsm_calls, __READ_ARG_ALL);
 }
 
 __attribute__((section("lsm"), used)) int

--- a/bpf/process/bpf_generic_rawtp.c
+++ b/bpf/process/bpf_generic_rawtp.c
@@ -84,7 +84,7 @@ generic_rawtp_setup_event(void *ctx)
 __attribute__((section("raw_tp"), used)) int
 generic_rawtp_process_event(void *ctx)
 {
-	return generic_process_event(ctx, (struct bpf_map_def *)&tp_calls);
+	return generic_process_event(ctx, (struct bpf_map_def *)&tp_calls, __READ_ARG_ALL);
 }
 
 __attribute__((section("raw_tp"), used)) int

--- a/bpf/process/bpf_generic_usdt.c
+++ b/bpf/process/bpf_generic_usdt.c
@@ -72,7 +72,7 @@ generic_usdt_setup_event(void *ctx)
 __attribute__((section(COMMON), used)) int
 generic_usdt_process_event(void *ctx)
 {
-	return generic_process_event(ctx, (struct bpf_map_def *)&usdt_calls);
+	return generic_process_event(ctx, (struct bpf_map_def *)&usdt_calls, __READ_ARG_ALL);
 }
 
 __attribute__((section(COMMON), used)) int

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -138,6 +138,7 @@ enum {
 	TAIL_CALL_ACTIONS = 4,
 	TAIL_CALL_SEND = 5,
 	TAIL_CALL_PATH = 6,
+	TAIL_CALL_PROCESS_2 = 7,
 };
 
 struct selector_action {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4421,12 +4421,6 @@ func TestLoadKprobeSensor(t *testing.T) {
 		}
 
 		sensorMaps = []tus.SensorMap{
-			// all kprobe programs
-			{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}},
-
-			// all but generic_kprobe_output
-			{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7}},
-
 			// generic_retkprobe_event
 			{Name: "retkprobe_calls", Progs: []uint{8, 9, 10}},
 
@@ -4436,12 +4430,18 @@ func TestLoadKprobeSensor(t *testing.T) {
 
 			// generic_kprobe_actions
 			{Name: "override_tasks", Progs: []uint{5}},
-
-			// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
-			{Name: "config_map", Progs: []uint{0, 1, 2}},
 		}
 
 		if config.EnableLargeProgs() {
+			// all kprobe programs
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}})
+
+			// all but generic_kprobe_output
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7}})
+
+			// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2}})
+
 			// shared with base sensor
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4, 5, 6, 8, 10}})
 
@@ -4462,6 +4462,17 @@ func TestLoadKprobeSensor(t *testing.T) {
 				sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}})
 			}
 		} else {
+			sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_kprobe_process_event_2", Type: ebpf.Kprobe})
+
+			// all kprobe programs
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}})
+
+			// all but generic_kprobe_output
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7, 12}})
+
+			// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 12}})
+
 			// shared with base sensor
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4, 8}})
 

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -444,23 +444,23 @@ func TestLoadTracepointSensor(t *testing.T) {
 	}
 
 	var sensorMaps = []tus.SensorMap{
-		// all programs
-		{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5}},
-
-		// all but generic_tracepoint_output
-		{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4}},
-
-		// all but generic_tracepoint_event,generic_tracepoint_filter
-		{Name: "retprobe_map", Progs: []uint{1, 2}},
-
 		// generic_tracepoint_output
 		{Name: "tcpmon_map", Progs: []uint{5}},
-
-		// all kprobe but generic_tracepoint_filter
-		{Name: "config_map", Progs: []uint{0, 2}},
 	}
 
 	if config.EnableLargeProgs() {
+		// all programs
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5}})
+
+		// all but generic_tracepoint_output
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4}})
+
+		// all but generic_tracepoint_event,generic_tracepoint_filter
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2}})
+
+		// all kprobe but generic_tracepoint_filter
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 2}})
+
 		// shared with base sensor
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{3, 4, 5}})
 
@@ -474,11 +474,25 @@ func TestLoadTracepointSensor(t *testing.T) {
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}})
 		}
 	} else {
+		sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_tracepoint_process_event_2", Type: ebpf.TracePoint})
+
+		// all programs
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6}})
+
+		// all but generic_tracepoint_output
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 6}})
+
+		// all but generic_tracepoint_event,generic_tracepoint_filter
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 6}})
+
+		// all kprobe but generic_tracepoint_filter
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 2, 6}})
+
 		// shared with base sensor
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{3}})
 
 		// only generic_tracepoint_event*
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "buffer_heap_map", Progs: []uint{2}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "buffer_heap_map", Progs: []uint{2, 6}})
 
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}})
 	}

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -87,12 +87,6 @@ func TestLoadUprobeSensor(t *testing.T) {
 		}
 
 		sensorMaps = []tus.SensorMap{
-			// all uprobe programs
-			{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7}},
-
-			// all but generic_uprobe_output
-			{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7}},
-
 			// generic_uprobe_process_filter,generic_uprobe_filter_arg*,generic_uprobe_actions
 			{Name: "filter_map", Progs: []uint{3, 4, 5}},
 
@@ -101,6 +95,12 @@ func TestLoadUprobeSensor(t *testing.T) {
 		}
 
 		if config.EnableLargeProgs() {
+			// all uprobe programs
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7}})
+
+			// all but generic_uprobe_output
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7}})
+
 			// shared with base sensor
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4, 5, 6}})
 
@@ -111,6 +111,14 @@ func TestLoadUprobeSensor(t *testing.T) {
 				sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}})
 			}
 		} else {
+			sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_uprobe_process_event_2", Type: ebpf.Kprobe})
+
+			// all uprobe programs
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8}})
+
+			// all but generic_uprobe_output
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7, 8}})
+
 			// shared with base sensor
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4}})
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}})


### PR DESCRIPTION
Split generic_[ku]probe_process_event into two separate tail calls, so we have space (there's 4096 instructions limit on 4.19 kernels) for new features in processing event code.
 
```
Before:
      generic_kprobe_process_event 4029 insns
      generic_uprobe_process_event 4029 insns
 
Now:
      generic_uprobe_process_event   2795 insns
      generic_uprobe_process_event_2 3147 insns
    
      generic_kprobe_process_event   2795 insns
      generic_kprobe_process_event_2 3147 insns
```