### PR TITLE
Reflect support for followChildren NotIn operator in documentation

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -276,9 +276,9 @@ this, set `followChildren` to `true`. For example:
 ```
 
 There are a number of limitations when using followChildren:
-- Children created before the policy was installed will not be matched
+- Children created before the policy was installed will not be matched.
 - The number of `matchBinaries` sections with `followChildren: true` cannot exceed 64.
-- Operators other than `In` are not supported.
+- `operator` can be `In` or `NotIn`.
 
 
 **Further examples**


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
Reflect support for the followChildren NotIn operator in documentation. Actual support for it was already implemented in [PR 3821](https://github.com/cilium/tetragon/pull/3821) b4c880d.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Reflect support for the followChildren NotIn operator in documentation
```
