### PR TITLE
ci: bump RHEL8 version to RHEL 8.10

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -267,7 +267,7 @@
       ],
       // LVH uses custom versioning for its images, need to match those kinds of tags:
       // - bpf-next-20230914.012459
-      // - rhel8-20240304.134252
+      // - rhel8.10-20260206.193128
       // - 5.15-20230912.232842
       // - 5.19-20230912.232842@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
       "versioning": "regex:^((?<compatibility>[a-z0-9-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -67,7 +67,7 @@ jobs:
         matrix:
            kernel:
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
-              - 'rhel8.9-20240806.173325'
+              - 'rhel8.10-20260206.193128'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images
               - 'bpf-next-20260209.013541'
               # renovate: datasource=docker depName=quay.io/lvh-images/kernel-images


### PR DESCRIPTION
### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

As per [^1], only rhel 8.10 is still under support, let's use it in CI then.

[^1]: https://access.redhat.com/support/policy/updates/errata#RHEL8_Planning_Guide

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
ci: bump RHEL8 version to RHEL 8.10
```
