### PR TITLE
synthetic: add event recording and replay support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ all: tetragon-bpf tetragon tetra test-compile tester-progs protoc-gen-go-tetrago
 .PHONY: clean
 clean: cli-clean tarball-clean
 	$(MAKE) -C ./bpf clean
-	rm -f go-tests/*.test ./ksyms ./tetragon ./tetragon-operator ./tetra ./alignchecker ./tetragon.exe
+	rm -f go-tests/*.test ./ksyms ./tetragon ./tetragon-synthetic ./tetragon-operator ./tetra ./alignchecker ./tetragon.exe
 	rm -f contrib/sigkill-tester/sigkill-tester contrib/namespace-tester/test_ns contrib/capabilities-tester/test_caps
 	$(MAKE) -C $(TESTER_PROGS_DIR) clean
 
@@ -107,6 +107,10 @@ clean: cli-clean tarball-clean
 .PHONY: tetragon
 tetragon: ## Compile the Tetragon agent.
 	$(GO_BUILD) ./cmd/tetragon/
+
+.PHONY: tetragon-synthetic
+tetragon-synthetic: ## Compile the Tetragon synthetic events agent.
+	$(GO_BUILD) -tags synthetic -o tetragon-synthetic ./cmd/tetragon/
 
 .PHONY: tetragon-operator
 tetragon-operator: ## Compile the Tetragon operator.
@@ -171,6 +175,12 @@ image: ## Build the Tetragon agent container image.
 	$(CONTAINER_ENGINE) build -t "cilium/tetragon:${DOCKER_IMAGE_TAG}" --target release --build-arg TETRAGON_VERSION=$(VERSION) ${CONTAINER_ENGINE_ARGS} --platform=linux/${TARGET_ARCH} .
 	@echo "Push like this when ready:"
 	@echo "${CONTAINER_ENGINE} push cilium/tetragon:$(DOCKER_IMAGE_TAG)"
+
+.PHONY: image-synthetic
+image-synthetic: ## Build the Tetragon synthetic debug container image.
+	$(CONTAINER_ENGINE) build -t "cilium/tetragon-synthetic:${DOCKER_IMAGE_TAG}" --target synthetic-debug --build-arg TETRAGON_VERSION=$(VERSION) --build-arg BUILD_EXTRA_TARGETS="tetragon-synthetic" ${CONTAINER_ENGINE_ARGS} --platform=linux/${TARGET_ARCH} .
+	@echo "Push like this when ready:"
+	@echo "${CONTAINER_ENGINE} push cilium/tetragon-synthetic:$(DOCKER_IMAGE_TAG)"
 
 .PHONY: image-operator
 image-operator: ## Build the Tetragon operator container image.

--- a/cmd/tetragon/mode_default.go
+++ b/cmd/tetragon/mode_default.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !synthetic
+
+package main
+
+import (
+	"context"
+
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/tetragon/pkg/grpc"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/observer"
+)
+
+func binaryName() string {
+	return "tetragon"
+}
+
+func addExtraFlags(_ *pflag.FlagSet) {}
+
+func readExtraFlags() error {
+	return nil
+}
+
+func setupObserver(_ context.Context, obs observer.EventObserver, _ logger.FieldLogger) (observer.EventObserver, error) {
+	return obs, nil
+}
+
+func setupListener(_ context.Context, obs observer.EventObserver, pm *grpc.ProcessManager, _ logger.FieldLogger) error {
+	obs.AddListener(pm)
+	return nil
+}

--- a/cmd/tetragon/mode_synthetic.go
+++ b/cmd/tetragon/mode_synthetic.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build synthetic
+
+package main
+
+import (
+	"context"
+
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/tetragon/pkg/grpc"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/synthetic"
+)
+
+func binaryName() string {
+	return "tetragon-synthetic"
+}
+
+func addExtraFlags(flags *pflag.FlagSet) {
+	option.AddSyntheticFlags(flags)
+}
+
+func readExtraFlags() error {
+	return option.ReadAndSetSyntheticFlags()
+}
+
+func setupObserver(ctx context.Context, obs observer.EventObserver, log logger.FieldLogger) (observer.EventObserver, error) {
+	if option.Config.SyntheticEventsSource != "" {
+		readingObs, err := synthetic.NewReadingObserverFromFile(ctx, option.Config.SyntheticEventsSource, log)
+		if err != nil {
+			return nil, err
+		}
+		readingObs.Observer = obs.(*observer.Observer)
+		return readingObs, nil
+	}
+	return obs, nil
+}
+
+func setupListener(ctx context.Context, obs observer.EventObserver, pm *grpc.ProcessManager, log logger.FieldLogger) error {
+	if option.Config.SyntheticEventsLog != "" {
+		// Create synthetic listener with ProcessManager as delegate.
+		// Events are recorded before ProcessManager modifies them.
+		syntheticListener, err := synthetic.NewWritingListenerToFile(
+			ctx,
+			option.Config.SyntheticEventsLog,
+			log,
+			synthetic.WithVerifyRoundtrip(option.Config.SyntheticEventsVerifyRoundtrip),
+			synthetic.WithDelegate(pm),
+		)
+		if err != nil {
+			return err
+		}
+		obs.AddListener(syntheticListener)
+	} else {
+		obs.AddListener(pm)
+	}
+	return nil
+}

--- a/docs/content/en/docs/contribution-guide/development-setup.md
+++ b/docs/content/en/docs/contribution-guide/development-setup.md
@@ -157,6 +157,18 @@ You can now build Tetragon in your VM:
 make -j3 tetragon-bpf tetragon tetra
 ```
 
+## Synthetic debug image (developers only)
+
+To build the synthetic debug image:
+```shell
+make image-synthetic
+```
+
+Synthetic debug flags (`tetragon-synthetic` only):
+- `--synthetic-events-source`: replay events from a JSONL file
+- `--synthetic-events-log`: write events to a JSONL file
+- `--synthetic-events-verify-roundtrip`: verify marshal/unmarshal roundtrip (only with `--synthetic-events-log`). For each recorded event, it unmarshals and compares the result to the original event. On mismatch it logs `Roundtrip verification: unmarshal failed` or `Roundtrip verification: mismatch detected`. If an event type is not registered, the warning includes `error unknown type: <Type>`; register new types in `pkg/synthetic/types_linux.go` via `RegisterType((*NewType)(nil))`.
+
 ## What's next
 
 - See how to [make your first changes](/docs/contribution-guide/making-changes).

--- a/pkg/observer/listener.go
+++ b/pkg/observer/listener.go
@@ -5,22 +5,8 @@ package observer
 
 import (
 	"encoding/gob"
-	"io"
 	"net"
-
-	"github.com/cilium/tetragon/pkg/reader/notify"
 )
-
-// Listener defines the interface to receive events from Observer. Listeners
-// will merge and complete out-of-order events before they're passed to
-// human-readable sinks such as the printer or GRPC encoder.
-type Listener interface {
-	// Notify gets called for each events from ObserverKprobe.
-	Notify(msg notify.Message) error
-
-	// Close the listener.
-	io.Closer
-}
 
 // Channel is a Listener that gob encodes events and sends them to a
 // network connection.

--- a/pkg/observer/types.go
+++ b/pkg/observer/types.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// Package observer defines interfaces for the observer subsystem.
+package observer
+
+import (
+	"context"
+	"io"
+
+	"github.com/cilium/tetragon/pkg/reader/notify"
+)
+
+// Listener defines the interface to receive events from Observer. Listeners
+// will merge and complete out-of-order events before they're passed to
+// human-readable sinks such as the printer or GRPC encoder.
+type Listener interface {
+	// Notify gets called for each events from ObserverKprobe.
+	Notify(msg notify.Message) error
+
+	// Close the listener.
+	io.Closer
+}
+
+// EventObserver defines the interface for event observation and processing.
+type EventObserver interface {
+	Start(ctx context.Context) error
+	StartReady(ctx context.Context, ready func()) error
+	InitSensorManager() error
+	UpdateRuntimeConf(bpfDir string) error
+	AddListener(listener Listener)
+	RemoveListener(listener Listener)
+	PrintStats()
+	LogPinnedBpf(observerDir string)
+	ReadLostEvents() uint64
+	ReadErrorEvents() uint64
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -140,6 +140,10 @@ type config struct {
 	RetprobesCacheSize int
 
 	KeepCollection bool
+
+	SyntheticEventsSource          string
+	SyntheticEventsLog             string
+	SyntheticEventsVerifyRoundtrip bool
 }
 
 var (

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -143,6 +143,10 @@ const (
 	KeyParentsMapSize    = "parents-map-size"
 
 	KeyRetprobesCacheSize = "retprobes-cache-size"
+
+	KeySyntheticEventsSource          = "synthetic-events-source"
+	KeySyntheticEventsLog             = "synthetic-events-log"
+	KeySyntheticEventsVerifyRoundtrip = "synthetic-events-verify-roundtrip"
 )
 
 type UsernameMetadaCode int
@@ -313,6 +317,13 @@ func ReadAndSetFlags() error {
 	Config.ParentsMapSize = viper.GetString(KeyParentsMapSize)
 
 	Config.RetprobesCacheSize = viper.GetInt(KeyRetprobesCacheSize)
+	return nil
+}
+
+func ReadAndSetSyntheticFlags() error {
+	Config.SyntheticEventsSource = viper.GetString(KeySyntheticEventsSource)
+	Config.SyntheticEventsLog = viper.GetString(KeySyntheticEventsLog)
+	Config.SyntheticEventsVerifyRoundtrip = viper.GetBool(KeySyntheticEventsVerifyRoundtrip)
 	return nil
 }
 
@@ -516,4 +527,10 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.String(KeyParentsMapSize, "", "Set size for parents_map table (allows K/M/G suffix)")
 
 	flags.Int(KeyRetprobesCacheSize, defaults.DefaultRetprobesCacheSize, "Set {k,u}retprobes events cache maximum size")
+}
+
+func AddSyntheticFlags(flags *pflag.FlagSet) {
+	flags.String(KeySyntheticEventsSource, "", "File path for synthetic events source")
+	flags.String(KeySyntheticEventsLog, "", "File path to log events for synthetic events testing")
+	flags.Bool(KeySyntheticEventsVerifyRoundtrip, false, "Verify synthetic events roundtrip (marshal/unmarshal equality)")
 }

--- a/pkg/synthetic/factory_linux.go
+++ b/pkg/synthetic/factory_linux.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package synthetic
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/tetragon/pkg/logger"
+)
+
+// NewReadingObserverFromFile creates a ReadingObserver that reads from the specified file.
+// The file will be closed when the context is cancelled.
+func NewReadingObserverFromFile(ctx context.Context, path string, log logger.FieldLogger) (*ReadingObserver, error) {
+	f, err := openSourceFile(path)
+	if err != nil {
+		return nil, err
+	}
+	context.AfterFunc(ctx, func() {
+		f.Close()
+	})
+	return NewReadingObserver(f, Serializer{}, log), nil
+}
+
+// NewWritingListenerToFile creates a WritingListener that writes to the specified file.
+// If the file already exists, it will be renamed with a timestamp prefix.
+// The file will be closed when the context is cancelled.
+func NewWritingListenerToFile(ctx context.Context, path string, log logger.FieldLogger, opts ...Option) (*WritingListener, error) {
+	f, err := openLogFile(path)
+	if err != nil {
+		return nil, err
+	}
+	bufWriter := bufio.NewWriter(f)
+	context.AfterFunc(ctx, func() {
+		bufWriter.Flush()
+		f.Close()
+	})
+	return NewWritingListener(bufWriter, Serializer{}, log, opts...), nil
+}
+
+// openSourceFile opens a file for reading synthetic events.
+func openSourceFile(path string) (*os.File, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open synthetic events source: %w", err)
+	}
+	return f, nil
+}
+
+// openLogFile opens a file for writing synthetic events.
+// If the file already exists, it will be renamed with a timestamp prefix.
+func openLogFile(path string) (*os.File, error) {
+	// If file exists, rename it with modification time prefix
+	if info, err := os.Stat(path); err == nil {
+		modTime := info.ModTime().Format("2006-01-02_15-04-05")
+		dir := filepath.Dir(path)
+		base := filepath.Base(path)
+		newName := filepath.Join(dir, modTime+"_"+base)
+		if err := os.Rename(path, newName); err != nil {
+			return nil, fmt.Errorf("failed to rename existing synthetic events file: %w", err)
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open synthetic events file: %w", err)
+	}
+	return f, nil
+}

--- a/pkg/synthetic/factory_windows.go
+++ b/pkg/synthetic/factory_windows.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package synthetic
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/reader/notify"
+)
+
+var errNotSupported = errors.New("synthetic events are only supported on Linux")
+
+// NewReadingObserverFromFile is not supported on non-Linux platforms.
+func NewReadingObserverFromFile(_ context.Context, _ string, _ logger.FieldLogger) (*ReadingObserver, error) {
+	return nil, errNotSupported
+}
+
+// NewWritingListenerToFile is not supported on non-Linux platforms.
+func NewWritingListenerToFile(_ context.Context, _ string, _ logger.FieldLogger, _ ...Option) (*WritingListener, error) {
+	return nil, errNotSupported
+}
+
+// ReadingObserver stub for non-Linux platforms.
+type ReadingObserver struct {
+	*observer.Observer
+}
+
+// Start stub for non-Linux platforms.
+func (r *ReadingObserver) Start(_ context.Context) error { return errNotSupported }
+
+// StartReady stub for non-Linux platforms.
+func (r *ReadingObserver) StartReady(_ context.Context, _ func()) error { return errNotSupported }
+
+// InitSensorManager stub for non-Linux platforms.
+func (r *ReadingObserver) InitSensorManager() error { return errNotSupported }
+
+// UpdateRuntimeConf stub for non-Linux platforms.
+func (r *ReadingObserver) UpdateRuntimeConf(_ string) error { return errNotSupported }
+
+// AddListener stub for non-Linux platforms.
+func (r *ReadingObserver) AddListener(_ observer.Listener) {}
+
+// RemoveListener stub for non-Linux platforms.
+func (r *ReadingObserver) RemoveListener(_ observer.Listener) {}
+
+// PrintStats stub for non-Linux platforms.
+func (r *ReadingObserver) PrintStats() {}
+
+// LogPinnedBpf stub for non-Linux platforms.
+func (r *ReadingObserver) LogPinnedBpf(_ string) {}
+
+// ReadLostEvents stub for non-Linux platforms.
+func (r *ReadingObserver) ReadLostEvents() uint64 { return 0 }
+
+// ReadErrorEvents stub for non-Linux platforms.
+func (r *ReadingObserver) ReadErrorEvents() uint64 { return 0 }
+
+// WritingListener stub for non-Linux platforms.
+type WritingListener struct{}
+
+// Notify stub for non-Linux platforms.
+func (l *WritingListener) Notify(_ notify.Message) error { return nil }
+
+// Close stub for non-Linux platforms.
+func (l *WritingListener) Close() error { return nil }
+
+// Option configures WritingListener.
+type Option func(*WritingListener)
+
+// WithVerifyRoundtrip is a no-op on non-Linux platforms.
+func WithVerifyRoundtrip(_ bool) Option {
+	return func(_ *WritingListener) {}
+}
+
+// WithDelegate is a no-op on non-Linux platforms.
+func WithDelegate(_ observer.Listener) Option {
+	return func(_ *WritingListener) {}
+}

--- a/pkg/synthetic/reading_observer_linux.go
+++ b/pkg/synthetic/reading_observer_linux.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// reading_observer.go implements ReadingObserver that reads and replays Tetragon events
+// from a reader. It implements the observer.EventObserver interface.
+
+package synthetic
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"sync/atomic"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/logger/logfields"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/reader/notify"
+)
+
+// ReadingObserver reads and replays synthetic events from a reader.
+// It implements observer.EventObserver interface.
+type ReadingObserver struct {
+	*observer.Observer
+	reader    io.Reader
+	codec     Codec
+	log       logger.FieldLogger
+	listeners map[observer.Listener]struct{}
+	events    uint64
+	errors    uint64
+}
+
+// NewReadingObserver creates a new ReadingObserver with the given reader, codec and logger.
+func NewReadingObserver(reader io.Reader, codec Codec, log logger.FieldLogger) *ReadingObserver {
+	return &ReadingObserver{
+		reader:    reader,
+		codec:     codec,
+		log:       log,
+		listeners: make(map[observer.Listener]struct{}),
+	}
+}
+
+// StartReady implements observer.EventObserver.StartReady.
+func (r *ReadingObserver) StartReady(ctx context.Context, ready func()) error {
+	ready()
+
+	r.log.Info("Starting synthetic event replay")
+
+	scanner := bufio.NewScanner(r.reader)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			break
+		}
+
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		// Unmarshal the event using codec
+		event, err := r.codec.Unmarshal(line)
+		if err != nil {
+			r.log.Warn("Failed to unmarshal event", "error", err)
+			atomic.AddUint64(&r.errors, 1)
+			continue
+		}
+
+		msg, ok := event.(notify.Message)
+		if !ok {
+			r.log.Warn("Event does not implement notify.Message")
+			atomic.AddUint64(&r.errors, 1)
+			continue
+		}
+
+		atomic.AddUint64(&r.events, 1)
+		r.observerListeners(msg)
+	}
+
+	r.log.Info("Finished synthetic event replay", "events", atomic.LoadUint64(&r.events))
+
+	// Keep running until context is cancelled
+	<-ctx.Done()
+	return nil
+}
+
+// observerListeners sends a message to all registered listeners.
+func (r *ReadingObserver) observerListeners(msg notify.Message) {
+	for listener := range r.listeners {
+		if err := listener.Notify(msg); err != nil {
+			r.log.Debug("Write failure removing Listener")
+			r.RemoveListener(listener)
+		}
+	}
+}
+
+// AddListener implements observer.EventObserver.AddListener.
+func (r *ReadingObserver) AddListener(listener observer.Listener) {
+	r.log.Debug("Add listener", "listener", listener)
+	r.listeners[listener] = struct{}{}
+}
+
+// RemoveListener implements observer.EventObserver.RemoveListener.
+func (r *ReadingObserver) RemoveListener(listener observer.Listener) {
+	r.log.Debug("Delete listener", "listener", listener)
+	delete(r.listeners, listener)
+	if err := listener.Close(); err != nil {
+		r.log.Warn("failed to close listener", logfields.Error, err)
+	}
+}

--- a/pkg/synthetic/reading_observer_linux_test.go
+++ b/pkg/synthetic/reading_observer_linux_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package synthetic_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/synthetic"
+)
+
+func TestStartReady_Success(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel when we see log message "Finished synthetic event replay"
+	log := slog.New(&triggerHandler{
+		Handler:   logger.SlogNopHandler,
+		trigger:   "Finished synthetic event replay",
+		onTrigger: cancel,
+	})
+
+	reader := strings.NewReader("{}\n{}\n{}\n")
+	obs := synthetic.NewReadingObserver(reader, &testCodec{}, log)
+
+	listener := &testListener{}
+	obs.AddListener(listener)
+
+	if err := obs.StartReady(ctx, func() {}); err != nil {
+		t.Fatal(err)
+	}
+
+	if listener.received != 3 {
+		t.Fatalf("expected 3 events, got %d", listener.received)
+	}
+}
+
+func TestStartReady_EmptyLines(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	log := slog.New(&triggerHandler{
+		Handler:   logger.SlogNopHandler,
+		trigger:   "Finished synthetic event replay",
+		onTrigger: cancel,
+	})
+
+	reader := strings.NewReader("\n\n{}\n\n")
+	obs := synthetic.NewReadingObserver(reader, &testCodec{}, log)
+
+	listener := &testListener{}
+	obs.AddListener(listener)
+
+	if err := obs.StartReady(ctx, func() {}); err != nil {
+		t.Fatal(err)
+	}
+
+	if listener.received != 1 {
+		t.Fatalf("expected 1 event (empty lines skipped), got %d", listener.received)
+	}
+}
+
+func TestStartReady_ContextCancel(t *testing.T) {
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		pr.Close()
+		pw.Close()
+	})
+
+	obs := synthetic.NewReadingObserver(pr, &testCodec{}, nopLog)
+
+	listener := &testListener{}
+	obs.AddListener(listener)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		// Write first line
+		pw.Write([]byte("{}\n"))
+
+		// Wait for first event to be processed (or timeout)
+		deadline := time.Now().Add(2 * time.Second)
+		for listener.received < 1 {
+			if time.Now().After(deadline) {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		// Cancel before second line
+		cancel()
+
+		// Write second line to unblock scanner
+		pw.Write([]byte("{}\n"))
+	}()
+
+	err := obs.StartReady(ctx, func() {})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only first event should be processed
+	if listener.received != 1 {
+		t.Fatalf("expected 1 event (before cancel), got %d", listener.received)
+	}
+}
+
+func TestListenerError_RemovesListener(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	log := slog.New(&triggerHandler{
+		Handler:   logger.SlogNopHandler,
+		trigger:   "Finished synthetic event replay",
+		onTrigger: cancel,
+	})
+
+	reader := strings.NewReader("{}\n{}\n")
+	obs := synthetic.NewReadingObserver(reader, &testCodec{}, log)
+
+	good := &testListener{}
+	bad := &testListener{notifyErr: errors.New("fail")}
+	obs.AddListener(good)
+	obs.AddListener(bad)
+
+	if err := obs.StartReady(ctx, func() {}); err != nil {
+		t.Fatal(err)
+	}
+
+	if good.received != 2 {
+		t.Fatalf("expected good listener to receive 2 events, got %d", good.received)
+	}
+
+	if !bad.closed {
+		t.Error("bad listener should be closed after error")
+	}
+}
+
+func TestAddRemoveListener(t *testing.T) {
+	obs := synthetic.NewReadingObserver(
+		strings.NewReader(""),
+		&testCodec{},
+		nopLog,
+	)
+
+	listener := &testListener{}
+	obs.AddListener(listener)
+	obs.RemoveListener(listener)
+
+	if !listener.closed {
+		t.Error("listener should be closed on remove")
+	}
+}
+
+func TestRemoveListener_CloseError(t *testing.T) {
+	obs := synthetic.NewReadingObserver(
+		strings.NewReader(""),
+		&testCodec{},
+		nopLog,
+	)
+
+	listener := &testListener{closeErr: errors.New("close failed")}
+	obs.AddListener(listener)
+	obs.RemoveListener(listener)
+
+	if !listener.closed {
+		t.Error("listener should be closed even on error")
+	}
+}
+
+func TestStartReady_UnmarshalError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	log := slog.New(&triggerHandler{
+		Handler:   logger.SlogNopHandler,
+		trigger:   "Finished",
+		onTrigger: cancel,
+	})
+
+	reader := strings.NewReader("{}\n{}\n")
+	obs := synthetic.NewReadingObserver(reader, &unmarshalErrorCodec{}, log)
+
+	listener := &testListener{}
+	obs.AddListener(listener)
+
+	if err := obs.StartReady(ctx, func() {}); err != nil {
+		t.Fatal(err)
+	}
+
+	// No events delivered due to unmarshal errors
+	if listener.received != 0 {
+		t.Fatalf("expected 0 events, got %d", listener.received)
+	}
+}
+
+func TestStartReady_NotMessageType(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	log := slog.New(&triggerHandler{
+		Handler:   logger.SlogNopHandler,
+		trigger:   "Finished",
+		onTrigger: cancel,
+	})
+
+	reader := strings.NewReader("{}\n{}\n")
+	obs := synthetic.NewReadingObserver(reader, &notMessageCodec{}, log)
+
+	listener := &testListener{}
+	obs.AddListener(listener)
+
+	if err := obs.StartReady(ctx, func() {}); err != nil {
+		t.Fatal(err)
+	}
+
+	// No events delivered because codec returns non-Message type
+	if listener.received != 0 {
+		t.Fatalf("expected 0 events, got %d", listener.received)
+	}
+}

--- a/pkg/synthetic/serializer.go
+++ b/pkg/synthetic/serializer.go
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// serializer.go provides JSON serialization and deserialization with type preservation
+// for interface fields. This enables roundtrip of events through JSON while maintaining
+// concrete type information.
+
+package synthetic
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// Serializer implements Codec with type-preserving serialization.
+type Serializer struct{}
+
+// Marshal serializes any value with type wrapper at top level and for interface fields.
+func (Serializer) Marshal(v any) ([]byte, error) {
+	ifaceVal := reflect.ValueOf(&v).Elem()
+	wrapped, err := wrapValue(ifaceVal)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wrapped)
+}
+
+// Unmarshal deserializes JSON with type wrappers.
+func (Serializer) Unmarshal(data []byte) (any, error) {
+	var wrapper TypedValue
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal event wrapper: %w", err)
+	}
+
+	if wrapper.Type == "" {
+		return nil, errors.New("missing type in event wrapper")
+	}
+
+	factory, ok := InterfaceRegistry[wrapper.Type]
+	if !ok {
+		return nil, fmt.Errorf("unknown type: %s", wrapper.Type)
+	}
+
+	event := factory()
+	if err := unmarshalWithTypes(wrapper.Value, event); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+// unmarshalWithTypes deserializes JSON with type wrappers back to the target.
+func unmarshalWithTypes(data []byte, v any) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("target must be non-nil pointer")
+	}
+
+	// Use Decoder with UseNumber to preserve precision for large integers (uint64)
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	var raw any
+	if err := dec.Decode(&raw); err != nil {
+		return err
+	}
+
+	return unwrapInto(raw, rv.Elem())
+}
+
+// getTypeName returns the type name for a value (e.g. "*tracing.MsgGenericKprobeUnix").
+func getTypeName(v any) string {
+	return reflect.TypeOf(v).String()
+}
+
+// wrapValue recursively wraps interface values with type info.
+func wrapValue(v reflect.Value) (any, error) {
+	switch v.Kind() {
+	case reflect.Interface:
+		if v.IsNil() {
+			return nil, nil
+		}
+		elem := v.Elem()
+		// Wrap interface value with type info
+		wrapped, err := wrapValue(elem)
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.Marshal(wrapped)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal interface value: %w", err)
+		}
+		return TypedValue{
+			Type:  getTypeName(elem.Interface()),
+			Value: data,
+		}, nil
+
+	case reflect.Ptr:
+		if v.IsNil() {
+			return nil, nil
+		}
+		// For pointers, wrap the element and return as-is (json.Marshal handles pointers)
+		return wrapValue(v.Elem())
+
+	case reflect.Struct:
+		result := make(map[string]any)
+		t := v.Type()
+		for i := range v.NumField() {
+			field := t.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			name := getJSONFieldName(field)
+			if name == "-" {
+				continue
+			}
+			wrapped, err := wrapValue(v.Field(i))
+			if err != nil {
+				return nil, fmt.Errorf("field %s: %w", name, err)
+			}
+			result[name] = wrapped
+		}
+		return result, nil
+
+	case reflect.Slice:
+		if v.IsNil() {
+			return nil, nil
+		}
+		result := make([]any, v.Len())
+		for i := range v.Len() {
+			wrapped, err := wrapValue(v.Index(i))
+			if err != nil {
+				return nil, fmt.Errorf("index %d: %w", i, err)
+			}
+			result[i] = wrapped
+		}
+		return result, nil
+
+	case reflect.Map:
+		if v.IsNil() {
+			return nil, nil
+		}
+		result := make(map[string]any)
+		for _, key := range v.MapKeys() {
+			wrapped, err := wrapValue(v.MapIndex(key))
+			if err != nil {
+				return nil, fmt.Errorf("map key %v: %w", key.Interface(), err)
+			}
+			result[fmt.Sprint(key.Interface())] = wrapped
+		}
+		return result, nil
+
+	case reflect.Array:
+		result := make([]any, v.Len())
+		for i := range v.Len() {
+			wrapped, err := wrapValue(v.Index(i))
+			if err != nil {
+				return nil, fmt.Errorf("index %d: %w", i, err)
+			}
+			result[i] = wrapped
+		}
+		return result, nil
+
+	default:
+		return v.Interface(), nil
+	}
+}
+
+// unwrapInto recursively unwraps typed values into the target.
+func unwrapInto(raw any, target reflect.Value) error {
+	if raw == nil {
+		return nil
+	}
+
+	// Check if this is a typed wrapper
+	if m, ok := raw.(map[string]any); ok {
+		if typeName, hasType := m["synthetic_type"]; hasType {
+			if valueRaw, hasValue := m["synthetic_value"]; hasValue {
+				typeNameStr, ok := typeName.(string)
+				if !ok {
+					return fmt.Errorf("synthetic_type must be string, got %T", typeName)
+				}
+				return unwrapTypedValue(typeNameStr, valueRaw, target)
+			}
+		}
+	}
+
+	switch target.Kind() {
+	case reflect.Interface:
+		// Should not happen if serialization is correct - all interfaces should have typed wrappers
+		return fmt.Errorf("interface field without typed wrapper, got %T", raw)
+
+	case reflect.Ptr:
+		if target.IsNil() {
+			target.Set(reflect.New(target.Type().Elem()))
+		}
+		return unwrapInto(raw, target.Elem())
+
+	case reflect.Struct:
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("expected map for struct, got %T", raw)
+		}
+
+		t := target.Type()
+		for i := range target.NumField() {
+			field := t.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			name := getJSONFieldName(field)
+			if val, exists := m[name]; exists {
+				if err := unwrapInto(val, target.Field(i)); err != nil {
+					return fmt.Errorf("field %s: %w", name, err)
+				}
+			}
+		}
+		return nil
+
+	case reflect.Slice:
+		arr, ok := raw.([]any)
+		if !ok {
+			return fmt.Errorf("expected array for slice, got %T", raw)
+		}
+
+		slice := reflect.MakeSlice(target.Type(), len(arr), len(arr))
+		for i, elem := range arr {
+			if err := unwrapInto(elem, slice.Index(i)); err != nil {
+				return fmt.Errorf("index %d: %w", i, err)
+			}
+		}
+		target.Set(slice)
+		return nil
+
+	case reflect.Array:
+		arr, ok := raw.([]any)
+		if !ok {
+			return fmt.Errorf("expected array for array, got %T", raw)
+		}
+
+		for i := 0; i < target.Len() && i < len(arr); i++ {
+			if err := unwrapInto(arr[i], target.Index(i)); err != nil {
+				return fmt.Errorf("index %d: %w", i, err)
+			}
+		}
+		return nil
+
+	case reflect.Map:
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("expected map for map, got %T", raw)
+		}
+
+		if target.IsNil() {
+			target.Set(reflect.MakeMap(target.Type()))
+		}
+		for k, v := range m {
+			keyVal := reflect.New(target.Type().Key()).Elem()
+			if err := setBasicValue(keyVal, k); err != nil {
+				return fmt.Errorf("map key %q: %w", k, err)
+			}
+			valVal := reflect.New(target.Type().Elem()).Elem()
+			if err := unwrapInto(v, valVal); err != nil {
+				return err
+			}
+			target.SetMapIndex(keyVal, valVal)
+		}
+		return nil
+
+	default:
+		return setBasicValue(target, raw)
+	}
+}
+
+// unwrapTypedValue creates an instance from registry and unmarshals the value.
+func unwrapTypedValue(typeName string, valueRaw any, target reflect.Value) error {
+	factory, ok := InterfaceRegistry[typeName]
+	if !ok {
+		return fmt.Errorf("unknown type in registry: %s", typeName)
+	}
+
+	instance := factory()
+	instanceVal := reflect.ValueOf(instance)
+
+	if err := unwrapInto(valueRaw, instanceVal.Elem()); err != nil {
+		return err
+	}
+
+	// Set based on whether original was pointer or value
+	if strings.HasPrefix(typeName, "*") {
+		target.Set(instanceVal)
+	} else {
+		target.Set(instanceVal.Elem())
+	}
+
+	return nil
+}
+
+// getJSONFieldName returns the JSON field name for a struct field.
+func getJSONFieldName(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	if tag == "" {
+		return field.Name
+	}
+	parts := strings.Split(tag, ",")
+	if parts[0] == "" {
+		return field.Name
+	}
+	return parts[0]
+}
+
+// setBasicValue sets a basic value from raw JSON data.
+func setBasicValue(target reflect.Value, raw any) error {
+	targetKind := target.Kind()
+
+	// Get string representation for parsing
+	var s string
+	switch v := raw.(type) {
+	case json.Number:
+		s = v.String()
+	case string:
+		s = v
+	case bool:
+		if targetKind == reflect.Bool {
+			target.SetBool(v)
+			return nil
+		}
+		return fmt.Errorf("cannot assign bool to %v", targetKind)
+	}
+
+	// Parse string into target type
+	switch targetKind {
+	case reflect.String:
+		target.SetString(s)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid int %q: %w", s, err)
+		}
+		target.SetInt(n)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		n, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid uint %q: %w", s, err)
+		}
+		target.SetUint(n)
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return fmt.Errorf("invalid float %q: %w", s, err)
+		}
+		target.SetFloat(f)
+	default:
+		return fmt.Errorf("cannot assign %q to %v", s, targetKind)
+	}
+	return nil
+}

--- a/pkg/synthetic/serializer_test.go
+++ b/pkg/synthetic/serializer_test.go
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package synthetic_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cilium/tetragon/pkg/synthetic"
+)
+
+// Test types for serialization tests
+type testEvent struct {
+	ID      int    `json:"id"`
+	Message string `json:"message"`
+	Data    any    `json:"data"`
+}
+
+type testData struct {
+	Value int    `json:"value"`
+	Name  string `json:"name"`
+}
+
+type testWithSlice struct {
+	Items []testData `json:"items"`
+}
+
+type testWithMap struct {
+	Data map[string]int `json:"data"`
+}
+
+type testWithIntKey struct {
+	Data map[int]string `json:"data"`
+}
+
+type testWithArray struct {
+	Arr [3]int `json:"arr"`
+}
+
+type testWithBool struct {
+	Active bool `json:"active"`
+}
+
+type testWithFloats struct {
+	F32 float32 `json:"f32"`
+	F64 float64 `json:"f64"`
+}
+
+type testWithPointer struct {
+	Ptr *testData `json:"ptr"`
+}
+
+type testWithAllInts struct {
+	I   int   `json:"i"`
+	I8  int8  `json:"i8"`
+	I16 int16 `json:"i16"`
+	I32 int32 `json:"i32"`
+	I64 int64 `json:"i64"`
+}
+
+type testWithAllUints struct {
+	U   uint   `json:"u"`
+	U8  uint8  `json:"u8"`
+	U16 uint16 `json:"u16"`
+	U32 uint32 `json:"u32"`
+	U64 uint64 `json:"u64"`
+}
+
+type testIgnoredField struct {
+	Public  string `json:"public"`
+	Ignored string `json:"-"`
+	private string //nolint:unused
+}
+
+type testEmptyTag struct {
+	Field string `json:",omitempty"`
+}
+
+type testNoTag struct {
+	Field string
+}
+
+type testUnsupportedField struct {
+	Ch chan int `json:"ch"`
+}
+
+type testMapWithComplexValue struct {
+	Data map[string]testData `json:"data"`
+}
+
+type testValueType struct {
+	X int `json:"x"`
+}
+
+type testWithChan struct {
+	Data any `json:"data"`
+}
+
+type testWithChanSlice struct {
+	Items []any `json:"items"`
+}
+
+type testWithChanMap struct {
+	Data map[string]any `json:"data"`
+}
+
+type testWithChanArray struct {
+	Arr [2]any `json:"arr"`
+}
+
+func init() {
+	synthetic.RegisterType((*testEvent)(nil))
+	synthetic.RegisterType((*testData)(nil))
+	synthetic.RegisterType((*testWithSlice)(nil))
+	synthetic.RegisterType((*testWithMap)(nil))
+	synthetic.RegisterType((*testWithIntKey)(nil))
+	synthetic.RegisterType((*testWithArray)(nil))
+	synthetic.RegisterType((*testWithBool)(nil))
+	synthetic.RegisterType((*testWithFloats)(nil))
+	synthetic.RegisterType((*testWithPointer)(nil))
+	synthetic.RegisterType((*testWithAllInts)(nil))
+	synthetic.RegisterType((*testWithAllUints)(nil))
+	synthetic.RegisterType((*testIgnoredField)(nil))
+	synthetic.RegisterType((*testEmptyTag)(nil))
+	synthetic.RegisterType((*testNoTag)(nil))
+	synthetic.RegisterType((*testUnsupportedField)(nil))
+	synthetic.RegisterType((*testMapWithComplexValue)(nil))
+	// Non-pointer registration for testValueType
+	synthetic.InterfaceRegistry["test.valueType"] = func() any { return new(testValueType) }
+	synthetic.RegisterType((*testWithChan)(nil))
+}
+
+func TestMarshalEvent(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{"simple struct", &testData{Value: 42, Name: "test"},
+			`{"synthetic_type":"*synthetic_test.testData","synthetic_value":{"name":"test","value":42}}`},
+		{"struct with interface", &testEvent{ID: 1, Message: "hello", Data: &testData{Value: 100, Name: "nested"}},
+			`{"synthetic_type":"*synthetic_test.testEvent","synthetic_value":{"data":{"synthetic_type":"*synthetic_test.testData","synthetic_value":{"name":"nested","value":100}},"id":1,"message":"hello"}}`},
+		{"nil interface", &testEvent{ID: 2, Data: nil},
+			`{"synthetic_type":"*synthetic_test.testEvent","synthetic_value":{"data":null,"id":2,"message":""}}`},
+		{"slice", &testWithSlice{Items: []testData{{Value: 1, Name: "a"}}},
+			`{"synthetic_type":"*synthetic_test.testWithSlice","synthetic_value":{"items":[{"name":"a","value":1}]}}`},
+		{"empty slice", &testWithSlice{Items: []testData{}},
+			`{"synthetic_type":"*synthetic_test.testWithSlice","synthetic_value":{"items":[]}}`},
+		{"nil slice", &testWithSlice{Items: nil},
+			`{"synthetic_type":"*synthetic_test.testWithSlice","synthetic_value":{"items":null}}`},
+		{"array", &testWithArray{Arr: [3]int{10, 20, 30}},
+			`{"synthetic_type":"*synthetic_test.testWithArray","synthetic_value":{"arr":[10,20,30]}}`},
+		{"bool true", &testWithBool{Active: true},
+			`{"synthetic_type":"*synthetic_test.testWithBool","synthetic_value":{"active":true}}`},
+		{"bool false", &testWithBool{Active: false},
+			`{"synthetic_type":"*synthetic_test.testWithBool","synthetic_value":{"active":false}}`},
+		{"floats", &testWithFloats{F32: 3.14, F64: 2.718281828},
+			`{"synthetic_type":"*synthetic_test.testWithFloats","synthetic_value":{"f32":3.14,"f64":2.718281828}}`},
+		{"pointer nil", &testWithPointer{Ptr: nil},
+			`{"synthetic_type":"*synthetic_test.testWithPointer","synthetic_value":{"ptr":null}}`},
+		{"pointer non-nil", &testWithPointer{Ptr: &testData{Value: 42, Name: "ptr"}},
+			`{"synthetic_type":"*synthetic_test.testWithPointer","synthetic_value":{"ptr":{"name":"ptr","value":42}}}`},
+		{"map", &testWithMap{Data: map[string]int{"x": 10}},
+			`{"synthetic_type":"*synthetic_test.testWithMap","synthetic_value":{"data":{"x":10}}}`},
+		{"empty map", &testWithMap{Data: map[string]int{}},
+			`{"synthetic_type":"*synthetic_test.testWithMap","synthetic_value":{"data":{}}}`},
+		{"nil map", &testWithMap{Data: nil},
+			`{"synthetic_type":"*synthetic_test.testWithMap","synthetic_value":{"data":null}}`},
+		{"int key map", &testWithIntKey{Data: map[int]string{1: "one"}},
+			`{"synthetic_type":"*synthetic_test.testWithIntKey","synthetic_value":{"data":{"1":"one"}}}`},
+		{"all ints", &testWithAllInts{I: 1, I8: 2, I16: 3, I32: 4, I64: 5},
+			`{"synthetic_type":"*synthetic_test.testWithAllInts","synthetic_value":{"i":1,"i16":3,"i32":4,"i64":5,"i8":2}}`},
+		{"all uints", &testWithAllUints{U: 1, U8: 2, U16: 3, U32: 4, U64: 18446744073709551615},
+			`{"synthetic_type":"*synthetic_test.testWithAllUints","synthetic_value":{"u":1,"u16":3,"u32":4,"u64":18446744073709551615,"u8":2}}`},
+		{"ignored field", &testIgnoredField{Public: "visible", Ignored: "hidden", private: "hidden2"},
+			`{"synthetic_type":"*synthetic_test.testIgnoredField","synthetic_value":{"public":"visible"}}`},
+		{"empty tag", &testEmptyTag{Field: "value"},
+			`{"synthetic_type":"*synthetic_test.testEmptyTag","synthetic_value":{"Field":"value"}}`},
+		{"no tag", &testNoTag{Field: "value"},
+			`{"synthetic_type":"*synthetic_test.testNoTag","synthetic_value":{"Field":"value"}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := synthetic.Serializer{}.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("MarshalEvent failed: %v", err)
+			}
+
+			if string(data) != tt.expected {
+				t.Errorf("JSON mismatch:\ngot:  %s\nwant: %s", data, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMarshalErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     any
+		wantError string
+	}{
+		{"channel in interface field", &testWithChan{Data: make(chan int)}, "failed to marshal interface value"},
+		{"channel in slice", &testWithChanSlice{Items: []any{make(chan int)}}, "index 0"},
+		{"channel in map", &testWithChanMap{Data: map[string]any{"key": make(chan int)}}, "map key"},
+		{"channel in array", &testWithChanArray{Arr: [2]any{make(chan int), nil}}, "index 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := synthetic.Serializer{}.Marshal(tt.input)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantError)
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantError)
+			}
+		})
+	}
+}
+
+func TestUnmarshalEvent(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected any
+	}{
+		{"simple struct",
+			`{"synthetic_type":"*synthetic_test.testData","synthetic_value":{"value":42,"name":"test"}}`,
+			&testData{Value: 42, Name: "test"}},
+		{"struct with interface",
+			`{"synthetic_type":"*synthetic_test.testEvent","synthetic_value":{"id":1,"message":"hello","data":{"synthetic_type":"*synthetic_test.testData","synthetic_value":{"value":100,"name":"nested"}}}}`,
+			&testEvent{ID: 1, Message: "hello", Data: &testData{Value: 100, Name: "nested"}}},
+		{"nil interface",
+			`{"synthetic_type":"*synthetic_test.testEvent","synthetic_value":{"id":2,"data":null}}`,
+			&testEvent{ID: 2, Data: nil}},
+		{"slice",
+			`{"synthetic_type":"*synthetic_test.testWithSlice","synthetic_value":{"items":[{"value":1,"name":"a"},{"value":2,"name":"b"}]}}`,
+			&testWithSlice{Items: []testData{{Value: 1, Name: "a"}, {Value: 2, Name: "b"}}}},
+		{"empty slice",
+			`{"synthetic_type":"*synthetic_test.testWithSlice","synthetic_value":{"items":[]}}`,
+			&testWithSlice{Items: []testData{}}},
+		{"array",
+			`{"synthetic_type":"*synthetic_test.testWithArray","synthetic_value":{"arr":[10,20,30]}}`,
+			&testWithArray{Arr: [3]int{10, 20, 30}}},
+		{"bool true",
+			`{"synthetic_type":"*synthetic_test.testWithBool","synthetic_value":{"active":true}}`,
+			&testWithBool{Active: true}},
+		{"bool false",
+			`{"synthetic_type":"*synthetic_test.testWithBool","synthetic_value":{"active":false}}`,
+			&testWithBool{Active: false}},
+		{"floats",
+			`{"synthetic_type":"*synthetic_test.testWithFloats","synthetic_value":{"f32":3.14,"f64":2.718281828}}`,
+			&testWithFloats{F32: 3.14, F64: 2.718281828}},
+		{"pointer nil",
+			`{"synthetic_type":"*synthetic_test.testWithPointer","synthetic_value":{"ptr":null}}`,
+			&testWithPointer{Ptr: nil}},
+		{"pointer non-nil",
+			`{"synthetic_type":"*synthetic_test.testWithPointer","synthetic_value":{"ptr":{"value":42,"name":"ptr"}}}`,
+			&testWithPointer{Ptr: &testData{Value: 42, Name: "ptr"}}},
+		{"map",
+			`{"synthetic_type":"*synthetic_test.testWithMap","synthetic_value":{"data":{"x":10,"y":20}}}`,
+			&testWithMap{Data: map[string]int{"x": 10, "y": 20}}},
+		{"empty map",
+			`{"synthetic_type":"*synthetic_test.testWithMap","synthetic_value":{"data":{}}}`,
+			&testWithMap{Data: map[string]int{}}},
+		{"int key map",
+			`{"synthetic_type":"*synthetic_test.testWithIntKey","synthetic_value":{"data":{"1":"one","2":"two"}}}`,
+			&testWithIntKey{Data: map[int]string{1: "one", 2: "two"}}},
+		{"all ints",
+			`{"synthetic_type":"*synthetic_test.testWithAllInts","synthetic_value":{"i":1,"i8":2,"i16":3,"i32":4,"i64":5}}`,
+			&testWithAllInts{I: 1, I8: 2, I16: 3, I32: 4, I64: 5}},
+		{"all uints",
+			`{"synthetic_type":"*synthetic_test.testWithAllUints","synthetic_value":{"u":1,"u8":2,"u16":3,"u32":4,"u64":18446744073709551615}}`,
+			&testWithAllUints{U: 1, U8: 2, U16: 3, U32: 4, U64: 18446744073709551615}},
+		{"empty tag",
+			`{"synthetic_type":"*synthetic_test.testEmptyTag","synthetic_value":{"Field":"value"}}`,
+			&testEmptyTag{Field: "value"}},
+		{"no tag",
+			`{"synthetic_type":"*synthetic_test.testNoTag","synthetic_value":{"Field":"value"}}`,
+			&testNoTag{Field: "value"}},
+		{"non-pointer type in nested interface",
+			`{"synthetic_type":"*synthetic_test.testEvent","synthetic_value":{"id":1,"message":"test","data":{"synthetic_type":"test.valueType","synthetic_value":{"x":42}}}}`,
+			&testEvent{ID: 1, Message: "test", Data: testValueType{X: 42}}},
+		{"ignored fields in input",
+			`{"synthetic_type":"*synthetic_test.testIgnoredField","synthetic_value":{"public":"visible","Ignored":"hidden","private":"hidden2"}}`,
+			&testIgnoredField{Public: "visible"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := synthetic.Serializer{}.Unmarshal([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("UnmarshalEvent failed: %v", err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("result = %+v, want %+v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUnmarshalEventErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantError string
+	}{
+		// Wrapper errors
+		{"invalid JSON", `{invalid`, "failed to unmarshal event wrapper"},
+		{"missing type", `{"synthetic_value":{"value":1}}`, "missing type in event wrapper"},
+		{"unknown type", `{"synthetic_type":"unknown.Type","synthetic_value":{}}`, "unknown type"},
+		{"missing value", `{"synthetic_type":"*synthetic_test.testData"}`, "EOF"},
+
+		// Type mismatch errors
+		{"value not object", `{"synthetic_type":"*synthetic_test.testData","synthetic_value":"not-a-json-object"}`, "expected map for struct"},
+		{"wrong type for struct", `{"synthetic_type":"*synthetic_test.testData","synthetic_value":[1,2,3]}`, "expected map for struct"},
+		{"wrong type for slice", `{"synthetic_type":"*synthetic_test.testWithSlice","synthetic_value":{"items":"not-an-array"}}`, "expected array for slice"},
+		{"wrong type for array", `{"synthetic_type":"*synthetic_test.testWithArray","synthetic_value":{"arr":"not-an-array"}}`, "expected array for array"},
+		{"wrong type for map", `{"synthetic_type":"*synthetic_test.testWithMap","synthetic_value":{"data":[1,2,3]}}`, "expected map for map"},
+
+		// Nested type errors
+		{"nested non-string type", `{"synthetic_type":"*synthetic_test.testEvent","synthetic_value":{"id":1,"message":"test","data":{"synthetic_type":123,"synthetic_value":{}}}}`, "synthetic_type must be string"},
+		{"nested unknown type", `{"synthetic_type":"*synthetic_test.testEvent","synthetic_value":{"id":1,"message":"test","data":{"synthetic_type":"unknown.Type","synthetic_value":{}}}}`, "unknown type"},
+		{"nested value error", `{"synthetic_type":"*synthetic_test.testEvent","synthetic_value":{"id":1,"message":"test","data":{"synthetic_type":"*synthetic_test.testData","synthetic_value":{"value":"bad","name":"test"}}}}`, "invalid int"},
+		{"interface without wrapper", `{"synthetic_type":"*synthetic_test.testEvent","synthetic_value":{"id":1,"message":"test","data":"plain-string"}}`, "interface field without typed wrapper"},
+
+		// Field parsing errors
+		{"invalid int field", `{"synthetic_type":"*synthetic_test.testData","synthetic_value":{"value":"not-an-int","name":"test"}}`, "invalid int"},
+		{"invalid int in struct", `{"synthetic_type":"*synthetic_test.testWithAllInts","synthetic_value":{"i":"not-an-int","i8":0,"i16":0,"i32":0,"i64":0}}`, "invalid int"},
+		{"invalid uint", `{"synthetic_type":"*synthetic_test.testWithAllUints","synthetic_value":{"u":"not-a-uint","u8":0,"u16":0,"u32":0,"u64":0}}`, "invalid uint"},
+		{"invalid float", `{"synthetic_type":"*synthetic_test.testWithFloats","synthetic_value":{"f32":"not-a-float","f64":0}}`, "invalid float"},
+		{"bool to non-bool", `{"synthetic_type":"*synthetic_test.testWithAllInts","synthetic_value":{"i":true,"i8":0,"i16":0,"i32":0,"i64":0}}`, "cannot assign bool"},
+		{"unsupported field type", `{"synthetic_type":"*synthetic_test.testUnsupportedField","synthetic_value":{"ch":"something"}}`, "cannot assign"},
+
+		// Collection element errors
+		{"slice element error", `{"synthetic_type":"*synthetic_test.testWithSlice","synthetic_value":{"items":[{"value":"bad","name":"test"}]}}`, "index"},
+		{"array element error", `{"synthetic_type":"*synthetic_test.testWithArray","synthetic_value":{"arr":["not-an-int",2,3]}}`, "invalid int"},
+		{"map key error", `{"synthetic_type":"*synthetic_test.testWithIntKey","synthetic_value":{"data":{"not-an-int":"value"}}}`, "map key"},
+		{"map value error", `{"synthetic_type":"*synthetic_test.testMapWithComplexValue","synthetic_value":{"data":{"key":{"value":"not-an-int","name":"test"}}}}`, "invalid int"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := synthetic.Serializer{}.Unmarshal([]byte(tt.input))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantError)
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantError)
+			}
+		})
+	}
+}
+
+func TestUnmarshalInvalidFactoryResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		typeName  string
+		factory   func() any
+		input     string
+		wantError string
+	}{
+		{
+			name:      "nil factory result",
+			typeName:  "nilFactory",
+			factory:   func() any { return nil },
+			input:     `{"synthetic_type":"nilFactory","synthetic_value":{}}`,
+			wantError: "non-nil pointer",
+		},
+		{
+			name:      "non-pointer factory result",
+			typeName:  "nonPtrFactory",
+			factory:   func() any { return testData{Value: 1, Name: "not-a-pointer"} },
+			input:     `{"synthetic_type":"nonPtrFactory","synthetic_value":{"value":42,"name":"test"}}`,
+			wantError: "non-nil pointer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synthetic.InterfaceRegistry[tt.typeName] = tt.factory
+			defer delete(synthetic.InterfaceRegistry, tt.typeName)
+
+			_, err := synthetic.Serializer{}.Unmarshal([]byte(tt.input))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantError)
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantError)
+			}
+		})
+	}
+}

--- a/pkg/synthetic/test_helpers_linux_test.go
+++ b/pkg/synthetic/test_helpers_linux_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package synthetic_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/process"
+	"github.com/cilium/tetragon/pkg/reader/notify"
+	"github.com/cilium/tetragon/pkg/synthetic"
+)
+
+// nopLog is a logger that discards all output.
+var nopLog = slog.New(logger.SlogNopHandler)
+
+func init() {
+	synthetic.RegisterType((*testMessage)(nil))
+}
+
+// testMessage implements notify.Message for testing.
+type testMessage struct{}
+
+func (testMessage) HandleMessage() *tetragon.GetEventsResponse { return nil }
+func (testMessage) RetryInternal(notify.Event, uint64) (*process.ProcessInternal, error) {
+	return nil, nil
+}
+func (testMessage) Retry(*process.ProcessInternal, notify.Event) error { return nil }
+func (testMessage) Notify() bool                                       { return true }
+func (m testMessage) Cast(any) notify.Message                          { return m }
+
+// testCodec is a simple codec for testing.
+type testCodec struct{}
+
+func (testCodec) Marshal(any) ([]byte, error)   { return []byte("{}"), nil }
+func (testCodec) Unmarshal([]byte) (any, error) { return &testMessage{}, nil }
+
+// marshalErrorCodec returns error on Marshal.
+type marshalErrorCodec struct{}
+
+func (marshalErrorCodec) Marshal(any) ([]byte, error)   { return nil, errors.New("marshal error") }
+func (marshalErrorCodec) Unmarshal([]byte) (any, error) { return nil, nil }
+
+// unmarshalErrorCodec returns error on Unmarshal.
+type unmarshalErrorCodec struct{}
+
+func (unmarshalErrorCodec) Marshal(any) ([]byte, error)   { return nil, nil }
+func (unmarshalErrorCodec) Unmarshal([]byte) (any, error) { return nil, errors.New("unmarshal error") }
+
+// notMessageCodec returns something that doesn't implement notify.Message.
+type notMessageCodec struct{}
+
+func (notMessageCodec) Marshal(any) ([]byte, error)   { return nil, nil }
+func (notMessageCodec) Unmarshal([]byte) (any, error) { return "not a message", nil }
+
+// mismatchCodec returns different object on Unmarshal to trigger mismatch.
+type mismatchCodec struct{}
+
+func (mismatchCodec) Marshal(any) ([]byte, error)   { return []byte("{}"), nil }
+func (mismatchCodec) Unmarshal([]byte) (any, error) { return &testCodec{}, nil }
+
+// testListener implements observer.Listener for testing.
+type testListener struct {
+	received  int
+	notifyErr error
+	closeErr  error
+	closed    bool
+}
+
+func (l *testListener) Notify(notify.Message) error {
+	l.received++
+	return l.notifyErr
+}
+
+func (l *testListener) Close() error {
+	l.closed = true
+	return l.closeErr
+}
+
+// triggerHandler wraps slog.Handler and calls onTrigger when msg contains trigger.
+type triggerHandler struct {
+	slog.Handler
+	trigger   string
+	onTrigger func()
+}
+
+func (triggerHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h triggerHandler) Handle(_ context.Context, r slog.Record) error {
+	if strings.Contains(r.Message, h.trigger) {
+		h.onTrigger()
+	}
+	return nil
+}
+
+// warnHandler captures Warn calls for assertions.
+type warnHandler struct {
+	slog.Handler
+	warnCalled  bool
+	wantMessage string
+	gotMessage  bool
+}
+
+func (warnHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *warnHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		h.warnCalled = true
+		if h.wantMessage != "" && strings.Contains(r.Message, h.wantMessage) {
+			h.gotMessage = true
+		}
+	}
+	return nil
+}
+
+// errorWriter returns error on Write.
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) { return 0, errors.New("write error") }
+
+// mockDelegate implements observer.Listener for testing delegate.
+type mockDelegate struct{}
+
+func (mockDelegate) Notify(notify.Message) error { return errors.New("delegate notify") }
+func (mockDelegate) Close() error                { return errors.New("delegate close") }

--- a/pkg/synthetic/types.go
+++ b/pkg/synthetic/types.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// Package synthetic provides components for recording and replaying Tetragon events.
+// This includes:
+// - EventListener: writes events to a file for later replay
+// - FileObserver: reads and replays events from a file
+package synthetic
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// Codec provides type-preserving serialization for events.
+type Codec interface {
+	Marshal(v any) ([]byte, error)
+	Unmarshal(data []byte) (any, error)
+}
+
+// TypedValue wraps any interface value with type info for JSON serialization.
+type TypedValue struct {
+	Type  string          `json:"synthetic_type"`
+	Value json.RawMessage `json:"synthetic_value"`
+}
+
+// InterfaceRegistry maps type names to factory functions for creating interface instances.
+// Used during unmarshal to reconstruct typed values from JSON.
+var InterfaceRegistry = make(map[string]func() any)
+
+// RegisterType adds a type to the interface registry.
+// Call with a typed nil pointer: RegisterType((*MyType)(nil))
+// Registers both pointer and non-pointer names to handle both cases during unmarshal.
+func RegisterType(v any) {
+	t := reflect.TypeOf(v)
+	ptrName := t.String() // e.g. "*tracing.MsgGenericKprobeUnix"
+
+	// Unwrap all pointer levels (handles **T, ***T, etc.)
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	valueName := t.String() // e.g. "tracing.MsgGenericKprobeUnix"
+
+	factory := func() any {
+		return reflect.New(t).Interface()
+	}
+
+	// Register both pointer and value type names
+	InterfaceRegistry[ptrName] = factory
+	InterfaceRegistry[valueName] = factory
+}

--- a/pkg/synthetic/types_linux.go
+++ b/pkg/synthetic/types_linux.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// types_linux.go registers Tetragon event types for JSON serialization.
+// This file contains Linux-specific type registrations.
+package synthetic
+
+import (
+	"github.com/cilium/tetragon/pkg/api/readyapi"
+	"github.com/cilium/tetragon/pkg/api/tracingapi"
+	"github.com/cilium/tetragon/pkg/grpc/exec"
+	"github.com/cilium/tetragon/pkg/grpc/tracing"
+)
+
+func init() {
+	// Register top-level event types
+	RegisterType((*exec.MsgExecveEventUnix)(nil))
+	RegisterType((*exec.MsgExitEventUnix)(nil))
+	RegisterType((*exec.MsgCloneEventUnix)(nil))
+	RegisterType((*exec.MsgCgroupEventUnix)(nil))
+	RegisterType((*exec.MsgKThreadInitUnix)(nil))
+	RegisterType((*readyapi.MsgTetragonReady)(nil))
+	RegisterType((*tracing.MsgGenericKprobeUnix)(nil))
+
+	// Register all MsgGenericKprobeArg types for JSON serialization
+	RegisterType((*tracingapi.MsgGenericKprobeArgPath)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgFile)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgString)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgBytes)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgInt)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgUInt)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgSize)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgLong)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgSock)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgSkb)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgSockaddr)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgNetDev)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgCred)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgCapability)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgKernelCapType)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgCapInheritable)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgCapPermitted)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgCapEffective)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgLinuxBinprm)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgUserNamespace)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgLoadModule)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgKernelModule)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgBpfAttr)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgBpfProg)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgPerfEvent)(nil))
+	RegisterType((*tracingapi.MsgGenericKprobeArgBpfMap)(nil))
+}

--- a/pkg/synthetic/types_test.go
+++ b/pkg/synthetic/types_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package synthetic_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cilium/tetragon/pkg/synthetic"
+)
+
+func TestRegisterType(t *testing.T) {
+	type newType struct {
+		Field string `json:"field"`
+	}
+
+	// Register new type
+	synthetic.RegisterType((*newType)(nil))
+
+	// Verify it's registered (can marshal/unmarshal)
+	original := &newType{Field: "test"}
+	codec := synthetic.Serializer{}
+	data, err := codec.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	result, err := codec.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, original) {
+		t.Errorf("result = %#v, want %#v", result, original)
+	}
+}

--- a/pkg/synthetic/writing_listener_linux.go
+++ b/pkg/synthetic/writing_listener_linux.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// writing_listener.go implements WritingListener that writes Tetragon events to a file
+// for later replay and debugging. Supports optional roundtrip verification.
+
+package synthetic
+
+import (
+	"encoding/json"
+	"io"
+	"reflect"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/reader/notify"
+)
+
+// WritingListener implements observer.Listener and writes all received events
+// to a JSON lines file for later replay.
+type WritingListener struct {
+	writer          io.Writer
+	codec           Codec
+	log             logger.FieldLogger
+	verifyRoundtrip bool
+	delegate        observer.Listener
+}
+
+// Option configures WritingListener.
+type Option func(*WritingListener)
+
+// NewWritingListener creates a new WritingListener with the given writer, codec and logger.
+func NewWritingListener(writer io.Writer, codec Codec, log logger.FieldLogger, opts ...Option) *WritingListener {
+	l := &WritingListener{
+		writer: writer,
+		codec:  codec,
+		log:    log,
+	}
+
+	for _, opt := range opts {
+		opt(l)
+	}
+
+	return l
+}
+
+// Notify implements observer.Listener.Notify.
+// It serializes the event to JSON and writes it to the file.
+func (l *WritingListener) Notify(msg notify.Message) error {
+	logBytes, err := l.codec.Marshal(msg)
+	if err != nil {
+		l.log.Warn("Failed to marshal event for synthetic logging", "error", err)
+		return err
+	}
+
+	if l.verifyRoundtrip {
+		l.verifyRoundtripEquality(msg, logBytes)
+	}
+
+	if l.writer != nil {
+		_, err = l.writer.Write(append(logBytes, '\n'))
+		if err != nil {
+			l.log.Warn("Failed to write synthetic event", "error", err)
+			return err
+		}
+	}
+
+	if l.delegate != nil {
+		return l.delegate.Notify(msg)
+	}
+	return nil
+}
+
+// Close implements observer.Listener.Close.
+func (l *WritingListener) Close() error {
+	if l.delegate != nil {
+		return l.delegate.Close()
+	}
+	return nil
+}
+
+// WithVerifyRoundtrip enables roundtrip verification.
+func WithVerifyRoundtrip(enabled bool) Option {
+	return func(l *WritingListener) {
+		l.verifyRoundtrip = enabled
+	}
+}
+
+// WithDelegate sets the delegate listener that receives events after recording.
+func WithDelegate(delegate observer.Listener) Option {
+	return func(l *WritingListener) {
+		l.delegate = delegate
+	}
+}
+
+// verifyRoundtripEquality unmarshals serialized data and compares with original.
+func (l *WritingListener) verifyRoundtripEquality(original notify.Message, data []byte) {
+	reconstructed, err := l.codec.Unmarshal(data)
+	if err != nil {
+		l.log.Warn("Roundtrip verification: unmarshal failed",
+			"error", err,
+			"type", reflect.TypeOf(original).String())
+		return
+	}
+
+	if !reflect.DeepEqual(original, reconstructed) {
+		origJSON, _ := json.Marshal(original)
+		reconJSON, _ := json.Marshal(reconstructed)
+		l.log.Warn("Roundtrip verification: mismatch detected",
+			"type", reflect.TypeOf(original).String(),
+			"original", string(origJSON),
+			"reconstructed", string(reconJSON))
+	}
+}

--- a/pkg/synthetic/writing_listener_linux_test.go
+++ b/pkg/synthetic/writing_listener_linux_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package synthetic_test
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/synthetic"
+)
+
+func TestNotify_Success(t *testing.T) {
+	var buf bytes.Buffer
+	listener := synthetic.NewWritingListener(&buf, synthetic.Serializer{}, nopLog)
+
+	if err := listener.Notify(&testMessage{}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := `{"synthetic_type":"*synthetic_test.testMessage","synthetic_value":{}}` + "\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNotify_MarshalError(t *testing.T) {
+	var buf bytes.Buffer
+	listener := synthetic.NewWritingListener(&buf, marshalErrorCodec{}, nopLog)
+
+	if err := listener.Notify(&testMessage{}); err == nil {
+		t.Error("expected error on marshal failure")
+	}
+
+	if buf.Len() != 0 {
+		t.Error("no data should be written on marshal failure")
+	}
+}
+
+func TestNotify_WriteError(t *testing.T) {
+	listener := synthetic.NewWritingListener(errorWriter{}, synthetic.Serializer{}, nopLog)
+
+	if err := listener.Notify(&testMessage{}); err == nil {
+		t.Error("expected error on write failure")
+	}
+}
+
+func TestNotify_WithVerifyRoundtrip(t *testing.T) {
+	var buf bytes.Buffer
+	h := &warnHandler{Handler: logger.SlogNopHandler}
+	listener := synthetic.NewWritingListener(
+		&buf,
+		synthetic.Serializer{},
+		slog.New(h),
+		synthetic.WithVerifyRoundtrip(true),
+	)
+
+	if err := listener.Notify(&testMessage{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if h.warnCalled {
+		t.Error("expected no warnings on successful roundtrip")
+	}
+}
+
+func TestNotify_VerifyRoundtrip_UnmarshalError(t *testing.T) {
+	var buf bytes.Buffer
+	h := &warnHandler{
+		Handler:     logger.SlogNopHandler,
+		wantMessage: "Roundtrip verification: unmarshal failed",
+	}
+	listener := synthetic.NewWritingListener(
+		&buf,
+		unmarshalErrorCodec{},
+		slog.New(h),
+		synthetic.WithVerifyRoundtrip(true),
+	)
+
+	if err := listener.Notify(&testMessage{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !h.gotMessage {
+		t.Error("expected unmarshal failed warning")
+	}
+}
+
+func TestNotify_VerifyRoundtrip_Mismatch(t *testing.T) {
+	var buf bytes.Buffer
+	h := &warnHandler{
+		Handler:     logger.SlogNopHandler,
+		wantMessage: "Roundtrip verification: mismatch detected",
+	}
+	listener := synthetic.NewWritingListener(
+		&buf,
+		mismatchCodec{},
+		slog.New(h),
+		synthetic.WithVerifyRoundtrip(true),
+	)
+
+	if err := listener.Notify(&testMessage{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !h.gotMessage {
+		t.Error("expected mismatch warning")
+	}
+}
+
+func TestNotify_WithDelegate(t *testing.T) {
+	var buf bytes.Buffer
+	listener := synthetic.NewWritingListener(
+		&buf,
+		synthetic.Serializer{},
+		nopLog,
+		synthetic.WithDelegate(mockDelegate{}),
+	)
+
+	err := listener.Notify(&testMessage{})
+	if err == nil || err.Error() != "delegate notify" {
+		t.Errorf("expected delegate notify error, got %v", err)
+	}
+}
+
+func TestClose_Success(t *testing.T) {
+	listener := synthetic.NewWritingListener(nil, synthetic.Serializer{}, nopLog)
+
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClose_WithDelegate(t *testing.T) {
+	listener := synthetic.NewWritingListener(
+		nil,
+		synthetic.Serializer{},
+		nopLog,
+		synthetic.WithDelegate(mockDelegate{}),
+	)
+
+	err := listener.Close()
+	if err == nil || err.Error() != "delegate close" {
+		t.Errorf("expected delegate close error, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes: cilium#4497

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
Added a full synthetic events record/replay pipeline for deterministic debugging and testing.  
This includes a JSONL recorder (WritingListener), a replay observer (ReadingObserver), type‑preserving JSON serialization for interface fields, and factory helpers wired to CLI flags.

**How to run (record):**
```bash
sudo ./tetragon --synthetic-events-log /tmp/synthetic-events.jsonl --synthetic-events-verify-roundtrip
```
- If the log file already exists, it is renamed with a timestamp prefix (e.g. `2026-02-02_11-05-30_synthetic-events.jsonl`) and a fresh file is created.
- The `--synthetic-events-verify-roundtrip` flag enables a check to ensure each recorded event is marshaled/unmarshaled and verified to be identical to the original event. In case of a mismatch, the following warnings will be logged: `Roundtrip verification: unmarshal failed` or `Roundtrip verification: mismatch detected`.
- If a recorded event contains an unregistered type, round‑trip verification logs `Roundtrip verification: unmarshal failed` (error `unknown type: <Type>`). Register new event types in `pkg/synthetic/types_linux.go` via `RegisterType((*NewType)(nil))`.

**How to run (replay):**
```bash
sudo ./tetragon --synthetic-events-source /tmp/synthetic-events.jsonl
```

**Expected logs:**
- `Starting synthetic event replay`
- `Finished synthetic event replay` (with event count)
- `Failed to unmarshal event` `unknown type:` (needs to register new event types in `pkg/synthetic/types_linux.go`) 

**Event Log format:**
JSONL, with type‑preserving wrappers:
```json
{"synthetic_type":"<type>","synthetic_value":{...}}
```

**Unit tests (example):**
```bash
go test -coverprofile=coverage.out ./pkg/synthetic/... && go tool cover -func=coverage.out
```
Example output:
```
ok      github.com/cilium/tetragon/pkg/synthetic        0.053s  coverage: 91.0% of statements
github.com/cilium/tetragon/pkg/synthetic/factory_linux.go:18:           NewReadingObserverFromFile      0.0%
github.com/cilium/tetragon/pkg/synthetic/factory_linux.go:32:           NewWritingListenerToFile        0.0%
github.com/cilium/tetragon/pkg/synthetic/factory_linux.go:46:           openSourceFile                  0.0%
github.com/cilium/tetragon/pkg/synthetic/factory_linux.go:56:           openLogFile                     0.0%
github.com/cilium/tetragon/pkg/synthetic/reading_observer_linux.go:35:  NewReadingObserver              100.0%
github.com/cilium/tetragon/pkg/synthetic/reading_observer_linux.go:45:  StartReady                      100.0%
github.com/cilium/tetragon/pkg/synthetic/reading_observer_linux.go:88:  observerListeners               100.0%
github.com/cilium/tetragon/pkg/synthetic/reading_observer_linux.go:98:  AddListener                     100.0%
github.com/cilium/tetragon/pkg/synthetic/reading_observer_linux.go:104: RemoveListener                  100.0%
github.com/cilium/tetragon/pkg/synthetic/serializer.go:24:              Marshal                         100.0%
github.com/cilium/tetragon/pkg/synthetic/serializer.go:34:              Unmarshal                       100.0%
github.com/cilium/tetragon/pkg/synthetic/serializer.go:57:              unmarshalWithTypes              100.0%
github.com/cilium/tetragon/pkg/synthetic/serializer.go:76:              getTypeName                     100.0%
github.com/cilium/tetragon/pkg/synthetic/serializer.go:81:              wrapValue                       100.0%
github.com/cilium/tetragon/pkg/synthetic/serializer.go:174:             unwrapInto                      100.0%
github.com/cilium/tetragon/pkg/synthetic/serializer.go:280:             unwrapTypedValue                100.0%
github.com/cilium/tetragon/pkg/synthetic/serializer.go:304:             getJSONFieldName                100.0%
github.com/cilium/tetragon/pkg/synthetic/serializer.go:317:             setBasicValue                   100.0%
github.com/cilium/tetragon/pkg/synthetic/types.go:34:                   RegisterType                    100.0%
github.com/cilium/tetragon/pkg/synthetic/types_linux.go:15:             init                            100.0%
github.com/cilium/tetragon/pkg/synthetic/writing_listener_linux.go:33:  NewWritingListener              100.0%
github.com/cilium/tetragon/pkg/synthetic/writing_listener_linux.go:49:  Notify                          100.0%
github.com/cilium/tetragon/pkg/synthetic/writing_listener_linux.go:75:  Close                           100.0%
github.com/cilium/tetragon/pkg/synthetic/writing_listener_linux.go:83:  WithVerifyRoundtrip             100.0%
github.com/cilium/tetragon/pkg/synthetic/writing_listener_linux.go:90:  WithDelegate                    100.0%
github.com/cilium/tetragon/pkg/synthetic/writing_listener_linux.go:97:  verifyRoundtripEquality         100.0%
total:                                                                  (statements)                    91.0%
```

Also here is the post describing the Usage & Testing Guide. https://github.com/cilium/tetragon/issues/4497#issuecomment-3836611060

**release-note**
```release-note
Added synthetic event recording/replay via --synthetic-events-log and --synthetic-events-source, with optional --synthetic-events-verify-roundtrip validation.
```
