### PR TITLE
ci/e2e: Fallback to load images from registry

### DIFF
--- a/tests/e2e/install/tetragon/tetragon.go
+++ b/tests/e2e/install/tetragon/tetragon.go
@@ -168,7 +168,14 @@ func Install(opts ...Option) env.Func {
 							klog.InfoS("Image is not present locally, attempting to install Tetragon regardless", "cluster", clusterName, "image", v, "helm", k)
 							break
 						}
-						return ctx, fmt.Errorf("failed to load image %s into cluster %s: %w", v, clusterName, err)
+
+						// If failed to load the image, this could be related to kind/containerd issues, so just log
+						// the message and attempt to install Tetragon regardless. See
+						// https://github.com/kubernetes-sigs/kind/issues/3795
+						if err != nil {
+							klog.InfoS("Failed to load image into kind cluster", "cluster", clusterName, "image", v, "error", err)
+							break
+						}
 					}
 				}
 			}


### PR DESCRIPTION

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description

Don't fail the test if the image is not loaded into kind, as the error could be related other upstream issues (e.g. kind, containerd). Similar approach is already used if the images are not available locally.

Fixes: https://github.com/cilium/tetragon/issues/4656

```release-note
ci/e2e: Fallback to load images from registry
```
