### PR TITLE
docs: update TracingPolicy selector limitations

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -2044,18 +2044,17 @@ The above would be executed in kernel as:
 
 ### Limitations
 
-{{% pageinfo %}}
-Those limitations might be outdated, see [issue #709](https://github.com/cilium/tetragon/issues/709).
-{{% /pageinfo %}}
-
 Because BPF must be bounded we have to place limits on how many selectors can
 exist.
 
-- Max Selectors 8.
+- Max Selectors 5.
 - Max PID values per selector 4
 - Max MatchArgs per selector 5 (one per index)
-- Max MatchArg Values per MatchArgs 1 (limiting initial implementation can bump
-  to 16 or so)
+- Max MatchArg Values per MatchArgs 4 (for operators like `Equal`, `NotEqual`,
+  `GT`, `LT`, etc.)
+
+For an unlimited number of values, consider using the `InMap` or `NotInMap`
+operators which store values in a BPF map.
 
 
 ## Return Actions filter


### PR DESCRIPTION
### Description
Update the Limitations section in the selectors documentation:

- Remove outdated warning banner referencing  #709
- Correct `Max Selectors` from 8 to 5 (per MAX_SELECTORS in `basic.h`)
- Correct `Max MatchArg Values` from 1 to 4 (per MAX_MATCH_VALUES in `basic.h`)
- Add note about `InMap/NotInMap` operators for unlimited values

Fixes: #709



<!-- Please describe quickly the change but most importantly the reason or context of your change -->

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
docs: Fix outdated TracingPolicy selector limitations (Max Selectors: 8 -> 5, Max MatchArg Values: 1 -> 4)
```
