### PR TITLE
tetragon: Do not process stack data when it's not present

### DIFF
--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -60,6 +60,14 @@ type MsgGenericKprobe struct {
 	UserStackID   int64
 }
 
+func (m MsgGenericKprobe) HasKernelStack() bool {
+	return m.Common.Flags&processapi.MSG_COMMON_FLAG_KERNEL_STACKTRACE != 0
+}
+
+func (m MsgGenericKprobe) HasUserStack() bool {
+	return m.Common.Flags&processapi.MSG_COMMON_FLAG_USER_STACKTRACE != 0
+}
+
 type MsgGenericKprobeArgPath struct {
 	Index      uint64
 	Value      string

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -1380,7 +1380,7 @@ func handleMsgGenericKprobe(m *api.MsgGenericKprobe, gk *genericKprobe, r *bytes
 		printers = gk.argSigPrinters
 	}
 
-	if m.Common.Flags&(processapi.MSG_COMMON_FLAG_KERNEL_STACKTRACE|processapi.MSG_COMMON_FLAG_USER_STACKTRACE) != 0 {
+	if m.HasKernelStack() || m.HasUserStack() {
 		if m.KernelStackID < 0 {
 			logger.GetLogger().Warn(fmt.Sprintf("failed to retrieve kernel stacktrace: id equal to errno %d", m.KernelStackID))
 		}


### PR DESCRIPTION
Currently we check each stack value for 0 even in case we do not retrieve stack, let's skip it.
