### PR TITLE
docs: add kernel version-specific selector limits

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -2052,6 +2052,9 @@ exist.
 - Max MatchArgs per selector 5 (one per index)
 - Max MatchArg Values per MatchArgs 4 (for operators like `Equal`, `NotEqual`,
   `GT`, `LT`, etc.)
+- Max file match values (using `fd` or `file` arg): 8 on kernels ≥5.3, 2 on kernels <5.3
+- String prefix max length: 256 chars
+- String postfix max length: 128 chars
 
 For an unlimited number of values, consider using the `InMap` or `NotInMap`
 operators which store values in a BPF map.


### PR DESCRIPTION
Follow-up to  #4549 documenting additional limits from  #709


### Description
Added kernel version-specific limits that were discussed in  #709 :
- Max file match values: 8 on kernels ≥ 5.3, 2 on kernels < 5.3
- String prefix max length: 256 chars
- String postfix max length: 128 chars
- matchBinaries values: Unlimited (stored in BPF map)

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
docs: add kernel version-specific selector limitations
```
