### PR TITLE
docs: add missing index field to data section examples

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -699,7 +699,8 @@ kernel `current_task` object.
 
 ```yaml
 data:
-- type: "string"
+- index: 0
+  type: "string"
   source: "current_task"
   resolve: "comm"
 selectors:

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -166,7 +166,8 @@ on all values except for `1`.
 
 ```yaml
 data:
-- type: "string"
+- index: 0
+  type: "string"
   source: "current_task"
   resolve: "pid"
 selectors:


### PR DESCRIPTION
### Description
The data section examples were missing the required index field. Added index: 0 to both examples in hooks.md and selectors.md to match the correct data section format.

When trying to load a policy with previous example Tetragon triggers this error:

```shell
level=error msg="Failed to execute tetragon" error="validation failed: spec.kprobes[0].data[0].index in body is required"
```

