### PR TITLE
chore: Add sloglint in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - modernize
     - perfsprint
     - revive
+    - sloglint
     - staticcheck
     - testifylint
     - unused


### PR DESCRIPTION
The migration from logrus to slog is done recently, add linter for consistency in the future.


```release-note
chore: Add sloglint in golangci-lint
```
