### PR TITLE
metrics: Standardize error labels to `error`

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -118,7 +118,7 @@ The total number of Tetragon errors. For internal use only.
 
 | label | values |
 | ----- | ------ |
-| `type ` | `event_finalize_process_info_failed, process_metadata_username_failed, process_pid_tid_mismatch_clone, process_pid_tid_mismatch_exec, process_pid_tid_mismatch_exit` |
+| `error` | `event_finalize_process_info_failed, process_metadata_username_failed, process_pid_tid_mismatch_clone, process_pid_tid_mismatch_exec, process_pid_tid_mismatch_exit` |
 
 ### `tetragon_event_cache_entries`
 
@@ -207,7 +207,7 @@ The total number of event handler errors. For internal use only.
 
 | label | values |
 | ----- | ------ |
-| `error_type` | `event_handler_failed, unknown_opcode` |
+| `error` | `event_handler_failed, unknown_opcode` |
 | `opcode` | `0, 13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
 
 ### `tetragon_handling_latency`

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -61,7 +61,7 @@ func (e EventHandlerError) String() string {
 var (
 	// Constrained label for error type
 	errorTypeLabel = metrics.ConstrainedLabel{
-		Name:   "type",
+		Name:   "error",
 		Values: slices.Collect(maps.Values(errorTypeLabelValues)),
 	}
 	// Constrained label for opcode (numeric strings)
@@ -80,7 +80,7 @@ var (
 	}
 	// Constrained label for handler error type
 	handlerErrTypeLabel = metrics.ConstrainedLabel{
-		Name:   "error_type",
+		Name:   "error",
 		Values: slices.Collect(maps.Values(eventHandlerErrorLabelValues)),
 	}
 


### PR DESCRIPTION
part of #2785

>  Standardize on error label (rather than error_type, type, etc)

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->


### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Standardize error metric labels to `error` for consistency.(see commit)

Example output with this patch:
```
# HELP tetragon_errors_total The total number of Tetragon errors. For internal use only.
# TYPE tetragon_errors_total counter
tetragon_errors_total{error="event_finalize_process_info_failed"} 1
tetragon_errors_total{error="process_metadata_username_failed"} 1
tetragon_errors_total{error="process_pid_tid_mismatch"} 1
```
### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Standardize error metric labels to `error`.
```
