### PR TITLE
Correction of  cgroup-rate mentioned limitations 

### DIFF
--- a/docs/content/en/docs/concepts/cgroup-rate.md
+++ b/docs/content/en/docs/concepts/cgroup-rate.md
@@ -166,7 +166,7 @@ This example shows how to generate throttle events when cgroup rate monitoring i
 ##  Limitations
 
 - The cgroup rate is monitored per CPU
-- At the moment we only monitor and limit base sensor and kprobe events:
+- At the moment we only monitor and limit base sensor:
   - `PROCESS_EXEC`
   - `PROCESS_EXIT`
 


### PR DESCRIPTION
Cgroup rate limit is not part of the kprobe logic it only controls the base events.

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes <!-- #issue-number -->
cgroup -rate page update 
### Description
The limitations described in the page are incorrect. cgroup rate only controls the base events 'process exec' and 'process exit' and not the kprobe events. Thus pushing the change

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->
cgroup-rate.md file change.

```release-note
```
