### PR TITLE
build(renovate): enable shell executor for post-upgrade commands

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
   // config, for example the regex. See:
   // https://docs.renovatebot.com/self-hosted-configuration/#requireconfig
   "requireConfig": "ignored",
+  "allowShellExecutorForPostUpgradeCommands": true,
   "allowedCommands": [
     "^/tmp/install-buildx$", 
     "^make protogen$",


### PR DESCRIPTION
### Description
Add `allowShellExecutorForPostUpgradeCommands` configuration option to allow Renovate to execute shell commands during post-upgrade tasks. It failed due to this error

```
"stdout": "Unknown Syntax Error: Command not found; did you mean one of:\n\n  0. install-tool [-d,--dry-run] <name> [version]\n  1. install-tool [-d,--dry-run] <name> [version]\n\nWhile running golang $(grep -oP \"^toolchain go\\\\K.+$\" go.mod || grep -oP \"^go \\\\K.+$\" go.mod)\n"
```