### PR TITLE
procsyms: Implement caching for process memory maps

### DIFF
--- a/pkg/procsyms/procsyms_linux.go
+++ b/pkg/procsyms/procsyms_linux.go
@@ -45,6 +45,14 @@ type procMapEntry struct {
 	pathname  string
 }
 
+// InvalidatePID removes cached memory maps for a PID.
+// Call this when a process exits or execs to avoid stale data.
+func InvalidatePID(pid int) {
+	if procMapCache != nil {
+		procMapCache.Remove(pid)
+	}
+}
+
 // initSymbolCache initializes the Level 2 symbol cache (thread-safe, called once)
 func initSymbolCache() {
 	setSymbolCache.Do(func() {

--- a/pkg/procsyms/procsyms_linux.go
+++ b/pkg/procsyms/procsyms_linux.go
@@ -205,4 +205,3 @@ func GetFnSymbol(pid int, addr uint64) (*FnSym, error) {
 	}
 	return &sym, nil
 }
-

--- a/pkg/procsyms/procsyms_linux_test.go
+++ b/pkg/procsyms/procsyms_linux_test.go
@@ -130,3 +130,22 @@ func TestProcMapCacheInit(t *testing.T) {
 		t.Error("proc map cache should be initialized")
 	}
 }
+
+// BenchmarkGetProcMaps measures the performance of the cached implementation
+func BenchmarkGetProcMaps(b *testing.B) {
+	pid := os.Getpid()
+
+	// Warm up cache
+	_, err := getProcMaps(pid)
+	if err != nil {
+		b.Fatalf("setup failed: %v", err)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := getProcMaps(pid)
+		if err != nil {
+			b.Fatalf("getProcMaps failed: %v", err)
+		}
+	}
+}

--- a/pkg/procsyms/procsyms_linux_test.go
+++ b/pkg/procsyms/procsyms_linux_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package procsyms
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetProcMaps(t *testing.T) {
+	pid := os.Getpid()
+
+	maps1, err := getProcMaps(pid)
+	if err != nil {
+		t.Fatalf("getProcMaps failed: %v", err)
+	}
+
+	if len(maps1) == 0 {
+		t.Fatal("expected non-empty memory maps")
+	}
+
+	maps2, err := getProcMaps(pid)
+	if err != nil {
+		t.Fatalf("second getProcMaps failed: %v", err)
+	}
+
+	if len(maps1) != len(maps2) {
+		t.Errorf("cache returned different data: got %d entries, want %d", len(maps2), len(maps1))
+	}
+
+	for i, entry := range maps1 {
+		if entry.startAddr >= entry.endAddr {
+			t.Errorf("entry %d: invalid address range: start=%x end=%x", i, entry.startAddr, entry.endAddr)
+		}
+	}
+}
+
+func TestInvalidatePID(t *testing.T) {
+	pid := os.Getpid()
+
+	_, err := getProcMaps(pid)
+	if err != nil {
+		t.Fatalf("getProcMaps failed: %v", err)
+	}
+
+	if procMapCache == nil {
+		t.Fatal("cache not initialized")
+	}
+
+	if !procMapCache.Contains(pid) {
+		t.Fatal("PID should be in cache after getProcMaps")
+	}
+
+	InvalidatePID(pid)
+
+	if procMapCache.Contains(pid) {
+		t.Error("PID should not be in cache after InvalidatePID")
+	}
+}
+
+func TestInvalidatePIDNonExistent(_ *testing.T) {
+	InvalidatePID(999999)
+}
+
+func TestFindMapEntry(t *testing.T) {
+	entries := []*procMapEntry{
+		{startAddr: 0x1000, endAddr: 0x2000, pathname: "/bin/a"},
+		{startAddr: 0x3000, endAddr: 0x4000, pathname: "/bin/b"},
+		{startAddr: 0x5000, endAddr: 0x6000, pathname: "/bin/c"},
+	}
+
+	tests := []struct {
+		name     string
+		addr     uint64
+		wantPath string
+	}{
+		{"first region", 0x1500, "/bin/a"},
+		{"second region", 0x3500, "/bin/b"},
+		{"third region", 0x5500, "/bin/c"},
+		{"start of first", 0x1000, "/bin/a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := findMapEntry(entries, tt.addr)
+			if entry.pathname != tt.wantPath {
+				t.Errorf("findMapEntry(%x) = %s, want %s", tt.addr, entry.pathname, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestGetFnSymbol(t *testing.T) {
+	pid := os.Getpid()
+	fnAddr := getFunctionAddr()
+
+	if fnAddr == 0 {
+		t.Skip("could not get function address for testing")
+	}
+
+	sym, err := GetFnSymbol(pid, fnAddr)
+	if err != nil {
+		t.Fatalf("GetFnSymbol failed: %v", err)
+	}
+
+	if sym.Module == "" {
+		t.Error("expected non-empty module")
+	}
+
+	t.Logf("Resolved symbol: module=%s offset=%x name=%s", sym.Module, sym.Offset, sym.Name)
+}
+
+func getFunctionAddr() uint64 {
+	return 0
+}
+
+func TestSymbolCacheInit(t *testing.T) {
+	initSymbolCache()
+
+	if symbolCache == nil {
+		t.Error("symbol cache should be initialized")
+	}
+}
+
+func TestProcMapCacheInit(t *testing.T) {
+	initProcMapCache()
+
+	if procMapCache == nil {
+		t.Error("proc map cache should be initialized")
+	}
+}

--- a/pkg/sensors/exec/exec_linux.go
+++ b/pkg/sensors/exec/exec_linux.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/procsyms"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/exec/procevents"
 	"github.com/cilium/tetragon/pkg/sensors/exec/userinfo"
@@ -210,6 +211,8 @@ func handleExecve(r *bytes.Reader) ([]observer.Event, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Invalidate cached memory maps since exec replaces the address space
+	procsyms.InvalidatePID(int(m.Parent.Pid))
 	msgUnix := msgToExecveUnix(&m)
 	msgUnix.Unix.Process, err = execParse(r)
 	if err == nil {
@@ -236,6 +239,8 @@ func handleExit(r *bytes.Reader) ([]observer.Event, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Invalidate cached memory maps for exiting process
+	procsyms.InvalidatePID(int(m.ProcessKey.Pid))
 	msgUnix := msgToExitUnix(&m)
 	return []observer.Event{msgUnix}, nil
 }


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
This PR implements a TODO to make symbol resolution much faster by caching memory maps.

Right now, we read the `/proc/[pid]/maps` file every time we need to find a symbol. This is slow because it involves reading from the disk over and over again.

Implemented a cache that stores the memory maps for each process ID so we don't have to read the file every time. The cache automatically clears itself when a process dies or starts a new program (execve) to ensure we always have the correct data. (split this into multiple commits, so please review them commit-wise.) 

**Output of benchmark test**(commit https://github.com/cilium/tetragon/commit/1be92a42bf7e33e2df65d9e24471c14ef5f4fb58)

**With this patch**
```
go test -bench=. -benchmem -count=1 ./pkg/procsyms/...
goos: linux
goarch: amd64
pkg: github.com/cilium/tetragon/pkg/procsyms
cpu: 13th Gen Intel(R) Core(TM) i5-13420H
BenchmarkGetProcMaps-12         41458305                27.40 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/cilium/tetragon/pkg/procsyms 2.089s
```
**without this patch**
```
go test -bench=. -benchmem -count=1 ./pkg/procsyms/...
goos: linux
goarch: amd64
pkg: github.com/cilium/tetragon/pkg/procsyms
cpu: 13th Gen Intel(R) Core(TM) i5-13420H
BenchmarkGetProcMaps-12    
   22100             58114 ns/op           33469 B/op        499 allocs/op
PASS
ok      github.com/cilium/tetragon/pkg/procsyms 2.949s
```

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Made symbol lookups faster by caching memory maps.
```
