### PR TITLE
eventchecker: support generic map types

### DIFF
--- a/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -12,6 +12,7 @@ import (
 	tetragon "github.com/cilium/tetragon/api/v1/tetragon"
 	bytesmatcher "github.com/cilium/tetragon/pkg/matchers/bytesmatcher"
 	listmatcher "github.com/cilium/tetragon/pkg/matchers/listmatcher"
+	mapmatcher "github.com/cilium/tetragon/pkg/matchers/mapmatcher"
 	stringmatcher "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	timestampmatcher "github.com/cilium/tetragon/pkg/matchers/timestampmatcher"
 	slog "log/slog"
@@ -3038,14 +3039,14 @@ func (checker *ContainerChecker) FromContainer(event *tetragon.Container) *Conta
 
 // PodChecker implements a checker struct to check a Pod field
 type PodChecker struct {
-	Namespace      *stringmatcher.StringMatcher           `json:"namespace,omitempty"`
-	Name           *stringmatcher.StringMatcher           `json:"name,omitempty"`
-	Uid            *stringmatcher.StringMatcher           `json:"uid,omitempty"`
-	Container      *ContainerChecker                      `json:"container,omitempty"`
-	PodLabels      map[string]stringmatcher.StringMatcher `json:"podLabels,omitempty"`
-	Workload       *stringmatcher.StringMatcher           `json:"workload,omitempty"`
-	WorkloadKind   *stringmatcher.StringMatcher           `json:"workloadKind,omitempty"`
-	PodAnnotations map[string]stringmatcher.StringMatcher `json:"podAnnotations,omitempty"`
+	Namespace      *stringmatcher.StringMatcher                                       `json:"namespace,omitempty"`
+	Name           *stringmatcher.StringMatcher                                       `json:"name,omitempty"`
+	Uid            *stringmatcher.StringMatcher                                       `json:"uid,omitempty"`
+	Container      *ContainerChecker                                                  `json:"container,omitempty"`
+	PodLabels      mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher] `json:"podLabels,omitempty"`
+	Workload       *stringmatcher.StringMatcher                                       `json:"workload,omitempty"`
+	WorkloadKind   *stringmatcher.StringMatcher                                       `json:"workloadKind,omitempty"`
+	PodAnnotations mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher] `json:"podAnnotations,omitempty"`
 }
 
 // NewPodChecker creates a new PodChecker
@@ -3086,28 +3087,8 @@ func (checker *PodChecker) Check(event *tetragon.Pod) error {
 			}
 		}
 		{
-			var unmatched []string
-			matched := make(map[string]struct{})
-			for key, value := range event.PodLabels {
-				if len(checker.PodLabels) > 0 {
-					// Attempt to grab the matcher for this key
-					if matcher, ok := checker.PodLabels[key]; ok {
-						if err := matcher.Match(value); err != nil {
-							return fmt.Errorf("PodLabels[%s] (%s=%s) check failed: %w", key, key, value, err)
-						}
-						matched[key] = struct{}{}
-					}
-				}
-			}
-
-			// See if we have any unmatched values that we wanted to match
-			if len(matched) != len(checker.PodLabels) {
-				for k := range checker.PodLabels {
-					if _, ok := matched[k]; !ok {
-						unmatched = append(unmatched, k)
-					}
-				}
-				return fmt.Errorf("PodLabels unmatched: %v", unmatched)
+			if err := checker.PodLabels.Match(event.PodLabels); err != nil {
+				return fmt.Errorf("PodLabels check failed: %w", err)
 			}
 		}
 		if checker.Workload != nil {
@@ -3121,28 +3102,8 @@ func (checker *PodChecker) Check(event *tetragon.Pod) error {
 			}
 		}
 		{
-			var unmatched []string
-			matched := make(map[string]struct{})
-			for key, value := range event.PodAnnotations {
-				if len(checker.PodAnnotations) > 0 {
-					// Attempt to grab the matcher for this key
-					if matcher, ok := checker.PodAnnotations[key]; ok {
-						if err := matcher.Match(value); err != nil {
-							return fmt.Errorf("PodAnnotations[%s] (%s=%s) check failed: %w", key, key, value, err)
-						}
-						matched[key] = struct{}{}
-					}
-				}
-			}
-
-			// See if we have any unmatched values that we wanted to match
-			if len(matched) != len(checker.PodAnnotations) {
-				for k := range checker.PodAnnotations {
-					if _, ok := matched[k]; !ok {
-						unmatched = append(unmatched, k)
-					}
-				}
-				return fmt.Errorf("PodAnnotations unmatched: %v", unmatched)
+			if err := checker.PodAnnotations.Match(event.PodAnnotations); err != nil {
+				return fmt.Errorf("PodAnnotations check failed: %w", err)
 			}
 		}
 		return nil
@@ -3178,7 +3139,7 @@ func (checker *PodChecker) WithContainer(check *ContainerChecker) *PodChecker {
 }
 
 // WithPodLabels adds a PodLabels check to the PodChecker
-func (checker *PodChecker) WithPodLabels(check map[string]stringmatcher.StringMatcher) *PodChecker {
+func (checker *PodChecker) WithPodLabels(check mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher]) *PodChecker {
 	checker.PodLabels = check
 	return checker
 }
@@ -3196,7 +3157,7 @@ func (checker *PodChecker) WithWorkloadKind(check *stringmatcher.StringMatcher) 
 }
 
 // WithPodAnnotations adds a PodAnnotations check to the PodChecker
-func (checker *PodChecker) WithPodAnnotations(check map[string]stringmatcher.StringMatcher) *PodChecker {
+func (checker *PodChecker) WithPodAnnotations(check mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher]) *PodChecker {
 	checker.PodAnnotations = check
 	return checker
 }
@@ -3212,10 +3173,22 @@ func (checker *PodChecker) FromPod(event *tetragon.Pod) *PodChecker {
 	if event.Container != nil {
 		checker.Container = NewContainerChecker().FromContainer(event.Container)
 	}
-	// TODO: implement fromMap
+	{
+		checkerVar := make(mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher])
+		for k, v := range event.PodLabels {
+			checkerVar[k] = *stringmatcher.Full(v)
+		}
+		checker.PodLabels = checkerVar
+	}
 	checker.Workload = stringmatcher.Full(event.Workload)
 	checker.WorkloadKind = stringmatcher.Full(event.WorkloadKind)
-	// TODO: implement fromMap
+	{
+		checkerVar := make(mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher])
+		for k, v := range event.PodAnnotations {
+			checkerVar[k] = *stringmatcher.Full(v)
+		}
+		checker.PodAnnotations = checkerVar
+	}
 	return checker
 }
 

--- a/api/vendor/github.com/cilium/tetragon/pkg/matchers/mapmatcher/mapmatcher.go
+++ b/api/vendor/github.com/cilium/tetragon/pkg/matchers/mapmatcher/mapmatcher.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package mapmatcher
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Matcher is a generic interface for matching values of type T.
+type Matcher[T any] interface {
+	Match(T) error
+}
+
+// MapMatcher matches a map of type map[K]V using matchers for each value.
+// K is the key type, V is the value type, and M is the matcher type for V.
+type MapMatcher[K comparable, V any, M any] map[K]M
+
+// Match matches the actual map against the expected matchers.
+// It iterates over all expected matchers and ensures they match the values in the actual map.
+func (m MapMatcher[K, V, M]) Match(actual map[K]V) error {
+	var unmatched []K
+
+	for key, matcher := range m {
+		val, ok := actual[key]
+		if !ok {
+			unmatched = append(unmatched, key)
+			continue
+		}
+
+		// Try to match using the value or its pointer. This allows MapMatcher to work
+		// with matchers that have pointer receivers even when stored as values in the map.
+		var err error
+		if im, ok := any(matcher).(interface{ Match(V) error }); ok {
+			err = im.Match(val)
+		} else if im, ok := any(&matcher).(interface{ Match(V) error }); ok {
+			err = im.Match(val)
+		} else {
+			return fmt.Errorf("key %v: matcher of type %T does not implement Match(%T) error", key, matcher, val)
+		}
+
+		if err != nil {
+			return fmt.Errorf("key %v match failed: %w", key, err)
+		}
+	}
+
+	if len(unmatched) > 0 {
+		return fmt.Errorf("unmatched keys: %v", unmatched)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler for MapMatcher.
+func (m *MapMatcher[K, V, M]) UnmarshalJSON(b []byte) error {
+	type Alias MapMatcher[K, V, M]
+	var alias Alias
+	if err := yaml.UnmarshalStrict(b, &alias); err != nil {
+		return fmt.Errorf("unmarshal MapMatcher: %w", err)
+	}
+	*m = MapMatcher[K, V, M](alias)
+	return nil
+}
+
+// PrimitiveMatcher is a generic matcher for primitive types (string, int, bool, etc.)
+// that performs a simple equality check.
+type PrimitiveMatcher[V comparable] struct {
+	Value V `json:"value"`
+}
+
+// Match implements the Matcher interface for PrimitiveMatcher.
+func (m PrimitiveMatcher[V]) Match(actual V) error {
+	if m.Value != actual {
+		return fmt.Errorf("expected %v, got %v", m.Value, actual)
+	}
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler for PrimitiveMatcher.
+// It allows the user to provide a plain value as a shorthand for the matcher.
+func (m *PrimitiveMatcher[V]) UnmarshalJSON(b []byte) error {
+	// Try to unmarshal as a plain value first
+	var val V
+	if err := yaml.UnmarshalStrict(b, &val); err == nil {
+		m.Value = val
+		return nil
+	}
+
+	// Otherwise, unmarshal as a struct
+	type Alias PrimitiveMatcher[V]
+	var alias Alias
+	if err := yaml.UnmarshalStrict(b, &alias); err != nil {
+		return fmt.Errorf("unmarshal PrimitiveMatcher: %w", err)
+	}
+	*m = PrimitiveMatcher[V](alias)
+	return nil
+}
+
+// Operator strings for PrimitiveMatcher
+func (m PrimitiveMatcher[V]) Operator() string {
+	return "Equals"
+}
+
+// String returns a string representation of the matcher.
+func (m PrimitiveMatcher[V]) String() string {
+	return fmt.Sprintf("%v", m.Value)
+}

--- a/api/vendor/modules.txt
+++ b/api/vendor/modules.txt
@@ -2,6 +2,7 @@
 ## explicit; go 1.26.0
 github.com/cilium/tetragon/pkg/matchers/bytesmatcher
 github.com/cilium/tetragon/pkg/matchers/listmatcher
+github.com/cilium/tetragon/pkg/matchers/mapmatcher
 github.com/cilium/tetragon/pkg/matchers/stringmatcher
 github.com/cilium/tetragon/pkg/matchers/timestampmatcher
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/pkg/matchers/mapmatcher/mapmatcher.go
+++ b/pkg/matchers/mapmatcher/mapmatcher.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package mapmatcher
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Matcher is a generic interface for matching values of type T.
+type Matcher[T any] interface {
+	Match(T) error
+}
+
+// MapMatcher matches a map of type map[K]V using matchers for each value.
+// K is the key type, V is the value type, and M is the matcher type for V.
+type MapMatcher[K comparable, V any, M any] map[K]M
+
+// Match matches the actual map against the expected matchers.
+// It iterates over all expected matchers and ensures they match the values in the actual map.
+func (m MapMatcher[K, V, M]) Match(actual map[K]V) error {
+	var unmatched []K
+
+	for key, matcher := range m {
+		val, ok := actual[key]
+		if !ok {
+			unmatched = append(unmatched, key)
+			continue
+		}
+
+		// Try to match using the value or its pointer. This allows MapMatcher to work
+		// with matchers that have pointer receivers even when stored as values in the map.
+		var err error
+		if im, ok := any(matcher).(interface{ Match(V) error }); ok {
+			err = im.Match(val)
+		} else if im, ok := any(&matcher).(interface{ Match(V) error }); ok {
+			err = im.Match(val)
+		} else {
+			return fmt.Errorf("key %v: matcher of type %T does not implement Match(%T) error", key, matcher, val)
+		}
+
+		if err != nil {
+			return fmt.Errorf("key %v match failed: %w", key, err)
+		}
+	}
+
+	if len(unmatched) > 0 {
+		return fmt.Errorf("unmatched keys: %v", unmatched)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler for MapMatcher.
+func (m *MapMatcher[K, V, M]) UnmarshalJSON(b []byte) error {
+	type Alias MapMatcher[K, V, M]
+	var alias Alias
+	if err := yaml.UnmarshalStrict(b, &alias); err != nil {
+		return fmt.Errorf("unmarshal MapMatcher: %w", err)
+	}
+	*m = MapMatcher[K, V, M](alias)
+	return nil
+}
+
+// PrimitiveMatcher is a generic matcher for primitive types (string, int, bool, etc.)
+// that performs a simple equality check.
+type PrimitiveMatcher[V comparable] struct {
+	Value V `json:"value"`
+}
+
+// Match implements the Matcher interface for PrimitiveMatcher.
+func (m PrimitiveMatcher[V]) Match(actual V) error {
+	if m.Value != actual {
+		return fmt.Errorf("expected %v, got %v", m.Value, actual)
+	}
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler for PrimitiveMatcher.
+// It allows the user to provide a plain value as a shorthand for the matcher.
+func (m *PrimitiveMatcher[V]) UnmarshalJSON(b []byte) error {
+	// Try to unmarshal as a plain value first
+	var val V
+	if err := yaml.UnmarshalStrict(b, &val); err == nil {
+		m.Value = val
+		return nil
+	}
+
+	// Otherwise, unmarshal as a struct
+	type Alias PrimitiveMatcher[V]
+	var alias Alias
+	if err := yaml.UnmarshalStrict(b, &alias); err != nil {
+		return fmt.Errorf("unmarshal PrimitiveMatcher: %w", err)
+	}
+	*m = PrimitiveMatcher[V](alias)
+	return nil
+}
+
+// Operator strings for PrimitiveMatcher
+func (m PrimitiveMatcher[V]) Operator() string {
+	return "Equals"
+}
+
+// String returns a string representation of the matcher.
+func (m PrimitiveMatcher[V]) String() string {
+	return fmt.Sprintf("%v", m.Value)
+}

--- a/pkg/matchers/mapmatcher/mapmatcher_test.go
+++ b/pkg/matchers/mapmatcher/mapmatcher_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package mapmatcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+type mockMatcher struct {
+	expected string
+}
+
+func (m mockMatcher) Match(actual string) error {
+	if m.expected != actual {
+		return assert.AnError
+	}
+	return nil
+}
+
+func TestMapMatcher(t *testing.T) {
+	m := MapMatcher[string, string, mockMatcher]{
+		"key1": mockMatcher{"val1"},
+		"key2": mockMatcher{"val2"},
+	}
+
+	// Successful match
+	actual := map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+	}
+	require.NoError(t, m.Match(actual))
+
+	// Unmatched key in actual (allowed, we only check what's in the matcher)
+	actualExtra := map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+		"key3": "val3",
+	}
+	require.NoError(t, m.Match(actualExtra))
+
+	// Missing key in actual
+	actualMissing := map[string]string{
+		"key1": "val1",
+	}
+	require.Error(t, m.Match(actualMissing))
+
+	// Value mismatch
+	actualMismatch := map[string]string{
+		"key1": "val1",
+		"key2": "wrong",
+	}
+	require.Error(t, m.Match(actualMismatch))
+}
+
+func TestPrimitiveMatcher(t *testing.T) {
+	// Int32
+	mInt := PrimitiveMatcher[int32]{Value: 42}
+	require.NoError(t, mInt.Match(42))
+	require.Error(t, mInt.Match(43))
+
+	// Bool
+	mBool := PrimitiveMatcher[bool]{Value: true}
+	require.NoError(t, mBool.Match(true))
+	require.Error(t, mBool.Match(false))
+
+	// YAML unmarshaling
+	var mUnsh PrimitiveMatcher[int32]
+	err := yaml.Unmarshal([]byte("42"), &mUnsh)
+	require.NoError(t, err)
+	assert.Equal(t, int32(42), mUnsh.Value)
+}

--- a/tools/protoc-gen-go-tetragon/common/common.go
+++ b/tools/protoc-gen-go-tetragon/common/common.go
@@ -124,6 +124,10 @@ func TimestampMatcherIdent(g *protogen.GeneratedFile, name string) string {
 	return GoIdent(g, importPath, name)
 }
 
+func MapMatcherIdent(g *protogen.GeneratedFile, name string) string {
+	return GoIdent(g, "github.com/cilium/tetragon/pkg/matchers/mapmatcher", name)
+}
+
 func PkgProcessIdent(g *protogen.GeneratedFile, name string) string {
 	importPath := filepath.Join("github.com/cilium/tetragon/pkg/process")
 	return GoIdent(g, importPath, name)

--- a/tools/protoc-gen-go-tetragon/eventchecker/field.go
+++ b/tools/protoc-gen-go-tetragon/eventchecker/field.go
@@ -215,7 +215,7 @@ func doGetFieldFrom(field *Field, g *protogen.GeneratedFile, handleList, handleO
 	}
 
 	if handleList && field.Desc.IsMap() {
-		return "// TODO: implement fromMap", nil
+		return field.doGetFieldFromMap(g)
 	}
 
 	switch kind {
@@ -298,59 +298,32 @@ func (field *Field) getFieldCheck(g *protogen.GeneratedFile, checkerName, checke
 
 // checkForMap returns the checker body for map fields and, as a special case, the
 // Pod_Labels field of the Pod message.
-func checkForMap(g *protogen.GeneratedFile, field *Field, checkerName, checkerVar, eventVar string) (string, error) {
-	// Common part of the map check
-	mapCheck := func(eventVar string) (string, error) {
-		return `var unmatched []string
-            matched := make(map[string]struct{})
-            for key, value := range ` + eventVar + ` {
-                if len(` + checkerVar + `) > 0 {
-                    // Attempt to grab the matcher for this key
-                    if matcher, ok := ` + checkerVar + `[key]; ok {
-                        if err := matcher.Match(value); err != nil {
-                            return ` + common.FmtErrorf(g, field.GoName+"[%s] (%s=%s) check failed: %w", "key", "key", "value", "err") + `
-                        }
-                        matched[key] = struct{}{}
-                    }
-                }
-            }
-
-            // See if we have any unmatched values that we wanted to match
-            if len(matched) != len(` + checkerVar + `) {
-                for k := range ` + checkerVar + ` {
-                    if _, ok := matched[k]; !ok {
-                        unmatched = append(unmatched, k)
-                    }
-                }
-                return ` + common.FmtErrorf(g, field.GoName+" unmatched: %v", "unmatched") + `
-            }`, nil
-	}
-
+func checkForMap(g *protogen.GeneratedFile, field *Field, _, checkerVar, eventVar string) (string, error) {
 	// Specific to Pod_Labels which needs to be converted into a map
 	if field.GoIdent.GoName == "Pod_Labels" {
+		smatcher := common.StringMatcherIdent(g, "StringMatcher")
 		splitN := common.GoIdent(g, "strings", "SplitN")
-		preamble := `values := make(map[string]string)
+		preamble := `values := make(map[string]` + smatcher + `)
         for _, s := range ` + eventVar + ` {
             // Split out key,value pair
             kv := ` + splitN + `(s, "=", 2)
             if len(kv) != 2 {
                 // If we wanted to match an invalid label, error out
                 if _, ok := ` + checkerVar + `[s]; ok {
-                    return ` + common.FmtErrorf(g, checkerName+": Label %s is in an invalid format (want key=value)", "s") + `
+                    return ` + common.FmtErrorf(g, "Label %s is in an invalid format (want key=value)", "s") + `
                 }
                 continue
             }
             values[kv[0]] = kv[1]
         }`
-
-		check, err := mapCheck("values")
-		if err != nil {
-			return "", err
-		}
-		return preamble + "\n" + check, nil
+		return preamble + "\n" + `if err := ` + checkerVar + `.Match(values); err != nil {
+            return ` + common.FmtErrorf(g, field.GoName+" check failed: %w", "err") + `
+        }`, nil
 	}
 
-	return mapCheck(eventVar)
+	return `if err := ` + checkerVar + `.Match(` + eventVar + `); err != nil {
+        return ` + common.FmtErrorf(g, field.GoName+" check failed: %w", "err") + `
+    }`, nil
 }
 
 // checkForOneof returns the event checker body for a Oneof.
@@ -840,13 +813,20 @@ func (field *Field) typeName(g *protogen.GeneratedFile) (string, error) {
 	}
 
 	if field.isMap() {
-		if field.Desc.MapKey().Kind() != protoreflect.StringKind {
-			return "", errors.New("maps without string keys are not supported")
+		mident := common.MapMatcherIdent(g, "MapMatcher")
+		keyType, err := field.mapKeyTypeName(g)
+		if err != nil {
+			return "", err
 		}
-		if field.Desc.MapValue().Kind() != protoreflect.StringKind {
-			return "", errors.New("maps without string values are not supported")
+		valMatcher, err := field.mapValueMatchTypeName(g)
+		if err != nil {
+			return "", err
 		}
-		return "map[string]" + common.StringMatcherIdent(g, "StringMatcher"), nil
+		valActual, err := field.mapValueActualTypeName(g)
+		if err != nil {
+			return "", err
+		}
+		return mident + "[" + keyType + ", " + valActual + ", " + valMatcher + "]", nil
 	} else if field.isList() {
 		if field.isPrimitive() {
 			return "[]" + type_, nil
@@ -855,6 +835,67 @@ func (field *Field) typeName(g *protogen.GeneratedFile) (string, error) {
 	}
 
 	return type_, nil
+}
+
+func (field *Field) mapKeyTypeName(_ *protogen.GeneratedFile) (string, error) {
+	kind := field.Desc.MapKey().Kind()
+	switch kind {
+	case protoreflect.StringKind:
+		return "string", nil
+	default:
+		return "", fmt.Errorf("unsupported map key kind: %s", kind)
+	}
+}
+
+func (field *Field) mapValueMatchTypeName(g *protogen.GeneratedFile) (string, error) {
+	kind := field.Desc.MapValue().Kind()
+	switch kind {
+	case protoreflect.StringKind:
+		return common.StringMatcherIdent(g, "StringMatcher"), nil
+	case protoreflect.BytesKind:
+		return common.BytesMatcherIdent(g, "BytesMatcher"), nil
+	case protoreflect.MessageKind:
+		return "", errors.New("message values in maps are not yet supported")
+	default:
+		// For primitive types, use PrimitiveMatcher
+		pm := common.MapMatcherIdent(g, "PrimitiveMatcher")
+		actual, err := field.mapValueActualTypeName(g)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s[%s]", pm, actual), nil
+	}
+}
+
+func (field *Field) mapValueActualTypeName(_ *protogen.GeneratedFile) (string, error) {
+	kind := field.Desc.MapValue().Kind()
+	return kind.String(), nil
+}
+
+func (field *Field) doGetFieldFromMap(g *protogen.GeneratedFile) (string, error) {
+	mident, err := field.typeName(g)
+	if err != nil {
+		return "", err
+	}
+
+	valKind := field.Desc.MapValue().Kind()
+	innerFrom := ""
+	if valKind == protoreflect.StringKind {
+		smatcher := common.StringMatcherIdent(g, "Full")
+		innerFrom = `checkerVar[k] = *` + smatcher + `(v)`
+	} else {
+		pm := common.MapMatcherIdent(g, "PrimitiveMatcher")
+		actual, _ := field.mapValueActualTypeName(g)
+		innerFrom = `checkerVar[k] = ` + pm + `[` + actual + `]{Value: v}`
+	}
+
+	return `{
+        checkerVar := make(` + mident + `)
+        for k, v := range event.` + field.GoName + ` {
+            ` + innerFrom + `
+        }
+        checker.` + field.GoName + ` = checkerVar
+    }`, nil
 }
 
 func kindToFormat(k protoreflect.Kind) string {

--- a/tools/protoc-gen-go-tetragon/eventchecker/field.go
+++ b/tools/protoc-gen-go-tetragon/eventchecker/field.go
@@ -70,8 +70,8 @@ func (field *Field) generateFrom(g *protogen.GeneratedFile, msg *CheckedMessage)
 }
 
 func (field *Field) getFrom(g *protogen.GeneratedFile, msg *CheckedMessage) (string, error) {
-	checkerVar := fmt.Sprintf("%s.%s", checkerVarName, field.GoName)
-	eventVar := fmt.Sprintf("%s.%s", eventVarName, field.GoName)
+	checkerVar := checkerVarName + "." + field.GoName
+	eventVar := eventVarName + "." + field.GoName
 
 	from, err := doGetFieldFrom(field, g, true, true, msg.checkerName(g), checkerVar, eventVar)
 	if err != nil {
@@ -117,7 +117,7 @@ func doGetFieldFrom(field *Field, g *protogen.GeneratedFile, handleList, handleO
 
 		innerType := common.TetragonApiIdent(g, field.GoIdent.GoName)
 
-		return `switch event := ` + fmt.Sprintf("%s.%s", eventVarName, oneof.GoName) + `.(type) {
+		return `switch event := ` + eventVarName + "." + oneof.GoName + `.(type) {
             case * ` + innerType + `:
                 ` + innerFrom + `
             }`, nil
@@ -172,7 +172,7 @@ func doGetFieldFrom(field *Field, g *protogen.GeneratedFile, handleList, handleO
 	}
 
 	doCheckerFrom := func() string {
-		newCall := fmt.Sprintf("New%sChecker()", field.Message.GoIdent.GoName)
+		newCall := "New" + field.Message.GoIdent.GoName + "Checker()"
 		typeImportPath := string(field.Message.GoIdent.GoImportPath)
 		if !strings.HasPrefix(typeImportPath, common.TetragonPackageName) {
 			importPath := filepath.Join(typeImportPath, "codegen", "eventchecker")
@@ -256,8 +256,8 @@ func doGetFieldFrom(field *Field, g *protogen.GeneratedFile, handleList, handleO
 }
 
 func (field *Field) generateFieldCheck(g *protogen.GeneratedFile, msg *CheckedMessage) error {
-	checkerVar := fmt.Sprintf("%s.%s", checkerVarName, field.GoName)
-	eventVar := fmt.Sprintf("%s.%s", eventVarName, field.GoName)
+	checkerVar := checkerVarName + "." + field.GoName
+	eventVar := eventVarName + "." + field.GoName
 
 	check, err := field.getFieldCheck(g, msg.checkerName(g), checkerVar, eventVar)
 	if err != nil {
@@ -360,7 +360,7 @@ func checkForOneof(g *protogen.GeneratedFile, field *Field, checkerName string, 
 		return "", err
 	}
 	fieldIdent := common.TetragonApiIdent(g, field.GoIdent.GoName)
-	return `switch event := ` + fmt.Sprintf("%s.%s", eventVarName, field.Oneof.GoName) + `.(type) {
+	return `switch event := ` + eventVarName + "." + field.Oneof.GoName + `.(type) {
     case *` + fieldIdent + `:
         ` + inner + `
     default:
@@ -672,7 +672,7 @@ func (field *Field) listCheckerName(g *protogen.GeneratedFile) string {
 func (field *Field) newListCheckerName(g *protogen.GeneratedFile) string {
 	if msg := field.Message; msg != nil {
 		typeImportPath := string(field.Message.GoIdent.GoImportPath)
-		ret := fmt.Sprintf("New%sListMatcher", msg.GoIdent.GoName)
+		ret := "New" + msg.GoIdent.GoName + "ListMatcher"
 		if !strings.HasPrefix(typeImportPath, common.TetragonPackageName) {
 			importPath := filepath.Join(typeImportPath, "codegen", "eventchecker")
 			ret = g.QualifiedGoIdent(protogen.GoIdent{
@@ -683,7 +683,7 @@ func (field *Field) newListCheckerName(g *protogen.GeneratedFile) string {
 		return ret
 	} else if enum := field.Enum; enum != nil {
 		typeImportPath := string(field.Enum.GoIdent.GoImportPath)
-		ret := fmt.Sprintf("New%sListMatcher", enum.GoIdent.GoName)
+		ret := "New" + enum.GoIdent.GoName + "ListMatcher"
 		if !strings.HasPrefix(typeImportPath, common.TetragonPackageName) {
 			importPath := filepath.Join(typeImportPath, "codegen", "eventchecker")
 			ret = g.QualifiedGoIdent(protogen.GoIdent{
@@ -694,7 +694,7 @@ func (field *Field) newListCheckerName(g *protogen.GeneratedFile) string {
 		return ret
 	}
 	varIdent := field.kind().String()
-	return fmt.Sprintf("New%sListMatcher", strcase.ToCamel(varIdent))
+	return "New" + strcase.ToCamel(varIdent) + "ListMatcher"
 }
 
 func (field *Field) kind() protoreflect.Kind {
@@ -771,7 +771,7 @@ func (field *Field) isEnum() bool {
 }
 
 func (field *Field) jsonTag() string {
-	return fmt.Sprintf("json:\"%s,omitempty\"", field.Desc.JSONName())
+	return `json:"` + field.Desc.JSONName() + `,omitempty"`
 }
 
 func (field *Field) typeName(g *protogen.GeneratedFile) (string, error) {

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -12,6 +12,7 @@ import (
 	tetragon "github.com/cilium/tetragon/api/v1/tetragon"
 	bytesmatcher "github.com/cilium/tetragon/pkg/matchers/bytesmatcher"
 	listmatcher "github.com/cilium/tetragon/pkg/matchers/listmatcher"
+	mapmatcher "github.com/cilium/tetragon/pkg/matchers/mapmatcher"
 	stringmatcher "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	timestampmatcher "github.com/cilium/tetragon/pkg/matchers/timestampmatcher"
 	slog "log/slog"
@@ -3038,14 +3039,14 @@ func (checker *ContainerChecker) FromContainer(event *tetragon.Container) *Conta
 
 // PodChecker implements a checker struct to check a Pod field
 type PodChecker struct {
-	Namespace      *stringmatcher.StringMatcher           `json:"namespace,omitempty"`
-	Name           *stringmatcher.StringMatcher           `json:"name,omitempty"`
-	Uid            *stringmatcher.StringMatcher           `json:"uid,omitempty"`
-	Container      *ContainerChecker                      `json:"container,omitempty"`
-	PodLabels      map[string]stringmatcher.StringMatcher `json:"podLabels,omitempty"`
-	Workload       *stringmatcher.StringMatcher           `json:"workload,omitempty"`
-	WorkloadKind   *stringmatcher.StringMatcher           `json:"workloadKind,omitempty"`
-	PodAnnotations map[string]stringmatcher.StringMatcher `json:"podAnnotations,omitempty"`
+	Namespace      *stringmatcher.StringMatcher                                       `json:"namespace,omitempty"`
+	Name           *stringmatcher.StringMatcher                                       `json:"name,omitempty"`
+	Uid            *stringmatcher.StringMatcher                                       `json:"uid,omitempty"`
+	Container      *ContainerChecker                                                  `json:"container,omitempty"`
+	PodLabels      mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher] `json:"podLabels,omitempty"`
+	Workload       *stringmatcher.StringMatcher                                       `json:"workload,omitempty"`
+	WorkloadKind   *stringmatcher.StringMatcher                                       `json:"workloadKind,omitempty"`
+	PodAnnotations mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher] `json:"podAnnotations,omitempty"`
 }
 
 // NewPodChecker creates a new PodChecker
@@ -3086,28 +3087,8 @@ func (checker *PodChecker) Check(event *tetragon.Pod) error {
 			}
 		}
 		{
-			var unmatched []string
-			matched := make(map[string]struct{})
-			for key, value := range event.PodLabels {
-				if len(checker.PodLabels) > 0 {
-					// Attempt to grab the matcher for this key
-					if matcher, ok := checker.PodLabels[key]; ok {
-						if err := matcher.Match(value); err != nil {
-							return fmt.Errorf("PodLabels[%s] (%s=%s) check failed: %w", key, key, value, err)
-						}
-						matched[key] = struct{}{}
-					}
-				}
-			}
-
-			// See if we have any unmatched values that we wanted to match
-			if len(matched) != len(checker.PodLabels) {
-				for k := range checker.PodLabels {
-					if _, ok := matched[k]; !ok {
-						unmatched = append(unmatched, k)
-					}
-				}
-				return fmt.Errorf("PodLabels unmatched: %v", unmatched)
+			if err := checker.PodLabels.Match(event.PodLabels); err != nil {
+				return fmt.Errorf("PodLabels check failed: %w", err)
 			}
 		}
 		if checker.Workload != nil {
@@ -3121,28 +3102,8 @@ func (checker *PodChecker) Check(event *tetragon.Pod) error {
 			}
 		}
 		{
-			var unmatched []string
-			matched := make(map[string]struct{})
-			for key, value := range event.PodAnnotations {
-				if len(checker.PodAnnotations) > 0 {
-					// Attempt to grab the matcher for this key
-					if matcher, ok := checker.PodAnnotations[key]; ok {
-						if err := matcher.Match(value); err != nil {
-							return fmt.Errorf("PodAnnotations[%s] (%s=%s) check failed: %w", key, key, value, err)
-						}
-						matched[key] = struct{}{}
-					}
-				}
-			}
-
-			// See if we have any unmatched values that we wanted to match
-			if len(matched) != len(checker.PodAnnotations) {
-				for k := range checker.PodAnnotations {
-					if _, ok := matched[k]; !ok {
-						unmatched = append(unmatched, k)
-					}
-				}
-				return fmt.Errorf("PodAnnotations unmatched: %v", unmatched)
+			if err := checker.PodAnnotations.Match(event.PodAnnotations); err != nil {
+				return fmt.Errorf("PodAnnotations check failed: %w", err)
 			}
 		}
 		return nil
@@ -3178,7 +3139,7 @@ func (checker *PodChecker) WithContainer(check *ContainerChecker) *PodChecker {
 }
 
 // WithPodLabels adds a PodLabels check to the PodChecker
-func (checker *PodChecker) WithPodLabels(check map[string]stringmatcher.StringMatcher) *PodChecker {
+func (checker *PodChecker) WithPodLabels(check mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher]) *PodChecker {
 	checker.PodLabels = check
 	return checker
 }
@@ -3196,7 +3157,7 @@ func (checker *PodChecker) WithWorkloadKind(check *stringmatcher.StringMatcher) 
 }
 
 // WithPodAnnotations adds a PodAnnotations check to the PodChecker
-func (checker *PodChecker) WithPodAnnotations(check map[string]stringmatcher.StringMatcher) *PodChecker {
+func (checker *PodChecker) WithPodAnnotations(check mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher]) *PodChecker {
 	checker.PodAnnotations = check
 	return checker
 }
@@ -3212,10 +3173,22 @@ func (checker *PodChecker) FromPod(event *tetragon.Pod) *PodChecker {
 	if event.Container != nil {
 		checker.Container = NewContainerChecker().FromContainer(event.Container)
 	}
-	// TODO: implement fromMap
+	{
+		checkerVar := make(mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher])
+		for k, v := range event.PodLabels {
+			checkerVar[k] = *stringmatcher.Full(v)
+		}
+		checker.PodLabels = checkerVar
+	}
 	checker.Workload = stringmatcher.Full(event.Workload)
 	checker.WorkloadKind = stringmatcher.Full(event.WorkloadKind)
-	// TODO: implement fromMap
+	{
+		checkerVar := make(mapmatcher.MapMatcher[string, string, stringmatcher.StringMatcher])
+		for k, v := range event.PodAnnotations {
+			checkerVar[k] = *stringmatcher.Full(v)
+		}
+		checker.PodAnnotations = checkerVar
+	}
 	return checker
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->


### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
This PR extends the `eventchecker` to support generic map fields. Previously,PR #260 hardcoded support only for `map[string]string`. 

This PR introduces a generic `MapMatcher` to automatically handle different key-value types (like int and bool).

**Note**: `MapMatcher` is made generic so future proto map fields with non-string value types (e.g. `map<string, uint32>`) are automatically supported by codegen without additional matcher changes.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
eventchecker: support generic map types
```
