### PR TITLE
feat: Add matchScript option to matchBinaries selector for shebang script filtering

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -320,6 +320,19 @@ struct binary {
 	char end_r[STRING_POSTFIX_MAX_LENGTH];
 	// args for the binary
 	char args[MAXARGLENGTH];
+	/**
+	 * filename_length - Length of script path for matchScript support
+	 *
+	 * When matchScript is enabled, this field stores the length of the
+	 * script path found in args[0]. For shebang scripts (e.g., #!/bin/bash),
+	 * this allows matching against the script path (/path/script.sh) instead
+	 * of the interpreter path (/bin/bash).
+	 * 
+	 * Set during execve processing and used by matchScript selectors.
+	 * Value of 0 indicates no script path available.
+	 */
+	__s32 filename_length;
+	__s32 __pad_filename; // padding for uint64 alignment
 	// matchBinary bitset for binary
 	// NB: everything after and including ->mb_bitset will not be zeroed on a new exec. See
 	// binary_reset().
@@ -365,6 +378,7 @@ struct {
 	__type(key, __u32);
 	__type(value, struct binary);
 } tg_binary_heap SEC(".maps");
+
 
 // Parent binaries map is used for saving actual immediate parents
 // for processes to get check them in matchParentBinaries selector.

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -442,9 +442,13 @@ execve_send(struct exec_ctx_struct *ctx __arg_ctx)
 		with_errmetrics(probe_read, curr->bin.args, len, (char *)&event->process + off);
 
 		// there's a null byte between each argv element, so we terminate with
-		// two of them to make it possible to identify the end of the buffer
 		curr->bin.args[len] = 0x00;
 		curr->bin.args[len + 1] = 0x00;
+
+		// Store filename length for matchScript support.
+		// The filename (script path) is already in args as the first element.
+		if (p->size_path > 0 && p->size_path < BINARY_PATH_MAX_LEN)
+			curr->bin.filename_length = p->size_path;
 #else
 		char *filename = (char *)ctx + (_(ctx->__data_loc_filename) & 0xFFFF);
 
@@ -467,3 +471,4 @@ execve_send(struct exec_ctx_struct *ctx __arg_ctx)
 	event_output_metric(ctx, MSG_OP_EXECVE, event, size);
 	return 0;
 }
+

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1849,6 +1849,9 @@ struct match_binaries_sel_opts {
 	__u32 op;
 	__u32 map_id;
 	__u32 mbset_id;
+	// match_script: if true, match against the script path (filename from execve)
+	// instead of the interpreter path (exe_file) for shebang scripts
+	__u32 match_script;
 };
 
 // We need data for:
@@ -1904,7 +1907,20 @@ FUNC_INLINE int match_binaries(__u32 key, struct execve_map_value *current, stru
 		if (selector_options->op == op_filter_none)
 			return 1; // matchBinaries selector is empty <=> match
 
-		if (bin->path_length < 0) {
+		// Select which path to match against based on match_script option.
+		// If match_script is true, use the resolved script path from tg_script_path_map.
+		// This handles both absolute and relative paths (resolved at execve time).
+		// Otherwise use path (exe_file, which is the interpreter for shebang scripts).
+		char *match_path = bin->path;
+		__s32 match_path_length = bin->path_length;
+
+		if (selector_options->match_script) {
+			// Use script path (bin->args) instead of interpreter path (bin->path)
+			match_path = bin->args;
+			match_path_length = bin->filename_length;
+		}
+
+		if (match_path_length < 0) {
 			// something wrong happened when copying the filename to execve_map
 			return 0;
 		}
@@ -1928,7 +1944,7 @@ FUNC_INLINE int match_binaries(__u32 key, struct execve_map_value *current, stru
 			path_map = map_lookup_elem(&tg_mb_paths, &key);
 			if (!path_map)
 				return 0;
-			found_key = map_lookup_elem(path_map, bin->path);
+			found_key = map_lookup_elem(path_map, match_path);
 			break;
 #ifdef __LARGE_BPF_PROG
 		case op_filter_str_prefix:

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -1097,6 +1097,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -1429,6 +1441,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -2218,6 +2242,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -2550,6 +2586,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -3412,6 +3460,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -3744,6 +3804,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -4749,6 +4821,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -5081,6 +5165,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -5835,6 +5931,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -6167,6 +6275,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -7442,6 +7562,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -7774,6 +7906,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -8563,6 +8707,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -8895,6 +9051,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -9757,6 +9925,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -10089,6 +10269,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -11094,6 +11286,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -11426,6 +11630,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -12180,6 +12396,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
             <i>Default</i>: false<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -12512,6 +12740,18 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>boolean</td>
         <td>
           In addition to binaries, match children processes of specified binaries.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchScript</b></td>
+        <td>boolean</td>
+        <td>
+          Match against the script path instead of the interpreter for scripts with shebangs.
+When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+Setting matchScript to true will match against /path/script.py instead.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -657,6 +657,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -903,6 +911,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -1445,6 +1461,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -1691,6 +1715,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -2269,6 +2301,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -2515,6 +2555,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -3271,6 +3319,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -3517,6 +3573,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -4037,6 +4101,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -4283,6 +4355,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -657,6 +657,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -903,6 +911,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -1445,6 +1461,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -1691,6 +1715,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -2269,6 +2301,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -2515,6 +2555,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -3271,6 +3319,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -3517,6 +3573,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -4037,6 +4101,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -4283,6 +4355,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -161,14 +161,16 @@ type MsgCapabilities struct {
 }
 
 type Binary struct {
-	PathLength int32
-	Reversed   uint32
-	Path       [BINARY_PATH_MAX_LEN]byte
-	End        [STRING_POSTFIX_MAX_LENGTH]byte
-	EndR       [STRING_POSTFIX_MAX_LENGTH]byte
-	Args       [MAX_ARG_LENGTH]byte
-	MBSet      uint64
-	MBGen      uint64
+	PathLength     int32
+	Reversed       uint32
+	Path           [BINARY_PATH_MAX_LEN]byte
+	End            [STRING_POSTFIX_MAX_LENGTH]byte
+	EndR           [STRING_POSTFIX_MAX_LENGTH]byte
+	Args           [MAX_ARG_LENGTH]byte
+	FilenameLength int32 // Length of script path in Args for matchScript
+	_              int32 // padding for alignment
+	MBSet          uint64
+	MBGen          uint64
 }
 
 type MsgNamespaces struct {

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -657,6 +657,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -903,6 +911,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -1445,6 +1461,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -1691,6 +1715,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -2269,6 +2301,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -2515,6 +2555,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -3271,6 +3319,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -3517,6 +3573,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -4037,6 +4101,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -4283,6 +4355,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -657,6 +657,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -903,6 +911,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -1445,6 +1461,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -1691,6 +1715,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -2269,6 +2301,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -2515,6 +2555,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -3271,6 +3319,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -3517,6 +3573,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -4037,6 +4101,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -4283,6 +4355,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -124,6 +124,13 @@ type BinarySelector struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	FollowChildren bool `json:"followChildren"`
+	// Match against the script path instead of the interpreter for scripts with shebangs.
+	// When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+	// matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+	// Setting matchScript to true will match against /path/script.py instead.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	MatchScript bool `json:"matchScript"`
 }
 
 // KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.6"
+const CustomResourceDefinitionSchemaVersion = "1.7.7"

--- a/pkg/selectors/kernel_matchscript_test.go
+++ b/pkg/selectors/kernel_matchscript_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package selectors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/tetragon/pkg/api/processapi"
+)
+
+// TestGeneratePathVariants validates generatePathVariants creates correct bidirectional path variants
+// for matchScript functionality, enabling single policy entries to match both absolute and relative paths.
+func TestGeneratePathVariants(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty path",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "absolute path",
+			input:    "/tmp/test_script.sh",
+			expected: []string{"/tmp/test_script.sh", "./test_script.sh", "test_script.sh"},
+		},
+		{
+			name:     "relative path",
+			input:    "./script.sh",
+			expected: []string{"./script.sh", "script.sh"},
+		},
+		{
+			name:     "basename only",
+			input:    "script.sh",
+			expected: []string{"script.sh", "./script.sh"},
+		},
+		{
+			name:     "root path",
+			input:    "/script.sh",
+			expected: []string{"/script.sh", "./script.sh", "script.sh"},
+		},
+		{
+			name:     "nested absolute path",
+			input:    "/usr/local/bin/myscript",
+			expected: []string{"/usr/local/bin/myscript", "./myscript", "myscript"},
+		},
+		{
+			name:     "path with special characters",
+			input:    "/tmp/script-test_v1.sh",
+			expected: []string{"/tmp/script-test_v1.sh", "./script-test_v1.sh", "script-test_v1.sh"},
+		},
+		{
+			name:     "very long path exceeds limit",
+			input:    "/very/long/path/" + strings.Repeat("a", processapi.BINARY_PATH_MAX_LEN),
+			expected: []string{"/very/long/path/" + strings.Repeat("a", processapi.BINARY_PATH_MAX_LEN), "./" + strings.Repeat("a", processapi.BINARY_PATH_MAX_LEN), strings.Repeat("a", processapi.BINARY_PATH_MAX_LEN)},
+		},
+	}
+
+	// Run each test case
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call generatePathVariants function with input path
+			result := generatePathVariants(tt.input)
+			// Assert result matches expected output
+			require.Equal(t, tt.expected, result, "generatePathVariants(%q) should return expected variants", tt.input)
+		})
+	}
+}
+
+// setupKernelSelectorState creates a fresh KernelSelectorState for testing.
+func setupKernelSelectorState() *KernelSelectorState {
+	return &KernelSelectorState{
+		matchBinariesPaths: make(map[int][][processapi.BINARY_PATH_MAX_LEN]byte),
+	}
+}
+
+// extractPathsFromMap extracts string paths from KernelSelectorState map entries.
+func extractPathsFromMap(paths [][processapi.BINARY_PATH_MAX_LEN]byte) []string {
+	// Initialize empty slice to avoid nil vs empty slice comparison issues
+	result := make([]string, 0)
+	for _, bytePath := range paths {
+		pathStr := string(bytePath[:])
+		if nullIndex := strings.Index(pathStr, "\x00"); nullIndex != -1 {
+			pathStr = pathStr[:nullIndex]
+		}
+		result = append(result, pathStr)
+	}
+	return result
+}
+
+// TestWriteMatchScriptPaths validates writeMatchScriptPaths correctly writes path variants
+// to BPF maps based on matchScript flag, ensuring proper integration with kernel selectors.
+func TestWriteMatchScriptPaths(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		isMatchScript bool
+		expectedPaths []string
+	}{
+		{
+			name:          "non-matchScript path",
+			path:          "/tmp/test.sh",
+			isMatchScript: false,
+			expectedPaths: []string{"/tmp/test.sh"},
+		},
+		{
+			name:          "matchScript absolute path",
+			path:          "/tmp/test.sh",
+			isMatchScript: true,
+			expectedPaths: []string{"/tmp/test.sh", "./test.sh", "test.sh"},
+		},
+		{
+			name:          "matchScript relative path",
+			path:          "./test.sh",
+			isMatchScript: true,
+			expectedPaths: []string{"./test.sh", "test.sh"},
+		},
+		{
+			name:          "matchScript with empty path",
+			path:          "",
+			isMatchScript: true,
+			expectedPaths: []string{},
+		},
+		{
+			name:          "path too long gets truncated",
+			path:          "/" + strings.Repeat("x", processapi.BINARY_PATH_MAX_LEN+10),
+			isMatchScript: true,
+			expectedPaths: []string{}, // Should be filtered out due to length
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := setupKernelSelectorState()
+			
+			err := writeMatchScriptPaths(k, 1, tt.path, tt.isMatchScript)
+			require.NoError(t, err, "writeMatchScriptPaths should not return error for valid input")
+			
+			// Extract and validate written paths
+			writtenPaths := k.matchBinariesPaths[1]
+			actualPaths := extractPathsFromMap(writtenPaths)
+			
+			require.Equal(t, tt.expectedPaths, actualPaths, "writeMatchScriptPaths should write expected paths to map")
+		})
+	}
+}
+
+// BenchmarkGeneratePathVariants measures performance of path variant generation.
+func BenchmarkGeneratePathVariants(b *testing.B) {
+	testPaths := []string{
+		"/usr/bin/python3",
+		"./script.py", 
+		"script.sh",
+		"/very/long/nested/path/to/executable",
+	}
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, path := range testPaths {
+			_ = generatePathVariants(path)
+		}
+	}
+}

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -103,6 +103,9 @@ type MatchBinariesSelectorOptions struct {
 	MapID uint32
 	// matchBinaries set for the selector
 	MBSetID uint32
+	// MatchScript indicates to match against the script path (filename from execve)
+	// instead of the interpreter path (exe_file) for shebang scripts
+	MatchScript uint32
 }
 
 type KernelSelectorData struct {

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -657,6 +657,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -903,6 +911,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -1445,6 +1461,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -1691,6 +1715,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -2269,6 +2301,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -2515,6 +2555,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -3271,6 +3319,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -3517,6 +3573,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -4037,6 +4101,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -4283,6 +4355,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -657,6 +657,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -903,6 +911,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -1445,6 +1461,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -1691,6 +1715,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -2269,6 +2301,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -2515,6 +2555,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -3271,6 +3319,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -3517,6 +3573,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.
@@ -4037,6 +4101,14 @@ spec:
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
                                   type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
+                                  type: boolean
                                 operator:
                                   description: Filter operation.
                                   enum:
@@ -4283,6 +4355,14 @@ spec:
                                   default: false
                                   description: In addition to binaries, match children
                                     processes of specified binaries.
+                                  type: boolean
+                                matchScript:
+                                  default: false
+                                  description: |-
+                                    Match against the script path instead of the interpreter for scripts with shebangs.
+                                    When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+                                    matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+                                    Setting matchScript to true will match against /path/script.py instead.
                                   type: boolean
                                 operator:
                                   description: Filter operation.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -124,6 +124,13 @@ type BinarySelector struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	FollowChildren bool `json:"followChildren"`
+	// Match against the script path instead of the interpreter for scripts with shebangs.
+	// When a script like (i.e. /path/script.py) with shebang #!/usr/bin/python3 is executed,
+	// matchBinaries normally matches against /usr/bin/python3 (the interpreter).
+	// Setting matchScript to true will match against /path/script.py instead.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	MatchScript bool `json:"matchScript"`
 }
 
 // KProbeSelector selects function calls for kprobe based on PIDs and function arguments. The

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.6"
+const CustomResourceDefinitionSchemaVersion = "1.7.7"


### PR DESCRIPTION
Add support for matching against script paths instead of interpreter paths when filtering shebang scripts. When a script with a shebang (e.g., /path/script.py with #!/usr/bin/python3) is executed, matchBinaries normally matches against the interpreter (/usr/bin/python3). The new matchScript option allows matching against the script path instead.

In this PR you will see two commits:

[feat: Add matchScript to matchBinaries for shebang scripts](https://github.com/cilium/tetragon/pull/4602/changes/bafe4024f7853c3c63019f64474638b5b59614d4) -> Implementation files

[chore: Regenerate files](https://github.com/cilium/tetragon/pull/4602/changes/143841d025e2b7db3f56d346b5bbe9a4b9e288e3) -> FIle generated after $ make generate command line

Evidence of the implementation:
1️⃣ Tracing-policy with matchScript: true (new matchBinaries feature added)

```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: test-matchscript-true
spec:
  kprobes:
  - call: "sys_write"
    syscall: true
    args:
    - index: 0
      type: int
    - index: 2
      type: size_t
    selectors:
    - matchBinaries:
      - operator: In
        values:
        - /tmp/test_script.sh
        matchScript: true
```

Script to run some events: 

```yaml
#!/bin/bash
echo "Hello from script"
```

Tetragon log

```bash
🚀 process 9447eedcf851 /tmp/test_script.sh /tmp/test_script.sh
📝 write   9447eedcf851 /tmp/test_script.sh
💥 exit    9447eedcf851 /tmp/test_script.sh /tmp/test_script.sh 0
```

2️⃣ Check if the previos implementation with interpreter continue working. 

Tracing-policy using matchBinaries `/usr/bin/bash`

```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: test-usrbash
spec:
  kprobes:
  - call: "sys_write"
    syscall: true
    args:
    - index: 0
      type: int
    - index: 2
      type: size_t
    selectors:
    - matchBinaries:
      - operator: In
        values:
        - /usr/bin/bash
```

Script to run some events: 

```yaml
#!/bin/bash
echo "Hello from script"
```

Tetragon log: 

```yaml
📝 write   9447eedcf851 /bin/bash
📝 write   9447eedcf851 /bin/bash
🚀 process 9447eedcf851 /tmp/test_script.sh /tmp/test_script.sh
📝 write   9447eedcf851 /tmp/test_script.sh
💥 exit    9447eedcf851 /tmp/test_script.sh /tmp/test_script.sh 0
📝 write   9447eedcf851 /bin/bash
📝 write   9447eedcf851 /bin/bash
```

3️⃣ Test without  `matchScript` in the tracingpolicy

```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: test-script-nomatch
spec:
  kprobes:
  - call: "sys_write"
    syscall: true
    args:
    - index: 0
      type: int
    - index: 2
      type: size_t
    selectors:
    - matchBinaries:
      - operator: In
        values:
        - /tmp/test_script.sh
```

Script to run some events: 

```yaml
#!/bin/bash
echo "Hello from script"
```

Tetragon log: 

```yaml
🚀 process 9447eedcf851 /tmp/test_script.sh /tmp/test_script.sh
💥 exit    9447eedcf851 /tmp/test_script.sh /tmp/test_script.sh 0
```

4️⃣ Test with `matchScript: false`

```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: test-nomatchscript
spec:
  kprobes:
  - call: sys_write
    syscall: true
    args:
    - index: 0
      type: int
    - index: 2
      type: size_t
    selectors:
    - matchBinaries:
      - operator: In
        values:
        - /tmp/test_script.sh
        matchScript: false
```

Script to run some events: 

```yaml
#!/bin/bash
echo "Hello from script"
```

Tetragon log:
```yaml
🚀 process 9447eedcf851 /tmp/test_script.sh /tmp/test_script.sh
💥 exit    9447eedcf851 /tmp/test_script.sh /tmp/test_script.sh 0
```

## Unit test: 
Please check the unit test created in this path: [pkg/sensors/tracing/matchbinaries_script_test.go](https://github.com/cilium/tetragon/pull/4602/changes/bafe4024f7853c3c63019f64474638b5b59614d4#diff-303e09c4d5283ef9bada22426050d7b17190c48e0ae8deff8d444d35976744a2:~:text=//%20SPDX%2DLicense%2DIdentifier%3A%20Apache%2D2.0)

```bash
go test -v ./pkg/sensors/tracing/... -run TestMatchBinariesMatchScript

Output: 

=== NAME  TestMatchBinariesMatchScriptValidation/NotPostfix
    base.go:215: cleanup: unloading base sensor
=== NAME  TestMatchBinariesMatchScriptValidation
    logcapture.go:24: time=2026-02-03T01:44:09.490Z level=INFO msg="Unloading sensor __base__"
--- PASS: TestMatchBinariesMatchScriptValidation (0.89s)
    --- PASS: TestMatchBinariesMatchScriptValidation/Prefix (0.28s)
    --- PASS: TestMatchBinariesMatchScriptValidation/NotPrefix (0.21s)
    --- PASS: TestMatchBinariesMatchScriptValidation/Postfix (0.21s)
    --- PASS: TestMatchBinariesMatchScriptValidation/NotPostfix (0.20s)
PASS
ok  	github.com/cilium/tetragon/pkg/sensors/tracing	(cached)
```
