### PR TITLE
fix(pkg/sensors): skip nested ptr detection for indexed array access.

### DIFF
--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -73,10 +73,21 @@ func formatBTFPath(resolvePath string) ([]string, error) {
 	return path, nil
 }
 
+// First argument is added to enforce the method to be called on a pointer type
+func isPointerToIndexedArray(_ *ebtf.Pointer, firstResolvePath string) bool {
+	var idx int
+	n, _ := fmt.Sscanf(firstResolvePath, `[%d]`, &idx)
+	return n == 1
+}
+
 func addPaddingOnNestedPtr(ty ebtf.Type, path []string) []string {
 	if t, ok := ty.(*ebtf.Pointer); ok {
-		updatedPath := append([]string{"[0]"}, path...)
-		return addPaddingOnNestedPtr(t.Target, updatedPath)
+		// If we are going to dereference the pointer by index,
+		// there is no need to force-dereference it.
+		if !isPointerToIndexedArray(t, path[0]) {
+			updatedPath := append([]string{"[0]"}, path...)
+			return addPaddingOnNestedPtr(t.Target, updatedPath)
+		}
 	}
 	return path
 }
@@ -145,7 +156,11 @@ func resolveBTFArg(hook string, arg *v1alpha1.KProbeArg, tp bool) (*ebtf.Type, [
 
 		ty = param.Type
 		if ptr, isPointer := param.Type.(*ebtf.Pointer); isPointer {
-			ty = ptr.Target
+			if !isPointerToIndexedArray(ptr, arg.Resolve) {
+				// If we are going to dereference the pointer by index,
+				// there is no need to force-dereference it.
+				ty = ptr.Target
+			}
 		}
 	}
 	return resolveBTFType(arg, ty)

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -123,6 +123,16 @@ spec:
     - index: 1
       type: "int"
       resolve: 'user.uid.val'
+  - call: "do_pipe2"
+    args:
+    - index: 0
+      resolve: "[0]"
+      type: int
+      label: "pipefd[0]"
+    - index: 0
+      resolve: "[1]"
+      type: int
+      label: "pipefd[1]"
   - call: "security_bprm_check"
     args:
     - index: 0
@@ -132,7 +142,7 @@ spec:
 	policy, err := tracingpolicy.FromYAML(rawPolicy)
 	require.NoError(t, err, "FromYAML rawPolicy error %q", err)
 
-	successHook := policy.TpSpec().KProbes[:2]
+	successHook := policy.TpSpec().KProbes[:3]
 	for _, hook := range successHook {
 		for _, arg := range hook.Args {
 			lastBTFType, btfArg, err := resolveBTFArg(hook.Call, &arg, false)
@@ -148,7 +158,7 @@ spec:
 		}
 	}
 
-	failHook := policy.TpSpec().KProbes[2]
+	failHook := policy.TpSpec().KProbes[3]
 	for _, arg := range failHook.Args {
 		_, _, err := resolveBTFArg(failHook.Call, &arg, false)
 


### PR DESCRIPTION

Refs #4442

### Description

When we want to resolve a precise index of an array, like for example `do_pipe2` with `resolve: "[1]"`, we want to skip nested pointer logic, since we are already going to dereference the correct index. 
Also, updated `TestResolveBTFArgFromKprobePolicy` to test the behavior.