### PR TITLE
docs: exclude nakryiko.com from link checker

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -11,6 +11,8 @@ exclude = [
   'docs/assets/icons/logo.*\.svg', 
   # the virtualbox website sends 500 regularly
   'virtualbox.org',
+  # this blog has transient certificate issues
+  'nakryiko.com',
   # this is for the documentation contributor guide
   '^http://localhost:1313/docs$',
   # this is a form POST link in the index.html


### PR DESCRIPTION
The nakryiko.com blog has transient certificate issues that cause false positives in the automated link checker.

Fixes: #4502


### Description
Added `nakryiko.com` to the lychee link checker exclude list in `.github/lychee.toml`. The automated link checker periodically reports certificate/network errors for links to this domain, even though the site and links are valid. This follows the existing pattern used for other domains with similar transient issues (e.g., `virtualbox.org`, `slack.cilium.io`)

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
docs: Exclude nakryiko.com from automated link checker to prevent false positives
```
