### PR TITLE
renovate: add gomodVendor to postUpdateTasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -182,6 +182,7 @@
       "matchManagers": ["gomod"],
       "postUpdateOptions": [
         // update source import paths on major updates
+        "gomodVendor",
         "gomodUpdateImportPaths",
       ],
       postUpgradeTasks: {


### PR DESCRIPTION
### Description
Sometimes the following error is shown when doing a major release update:

  go: inconsistent vendoring in ...

This is triggered because some tasks like updating the imports with 'mod' requires vendor packages to be updated too. This change shouldn't have repercusions as 'make vendor' runs anyway in postUpgradeTasks
