### PR TITLE
vmtests: Migrate logrus to slog

### DIFF
--- a/cmd/tetragon-vmtests-run/image.go
+++ b/cmd/tetragon-vmtests-run/image.go
@@ -13,8 +13,8 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/little-vm-helper/pkg/images"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 	"github.com/cilium/little-vm-helper/pkg/step"
-	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/tetragon/pkg/vmtests"
 )
@@ -215,7 +215,7 @@ func (rc *NoNetworkCommand) ToSteps(s *images.StepConf) ([]step.Step, error) {
 	}}, nil
 }
 
-func buildTestImage(log *logrus.Logger, rcnf *RunConf) error {
+func buildTestImage(log slogger.Logger, rcnf *RunConf) error {
 
 	imagesDir, baseImage := filepath.Split(rcnf.baseImageFilename)
 

--- a/cmd/tetragon-vmtests-run/main.go
+++ b/cmd/tetragon-vmtests-run/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/cilium/little-vm-helper/pkg/arch"
 	"github.com/cilium/little-vm-helper/pkg/runner"
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 )
@@ -30,7 +30,7 @@ func main() {
 		Short:        "vmtest-run: helper to run tetragon unit tests on VMs",
 		SilenceUsage: true,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			log := logrus.New()
+			log := slogger.New()
 			t0 := time.Now()
 
 			var err error

--- a/cmd/tetragon-vmtests-run/qemu.go
+++ b/cmd/tetragon-vmtests-run/qemu.go
@@ -9,12 +9,12 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/little-vm-helper/pkg/runner"
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 )
 
 // buildQemuArgs is a wrapper around LVH's runner.BuildQemuArgs and also handles
 // custom configuration from vmtests
-func buildQemuArgs(log *logrus.Logger, rcnf RunConf) ([]string, error) {
+func buildQemuArgs(log slogger.Logger, rcnf RunConf) ([]string, error) {
 	if rcnf.KernelFname != "" {
 		if rcnf.disableUnifiedCgroups {
 			rcnf.KernelAppendArgs = append(rcnf.KernelAppendArgs, "systemd.unified_cgroup_hierarchy=0")

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25.0
 require (
 	github.com/alecthomas/kong v1.13.0
 	github.com/cilium/ebpf v0.20.0
-	github.com/cilium/little-vm-helper v0.0.28
+	github.com/cilium/little-vm-helper v0.0.29-0.20260118112734-08d16157e542
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/tetragon/api v0.0.0-00010101000000-000000000000
 	github.com/cilium/tetragon/pkg/k8s v0.0.0-00010101000000-000000000000
@@ -31,7 +31,6 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/procfs v0.19.2
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -119,6 +118,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
@@ -138,7 +138,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f // indirect
-	golang.org/x/mod v0.31.0 // indirect
+	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/text v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cilium/ebpf v0.20.0 h1:atwWj9d3NffHyPZzVlx3hmw1on5CLe9eljR8VuHTwhM=
 github.com/cilium/ebpf v0.20.0/go.mod h1:pzLjFymM+uZPLk/IXZUL63xdx5VXEo+enTzxkZXdycw=
-github.com/cilium/little-vm-helper v0.0.28 h1:1rgPe7dQ3/ytfLQp+gpP6hXEukwMyYOnhYJP47hJfSE=
-github.com/cilium/little-vm-helper v0.0.28/go.mod h1:ONZ2V4aTXuJo8Pi5ArlFdy/kxiDhFekwRMhlm+wg5zE=
+github.com/cilium/little-vm-helper v0.0.29-0.20260118112734-08d16157e542 h1:C6iBTxIh9EspvM2J7fXDtNCoXvPG20n8+0a3Fr5IEV4=
+github.com/cilium/little-vm-helper v0.0.29-0.20260118112734-08d16157e542/go.mod h1:HicZnbjK/HeJP7FLcMq4b0CjuaHe43DsNd0cO9JInf4=
 github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y2qDBs=
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -113,8 +113,8 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66D
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
-github.com/go-git/go-git/v5 v5.16.3 h1:Z8BtvxZ09bYm/yYNgPKCzgWtaRqDTgIKRgIRHBfU6Z8=
-github.com/go-git/go-git/v5 v5.16.3/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
+github.com/go-git/go-git/v5 v5.16.4 h1:7ajIEZHZJULcyJebDLo99bGgS0jRrOxzZG4uCk2Yb2Y=
+github.com/go-git/go-git/v5 v5.16.4/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -223,8 +223,8 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.1 h1:bcSGx7UbpBqMChDtsF28Lw6v/G94LPrrbMbdC3JH2co=
+github.com/klauspost/compress v1.18.1/go.mod h1:ZQFFVG+MdnR0P+l6wpXgIL4NTtwiKIdBnrBd8Nrxr+0=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -415,8 +415,8 @@ golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f/go.mod h1:D5SMRVC3C2/4+F/DB1
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
-golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
+golang.org/x/mod v0.32.0 h1:9F4d3PHLljb6x//jOyokMv3eX+YDeepZSEo3mFJy93c=
+golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/vendor/github.com/cilium/little-vm-helper/pkg/images/build.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/images/build.go
@@ -9,12 +9,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 )
 
 // BuildConf configures how a set of images are build
 type BuildConf struct {
-	Log *logrus.Logger
+	Log slogger.Logger
 
 	// if DryRun set, no actual images will be build. Instead, empty files will be created
 	DryRun bool
@@ -62,7 +62,7 @@ func (f *ImageForest) BuildImage(bldConf *BuildConf, image string) (*BuilderResu
 	images := append(deps, image)
 	for i := range images {
 		imgRes := st.buildImage(images[i])
-		xlog := log.WithFields(logrus.Fields{
+		xlog := log.WithFields(map[string]any{
 			"image":    image[i],
 			"all-deps": images,
 			"result":   fmt.Sprintf("%+v", imgRes),
@@ -89,7 +89,7 @@ func (f *ImageForest) BuildAllImages(bldConf *BuildConf) *BuilderResult {
 func (f *ImageForest) BuildImages(bldConf *BuildConf, queue []string) *BuilderResult {
 	log := bldConf.Log
 	st := newBuildState(f, bldConf)
-	log.WithFields(logrus.Fields{
+	log.WithFields(map[string]any{
 		"queue": strings.Join(queue, ","),
 	}).Info("starting to build images")
 	for {
@@ -104,7 +104,7 @@ func (f *ImageForest) BuildImages(bldConf *BuildConf, queue []string) *BuilderRe
 			queue = append(queue, children...)
 		}
 
-		xlog := log.WithFields(logrus.Fields{
+		xlog := log.WithFields(map[string]any{
 			"image":  image,
 			"queue":  strings.Join(queue, ","),
 			"result": fmt.Sprintf("%+v", imgRes),

--- a/vendor/github.com/cilium/little-vm-helper/pkg/images/image_build.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/images/image_build.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 	"github.com/cilium/little-vm-helper/pkg/step"
-	"github.com/sirupsen/logrus"
 )
 
 // doBuildImageDryRun just creates an empty file for the image.
@@ -45,7 +45,7 @@ func mergeSteps(step1, step2 step.Step) error {
 
 func (f *ImageForest) doBuildImage(
 	ctx context.Context,
-	log *logrus.Logger,
+	log slogger.Logger,
 	image string,
 	merge bool,
 	pkgRepository string,

--- a/vendor/github.com/cilium/little-vm-helper/pkg/images/step.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/images/step.go
@@ -3,11 +3,11 @@
 
 package images
 
-import "github.com/sirupsen/logrus"
+import "github.com/cilium/little-vm-helper/pkg/slogger"
 
 // StepConf is common step configuration
 type StepConf struct {
 	imagesDir string
 	imgCnf    *ImgConf
-	log       *logrus.Logger
+	log       slogger.Logger
 }

--- a/vendor/github.com/cilium/little-vm-helper/pkg/images/step_create_image.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/images/step_create_image.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/cilium/little-vm-helper/pkg/arch"
 	"github.com/cilium/little-vm-helper/pkg/logcmd"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 	"github.com/cilium/little-vm-helper/pkg/step"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -175,7 +175,7 @@ func (s *CreateImage) makeRootImage(ctx context.Context) error {
 }
 
 func resizeImage(ctx context.Context,
-	log logrus.FieldLogger,
+	log slogger.Logger,
 	imgFname string, size string,
 ) error {
 

--- a/vendor/github.com/cilium/little-vm-helper/pkg/kernels/conf.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/kernels/conf.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 )
 
 // ConfigOption are switches passed to scripts/config in a kernel dir
@@ -137,7 +137,7 @@ func GetConfigGroupNames() []string {
 	return ret
 }
 
-func (cnf *Conf) SaveTo(log logrus.FieldLogger, dir string, backup bool) error {
+func (cnf *Conf) SaveTo(log slogger.Logger, dir string, backup bool) error {
 	fname := path.Join(dir, ConfigFname)
 	confb, err := json.MarshalIndent(cnf, "", "    ")
 	if err != nil {

--- a/vendor/github.com/cilium/little-vm-helper/pkg/kernels/dir.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/kernels/dir.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/cilium/little-vm-helper/pkg/arch"
 	"github.com/cilium/little-vm-helper/pkg/logcmd"
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 )
 
 type KernelsDir struct {
@@ -46,7 +46,7 @@ func (kd *KernelsDir) RemoveKernelConfig(name string) *KernelConf {
 	return nil
 }
 
-func (kd *KernelsDir) ConfigureKernel(ctx context.Context, log *logrus.Logger, kernName string, targetArch string) error {
+func (kd *KernelsDir) ConfigureKernel(ctx context.Context, log slogger.Logger, kernName string, targetArch string) error {
 	kc := kd.KernelConfig(kernName)
 	if kc == nil {
 		return fmt.Errorf("kernel '%s' not found", kernName)
@@ -54,7 +54,7 @@ func (kd *KernelsDir) ConfigureKernel(ctx context.Context, log *logrus.Logger, k
 	return kd.configureKernel(ctx, log, kc, targetArch)
 }
 
-func (kd *KernelsDir) RawConfigure(ctx context.Context, log *logrus.Logger, kernDir, kernName string, targetArch string) error {
+func (kd *KernelsDir) RawConfigure(ctx context.Context, log slogger.Logger, kernDir, kernName string, targetArch string) error {
 	kc := kd.KernelConfig(kernName)
 	return kd.rawConfigureKernel(ctx, log, kc, kernDir, targetArch)
 }
@@ -153,7 +153,7 @@ func kConfigValidate(opts []ConfigOption) error {
 
 func runAndLogMake(
 	ctx context.Context,
-	log *logrus.Logger,
+	log slogger.Logger,
 	kc *KernelConf,
 	makeArgs ...string,
 ) error {
@@ -164,7 +164,7 @@ func runAndLogMake(
 }
 
 func (kd *KernelsDir) rawConfigureKernel(
-	ctx context.Context, log *logrus.Logger,
+	ctx context.Context, log slogger.Logger,
 	kc *KernelConf, srcDir string, targetArch string,
 	makePrepareArgs ...string,
 ) error {
@@ -176,7 +176,7 @@ func (kd *KernelsDir) rawConfigureKernel(
 	// If the source directory does not exist, there is nothing to configure so let's fetch the
 	// kernel
 	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
-		log.WithFields(logrus.Fields{
+		log.WithFields(map[string]any{
 			"kernel": kc.Name,
 			"srcDir": srcDir,
 		}).Info("src directory does not exist, fetching kernel")
@@ -247,7 +247,7 @@ func (kd *KernelsDir) rawConfigureKernel(
 	return nil
 }
 
-func (kd *KernelsDir) configureKernel(ctx context.Context, log *logrus.Logger, kc *KernelConf, targetArch string) error {
+func (kd *KernelsDir) configureKernel(ctx context.Context, log slogger.Logger, kc *KernelConf, targetArch string) error {
 	srcDir := filepath.Join(kd.Dir, kc.Name)
 	tarch, err := arch.NewArch(targetArch)
 	if err != nil {
@@ -261,7 +261,7 @@ func (kd *KernelsDir) configureKernel(ctx context.Context, log *logrus.Logger, k
 
 }
 
-func (kd *KernelsDir) buildKernel(ctx context.Context, log *logrus.Logger, kc *KernelConf, targetArch string) error {
+func (kd *KernelsDir) buildKernel(ctx context.Context, log slogger.Logger, kc *KernelConf, targetArch string) error {
 	if err := CheckEnvironment(); err != nil {
 		return err
 	}

--- a/vendor/github.com/cilium/little-vm-helper/pkg/kernels/git.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/kernels/git.go
@@ -11,8 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/little-vm-helper/pkg/logcmd"
-
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 )
 
 type gitCloneOrFetchDirArg struct {
@@ -22,7 +21,7 @@ type gitCloneOrFetchDirArg struct {
 	depth        int
 }
 
-func gitCloneOrFetchDir(ctx context.Context, log logrus.FieldLogger, arg *gitCloneOrFetchDirArg) error {
+func gitCloneOrFetchDir(ctx context.Context, log slogger.Logger, arg *gitCloneOrFetchDirArg) error {
 
 	var args []string
 	if exists, err := directoryExists(arg.dir); err != nil {
@@ -63,7 +62,7 @@ type gitAddWorkdirArg struct {
 	localBranch  string
 }
 
-func gitAddWorkdir(ctx context.Context, log logrus.FieldLogger, arg *gitAddWorkdirArg) error {
+func gitAddWorkdir(ctx context.Context, log slogger.Logger, arg *gitAddWorkdirArg) error {
 	remoteAddArgs := []string{
 		"--git-dir", arg.bareDir,
 		"remote", "add",
@@ -89,7 +88,7 @@ func gitLocalBranch(kname string) string {
 	return fmt.Sprintf("lvh-%s", kname)
 }
 
-func removeGitWorkDir(ctx context.Context, log logrus.FieldLogger, dir, kName string) error {
+func removeGitWorkDir(ctx context.Context, log slogger.Logger, dir, kName string) error {
 	return gitRemoveWorkdir(context.Background(), log,
 		&gitRemoveWorkdirArg{
 			workDir:     kName,
@@ -107,7 +106,7 @@ type gitRemoveWorkdirArg struct {
 	localBranch string
 }
 
-func gitRemoveWorkdir(ctx context.Context, log logrus.FieldLogger, arg *gitRemoveWorkdirArg) error {
+func gitRemoveWorkdir(ctx context.Context, log slogger.Logger, arg *gitRemoveWorkdirArg) error {
 	var res error
 
 	worktreeRemoveArgs := []string{

--- a/vendor/github.com/cilium/little-vm-helper/pkg/kernels/kernels.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/kernels/kernels.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 )
 
 var (
@@ -28,7 +28,7 @@ type InitDirFlags struct {
 //
 // the provided conf will be saved in the directory.
 // if conf is nil, an empty configuration will be used.
-func InitDir(log *logrus.Logger, dir string, conf *Conf, flags InitDirFlags) error {
+func InitDir(log slogger.Logger, dir string, conf *Conf, flags InitDirFlags) error {
 	err := os.MkdirAll(dir, 0755)
 	if err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to create directory '%s': %w", dir, err)
@@ -71,7 +71,7 @@ type AddKernelFlags struct {
 	Fetch      bool
 }
 
-func AddKernel(ctx context.Context, log *logrus.Logger, dir string, cnf *KernelConf, flags AddKernelFlags) error {
+func AddKernel(ctx context.Context, log slogger.Logger, dir string, cnf *KernelConf, flags AddKernelFlags) error {
 	kd, err := LoadDir(dir)
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func AddKernel(ctx context.Context, log *logrus.Logger, dir string, cnf *KernelC
 
 // RemoveKernel will remove a kernel.
 // It will typically try to continue, even if it encounters an error
-func RemoveKernel(ctx context.Context, log_ *logrus.Logger, dir string, name string, backupConf bool) error {
+func RemoveKernel(ctx context.Context, log_ slogger.Logger, dir string, name string, backupConf bool) error {
 	kd, err := LoadDir(dir)
 	if err != nil {
 		return err
@@ -154,7 +154,7 @@ func getKernelInfo(dir, kname string) (*KernelsDir, *KernelConf, KernelURL, erro
 
 }
 
-func FetchKernel(ctx context.Context, log *logrus.Logger, dir, kname string) error {
+func FetchKernel(ctx context.Context, log slogger.Logger, dir, kname string) error {
 	kd, kc, kurl, err := getKernelInfo(dir, kname)
 	if err != nil {
 		return err
@@ -163,7 +163,7 @@ func FetchKernel(ctx context.Context, log *logrus.Logger, dir, kname string) err
 	return kurl.fetch(ctx, log, kd.Dir, kc.Name)
 }
 
-func BuildKernel(ctx context.Context, log *logrus.Logger, dir, kname string, fetch bool, arch string) error {
+func BuildKernel(ctx context.Context, log slogger.Logger, dir, kname string, fetch bool, arch string) error {
 	kd, kc, kurl, err := getKernelInfo(dir, kname)
 	if err != nil {
 		return err

--- a/vendor/github.com/cilium/little-vm-helper/pkg/kernels/url.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/kernels/url.go
@@ -8,14 +8,14 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 )
 
 type KernelURL interface {
 	// fetches the kernel named <name> in <dir>/<name>
-	fetch(ctx context.Context, log logrus.FieldLogger, dir string, name string) error
+	fetch(ctx context.Context, log slogger.Logger, dir string, name string) error
 	// removes the kernel named <name>
-	remove(ctx context.Context, log logrus.FieldLogger, dir string, name string) error
+	remove(ctx context.Context, log slogger.Logger, dir string, name string) error
 }
 
 func ParseURL(s string) (KernelURL, error) {

--- a/vendor/github.com/cilium/little-vm-helper/pkg/kernels/url_git.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/kernels/url_git.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 
 	"github.com/cilium/little-vm-helper/pkg/logcmd"
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 )
 
 // By default, we use a single directory (MainGitDir) for all git URLs (first
@@ -79,7 +79,7 @@ func newGitURL(repo string, branch string) *GitURL {
 
 func (gu *GitURL) syncWorktree(
 	ctx context.Context,
-	log logrus.FieldLogger,
+	log slogger.Logger,
 	idDir string,
 ) error {
 	oldPath, err := os.Getwd()
@@ -97,7 +97,7 @@ func (gu *GitURL) syncWorktree(
 	return logcmd.RunAndLogCommand(cmd, log)
 }
 
-func makeGitDir(ctx context.Context, log logrus.FieldLogger, gitDir string) error {
+func makeGitDir(ctx context.Context, log slogger.Logger, gitDir string) error {
 	err := os.MkdirAll(gitDir, 0755)
 	if err != nil {
 		return err
@@ -115,7 +115,7 @@ func makeGitDir(ctx context.Context, log logrus.FieldLogger, gitDir string) erro
 // fetch will fetches the code pointed by gu, into dir/id
 func (gu *GitURL) fetch(
 	ctx context.Context,
-	log logrus.FieldLogger,
+	log slogger.Logger,
 	dir string,
 	id string,
 ) error {
@@ -170,7 +170,7 @@ func (gu *GitURL) fetch(
 
 func (gu *GitURL) remove(
 	ctx context.Context,
-	log logrus.FieldLogger,
+	log slogger.Logger,
 	dir string,
 	id string,
 ) error {

--- a/vendor/github.com/cilium/little-vm-helper/pkg/runner/conf.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/runner/conf.go
@@ -4,7 +4,7 @@
 package runner
 
 import (
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 )
 
 type RunConf struct {
@@ -30,7 +30,7 @@ type RunConf struct {
 	DisableNetwork bool
 	ForwardedPorts PortForwards
 
-	Logger *logrus.Logger
+	Logger slogger.Logger
 
 	HostMount string
 

--- a/vendor/github.com/cilium/little-vm-helper/pkg/runner/qemu.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/runner/qemu.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/cilium/little-vm-helper/pkg/arch"
-	"github.com/sirupsen/logrus"
+	"github.com/cilium/little-vm-helper/pkg/slogger"
 	"golang.org/x/sys/unix"
 )
 
@@ -24,7 +24,7 @@ func getArch(rcnf *RunConf) (arch.Arch, error) {
 	return arch.NewArch(a)
 }
 
-func BuildQemuArgs(log *logrus.Logger, rcnf *RunConf) ([]string, error) {
+func BuildQemuArgs(log slogger.Logger, rcnf *RunConf) ([]string, error) {
 	qemuArgs := []string{
 		// no need for all the default devices
 		"-nodefaults",

--- a/vendor/github.com/cilium/little-vm-helper/pkg/slogger/slogger.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/slogger/slogger.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package slogger provides a structured logging abstraction using Go's log/slog.
+// It provides an interface Logger that mirrors common logging patterns and
+// supports structured logging with fields.
+package slogger
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+)
+
+// Level represents log severity levels
+type Level = slog.Level
+
+// Log levels matching slog's levels
+const (
+	LevelDebug = slog.LevelDebug
+	LevelInfo  = slog.LevelInfo
+	LevelWarn  = slog.LevelWarn
+	LevelError = slog.LevelError
+)
+
+// Logger is the interface for structured logging operations.
+// It provides methods for logging at different levels with optional structured fields.
+type Logger interface {
+	// WithField returns a new Logger with the given field added
+	WithField(key string, value any) Logger
+	// WithFields returns a new Logger with the given fields added
+	WithFields(fields map[string]any) Logger
+	// WithError returns a new Logger with an error field added
+	WithError(err error) Logger
+
+	// Log methods
+	Debug(msg string)
+	Debugf(format string, args ...any)
+	Info(msg string)
+	Infof(format string, args ...any)
+	Warn(msg string)
+	Warnf(format string, args ...any)
+	Error(msg string)
+	Errorf(format string, args ...any)
+	Fatal(v any)
+	Fatalf(format string, args ...any)
+	Panic(v any)
+	Panicf(format string, args ...any)
+
+	// Handler returns the underlying slog.Handler for advanced use cases
+	Handler() slog.Handler
+	// SetOutput changes the output destination (for testing)
+	SetOutput(w io.Writer)
+}
+
+// logger is the default implementation of Logger using slog
+type logger struct {
+	slog   *slog.Logger
+	attrs  []slog.Attr
+	output io.Writer
+	level  *slog.LevelVar
+}
+
+// New creates a new Logger with default settings (text handler, stdout)
+func New() Logger {
+	level := &slog.LevelVar{}
+	level.Set(LevelInfo)
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: level,
+	})
+	return &logger{
+		slog:   slog.New(handler),
+		attrs:  nil,
+		output: os.Stderr,
+		level:  level,
+	}
+}
+
+// NewWithHandler creates a new Logger with a custom handler
+func NewWithHandler(handler slog.Handler) Logger {
+	return &logger{
+		slog:  slog.New(handler),
+		attrs: nil,
+	}
+}
+
+// NewWithLevel creates a new Logger with a specified log level
+func NewWithLevel(level Level) Logger {
+	levelVar := &slog.LevelVar{}
+	levelVar.Set(level)
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: levelVar,
+	})
+	return &logger{
+		slog:   slog.New(handler),
+		attrs:  nil,
+		output: os.Stderr,
+		level:  levelVar,
+	}
+}
+
+func (l *logger) WithField(key string, value any) Logger {
+	newAttrs := make([]slog.Attr, len(l.attrs), len(l.attrs)+1)
+	copy(newAttrs, l.attrs)
+	newAttrs = append(newAttrs, slog.Any(key, value))
+	return &logger{
+		slog:   l.slog,
+		attrs:  newAttrs,
+		output: l.output,
+		level:  l.level,
+	}
+}
+
+func (l *logger) WithFields(fields map[string]any) Logger {
+	newAttrs := make([]slog.Attr, len(l.attrs), len(l.attrs)+len(fields))
+	copy(newAttrs, l.attrs)
+	for k, v := range fields {
+		newAttrs = append(newAttrs, slog.Any(k, v))
+	}
+	return &logger{
+		slog:   l.slog,
+		attrs:  newAttrs,
+		output: l.output,
+		level:  l.level,
+	}
+}
+
+func (l *logger) WithError(err error) Logger {
+	return l.WithField("error", err)
+}
+
+func (l *logger) log(level Level, msg string) {
+	if l.slog.Enabled(context.Background(), level) {
+		args := make([]any, 0, len(l.attrs)*2)
+		for _, attr := range l.attrs {
+			args = append(args, attr.Key, attr.Value.Any())
+		}
+		l.slog.Log(context.Background(), level, msg, args...)
+	}
+}
+
+func (l *logger) logf(level Level, format string, fmtArgs ...any) {
+	if l.slog.Enabled(context.Background(), level) {
+		msg := formatMessage(format, fmtArgs...)
+		args := make([]any, 0, len(l.attrs)*2)
+		for _, attr := range l.attrs {
+			args = append(args, attr.Key, attr.Value.Any())
+		}
+		l.slog.Log(context.Background(), level, msg, args...)
+	}
+}
+
+func (l *logger) Debug(msg string) {
+	l.log(LevelDebug, msg)
+}
+
+func (l *logger) Debugf(format string, args ...any) {
+	l.logf(LevelDebug, format, args...)
+}
+
+func (l *logger) Info(msg string) {
+	l.log(LevelInfo, msg)
+}
+
+func (l *logger) Infof(format string, args ...any) {
+	l.logf(LevelInfo, format, args...)
+}
+
+func (l *logger) Warn(msg string) {
+	l.log(LevelWarn, msg)
+}
+
+func (l *logger) Warnf(format string, args ...any) {
+	l.logf(LevelWarn, format, args...)
+}
+
+func (l *logger) Error(msg string) {
+	l.log(LevelError, msg)
+}
+
+func (l *logger) Errorf(format string, args ...any) {
+	l.logf(LevelError, format, args...)
+}
+
+func (l *logger) Fatal(v any) {
+	msg := fmt.Sprint(v)
+	l.log(LevelError, msg)
+	os.Exit(1)
+}
+
+func (l *logger) Fatalf(format string, args ...any) {
+	l.logf(LevelError, format, args...)
+	os.Exit(1)
+}
+
+func (l *logger) Panic(v any) {
+	msg := fmt.Sprint(v)
+	l.log(LevelError, msg)
+	panic(msg)
+}
+
+func (l *logger) Panicf(format string, args ...any) {
+	msg := formatMessage(format, args...)
+	l.log(LevelError, msg)
+	panic(msg)
+}
+
+func (l *logger) Handler() slog.Handler {
+	return l.slog.Handler()
+}
+
+func (l *logger) SetOutput(w io.Writer) {
+	l.output = w
+	var handler slog.Handler
+	if l.level != nil {
+		handler = slog.NewTextHandler(w, &slog.HandlerOptions{
+			Level: l.level,
+		})
+	} else {
+		handler = slog.NewTextHandler(w, nil)
+	}
+	l.slog = slog.New(handler)
+}
+
+// formatMessage formats a message with arguments, similar to fmt.Sprintf
+func formatMessage(format string, args ...any) string {
+	if len(args) == 0 {
+		return format
+	}
+	return fmt.Sprintf(format, args...)
+}

--- a/vendor/github.com/cilium/little-vm-helper/pkg/slogger/testhandler.go
+++ b/vendor/github.com/cilium/little-vm-helper/pkg/slogger/testhandler.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package slogger
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// RecordingHandler is a slog.Handler that records log entries for testing.
+// It can filter by level and store messages for later inspection.
+// When exactLevel is true, only messages at exactly the specified level are recorded.
+// When exactLevel is false, messages at or above the specified level are recorded.
+type RecordingHandler struct {
+	mu         sync.Mutex
+	level      Level
+	exactLevel bool
+	messages   []string
+	records    []slog.Record
+	attrs      []slog.Attr
+	groups     []string
+}
+
+// NewRecordingHandler creates a handler that records messages at exactly the specified level.
+// This is useful for testing where you want to capture only messages at a specific level.
+func NewRecordingHandler(level Level) *RecordingHandler {
+	return &RecordingHandler{
+		level:      level,
+		exactLevel: true,
+		messages:   nil,
+		records:    nil,
+	}
+}
+
+// NewRecordingHandlerAtOrAbove creates a handler that records messages at or above the specified level.
+func NewRecordingHandlerAtOrAbove(level Level) *RecordingHandler {
+	return &RecordingHandler{
+		level:      level,
+		exactLevel: false,
+		messages:   nil,
+		records:    nil,
+	}
+}
+
+// Enabled reports whether the handler handles records at the given level.
+func (h *RecordingHandler) Enabled(_ context.Context, level slog.Level) bool {
+	if h.exactLevel {
+		return level == h.level
+	}
+	return level >= h.level
+}
+
+// Handle records the log message.
+func (h *RecordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	shouldRecord := false
+	if h.exactLevel {
+		shouldRecord = r.Level == h.level
+	} else {
+		shouldRecord = r.Level >= h.level
+	}
+	if shouldRecord {
+		h.messages = append(h.messages, r.Message)
+		h.records = append(h.records, r)
+	}
+	return nil
+}
+
+// WithAttrs returns a new handler with the given attributes added.
+func (h *RecordingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	newAttrs := make([]slog.Attr, len(h.attrs), len(h.attrs)+len(attrs))
+	copy(newAttrs, h.attrs)
+	newAttrs = append(newAttrs, attrs...)
+	return &RecordingHandler{
+		level:      h.level,
+		exactLevel: h.exactLevel,
+		messages:   h.messages, // share the slice for recording
+		records:    h.records,
+		attrs:      newAttrs,
+		groups:     h.groups,
+	}
+}
+
+// WithGroup returns a new handler with the given group name.
+func (h *RecordingHandler) WithGroup(name string) slog.Handler {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	newGroups := make([]string, len(h.groups), len(h.groups)+1)
+	copy(newGroups, h.groups)
+	newGroups = append(newGroups, name)
+	return &RecordingHandler{
+		level:      h.level,
+		exactLevel: h.exactLevel,
+		messages:   h.messages,
+		records:    h.records,
+		attrs:      h.attrs,
+		groups:     newGroups,
+	}
+}
+
+// Messages returns all recorded messages.
+func (h *RecordingHandler) Messages() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	result := make([]string, len(h.messages))
+	copy(result, h.messages)
+	return result
+}
+
+// Records returns all recorded log records.
+func (h *RecordingHandler) Records() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	result := make([]slog.Record, len(h.records))
+	copy(result, h.records)
+	return result
+}
+
+// Clear removes all recorded messages and records.
+func (h *RecordingHandler) Clear() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.messages = h.messages[:0]
+	h.records = h.records[:0]
+}
+
+// MultiHandler combines multiple handlers, routing logs to all of them.
+// This is useful for testing where you want to capture logs at different levels.
+type MultiHandler struct {
+	handlers []slog.Handler
+}
+
+// NewMultiHandler creates a handler that routes to multiple handlers.
+func NewMultiHandler(handlers ...slog.Handler) *MultiHandler {
+	return &MultiHandler{handlers: handlers}
+}
+
+// Enabled reports whether any handler handles records at the given level.
+func (h *MultiHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range h.handlers {
+		if handler.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+// Handle sends the record to all handlers.
+func (h *MultiHandler) Handle(ctx context.Context, r slog.Record) error {
+	for _, handler := range h.handlers {
+		if handler.Enabled(ctx, r.Level) {
+			if err := handler.Handle(ctx, r); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// WithAttrs returns a new MultiHandler with the given attributes added to all handlers.
+func (h *MultiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newHandlers := make([]slog.Handler, len(h.handlers))
+	for i, handler := range h.handlers {
+		newHandlers[i] = handler.WithAttrs(attrs)
+	}
+	return &MultiHandler{handlers: newHandlers}
+}
+
+// WithGroup returns a new MultiHandler with the given group name added to all handlers.
+func (h *MultiHandler) WithGroup(name string) slog.Handler {
+	newHandlers := make([]slog.Handler, len(h.handlers))
+	for i, handler := range h.handlers {
+		newHandlers[i] = handler.WithGroup(name)
+	}
+	return &MultiHandler{handlers: newHandlers}
+}
+
+// DiscardHandler is a handler that discards all logs.
+type DiscardHandler struct{}
+
+// Enabled always returns true (all levels accepted).
+func (h *DiscardHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+// Handle discards the record.
+func (h *DiscardHandler) Handle(_ context.Context, _ slog.Record) error {
+	return nil
+}
+
+// WithAttrs returns the same handler (no-op).
+func (h *DiscardHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return h
+}
+
+// WithGroup returns the same handler (no-op).
+func (h *DiscardHandler) WithGroup(_ string) slog.Handler {
+	return h
+}
+
+// NewDiscard creates a Logger that discards all output.
+func NewDiscard() Logger {
+	return NewWithHandler(&DiscardHandler{})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -52,13 +52,14 @@ github.com/cilium/ebpf/perf
 github.com/cilium/ebpf/pin
 github.com/cilium/ebpf/ringbuf
 github.com/cilium/ebpf/rlimit
-# github.com/cilium/little-vm-helper v0.0.28
+# github.com/cilium/little-vm-helper v0.0.29-0.20260118112734-08d16157e542
 ## explicit; go 1.24.0
 github.com/cilium/little-vm-helper/pkg/arch
 github.com/cilium/little-vm-helper/pkg/images
 github.com/cilium/little-vm-helper/pkg/kernels
 github.com/cilium/little-vm-helper/pkg/logcmd
 github.com/cilium/little-vm-helper/pkg/runner
+github.com/cilium/little-vm-helper/pkg/slogger
 github.com/cilium/little-vm-helper/pkg/step
 # github.com/cilium/lumberjack/v2 v2.4.1
 ## explicit; go 1.13
@@ -508,7 +509,7 @@ go.yaml.in/yaml/v3
 golang.org/x/exp/constraints
 golang.org/x/exp/maps
 golang.org/x/exp/slices
-# golang.org/x/mod v0.31.0
+# golang.org/x/mod v0.32.0
 ## explicit; go 1.24.0
 golang.org/x/mod/internal/lazyregexp
 golang.org/x/mod/module


### PR DESCRIPTION
~Wait for the below PR to land in first.~

Relates: https://github.com/cilium/little-vm-helper/pull/566
Relates: https://github.com/cilium/tetragon/pull/4532#issuecomment-3760607153

```release-note
vmtests: Migrate logrus to slog
```
