### PR TITLE
tests: fix flaky pkg.bugtool.TestFindMaps

### DIFF
--- a/pkg/bugtool/maps_test.go
+++ b/pkg/bugtool/maps_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/tetragon/pkg/bpf"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 
 	// needed to register the probe type execve for the base sensor
@@ -32,6 +33,14 @@ func TestFindMaps(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	sumMemlock := func(mapInfos []bpf.ExtendedMapInfo) int {
+		sumMemlock := 0
+		for _, mapInfo := range mapInfos {
+			sumMemlock += mapInfo.Memlock
+		}
+		return sumMemlock
+	}
+
 	t.Run("BaseSensorMemlock", func(t *testing.T) {
 		tus.LoadInitialSensor(t)
 
@@ -39,19 +48,19 @@ func TestFindMaps(t *testing.T) {
 		pinnedMaps, err := FindPinnedMaps(path)
 		require.NoError(t, err)
 		if assert.NotEmpty(t, pinnedMaps) {
-			assert.NotZero(t, pinnedMaps[0].Memlock)
+			assert.NotZero(t, sumMemlock(pinnedMaps))
 		}
 
 		mapsUsedByProgs, err := FindMapsUsedByPinnedProgs(path)
 		require.NoError(t, err)
 		if assert.NotEmpty(t, mapsUsedByProgs) {
-			assert.NotZero(t, mapsUsedByProgs[0].Memlock)
+			assert.NotZero(t, sumMemlock(mapsUsedByProgs))
 		}
 
 		allMaps, err := FindAllMaps()
 		require.NoError(t, err)
 		if assert.NotEmpty(t, allMaps) {
-			assert.NotZero(t, allMaps[0].Memlock)
+			assert.NotZero(t, sumMemlock(allMaps))
 		}
 	})
 


### PR DESCRIPTION
Fixes #4220.

We had a few failures in the CI from times to times with:

	maps_test.go:48:
		Error Trace:	/home/runner/work/tetragon/tetragon/go/src/github.com/cilium/tetragon/pkg/bugtool/maps_test.go:48
		Error:      	Should not be zero, but was 0
		Test:       	TestFindMaps/BaseSensorMemlock

Showing that this part of the test was sometime failing:

	mapsUsedByProgs, err := FindMapsUsedByPinnedProgs(path)
	require.NoError(t, err)
	if assert.NotEmpty(t, mapsUsedByProgs) {
		assert.NotZero(t, mapsUsedByProgs[0].Memlock)
	}

I didn't think that memlock could be zero on a map. From the kernel it's now calculated per map type by using the map_mem_usage function pointer and it appears from the failures above that we observe, that in some situations, some of these functions can return zero. Let's decrease the probability we run into this by summing all the memlock of the maps we observe instead of blindly taking the first one.