### PR TITLE
[v1.6] tetragon: Fix TestMatchBinariesFollowChildrenUpdate test

### DIFF
--- a/pkg/sensors/tracing/matchbinaries_follow_children_test.go
+++ b/pkg/sensors/tracing/matchbinaries_follow_children_test.go
@@ -298,8 +298,11 @@ func TestMatchBinariesFollowChildrenUpdate(t *testing.T) {
 		found = 0
 		iter := hash.Iterate()
 		for iter.Next(&key, &val) {
-			if unix.ByteSliceToString(val.Binary.Path[:]) == forks {
-				require.Equal(t, uint64(1), val.Binary.MBSet, "Binary.MBSet_1")
+			// We need to ccount execve_map records with:
+			// - forks binary path
+			// - val.Binary.MBSet == 1
+			if unix.ByteSliceToString(val.Binary.Path[:]) == forks &&
+				val.Binary.MBSet == 1 {
 				found++
 			}
 		}


### PR DESCRIPTION
[ upstream commit 7a6000b64471283e6f140ca85f5b4cb43076c98b ]

The test checks on amount of execve_map records updated correctly with MBSet == 1 and it has to match the expected count.

But because MBSet field is updated only after execve_map record is created, we could actually get half baked record with MBSet still unset.

Removing the require.Equal on MBSet.