### PR TITLE
fix: Added WaitCRDsWithResync with resync period

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -138,6 +138,26 @@ func (cm *ControllerManager) ListNamespaces() ([]corev1.Namespace, error) {
 	return namespaceList.Items, nil
 }
 
+// WaitCRDs waits for the specified Custom Resource Definitions (CRDs) to become available
+// in the Kubernetes cluster using a simple event-driven approach. This method sets up an
+// event handler that responds to CRD addition events and completes when all required CRDs
+// are found. It does not perform periodic resyncs or cache refreshes, making it suitable
+// for scenarios where CRDs are expected to be created shortly after startup and network
+// connectivity is stable.
+//
+// Use WaitCRDs when:
+//   - You expect CRDs to be available soon after application startup
+//   - Network connectivity to the API server is reliable
+//   - You want minimal resource overhead (no periodic resyncs)
+//   - The application can tolerate potentially missing CRDs that exist but weren't detected
+//     due to missed events or temporary network issues
+//
+// Parameters:
+//   - ctx: Context for cancellation
+//   - crds: Map of CRD names to wait for (map keys are CRD names, values are ignored)
+//
+// Returns:
+//   - error: Non-nil if waiting fails or context is cancelled
 func (cm *ControllerManager) WaitCRDs(ctx context.Context, crds map[string]struct{}) error {
 	log := logger.GetLogger()
 	log.Info("Waiting for required CRDs", "crds", crds)
@@ -173,6 +193,151 @@ func (cm *ControllerManager) WaitCRDs(ctx context.Context, crds map[string]struc
 	if err != nil {
 		log.Warn("failed to remove CRD informer", logfields.Error, err)
 	}
+	return nil
+}
+
+// WaitCRDsWithResync waits for the specified Custom Resource Definitions (CRDs) to become
+// available with enhanced reliability through periodic cache resyncs and comprehensive
+// error handling. This method first checks the existing cache for CRDs, then sets up an
+// event handler with a configurable resync period to ensure missed events are recovered.
+// The resync mechanism periodically refreshes the cache, making this approach more robust
+// against network issues, missed events, or temporary API server connectivity problems.
+//
+// Applications can use WaitCRDsWithResync when:
+// - You need guaranteed detection of existing CRDs that might be missed due to timing issues
+// - Network connectivity to the API server may be unreliable
+// - You can afford the additional resource overhead of periodic resyncs for improved reliability
+// - Long-running applications where CRDs might be created at any time during execution
+//
+// The method performs an initial cache check for efficiency, avoiding unnecessary waiting
+// if all required CRDs already exist. The resync period should be chosen based on your
+// tolerance for detection delay versus resource usage.
+//
+// Parameters:
+//   - ctx: Context for cancellation
+//   - crds: Map of CRD names to wait for (map keys are CRD names, values are ignored)
+//   - resyncPeriod: How often to refresh the cache and re-evaluate existing CRDs
+//
+// Returns:
+//   - error: Non-nil if waiting fails or context is cancelled
+func (cm *ControllerManager) WaitCRDsWithResync(ctx context.Context, crds map[string]struct{}, resyncPeriod time.Duration) error {
+	log := logger.GetLogger()
+	log.Info("Waiting for required CRDs with resync", "crds", crds, "resyncPeriod", resyncPeriod)
+
+	// If no CRDs to wait for, return immediately
+	if len(crds) == 0 {
+		log.Info("No CRDs to wait for")
+		return nil
+	}
+
+	// Get CRD informer to watch for CRD events
+	crdInformer, err := cm.Manager.GetCache().GetInformer(ctx, &apiextensionsv1.CustomResourceDefinition{})
+	if err != nil {
+		log.Error("Failed to get CRD informer", logfields.Error, err)
+		return err
+	}
+
+	// Check if the informer has synced before relying on it.
+	// If not, log a message but continue with event handler approach.
+	if !crdInformer.HasSynced() {
+		log.Info("Informer cache not synced yet")
+	}
+
+	// Make a copy of crds to avoid modifying the original map
+	remainingCRDs := make(map[string]struct{})
+	for crd := range crds {
+		remainingCRDs[crd] = struct{}{}
+	}
+
+	// Check the cache first for existing CRDs
+	existingCRDs := &apiextensionsv1.CustomResourceDefinitionList{}
+	err = cm.Manager.GetCache().List(ctx, existingCRDs)
+	if err != nil {
+		log.Warn("Failed to list existing CRDs from cache", logfields.Error, err)
+		// Continue with event handler approach
+	} else {
+		for _, crdObject := range existingCRDs.Items {
+			if _, required := remainingCRDs[crdObject.Name]; required {
+				log.Info("Found CRD in cache", "crd", crdObject.Name)
+				delete(remainingCRDs, crdObject.Name)
+			}
+		}
+	}
+
+	// If all CRDs already exist, we're done
+	if len(remainingCRDs) == 0 {
+		log.Info("Found all required CRDs in cache")
+		return nil
+	}
+
+	log.Debug("Still waiting for CRDs", "remaining", remainingCRDs)
+
+	// Set up waiting mechanism for remaining CRDs
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	completed := false
+	var once sync.Once
+	finish := func() {
+		once.Do(func() {
+			close(done)
+			wg.Done()
+		})
+	}
+
+	_, err = crdInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			if completed {
+				return
+			}
+			crdObject, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+			if !ok {
+				log.Warn("Received an invalid object", "obj", obj)
+				return
+			}
+			if _, required := remainingCRDs[crdObject.Name]; required {
+				log.Info("Found CRD", "crd", crdObject.Name)
+				delete(remainingCRDs, crdObject.Name)
+				if len(remainingCRDs) == 0 {
+					log.Info("Found all the required CRDs")
+					completed = true
+					finish()
+				}
+			}
+		},
+	}, resyncPeriod)
+	if err != nil {
+		// Check if this is due to informer being stopped (context cancelled during startup)
+		if ctx.Err() != nil {
+			log.Info("Context cancelled while setting up CRD waiting", logfields.Error, ctx.Err())
+			return ctx.Err()
+		}
+		log.Error("failed to add CRD event handler", logfields.Error, err)
+		return err
+	}
+
+	// Wait with context cancellation
+	go func() {
+		select {
+		case <-ctx.Done():
+			log.Info("Context cancelled while waiting for CRDs", logfields.Error, ctx.Err())
+			finish()
+		case <-done:
+			// CRDs found, normal completion
+		}
+	}()
+
+	wg.Wait()
+
+	// Check if context was cancelled
+	if ctx.Err() != nil {
+		// Context was cancelled before finding all CRDs
+		return ctx.Err()
+	}
+
+	// Do not remove the informer, as GetInformer may return a shared informer that is used elsewhere.
+	// We're only adding an event handler, not owning the informer.
+	// The controller-runtime manager handles informer cleanup automatically when stopped
 	return nil
 }
 


### PR DESCRIPTION
Fixes #4707

### Description
Problem:
Client uses Tetragon controller manager for connecting to external K8s api_server and getting resources from CRDs.
There appears to be a race condition:
If WaitCRDs is called early when initial sync might still be in progress, but the Informer's AddFunc only triggers on new CRD events. Then we'd miss that CRD and wait for the CRD that's already there. 
Also, error we see is from s.stopped where the informer is getting stopped, as a result of RemoveInformer. This can cause race condition using the shared informer, where one stops it while another tries to add handler, from the same informer cache. The client has more than 1 CRD, trying to access at startup. 

Error message:
```
time=2026-02-24T19:58:13Z level=error msg="failed to add event handler" error="handler {0x18139c0 <nil> <nil>} 
```
 
 The default resync period for AddEventHandler() in controller-runtime is 10 hours (defaultSyncPeriod = 10 * time.Hour).
In controller-runtime/pkg/cache/cache.go
var (
	defaultSyncPeriod = 10 * time.Hour
)


### Solution:
- Added a new function WaitCRDsWithResync, instead of modifying existing WaitCRDs.
- Use AddEventHandlerWithResyncPeriod with configurable resync period from caller, instead of default 10h
- Add completion flag to prevent duplicate processing after CRDs found
- Add context cancellation handling for graceful shutdown in the client

Behavior Flow Before (AddEventHandler):
1. Informer starts
2. Initial cache sync happens → AddFunc called for existing CRDs. The CRD we are looking is not present.
3. Wait indefinitely for new CRD events
4. Only get AddFunc calls when NEW CRDs are created.
5. Resync every 10 HOURS (default) → AddFunc called for ALL existing CRDs
6. RemoveInformer, when found.

Behavior Flow After (WaitCRDsWithResync with AddEventHandlerWithResyncPeriod):
1. Informer starts  
2. Check if CRDs already in cache -> We have what we need, return immediately. No event handler needed.
3. For CRDs missing from cache, 
  4. Initial cache sync happens → AddFunc called for existing CRDs. The CRD we are looking is not present.
  5. Wait for new CRD events OR resync
  7. Get AddFunc calls when NEW CRDs are created
  8. Resync every configurable SECONDS → AddFunc called for ALL existing CRDs. The CRD can be found.
  9. Context cancellation handling → graceful shutdown

### Logs from Client invocation:
err = kubernetesManager.WaitCRDsWithResync(ctx, crds, 60*time.Second)
```
time=2026-02-28T17:20:55Z level=info msg="starting Kubernetes Manager for on-prem deployment"                         
...
time=2026-02-28T17:20:55Z level=info msg="Waiting for required CRDs with resync" crds=map[smartswitchnetworkpolicies.isovalent.com:{}] resyncPeriod=1m0s
time=2026-02-28T17:20:56Z level=info msg="Found CRD in cache" crd=smartswitchnetworkpolicies.isovalent.com            
time=2026-02-28T17:20:56Z level=info msg="Found all required CRDs in cache"  
```
```
time=2026-02-28T01:11:50Z level=info msg="Waiting for required CRDs with resync" crds=map[smartswitchnetworkpolicies.isovalent.com:{}] resyncPeriod=1m0s                   
...                                    
time=2026-02-28T01:11:50Z level=info msg="\"Warning: resync period is smaller than resync check period and the informer has already started. Changing it to the resync check period\" resyncPeriod=\"30s\" resyncCheckPeriod=\"9h27m38.395867694s\"" subsys=klog                                                                                                                             
time=2026-02-28T01:11:50Z level=info msg="Found CRD" crd=smartswitchnetworkpolicies.isovalent.com                               
time=2026-02-28T01:11:50Z level=info msg="Found all the required CRDs"
```

Detailed notes of the fix:
```
### Introduces New WaitCRDsWithResync function that addresses CRD Wait Mechanism
#### Fixes Missing CRDs During Early Initialization in WaitCRDsWithResync
- **Problem**: If `WaitCRDs` was called early when initial sync might still be in progress, the `AddFunc` would only trigger on new CRD events, causing the function to miss CRDs that were already present in the cluster
- **Solution**: Added cache pre-check that queries existing CRDs from the informer cache before setting up event handlers
- **Cache validation**: Check `informer.HasSynced()` to detect if cache is not yet synchronized
- **Immediate detection**: CRDs already present in the cache are detected immediately without waiting for events
- **Fallback mechanism**: If cache listing fails, the function gracefully falls back to event-driven approach

#### Fixes SharedIndexInformer Race Condition in multiple waitCRDs calls
 - **Problem**: The `WaitCRDs` function was calling `RemoveInformer()` after waiting for CRDs, which could cause race conditions where other parts of the code would get "handler was not added to shared informer because it has stopped already" intermittent errors when trying to add event handlers to the same shared informer
- **Root Cause**: Controller-runtime returns shared informers via `GetInformer()`, and removing them affects other consumers to use same shared CRD informer later
- **Solution**: Did not add `cm.Manager.GetCache().RemoveInformer(ctx, &apiextensionsv1.CustomResourceDefinition{})` call in `WaitCRDsWithResync`

#### New AddEventHandlerWithResyncPeriod in WaitCRDsWithResync
- **Resync support**: Enhanced `WaitCRDsWithResync` function now uses `AddEventHandlerWithResyncPeriod` instead of basic `AddEventHandler`
- **Configurable resync period**: Allows specification of resync period for CRD discovery operations to handle missed events
- **Improved reliability**: Periodic resync ensures CRDs are detected even if initial events are missed during informer startup
- **Context Cancel Aware**: Handling context cancel during resync wait period
```

### Release note
```release-note
Introduces WaitCRDsWithResync function with cache pre-check, configurable resync period, cancel context aware, and eliminates SharedIndexInformer race conditions by avoiding RemoveInformer calls.
```
