### PR TITLE
logger: do not ignore time-stamped formats

### DIFF
--- a/pkg/logger/log.go
+++ b/pkg/logger/log.go
@@ -100,7 +100,7 @@ func PopulateLogOpts(o LogOptions, level string, format string) {
 	if format != "" {
 		format = strings.ToLower(format)
 		switch LogFormat(format) {
-		case logFormatText, logFormatJSON:
+		case logFormatText, logFormatTextTimestamp, logFormatJSON, logFormatJSONTimestamp:
 			o[FormatOpt] = format
 		default:
 			o[FormatOpt] = string(logFormatText)


### PR DESCRIPTION
--log-format text-ts and json-ts are currently ignored. This commit fixes it.
