### PR TITLE
Adjusting raw_syscalls policy to use syscall type

### DIFF
--- a/examples/tracingpolicy/raw_syscalls.yaml
+++ b/examples/tracingpolicy/raw_syscalls.yaml
@@ -9,7 +9,7 @@ spec:
       # args: add both the syscall id, and the array with the arguments
       args:
         - index: 4
-          type: "int64"
+          type: "syscall64"
       #  - index: 5
       #selectors:
       #- matchPIDs:


### PR DESCRIPTION
Using the syscall64 type ensures the client maps the syscall to the correct name.

Fixes #539 

### Description
If a client running on a different architecture from the agent received events from the `raw_syscalls.yaml` policy, it would map the syscall id to the name based on the client ABI.

```
syscall x86-vm /home/berose/Development/tetragon/tetragon mlock(unsigned long start=?, size_t len=?)(228)
```
(228 should be `clock_gettime` on x86)

By changing the policy's syscall argument from `int64` to `syscall64`, the ABI of the agent is provided in the event passed to the client and the correct syscall name is displayed.

```
syscall x86-vm /home/berose/Development/tetragon/tetragon x64/clock_gettime(228)
```