### PR TITLE
clang-format: combine update and install lines

### DIFF
--- a/Dockerfile.clang-format
+++ b/Dockerfile.clang-format
@@ -1,7 +1,6 @@
 FROM docker.io/library/ubuntu:24.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 
-RUN apt-get -y update
-RUN apt-get -y install clang-format-18
+RUN apt-get -y update && apt-get -y install clang-format-18
 RUN ln -s /bin/clang-format-18 /bin/clang-format
 
 USER 1000


### PR DESCRIPTION
Having update and install on separate RUN lines can cause issues in some container environments where layer caching may serve stale package indexes, leading to build failures.
