### PR TITLE
fix: incorrect default logger configuration

### DIFF
--- a/pkg/logger/slog.go
+++ b/pkg/logger/slog.go
@@ -71,18 +71,22 @@ func initializeSlog(logOpts LogOptions, useStdout bool) {
 		writer = os.Stdout
 	}
 
+	var newDefaultLogger = DefaultSlogLogger
 	switch logFormat {
 	case logFormatJSON, logFormatJSONTimestamp:
-		DefaultSlogLogger = slog.New(slog.NewJSONHandler(
+		newDefaultLogger = slog.New(slog.NewJSONHandler(
 			writer,
 			&opts,
 		))
 	case logFormatText, logFormatTextTimestamp:
-		DefaultSlogLogger = slog.New(slog.NewTextHandler(
+		newDefaultLogger = slog.New(slog.NewTextHandler(
 			writer,
 			&opts,
 		))
 	}
+
+	// update in place so package-level cached logger pointers pick up the new config
+	*DefaultSlogLogger = *newDefaultLogger
 }
 
 func replaceAttrFn(_ []string, a slog.Attr) slog.Attr {


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes #4733 

### Description
Update logging setup to reconfigure `DefaultSlogLogger` in place so cached logger pointers use the configured level and format.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
fix: startup logging to consistently honor configured log level and format
```