### PR TITLE
tetragon: Fix log format and level not honored during startup

### DIFF
--- a/pkg/logger/slog.go
+++ b/pkg/logger/slog.go
@@ -73,12 +73,12 @@ func initializeSlog(logOpts LogOptions, useStdout bool) {
 
 	switch logFormat {
 	case logFormatJSON, logFormatJSONTimestamp:
-		DefaultSlogLogger = slog.New(slog.NewJSONHandler(
+		*DefaultSlogLogger = *slog.New(slog.NewJSONHandler(
 			writer,
 			&opts,
 		))
 	case logFormatText, logFormatTextTimestamp:
-		DefaultSlogLogger = slog.New(slog.NewTextHandler(
+		*DefaultSlogLogger = *slog.New(slog.NewTextHandler(
 			writer,
 			&opts,
 		))


### PR DESCRIPTION


### Description
Some packages have logger reference cached at init time via package level. When SetupLogging function is called, new slog.Logger pointer is created, while cached logger is still with old reference. This causes the mismatch.

Fixes: #4733

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
tetragon: Fix log format and level not honored during startup
```
