### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/pkg/logger/klog_bridge.go
+++ b/pkg/logger/klog_bridge.go
@@ -36,6 +36,10 @@ func initializeKLog(logger *slog.Logger) error {
 	// update them from this file.
 	klog.InitFlags(klogFlags)
 
+	// Opt into fixed stderrthreshold behavior (kubernetes/klog#212).
+	klogFlags.Set("legacy_stderr_threshold_behavior", "false")
+	klogFlags.Set("stderrthreshold", "INFO")
+
 	// Make sure klog does not log to stderr as we want it to control the output
 	// of klog so we want klog to log the errors to each writer of each level.
 	klogFlags.Set("logtostderr", "false")


### PR DESCRIPTION
## Description

klog has a long-standing bug where setting `-logtostderr=true` causes the `-stderrthreshold` flag to be silently ignored. All log messages are sent to stderr regardless of their severity.

klog v2.140.0 introduced two new flags that allow callers to opt into the correct behavior:
- `-legacy_stderr_threshold_behavior=false`
- `-stderrthreshold=INFO`

This PR sets them in `initializeKLog()` (inside `pkg/logger/klog_bridge.go`), right after `klog.InitFlags()` is called.

### Defensive fix

While Tetragon currently sets `logtostderr=false` and uses `SetOutputBySeverity` to route klog output through its own logging pipeline, this fix is defensive: if the klog configuration changes in the future, `-stderrthreshold` will be honored correctly.

### go.mod

No dependency bump needed — Tetragon already uses `k8s.io/klog/v2 v2.140.0`.

Reference: kubernetes/klog#212

/cc @tklauser @mtardy