### PR TITLE
metrics: clean up policy metrics when tracing policies are deleted

### DIFF
--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -74,7 +74,7 @@ var (
 		nil, nil, nil,
 	), nil)
 
-	policyStats = metrics.MustNewGranularCounterWithInit[metrics.ProcessLabels](
+	policyStats = metrics.MustNewGranularCounterWithInitAndPolicy[metrics.ProcessLabels](
 		metrics.NewOpts(
 			consts.MetricsNamespace, "", "policy_events_total",
 			"Policy events calls observed.",

--- a/pkg/metrics/metricwithpolicy.go
+++ b/pkg/metrics/metricwithpolicy.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	metricsWithPolicy      []*prometheus.MetricVec
+	metricsWithPolicyMutex sync.Mutex
+)
+func registerCounterVecForPolicyCleanup(metric *prometheus.CounterVec) {
+	metricsWithPolicyMutex.Lock()
+	metricsWithPolicy = append(metricsWithPolicy, metric.MetricVec)
+	metricsWithPolicyMutex.Unlock()
+}
+
+// NewCounterVecWithPolicy is a wrapper around prometheus.NewCounterVec that also
+// registers the metric to be cleaned up when a policy is deleted.
+//
+// It should be used only to register metrics that have "policy" label. Using it
+// for metrics without this label won't break anything, but might add an
+// unnecessary overhead.
+func NewCounterVecWithPolicy(opts prometheus.CounterOpts, labels []string) *prometheus.CounterVec {
+	metric := prometheus.NewCounterVec(opts, labels)
+	registerCounterVecForPolicyCleanup(metric)
+	return metric
+}
+
+// NewCounterVecWithPolicyV2 is a wrapper around prometheus.V2.NewCounterVec that also
+// registers the metric to be cleaned up when a policy is deleted.
+//
+// See NewCounterVecWithPolicy for usage notes.
+func NewCounterVecWithPolicyV2(opts prometheus.CounterVecOpts) *prometheus.CounterVec {
+	metric := prometheus.V2.NewCounterVec(opts)
+	registerCounterVecForPolicyCleanup(metric)
+	return metric
+}
+
+// DeleteMetricsForPolicy removes all metric series for the given policy.
+func DeleteMetricsForPolicy(policyName string) {
+	metricsWithPolicyMutex.Lock()
+	metricsCopy := append([]*prometheus.MetricVec(nil), metricsWithPolicy...)
+	metricsWithPolicyMutex.Unlock()
+	for _, metric := range metricsCopy {
+		// DeletePartialMatch removes all series for the policy regardless of other labels.
+		metric.DeletePartialMatch(prometheus.Labels{
+			"policy": policyName,
+		})
+	}
+}

--- a/pkg/sensors/handler.go
+++ b/pkg/sensors/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
@@ -182,6 +183,9 @@ func (h *handler) deleteTracingPolicy(op *tracingPolicyDelete) error {
 	h.collections.mu.Unlock()
 
 	col.destroy(true)
+
+	// Clean up stale policy-labeled metric series for this policy.
+	metrics.DeleteMetricsForPolicy(op.ck.name)
 
 	filterID := policyfilter.PolicyID(col.policyfilterID)
 	err := h.pfState.DelPolicy(filterID)


### PR DESCRIPTION
Policy-labeled metric series are currently kept after a TracingPolicy is deleted, which can cause stale metrics to remain exported.

Register tracing-policy metrics for cleanup and removes their series from the registry when a policy is deleted, regardless of how the policy was created or removed.

Fixes: #2256

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->


### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Ensure policy-labeled metric series are properly cleaned up when a TracingPolicy is deleted, preventing stale metrics from remaining exported.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Fix cleanup of policy-labeled metric series when tracing policies are deleted.
```
