### PR TITLE
new(pkg/sensors): expose LinkPin

### DIFF
--- a/pkg/sensors/program/loader_linux.go
+++ b/pkg/sensors/program/loader_linux.go
@@ -23,7 +23,7 @@ import (
 
 type uprobeAttachFunc func(*Program, *ebpf.Program, *ebpf.ProgramSpec, string, ...string) (unloader.Unloader, error)
 
-func linkPin(lnk link.Link, bpfDir string, load *Program, extra ...string) error {
+func LinkPin(lnk link.Link, bpfDir string, load *Program, extra ...string) error {
 	// pinned link is not supported
 	if !bpf.HasLinkPin() {
 		return nil
@@ -78,7 +78,7 @@ func TracepointAttach(load *Program, bpfDir string) AttachFunc {
 		if err != nil {
 			return nil, fmt.Errorf("attaching '%s' failed: %w", spec.Name, err)
 		}
-		err = linkPin(tpLink, bpfDir, load)
+		err = LinkPin(tpLink, bpfDir, load)
 		if err != nil {
 			tpLink.Close()
 			return nil, err
@@ -167,7 +167,7 @@ func kprobeAttach(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec,
 	if err != nil {
 		return nil, fmt.Errorf("attaching '%s' failed: %w", spec.Name, err)
 	}
-	err = linkPin(lnk, bpfDir, load, extra...)
+	err = LinkPin(lnk, bpfDir, load, extra...)
 	if err != nil {
 		lnk.Close()
 		return nil, err
@@ -248,7 +248,7 @@ func fmodretAttachOverride(load *Program, bpfDir string,
 		return fmt.Errorf("attaching '%s' failed: %w", spec.Name, err)
 	}
 
-	err = linkPin(lnk, bpfDir, load, "override")
+	err = LinkPin(lnk, bpfDir, load, "override")
 	if err != nil {
 		lnk.Close()
 		return err
@@ -334,7 +334,7 @@ func uprobeAttachSingle(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpe
 		return nil, fmt.Errorf("attaching '%s' failed: %w", spec.Name, err)
 	}
 
-	err = linkPin(lnk, bpfDir, load, extra...)
+	err = LinkPin(lnk, bpfDir, load, extra...)
 	if err != nil {
 		lnk.Close()
 		return nil, err
@@ -387,7 +387,7 @@ func uprobeAttachMulti(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec
 			if err != nil {
 				return nil, err
 			}
-			err = linkPin(lnk, bpfDir, load, extra...)
+			err = LinkPin(lnk, bpfDir, load, extra...)
 			if err != nil {
 				lnk.Close()
 				return nil, err
@@ -506,7 +506,7 @@ func TracingAttach(load *Program, bpfDir string) AttachFunc {
 		if err != nil {
 			return nil, fmt.Errorf("attaching '%s' failed: %w", spec.Name, err)
 		}
-		err = linkPin(lnk, bpfDir, load)
+		err = LinkPin(lnk, bpfDir, load)
 		if err != nil {
 			lnk.Close()
 			return nil, err
@@ -570,7 +570,7 @@ func multiKprobeAttach(load *Program, prog *ebpf.Program,
 	if err != nil {
 		return nil, fmt.Errorf("attaching '%s' failed: %w", spec.Name, err)
 	}
-	err = linkPin(lnk, bpfDir, load, extra...)
+	err = LinkPin(lnk, bpfDir, load, extra...)
 	if err != nil {
 		lnk.Close()
 		return nil, err


### PR DESCRIPTION
### Description

This way, external projects have a way to leverage it for custom `attach` helpers.
