### PR TITLE
test: Fix the defined but not used variable in arm

### DIFF
--- a/contrib/tester-progs/regs-override.c
+++ b/contrib/tester-progs/regs-override.c
@@ -58,9 +58,9 @@ __asm__ (
 );
 #endif
 
+#if defined(__x86_64__)
 static const char *test_3_string = "test_3_string_CASE";
 
-#if defined(__x86_64__)
 static __naked unsigned long test_3()
 {
 	asm volatile (


### PR DESCRIPTION
This is to avoid the compilication failure in arm64.


```release-note
test: Fix the defined but not used variable in arm
```
