### PR TITLE
bpf: use FNV-1a variant for ratelimit hash

### DIFF
--- a/bpf/process/heap.h
+++ b/bpf/process/heap.h
@@ -9,7 +9,7 @@
 struct heap_ro_value {
 	union {
 		char string_maps_heap[STRING_MAPS_HEAP_SIZE];
-		char ratelimit_heap[sizeof(struct ratelimit_key) + 128];
+		char ratelimit_heap[sizeof(struct ratelimit_key) + MAX_HASH_BYTES];
 	};
 };
 

--- a/bpf/process/ratelimit_maps.h
+++ b/bpf/process/ratelimit_maps.h
@@ -4,12 +4,6 @@
 #ifndef __RATELIMIT_MAPS_H__
 #define __RATELIMIT_MAPS_H__
 
-/* The number of bytes per argument to include in the key
- * that we use to check for repeating data.
- * 40 is good for IPv6 data.
- */
-#define KEY_BYTES_PER_ARG 40
-
 /* Can't really include generic.h in here..
  */
 #define MAX_POSSIBLE_ARGS 5
@@ -19,11 +13,50 @@
 #define ACTION_RATE_LIMIT_SCOPE_PROCESS 1
 #define ACTION_RATE_LIMIT_SCOPE_GLOBAL	2
 
+/* FNV-1a hash constants for 64-bit. */
+#define FNV1A_64_INIT  ((__u64)0xcbf29ce484222325ULL)
+#define FNV1A_64_PRIME ((__u64)0x100000001b3ULL)
+
+/*
+ * Maximum bytes of each argument to hash for the rate-limit dedup key.
+ *
+ * We hash up to MAX_HASH_BYTES of each arg with FNV-1a, producing
+ * one u64 per arg. copy_path() already caps paths at 255 bytes
+ * (size &= 0xff), so 255 matches that cap exactly and fits within
+ * the BPF verifier loop bound.
+ */
+#define MAX_HASH_BYTES 255
+
+/*
+ * FNV-1a hash of up to MAX_HASH_BYTES of src into a single u64.
+ */
+static inline __attribute__((always_inline)) __u64
+fnv1a_hash_bytes(char *src, __u32 len)
+{
+	__u64 hash = FNV1A_64_INIT;
+	__u32 i;
+
+	if (len > MAX_HASH_BYTES)
+		len = MAX_HASH_BYTES;
+	/* Mask len so the verifier can prove the loop bound. */
+	asm volatile("%[len] &= 0xff;\n"
+		     : [len] "+r"(len)
+		     :);
+
+	for (i = 0; i < MAX_HASH_BYTES; i++) {
+		if (i >= len)
+			break;
+		hash ^= (__u64)(__u8)src[i];
+		hash *= FNV1A_64_PRIME;
+	}
+	return hash;
+}
+
 struct ratelimit_key {
 	__u64 func_id;
 	__u64 action;
 	__u64 tid;
-	__u8 data[MAX_POSSIBLE_ARGS * KEY_BYTES_PER_ARG];
+	__u64 arg_hash[MAX_POSSIBLE_ARGS];
 };
 
 struct ratelimit_value {
@@ -37,13 +70,11 @@ struct {
 	__type(value, struct ratelimit_value);
 } ratelimit_map SEC(".maps");
 
-// The value has extra headroom to allow copying argument data without upsetting the verifier.
-// This is not hashed when the key is used in the ratelimit_map.
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
 	__type(key, __u32);
-	__type(value, __u8[sizeof(struct ratelimit_key) + 128]);
+	__type(value, __u8[sizeof(struct ratelimit_key) + MAX_HASH_BYTES]); // Extra headroom after the key for probe_read scratch space.
 } ratelimit_heap SEC(".maps");
 
 #endif /* __RATELIMIT_MAPS_H__ */

--- a/bpf/process/ratelimit_maps.h
+++ b/bpf/process/ratelimit_maps.h
@@ -14,8 +14,8 @@
 #define ACTION_RATE_LIMIT_SCOPE_GLOBAL	2
 
 /* FNV-1a hash constants for 64-bit. */
-#define FNV1A_64_INIT  ((__u64)0xcbf29ce484222325ULL)
-#define FNV1A_64_PRIME ((__u64)0x100000001b3ULL)
+#define FNV_OFFSET_BASIS 0xcbf29ce484222325ULL
+#define FNV_PRIME        0x100000001b3ULL
 
 /*
  * Maximum bytes of each argument to hash for the rate-limit dedup key.
@@ -27,28 +27,59 @@
  */
 #define MAX_HASH_BYTES 255
 
+/* MurmurHash3 fmix64 finalizer — guarantees full avalanche. */
+static inline __attribute__((always_inline)) __u64
+fnv1a_wordmix_fmix64(__u64 h)
+{
+	h ^= h >> 33;
+	h *= 0xff51afd7ed558ccdULL;
+	h ^= h >> 33;
+	h *= 0xc4ceb9fe1a85ec53ULL;
+	h ^= h >> 33;
+	return h;
+}
+
 /*
  * FNV-1a hash of up to MAX_HASH_BYTES of src into a single u64.
+ * Processes 8-byte words for efficiency, with fmix64 avalanche finalizer.
  */
 static inline __attribute__((always_inline)) __u64
-fnv1a_hash_bytes(char *src, __u32 len)
+fnv1a_wordmix_hash_bytes(char *src, __u32 len)
 {
-	__u64 hash = FNV1A_64_INIT;
-	__u32 i;
+	__u64 hash = FNV_OFFSET_BASIS;
+	__u32 i = 0;
+	__u64 word;
 
 	if (len > MAX_HASH_BYTES)
 		len = MAX_HASH_BYTES;
-	/* Mask len so the verifier can prove the loop bound. */
+	// Mask len so the verifier can prove the loop bound.
 	asm volatile("%[len] &= 0xff;\n"
 		     : [len] "+r"(len)
 		     :);
 
-	for (i = 0; i < MAX_HASH_BYTES; i++) {
+	// Process 8-bytes per iteration vs 1-byte per iteration in FNV-1a.
+	for (__u32 j = 0; j < MAX_HASH_BYTES / 8; j++) {
+		if (i + 8 > len)
+			break;
+		__builtin_memcpy(&word, &src[i], sizeof(word));
+		hash ^= word;
+		hash *= FNV_PRIME;
+		i += 8;
+	}
+
+	// Process remaining bytes (at most 7).
+	for (__u32 j = 0; j < 7; j++) {
 		if (i >= len)
 			break;
 		hash ^= (__u64)(__u8)src[i];
-		hash *= FNV1A_64_PRIME;
+		hash *= FNV_PRIME;
+		i++;
 	}
+
+	// Apply MurmurHash finalizer to ensure bit mixing.
+	hash ^= (__u64)len;
+	hash = fnv1a_wordmix_fmix64(hash);
+
 	return hash;
 }
 

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -2456,7 +2456,7 @@ rate_limit(__u64 ratelimit_interval, __u64 ratelimit_scope, struct msg_generic_k
 				     : [arg_size] "+r"(arg_size)
 				     :);
 			probe_read(scratch, arg_size, &e->args[key_index]);
-			key->arg_hash[i] = fnv1a_hash_bytes(scratch, arg_size);
+			key->arg_hash[i] = fnv1a_wordmix_hash_bytes(scratch, arg_size);
 		}
 	}
 

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -2404,11 +2404,10 @@ rate_limit(__u64 ratelimit_interval, __u64 ratelimit_scope, struct msg_generic_k
 	struct ratelimit_key *key;
 	void *ro_heap;
 	__u32 zero = 0;
-	__u32 index = 0;
 	__u32 key_index = 0;
 	int arg_size;
 	int i;
-	__u8 *dst;
+	char *scratch;
 
 	if (!ratelimit_interval)
 		return false;
@@ -2435,8 +2434,10 @@ rate_limit(__u64 ratelimit_interval, __u64 ratelimit_scope, struct msg_generic_k
 	}
 
 	// Clean the heap
-	probe_read(key->data, MAX_POSSIBLE_ARGS * KEY_BYTES_PER_ARG, ro_heap);
-	dst = key->data;
+	probe_read(key->arg_hash, sizeof(key->arg_hash), ro_heap);
+
+	// Scratch buffer sits right after the key in the heap.
+	scratch = (char *)key + sizeof(*key);
 
 	for (i = 0; i < MAX_POSSIBLE_ARGS; i++) {
 		if (arg_idx(i) == -1)
@@ -2449,16 +2450,13 @@ rate_limit(__u64 ratelimit_interval, __u64 ratelimit_scope, struct msg_generic_k
 			arg_size = e->common.size - e->argsoff[i] + sizeof(arg_status_t);
 		if (arg_size > 0) {
 			key_index = (e->argsoff[i] - sizeof(arg_status_t)) & 16383;
-			if (arg_size > KEY_BYTES_PER_ARG)
-				arg_size = KEY_BYTES_PER_ARG;
-			asm volatile("%[arg_size] &= 0x3f;\n" // ensure this mask is greater than KEY_BYTES_PER_ARG
+			if (arg_size > MAX_HASH_BYTES)
+				arg_size = MAX_HASH_BYTES;
+			asm volatile("%[arg_size] &= 0xff;\n" // ensure this mask is greater than MAX_HASH_BYTES
 				     : [arg_size] "+r"(arg_size)
 				     :);
-			asm volatile("%[index] &= 0xff;\n"
-				     : [index] "+r"(index)
-				     :);
-			probe_read(&dst[index], arg_size, &e->args[key_index]);
-			index += arg_size;
+			probe_read(scratch, arg_size, &e->args[key_index]);
+			key->arg_hash[i] = fnv1a_hash_bytes(scratch, arg_size);
 		}
 	}
 


### PR DESCRIPTION
FNV-1a is a very simple non-cryptographic hash algorithm. It accumulates
each byte of input using an XOR and a multiply. As a result, its code
size is ~10x smaller than comparable hash functions.

However byte-by-byte hash functions often struggle over large input.
Here, FNV-1a is nearly 10x slower than a comparable algorithm, Murmur
Hash, for 1K inputs (about the upper bound of what we'd care about
here).

Word-by-word hash functions like Murmur Hash can be much faster but risk
insufficient "mixing" across bits within each word. To provide this
bit-mixing, Murmur Hash defines a final mixer ("fmix").

A relatively common way of repurposing a byte-by-byte hasher to word
size is to add a mixer and doing so here with "fmix" on top of FNV-1a
has great results with no loss of collision-resistence, randomness, or
skewedness.

Code size:

FNV-1a 8mix - 100 ins
FNV-1a      -  35 ins
MurmurHash3 - 350 ins
Jenkins     - 400 ins

1K Hash Speed:

FNV-1a 8mix -  150 ns
FNV-1a      - 1500 ns
MurmurHash3 -  175 ns
Jenkins     - 2500 ns

> Parents: [#4696](https://redirect.github.com/cilium/tetragon/pull/4696)