### PR TITLE
test: improve uniqueness of pod names in TestFindContainer

### DIFF
--- a/pkg/manager/manager_integration_test.go
+++ b/pkg/manager/manager_integration_test.go
@@ -8,6 +8,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -76,7 +77,7 @@ func (suite *ManagerTestSuite) TestFindPod() {
 
 func (suite *ManagerTestSuite) TestFindContainer() {
 	// Create a pod with a unique name to avoid collisions.
-	name := fmt.Sprintf("nginx-%d", time.Now().UnixNano())
+	name := fmt.Sprintf("nginx-%d", rand.Intn(1000000))
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,


### PR DESCRIPTION
This PR improves the uniqueness of pod names in `TestFindContainer` by using a random integer instead of a nanosecond timestamp. This helps avoid potential collisions in environments where tests might run in parallel or where the clock resolution is limited.

Suggested by Shagnik Sarkar's AI assistant.