### PR TITLE
fix(pkg/sensors): force `__base__` sensor to be unloaded last.

### DIFF
--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -29,15 +29,13 @@ const (
 )
 
 var (
-	basePolicy = "__base__"
-
 	Execve = program.Builder(
 		config.ExecObj(),
 		"sched/sched_process_exec",
 		"tracepoint/sys_execve",
 		"event_execve",
 		"execve",
-	).SetPolicy(basePolicy)
+	).SetPolicy(sensors.BaseSensorName)
 
 	ExecveMapUpdate = program.Builder(
 		config.ExecUpdateObj(),
@@ -45,7 +43,7 @@ var (
 		"seccomp",
 		"execve_map_update",
 		"seccomp",
-	).SetPolicy(basePolicy)
+	).SetPolicy(sensors.BaseSensorName)
 
 	ExecveBprmCommit = program.Builder(
 		"bpf_execve_bprm_commit_creds.o",
@@ -53,7 +51,7 @@ var (
 		"kprobe/security_bprm_committing_creds",
 		"tg_kp_bprm_committing_creds",
 		"kprobe",
-	).SetPolicy(basePolicy)
+	).SetPolicy(sensors.BaseSensorName)
 
 	Exit = program.Builder(
 		config.ExitObj(),
@@ -61,7 +59,7 @@ var (
 		"kprobe/acct_process",
 		"event_exit",
 		"kprobe",
-	).SetPolicy(basePolicy)
+	).SetPolicy(sensors.BaseSensorName)
 
 	Fork = program.Builder(
 		config.ForkObj(),
@@ -69,7 +67,7 @@ var (
 		"kprobe/wake_up_new_task",
 		"kprobe_pid_clear",
 		"kprobe",
-	).SetPolicy(basePolicy)
+	).SetPolicy(sensors.BaseSensorName)
 
 	/* Event Ring map */
 	TCPMonMap     = program.MapBuilder("tcpmon_map", Execve)
@@ -187,7 +185,7 @@ func GetTetragonConfMap() *program.Map {
 
 func initBaseSensor() *sensors.Sensor {
 	sensor := sensors.Sensor{
-		Name: basePolicy,
+		Name: sensors.BaseSensorName,
 	}
 	setupSensor()
 	if config.EnableLargeProgs() {

--- a/pkg/sensors/base/base_windows.go
+++ b/pkg/sensors/base/base_windows.go
@@ -4,6 +4,7 @@
 package base
 
 import (
+	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/program"
 )
 
@@ -14,7 +15,7 @@ var (
 		"ProcessMonitor",
 		"process__program",
 		"windows",
-	).SetPolicy(basePolicy)
+	).SetPolicy(sensors.BaseSensorName)
 
 	ProcessRingBufMap = program.MapBuilder("process_ringbuf", CreateProcess)
 	ProcessPidMap     = program.MapBuilder("process_map", CreateProcess)

--- a/pkg/sensors/base/utils.go
+++ b/pkg/sensors/base/utils.go
@@ -3,17 +3,20 @@
 
 package base
 
-import "github.com/cilium/tetragon/pkg/sensors/program"
+import (
+	"github.com/cilium/tetragon/pkg/sensors"
+	"github.com/cilium/tetragon/pkg/sensors/program"
+)
 
 // IsExecve returns true if this is a base execve program
 func IsExecve(p *program.Program) bool {
-	return p.PinName == "event_execve" && p.Policy == basePolicy
+	return p.PinName == "event_execve" && p.Policy == sensors.BaseSensorName
 }
 
 func IsFork(p *program.Program) bool {
-	return p.PinName == "kprobe_pid_clear" && p.Policy == basePolicy
+	return p.PinName == "kprobe_pid_clear" && p.Policy == sensors.BaseSensorName
 }
 
 func IsExit(p *program.Program) bool {
-	return p.PinName == "event_exit" && p.Policy == basePolicy
+	return p.PinName == "event_exit" && p.Policy == sensors.BaseSensorName
 }

--- a/pkg/sensors/handler.go
+++ b/pkg/sensors/handler.go
@@ -15,6 +15,8 @@ import (
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
 
+var BaseSensorName = "__base__"
+
 type handler struct {
 	collections *collectionMap
 	bpfDir      string
@@ -291,7 +293,7 @@ func removeAllSensors(h *handler, unpin bool) {
 	defer h.collections.mu.Unlock()
 	collections := h.collections.c
 	for ck, col := range collections {
-		if col.name == "__base__" {
+		if col.name == BaseSensorName {
 			// Base sensor always unloaded last
 			defer func(ck collectionKey, col *collection) {
 				col.destroy(unpin)


### PR DESCRIPTION
### Description

Since many sensors depend on its maps and progs to be available, always unload it last.

The patch is the easiest possible, but we could also add a way, when creating sensors, to specify a `priority`. 
For now, that seems like a little over-engineered since we don't have any real use case for it. 


### Changelog

```release-note
fix(pkg/sensors): force `__base__` sensor to be unloaded last.
```
