### PR TITLE
process cache: metric for implicit evictions

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -348,7 +348,7 @@ The capacity of the process cache. Expected to be constant.
 
 ### `tetragon_process_cache_evictions_total`
 
-Number of process cache LRU evictions.
+Number of process cache LRU evictions. This includes all evictions: both explicit and capacity (implicit).
 
 ### `tetragon_process_cache_misses_total`
 

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -178,6 +178,8 @@ func (pc *Cache) add(process *ProcessInternal) bool {
 	evicted := pc.cache.Add(process.process.ExecId, process)
 	if !evicted {
 		processCacheTotal.Inc()
+	} else {
+		processCacheCapacityEvictions.Inc()
 	}
 	return evicted
 }

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -32,7 +32,12 @@ var (
 	processCacheEvictions = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: consts.MetricsNamespace,
 		Name:      "process_cache_evictions_total",
-		Help:      "Number of process cache LRU evictions.",
+		Help:      "Number of process cache LRU evictions. This includes all evictions: both explicit and capacity (implicit).",
+	})
+	processCacheCapacityEvictions = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: consts.MetricsNamespace,
+		Name:      "process_cache_capacity_evictions_total",
+		Help:      "Number of process cache capacity (implicit) LRU evictions.",
 	})
 	processCacheMisses = metrics.MustNewCounter(metrics.NewOpts(
 		consts.MetricsNamespace, "", "process_cache_misses_total",


### PR DESCRIPTION
There are two types of evictions happening in the process cache:
1. Explicit, i.e., by removing a key
2. Capacity / Implicit, i.e., by running out of entries when we add a key

The metric that Tetragon currently exports includes both. This commit adds a new metric for the capacity evictions only.

```release-note
process cache: add a metric for capacity evictions
```