### PR TITLE
tetragon: Remove the bpf_kfunc tag check from detectKfunc

### DIFF
--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -591,8 +591,7 @@ func detectKfunc(name string) bool {
 		return false
 	}
 
-	// kfunc has bpf_kfunc tag attached
-	return len(fn.Tags) == 1 && fn.Tags[0] == "bpf_kfunc"
+	return true
 }
 
 func HasKfunc(name string) bool {


### PR DESCRIPTION
It's enough to check function presence in kernel's BTF.

The check for bpf_kfunc tag is nice to have but was introduced after kfuncs, so not all kernels have it. Tetragon uses only straight forward kfuncs (without kernel functions name collisions) so just the BTF check is fine.