### PR TITLE
[v1.6 backport] bpf: make op_capabilities_gained filter consistent

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1788,7 +1788,7 @@ selector_arg_offset(__u8 *f, struct msg_generic_kprobe *e, __u32 selidx,
 				__u32 index2 = *((__u32 *)&filter->value);
 				__u64 cap_new = *(__u64 *)get_arg(e, index2);
 
-				pass = !!((cap_old ^ cap_new) & cap_new);
+				pass &= !!((cap_old ^ cap_new) & cap_new);
 				break;
 			}
 			fallthrough;


### PR DESCRIPTION
[ upstream commit 7d16d8f2a981a49810805aedada6a97a6330a54d ]

For a selector to match, all of its filters must match (AND operator). Without this change, an earlier failed filter for the selector will not prevent the selector from matching if capabilities are gained.

Upstream PR: https://github.com/cilium/tetragon/pull/4527

```release-not
policies: fix issue in capabilities gained operator when using multiple selectors
```