### PR TITLE
[backport/v1.6] helm: fix rthooks container resources not being applied

### DIFF
--- a/install/kubernetes/tetragon/templates/_container_rthooks.tpl
+++ b/install/kubernetes/tetragon/templates/_container_rthooks.tpl
@@ -37,7 +37,7 @@
       mountPath: {{ .Values.rthooks.nriHook.nriSocket }}
 {{- end }}
 {{- with .Values.rthooks.resources }}
-  resources: {}
+  resources:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Backport of https://github.com/cilium/tetragon/pull/4766