### PR TITLE
Backports/kevsecurity/v1.5/zero cleanup key on exec

### DIFF
--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -198,6 +198,7 @@ event_execve(struct exec_ctx_struct *ctx)
 	if (parent) {
 		event->parent = parent->key;
 		update_mb_task(parent);
+		event->parent_flags = 0;
 	} else {
 		event_minimal_parent(event, task);
 	}
@@ -223,6 +224,7 @@ event_execve(struct exec_ctx_struct *ctx)
 	p->size += read_cwd(ctx, p);
 
 	event->common.op = MSG_OP_EXECVE;
+	event->common.flags = 0;
 	event->common.ktime = p->ktime;
 	event->common.size = offsetof(struct msg_execve_event, process) + p->size;
 


### PR DESCRIPTION
On process execution (execve) we send a message to user space with the details. In the case where a process hasn't previously forked (script execution, for example), we will already have an entry in our maps for this PID. We set the cleanup_key to this entry so that user space can harmonise the processes and set the referece counting flags accordingly.

If, however, the process isn't in our map, then we still send the message to user space but we fail to zero the cleanup_key, thereby sending the previous value that a previous execution had set (the heap memory is reused). This causes user space confusion, so this commit resets the cleanup_key before checking if the process is in the map. This should correct the reference counting issue where a process is marked with an additional "parent--" count.

[Upstream PR: #4466]