### PR TITLE
fix(process/cache): balance parent refcount ops during LRU eviction (1.5)

### DIFF
--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -144,19 +144,41 @@ func NewCache(
 	processCacheSize int,
 	GCInterval time.Duration,
 ) (*Cache, error) {
+	// Stash a reference to the Cache to refer to later in the eviction closure.
+	pm := &Cache{
+		size: processCacheSize,
+	}
+
 	lruCache, err := lru.NewWithEvict(
 		processCacheSize,
-		func(_ string, _ *ProcessInternal) {
+		func(_ string, evicted *ProcessInternal) {
 			processCacheEvictions.Inc()
+
+			// Perform parent-- for LRU-evicted entries that will never
+			// reach the exit handler.
+
+			// Skip non-inUse entries whose exit path already performed parent--
+			if evicted.color != inUse {
+				return
+			}
+
+			// Is the parent still in the cache?
+			if evicted.process == nil {
+				return
+			}
+			parent, ok := pm.cache.Peek(evicted.process.ParentExecId)
+			if !ok {
+				return
+			}
+
+			pm.refDec(parent, "parent--")
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
-	pm := &Cache{
-		cache: lruCache,
-		size:  processCacheSize,
-	}
+
+	pm.cache = lruCache
 	pm.cacheGarbageCollector(GCInterval)
 	return pm, nil
 }


### PR DESCRIPTION
## Description

Backport of 8c9cf10b7 from `main` to `v1.5`.

When a child process gets LRU-evicted under cache pressure before its exit event arrives, the eviction callback only increments a metric without performing the parent refcount decrement. The child's exit handler later cannot find the child in the cache, so `parent--` never fires. This leaves the parent's refcount permanently elevated, preventing garbage collection and causing stale entries to accumulate — increasing eviction pressure further.

This fix decrements the parent refcount in the eviction callback, but only for entries still marked `inUse` (whose normal exit path has not already handled it), avoiding a double-decrement for normally-exiting processes.