### PR TITLE
Add support for spec.hostSelector

### DIFF
--- a/bpf/process/policy_filter.h
+++ b/bpf/process/policy_filter.h
@@ -10,11 +10,22 @@
 #define POLICY_FILTER_MAX_POLICIES   128
 #define POLICY_FILTER_MAX_CGROUP_IDS 1024
 
+#define ALL_PODS_POLICY_ID 0x01
+#define HOST_SELECTOR_MODE 0xFFFFFFFFFFFFFFFFull
+
+// In order to implement the hostSelector we add one more entry in the outer map
+// that is not related to any specific policy. This entry has policy_id equals
+// to ALL_PODS_POLICY_ID. In that case the inner map contains the cgroup_ids for
+// *all* containers inside *all* pods. This allows us to generate a mechanism to
+// match (i) on all pods or (ii) in none of the pods (which is the same as the
+// host workload).
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
 	__uint(max_entries, POLICY_FILTER_MAX_POLICIES);
 	__type(key, u32); /* policy id */
 	__array(
+		// If a specific policy needs to match on host workloads as well we also
+		// add an entry with key HOST_SELECTOR_MODE (UINT64_MAX).
 		values, struct {
 			__uint(type, BPF_MAP_TYPE_HASH);
 			__uint(max_entries, 1);
@@ -63,7 +74,23 @@ FUNC_INLINE bool policy_filter_check(u32 policy_id)
 	if (trackerid)
 		cgroupid = trackerid;
 
-	return map_lookup_elem(policy_map, &cgroupid);
+	if (map_lookup_elem(policy_map, &cgroupid))
+		return true; // We have a match from the podSelector and/or the containerSelector.
+
+	// We didn't match on the podSelector and/or the containerSelector.
+	// Now we need to check if we have a hostSelector match.
+
+	trackerid = HOST_SELECTOR_MODE;
+	if (!map_lookup_elem(policy_map, &trackerid))
+		return false; // Cannot find the match mode of the hostSelector so we do not care to match any host workloads.
+
+	policy_id = ALL_PODS_POLICY_ID;
+	policy_map = map_lookup_elem(&policy_filter_maps, &policy_id);
+	if (!policy_map)
+		return false; // Cannot find the cgroupids of all containers inside all pods. This should not happen.
+
+	// If !map_lookup_elem(policy_map, &cgroupid) then our cgroupid belongs to a host workload.
+	return !map_lookup_elem(policy_map, &cgroupid);
 }
 
 #endif /* POLICY_FILTER_MAPS_H__ */

--- a/docs/content/en/docs/concepts/tracing-policy/k8s-filtering.md
+++ b/docs/content/en/docs/concepts/tracing-policy/k8s-filtering.md
@@ -49,6 +49,67 @@ the policy is applied to.
 
 For container field filters, we use the `containerSelector` field of tracing policies to select the containers that the policy is applied to. At the moment, the only supported fields are `name` and `repo` which refers to the container repository.
 
+## Host workload filters
+
+To filter host workloads we use the `hostSelector` field of tracing policies to select if a policy
+should be applied to host workloads or not. For now this only supports `{}` to match all host workloads
+and `null` to match none of the host workloads.
+
+Based on these, the user can filter out specific workloads.
+
+## Examples
+
+By default, a policy match on all workloads, similar to the following example:
+
+```yaml
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "workload-filtering"
+spec:
+  hostSelector: {}
+  podSelector: {}
+  containerSelector: {}
+  kprobes:
+```
+
+This is equivalent as if the user does not define any of `hostSelector`, `podSelector`, and
+`containerSelector`.
+
+The following example will match only host workloads.
+
+```yaml
+spec:
+  hostSelector: {}
+  podSelector: null
+  containerSelector: null
+```
+
+The following example will match only pod workloads.
+
+```yaml
+spec:
+  hostSelector: null
+  podSelector: {}
+  containerSelector: {}
+```
+
+`containerSelector` acts as a second level filtering on the `podSelector`. This means that first the
+`podSelector` is evaluated and if pod match we then apply the `containerSelector`. The following example
+will match all pods inside the `kube-system` namespace and all host workloads.
+
+```yaml
+spec:
+  hostSelector: {}
+  podSelector:
+    matchExpressions:
+    - key: "k8s:io.kubernetes.pod.namespace"
+      operator: In
+      values:
+      - "kube-system"
+  containerSelector: {} # this can be also omitted as the default value is {}
+```
+
 ## Demo
 
 ### Setup

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -107,6 +107,8 @@ Tracing policy specification.
 A map of container fields will be constructed in the same way as a map of labels.
 The name of the field represents the label "key", and the value of the field - label "value".
 Currently, only the "name" field is supported.<br/>
+          <br/>
+            <i>Default</i>: map[]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -121,6 +123,16 @@ Currently, only the "name" field is supported.<br/>
         <td>[]object</td>
         <td>
           A list of fentry specs.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicyspechostselector">hostSelector</a></b></td>
+        <td>object</td>
+        <td>
+          HostSelector selects hosts that this policy applies to.
+For now only ~ (none) and {} (all) is supported.<br/>
+          <br/>
+            <i>Default</i>: map[]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -163,6 +175,8 @@ Currently, only the "name" field is supported.<br/>
         <td>object</td>
         <td>
           PodSelector selects pods that this policy applies to<br/>
+          <br/>
+            <i>Default</i>: map[]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1663,6 +1677,89 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]string</td>
         <td>
           Value to compare the argument against.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.hostSelector
+<sup><sup>[↩ Parent](#tracingpolicyspec)</sup></sup>
+
+
+HostSelector selects hosts that this policy applies to.
+For now only ~ (none) and {} (all) is supported.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#tracingpolicyspechostselectormatchexpressionsindex">matchExpressions</a></b></td>
+        <td>[]object</td>
+        <td>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchLabels</b></td>
+        <td>map[string]string</td>
+        <td>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicy.spec.hostSelector.matchExpressions[index]
+<sup><sup>[↩ Parent](#tracingpolicyspechostselector)</sup></sup>
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          key is the label key that the selector applies to.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn, Exists, DoesNotExist<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8777,6 +8874,8 @@ Tracing policy specification.
 A map of container fields will be constructed in the same way as a map of labels.
 The name of the field represents the label "key", and the value of the field - label "value".
 Currently, only the "name" field is supported.<br/>
+          <br/>
+            <i>Default</i>: map[]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8791,6 +8890,16 @@ Currently, only the "name" field is supported.<br/>
         <td>[]object</td>
         <td>
           A list of fentry specs.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#tracingpolicynamespacedspechostselector">hostSelector</a></b></td>
+        <td>object</td>
+        <td>
+          HostSelector selects hosts that this policy applies to.
+For now only ~ (none) and {} (all) is supported.<br/>
+          <br/>
+            <i>Default</i>: map[]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8833,6 +8942,8 @@ Currently, only the "name" field is supported.<br/>
         <td>object</td>
         <td>
           PodSelector selects pods that this policy applies to<br/>
+          <br/>
+            <i>Default</i>: map[]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10333,6 +10444,89 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td>[]string</td>
         <td>
           Value to compare the argument against.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.hostSelector
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspec)</sup></sup>
+
+
+HostSelector selects hosts that this policy applies to.
+For now only ~ (none) and {} (all) is supported.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#tracingpolicynamespacedspechostselectormatchexpressionsindex">matchExpressions</a></b></td>
+        <td>[]object</td>
+        <td>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchLabels</b></td>
+        <td>map[string]string</td>
+        <td>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TracingPolicyNamespaced.spec.hostSelector.matchExpressions[index]
+<sup><sup>[↩ Parent](#tracingpolicynamespacedspechostselector)</sup></sup>
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          key is the label key that the selector applies to.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>enum</td>
+        <td>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          <br/>
+            <i>Enum</i>: In, NotIn, Exists, DoesNotExist<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -43,11 +43,13 @@ spec:
             description: Tracing policy specification.
             properties:
               containerSelector:
+                default: {}
                 description: |-
                   ContainerSelector selects containers that this policy applies to.
                   A map of container fields will be constructed in the same way as a map of labels.
                   The name of the field represents the label "key", and the value of the field - label "value".
                   Currently, only the "name" field is supported.
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1131,6 +1133,65 @@ spec:
                   - call
                   type: object
                 type: array
+              hostSelector:
+                default: {}
+                description: |-
+                  HostSelector selects hosts that this policy applies to.
+                  For now only ~ (none) and {} (all) is supported.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               kprobes:
                 description: A list of kprobe specs.
                 items:
@@ -2971,7 +3032,9 @@ spec:
                   type: object
                 type: array
               podSelector:
+                default: {}
                 description: PodSelector selects pods that this policy applies to
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -43,11 +43,13 @@ spec:
             description: Tracing policy specification.
             properties:
               containerSelector:
+                default: {}
                 description: |-
                   ContainerSelector selects containers that this policy applies to.
                   A map of container fields will be constructed in the same way as a map of labels.
                   The name of the field represents the label "key", and the value of the field - label "value".
                   Currently, only the "name" field is supported.
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1131,6 +1133,65 @@ spec:
                   - call
                   type: object
                 type: array
+              hostSelector:
+                default: {}
+                description: |-
+                  HostSelector selects hosts that this policy applies to.
+                  For now only ~ (none) and {} (all) is supported.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               kprobes:
                 description: A list of kprobe specs.
                 items:
@@ -2971,7 +3032,9 @@ spec:
                   type: object
                 type: array
               podSelector:
+                default: {}
                 description: PodSelector selects pods that this policy applies to
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/pkg/cgtracker/test/cgtracker_test.go
+++ b/pkg/cgtracker/test/cgtracker_test.go
@@ -24,6 +24,7 @@ import (
 	grpcexec "github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
@@ -431,6 +432,8 @@ func namespacedLseekPolicy(namespace string, fd int) *tracingpolicy.GenericTraci
 			Namespace: namespace,
 		},
 		Spec: v1alpha1.TracingPolicySpec{
+			PodSelector:       &slimv1.LabelSelector{},
+			ContainerSelector: &slimv1.LabelSelector{},
 			KProbes: []v1alpha1.KProbeSpec{{
 				Call:    "sys_lseek",
 				Return:  false,

--- a/pkg/crdutils/crdutils_test.go
+++ b/pkg/crdutils/crdutils_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/tetragon/pkg/testutils/tempfile"
 )
 
@@ -97,6 +98,9 @@ var expectedWrite = GenericTracingPolicy{
 	},
 	Metadata: metav1.ObjectMeta{Name: "sys-write"},
 	Spec: v1alpha1.TracingPolicySpec{
+		PodSelector:       &slimv1.LabelSelector{},
+		ContainerSelector: &slimv1.LabelSelector{},
+		HostSelector:      &slimv1.LabelSelector{},
 		KProbes: []v1alpha1.KProbeSpec{
 			{
 				Call:    "sys_write",
@@ -263,6 +267,9 @@ var expectedData = GenericTracingPolicy{
 	},
 	Metadata: metav1.ObjectMeta{Name: "sys-write"},
 	Spec: v1alpha1.TracingPolicySpec{
+		PodSelector:       &slimv1.LabelSelector{},
+		ContainerSelector: &slimv1.LabelSelector{},
+		HostSelector:      &slimv1.LabelSelector{},
 		KProbes: []v1alpha1.KProbeSpec{
 			{
 				Call:    "example_func",

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -43,11 +43,13 @@ spec:
             description: Tracing policy specification.
             properties:
               containerSelector:
+                default: {}
                 description: |-
                   ContainerSelector selects containers that this policy applies to.
                   A map of container fields will be constructed in the same way as a map of labels.
                   The name of the field represents the label "key", and the value of the field - label "value".
                   Currently, only the "name" field is supported.
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1131,6 +1133,65 @@ spec:
                   - call
                   type: object
                 type: array
+              hostSelector:
+                default: {}
+                description: |-
+                  HostSelector selects hosts that this policy applies to.
+                  For now only ~ (none) and {} (all) is supported.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               kprobes:
                 description: A list of kprobe specs.
                 items:
@@ -2971,7 +3032,9 @@ spec:
                   type: object
                 type: array
               podSelector:
+                default: {}
                 description: PodSelector selects pods that this policy applies to
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -43,11 +43,13 @@ spec:
             description: Tracing policy specification.
             properties:
               containerSelector:
+                default: {}
                 description: |-
                   ContainerSelector selects containers that this policy applies to.
                   A map of container fields will be constructed in the same way as a map of labels.
                   The name of the field represents the label "key", and the value of the field - label "value".
                   Currently, only the "name" field is supported.
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1131,6 +1133,65 @@ spec:
                   - call
                   type: object
                 type: array
+              hostSelector:
+                default: {}
+                description: |-
+                  HostSelector selects hosts that this policy applies to.
+                  For now only ~ (none) and {} (all) is supported.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               kprobes:
                 description: A list of kprobe specs.
                 items:
@@ -2971,7 +3032,9 @@ spec:
                   type: object
                 type: array
               podSelector:
+                default: {}
                 description: PodSelector selects pods that this policy applies to
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -97,15 +97,26 @@ type TracingPolicySpec struct {
 	Fentries []KProbeSpec `json:"fentries,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
+	// +nullable
 	// PodSelector selects pods that this policy applies to
 	PodSelector *slimv1.LabelSelector `json:"podSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
+	// +nullable
 	// ContainerSelector selects containers that this policy applies to.
 	// A map of container fields will be constructed in the same way as a map of labels.
 	// The name of the field represents the label "key", and the value of the field - label "value".
 	// Currently, only the "name" field is supported.
 	ContainerSelector *slimv1.LabelSelector `json:"containerSelector,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
+	// +nullable
+	// HostSelector selects hosts that this policy applies to.
+	// For now only ~ (none) and {} (all) is supported.
+	HostSelector *slimv1.LabelSelector `json:"hostSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// A list of list specs.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.13"
+const CustomResourceDefinitionSchemaVersion = "1.7.14"

--- a/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
@@ -749,6 +749,11 @@ func (in *TracingPolicySpec) DeepCopyInto(out *TracingPolicySpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HostSelector != nil {
+		in, out := &in.HostSelector, &out.HostSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Lists != nil {
 		in, out := &in.Lists, &out.Lists
 		*out = make([]ListSpec, len(*in))

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -53,11 +53,13 @@ func (s *selectorOp) match(labels Labels) bool {
 	}
 }
 
-type Selector []selectorOp
+type SelectorWithValues struct {
+	m []selectorOp
+}
 
-func (s Selector) Match(labels Labels) bool {
-	for i := range s {
-		if !s[i].match(labels) {
+func (s SelectorWithValues) Match(labels Labels) bool {
+	for i := range s.m {
+		if !s.m[i].match(labels) {
 			return false
 		}
 	}
@@ -65,9 +67,24 @@ func (s Selector) Match(labels Labels) bool {
 	return true
 }
 
+type SelectorAllOrNothing struct {
+	m bool
+}
+
+func (s SelectorAllOrNothing) Match(_ Labels) bool {
+	return s.m
+}
+
+type Selector interface {
+	Match(labels Labels) bool
+}
+
 func SelectorFromLabelSelector(ls *slimv1.LabelSelector) (Selector, error) {
 	if ls == nil {
-		return []selectorOp{}, nil
+		return SelectorAllOrNothing{false}, nil
+	}
+	if ls != nil && (len(ls.MatchLabels)+len(ls.MatchExpressions) == 0) {
+		return SelectorAllOrNothing{true}, nil
 	}
 	ret := make([]selectorOp, 0, len(ls.MatchLabels)+len(ls.MatchExpressions))
 	for key, val := range ls.MatchLabels {
@@ -99,7 +116,7 @@ func SelectorFromLabelSelector(ls *slimv1.LabelSelector) (Selector, error) {
 		})
 	}
 
-	return ret, nil
+	return SelectorWithValues{ret}, nil
 }
 
 // Cmp checks if the labels are different. Returns true if they are.

--- a/pkg/policyconf/test/mode_test.go
+++ b/pkg/policyconf/test/mode_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/tetragon/pkg/build"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/policyconf"
 	"github.com/cilium/tetragon/pkg/reader/notify"
@@ -55,6 +56,9 @@ func TestModeSigKill(t *testing.T) {
 			Namespace: "namespace",
 		},
 		Spec: v1alpha1.TracingPolicySpec{
+			PodSelector:       &slimv1.LabelSelector{},
+			ContainerSelector: &slimv1.LabelSelector{},
+			HostSelector:      &slimv1.LabelSelector{},
 			KProbes: []v1alpha1.KProbeSpec{{
 				Call:    "sys_getcpu",
 				Return:  true,
@@ -161,6 +165,9 @@ func TestModeEnforcer(t *testing.T) {
 			Namespace: polNamespace,
 		},
 		Spec: v1alpha1.TracingPolicySpec{
+			PodSelector:       &slimv1.LabelSelector{},
+			ContainerSelector: &slimv1.LabelSelector{},
+			HostSelector:      &slimv1.LabelSelector{},
 			Enforcers: []v1alpha1.EnforcerSpec{{
 				// NB: add another enforcer call so that we can just check the map
 				Calls: []string{"sys_lseek"},

--- a/pkg/policyfilter/common.go
+++ b/pkg/policyfilter/common.go
@@ -3,13 +3,23 @@
 
 package policyfilter
 
-import "github.com/google/uuid"
+import (
+	"math"
+
+	"github.com/google/uuid"
+)
 
 const (
 	// we reserve 0 as a special value to indicate no filtering
-	NoFilterPolicyID         = 0
-	NoFilterID               = PolicyID(NoFilterPolicyID)
-	FirstValidFilterPolicyID = NoFilterPolicyID + 1
+	NoFilterPolicyID = 0
+	NoFilterID       = PolicyID(NoFilterPolicyID)
+	// AllPodsID is a reserved synthetic policy id that tracks all pod cgroup ids.
+	AllPodsPolicyID          = 1
+	AllPodsID                = PolicyID(AllPodsPolicyID)
+	FirstValidFilterPolicyID = AllPodsPolicyID + 1
+
+	// Special CgroupID to store the hostSelector mode.
+	HostSelectorMode = math.MaxUint64
 )
 
 const (

--- a/pkg/policyfilter/disabled.go
+++ b/pkg/policyfilter/disabled.go
@@ -22,7 +22,7 @@ type disabled struct {
 }
 
 func (s *disabled) AddPolicy(polID PolicyID, namespace string, podSelector *slimv1.LabelSelector,
-	containerSelector *slimv1.LabelSelector) error {
+	containerSelector *slimv1.LabelSelector, hostSelector *slimv1.LabelSelector) error {
 	return errors.New("policyfilter is disabled")
 }
 

--- a/pkg/policyfilter/k8s_test.go
+++ b/pkg/policyfilter/k8s_test.go
@@ -343,9 +343,9 @@ func (ts *testState) containersCgroupIDs(t *testing.T, podContainerMap map[strin
 }
 
 func testNamespacePods(t *testing.T, st *state, ts *testState) {
-	err := st.AddPolicy(PolicyID(1), "ns1", nil, nil)
+	err := st.AddPolicy(PolicyID(2), "ns1", &slimv1.LabelSelector{}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
-	err = st.AddPolicy(PolicyID(2), "ns2", nil, nil)
+	err = st.AddPolicy(PolicyID(3), "ns2", &slimv1.LabelSelector{}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
 
 	emptyLabels := labels.Labels{}
@@ -354,20 +354,25 @@ func testNamespacePods(t *testing.T, st *state, ts *testState) {
 	ts.createPod(t, "p3", "ns1", emptyLabels, "p3c1")
 	ts.waitForCallbacks(t)
 
+	c1 := ts.podsCgroupIDs(t, "p1", "p3")
+	c2 := ts.podsCgroupIDs(t, "p2")
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			1: ts.podsCgroupIDs(t, "p1", "p3"),
-			2: ts.podsCgroupIDs(t, "p2"),
+			2:                 c1,
+			3:                 c2,
+			uint64(AllPodsID): append(c2, c1...),
 		},
 	)
 
 	ts.deletePod(t, "p3")
 	ts.waitForCallbacks(t)
 
+	c1 = ts.podsCgroupIDs(t, "p1")
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			1: ts.podsCgroupIDs(t, "p1"),
-			2: ts.podsCgroupIDs(t, "p2"),
+			2:                 c1,
+			3:                 c2,
+			uint64(AllPodsID): append(c2, c1...),
 		},
 	)
 
@@ -375,8 +380,18 @@ func testNamespacePods(t *testing.T, st *state, ts *testState) {
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			1: ts.podsCgroupIDs(t, "p1"),
-			2: {},
+			2:                 c1,
+			3:                 {},
+			uint64(AllPodsID): c1,
+		},
+	)
+
+	err = st.DelPolicy(PolicyID(3))
+	require.NoError(t, err)
+	requirePfmEqualTo(t, st.pfMap,
+		map[uint64][]uint64{
+			2:                 c1,
+			uint64(AllPodsID): c1,
 		},
 	)
 
@@ -384,29 +399,25 @@ func testNamespacePods(t *testing.T, st *state, ts *testState) {
 	require.NoError(t, err)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			1: ts.podsCgroupIDs(t, "p1"),
+			uint64(AllPodsID): c1,
 		},
-	)
-
-	err = st.DelPolicy(PolicyID(1))
-	require.NoError(t, err)
-	requirePfmEqualTo(t, st.pfMap,
-		map[uint64][]uint64{},
 	)
 
 	ts.deletePod(t, "p1")
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
-		map[uint64][]uint64{},
+		map[uint64][]uint64{
+			uint64(AllPodsID): {},
+		},
 	)
 }
 
 func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 	// create policies
-	matchesAllID := uint32(1)
-	matchesWebID := uint32(2)
-	matchesAppsID := uint32(3)
-	err := st.AddPolicy(PolicyID(matchesAllID), "", nil, nil)
+	matchesAllID := uint32(2)
+	matchesWebID := uint32(3)
+	matchesAppsID := uint32(4)
+	err := st.AddPolicy(PolicyID(matchesAllID), "", &slimv1.LabelSelector{}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
 	err = st.AddPolicy(PolicyID(matchesWebID), "", &slimv1.LabelSelector{
 		MatchExpressions: []slimv1.LabelSelectorRequirement{{
@@ -414,14 +425,14 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 			Operator: slimv1.LabelSelectorOpIn,
 			Values:   []string{"web"},
 		}},
-	}, nil)
+	}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
 	err = st.AddPolicy(PolicyID(matchesAppsID), "", &slimv1.LabelSelector{
 		MatchExpressions: []slimv1.LabelSelectorRequirement{{
 			Key:      "app",
 			Operator: slimv1.LabelSelectorOpExists,
 		}},
-	}, nil)
+	}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
 
 	// create pods
@@ -430,11 +441,19 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 	ts.createPod(t, "log", "default", labels.Labels{}, "log-c1")
 
 	ts.waitForCallbacks(t)
+
+	c1 := ts.podsCgroupIDs(t, "web", "db", "log")
+	c2 := ts.podsCgroupIDs(t, "web")
+	c3 := ts.podsCgroupIDs(t, "web", "db")
+	c4 := ts.podsCgroupIDs(t, "db", "log")
+	c5 := ts.podsCgroupIDs(t, "db")
+
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesAllID):  ts.podsCgroupIDs(t, "web", "db", "log"),
-			uint64(matchesWebID):  ts.podsCgroupIDs(t, "web"),
-			uint64(matchesAppsID): ts.podsCgroupIDs(t, "web", "db"),
+			uint64(matchesAllID):  c1,
+			uint64(matchesWebID):  c2,
+			uint64(matchesAppsID): c3,
+			uint64(AllPodsID):     append(c3, append(c2, c1...)...),
 		},
 	)
 
@@ -443,9 +462,10 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesAllID):  ts.podsCgroupIDs(t, "web", "db", "log"),
-			uint64(matchesWebID):  ts.podsCgroupIDs(t, "web"),
-			uint64(matchesAppsID): ts.podsCgroupIDs(t, "web", "db", "log"),
+			uint64(matchesAllID):  c1,
+			uint64(matchesWebID):  c2,
+			uint64(matchesAppsID): c1,
+			uint64(AllPodsID):     append(c2, c1...),
 		},
 	)
 
@@ -453,9 +473,10 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesAllID):  ts.podsCgroupIDs(t, "web", "db", "log"),
-			uint64(matchesWebID):  ts.podsCgroupIDs(t),
-			uint64(matchesAppsID): ts.podsCgroupIDs(t, "db", "log"),
+			uint64(matchesAllID):  c1,
+			uint64(matchesWebID):  {},
+			uint64(matchesAppsID): c4,
+			uint64(AllPodsID):     append(c4, c1...),
 		},
 	)
 
@@ -463,9 +484,10 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesAllID):  ts.podsCgroupIDs(t, "web", "db"),
-			uint64(matchesWebID):  ts.podsCgroupIDs(t),
-			uint64(matchesAppsID): ts.podsCgroupIDs(t, "db"),
+			uint64(matchesAllID):  c3,
+			uint64(matchesWebID):  {},
+			uint64(matchesAppsID): c5,
+			uint64(AllPodsID):     append(c5, c3...),
 		},
 	)
 
@@ -474,8 +496,9 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesWebID):  ts.podsCgroupIDs(t),
-			uint64(matchesAppsID): ts.podsCgroupIDs(t, "db"),
+			uint64(matchesWebID):  {},
+			uint64(matchesAppsID): c5,
+			uint64(AllPodsID):     append(c5, c3...),
 		},
 	)
 
@@ -487,25 +510,27 @@ func testPodLabelFilters(t *testing.T, st *state, ts *testState) {
 	require.NoError(t, err)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
-		map[uint64][]uint64{},
+		map[uint64][]uint64{
+			uint64(AllPodsID): {},
+		},
 	)
 }
 
 func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 	// create policies
-	matchesAllContainers := uint32(1)
-	matchesWebContainers := uint32(2)
-	matchesNotInitContainers := uint32(3)
-	err := st.AddPolicy(PolicyID(matchesAllContainers), "", nil, nil)
+	matchesAllContainers := uint32(2)
+	matchesWebContainers := uint32(3)
+	matchesNotInitContainers := uint32(4)
+	err := st.AddPolicy(PolicyID(matchesAllContainers), "", &slimv1.LabelSelector{}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
-	err = st.AddPolicy(PolicyID(matchesWebContainers), "", nil,
+	err = st.AddPolicy(PolicyID(matchesWebContainers), "", &slimv1.LabelSelector{},
 		&slimv1.LabelSelector{
 			MatchExpressions: []slimv1.LabelSelectorRequirement{{
 				Key:      "name",
 				Operator: slimv1.LabelSelectorOpIn,
 				Values:   []string{"web-c1", "web-c2", "web-c3"},
 			}},
-		})
+		}, nil)
 	require.NoError(t, err)
 	err = st.AddPolicy(PolicyID(matchesNotInitContainers), "", &slimv1.LabelSelector{
 		MatchExpressions: []slimv1.LabelSelectorRequirement{{
@@ -519,7 +544,7 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 			Operator: slimv1.LabelSelectorOpNotIn,
 			Values:   []string{"init"},
 		}},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// create pods
@@ -527,23 +552,28 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 	ts.createPod(t, "db", "default", labels.Labels{"app": "db"}, "db-c1")
 	ts.createPod(t, "log", "default", labels.Labels{}, "log-c1", "init")
 
+	c1 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c1", "web-c2", "init"},
+		"db":  {"db-c1"},
+		"log": {"log-c1", "init"},
+	})
+	c2 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c1", "web-c2"},
+	})
+	c3 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c1", "web-c2"},
+		"db":  {"db-c1"},
+		"log": {},
+	})
+
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesAllContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c1", "web-c2", "init"},
-				"db":  {"db-c1"},
-				"log": {"log-c1", "init"},
-			}),
-			uint64(matchesWebContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c1", "web-c2"},
-			}),
+			uint64(matchesAllContainers): c1,
+			uint64(matchesWebContainers): c2,
 			// test policy state before we label the log with the matching label
-			uint64(matchesNotInitContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c1", "web-c2"},
-				"db":  {"db-c1"},
-				"log": {},
-			}),
+			uint64(matchesNotInitContainers): c3,
+			uint64(AllPodsID):                append(c3, append(c2, c1...)...),
 		},
 	)
 
@@ -551,21 +581,27 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 	ts.updatePodLabels(t, "log", labels.Labels{"app": "log"})
 	ts.updatePodContainers(t, "web", "web-c3", "app-c1")
 	ts.waitForCallbacks(t)
+
+	c4 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c3", "app-c1"},
+		"db":  {"db-c1"},
+		"log": {"log-c1", "init"},
+	})
+	c5 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c3"},
+	})
+	c6 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c3", "app-c1"},
+		"db":  {"db-c1"},
+		"log": {"log-c1"},
+	})
+
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesAllContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c3", "app-c1"},
-				"db":  {"db-c1"},
-				"log": {"log-c1", "init"},
-			}),
-			uint64(matchesWebContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c3"},
-			}),
-			uint64(matchesNotInitContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c3", "app-c1"},
-				"db":  {"db-c1"},
-				"log": {"log-c1"},
-			}),
+			uint64(matchesAllContainers):     c4,
+			uint64(matchesWebContainers):     c5,
+			uint64(matchesNotInitContainers): c6,
+			uint64(AllPodsID):                append(c6, append(c5, c4...)...),
 		},
 	)
 
@@ -574,20 +610,26 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 	ts.updatePodLabels(t, "log", labels.Labels{"app": "not-log"})
 	ts.updatePodContainers(t, "db", "db-c1", "init")
 	ts.waitForCallbacks(t)
+
+	c7 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c3", "app-c1"},
+		"db":  {"db-c1", "init"},
+		"log": {"log-c1", "init"},
+	})
+	c8 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c3"},
+	})
+	c9 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c3", "app-c1"},
+		"db":  {"db-c1"},
+	})
+
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesAllContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c3", "app-c1"},
-				"db":  {"db-c1", "init"},
-				"log": {"log-c1", "init"},
-			}),
-			uint64(matchesWebContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c3"},
-			}),
-			uint64(matchesNotInitContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c3", "app-c1"},
-				"db":  {"db-c1"},
-			}),
+			uint64(matchesAllContainers):     c7,
+			uint64(matchesWebContainers):     c8,
+			uint64(matchesNotInitContainers): c9,
+			uint64(AllPodsID):                append(c9, append(c8, c7...)...),
 		},
 	)
 
@@ -595,15 +637,24 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 	require.NoError(t, err)
 	ts.deletePod(t, "log")
 	ts.waitForCallbacks(t)
+
+	c10 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c3", "app-c1"},
+		"db":  {"db-c1", "init"},
+	})
+	c11 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c3"},
+	})
+	c12 := ts.containersCgroupIDs(t, map[string][]string{
+		"web": {"web-c3", "app-c1"},
+		"db":  {"db-c1"},
+	})
+
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesWebContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c3"},
-			}),
-			uint64(matchesNotInitContainers): ts.containersCgroupIDs(t, map[string][]string{
-				"web": {"web-c3", "app-c1"},
-				"db":  {"db-c1"},
-			}),
+			uint64(matchesWebContainers):     c11,
+			uint64(matchesNotInitContainers): c12,
+			uint64(AllPodsID):                append(c12, append(c10, c11...)...),
 		},
 	)
 
@@ -615,7 +666,9 @@ func testContainerFieldFilters(t *testing.T, st *state, ts *testState) {
 	require.NoError(t, err)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
-		map[uint64][]uint64{},
+		map[uint64][]uint64{
+			uint64(AllPodsID): {},
+		},
 	)
 }
 
@@ -633,13 +686,17 @@ func testPreExistingPods(t *testing.T, st *state, ts *testState) {
 			Operator: slimv1.LabelSelectorOpIn,
 			Values:   []string{"web"},
 		}},
-	}, nil)
+	}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
+
+	c1 := ts.podsCgroupIDs(t, "web")
+	c2 := ts.podsCgroupIDs(t, "db")
 
 	require.Len(t, ts.podsCgroupIDs(t, "web"), 2)
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(matchesWebID): ts.podsCgroupIDs(t, "web"),
+			uint64(matchesWebID): c1,
+			uint64(AllPodsID):    append(c2, c1...),
 		},
 	)
 
@@ -649,7 +706,9 @@ func testPreExistingPods(t *testing.T, st *state, ts *testState) {
 	require.NoError(t, err)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
-		map[uint64][]uint64{},
+		map[uint64][]uint64{
+			uint64(AllPodsID): {},
+		},
 	)
 }
 
@@ -669,15 +728,19 @@ func testContainersChange(t *testing.T, st *state, ts *testState) {
 					Operator: slimv1.LabelSelectorOpNotIn,
 					Values:   []string{"log-c1"},
 				}},
-		})
+		}, nil)
 	require.NoError(t, err)
+
+	c1 := ts.podsCgroupIDs(t, "web", "db")
+	c2 := ts.podsCgroupIDs(t, "log")
 
 	require.Len(t, ts.podsCgroupIDs(t, "web"), 2)
 	require.Len(t, ts.podsCgroupIDs(t, "db"), 1)
 	require.Empty(t, ts.containersCgroupIDs(t, map[string][]string{"log": {}}))
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(policyID): ts.podsCgroupIDs(t, "web", "db"),
+			uint64(policyID):  c1,
+			uint64(AllPodsID): append(c2, c1...),
 		},
 	)
 
@@ -686,9 +749,13 @@ func testContainersChange(t *testing.T, st *state, ts *testState) {
 	require.Len(t, ts.podsCgroupIDs(t, "web"), 3)
 	require.Len(t, ts.podsCgroupIDs(t, "db"), 1)
 	ts.waitForCallbacks(t)
+
+	c3 := ts.podsCgroupIDs(t, "web", "db")
+
 	requirePfmEqualTo(t, st.pfMap,
 		map[uint64][]uint64{
-			uint64(policyID): ts.podsCgroupIDs(t, "web", "db"),
+			uint64(policyID):  c3,
+			uint64(AllPodsID): append(c2, c3...),
 		},
 	)
 
@@ -699,7 +766,9 @@ func testContainersChange(t *testing.T, st *state, ts *testState) {
 	require.NoError(t, err)
 	ts.waitForCallbacks(t)
 	requirePfmEqualTo(t, st.pfMap,
-		map[uint64][]uint64{},
+		map[uint64][]uint64{
+			uint64(AllPodsID): {},
+		},
 	)
 }
 

--- a/pkg/policyfilter/map.go
+++ b/pkg/policyfilter/map.go
@@ -84,6 +84,19 @@ func newPfMap(enableCgroupMap bool) (PfMap, error) {
 		}
 	}
 
+	// Create the reserved entry once at initialization time.
+	allPodsMap, err := ret.newPolicyMap(AllPodsID, nil)
+	if err != nil {
+		ret.release()
+		return PfMap{}, fmt.Errorf("opening all-pods policy map failed: %w", err)
+	}
+
+	// We just initialized allPodsMap but we don't want that now so let's close that.
+	if err := allPodsMap.Inner.Close(); err != nil {
+		ret.release()
+		return PfMap{}, fmt.Errorf("closing all-pods policy map handle failed: %w", err)
+	}
+
 	return ret, nil
 }
 
@@ -215,6 +228,49 @@ func (m PfMap) newPolicyMap(polID PolicyID, cgIDs []CgroupID) (polMap, error) {
 	}
 
 	return ret, nil
+}
+
+func (m PfMap) openPolicyMap(polID PolicyID) (polMap, error) {
+	// Reopen an inner policy map from the shared outer map on demand instead of
+	// caching a dedicated handle in PfMap.
+	var innerID uint32
+	if err := m.policyMap.Lookup(&polID, &innerID); err != nil {
+		return polMap{}, fmt.Errorf("failed to lookup policy id %d: %w", polID, err)
+	}
+
+	inner, err := ebpf.NewMapFromID(ebpf.MapID(innerID))
+	if err != nil {
+		return polMap{}, fmt.Errorf("error opening inner map: %w", err)
+	}
+
+	return polMap{
+		Inner:     inner,
+		cgroupMap: m.cgroupMap,
+	}, nil
+}
+
+func (m PfMap) addCgroupIDsToPolicyMap(polID PolicyID, cgIDs []CgroupID) error {
+	polMap, err := m.openPolicyMap(polID)
+	if err != nil {
+		return err
+	}
+	defer polMap.Inner.Close()
+
+	if err := polMap.addCgroupIDs(cgIDs); err != nil {
+		return err
+	}
+
+	return polMap.addPolicyIDs(polID, cgIDs)
+}
+
+func (m PfMap) delCgroupIDsFromPolicyMap(polID PolicyID, cgIDs []CgroupID) error {
+	polMap, err := m.openPolicyMap(polID)
+	if err != nil {
+		return err
+	}
+	defer polMap.Inner.Close()
+
+	return polMap.delCgroupIDs(polID, cgIDs)
 }
 
 func getMapSize(m *ebpf.Map) (uint32, error) {
@@ -387,11 +443,6 @@ func (m polMap) addCgroupIDs(cgIDs []CgroupID) error {
 // delCgroupIDs delete cgroups ids from the policy map
 // todo: use batch operations when supported
 func (m polMap) delCgroupIDs(polID PolicyID, cgIDs []CgroupID) error {
-	// cgroup map does not exist, so nothing to do here
-	if m.cgroupMap == nil {
-		return nil
-	}
-
 	rmRevCgIDs := []CgroupID{}
 	for i, cgID := range cgIDs {
 		if err := m.Inner.Delete(&cgID); err != nil {
@@ -401,6 +452,11 @@ func (m polMap) delCgroupIDs(polID PolicyID, cgIDs []CgroupID) error {
 			}
 		}
 		rmRevCgIDs = append(rmRevCgIDs, cgID)
+	}
+
+	// Without the reverse cgroup map, deleting from the policy map is enough.
+	if m.cgroupMap == nil {
+		return nil
 	}
 
 	// update cgroup map

--- a/pkg/policyfilter/map_test.go
+++ b/pkg/policyfilter/map_test.go
@@ -24,6 +24,11 @@ func requirePfmEqualTo(t *testing.T, m PfMap, val map[uint64][]uint64) {
 	checkCgroupVals := map[CgroupID]map[PolicyID]struct{}{}
 	for k, ids := range val {
 		for _, id := range ids {
+			// The reverse mapping should not contain the Uint64Max special value.
+			// This is used to denote the mode of hostSelector.
+			if id == HostSelectorMode {
+				continue
+			}
 			if checkCgroupVals[CgroupID(id)] == nil {
 				checkCgroupVals[CgroupID(id)] = map[PolicyID]struct{}{}
 			}
@@ -51,17 +56,26 @@ func TestPfMapOps(t *testing.T) {
 
 	pm1, err := pfm.newPolicyMap(polID1, []CgroupID{10, 20})
 	require.NoError(t, err)
-	requirePfmEqualTo(t, pfm, map[uint64][]uint64{100: {10, 20}})
+	requirePfmEqualTo(t, pfm, map[uint64][]uint64{
+		100:                     {10, 20},
+		uint64(AllPodsPolicyID): {}, // simplified version where the entry exists but not populated
+	})
 
 	err = pm1.addCgroupIDs([]CgroupID{30})
 	require.NoError(t, err)
 	err = addPolicyIDMapping(pm1.cgroupMap, polID1, 30)
 	require.NoError(t, err)
-	requirePfmEqualTo(t, pfm, map[uint64][]uint64{100: {10, 20, 30}})
+	requirePfmEqualTo(t, pfm, map[uint64][]uint64{
+		100:                     {10, 20, 30},
+		uint64(AllPodsPolicyID): {}, // simplified version where the entry exists but not populated
+	})
 
 	err = pm1.delCgroupIDs(polID1, []CgroupID{20, 10})
 	require.NoError(t, err)
-	requirePfmEqualTo(t, pfm, map[uint64][]uint64{100: {30}})
+	requirePfmEqualTo(t, pfm, map[uint64][]uint64{
+		100:                     {30},
+		uint64(AllPodsPolicyID): {}, // simplified version where the entry exists but not populated
+	})
 
 	_, err = pfm.newPolicyMap(polID1, []CgroupID{40, 30})
 	require.Error(t, err)
@@ -69,5 +83,9 @@ func TestPfMapOps(t *testing.T) {
 	_, err = pfm.newPolicyMap(polID2, []CgroupID{10, 40, 30})
 	require.NoError(t, err)
 
-	requirePfmEqualTo(t, pfm, map[uint64][]uint64{100: {30}, 200: {10, 30, 40}})
+	requirePfmEqualTo(t, pfm, map[uint64][]uint64{
+		100:                     {30},
+		200:                     {10, 30, 40},
+		uint64(AllPodsPolicyID): {}, // simplified version where the entry exists but not populated
+	})
 }

--- a/pkg/policyfilter/policyfilter.go
+++ b/pkg/policyfilter/policyfilter.go
@@ -40,7 +40,7 @@ type State interface {
 	//  - label selector
 	//  - container field selector
 	AddPolicy(polID PolicyID, namespace string, podSelector *slimv1.LabelSelector,
-		containerSelector *slimv1.LabelSelector) error
+		containerSelector *slimv1.LabelSelector, hostSelector *slimv1.LabelSelector) error
 
 	// DelPolicy removes a policy from the state
 	DelPolicy(polID PolicyID) error

--- a/pkg/policyfilter/state.go
+++ b/pkg/policyfilter/state.go
@@ -39,7 +39,7 @@ import (
 //   policy_id -> [ cgroup_id -> u8 ]
 //
 // If entry policy_id -> cgroup_id exists, then policy is to be applied. (u8 value is ignored for
-// now.)
+// now.) The reserved policy id 1 always contains all pod container cgroup ids.
 //
 // This package provides functions that can be used to update the bpf map. The map
 // needs to be updated in the following conditions:
@@ -401,7 +401,7 @@ func (m *state) delPod(id PodID) *podInfo {
 
 // AddPolicy adds a policy
 func (m *state) AddPolicy(polID PolicyID, namespace string, podLabelSelector *slimv1.LabelSelector,
-	containerLabelSelector *slimv1.LabelSelector) error {
+	containerLabelSelector *slimv1.LabelSelector, hostLabelSelector *slimv1.LabelSelector) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -451,6 +451,16 @@ func (m *state) AddPolicy(polID PolicyID, namespace string, podLabelSelector *sl
 		return fmt.Errorf("adding policy data to map failed: %w", err)
 	}
 
+	// based on the hostSelector we should add one entry in the inner map of the policy
+	// if hostSelector: nil -> No entry should be added
+	// if hostSelector: {} -> We should add an entry with key HostSelectorMode (UINT64_MAX)
+	if hostLabelSelector != nil && (len(hostLabelSelector.MatchLabels)+len(hostLabelSelector.MatchExpressions) == 0) {
+		if err := policy.polMap.addCgroupIDs([]CgroupID{CgroupID(HostSelectorMode)}); err != nil {
+			m.DelPolicy(polID) // Revert all previous actions. This call cannot fail as it always returns nil.
+			return fmt.Errorf("adding policy data for hostSelector to map failed: %w", err)
+		}
+	}
+
 	m.policies = append(m.policies, policy)
 
 	return nil
@@ -459,7 +469,7 @@ func (m *state) AddPolicy(polID PolicyID, namespace string, podLabelSelector *sl
 // DelPolicy will destroy all information for the provided policy
 func (m *state) DelPolicy(polID PolicyID) error {
 
-	if polID == NoFilterPolicyID {
+	if polID == NoFilterPolicyID || polID == AllPodsPolicyID {
 		return nil
 	}
 
@@ -551,6 +561,18 @@ func (m *state) addPodContainers(pod *podInfo, containerIDs []string,
 		"namespace", pod.namespace,
 		"containers-info", cinfo)
 
+	allPodCgIDs := make([]CgroupID, 0, len(cinfo))
+	for _, c := range cinfo {
+		allPodCgIDs = append(allPodCgIDs, c.cgID)
+	}
+	if err := m.pfMap.addCgroupIDsToPolicyMap(AllPodsID, allPodCgIDs); err != nil {
+		m.log.Warn("failed to update all-pods policy map",
+			logfields.Error, err,
+			"policy-id", AllPodsID,
+			"pod-id", pod.id,
+			"cgroup-ids", allPodCgIDs)
+	}
+
 	// update matching policy maps
 	for _, policyID := range pod.matchedPolicies {
 		pol := m.findPolicy(policyID)
@@ -633,6 +655,18 @@ func (m *state) delPodCgroupIDsFromPolicyMaps(pod *podInfo, containers []contain
 
 	if len(containers) == 0 {
 		return
+	}
+
+	allPodCgIDs := make([]CgroupID, 0, len(containers))
+	for _, c := range containers {
+		allPodCgIDs = append(allPodCgIDs, c.cgID)
+	}
+	if err := m.pfMap.delCgroupIDsFromPolicyMap(AllPodsID, allPodCgIDs); err != nil {
+		m.log.Warn("delPodCgroupIDsFromPolicyMaps: failed to delete cgroup ids from all-pods policy map",
+			logfields.Error, err,
+			"policy-id", AllPodsID,
+			"pod-id", pod.id,
+			"cgroup-ids", allPodCgIDs)
 	}
 
 	// check what policies match the pod, and delete the cgroup ids

--- a/pkg/policyfilter/state_test.go
+++ b/pkg/policyfilter/state_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/tetragon/pkg/podhelpers"
 )
 
@@ -21,11 +22,11 @@ func TestState(t *testing.T) {
 	}
 	defer s.Close()
 
-	err = s.AddPolicy(PolicyID(1), "ns1", nil, nil)
+	err = s.AddPolicy(PolicyID(2), "ns1", &slimv1.LabelSelector{}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
-	err = s.AddPolicy(PolicyID(2), "ns2", nil, nil)
+	err = s.AddPolicy(PolicyID(3), "ns2", &slimv1.LabelSelector{}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
-	err = s.AddPolicy(PolicyID(3), "ns3", nil, nil)
+	err = s.AddPolicy(PolicyID(4), "ns3", &slimv1.LabelSelector{}, &slimv1.LabelSelector{}, nil)
 	require.NoError(t, err)
 
 	pod1 := PodID(uuid.New())
@@ -54,41 +55,48 @@ func TestState(t *testing.T) {
 	require.NoError(t, err)
 
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
-		1: {1001},
-		2: {2001, 2002},
-		3: {3001, 3002, 3003},
+		2:                 {1001},
+		3:                 {2001, 2002},
+		4:                 {3001, 3002, 3003},
+		uint64(AllPodsID): {1001, 2001, 2002, 3001, 3002, 3003},
 	})
 
 	err = s.DelPodContainer(pod2, "cont3")
 	require.NoError(t, err)
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
-		1: {},
-		2: {2001, 2002},
-		3: {3001, 3002, 3003},
-	})
-
-	err = s.DelPolicy(PolicyID(1))
-	require.NoError(t, err)
-	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
-		2: {2001, 2002},
-		3: {3001, 3002, 3003},
+		2:                 {},
+		3:                 {2001, 2002},
+		4:                 {3001, 3002, 3003},
+		uint64(AllPodsID): {2001, 2002, 3001, 3002, 3003},
 	})
 
 	err = s.DelPolicy(PolicyID(2))
 	require.NoError(t, err)
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
-		3: {3001, 3002, 3003},
+		3:                 {2001, 2002},
+		4:                 {3001, 3002, 3003},
+		uint64(AllPodsID): {2001, 2002, 3001, 3002, 3003},
+	})
+
+	err = s.DelPolicy(PolicyID(3))
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		4:                 {3001, 3002, 3003},
+		uint64(AllPodsID): {2001, 2002, 3001, 3002, 3003},
 	})
 
 	err = s.DelPod(pod4)
 	require.NoError(t, err)
 	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
-		3: {3001},
+		4:                 {3001},
+		uint64(AllPodsID): {2001, 2002, 3001},
 	})
 
-	err = s.DelPolicy(PolicyID(3))
+	err = s.DelPolicy(PolicyID(4))
 	require.NoError(t, err)
-	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{})
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {2001, 2002, 3001},
+	})
 
 	require.Empty(t, s.policies)
 	require.Len(t, s.pods, 3)
@@ -99,7 +107,9 @@ func TestState(t *testing.T) {
 	require.NoError(t, err)
 	err = s.DelPod(pod3)
 	require.NoError(t, err)
-	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{})
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {},
+	})
 
 	require.Empty(t, s.policies)
 	require.Empty(t, s.pods)

--- a/pkg/policyfilter/state_test.go
+++ b/pkg/policyfilter/state_test.go
@@ -114,3 +114,266 @@ func TestState(t *testing.T) {
 	require.Empty(t, s.policies)
 	require.Empty(t, s.pods)
 }
+
+func TestStateAllPodsPolicyEntry(t *testing.T) {
+	s, err := New(true)
+	if err != nil {
+		t.Skipf("failed to initialize policy filter state: %s", err)
+	}
+	defer s.Close()
+
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {},
+	})
+
+	pod1 := PodID(uuid.New())
+	cgid1 := CgroupID(4001)
+	err = s.AddPodContainer(pod1, "ns1", nil, "cont1", cgid1, podhelpers.ContainerInfo{Name: "main1", Repo: "repo1"})
+	require.NoError(t, err)
+
+	pod2 := PodID(uuid.New())
+	cgid2 := CgroupID(4002)
+	err = s.AddPodContainer(pod2, "ns2", nil, "cont2", cgid2, podhelpers.ContainerInfo{Name: "main2", Repo: "repo2"})
+	require.NoError(t, err)
+
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {4001, 4002},
+	})
+
+	err = s.AddPolicy(PolicyID(2), "ns2", &slimv1.LabelSelector{}, &slimv1.LabelSelector{}, nil)
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		2:                 {4002},
+		uint64(AllPodsID): {4001, 4002},
+	})
+
+	err = s.DelPolicy(PolicyID(2))
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {4001, 4002},
+	})
+
+	err = s.DelPodContainer(pod1, "cont1")
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {4002},
+	})
+
+	err = s.DelPod(pod2)
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {},
+	})
+}
+
+func TestStateAllPodsPolicyEntryWithoutCgroupMap(t *testing.T) {
+	s, err := New(false)
+	if err != nil {
+		t.Skipf("failed to inialize policy filter state: %s", err)
+	}
+	defer s.Close()
+
+	pod := PodID(uuid.New())
+	cgid := CgroupID(5001)
+	err = s.AddPodContainer(pod, "ns1", nil, "cont1", cgid, podhelpers.ContainerInfo{Name: "main1", Repo: "repo1"})
+	require.NoError(t, err)
+
+	dump, err := s.pfMap.readAll()
+	require.NoError(t, err)
+	require.Equal(t, map[PolicyID]map[CgroupID]struct{}{
+		AllPodsID: {cgid: {}},
+	}, dump.Policy)
+	require.Nil(t, dump.Cgroup)
+
+	err = s.DelPodContainer(pod, "cont1")
+	require.NoError(t, err)
+
+	dump, err = s.pfMap.readAll()
+	require.NoError(t, err)
+	require.Equal(t, map[PolicyID]map[CgroupID]struct{}{
+		AllPodsID: {},
+	}, dump.Policy)
+	require.Nil(t, dump.Cgroup)
+}
+
+func TestStateHostSelector(t *testing.T) {
+	s, err := New(true)
+	if err != nil {
+		t.Skipf("failed to inialize policy filter state: %s", err)
+	}
+	defer s.Close()
+
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {},
+	})
+
+	pod1 := PodID(uuid.New())
+	cgid1 := CgroupID(4001)
+	err = s.AddPodContainer(pod1, "ns1", nil, "cont1", cgid1, podhelpers.ContainerInfo{Name: "main1", Repo: "repo1"})
+	require.NoError(t, err)
+
+	pod2 := PodID(uuid.New())
+	cgid2 := CgroupID(4002)
+	err = s.AddPodContainer(pod2, "ns2", nil, "cont2", cgid2, podhelpers.ContainerInfo{Name: "main2", Repo: "repo2"})
+	require.NoError(t, err)
+
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {4001, 4002},
+	})
+
+	err = s.AddPolicy(PolicyID(2), "", nil, nil, &slimv1.LabelSelector{})
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		2:                 {HostSelectorMode},
+		uint64(AllPodsID): {4001, 4002},
+	})
+
+	// Pod namespace and hostSelector (with NamespacedPolicy)
+	// If podSelector or containerSelector is nil no pods will match.
+	err = s.AddPolicy(PolicyID(3), "ns1", &slimv1.LabelSelector{}, &slimv1.LabelSelector{}, &slimv1.LabelSelector{})
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		2:                 {HostSelectorMode},
+		3:                 {4001, HostSelectorMode},
+		uint64(AllPodsID): {4001, 4002},
+	})
+
+	// Pod namespace and hostSelector (with podSelector)
+	// If podSelector or containerSelector is nil no pods will match.
+	err = s.AddPolicy(PolicyID(4), "", &slimv1.LabelSelector{
+		MatchExpressions: []slimv1.LabelSelectorRequirement{{
+			Key:      "k8s:io.kubernetes.pod.namespace",
+			Operator: slimv1.LabelSelectorOpIn,
+			Values:   []string{"ns1"},
+		}},
+	}, &slimv1.LabelSelector{}, &slimv1.LabelSelector{})
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		2:                 {HostSelectorMode},
+		3:                 {4001, HostSelectorMode},
+		4:                 {4001, HostSelectorMode},
+		uint64(AllPodsID): {4001, 4002},
+	})
+
+	// Pod namespace and hostSelector (with NamespacedPolicy) but with nil podSelector
+	// This will not match any pods/containers.
+	err = s.AddPolicy(PolicyID(5), "ns1", nil, &slimv1.LabelSelector{}, &slimv1.LabelSelector{})
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		2:                 {HostSelectorMode},
+		3:                 {4001, HostSelectorMode},
+		4:                 {4001, HostSelectorMode},
+		5:                 {HostSelectorMode},
+		uint64(AllPodsID): {4001, 4002},
+	})
+
+	// Pod namespace and hostSelector (with podSelector) but with nil containerSelector
+	// This will not match any pods/containers.
+	err = s.AddPolicy(PolicyID(6), "ns1", &slimv1.LabelSelector{
+		MatchExpressions: []slimv1.LabelSelectorRequirement{{
+			Key:      "k8s:io.kubernetes.pod.namespace",
+			Operator: slimv1.LabelSelectorOpIn,
+			Values:   []string{"ns1"},
+		}},
+	}, nil, &slimv1.LabelSelector{})
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		2:                 {HostSelectorMode},
+		3:                 {4001, HostSelectorMode},
+		4:                 {4001, HostSelectorMode},
+		5:                 {HostSelectorMode},
+		6:                 {HostSelectorMode},
+		uint64(AllPodsID): {4001, 4002},
+	})
+
+	// Delete cont1 from pod1. cgid1 should be removed.
+	err = s.DelPodContainer(pod1, "cont1")
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		2:                 {HostSelectorMode},
+		3:                 {HostSelectorMode},
+		4:                 {HostSelectorMode},
+		5:                 {HostSelectorMode},
+		6:                 {HostSelectorMode},
+		uint64(AllPodsID): {4002},
+	})
+
+	// Create pod3 with new cgid3. Check that the correct policies applied.
+	pod3 := PodID(uuid.New())
+	cgid3 := CgroupID(4003)
+	err = s.AddPodContainer(pod3, "ns1", nil, "cont1", cgid3, podhelpers.ContainerInfo{Name: "main1", Repo: "repo1"})
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		2:                 {HostSelectorMode},
+		3:                 {4003, HostSelectorMode},
+		4:                 {4003, HostSelectorMode},
+		5:                 {HostSelectorMode},
+		6:                 {HostSelectorMode},
+		uint64(AllPodsID): {4003, 4002},
+	})
+
+	// Delete pod2. cgid2 should be removed.
+	err = s.DelPod(pod2)
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		2:                 {HostSelectorMode},
+		3:                 {4003, HostSelectorMode},
+		4:                 {4003, HostSelectorMode},
+		5:                 {HostSelectorMode},
+		6:                 {HostSelectorMode},
+		uint64(AllPodsID): {4003},
+	})
+
+	// Delete policy 2.
+	err = s.DelPolicy(PolicyID(2))
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		3:                 {4003, HostSelectorMode},
+		4:                 {4003, HostSelectorMode},
+		5:                 {HostSelectorMode},
+		6:                 {HostSelectorMode},
+		uint64(AllPodsID): {4003},
+	})
+
+	// Delete policy 4.
+	err = s.DelPolicy(PolicyID(4))
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		3:                 {4003, HostSelectorMode},
+		5:                 {HostSelectorMode},
+		6:                 {HostSelectorMode},
+		uint64(AllPodsID): {4003},
+	})
+
+	// Delete policy 6.
+	err = s.DelPolicy(PolicyID(6))
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		3:                 {4003, HostSelectorMode},
+		5:                 {HostSelectorMode},
+		uint64(AllPodsID): {4003},
+	})
+
+	// Delete policy 5.
+	err = s.DelPolicy(PolicyID(5))
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		3:                 {4003, HostSelectorMode},
+		uint64(AllPodsID): {4003},
+	})
+
+	// Delete pod3. cgid3 should be removed.
+	err = s.DelPod(pod3)
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		3:                 {HostSelectorMode},
+		uint64(AllPodsID): {},
+	})
+
+	// Delete policy 3. Nothing left.
+	err = s.DelPolicy(PolicyID(3))
+	require.NoError(t, err)
+	requirePfmEqualTo(t, s.pfMap, map[uint64][]uint64{
+		uint64(AllPodsID): {},
+	})
+}

--- a/pkg/sensors/k8s.go
+++ b/pkg/sensors/k8s.go
@@ -6,6 +6,8 @@
 package sensors
 
 import (
+	"errors"
+
 	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
@@ -25,30 +27,48 @@ func (h *handler) updatePolicyFilter(tp tracingpolicy.TracingPolicy, tpID uint64
 		namespace = tpNs.TpNamespace()
 	}
 
-	var podSelector *slimv1.LabelSelector
-	if ps := tp.TpSpec().PodSelector; ps != nil {
-		if len(ps.MatchLabels)+len(ps.MatchExpressions) > 0 {
-			podSelector = ps
-		}
+	// matches nothing           | tp.TpSpec().PodSelector == nil
+	// matches everything        | tp.TpSpec().PodSelector != nil && (len(ps.MatchLabels) + len(ps.MatchExpressions) == 0)
+	// matches based on selector | tp.TpSpec().PodSelector != nil && (len(ps.MatchLabels) + len(ps.MatchExpressions) != 0)
+	podSelector := tp.TpSpec().PodSelector
+
+	// matches nothing           | tp.TpSpec().ContainerSelector == nil
+	// matches everything        | tp.TpSpec().ContainerSelector != nil && (len(ps.MatchLabels) + len(ps.MatchExpressions) == 0)
+	// matches based on selector | tp.TpSpec().ContainerSelector != nil && (len(ps.MatchLabels) + len(ps.MatchExpressions) != 0)
+	containerSelector := tp.TpSpec().ContainerSelector
+
+	// matches nothing           | tp.TpSpec().HostSelector == nil
+	// matches everything        | tp.TpSpec().HostSelector != nil && (len(ps.MatchLabels) + len(ps.MatchExpressions) == 0)
+	// matches based on selector | Not supported yet
+	hostSelector := tp.TpSpec().HostSelector
+	if hostSelector != nil && (len(hostSelector.MatchLabels)+len(hostSelector.MatchExpressions) > 0) {
+		return policyfilter.NoFilterID, errors.New("spec.hostSelector does not support arbitrary labels. Only ~ (empty) and {} (all) is supported for now")
 	}
 
-	var containerSelector *slimv1.LabelSelector
-	if ps := tp.TpSpec().ContainerSelector; ps != nil {
-		if len(ps.MatchLabels)+len(ps.MatchExpressions) > 0 {
-			containerSelector = ps
-		}
+	// This is the case where all of PodSelector, ContainerSelector, HostSelector are {}.
+	// In that case we match everything so no need to apply a policyfilter as well.
+	matchAll := func(s *slimv1.LabelSelector) bool {
+		return (s != nil && (len(s.MatchLabels)+len(s.MatchExpressions) == 0))
 	}
+	globalSelectorsMatchAll := matchAll(podSelector) && matchAll(containerSelector) && matchAll(hostSelector)
+
+	// This covers the case where all of PodSelector, ContainerSelector, HostSelector are nil.
+	// This is not intended to be used by the end users but it reduces the boilerplate code
+	// in our non-k8s testing by a large factor.
+	matchNothing := func(s *slimv1.LabelSelector) bool {
+		return s == nil
+	}
+	globalSelectorsMatchNothing := matchNothing(podSelector) && matchNothing(containerSelector) && matchNothing(hostSelector)
 
 	// we do not call AddPolicy unless filtering is actually needed. This
 	// means that if policyfilter is disabled
 	// (option.Config.EnablePolicyFilter is false) then loading the policy
 	// will only fail if filtering is required.
-	if namespace == "" && podSelector == nil && containerSelector == nil {
+	if namespace == "" && (globalSelectorsMatchAll || globalSelectorsMatchNothing) {
 		return policyfilter.NoFilterID, nil
 	}
-
 	filterID := policyfilter.PolicyID(tpID)
-	if err := h.pfState.AddPolicy(filterID, namespace, podSelector, containerSelector); err != nil {
+	if err := h.pfState.AddPolicy(filterID, namespace, podSelector, containerSelector, hostSelector); err != nil {
 		return policyfilter.NoFilterID, err
 	}
 	return filterID, nil

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -31,6 +31,7 @@ import (
 	grpcexec "github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
@@ -185,7 +186,10 @@ func TestNamespacedPolicies(t *testing.T) {
 			Namespace: "ns1",
 		},
 		Spec: v1alpha1.TracingPolicySpec{
-			KProbes: []v1alpha1.KProbeSpec{kpSpec},
+			PodSelector:       &slimv1.LabelSelector{},
+			ContainerSelector: &slimv1.LabelSelector{},
+			HostSelector:      &slimv1.LabelSelector{},
+			KProbes:           []v1alpha1.KProbeSpec{kpSpec},
 		},
 	}
 
@@ -214,7 +218,10 @@ func TestNamespacedPolicies(t *testing.T) {
 			Namespace: "ns1",
 		},
 		Spec: v1alpha1.TracingPolicySpec{
-			Tracepoints: []v1alpha1.TracepointSpec{tpSpec},
+			PodSelector:       &slimv1.LabelSelector{},
+			ContainerSelector: &slimv1.LabelSelector{},
+			HostSelector:      &slimv1.LabelSelector{},
+			Tracepoints:       []v1alpha1.TracepointSpec{tpSpec},
 		},
 	}
 

--- a/pkg/testutils/policyfilter/policyfilter.go
+++ b/pkg/testutils/policyfilter/policyfilter.go
@@ -22,7 +22,7 @@ import (
 type DummyPF struct{}
 
 func (s *DummyPF) AddPolicy(_ policyfilter.PolicyID, _ string, _ *slimv1.LabelSelector,
-	_ *slimv1.LabelSelector) error {
+	_ *slimv1.LabelSelector, _ *slimv1.LabelSelector) error {
 	return nil
 }
 

--- a/pkg/tracingpolicy/generictracingpolicy_test.go
+++ b/pkg/tracingpolicy/generictracingpolicy_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/build"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/tetragon/pkg/testutils/tempfile"
 )
 
@@ -27,6 +28,9 @@ func TestYamlLseek(t *testing.T) {
 		},
 		Metadata: ObjectMeta{Name: "tracepoint-lseek"},
 		Spec: v1alpha1.TracingPolicySpec{
+			PodSelector:       &slimv1.LabelSelector{},
+			ContainerSelector: &slimv1.LabelSelector{},
+			HostSelector:      &slimv1.LabelSelector{},
 			Tracepoints: []v1alpha1.TracepointSpec{{
 				Subsystem: "syscalls",
 				Event:     "sys_enter_lseek",

--- a/tests/e2e/tests/policyfilter/policyfilter_test.go
+++ b/tests/e2e/tests/policyfilter/policyfilter_test.go
@@ -449,6 +449,7 @@ kind: TracingPolicyNamespaced
 metadata:
   name: "ubuntu-container-syscalls"
 spec:
+  hostSelector: ~
   containerSelector:
     matchExpressions:
     - key: name
@@ -544,6 +545,7 @@ kind: TracingPolicyNamespaced
 metadata:
   name: "debian-container-syscalls"
 spec:
+  hostSelector: ~
   containerSelector:
     matchExpressions:
     - key: repo

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -43,11 +43,13 @@ spec:
             description: Tracing policy specification.
             properties:
               containerSelector:
+                default: {}
                 description: |-
                   ContainerSelector selects containers that this policy applies to.
                   A map of container fields will be constructed in the same way as a map of labels.
                   The name of the field represents the label "key", and the value of the field - label "value".
                   Currently, only the "name" field is supported.
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1131,6 +1133,65 @@ spec:
                   - call
                   type: object
                 type: array
+              hostSelector:
+                default: {}
+                description: |-
+                  HostSelector selects hosts that this policy applies to.
+                  For now only ~ (none) and {} (all) is supported.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               kprobes:
                 description: A list of kprobe specs.
                 items:
@@ -2971,7 +3032,9 @@ spec:
                   type: object
                 type: array
               podSelector:
+                default: {}
                 description: PodSelector selects pods that this policy applies to
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -43,11 +43,13 @@ spec:
             description: Tracing policy specification.
             properties:
               containerSelector:
+                default: {}
                 description: |-
                   ContainerSelector selects containers that this policy applies to.
                   A map of container fields will be constructed in the same way as a map of labels.
                   The name of the field represents the label "key", and the value of the field - label "value".
                   Currently, only the "name" field is supported.
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1131,6 +1133,65 @@ spec:
                   - call
                   type: object
                 type: array
+              hostSelector:
+                default: {}
+                description: |-
+                  HostSelector selects hosts that this policy applies to.
+                  For now only ~ (none) and {} (all) is supported.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               kprobes:
                 description: A list of kprobe specs.
                 items:
@@ -2971,7 +3032,9 @@ spec:
                   type: object
                 type: array
               podSelector:
+                default: {}
                 description: PodSelector selects pods that this policy applies to
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -97,15 +97,26 @@ type TracingPolicySpec struct {
 	Fentries []KProbeSpec `json:"fentries,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
+	// +nullable
 	// PodSelector selects pods that this policy applies to
 	PodSelector *slimv1.LabelSelector `json:"podSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
+	// +nullable
 	// ContainerSelector selects containers that this policy applies to.
 	// A map of container fields will be constructed in the same way as a map of labels.
 	// The name of the field represents the label "key", and the value of the field - label "value".
 	// Currently, only the "name" field is supported.
 	ContainerSelector *slimv1.LabelSelector `json:"containerSelector,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={}
+	// +nullable
+	// HostSelector selects hosts that this policy applies to.
+	// For now only ~ (none) and {} (all) is supported.
+	HostSelector *slimv1.LabelSelector `json:"hostSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// A list of list specs.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.13"
+const CustomResourceDefinitionSchemaVersion = "1.7.14"

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
@@ -749,6 +749,11 @@ func (in *TracingPolicySpec) DeepCopyInto(out *TracingPolicySpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HostSelector != nil {
+		in, out := &in.HostSelector, &out.HostSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Lists != nil {
 		in, out := &in.Lists, &out.Lists
 		*out = make([]ListSpec, len(*in))


### PR DESCRIPTION
This PR adds support for `spec.hostSelector` to enable users to write policies that are applied only to host workloads and/or pod workloads (with additional filtering for the containers if needed).

The syntax is:
```yaml
spec:
  hostSelector: {}
  podSelector: {}
  containerSelector: {}
```
 and the previous example will match all workloads either in the host or inside pods without any filtering. This is also the default (i.e. if the user does not define any of those in a tracing policy).

If we need to match only host workloads we need to have something like:
```yaml
spec:
  hostSelector: {}
  podSelector: null
  containerSelector: null
```

For now we only support 2 types of `hostSelector`. These are the `{}` (everything) and `null` (nothing). Specific filters are not supported yet.

In order to make that work, we need to make some changes in the behaviour of the `podSelector`. Currently, `podSelector: {}` and `podSelector: null` are exactly the same thing and will match all workloads (including host workloads). Based on this behaviour, now we don't have a way to match on all pod workloads (excluding host workloads).

In this PR we change that behaviour. Now `podSelector: {}` will match all pod workloads and `podSelector: null` will not match any pod workloads. The behaviour of `containerSelector` is similar, but what actually does is a second level filtering on the `podSelector`. For this reason:
```yaml
spec:
  hostSelector: ~
  podSelector: ~
  containerSelector:
    matchExpressions:
      - key: name
        operator: In
        values:
        - ubuntu
```
will not match anything as podSelector is null. We need to have something like 
```yaml
spec:
  hostSelector: ~
  podSelector: {}
  containerSelector:
    matchExpressions:
      - key: name
        operator: In
        values:
        - ubuntu
```
to filter containers.

This PR also provides the ability to make `hostSelector`, `podSelector`, and `containerSelector` equals to `null` which was not possible before. 

## Implementation

In order to make that work, this PR adds one more entry in `policy_filter_maps` with key equals to `ALL_PODS_POLICY_ID` (`UINT32_MAX`). The inner map of that entry contains all `cgroup_id`s of all pods in the system. If a `cgroup_id` is part of that set, this means that it is a pod workload. If not this means that this is part of the host workload. Additionally, each policy contains an invalid `cgroup_id` entry with value `HOST_SELECTOR_MODE` (`UINT64_MAX`) if the policy itself cares about host workloads. 

Then we update `policy_filter_check` to check those as well. More specifically what policy_filter_check does is:
1. check if our cgroup_id match on the policy build from podSelector/containerSelector
    1. return true if we match
    2. continue to check if we care about host workloads
2. check if the policy cares also for host workloads
    1. return false if not
    2. continue to check if our cgroup_id is a host workload  
3. check if our cgroup_id is part of ALL_PODS_POLICY_ID
    1. return true if not (this means that out cgroup_id is not a pod workload --> so this is a host workload)
    2. return false if it is (this means that out cgroup_id is a pod workload)

Any updates needed for the policy_filter_maps are handled from the agent in a similar way to podSelector/containerSelector.

## Testing

All tests related to the policyfiler have been updated to reflect those changes. Some additional tests have been added to check the hostSelector explicitly.

## Limitations

This approach has similar issues with [Kubernetes Identity Aware Policies](https://tetragon.io/docs/concepts/tracing-policy/k8s-filtering/) and more specifically if we rely on the k8s API server, there may be a race on when we add a cgroup_id to our maps and when the pod actually starts. The hostSelector has similar issues. All of these issues can be resolved by using [Runtime Hooks](https://tetragon.io/docs/concepts/runtime-hooks/) instead of the K8s API server.

## Alternatives

Another way to do that is to use [bpf_current_task_under_cgroup](https://docs.ebpf.io/linux/helper-function/bpf_get_current_ancestor_cgroup_id/) or [bpf_get_current_ancestor_cgroup_id](https://docs.ebpf.io/linux/helper-function/bpf_get_current_ancestor_cgroup_id/) eBPF helpers. This allows us to check if a `cgroup_id` is somewhere under a specific cgroup subtree. If this specific cgroup subtree is where k8s adds new pods, then we can achieve the same results. The challenge here is to find the `cgroup_id` that k8s use to keep all pods. In most of the cases this is `/sys/fs/cgroup/kubepods.slice/` but this is not always the case in all deployments. It seems that there are ways to get that inside Tetragon but there may be a bit complicated. 

For this reason, we are starting with the approach proposed in this PR. It works in all cases, although it introduces a small increase in memory usage. At this point, the impact does not seem significant enough to justify a more complex design. We can always improve it in future PRs if needed.
