### PR TITLE
docs: document argument types for kprobes and tracepoints

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/argument_types.md
+++ b/docs/content/en/docs/concepts/tracing-policy/argument_types.md
@@ -23,7 +23,6 @@ List of described data types:
 - [`char_buf`](#char_buf)
 - [`char_iovec`](#char_iovec)
 - [`filename`](#filename)
-- [`path`](#path)
 - [`fd`](#fd)
 - [`cred`](#cred)
 - [`const_buf`](#const_buf)
@@ -50,6 +49,12 @@ List of described data types:
 - [`socket`](#socket)
 - [`file`](#file)
 - [`dentry`](#dentry)
+- [`path`](#path)
+
+{{< note >}}
+All integer types (`int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`)
+support `Equal`, `NotEqual`, `GT`, `LT`, and `Mask` operators in `matchArgs` or `matchData`.
+{{< /note >}}
 
 <a name="int8"></a>
 
@@ -91,135 +96,211 @@ The data type extracts 64-bit signed value.
 
 ## `ulong, uint64, size_t`
 
-The data type extracts  64-bit unsigned value.
+The data type extracts 64-bit unsigned value.
 
 ## `string`
 
 The data type extracts string terminated with zero byte.
 
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators.
+
 ## `skb`
 
-TBD
+The `skb` data type represents kernel `struct sk_buff` (socket buffer) object.
+It extracts network packet information including source/destination addresses,
+ports, and protocol.
+
+In `matchArgs` or `matchData`, use network operators: `SAddr`, `DAddr`,
+`SPort`, `DPort`, `Protocol`, or their negated variants `NotSAddr`,
+`NotDAddr`, `NotSPort`, `NotDPort`. Address values support CIDR notation.
 
 ## `sock`
 
-TBD
+The `sock` data type represents kernel `struct sock` object, which is the
+network layer representation of a socket. It extracts socket family, type,
+state, and address information.
+
+In `matchArgs` or `matchData`, use network operators: `SAddr`, `DAddr`,
+`SPort`, `DPort`, `Protocol`, `Family`, or `State`.
 
 ## `char_buf`
 
-TBD
+The `char_buf` data type represents a character buffer. When using this type,
+specify the buffer size using `sizeArgIndex` (referencing another argument)
+or `returnCopy` (using the return value).
+
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators.
 
 ## `char_iovec`
 
-TBD
+The `char_iovec` data type represents an I/O vector (`struct iovec`) for
+scatter/gather I/O operations. Use `sizeArgIndex` to specify the vector count.
+
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators.
 
 ## `filename`
 
-TBD
+The `filename` data type represents kernel `struct filename` object and
+retrieves the user-provided filename string.
+
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
+with path strings.
 
 ## `fd`
 
-TBD
+The `fd` data type represents a file descriptor. Tetragon resolves the
+file descriptor to retrieve the associated file path.
+
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
+with path strings.
 
 ## `cred`
 
-TBD
+The `cred` data type represents kernel `struct cred` object containing
+process credentials including UIDs, GIDs, and capabilities.
 
 ## `const_buf`
 
-TBD
+The `const_buf` data type represents a buffer with a constant, statically
+known size. Specify the buffer size using the `size` field.
 
 ## `nop`
 
-TBD
+The `nop` data type instructs Tetragon to skip retrieval of the argument.
+No data is extracted for this argument position.
 
 ## `bpf_attr`
 
-TBD
+The `bpf_attr` data type represents the `union bpf_attr` structure used
+in the `bpf()` syscall for BPF-related operations.
 
 ## `perf_event`
 
-TBD
+The `perf_event` data type represents kernel `struct perf_event` object
+used for performance monitoring.
 
 ## `bpf_map`
 
-TBD
+The `bpf_map` data type represents kernel `struct bpf_map` object. It
+extracts BPF map information including name, type, and key/value sizes.
 
 ## `bpf_prog`
 
-TBD
+The `bpf_prog` data type represents kernel `struct bpf_prog` object. It
+extracts BPF program information including name and type.
 
 ## `user_namespace`
 
-TBD
+The `user_namespace` data type represents kernel `struct user_namespace`
+object. It extracts the namespace identifier.
 
 ## `capability`
 
-TBD
+The `capability` data type represents a Linux capability value being
+checked or modified.
 
 ## `kiocb`
 
-TBD
+The `kiocb` data type represents kernel `struct kiocb` (kernel I/O control
+block) object. It retrieves the file path associated with the I/O operation.
+
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
+with path strings.
+
+See general path limitations in [path retrieval limits](#pathlimits).
 
 ## `iov_iter`
 
-TBD
+The `iov_iter` data type represents kernel `struct iov_iter` object, an
+iterator for I/O operations over potentially multiple buffers.
 
 ## `load_info`
 
-TBD
+The `load_info` data type represents kernel `struct load_info` object
+containing information about a kernel module being loaded.
 
 ## `module`
 
-TBD
+The `module` data type represents kernel `struct module` object. It extracts
+kernel module information including its name.
 
 ## `syscall64`
 
-TBD
+The `syscall64` data type represents a syscall ID that distinguishes between
+64-bit and 32-bit syscall ABIs. It outputs a `SyscallId` object containing
+the syscall number and ABI (e.g., `x64`, `i386`). Commonly used with
+`raw_syscalls` tracepoints and can be filtered with named syscalls using the
+`InMap` operator.
 
 ## `kernel_cap_t`
 
-TBD
+The `kernel_cap_t` data type represents a kernel capability bitmask holding
+the complete set of Linux capabilities.
 
 ## `cap_inheritable`
 
-TBD
+The `cap_inheritable` data type extracts the inheritable capability set
+from a process's credentials (`struct cred`).
 
 ## `cap_permitted`
 
-TBD
+The `cap_permitted` data type extracts the permitted capability set
+from a process's credentials (`struct cred`).
 
 ## `cap_effective`
 
-TBD
+The `cap_effective` data type extracts the effective capability set
+from a process's credentials (`struct cred`).
 
 ## `linux_binprm`
 
 The `linux_binprm` data type represents kernel `struct linux_binprm` object
 and retrieves the `struct linux_binprm::file` full path.
 
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
+with path strings.
+
 See general path limitations in [path retrieval limits](#pathlimits).
 
 ## `data_loc`
 
-TBD
+The `data_loc` data type is used with tracepoints to extract dynamically
+located string data using the kernel's `__data_loc` mechanism.
+
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators.
 
 ## `net_device`
 
-TBD
+The `net_device` data type represents kernel `struct net_device` object.
+It extracts the network device name (e.g., `eth0`, `lo`).
+
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
+with device name strings.
 
 ## `sockaddr`
 
-TBD
+The `sockaddr` data type represents kernel `struct sockaddr` object. It
+extracts socket address information including family, IP address, port,
+or Unix socket path.
+
+In `matchArgs` or `matchData`, use `SAddr`, `SPort`, or `Family` operators. Note that
+`sockaddr` does not support destination operators (`DAddr`, `DPort`).
 
 ## `socket`
 
-TBD
+The `socket` data type represents kernel `struct socket` object (BSD socket
+layer), as opposed to `struct sock` (network layer).
+
+In `matchArgs` or `matchData`, use network operators: `SAddr`, `DAddr`, `SPort`, `DPort`,
+`Protocol`, `Family`, or `State`.
 
 ## `file`
 
 The `file` data type represents kernel `struct file` object and retrieves
 the file's full path.
+
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
+with path strings.
 
 See general path limitations in [path retrieval limits](#pathlimits).
 
@@ -232,12 +313,18 @@ This stems from the fact that with just `struct dentry` tetragon does not have
 mount information and does not have enough data to pass through main point within
 the path.
 
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
+with path strings.
+
 See general path limitations in [path retrieval limits](#pathlimits).
 
 ## `path`
 
 The `path` data type represents kernel `struct path` object retrieves
 the related path.
+
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
+with path strings.
 
 <a name="pathlimits"></a>
 


### PR DESCRIPTION




### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

Documented all "TBD" argument types with descriptions and matchArgs operator information

Fixes: #707
