### PR TITLE
cleanup(pkg,docs): drop deprecated KeyCompatibilitySyscall64SizeType.

### DIFF
--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -46,10 +46,6 @@ options:
       default_value: "true"
       usage: |
         enable cgroup tracker id (only used if 'enable-cgidmap' is set)
-    - name: enable-compatibility-syscall64-size-type
-      default_value: "false"
-      usage: |
-        syscall64 type will produce output of type size (compatibility flag, will be removed in v1.4)
     - name: enable-cri
       default_value: "false"
       usage: enable CRI client for tetragon

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -128,8 +128,6 @@ type config struct {
 	EventCacheNumRetries int
 	EventCacheRetryDelay int
 
-	CompatibilitySyscall64SizeType bool
-
 	ExecveMapEntries int
 	ExecveMapSize    string
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -133,8 +133,6 @@ const (
 	KeyEventCacheRetries    = "event-cache-retries"
 	KeyEventCacheRetryDelay = "event-cache-retry-delay"
 
-	KeyCompatibilitySyscall64SizeType = "enable-compatibility-syscall64-size-type"
-
 	KeyExecveMapEntries = "execve-map-entries"
 	KeyExecveMapSize    = "execve-map-size"
 
@@ -302,8 +300,6 @@ func ReadAndSetFlags() error {
 
 	Config.EventCacheNumRetries = viper.GetInt(KeyEventCacheRetries)
 	Config.EventCacheRetryDelay = viper.GetInt(KeyEventCacheRetryDelay)
-
-	Config.CompatibilitySyscall64SizeType = viper.GetBool(KeyCompatibilitySyscall64SizeType)
 
 	Config.ExecveMapEntries = viper.GetInt(KeyExecveMapEntries)
 	Config.ExecveMapSize = viper.GetString(KeyExecveMapSize)
@@ -505,8 +501,6 @@ func AddFlags(flags *pflag.FlagSet) {
 
 	flags.Int(KeyEventCacheRetries, defaults.DefaultEventCacheNumRetries, "Number of retries for event cache")
 	flags.Int(KeyEventCacheRetryDelay, defaults.DefaultEventCacheRetryDelay, "Delay in seconds between event cache retries")
-
-	flags.Bool(KeyCompatibilitySyscall64SizeType, false, "syscall64 type will produce output of type size (compatibility flag, will be removed in v1.4)")
 
 	flags.Int(KeyExecveMapEntries, 0, "Set entries for execve_map table (default 32768)")
 	flags.String(KeyExecveMapSize, "", "Set size for execve_map table (allows K/M/G suffix)")

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -1005,14 +1005,8 @@ func handleMsgGenericTracepoint(
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
-			if option.Config.CompatibilitySyscall64SizeType {
-				// NB: clear Is32Bit to mantain previous behaviour
-				val = val & (^uint64(Is32Bit))
-				unix.Args = append(unix.Args, val)
-			} else {
-				val := parseSyscall64Value(val)
-				unix.Args = append(unix.Args, val)
-			}
+			val64 := parseSyscall64Value(val)
+			unix.Args = append(unix.Args, val64)
 
 		case gt.GenericLinuxBinprmType:
 			var arg tracingapi.MsgGenericKprobeArgLinuxBinprm


### PR DESCRIPTION


### Description
The KeyCompatibilitySyscall64SizeType was meant to be removed by 1.4.
Clean it up.