### PR TITLE
metrics: Split `tetragon_errors_total` metric

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -118,7 +118,7 @@ The total number of Tetragon errors. For internal use only.
 
 | label | values |
 | ----- | ------ |
-| `type ` | `event_finalize_process_info_failed, process_metadata_username_failed, process_pid_tid_mismatch` |
+| `type ` | `event_finalize_process_info_failed, process_metadata_username_failed, process_pid_tid_mismatch_clone, process_pid_tid_mismatch_exec, process_pid_tid_mismatch_exit` |
 
 ### `tetragon_event_cache_entries`
 

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -468,7 +468,7 @@ func GetProcessExit(event *MsgExitEventUnix) *tetragon.ProcessExit {
 			"event.process.pid", event.ProcessKey.Pid,
 			"event.process.tid", event.Info.Tid,
 			"event.process.binary", tetragonProcess.Binary)
-		errormetrics.ErrorTotalInc(errormetrics.ProcessPidTidMismatch)
+		errormetrics.ErrorTotalInc(errormetrics.ProcessPidTidMismatchExit)
 	}
 
 	tetragonEvent := &tetragon.ProcessExit{

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -19,7 +19,9 @@ type ErrorType int
 
 const (
 	// Tid and Pid mismatch that could affect BPF and user space caching logic
-	ProcessPidTidMismatch ErrorType = iota
+	ProcessPidTidMismatchExec ErrorType = iota
+	ProcessPidTidMismatchClone
+	ProcessPidTidMismatchExit
 	// An event finalizer on Process failed
 	EventFinalizeProcessInfoFailed
 	// Failed to resolve Process uid to username
@@ -27,7 +29,9 @@ const (
 )
 
 var errorTypeLabelValues = map[ErrorType]string{
-	ProcessPidTidMismatch:          "process_pid_tid_mismatch",
+	ProcessPidTidMismatchExec:      "process_pid_tid_mismatch_exec",
+	ProcessPidTidMismatchClone:     "process_pid_tid_mismatch_clone",
+	ProcessPidTidMismatchExit:      "process_pid_tid_mismatch_exit",
 	EventFinalizeProcessInfoFailed: "event_finalize_process_info_failed",
 	ProcessMetadataUsernameFailed:  "process_metadata_username_failed",
 }

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -371,7 +371,7 @@ func initProcessInternalExec(
 			"event.parent.exec_id", parentExecID)
 		// Explicitly reset TID to be PID
 		process.TID = process.PID
-		errormetrics.ErrorTotalInc(errormetrics.ProcessPidTidMismatch)
+		errormetrics.ErrorTotalInc(errormetrics.ProcessPidTidMismatchExec)
 	}
 
 	envs := process.Envs
@@ -462,7 +462,7 @@ func initProcessInternalClone(event *tetragonAPI.MsgCloneEvent,
 			"event.process.tid", event.TID,
 			"event.process.exec_id", pi.process.ExecId,
 			"event.parent.exec_id", parentExecId)
-		errormetrics.ErrorTotalInc(errormetrics.ProcessPidTidMismatch)
+		errormetrics.ErrorTotalInc(errormetrics.ProcessPidTidMismatchClone)
 	}
 	// Set the TID here and if we have an exit without an exec we report
 	// directly this TID without copying again objects.


### PR DESCRIPTION
part of #2785 

>  Consider further splitting tetragon_errors_total

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
 Splits the generic `process_pid_tid_mismatch` error in `tetragon_errors_total` into three error types:

-  process_pid_tid_mismatch_exec
-  process_pid_tid_mismatch_clone
-  process_pid_tid_mismatch_exit

Example Output:
```
# HELP tetragon_errors_total The total number of Tetragon errors. For internal use only.
# TYPE tetragon_errors_total counter
tetragon_errors_total{type="process_pid_tid_mismatch_clone"} 1
tetragon_errors_total{type="process_pid_tid_mismatch_exec"} 1
tetragon_errors_total{type="process_pid_tid_mismatch_exit"} 1
```

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
split `process_pid_tid_mismatch` error metric into exec,clone, and exit types.
```
