### PR TITLE
[v1.5] fix(pkg/sensors): fixed kretprobe args merge helper.

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -1385,10 +1385,13 @@ func retprobeMerge(prev pendingEvent, curr pendingEvent) *tracing.MsgGenericKpro
 	kprobemetrics.MergeOkTotalInc()
 
 	for _, retArg := range retEv.Args {
-		index := retArg.GetIndex()
-		if uint64(len(enterEv.Args)) > index {
-			enterEv.Args[index] = retArg
+		enterIdx := slices.IndexFunc(enterEv.Args, func(arg api.MsgGenericKprobeArg) bool {
+			return arg.GetIndex() == retArg.GetIndex()
+		})
+		if enterIdx != -1 {
+			enterEv.Args[enterIdx] = retArg
 		} else {
+			// Append it since we did not find the matching index in the enter event arguments
 			enterEv.Args = append(enterEv.Args, retArg)
 		}
 	}


### PR DESCRIPTION
[ upstream commit 97cc3ba ]

### Description

Cherry pick upstream PR: #4494  to v1.5.

### Changelog


```release-note
fix(pkg/sensors): fixed kretprobe args merge helper
```
