### PR TITLE
api/ops: Add missing MSG_OP_GENERIC_USDT to OpCodeStrings

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -28,7 +28,7 @@ Number of Tetragon perf events that are failed to be sent from the kernel.
 | label | values |
 | ----- | ------ |
 | `error` | `E2BIG, EAGAIN, EBUSY, EINVAL, ENOENT, ENOSPC, unknown` |
-| `msg_op` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 5, 7` |
+| `msg_op` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
 
 ### `tetragon_build_info`
 
@@ -208,7 +208,7 @@ The total number of event handler errors. For internal use only.
 | label | values |
 | ----- | ------ |
 | `error_type` | `event_handler_failed, unknown_opcode` |
-| `opcode` | `0, 13, 14, 15, 16, 23, 24, 25, 26, 27, 5, 7` |
+| `opcode` | `0, 13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
 
 ### `tetragon_handling_latency`
 
@@ -216,7 +216,7 @@ The latency of handling messages in us.
 
 | label | values |
 | ----- | ------ |
-| `op   ` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 5, 7` |
+| `op   ` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
 
 ### `tetragon_map_capacity`
 
@@ -274,7 +274,7 @@ The total number of times we encounter a given message opcode. For internal use 
 
 | label | values |
 | ----- | ------ |
-| `msg_op` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 5, 7` |
+| `msg_op` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
 
 ### `tetragon_notify_overflowed_events_total`
 

--- a/pkg/api/ops/ops.go
+++ b/pkg/api/ops/ops.go
@@ -80,6 +80,7 @@ var OpCodeStrings = map[OpCode]string{
 	MSG_OP_CGROUP:             "Cgroup",
 	MSG_OP_LOADER:             "Loader",
 	MSG_OP_THROTTLE:           "Throttle",
+	MSG_OP_GENERIC_USDT:       "GenericUSDT",
 	MSG_OP_TEST:               "Test",
 }
 


### PR DESCRIPTION
The MSG_OP_GENERIC_USDT opcode (28) was defined but missing from the OpCodeStrings map. This would cause the String() method to return "Unknown(28)" and log a bug report message when this opcode was encountered.

```release-note
api/ops: Add missing MSG_OP_GENERIC_USDT to OpCodeStrings
```
