### PR TITLE
e2e: Remove Cilium related flags

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -97,9 +97,6 @@ jobs:
         helm: v3.18.4
         # renovate: datasource=github-releases depName=kubernetes-sigs/kind
         kind: v0.29.0
-        # renovate: datasource=github-releases depName=cilium/cilium-cli
-        cilium: v0.18.5
-        print-summary: false
 
     - name: Pull Tetragon Images
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
@@ -118,7 +115,7 @@ jobs:
         GHA_OS: ${{matrix.os}}
       run: |
         cd go/src/github.com/cilium/tetragon
-        make e2e-test E2E_TESTS=${{matrix.package.f}} E2E_BUILD_IMAGES=0 E2E_AGENT=${{ needs.prepare.outputs.agentImage }} E2E_OPERATOR=${{ needs.prepare.outputs.operatorImage }} EXTRA_TESTFLAGS="-cluster-name=${{ env.clusterName }} -args -v=4 -tetragon.install-cilium=false"
+        make e2e-test E2E_TESTS=${{matrix.package.f}} E2E_BUILD_IMAGES=0 E2E_AGENT=${{ needs.prepare.outputs.agentImage }} E2E_OPERATOR=${{ needs.prepare.outputs.operatorImage }} EXTRA_TESTFLAGS="-cluster-name=${{ env.clusterName }} -args -v=4"
 
     - name: Upload Tetragon Logs
       if: failure() || cancelled()

--- a/tests/e2e/flags/flags.go
+++ b/tests/e2e/flags/flags.go
@@ -26,10 +26,7 @@ var Opts = Flags{
 			"tetragon.exportAllowList": "",
 		},
 	},
-	KeepExportData: false,
-	InstallCilium:  true,
-	// renovate: datasource=go depName=github.com/cilium/cilium
-	CiliumVersion:     "v1.17.6",
+	KeepExportData:    false,
 	UninstallTetragon: true,
 }
 
@@ -78,20 +75,10 @@ func init() {
 		Opts.KeepExportData,
 		"Should we keep export files regardless of pass/fail?")
 
-	flag.BoolVar(&Opts.InstallCilium,
-		"tetragon.install-cilium",
-		Opts.InstallCilium,
-		"Should we install Cilium in the test?")
-
 	flag.StringVar(&Opts.Helm.BTF,
 		"tetragon.btf",
 		Opts.Helm.BTF,
 		"A BTF file on the host that should be loaded into the KinD cluster. Will override helm BTF settings. Only makes sense when testing on a KinD cluster.")
-
-	flag.StringVar(&Opts.CiliumVersion,
-		"tetragon.cilium-version",
-		Opts.CiliumVersion,
-		"Version of Cilium to install. Only makes sense if tetragon.install-cilium is true.")
 
 	flag.BoolVar(&Opts.UninstallTetragon,
 		"tetragon.uninstall-tetragon",
@@ -103,10 +90,6 @@ type Flags struct {
 	Helm HelmOptions
 	// Should we keep the export file for the tests regardless of pass/fail?
 	KeepExportData bool
-	// Should we install Cilium in the test?
-	InstallCilium bool
-	// Version of Cilium to use
-	CiliumVersion string
 	// UninstallTetragon specifies whether Tetragon should be uninstalled after the test run.
 	UninstallTetragon bool
 }

--- a/tests/e2e/tests/skeleton/skeleton_test.go
+++ b/tests/e2e/tests/skeleton/skeleton_test.go
@@ -46,18 +46,14 @@ func TestMain(m *testing.M) {
 	// 2. After the cluster is configured and running, query the minimum kernel versions
 	//    supported by all nodes and set this as a variable in the test context.
 	//
-	// 3. Register a hook at the start of every test that installs Cilium into the
-	//    cluster with some default options (unless -tetragon.install-cilium=false is set
-	//    on thhe command line).
-	//
-	// 4. Register a hook at the start of every test that installs Tetragon into the
+	// 3. Register a hook at the start of every test that installs Tetragon into the
 	//    cluster with some default options.
 	//
-	// 5. Register a hook at the start of every test that port forwards Tetragon metrics
+	// 4. Register a hook at the start of every test that port forwards Tetragon metrics
 	//    and gRPC ports for all pods. These port forwards are registered in the test
 	//    context for later retrieval.
 	//
-	// 6. Register a hook at the end of every test that dumps information about the
+	// 5. Register a hook at the end of every test that dumps information about the
 	//    cluster and running event checkers. This information is only dumped if the test
 	//    fails or if -tetragon.keep-export=true is set on the command line.
 	//


### PR DESCRIPTION
[upstream 3ff85dd46da5d13b334f92fbf4fa2540277dc9aa]

E2E no longer installs Cilium, so it's better to clean up the related flags. One benefit is to bump cilium version unnecessarily (even by renovate).

```release-note
e2e: Remove Cilium related flags
```
