### PR TITLE
Revert "fix(pkg/sensors): fixed {k,u}retprobe args merge helper."

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -1513,13 +1513,10 @@ func retprobeMerge[T evArgsRetriever](prev pendingEvent[T], curr pendingEvent[T]
 	retArgs := retEv.GetArgs()
 	enterArgs := enterEv.GetArgs()
 	for _, retArg := range *retArgs {
-		enterIdx := slices.IndexFunc(*enterArgs, func(arg api.MsgGenericKprobeArg) bool {
-			return arg.GetIndex() == retArg.GetIndex()
-		})
-		if enterIdx != -1 {
-			(*enterArgs)[enterIdx] = retArg
+		index := retArg.GetIndex()
+		if uint64(len(*enterArgs)) > index {
+			(*enterArgs)[index] = retArg
 		} else {
-			// Append it since we did not find the matching index in the enter event arguments
 			*enterArgs = append(*enterArgs, retArg)
 		}
 	}


### PR DESCRIPTION
This reverts commit 4157093815eebb134e7e8a5be23b835d88a255b6.

This commit being reverted raced another approach, Commit 3368d2f062d3 ("tetragon: make GetIndex() consistent"). While the commit being reverted in this patch is still functionally correct/valid (with or without 3368d2f062d3), it's no longer needed with 3368d2f062d3 applied because GetIndex() now returns the index within the tracing policy. As such we don't need to iterate through the args to determine the configured index.

So, revert this commit to avoid confusion in the future.