### PR TITLE
bpf: Add reuasable marcos for bounds checking

### DIFF
--- a/bpf/lib/bpf_d_path.h
+++ b/bpf/lib/bpf_d_path.h
@@ -144,8 +144,7 @@ prepend_name(char *buf, char **bufptr, int *buflen, const char *name, u32 namele
 	// This ensures that namelen is < 256, which is aligned with kernel's max dentry name length
 	// that is 255 (https://elixir.bootlin.com/linux/v5.10/source/include/uapi/linux/limits.h#L12).
 	// Needed to bound that for probe_read call.
-	asm volatile("%[namelen] &= 0xff;\n"
-		     : [namelen] "+r"(namelen));
+	VERIFIER_BOUND_8BIT(namelen);
 	probe_read(buf + buffer_offset + write_slash, namelen * sizeof(char), name);
 
 	*bufptr = buf + buffer_offset;

--- a/bpf/lib/bpf_helpers.h
+++ b/bpf/lib/bpf_helpers.h
@@ -71,6 +71,7 @@ enum bpf_enum_value_kind {
 };
 
 #include "bpf_core_read.h"
+#include "verifier_helpers.h"
 
 /* relax_verifier is a dummy helper call to introduce a pruning checkpoint
  * to help relax the verifier to avoid reaching complexity limits.

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -708,8 +708,7 @@ read_exe(struct task_struct *task, struct heap_exe *exe)
 	// verifier for the > 0 check)
 	if (exe->len > BINARY_PATH_MAX_LEN - 1)
 		exe->len = BINARY_PATH_MAX_LEN - 1;
-	asm volatile("%[len] &= 0xff;\n"
-		     : [len] "+r"(exe->len));
+	VERIFIER_BOUND_8BIT(exe->len);
 	with_errmetrics(probe_read, exe->buf, exe->len, buffer);
 	if (revlen < STRING_POSTFIX_MAX_LENGTH)
 		with_errmetrics(probe_read, exe->end, revlen, (char *)(buffer + offset));

--- a/bpf/lib/verifier_helpers.h
+++ b/bpf/lib/verifier_helpers.h
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifndef __VERIFIER_HELPERS_H__
+#define __VERIFIER_HELPERS_H__
+
+/*
+ * BPF Verifier Bounds Masking Helpers
+ *
+ * These macros help the BPF verifier understand value bounds by applying
+ * bitwise AND masks. The verifier sometimes loses track of bounds during
+ * register spilling, complex control flow, or arithmetic operations.
+ *
+ * Using these macros prevents "unbounded value" errors by explicitly
+ * constraining values to known ranges.
+ *
+ * Usage: VERIFIER_BOUND_12BIT(offset);
+ *        // Now verifier knows: 0 <= offset <= 4095
+ */
+
+/* 3-bit mask: 0-7 */
+#define VERIFIER_BOUND_3BIT(x) \
+	asm volatile("%[v] &= 0x7;\n" : [v] "+r"(x))
+
+/* 4-bit mask: 0-15 */
+#define VERIFIER_BOUND_4BIT(x) \
+	asm volatile("%[v] &= 0xf;\n" : [v] "+r"(x))
+
+/* 5-bit mask: 0-31 */
+#define VERIFIER_BOUND_5BIT(x) \
+	asm volatile("%[v] &= 0x1f;\n" : [v] "+r"(x))
+
+/* 6-bit mask: 0-63 */
+#define VERIFIER_BOUND_6BIT(x) \
+	asm volatile("%[v] &= 0x3f;\n" : [v] "+r"(x))
+
+/* 8-bit mask: 0-255 */
+#define VERIFIER_BOUND_8BIT(x) \
+	asm volatile("%[v] &= 0xff;\n" : [v] "+r"(x))
+
+/* 10-bit mask: 0-1023 */
+#define VERIFIER_BOUND_10BIT(x) \
+	asm volatile("%[v] &= 0x3ff;\n" : [v] "+r"(x))
+
+/* 11-bit mask: 0-2047 */
+#define VERIFIER_BOUND_11BIT(x) \
+	asm volatile("%[v] &= 0x7ff;\n" : [v] "+r"(x))
+
+/* 12-bit mask: 0-4095 */
+#define VERIFIER_BOUND_12BIT(x) \
+	asm volatile("%[v] &= 0xfff;\n" : [v] "+r"(x))
+
+/* 13-bit mask: 0-8191 */
+#define VERIFIER_BOUND_13BIT(x) \
+	asm volatile("%[v] &= 0x1fff;\n" : [v] "+r"(x))
+
+/* 14-bit mask: 0-16383 */
+#define VERIFIER_BOUND_14BIT(x) \
+	asm volatile("%[v] &= 0x3fff;\n" : [v] "+r"(x))
+
+/* 15-bit mask: 0-32767 */
+#define VERIFIER_BOUND_15BIT(x) \
+	asm volatile("%[v] &= 0x7fff;\n" : [v] "+r"(x))
+
+/* 16-bit mask: 0-65535 */
+#define VERIFIER_BOUND_16BIT(x) \
+	asm volatile("%[v] &= 0xffff;\n" : [v] "+r"(x))
+
+/* 32-bit mask: Reminds verifier value is 32-bit */
+#define VERIFIER_BOUND_32BIT(x) \
+	asm volatile("%[v] &= 0xffffffff;\n" : [v] "+r"(x))
+
+#endif /* __VERIFIER_HELPERS_H__ */

--- a/bpf/process/bpf_execve_map_update.c
+++ b/bpf/process/bpf_execve_map_update.c
@@ -39,8 +39,7 @@ __execve_map_update(struct update_data *data)
 
 	bpf_for(idx, 0, LOOPS)
 	{
-		asm volatile("%[idx] &= 0x7fff;\n"
-			     : [idx] "+r"(idx));
+		VERIFIER_BOUND_15BIT(idx);
 		if (data->cnt == idx)
 			break;
 

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -197,40 +197,35 @@ generic_tracepoint_event(struct generic_tracepoint_event_arg *ctx)
 	msg->a0 = ({
 		unsigned long ctx_off = config->off[0];
 		int ty = config->arg[0];
-		asm volatile("%[ctx_off] &= 0xffff;\n"
-			     : [ctx_off] "+r"(ctx_off));
+		VERIFIER_BOUND_16BIT(ctx_off);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a1 = ({
 		unsigned long ctx_off = config->off[1];
 		int ty = config->arg[1];
-		asm volatile("%[ctx_off] &= 0xffff;\n"
-			     : [ctx_off] "+r"(ctx_off));
+		VERIFIER_BOUND_16BIT(ctx_off);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a2 = ({
 		unsigned long ctx_off = config->off[2];
 		int ty = config->arg[2];
-		asm volatile("%[ctx_off] &= 0xffff;\n"
-			     : [ctx_off] "+r"(ctx_off));
+		VERIFIER_BOUND_16BIT(ctx_off);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a3 = ({
 		unsigned long ctx_off = config->off[3];
 		int ty = config->arg[3];
-		asm volatile("%[ctx_off] &= 0xffff;\n"
-			     : [ctx_off] "+r"(ctx_off));
+		VERIFIER_BOUND_16BIT(ctx_off);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 
 	msg->a4 = ({
 		unsigned long ctx_off = config->off[4];
 		int ty = config->arg[4];
-		asm volatile("%[ctx_off] &= 0xffff;\n"
-			     : [ctx_off] "+r"(ctx_off));
+		VERIFIER_BOUND_16BIT(ctx_off);
 		get_ctx_ul((char *)ctx + ctx_off, ty);
 	});
 

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -69,10 +69,8 @@ getcwd(struct msg_process *curr, __u32 offset, __u32 proc_pid)
 	if (!buffer)
 		return 0;
 
-	asm volatile("%[offset] &= 0x3ff;\n"
-		     : [offset] "+r"(offset));
-	asm volatile("%[size] &= 0xfff;\n"
-		     : [size] "+r"(size));
+	VERIFIER_BOUND_10BIT(offset);
+	VERIFIER_BOUND_12BIT(size);
 	probe_read((char *)curr + offset, size, buffer);
 
 	// Unfortunate special case for '/' where nothing was added we need

--- a/bpf/process/generic_path.h
+++ b/bpf/process/generic_path.h
@@ -22,7 +22,7 @@ FUNC_INLINE int get_off(char *buffer, char *buf)
 
 FUNC_INLINE char *get_buf(char *buffer, int off)
 {
-	asm volatile("%[off] &= 0xfff;\n" : [off] "+r"(off));
+	VERIFIER_BOUND_12BIT(off);
 	return buffer + off;
 }
 

--- a/bpf/process/pfilter.h
+++ b/bpf/process/pfilter.h
@@ -134,8 +134,7 @@ process_filter_pid(struct selector_filter *sf, __u32 *f,
 	else {
 		__u64 o = (__u64)off;
 		o = o / 4;
-		asm volatile("%[o] &= 0x3ff;\n"
-			     : [o] "+r"(o));
+		VERIFIER_BOUND_10BIT(o);
 		sel = f[o];
 	}
 	return __process_filter_pid(sf->ty, sf->flags, sel, pid, enter);
@@ -156,8 +155,7 @@ process_filter_namespace(struct selector_filter *sf, __u32 *f,
 	else {
 		__u64 o = (__u64)off;
 		o = o / 4;
-		asm volatile("%[o] &= 0x3ff;\n"
-			     : [o] "+r"(o));
+		VERIFIER_BOUND_10BIT(o);
 		sel = f[o];
 	}
 
@@ -285,8 +283,7 @@ process_filter_capability_change(__u32 ty, __u32 op, __u32 ns, __u64 val,
 	// 5.4.278, the verifier complains than ty could be negative while in this
 	// context it's just the capability set type (effective, inheritable, or
 	// permitted), let's blindly remind the verifier it's a u32.
-	asm volatile("%[ty] &= 0xffffffff;\n"
-		     : [ty] "+r"(ty));
+	VERIFIER_BOUND_32BIT(ty);
 	ccaps = c->c[ty];
 
 	/* we have a change in the capabilities that we care */
@@ -436,8 +433,7 @@ selector_process_filter(__u32 *f, __u32 index, struct execve_map_value *enter,
 	/* read the start offset of the corresponding selector */
 	/* selector section offset by reading the relative offset in the array */
 	i = index;
-	asm volatile("%[i] &= 0x3ff;\n" // INDEX_MASK
-		     : [i] "+r"(i));
+	VERIFIER_BOUND_10BIT(i); // INDEX_MASK
 	index += *(__u32 *)((__u64)f + i);
 	index &= INDEX_MASK;
 	index += 4; /* skip selector size field */


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
bpf: Add reuasable marcos for bounds checking
```
