### PR TITLE
Revert "ci: Fix package e2e tests GHA"

### DIFF
--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Install Tetragon Tarball
         run: |
-          gzip -dc tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz | tar -zxvf - 
+          tar zxvf tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz
           sudo ./tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}/install.sh
         working-directory: ./build/${{ matrix.arch }}/linux-tarball/
 


### PR DESCRIPTION
This reverts commit 854fe5f40336f0c136bf624e609d199f72cea863.

https://github.com/cilium/tetragon/commit/854fe5f40336f0c136bf624e609d199f72cea863 was required because the tarball was double gzip'ed. The
tarball is no longer double gzip'ed, so revert.

If we run into this problem again, we should handle it by ensuring that the tarball is only gzip'ed once.

[Here](https://github.com/cilium/tetragon/actions/runs/22236687712/job/64330369791?pr=4666) is an example of how CI is failing without this revert.

```
gzip -dc tetragon-0f16f81-arm64.tar.gz | tar -zxvf - 
  sudo ./tetragon-0f16f81-arm64/install.sh
  shell: /usr/bin/bash -e {0}

gzip: stdin: not in gzip format
tar: Child died with signal 13
tar: Error is not recoverable: exiting now
```