### PR TITLE
fix data source pt_regs + resolve

### DIFF
--- a/bpf/process/uprobe_preload.h
+++ b/bpf/process/uprobe_preload.h
@@ -68,6 +68,8 @@ preload_pt_regs_arg(struct pt_regs *ctx, struct event_config *config, int index)
 	val = read_reg(ctx, reg->offset, shift);
 	ty = config->arg[index];
 
+	extract_arg(config, index, &val, true);
+
 	switch (ty) {
 	case string_type:
 		return preload_string_type(ctx, config, val);


### PR DESCRIPTION
Commit https://github.com/cilium/tetragon/commit/e862ccf6b150da2cf683ce06946a3553d3a2f357 ("uprobe: use preload for resolving string args")
attempted to make extract_arg execute in a sleepable context in order to
handle page faults. It did this correctly for the preload_arg case, but
failed to properly do this for preload_pt_regs_arg. As a result, that
commit made it so that extract_arg is never executed when we specify
both data source pt_regs and resolve.

This change corrects that oversight.

This made me realize that we don't support preload for multiple arguments -- the map that holds the preload read arg has one entry per thread, so it cannot accommodate preloading multiple args. I will try to fix this in a follow-up PR (or at least reject the policy instead of allowing silent failure).