### PR TITLE
Fix TestFindContainer integration test flakiness

### DIFF
--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -107,7 +107,7 @@ func (suite *ManagerTestSuite) TestFindContainer() {
 			return false
 		}
 		return true
-	}, 10*time.Second, 1*time.Second)
+	}, 30*time.Second, 1*time.Second)
 
 	// FindContainer should return the pod and container.
 	podFromCache, container, found := suite.manager.FindContainer(containerID)
@@ -121,15 +121,17 @@ func (suite *ManagerTestSuite) TestFindContainer() {
 		GracePeriodSeconds: &gracePeriod,
 	})
 	require.NoError(suite.T(), err)
-	assert.Eventually(suite.T(), func() bool {
+	require.Eventually(suite.T(), func() bool {
 		err = k8sClient.Get(context.Background(), client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name}, &podFromClient)
 		return errors.IsNotFound(err)
-	}, 10*time.Second, 1*time.Second)
+	}, 30*time.Second, 1*time.Second)
 
 	// FindContainer should still return the pod and container from the deleted pod cache.
-	podFromCache, container, found = suite.manager.FindContainer(containerID)
-	assert.True(suite.T(), found)
-	assert.Equal(suite.T(), pod.Name, podFromCache.Name)
+	require.Eventually(suite.T(), func() bool {
+		podFromCache, container, found = suite.manager.FindContainer(containerID)
+		return found
+	}, 30*time.Second, 1*time.Second)
+	require.Equal(suite.T(), pod.Name, podFromCache.Name)
 	assert.Equal(suite.T(), pod.Spec.Containers[0].Name, container.Name)
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->


### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
`TestFindContainer` integ test is flaky as reported in https://github.com/cilium/tetragon/issues/4636 . 
```
 === RUN   TestControllerSuite
level=warn msg="Unable to get Kubernetes config, using default controller-runtime config" error="unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"
level=info msg="retryCount is zero, which is invalid. Defaulting to 1"
level=info msg="created controller manager" attempts=1 duration=10.416237ms
=== RUN   TestControllerSuite/TestFindContainer
panic: runtime error: index out of range [0] with length 0

goroutine 40 [running]:
github.com/cilium/tetragon/pkg/manager.(*ManagerTestSuite).TestFindContainer.func1()
	/home/runner/work/tetragon/tetragon/pkg/manager/manager_integration_test.go:98 +0xe5
github.com/stretchr/testify/assert.Eventually.func1()
	/home/runner/work/tetragon/tetragon/vendor/github.com/stretchr/testify/assert/assertions.go:1994 +0x23
created by github.com/stretchr/testify/assert.Eventually in goroutine 114
	/home/runner/work/tetragon/tetragon/vendor/github.com/stretchr/testify/assert/assertions.go:2005 +0x193
FAIL	github.com/cilium/tetragon/pkg/manager	0.237s
```

With this patch, the tests were run using:
```
go test -v -tags=integration -failfast -count=100 ./pkg/manager -run TestControllerSuite/TestFindContainer
```
output:
```
== RUN   TestControllerSuite
=== RUN   TestControllerSuite/TestFindContainer
--- PASS: TestControllerSuite (5.08s)
    --- PASS: TestControllerSuite/TestFindContainer (5.04s)
PASS
ok      github.com/cilium/tetragon/pkg/manager  592.530s
```

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Fixed flakiness and panics in the `TestFindContainer` integration test.
```
