### PR TITLE
fix : add enum support for resolve

### DIFF
--- a/contrib/tester-progs/uprobe-resolve.c
+++ b/contrib/tester-progs/uprobe-resolve.c
@@ -14,11 +14,17 @@ struct mysubstruct {
 	char     *buff;
 };
 
+enum myenum_u32 {
+	SUCCESS = 1234,
+	FAILURE = 4321,
+};
+
 struct mystruct {
 	uint8_t  v8;
 	uint16_t v16;
 	uint32_t v32;
 	uint64_t v64;
+	enum myenum_u32 enum_u32;
 	struct mysubstruct sub;
 	struct mysubstruct *arr[10];
 	struct mysubstruct **dyn;
@@ -28,7 +34,7 @@ struct mystruct {
 void usage(char *argv0)
 {
 	fprintf(stderr, "Usage: %s <field> <val>\n", argv0);
-	fprintf(stderr, "field can be one of: v8, v16, v32, v64, sub.v32 arr[idx].v64 dyn[idx].v64, subp.buff, subp.v64\n");
+	fprintf(stderr, "field can be one of: v8, v16, v32, v64, enum_u32, sub.v32 arr[idx].v64 dyn[idx].v64, subp.buff, subp.v64\n");
 }
 
 // without noinline, the symbol is found, but no event fires
@@ -68,6 +74,8 @@ int main(int argc, char *argv[])
 		s.v32 = val;
 	} else if (!strcmp(field, "v64")) {
 		s.v64 = val;
+	} else if (!strcmp(field, "enum_u32")) {
+		s.enum_u32 = (val == SUCCESS) ? SUCCESS : FAILURE;
 	} else if (!strcmp(field, "subp.v64")) {
 		struct mysubstruct s2 = {
 			.v64 = val,

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -351,10 +351,11 @@ func processMembers(
 			members,
 		)
 	}
-	if t, ok := currentType.(*btf.Pointer); ok {
+	switch t := currentType.(type) {
+	case *btf.Pointer:
 		btfArgs[i].IsPointer = uint16(1)
 		currentType = t.Target
-	} else if _, ok := currentType.(*btf.Int); ok {
+	case *btf.Int, *btf.Enum:
 		btfArgs[i].IsPointer = uint16(1)
 	}
 	return &currentType, nil

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -222,6 +222,16 @@ func GenericTypeFromBTF(arg btf.Type) int {
 			return GenericTypeFromBTF(t.Type)
 		case *btf.Pointer:
 			return GenericTypeFromBTF(t.Target)
+		case *btf.Enum:
+			prefix := ""
+			if !t.Signed {
+				prefix = "u"
+			}
+			integerTy := fmt.Sprintf("%sint%d", prefix, t.Size*8)
+			if ty, ok := genericStringToType[integerTy]; ok {
+				return ty
+			}
+			return GenericInvalidType
 		default:
 			return GenericInvalidType
 		}

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -205,9 +205,9 @@ func TestUprobeResolve(t *testing.T) {
 			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("3"))),
 			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("2"))),
 		}},
-		{"uint32", 11, "v32", []*ec.KprobeArgumentChecker{
+		{"uint32", 1234, "enum_u32", []*ec.KprobeArgumentChecker{
 			ec.NewKprobeArgumentChecker().WithSizeArg(0),
-			ec.NewKprobeArgumentChecker().WithUintArg(11), // uint32(11)
+			ec.NewKprobeArgumentChecker().WithUintArg(1234), // uint32(1234)
 			ec.NewKprobeArgumentChecker().WithUintArg(0),
 			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("3"))),
 			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("2"))),


### PR DESCRIPTION
Fixes https://github.com/cilium/tetragon/issues/4799

## Description

Enums are uint32. Currently, because of the way integer are handled on BPF, we need to add an extra dereferencing in the resolve algo to have it working properly. For this reason I did not add tests as this little hack won't be necessary after a fix will be done.

```
[11] ENUM 'test_enum' encoding=UNSIGNED size=4 vlen=3
```