### PR TITLE
metrics: Keep in sync with bpf/errmetrics/fileids.h

### DIFF
--- a/pkg/errmetrics/files.go
+++ b/pkg/errmetrics/files.go
@@ -17,6 +17,7 @@ var Files = map[uint8]string{
 	8:  "process.h",
 	9:  "bpf_execve_event.c",
 	10: "uprobe_offload.h",
+	11: "uprobe_preload.h",
 }
 
 func BPFFileName(id uint8) string {


### PR DESCRIPTION
Relates: 171fb1d86d346852eba0262a1196402099110280

