### PR TITLE
pkg/sensors: reject unsupported returnArgAction values

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -1253,6 +1253,10 @@ FUNC_INLINE int generic_retprobe(void *ctx, struct bpf_map_def *calls, unsigned 
 #if defined(__LARGE_BPF_PROG) && (defined(GENERIC_KRETPROBE) || defined(GENERIC_FEXIT))
 		struct socket_owner owner;
 
+		/* ReturnArgAction only has return-path handling for socket tracking.
+		 * Userspace validation limits it to ACTION_TRACKSOCK and
+		 * ACTION_UNTRACKSOCK.
+		 */
 		switch (config->argreturnaction) {
 		case ACTION_TRACKSOCK:
 			owner.pid = e->current.pid;

--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -17,7 +17,10 @@ See the [Stack Traces](https://tetragon.io/docs/concepts/tracing-policy/selector
 
 ### TracingPolicy (k8s CRD)
 
-* TBD
+* `returnArgAction` no longer accepts `Post`. Use `returnArg` to include the
+  return value in events, and omit `returnArgAction` for the default return-value
+  behavior. Only `TrackSock` and `UntrackSock` are supported. Existing policies
+  that set `returnArgAction: "Post"` should remove the field.
 
 ### Events (protobuf API)
 

--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -806,7 +806,9 @@ Specifying socket tracking tells Tetragon to store a mapping between the socket
 and the process' PID and TGID; and to use that mapping when it sees the socket in a
 `sock` argument in another hook to replace the PID and TGID of the context with the
 process that actually owns the socket. This can be done by adding a `returnArgAction`
-to the call. Available actions are `TrackSock` and `UntrackSock`.
+to the call. Use `returnArg` to include the return value in the event output;
+`returnArgAction` is only for the socket-tracking actions `TrackSock` and
+`UntrackSock`.
 See [`TrackSock`](/docs/concepts/tracing-policy/selectors/#tracksock-action) and [`UntrackSock`](/docs/concepts/tracing-policy/selectors/#untracksock-action).
 
 ```yaml

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -388,8 +388,9 @@ in the event output to inform users what is going on.<br/>
         <td><b>returnArgAction</b></td>
         <td>string</td>
         <td>
-          An action to perform on the return argument.
-Available actions are: Post;TrackSock;UntrackSock<br/>
+          An action to perform on the return value.
+Use returnArg to include the return value in the event output.
+Supported actions are: TrackSock;UntrackSock<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1831,8 +1832,9 @@ in the event output to inform users what is going on.<br/>
         <td><b>returnArgAction</b></td>
         <td>string</td>
         <td>
-          An action to perform on the return argument.
-Available actions are: Post;TrackSock;UntrackSock<br/>
+          An action to perform on the return value.
+Use returnArg to include the return value in the event output.
+Supported actions are: TrackSock;UntrackSock<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9149,8 +9151,9 @@ in the event output to inform users what is going on.<br/>
         <td><b>returnArgAction</b></td>
         <td>string</td>
         <td>
-          An action to perform on the return argument.
-Available actions are: Post;TrackSock;UntrackSock<br/>
+          An action to perform on the return value.
+Use returnArg to include the return value in the event output.
+Supported actions are: TrackSock;UntrackSock<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10592,8 +10595,9 @@ in the event output to inform users what is going on.<br/>
         <td><b>returnArgAction</b></td>
         <td>string</td>
         <td>
-          An action to perform on the return argument.
-Available actions are: Post;TrackSock;UntrackSock<br/>
+          An action to perform on the return value.
+Use returnArg to include the return value in the event output.
+Supported actions are: TrackSock;UntrackSock<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/examples/policylibrary/bpf.yaml
+++ b/examples/policylibrary/bpf.yaml
@@ -39,7 +39,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:      
       - index: 0
@@ -72,7 +71,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:      
       - index: 0

--- a/examples/quickstart/file_monitoring.yaml
+++ b/examples/quickstart/file_monitoring.yaml
@@ -15,7 +15,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:      
       - index: 0
@@ -87,7 +86,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:      
       - index: 0
@@ -155,7 +153,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:
       - index: 0

--- a/examples/quickstart/file_monitoring_enforce.yaml
+++ b/examples/quickstart/file_monitoring_enforce.yaml
@@ -15,7 +15,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:      
       - index: 0
@@ -93,7 +92,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:      
       - index: 0
@@ -165,7 +163,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:
       - index: 0

--- a/examples/tracingpolicy/cves/cve-2024-3094-xz-ssh.yaml
+++ b/examples/tracingpolicy/cves/cve-2024-3094-xz-ssh.yaml
@@ -54,7 +54,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchBinaries:
       - operator: "In"

--- a/examples/tracingpolicy/filename_monitoring.yaml
+++ b/examples/tracingpolicy/filename_monitoring.yaml
@@ -15,7 +15,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:      
       - index: 0
@@ -35,7 +34,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:
       - index: 0
@@ -51,7 +49,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:
       - index: 0

--- a/examples/tracingpolicy/filename_monitoring_filtered.yaml
+++ b/examples/tracingpolicy/filename_monitoring_filtered.yaml
@@ -15,7 +15,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:      
       - index: 0
@@ -39,7 +38,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:
       - index: 0
@@ -59,7 +57,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:
       - index: 0

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -475,8 +475,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -1552,8 +1553,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -475,8 +475,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -1552,8 +1553,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -475,8 +475,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -1552,8 +1553,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -475,8 +475,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -1552,8 +1553,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -53,8 +53,9 @@ type KProbeSpec struct {
 	// A return argument to include in the trace output.
 	ReturnArg *KProbeArg `json:"returnArg,omitempty"`
 	// +kubebuilder:validation:Optional
-	// An action to perform on the return argument.
-	// Available actions are: Post;TrackSock;UntrackSock
+	// An action to perform on the return value.
+	// Use returnArg to include the return value in the event output.
+	// Supported actions are: TrackSock;UntrackSock
 	ReturnArgAction string `json:"returnArgAction,omitempty"`
 	// +kubebuilder:validation:Optional
 	// Selectors to apply before producing trace output. Selectors are ORed and short-circuited.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.16"
+const CustomResourceDefinitionSchemaVersion = "1.7.17"

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -725,10 +725,14 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 		if !config.EnableLargeProgs() {
 			return errFn(errors.New("ReturnArgAction requires kernel >=5.3"))
 		}
-		eventConfig.ArgReturnAction = selectors.ActionTypeFromString(f.ReturnArgAction)
-		if eventConfig.ArgReturnAction == selectors.ActionTypeInvalid {
+		actionID := selectors.ActionTypeFromString(f.ReturnArgAction)
+		if actionID == selectors.ActionTypeInvalid {
 			return errFn(fmt.Errorf("ReturnArgAction type '%s' unsupported", f.ReturnArgAction))
 		}
+		if actionID != selectors.ActionTypeTrackSock && actionID != selectors.ActionTypeUntrackSock {
+			return errFn(fmt.Errorf("ReturnArgAction type '%s' unsupported; omit returnArgAction or use 'TrackSock'/'UntrackSock'", f.ReturnArgAction))
+		}
+		eventConfig.ArgReturnAction = actionID
 	}
 
 	if selectors.HasOverride(f.Selectors) {

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -6106,7 +6106,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:
       - index: 0
@@ -6132,7 +6131,6 @@ spec:
     returnArg:
       index: 0
       type: "int"
-    returnArgAction: "Post"
     selectors:
     - matchArgs:      
       - index: 0

--- a/pkg/sensors/tracing/kprobe_validation_test.go
+++ b/pkg/sensors/tracing/kprobe_validation_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/build"
 	"github.com/cilium/tetragon/pkg/config"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
@@ -236,6 +238,83 @@ spec:
 	err := checkCrd(t, crd)
 	require.Error(t, err)
 
+}
+
+func forceLargeProgs(t *testing.T) {
+	t.Helper()
+
+	origForceLargeProgs := option.Config.ForceLargeProgs
+	origForceSmallProgs := option.Config.ForceSmallProgs
+	option.Config.ForceLargeProgs = true
+	option.Config.ForceSmallProgs = false
+	t.Cleanup(func() {
+		option.Config.ForceLargeProgs = origForceLargeProgs
+		option.Config.ForceSmallProgs = origForceSmallProgs
+	})
+}
+
+func TestKprobeValidationReturnArgActionSocketTracking(t *testing.T) {
+	forceLargeProgs(t)
+
+	tests := []struct {
+		name   string
+		action string
+	}{
+		{name: "tracksock", action: "TrackSock"},
+		{name: "untracksock", action: "UntrackSock"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kp := &v1alpha1.KProbeSpec{
+				Call:            "sys_dup",
+				Syscall:         true,
+				Return:          true,
+				ReturnArg:       &v1alpha1.KProbeArg{Index: 0, Type: "int"},
+				ReturnArgAction: tt.action,
+			}
+			in := &addKprobeIn{policyName: "return-arg-action-" + tt.name}
+
+			id, err := addKprobe("sys_dup", 0, kp, in, hasMaps{})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := genericKprobeTable.RemoveEntry(id)
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
+func TestKprobeValidationReturnArgActionPost(t *testing.T) {
+	forceLargeProgs(t)
+
+	kp := &v1alpha1.KProbeSpec{
+		Call:            "sys_dup",
+		Syscall:         true,
+		Return:          true,
+		ReturnArg:       &v1alpha1.KProbeArg{Index: 0, Type: "int"},
+		ReturnArgAction: "Post",
+	}
+	in := &addKprobeIn{policyName: "return-arg-action-post"}
+
+	_, err := addKprobe("sys_dup", 0, kp, in, hasMaps{})
+	require.ErrorContains(t, err, "omit returnArgAction or use 'TrackSock'/'UntrackSock'")
+}
+
+func TestKprobeValidationReturnArgActionInvalid(t *testing.T) {
+	forceLargeProgs(t)
+
+	kp := &v1alpha1.KProbeSpec{
+		Call:            "sys_dup",
+		Syscall:         true,
+		Return:          true,
+		ReturnArg:       &v1alpha1.KProbeArg{Index: 0, Type: "int"},
+		ReturnArgAction: "Bogus",
+	}
+	in := &addKprobeIn{policyName: "return-arg-action-invalid"}
+
+	_, err := addKprobe("sys_dup", 0, kp, in, hasMaps{})
+	require.ErrorContains(t, err, "ReturnArgAction type 'Bogus' unsupported")
 }
 
 func TestKprobeValidationMissingReturnArg(t *testing.T) {

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -475,8 +475,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -1552,8 +1553,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -475,8 +475,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.
@@ -1552,8 +1553,9 @@ spec:
                       type: object
                     returnArgAction:
                       description: |-
-                        An action to perform on the return argument.
-                        Available actions are: Post;TrackSock;UntrackSock
+                        An action to perform on the return value.
+                        Use returnArg to include the return value in the event output.
+                        Supported actions are: TrackSock;UntrackSock
                       type: string
                     selectors:
                       description: Selectors to apply before producing trace output.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -53,8 +53,9 @@ type KProbeSpec struct {
 	// A return argument to include in the trace output.
 	ReturnArg *KProbeArg `json:"returnArg,omitempty"`
 	// +kubebuilder:validation:Optional
-	// An action to perform on the return argument.
-	// Available actions are: Post;TrackSock;UntrackSock
+	// An action to perform on the return value.
+	// Use returnArg to include the return value in the event output.
+	// Supported actions are: TrackSock;UntrackSock
 	ReturnArgAction string `json:"returnArgAction,omitempty"`
 	// +kubebuilder:validation:Optional
 	// Selectors to apply before producing trace output. Selectors are ORed and short-circuited.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.16"
+const CustomResourceDefinitionSchemaVersion = "1.7.17"


### PR DESCRIPTION
This series tightens `ReturnArgAction` handling for kprobe return paths.

The return-path implementation only has explicit behavior for the
socket-tracking actions (`TrackSock` and `UntrackSock`), but the schema
and examples also suggested that `Post` was meaningful there. Based on
the review feedback in this PR, this series rejects unsupported values
instead of accepting a silent no-op.

Changes:
- reject unsupported `returnArgAction` values in kprobe return-path validation
- clarify that `returnArg` exports the return value, while `returnArgAction` is only for socket-tracking actions on that value
- regenerate CRDs/docs and sync the vendored `pkg/k8s` CRD copies
- remove redundant `returnArgAction: "Post"` from examples

Policies that explicitly set `returnArgAction: "Post"` should omit the
field instead.

Testing:
- `go test ./apis/cilium.io/v1alpha1 -count=1` from `pkg/k8s/`
- the equivalent pre-cleanup stack passed the full PR CI before this reviewer cleanup

```release-note
ReturnArgAction now only accepts TrackSock/UntrackSock for kprobe return args; unsupported values like Post are rejected to prevent silent no-ops.
```