### PR TITLE
update(contrib/tester-progrs): ignore pclntab-(un)stripped.

### DIFF
--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -43,3 +43,5 @@ usdt-args
 uprobe-null
 uprobe-null.btf
 /uprobe-simple
+pclntab-stripped
+pclntab-unstripped


### PR DESCRIPTION
Added in https://github.com/cilium/tetragon/pull/4721.