### PR TITLE
bpf: break up arg filter tail call to increase instruction budget

### DIFF
--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -329,4 +329,10 @@ enum {
 	__READ_ARG_ALL,
 };
 
+enum {
+	__FILTER_ARG_1,
+	__FILTER_ARG_2,
+	__FILTER_ARG_ALL,
+};
+
 #endif /* __BPF_API__ */

--- a/bpf/process/bpf_generic_kprobe.c
+++ b/bpf/process/bpf_generic_kprobe.c
@@ -21,6 +21,7 @@ int generic_kprobe_process_event(void *ctx);
 int generic_kprobe_process_event_2(void *ctx);
 int generic_kprobe_process_filter(void *ctx);
 int generic_kprobe_filter_arg(void *ctx);
+int generic_kprobe_filter_arg_2(void *ctx);
 int generic_kprobe_actions(void *ctx);
 int generic_kprobe_output(void *ctx);
 int generic_kprobe_path(void *ctx);
@@ -43,6 +44,7 @@ struct {
 #endif
 #ifndef __LARGE_BPF_PROG
 		[TAIL_CALL_PROCESS_2] = (void *)&generic_kprobe_process_event_2,
+		[TAIL_CALL_ARGS_2] = (void *)&generic_kprobe_filter_arg_2,
 #endif
 	},
 };
@@ -131,11 +133,25 @@ generic_kprobe_process_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
+#ifdef __LARGE_BPF_PROG
 __attribute__((section(COMMON), used)) int
 generic_kprobe_filter_arg(void *ctx)
 {
-	return generic_filter_arg(ctx, (struct bpf_map_def *)&kprobe_calls, true);
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&kprobe_calls, true, __FILTER_ARG_ALL);
 }
+#else
+__attribute__((section(COMMON), used)) int
+generic_kprobe_filter_arg(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&kprobe_calls, true, __FILTER_ARG_1);
+}
+
+__attribute__((section(COMMON), used)) int
+generic_kprobe_filter_arg_2(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&kprobe_calls, true, __FILTER_ARG_2);
+}
+#endif
 
 __attribute__((section(COMMON), used)) int
 generic_kprobe_actions(void *ctx)

--- a/bpf/process/bpf_generic_lsm_core.c
+++ b/bpf/process/bpf_generic_lsm_core.c
@@ -22,6 +22,7 @@ int generic_lsm_setup_event(void *ctx);
 int generic_lsm_process_event(void *ctx);
 int generic_lsm_process_filter(void *ctx);
 int generic_lsm_filter_arg(void *ctx);
+int generic_lsm_filter_arg_2(void *ctx);
 int generic_lsm_actions(void *ctx);
 int generic_lsm_path(void *ctx);
 
@@ -39,6 +40,9 @@ struct {
 		[TAIL_CALL_ACTIONS] = (void *)&generic_lsm_actions,
 #ifndef __V61_BPF_PROG
 		[TAIL_CALL_PATH] = (void *)&generic_lsm_path,
+#endif
+#ifndef __LARGE_BPF_PROG
+		[TAIL_CALL_ARGS_2] = (void *)&generic_lsm_filter_arg_2,
 #endif
 	},
 };
@@ -79,11 +83,25 @@ generic_lsm_process_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
+#ifdef __LARGE_BPF_PROG
 __attribute__((section("lsm"), used)) int
 generic_lsm_filter_arg(void *ctx)
 {
-	return generic_filter_arg(ctx, (struct bpf_map_def *)&lsm_calls, true);
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&lsm_calls, true, __FILTER_ARG_ALL);
 }
+#else
+__attribute__((section("lsm"), used)) int
+generic_lsm_filter_arg(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&lsm_calls, true, __FILTER_ARG_1);
+}
+
+__attribute__((section("lsm"), used)) int
+generic_lsm_filter_arg_2(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&lsm_calls, true, __FILTER_ARG_2);
+}
+#endif
 
 __attribute__((section("lsm"), used)) int
 generic_lsm_actions(void *ctx)

--- a/bpf/process/bpf_generic_rawtp.c
+++ b/bpf/process/bpf_generic_rawtp.c
@@ -20,6 +20,7 @@ int generic_rawtp_setup_event(void *ctx);
 int generic_rawtp_process_event(void *ctx);
 int generic_rawtp_process_filter(void *ctx);
 int generic_rawtp_filter_arg(void *ctx);
+int generic_rawtp_filter_arg_2(void *ctx);
 int generic_rawtp_actions(void *ctx);
 int generic_rawtp_output(void *ctx);
 int generic_rawtp_path(void *ctx);
@@ -39,6 +40,9 @@ struct {
 		[TAIL_CALL_SEND] = (void *)&generic_rawtp_output,
 #ifndef __V61_BPF_PROG
 		[TAIL_CALL_PATH] = (void *)&generic_rawtp_path,
+#endif
+#ifndef __LARGE_BPF_PROG
+		[TAIL_CALL_ARGS_2] = (void *)&generic_rawtp_filter_arg_2,
 #endif
 	},
 };
@@ -103,11 +107,28 @@ generic_rawtp_process_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
+#ifdef __LARGE_BPF_PROG
 __attribute__((section("raw_tp"), used)) int
 generic_rawtp_filter_arg(void *ctx)
 {
-	return generic_filter_arg(ctx, (struct bpf_map_def *)&tp_calls, true);
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&tp_calls, true,
+				  __FILTER_ARG_ALL);
 }
+#else
+__attribute__((section("raw_tp"), used)) int
+generic_rawtp_filter_arg(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&tp_calls, true,
+				  __FILTER_ARG_1);
+}
+
+__attribute__((section("raw_tp"), used)) int
+generic_rawtp_filter_arg_2(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&tp_calls, true,
+				  __FILTER_ARG_2);
+}
+#endif
 
 __attribute__((section("raw_tp"), used)) int
 generic_rawtp_actions(void *ctx)

--- a/bpf/process/bpf_generic_retkprobe.c
+++ b/bpf/process/bpf_generic_retkprobe.c
@@ -16,12 +16,13 @@
 char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
 
 int generic_retkprobe_filter_arg(struct pt_regs *ctx);
+int generic_retkprobe_filter_arg_2(struct pt_regs *ctx);
 int generic_retkprobe_actions(struct pt_regs *ctx);
 int generic_retkprobe_output(struct pt_regs *ctx);
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(max_entries, 6);
+	__uint(max_entries, 13);
 	__type(key, __u32);
 	__array(values, int(struct pt_regs *));
 } retkprobe_calls SEC(".maps") = {
@@ -29,6 +30,9 @@ struct {
 		[TAIL_CALL_ARGS] = (void *)&generic_retkprobe_filter_arg,
 		[TAIL_CALL_ACTIONS] = (void *)&generic_retkprobe_actions,
 		[TAIL_CALL_SEND] = (void *)&generic_retkprobe_output,
+#ifndef __LARGE_BPF_PROG
+		[TAIL_CALL_ARGS_2] = (void *)&generic_retkprobe_filter_arg_2,
+#endif
 	},
 };
 
@@ -49,11 +53,28 @@ BPF_KRETPROBE(generic_retkprobe_event, unsigned long ret)
 	return generic_retprobe(ctx, (struct bpf_map_def *)&retkprobe_calls, ret);
 }
 
+#ifdef __LARGE_BPF_PROG
 __attribute__((section(COMMON), used)) int
 BPF_KRETPROBE(generic_retkprobe_filter_arg)
 {
-	return generic_filter_arg(ctx, (struct bpf_map_def *)&retkprobe_calls, false);
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&retkprobe_calls, false,
+				  __FILTER_ARG_ALL);
 }
+#else
+__attribute__((section(COMMON), used)) int
+BPF_KRETPROBE(generic_retkprobe_filter_arg)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&retkprobe_calls, false,
+				  __FILTER_ARG_1);
+}
+
+__attribute__((section(COMMON), used)) int
+BPF_KRETPROBE(generic_retkprobe_filter_arg_2)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&retkprobe_calls, false,
+				  __FILTER_ARG_2);
+}
+#endif
 
 __attribute__((section(COMMON), used)) int
 BPF_KRETPROBE(generic_retkprobe_actions)

--- a/bpf/process/bpf_generic_tracepoint.c
+++ b/bpf/process/bpf_generic_tracepoint.c
@@ -20,6 +20,7 @@
 int generic_tracepoint_process_event(void *ctx);
 int generic_tracepoint_filter(void *ctx);
 int generic_tracepoint_arg(void *ctx);
+int generic_tracepoint_arg_2(void *ctx);
 int generic_tracepoint_actions(void *ctx);
 int generic_tracepoint_output(void *ctx);
 int generic_tracepoint_process_event_2(void *ctx);
@@ -38,6 +39,7 @@ struct {
 		[TAIL_CALL_SEND] = (void *)&generic_tracepoint_output,
 #ifndef __LARGE_BPF_PROG
 		[TAIL_CALL_PROCESS_2] = (void *)&generic_tracepoint_process_event_2,
+		[TAIL_CALL_ARGS_2] = (void *)&generic_tracepoint_arg_2,
 #endif
 	},
 };
@@ -300,11 +302,28 @@ generic_tracepoint_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
+#ifdef __LARGE_BPF_PROG
 __attribute__((section("tracepoint"), used)) int
 generic_tracepoint_arg(void *ctx)
 {
-	return generic_filter_arg(ctx, (struct bpf_map_def *)&tp_calls, true);
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&tp_calls, true,
+				  __FILTER_ARG_ALL);
 }
+#else
+__attribute__((section("tracepoint"), used)) int
+generic_tracepoint_arg(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&tp_calls, true,
+				  __FILTER_ARG_1);
+}
+
+__attribute__((section("tracepoint"), used)) int
+generic_tracepoint_arg_2(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&tp_calls, true,
+				  __FILTER_ARG_2);
+}
+#endif
 
 __attribute__((section("tracepoint"), used)) int
 generic_tracepoint_actions(void *ctx)

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -21,6 +21,7 @@ int generic_uprobe_process_event(void *ctx);
 int generic_uprobe_process_event_2(void *ctx);
 int generic_uprobe_process_filter(void *ctx);
 int generic_uprobe_filter_arg(void *ctx);
+int generic_uprobe_filter_arg_2(void *ctx);
 int generic_uprobe_actions(void *ctx);
 int generic_uprobe_output(void *ctx);
 int generic_uprobe_path(void *ctx);
@@ -43,6 +44,7 @@ struct {
 #endif
 #ifndef __LARGE_BPF_PROG
 		[TAIL_CALL_PROCESS_2] = (void *)&generic_uprobe_process_event_2,
+		[TAIL_CALL_ARGS_2] = (void *)&generic_uprobe_filter_arg_2,
 #endif
 	},
 };
@@ -108,11 +110,28 @@ generic_uprobe_process_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
+#ifdef __LARGE_BPF_PROG
 __attribute__((section(COMMON), used)) int
 generic_uprobe_filter_arg(void *ctx)
 {
-	return generic_filter_arg(ctx, (struct bpf_map_def *)&uprobe_calls, true);
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&uprobe_calls, true,
+				  __FILTER_ARG_ALL);
 }
+#else
+__attribute__((section(COMMON), used)) int
+generic_uprobe_filter_arg(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&uprobe_calls, true,
+				  __FILTER_ARG_1);
+}
+
+__attribute__((section(COMMON), used)) int
+generic_uprobe_filter_arg_2(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&uprobe_calls, true,
+				  __FILTER_ARG_2);
+}
+#endif
 
 __attribute__((section(COMMON), used)) int
 generic_uprobe_actions(void *ctx)

--- a/bpf/process/bpf_generic_usdt.c
+++ b/bpf/process/bpf_generic_usdt.c
@@ -19,6 +19,7 @@ int generic_usdt_setup_event(void *ctx);
 int generic_usdt_process_event(void *ctx);
 int generic_usdt_process_filter(void *ctx);
 int generic_usdt_filter_arg(void *ctx);
+int generic_usdt_filter_arg_2(void *ctx);
 int generic_usdt_actions(void *ctx);
 int generic_usdt_output(void *ctx);
 int generic_usdt_path(void *ctx);
@@ -38,6 +39,9 @@ struct {
 		[TAIL_CALL_SEND] = (void *)&generic_usdt_output,
 #ifndef __V61_BPF_PROG
 		[TAIL_CALL_PATH] = (void *)&generic_usdt_path,
+#endif
+#ifndef __LARGE_BPF_PROG
+		[TAIL_CALL_ARGS_2] = (void *)&generic_usdt_filter_arg_2,
 #endif
 	},
 };
@@ -91,11 +95,28 @@ generic_usdt_process_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
+#ifdef __LARGE_BPF_PROG
 __attribute__((section(COMMON), used)) int
 generic_usdt_filter_arg(void *ctx)
 {
-	return generic_filter_arg(ctx, (struct bpf_map_def *)&usdt_calls, true);
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&usdt_calls, true,
+				  __FILTER_ARG_ALL);
 }
+#else
+__attribute__((section(COMMON), used)) int
+generic_usdt_filter_arg(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&usdt_calls, true,
+				  __FILTER_ARG_1);
+}
+
+__attribute__((section(COMMON), used)) int
+generic_usdt_filter_arg_2(void *ctx)
+{
+	return generic_filter_arg(ctx, (struct bpf_map_def *)&usdt_calls, true,
+				  __FILTER_ARG_2);
+}
+#endif
 
 __attribute__((section(COMMON), used)) int
 generic_usdt_actions(void *ctx)

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -139,6 +139,7 @@ enum {
 	TAIL_CALL_SEND = 5,
 	TAIL_CALL_PATH = 6,
 	TAIL_CALL_PROCESS_2 = 7,
+	TAIL_CALL_ARGS_2 = 8,
 };
 
 struct selector_action {
@@ -2080,8 +2081,18 @@ filter_arg_2(struct msg_generic_kprobe *e, struct selector_arg_filter *filter, c
 }
 
 FUNC_INLINE long
-filter_arg(struct msg_generic_kprobe *e, struct selector_arg_filter *filter, char *args)
+filter_arg(struct msg_generic_kprobe *e, struct selector_arg_filter *filter, char *args, int arg)
 {
+	/*
+	 * Separate argument filtering based on the process const
+	 * for 4.19 kernels..
+	 */
+	if (arg == __FILTER_ARG_1)
+		return filter_arg_1(e, filter, args);
+	if (arg == __FILTER_ARG_2)
+		return filter_arg_2(e, filter, args);
+
+	/* .. and the rest of the world (i.e., process == __FILTER_ARG_ALL) */
 	if (is_filter_arg_1(filter->type))
 		return filter_arg_1(e, filter, args);
 	else
@@ -2089,8 +2100,9 @@ filter_arg(struct msg_generic_kprobe *e, struct selector_arg_filter *filter, cha
 }
 
 FUNC_INLINE int
-selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
-		    bool is_entry)
+selector_arg_offset(void *ctx, struct bpf_map_def *tailcalls,
+		    __u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
+		    bool is_entry, int arg)
 {
 	struct selector_arg_filters *filters;
 	struct selector_arg_filter *filter;
@@ -2142,12 +2154,20 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
 		margsoff = (seloff + argsoff) & INDEX_MASK;
 		filter = (struct selector_arg_filter *)&f[margsoff];
 
+#ifndef __LARGE_BPF_PROG
+		// if, in the future, 4.19 supports multiple filters, we
+		// will need to adjust this to cope with resuming this loop
+		// on the iteration where we left off prior to tail call
+		if (!is_filter_arg_1(filter->type) && arg == __FILTER_ARG_1)
+			tail_call(ctx, tailcalls, TAIL_CALL_ARGS_2);
+#endif
+
 		index = filter->index;
 		if (index > 5)
 			return 0;
 
 		args = get_arg(e, index);
-		if (!filter_arg(e, filter, args))
+		if (!filter_arg(e, filter, args, arg))
 			return 0;
 	}
 	return seloff;

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4463,13 +4463,6 @@ func TestLoadKprobeSensor(t *testing.T) {
 		}
 
 		sensorMaps = []tus.SensorMap{
-			// generic_retkprobe_event
-			{Name: "retkprobe_calls", Progs: []uint{8, 9, 10}},
-
-			// generic_kprobe_process_filter,generic_kprobe_filter_arg,
-			// generic_kprobe_actions,generic_kprobe_output
-			{Name: "filter_map", Progs: []uint{3, 4, 5}},
-
 			// generic_kprobe_actions
 			{Name: "override_tasks", Progs: []uint{5}},
 		}
@@ -4493,6 +4486,13 @@ func TestLoadKprobeSensor(t *testing.T) {
 			// generic_kprobe_process_event*,generic_kprobe_actions,retkprobe
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "socktrack_map", Progs: []uint{2, 5, 8, 10}})
 
+			// generic_retkprobe_event
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retkprobe_calls", Progs: []uint{8, 9, 10}})
+
+			// generic_kprobe_process_filter,generic_kprobe_filter_arg,
+			// generic_kprobe_actions,generic_kprobe_output
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}})
+
 			if config.EnableV511Progs() {
 				// generic_kprobe_process_event*,generic_kprobe_output,generic_retkprobe_output
 				sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_rb_events", Progs: []uint{2, 6, 11}})
@@ -4505,12 +4505,14 @@ func TestLoadKprobeSensor(t *testing.T) {
 			}
 		} else {
 			sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_kprobe_process_event_2", Type: ebpf.Kprobe})
+			sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_kprobe_filter_arg_2", Type: ebpf.Kprobe})
+			sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_retkprobe_filter_arg_2", Type: ebpf.Kprobe})
 
 			// all kprobe programs
-			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}})
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}})
 
 			// all but generic_kprobe_output
-			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7, 12}})
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "kprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7, 12, 13}})
 
 			// all kprobe but generic_kprobe_process_filter,generic_retkprobe_event
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 1, 2, 12}})
@@ -4523,6 +4525,13 @@ func TestLoadKprobeSensor(t *testing.T) {
 
 			// generic_kprobe_event
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}})
+
+			// generic_retkprobe_event
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retkprobe_calls", Progs: []uint{8, 9, 10, 14}})
+
+			// generic_kprobe_process_filter,generic_kprobe_filter_arg,
+			// generic_kprobe_actions,generic_kprobe_output
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5, 13}})
 		}
 	}
 

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -475,15 +475,16 @@ func TestLoadTracepointSensor(t *testing.T) {
 		}
 	} else {
 		sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_tracepoint_process_event_2", Type: ebpf.TracePoint})
+		sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_tracepoint_arg_2", Type: ebpf.TracePoint})
 
 		// all programs
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7}})
 
 		// all but generic_tracepoint_output
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 6}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 6, 7}})
 
 		// all but generic_tracepoint_event,generic_tracepoint_filter
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 6}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 6, 7}})
 
 		// all kprobe but generic_tracepoint_filter
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 2, 6}})

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -87,9 +87,6 @@ func TestLoadUprobeSensor(t *testing.T) {
 		}
 
 		sensorMaps = []tus.SensorMap{
-			// generic_uprobe_process_filter,generic_uprobe_filter_arg*,generic_uprobe_actions
-			{Name: "filter_map", Progs: []uint{3, 4, 5}},
-
 			// generic_uprobe_output
 			{Name: "tcpmon_map", Progs: []uint{6}},
 		}
@@ -104,6 +101,9 @@ func TestLoadUprobeSensor(t *testing.T) {
 			// shared with base sensor
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4, 5, 6}})
 
+			// generic_uprobe_process_filter,generic_uprobe_filter_arg*,generic_uprobe_actions
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5}})
+
 			if config.EnableV511Progs() {
 				sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0, 6}})
 				sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_rb_events", Progs: []uint{6}})
@@ -112,16 +112,20 @@ func TestLoadUprobeSensor(t *testing.T) {
 			}
 		} else {
 			sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_uprobe_process_event_2", Type: ebpf.Kprobe})
+			sensorProgs = append(sensorProgs, tus.SensorProg{Name: "generic_uprobe_filter_arg_2", Type: ebpf.Kprobe})
 
 			// all uprobe programs
-			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8}})
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "process_call_heap", Progs: []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}})
 
 			// all but generic_uprobe_output
-			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7, 8}})
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "uprobe_calls", Progs: []uint{0, 1, 2, 3, 4, 5, 7, 8, 9}})
 
 			// shared with base sensor
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "execve_map", Progs: []uint{4}})
 			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tg_conf_map", Progs: []uint{0}})
+
+			// generic_uprobe_process_filter,generic_uprobe_filter_arg*,generic_uprobe_actions
+			sensorMaps = append(sensorMaps, tus.SensorMap{Name: "filter_map", Progs: []uint{3, 4, 5, 9}})
 		}
 	}
 


### PR DESCRIPTION
### Description
We are running very short on instruction budget for the args tail call on 4.19 kernels. As a result, we haven't been able to add a lot of recent features for 4.19. In addition to missing features on 4.19, the complexity caused by `#ifdef __LARGE_BPF_PROG` makes it difficult to follow code. As I developed [exposing NULL dereferencing](https://github.com/cilium/tetragon/pull/4327#issuecomment-3753583454), we found the code hard to review because of the logic being split.

As a first step to solving this problem, @olsajiri created a [PR](https://github.com/cilium/tetragon/pull/4439) to address this issue for process tail call. This PR is modeled after that change, but instead breaks up the args tail call, which filters args.

While preparing for this change, I found bug related to the op_capabilities_gained filter's behavior, which I fixed in this series.

Finally, an optimization is included in this change, where we stop evaluating a selector's filters (return early) after a selector's filter has failed, because all of a selector's filters need to pass in order for the selector to match.