### PR TITLE
fix: Change kernel config detection failure to info level

### DIFF
--- a/pkg/kernels/config.go
+++ b/pkg/kernels/config.go
@@ -131,10 +131,9 @@ func initKernelConfig() error {
 
 // DetectConfig checks if a kernel config option is enabled
 // It first tries /proc/config.gz, then looks for config file in /boot for the current kernel
-func DetectConfig(conf Config) bool {
+func DetectConfig(conf Config) (bool, error) {
 	if err := getKernelConfig(); err != nil {
-		logger.GetLogger().Error("Detecting kernel config failed", logfields.Error, err)
-		return false
+		return false, fmt.Errorf("getting kernel config failed: %w", err)
 	}
 
 	if val, ok := kernelConfigMap[conf]; ok {
@@ -142,11 +141,11 @@ func DetectConfig(conf Config) bool {
 		// it's mostly treated as a kernel parameter rather than a feature switch,
 		// so we temporarily filter these out.
 		if val == "y" || val == "m" {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 func LogConfigs() string {


### PR DESCRIPTION
Tetragon attempts to read the kernel config by trying a couple of places where it is found. This should be `Info` instead of `Error`:

```
level=error msg="Detecting kernel config failed" error="open /boot/config: no such file or directory"
```

This PR changes `Error` for `Info` and fixes this log to be shown twice

