### PR TITLE
[v1.6] Revert "ci: Fix package e2e tests GHA"

### DIFF
--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Install Tetragon Tarball
         run: |
-          gzip -dc tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz | tar -zxvf - 
+          tar zxvf tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz
           sudo ./tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}/install.sh
         working-directory: ./build/${{ matrix.arch }}/linux-tarball/
 


### PR DESCRIPTION
[ upstream commit eacd983876450a1d2faf62ef691195180c183805 ]

This reverts commit 854fe5f40336f0c136bf624e609d199f72cea863.

854fe5f40336 was required because the tarball was double gzip'ed. The tarball is no longer double gzip'ed, so revert.

Upstream PR: https://github.com/cilium/tetragon/pull/4633
