### PR TITLE
helm: fix rthooks container resources not being applied

### DIFF
--- a/install/kubernetes/tetragon/templates/_container_rthooks.tpl
+++ b/install/kubernetes/tetragon/templates/_container_rthooks.tpl
@@ -37,7 +37,7 @@
       mountPath: {{ .Values.rthooks.nriHook.nriSocket }}
 {{- end }}
 {{- with .Values.rthooks.resources }}
-  resources: {}
+  resources:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
The resources block in the tetragon-rthooks container template was using an invalid YAML construct:

  resources: {}
    {{- toYaml . | nindent 4 }}

This results in a YAML parse error when rthooks.resources is set, because a flow-style empty map ({}) cannot have block-style children.

Fix by removing the erroneous {} so the toYaml output is correctly nested under the resources key.

```release-note
helm: fix rthooks container resources not being applied
```
