### PR TITLE
bpf: Remove un-used memcmp macro

### DIFF
--- a/bpf/include/api.h
+++ b/bpf/include/api.h
@@ -293,16 +293,6 @@ static int BPF_FUNC(seq_write, struct seq_file *m, const void *data, uint32_t le
 # define memmove(d, s, n)	__builtin_memmove((d), (s), (n))
 #endif
 
-/* FIXME: __builtin_memcmp() is not yet fully useable unless llvm bug
- * https://llvm.org/bugs/show_bug.cgi?id=26218 gets resolved. Also
- * this one would generate a reloc entry (non-map), otherwise.
- */
-#if 0
-#ifndef memcmp
-# define memcmp(a, b, n)	__builtin_memcmp((a), (b), (n))
-#endif
-#endif
-
 /**
  * atomic add is support from before 4.19 on both arm and x86,
  * x86 has other atomics support from 5.11, arm from 5.17


### PR DESCRIPTION


### Description

This should be fixed in Clang 15 as per below issue. Tetragon is using clang 20 as per Dockerfile.clang.

Relates: https://github.com/llvm/llvm-project/issues/26592

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
bpf: enable __builtin_memcmp() macro definition
```
