### PR TITLE
renovate: Bump golang to 1.25 for all stable versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -308,13 +308,13 @@
       ]
     },
     {
-      // update go patch for 1.24 for stable branches
+      // update go patch for 1.25 for stable branches
       "enabled": true,
       "matchPackageNames": [
         "go",
         "docker.io/library/golang"
       ],
-      "allowedVersions": "/^1\\.24\\.[0-9]+-?(alpine)?$/",
+      "allowedVersions": "/^1\\.25\\.[0-9]+-?(alpine)?$/",
       "matchBaseBranches": [
         "v1.4",
         "v1.5",


### PR DESCRIPTION
### Description
Golang 1.24 is EOL wheng 1.26 is released.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
renovate: Bump golang to 1.25 for all stable versions
```
