### PR TITLE
docs: add kind-hook-setup.sh script for NRI configuration

### DIFF
--- a/contrib/tetragon-rthooks/scripts/kind-hook-setup.sh
+++ b/contrib/tetragon-rthooks/scripts/kind-hook-setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+SCRIPTPATH=$(dirname "$0")
+RTHOOKSPATH=$(realpath "$SCRIPTPATH/..")
+CLUSTER_NAME="kind"
+
+usage() {
+	echo "Usage: $0 [--cluster NAME] [-h|--help]"
+	echo ""
+	echo "This script sets containerd configuration to enable NRI support. "
+	echo "It assumes a single-node kind cluster named '${CLUSTER_NAME}' as created in the documentation."
+	echo ""
+	echo "Options:"
+	echo "     --cluster: override kind cluster name (default: ${CLUSTER_NAME})"
+}
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--cluster)
+			CLUSTER_NAME="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "Unknown option $1"
+			usage
+			exit 1
+			;;
+	esac
+done
+
+NODE=$(kind get nodes --name "$CLUSTER_NAME" | head -n 1)
+if [ -z "$NODE" ]; then
+	echo "No kind nodes found for cluster \"$CLUSTER_NAME\""
+	exit 1
+fi
+
+xdir=$(mktemp -d /tmp/kind-nri-setup-XXXXXX)
+trap 'rm -rf -- "$xdir"' EXIT
+
+make -C "${RTHOOKSPATH}/"
+SETUPBIN="${RTHOOKSPATH}/tetragon-oci-hook-setup"
+
+echo "Enabling containerd NRI support on $NODE"
+docker cp "${NODE}:/etc/containerd/config.toml" "$xdir/config.old.toml"
+"$SETUPBIN" patch-containerd-conf enable-nri --config-file "$xdir/config.old.toml" --output "$xdir/config.toml"
+diff -u "$xdir/config.old.toml" "$xdir/config.toml" || true
+docker cp "$xdir/config.toml" "${NODE}:/etc/containerd/config.toml"
+docker exec "$NODE" systemctl restart containerd
+echo "NRI enabled on $NODE, containerd restarted"

--- a/docs/content/en/docs/concepts/tracing-policy/k8s-filtering.md
+++ b/docs/content/en/docs/concepts/tracing-policy/k8s-filtering.md
@@ -53,11 +53,13 @@ For container field filters, we use the `containerSelector` field of tracing pol
 
 ### Setup
 
-For this demo, we use containerd and configure appropriate run-time hooks using minikube.
+For this demo, we use containerd and configure appropriate run-time hooks.
 
-First, let us start minikube, build and load images, and install Tetragon and OCI hooks:
+First, let us start a cluster, build and load images, and install Tetragon and OCI hooks:
 
-```shell
+{{< tabpane lang=shell >}}
+{{< tab "minikube" >}}
+
 minikube start --container-runtime=containerd
 ./contrib/tetragon-rthooks/scripts/minikube-install-hook.sh
 make image image-operator
@@ -68,7 +70,22 @@ helm install --namespace kube-system \
 	--set tetragon.image.override=cilium/tetragon:latest  \
 	--set tetragon.grpc.address="unix:///var/run/cilium/tetragon/tetragon.sock" \
 	tetragon ./install/kubernetes/tetragon
-```
+
+{{< /tab >}}
+{{< tab "kind" >}}
+
+kind create cluster
+./contrib/tetragon-rthooks/scripts/kind-hook-setup.sh
+make image image-operator
+kind load docker-image cilium/tetragon:latest cilium/tetragon-operator:latest
+helm install --namespace kube-system \
+	--set tetragonOperator.image.override=cilium/tetragon-operator:latest \
+	--set tetragon.image.override=cilium/tetragon:latest  \
+	--set tetragon.grpc.address="unix:///var/run/cilium/tetragon/tetragon.sock" \
+	tetragon ./install/kubernetes/tetragon
+
+{{< /tab >}}
+{{< /tabpane >}}
 
 Once the tetragon pod is up and running, we can get its name and store it in a variable for convenience.
 ```shell


### PR DESCRIPTION
### Description
Add a script to automate containerd NRI setup for kind clusters. The script patches containerd configuration to enable NRI support and restarts the containerd service.

Update documentation to include kind setup instructions alongside existing minikube instructions, using tabbed panels to show both options.

Fixes https://github.com/cilium/tetragon/issues/1960

### Changelog

```release-note
Add support for running tracing policies on kind clusters
```
