### PR TITLE
process: use chan struct{} for stopChan signal channel

### DIFF
--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -25,7 +25,7 @@ type Cache struct {
 	cache      *lru.Cache[string, *ProcessInternal]
 	size       int
 	deleteChan chan *ProcessInternal
-	stopChan   chan bool
+	stopChan   chan struct{} // ← CHANGED from chan bool
 }
 
 // garbage collection states
@@ -46,7 +46,7 @@ var colorStr = map[int]string{
 func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 	ticker := time.NewTicker(intervalGC)
 	pc.deleteChan = make(chan *ProcessInternal)
-	pc.stopChan = make(chan bool)
+	pc.stopChan = make(chan struct{}) // ← CHANGED from make(chan bool)
 
 	go func() {
 		var deleteQueue []*ProcessInternal
@@ -130,14 +130,14 @@ func (pc *Cache) refDec(p *ProcessInternal, reason string) {
 
 func (pc *Cache) refInc(p *ProcessInternal, reason string) {
 	p.refcntOpsLock.Lock()
-	// count number of times refcnt is increamented for a specific reason (i.e. process, parent, etc.)
+	// count number of times refcnt is incremented for a specific reason (i.e. process, parent, etc.)
 	p.refcntOps[reason]++
 	p.refcntOpsLock.Unlock()
 	p.refcnt.Add(1)
 }
 
 func (pc *Cache) purge() {
-	pc.stopChan <- true
+	pc.stopChan <- struct{}{} // ← CHANGED from <- true
 	processCacheTotal.Set(0)
 }
 
@@ -268,3 +268,5 @@ func (pc *Cache) getEntries() []*tetragon.ProcessInternal {
 	}
 	return processes
 }
+
+


### PR DESCRIPTION
## Summary

Replace `chan bool` with `chan struct{}` for the `stopChan` signal
channel in the process cache.

## Background

The `stopChan` field in `Cache` is used exclusively as a shutdown
signal — no boolean value is ever read from it. Using `chan bool`
implies the value being sent carries meaning, which is misleading
to readers of the code.

## Changes

- Change `stopChan` field type from `chan bool` to `chan struct{}`
- Change `make(chan bool)` to `make(chan struct{})` in
  `cacheGarbageCollector`
- Change `pc.stopChan <- true` to `pc.stopChan <- struct{}{}`
  in `purge()`

## Why This Matters

`chan struct{}` is the idiomatic Go pattern for signal-only channels
because:

1. It explicitly communicates intent — no value, signal only
2. `struct{}` occupies zero bytes of memory vs `bool` which
   occupies 1 byte per send
3. Sending `true` implies there could be a `false` case — there
   is not, making `chan bool` semantically wrong here




