### PR TITLE
tetra: add global --max-recv-size flag

### DIFF
--- a/cmd/tetra/bugtool/bugtool.go
+++ b/cmd/tetra/bugtool/bugtool.go
@@ -6,14 +6,14 @@ package bugtool
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/cilium/tetragon/cmd/tetra/common"
 	"github.com/cilium/tetragon/pkg/bugtool"
 )
 
 var (
-	outFile     string
-	bpfTool     string
-	gops        string
-	maxRecvSize int
+	outFile string
+	bpfTool string
+	gops    string
 )
 
 type Command struct {
@@ -44,7 +44,7 @@ func New() *Command {
 		Use:   "bugtool",
 		Short: "Produce a tar archive with debug information",
 		Run: func(_ *cobra.Command, _ []string) {
-			bugtool.Bugtool(outFile, bpfTool, gops, maxRecvSize, bugtoolCmd.CommandActions, bugtoolCmd.GRPCActions)
+			bugtool.Bugtool(outFile, bpfTool, gops, common.MaxRecvMsgSize, bugtoolCmd.CommandActions, bugtoolCmd.GRPCActions)
 		},
 	}
 
@@ -52,6 +52,5 @@ func New() *Command {
 	flags.StringVarP(&outFile, "out", "o", "tetragon-bugtool.tar.gz", "Output filename")
 	flags.StringVar(&bpfTool, "bpftool", "", "Path to bpftool binary")
 	flags.StringVar(&gops, "gops", "", "Path to gops binary")
-	flags.IntVar(&maxRecvSize, "max-recv-size", 10*1024*1024, "Size of gRPC maxRecvSize")
 	return bugtoolCmd
 }

--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -111,6 +111,7 @@ func NewClient(ctx context.Context, address string, timeout time.Duration) (*Cli
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(RetryPolicy(Retries)),
 		grpc.WithMaxCallAttempts(Retries+1), // maxAttempt includes the first call
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC client with address %s: %w", address, err)

--- a/cmd/tetra/common/flags.go
+++ b/cmd/tetra/common/flags.go
@@ -15,15 +15,16 @@ import (
 )
 
 const (
-	KeyColor         = "color"          // string
-	KeyDebug         = "debug"          // bool
-	KeyOutput        = "output"         // string
-	KeyTty           = "tty-encode"     // string
-	KeyServerAddress = "server-address" // string
-	KeyTimeout       = "timeout"        // duration
-	KeyRetries       = "retries"        // int
-	KeyNamespace     = "namespace"      // string
-	KeyLogLevel      = "loglevel"       // string
+	KeyColor          = "color"          // string
+	KeyDebug          = "debug"          // bool
+	KeyOutput         = "output"         // string
+	KeyTty            = "tty-encode"     // string
+	KeyServerAddress  = "server-address" // string
+	KeyTimeout        = "timeout"        // duration
+	KeyRetries        = "retries"        // int
+	KeyNamespace      = "namespace"      // string
+	KeyLogLevel       = "loglevel"       // string
+	KeyMaxRecvMsgSize = "max-recv-size"  // int
 )
 
 const (
@@ -31,10 +32,11 @@ const (
 )
 
 var (
-	Debug         bool
-	ServerAddress string
-	Timeout       time.Duration
-	Retries       int
+	Debug          bool
+	ServerAddress  string
+	Timeout        time.Duration
+	Retries        int
+	MaxRecvMsgSize = defaults.DefaultMaxGRPCRecvMsgSize
 )
 
 func readActiveServerAddressFromFile(fname string) (string, error) {

--- a/cmd/tetra/debug/dump.go
+++ b/cmd/tetra/debug/dump.go
@@ -122,7 +122,6 @@ func dumpExecveMap(fname string) {
 func processCacheCmd() *cobra.Command {
 	skipZeroRefcnt := false
 	excludeExecveMapProcesses := false
-	var maxCallRecvMsgSize int
 
 	ret := &cobra.Command{
 		Use: "processcache",
@@ -136,7 +135,7 @@ func processCacheCmd() *cobra.Command {
 				return fmt.Errorf("failed to create a gRPC client: %w", err)
 			}
 
-			processes, err := dump.GetProcessCacheForDump(c.Ctx, c.Client, maxCallRecvMsgSize, skipZeroRefcnt, excludeExecveMapProcesses)
+			processes, err := dump.GetProcessCacheForDump(c.Ctx, c.Client, common.MaxRecvMsgSize, skipZeroRefcnt, excludeExecveMapProcesses)
 			if err != nil {
 				return fmt.Errorf("process cache dump failed: %w", err)
 			}
@@ -156,7 +155,6 @@ func processCacheCmd() *cobra.Command {
 	flags := ret.Flags()
 	flags.BoolVar(&skipZeroRefcnt, "skip-zero-refcnt", skipZeroRefcnt, "skip entries with zero refcnt")
 	flags.BoolVar(&excludeExecveMapProcesses, "exclude-execve-map-processes", excludeExecveMapProcesses, "exclude processes that also exist in the execve_map")
-	flags.IntVar(&maxCallRecvMsgSize, "max-recv-size", 4194304, "The maximum message size in bytes the client can receive. Default is gRPC 4MB default.")
 
 	return ret
 }

--- a/cmd/tetra/main.go
+++ b/cmd/tetra/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/tetragon/cmd/tetra/common"
+	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/logger"
 )
 
@@ -47,5 +48,6 @@ func New() *cobra.Command {
 	flags.StringVar(&common.ServerAddress, common.KeyServerAddress, "", "gRPC server address")
 	flags.DurationVar(&common.Timeout, common.KeyTimeout, 30*time.Second, "Connection timeout")
 	flags.IntVar(&common.Retries, common.KeyRetries, 1, "Connection retries with exponential backoff")
+	flags.IntVar(&common.MaxRecvMsgSize, common.KeyMaxRecvMsgSize, defaults.DefaultMaxGRPCRecvMsgSize, "Maximum gRPC message size in bytes the client can receive")
 	return rootCmd
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -63,6 +63,10 @@ const (
 
 	// defaults for the {k,u}retprobes lru cache
 	DefaultRetprobesCacheSize = 4096
+
+	// DefaultMaxGRPCRecvMsgSize is the default maximum gRPC receive message
+	// size for the tetra CLI (10MB).
+	DefaultMaxGRPCRecvMsgSize = 10 * 1024 * 1024
 )
 
 var (

--- a/pkg/defaults/defaults_windows.go
+++ b/pkg/defaults/defaults_windows.go
@@ -55,4 +55,8 @@ const (
 
 	// defaults for the {k,u}retprobes lru cache
 	DefaultRetprobesCacheSize = 4096
+
+	// DefaultMaxGRPCRecvMsgSize is the default maximum gRPC receive message
+	// size for the tetra CLI (10MB).
+	DefaultMaxGRPCRecvMsgSize = 10 * 1024 * 1024
 )


### PR DESCRIPTION
Add a global `--max-recv-size` persistent flag to the `tetra` CLI (default 10MB). Previously, the gRPC client connections used gRPC's hardcoded 4MB default, causing `ResourceExhausted` errors when a server response exceeds that limit.

The limit is now applied at the connection level via `WithDefaultCallOptions(MaxCallRecvMsgSize(...))` in `common.NewClient()`, so all commands benefit without any per-command changes.

The existing per-command `--max-recv-size` flags on `tetra bugtool` and `tetra debug dump processcache` are removed, as they are superseded by the new global flag. Both commands now read `common.MaxRecvMsgSize` directly.

```release-note
Add global `--max-recv-size` flag to `tetra` CLI to configure the maximum gRPC receive message size (default 10MB, up from 4MB).
```