### PR TITLE
bpf: Fix mnt_namespace RHEL7 fallback writing to wrong field

### DIFF
--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -197,7 +197,7 @@ get_namespaces(struct msg_ns *msg, struct task_struct *task)
 	} else {
 		struct mnt_namespace___rhel7 *ns = (struct mnt_namespace___rhel7 *)_(nsp.mnt_ns);
 
-		probe_read(&msg->ipc_inum, sizeof(msg->ipc_inum),
+		probe_read(&msg->mnt_inum, sizeof(msg->mnt_inum),
 			   _(&ns->proc_inum));
 	}
 


### PR DESCRIPTION
The RHEL7 fallback for mnt_namespace was incorrectly writing to msg->ipc_inum instead of msg->mnt_inum. This was a copy-paste error that would cause incorrect mount namespace inode numbers to be reported on RHEL7 kernels.
