### PR TITLE
Makefile: update buf breaking change check to v1.6 branch

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -13,6 +13,6 @@ GO ?= go
 CONTAINER_ENGINE ?= docker
 
 BUF ?= buf
-BUF_BREAKING_AGAINST_BRANCH ?= origin/main
+BUF_BREAKING_AGAINST_BRANCH ?= origin/v1.6
 # renovate: datasource=docker
 BUILDER_IMAGE=quay.io/cilium/cilium-builder:cd04ac813fb4763f840911c88beae99efc4aa457


### PR DESCRIPTION
### Description
`make protogen` is failing because buf breaking change is targeting the wrong branch, this fixes that issue
