### PR TITLE
feat: add requirements for Talos Linux v1.12.0+

### DIFF
--- a/docs/content/en/docs/installation/kubernetes.md
+++ b/docs/content/en/docs/installation/kubernetes.md
@@ -59,6 +59,17 @@ kubectl edit cm tetragon-config -n kube-system
 kubectl rollout restart ds/tetragon -n kube-system
 ```
 
+<details><summary>Requirements for Talos Linux (v1.12.0+)</summary>
+
+The following Helm values configuration is required to install Tetragon on Talos Linux:
+
+```yaml
+extraHostPathMounts:
+  - name: sys-kernel-tracing
+    mountPath: /sys/kernel/tracing
+```
+</details>
+
 ## Upgrade
 
 Upgrade Tetragon using a new specific version of the helm chart.


### PR DESCRIPTION
add snippet for Talos Linux in Kubernetes installation

Fixes #4541

### Description

Add a snippet for details on installing Tetragon on Talos Linux v1.12.0+

### Changelog

Updates documentation

```release-note
docs: add a snippet for details on installing Tetragon on Talos Linux v1.12.0+
```
