### PR TITLE
fix(eventcache): resolve missing container metadata in kprobe events

### DIFF
--- a/bpf/lib/generic.h
+++ b/bpf/lib/generic.h
@@ -78,6 +78,7 @@ struct msg_generic_kprobe {
 	__u32 tid; // Thread ID that triggered the event
 	__u64 kernel_stack_id; // Kernel stack trace ID on u32 and potential error, see flag in msg_common.flags
 	__u64 user_stack_id; // User Stack trace ID
+	__u64 cgrp_tracker_id; // Cgroup tracker ID of the process that triggered the event
 	/* anything above is shared with the userspace so it should match structs MsgGenericKprobe and MsgGenericTracepoint in Go */
 	char args[24000];
 	unsigned long a0, a1, a2, a3, a4;

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -43,7 +43,8 @@ generic_start_process_filter(void *ctx, struct bpf_map_def *calls)
 	config = map_lookup_elem(&config_map, &msg->idx);
 	if (!config)
 		return 0;
-	if (!policy_filter_check(config->policy_id))
+	msg->cgrp_tracker_id = tg_get_current_cgrp_tracker_id();
+	if (!do_policy_filter_check(config->policy_id, msg->cgrp_tracker_id))
 		return 0;
 	msg->func_id = config->func_id;
 	msg->retprobe_id = 0;

--- a/bpf/process/policy_filter.h
+++ b/bpf/process/policy_filter.h
@@ -51,30 +51,40 @@ struct {
 		});
 } policy_filter_cgroup_maps SEC(".maps");
 
-// policy_filter_check checks whether the policy applies on the current process.
-// Returns true if it does, false otherwise.
-
-FUNC_INLINE bool policy_filter_check(u32 policy_id)
+/**
+ * tg_get_current_cgrp_tracker_id() Returns tracker cgroup id of the current task or 0 on failure.
+ * If the cgroup tracker is not enabled, it returns the cgroup id of the current task.
+ */
+FUNC_INLINE __u64 tg_get_current_cgrp_tracker_id(void)
 {
-	void *policy_map;
 	__u64 cgroupid, trackerid;
 
-	if (!policy_id)
-		return true;
-
-	policy_map = map_lookup_elem(&policy_filter_maps, &policy_id);
-	if (!policy_map)
-		return false;
-
 	cgroupid = tg_get_current_cgroup_id();
-	if (!cgroupid) {
-		errmetrics(ENOENT);
-		return false;
-	}
+	if (!cgroupid)
+		return 0;
 
 	trackerid = cgrp_get_tracker_id(cgroupid);
 	if (trackerid)
 		cgroupid = trackerid;
+
+	return cgroupid;
+}
+
+// do_policy_filter_check checks whether the policy applies on a given cgroup id.
+// Returns true if it does, false otherwise.
+FUNC_INLINE bool do_policy_filter_check(__u32 policy_id, __u64 cgroupid)
+{
+	void *policy_map;
+
+	if (!policy_id)
+		return true;
+
+	if (!cgroupid)
+		return false;
+
+	policy_map = map_lookup_elem(&policy_filter_maps, &policy_id);
+	if (!policy_map)
+		return false;
 
 	if (map_lookup_elem(policy_map, &cgroupid))
 		return true; // We have a match from the podSelector and/or the containerSelector.
@@ -82,17 +92,33 @@ FUNC_INLINE bool policy_filter_check(u32 policy_id)
 	// We didn't match on the podSelector and/or the containerSelector.
 	// Now we need to check if we have a hostSelector match.
 
-	trackerid = HOST_SELECTOR_MODE;
-	if (!map_lookup_elem(policy_map, &trackerid))
-		return false; // Cannot find the match mode of the hostSelector so we do not care to match any host workloads.
+	{
+		__u64 trackerid = HOST_SELECTOR_MODE;
 
-	policy_id = ALL_PODS_POLICY_ID;
-	policy_map = map_lookup_elem(&policy_filter_maps, &policy_id);
-	if (!policy_map)
-		return false; // Cannot find the cgroupids of all containers inside all pods. This should not happen.
+		if (!map_lookup_elem(policy_map, &trackerid))
+			return false; // Cannot find the match mode of the hostSelector so we do not care to match any host workloads.
+	}
+
+	{
+		__u32 all_pods_id = ALL_PODS_POLICY_ID;
+
+		policy_map = map_lookup_elem(&policy_filter_maps, &all_pods_id);
+		if (!policy_map)
+			return false; // Cannot find the cgroupids of all containers inside all pods. This should not happen.
+	}
 
 	// If !map_lookup_elem(policy_map, &cgroupid) then our cgroupid belongs to a host workload.
 	return !map_lookup_elem(policy_map, &cgroupid);
+}
+
+// policy_filter_check checks whether the policy applies on the current process.
+// Returns true if it does, false otherwise.
+FUNC_INLINE bool policy_filter_check(__u32 policy_id)
+{
+	__u64 cgroupid;
+
+	cgroupid = tg_get_current_cgrp_tracker_id();
+	return do_policy_filter_check(policy_id, cgroupid);
 }
 
 struct {

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -58,6 +58,7 @@ type MsgGenericKprobe struct {
 	Tid           uint32 // The recorded TID that triggered the event
 	KernelStackID int64
 	UserStackID   int64
+	CgrpTrackerID uint64
 }
 
 func (m MsgGenericKprobe) HasKernelStack() bool {

--- a/pkg/api/tracingapi/client_tracepoint.go
+++ b/pkg/api/tracingapi/client_tracepoint.go
@@ -19,4 +19,5 @@ type MsgGenericTracepoint struct {
 	Tid           uint32 // The recorded TID that triggered the event
 	KernelStackID int64
 	UserStackID   int64
+	CgrpTrackerID uint64
 }

--- a/pkg/eventcache/eventcache.go
+++ b/pkg/eventcache/eventcache.go
@@ -113,6 +113,16 @@ func HandleGenericInternal(ev notify.Event, pid uint32, tid *uint32, timestamp u
 	return nil, err
 }
 
+// CgrpTrackerGetter is implemented by events that carry a cgroup tracker ID
+// from BPF for container metadata resolution.
+type CgrpTrackerGetter interface {
+	GetCgrpTrackerID() uint64
+}
+
+// ContainerIDResolver resolves a cgroup tracker ID to a container ID.
+// Set by the tracing package at init time to avoid circular imports.
+var ContainerIDResolver func(uint64) string
+
 // Generic Event handler without any extra msg specific details or debugging
 // so we only need to wait for the internal link to the process context to
 // resolve PodInfo. This happens when the msg populates the internal state
@@ -120,8 +130,28 @@ func HandleGenericInternal(ev notify.Event, pid uint32, tid *uint32, timestamp u
 func HandleGenericEvent(internal *process.ProcessInternal, ev notify.Event, tid *uint32) error {
 	p := internal.UnsafeGetProcess()
 	if option.Config.EnableK8s && p.Pod == nil {
-		CacheRetries(PodInfo).Inc()
-		return ErrFailedToGetPodInfo
+		docker := p.Docker
+		if docker == "" {
+			if g, ok := ev.(CgrpTrackerGetter); ok && ContainerIDResolver != nil {
+				if id := g.GetCgrpTrackerID(); id != 0 {
+					docker = ContainerIDResolver(id)
+				}
+			}
+		}
+		if docker != "" {
+			podInfo := process.GetPodInfo(docker, p.Binary, p.Arguments, 0)
+			if podInfo == nil {
+				CacheRetries(PodInfo).Inc()
+				return ErrFailedToGetPodInfo
+			}
+			internal.AddPodInfo(podInfo)
+			if p.Docker == "" {
+				internal.UnsafeGetProcess().Docker = docker
+			}
+		} else {
+			CacheRetries(PodInfo).Inc()
+			return ErrFailedToGetPodInfo
+		}
 	}
 
 	// When we report the per thread fields, take a copy

--- a/pkg/grpc/tracing/cgidmap_resolve.go
+++ b/pkg/grpc/tracing/cgidmap_resolve.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows && !nok8s
+
+package tracing
+
+import (
+	"github.com/cilium/tetragon/pkg/cgidmap"
+	"github.com/cilium/tetragon/pkg/eventcache"
+)
+
+func init() {
+	eventcache.ContainerIDResolver = resolveContainerID
+}
+
+// resolveContainerID resolves a cgroup tracker ID to a container ID using
+// cgidmap. The tracker ID is already resolved in BPF, so no additional
+// cgtracker lookup is needed.
+func resolveContainerID(cgrpTrackerID uint64) string {
+	if cgrpTrackerID == 0 {
+		return ""
+	}
+	m, err := cgidmap.GlobalMap()
+	if err != nil {
+		return ""
+	}
+	if containerID, ok := m.Get(cgrpTrackerID); ok {
+		return containerID
+	}
+	return ""
+}

--- a/pkg/grpc/tracing/cgidmap_resolve_stub.go
+++ b/pkg/grpc/tracing/cgidmap_resolve_stub.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build windows || nok8s
+
+package tracing
+
+// No ContainerIDResolver registration needed on platforms without cgidmap.
+// eventcache.ContainerIDResolver remains nil, and the type switch gracefully
+// handles the absence.

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -399,7 +399,10 @@ func GetProcessKprobe(event *MsgGenericKprobeUnix) *tetragon.ProcessKprobe {
 	if ec := eventcache.Get(); ec != nil && !isUnknown(tetragonProcess) &&
 		(ec.Needed(tetragonProcess) ||
 			(tetragonProcess.Pid.Value > 1 && ec.Needed(tetragonParent)) ||
-			(option.Config.EnableProcessKprobeAncestors && ec.NeededAncestors(parent, ancestors))) {
+			(option.Config.EnableProcessKprobeAncestors && ec.NeededAncestors(parent, ancestors)) ||
+			// Clone-to-exec race: cache events with no container
+			// metadata so retry can resolve via cgidmap.
+			(option.Config.EnableK8s && tetragonProcess.Docker == "" && tetragonProcess.Pod == nil && event.Msg.CgrpTrackerID != 0)) {
 		ec.Add(nil, tetragonEvent, event.Msg.Common.Ktime, event.Msg.ProcessKey.Ktime, event)
 		return nil
 	}
@@ -511,6 +514,10 @@ func (msg *MsgGenericTracepointUnix) RetryInternal(ev notify.Event, timestamp ui
 
 func (msg *MsgGenericTracepointUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
 	return eventcache.HandleGenericEvent(internal, ev, &msg.Msg.Tid)
+}
+
+func (msg *MsgGenericTracepointUnix) GetCgrpTrackerID() uint64 {
+	return msg.Msg.CgrpTrackerID
 }
 
 func familyString(family uint16) string {
@@ -774,6 +781,10 @@ func (msg *MsgGenericKprobeUnix) Retry(internal *process.ProcessInternal, ev not
 	return eventcache.HandleGenericEvent(internal, ev, &msg.Msg.Tid)
 }
 
+func (msg *MsgGenericKprobeUnix) GetCgrpTrackerID() uint64 {
+	return msg.Msg.CgrpTrackerID
+}
+
 func (msg *MsgGenericKprobeUnix) HandleMessage() *tetragon.GetEventsResponse {
 	k := GetProcessKprobe(msg)
 	if k == nil {
@@ -909,6 +920,10 @@ func (msg *MsgGenericUprobeUnix) Retry(internal *process.ProcessInternal, ev not
 	return eventcache.HandleGenericEvent(internal, ev, &msg.Msg.Tid)
 }
 
+func (msg *MsgGenericUprobeUnix) GetCgrpTrackerID() uint64 {
+	return msg.Msg.CgrpTrackerID
+}
+
 func GetProcessUprobe(event *MsgGenericUprobeUnix) *tetragon.ProcessUprobe {
 	var ancestors []*process.ProcessInternal
 	var tetragonAncestors []*tetragon.Process
@@ -1020,6 +1035,10 @@ func (msg *MsgGenericUsdtUnix) Retry(internal *process.ProcessInternal, ev notif
 	return eventcache.HandleGenericEvent(internal, ev, &msg.Msg.Tid)
 }
 
+func (msg *MsgGenericUsdtUnix) GetCgrpTrackerID() uint64 {
+	return msg.Msg.CgrpTrackerID
+}
+
 func GetProcessUsdt(event *MsgGenericUsdtUnix) *tetragon.ProcessUsdt {
 	var ancestors []*process.ProcessInternal
 	var tetragonAncestors []*tetragon.Process
@@ -1120,6 +1139,10 @@ func (msg *MsgGenericLsmUnix) RetryInternal(ev notify.Event, timestamp uint64) (
 
 func (msg *MsgGenericLsmUnix) Retry(internal *process.ProcessInternal, ev notify.Event) error {
 	return eventcache.HandleGenericEvent(internal, ev, &msg.Msg.Tid)
+}
+
+func (msg *MsgGenericLsmUnix) GetCgrpTrackerID() uint64 {
+	return msg.Msg.CgrpTrackerID
 }
 
 func (msg *MsgGenericLsmUnix) HandleMessage() *tetragon.GetEventsResponse {


### PR DESCRIPTION


Fixes: #4152





### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

When a kprobe fires during execve (e.g. `security_bprm_creds_for_exec` triggered by `kubectl exec`), the process entry in the cache comes from the clone event and has no Docker ID or Pod info. The exec event creates a separate cache entry under a different ExecId (different ktime), so the kprobe handler only finds the stale clone-based entry. These events bypassed the event cache entirely because `Needed()` only cached events with a non-empty Docker ID, so they were emitted immediately with missing container metadata.

### Changes
- Add `cgrpid` field to BPF `msg_generic_kprobe` and set it via  `tg_get_current_cgroup_id()` in `generic_start_process_filter`
- Add matching `Cgrpid` field to Go `MsgGenericKprobe` and  `MsgGenericTracepoint` structs
- Force-cache kprobe events where Docker and Pod are both empty  and cgrpid is non-zero
- Use `cgidmap.Get(cgrpid)` in `HandleGenericEvent` on retry to  resolve container ID (with CgTrackerID support), then resolve  pod info from the container ID
- Remove `GetByPidWithContainerInfo` PID-based lookup

Requires `--enable-cgidmap` and `--enable-cri`

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Fixed missing container metadata (pod name, namespace, container ID) in kprobe events when a tracing policy matches during `kubectl exec`
```
