### PR TITLE
bpf: Fix with_errmetrics_ptr to handle NULL pointers

### DIFF
--- a/bpf/lib/err.h
+++ b/bpf/lib/err.h
@@ -31,4 +31,9 @@ static inline long PTR_ERR(const void *ptr)
 	return (long)ptr;
 }
 
+static inline bool IS_ERR_OR_NULL(const void *ptr)
+{
+	return unlikely(!ptr) || IS_ERR_VALUE((unsigned long)ptr);
+}
+
 #endif /* BPF_ERR_H__ */

--- a/bpf/lib/errmetrics.h
+++ b/bpf/lib/errmetrics.h
@@ -69,14 +69,14 @@ errmetrics_update(__u16 error, __u8 file_id, __u16 line_nr, __u64 helper_id)
 	_err;                                                                  \
 })
 
-#define with_errmetrics_ptr(bpf_helper, ...) ({                                         \
-	__u16 fileid = get_fileid__(__FILE_NAME__);                                     \
-	if (!__builtin_constant_p(fileid) || !fileid)                                   \
-		compile_error(__FILE_NAME__, __COUNTER__);                              \
-	__auto_type _err = bpf_helper(__VA_ARGS__);                                     \
-	if (IS_ERR(_err))                                                               \
-		errmetrics_update(-PTR_ERR(_err), fileid, __LINE__, (__u64)bpf_helper); \
-	_err;                                                                           \
+#define with_errmetrics_ptr(bpf_helper, ...) ({                                                         \
+	__u16 fileid = get_fileid__(__FILE_NAME__);                                                     \
+	if (!__builtin_constant_p(fileid) || !fileid)                                                   \
+		compile_error(__FILE_NAME__, __COUNTER__);                                              \
+	__auto_type _err = bpf_helper(__VA_ARGS__);                                                     \
+	if (IS_ERR_OR_NULL(_err))                                                                       \
+		errmetrics_update(_err ? -PTR_ERR(_err) : ENOENT, fileid, __LINE__, (__u64)bpf_helper); \
+	_err;                                                                                           \
 })
 
 // To be used on error paths with a >=0 error value.


### PR DESCRIPTION

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

The with_errmetrics_ptr macro used IS_ERR() which only catches error
pointers. However, helpers like map_lookup_elem return NULL on failure,
not an error pointer. Since IS_ERR(NULL) is always false, errmetrics
tracking was never triggered for these helpers.

Add IS_ERR_OR_NULL() and use it in with_errmetrics_ptr. When the result
is an error pointer, the error code is extracted via PTR_ERR.
When the result is NULL, ENOENT is reported.


### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
bpf: Fix with_errmetrics_ptr to handle NULL pointers
```
