### PR TITLE
fix: update buf breaking to point to v1.5 branch

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -13,6 +13,6 @@ GO ?= go
 CONTAINER_ENGINE ?= docker
 
 BUF ?= buf
-BUF_BREAKING_AGAINST_BRANCH ?= origin/main
+BUF_BREAKING_AGAINST_BRANCH ?= origin/v1.5
 # renovate: datasource=docker
 BUILDER_IMAGE=quay.io/cilium/cilium-builder:cd04ac813fb4763f840911c88beae99efc4aa457


### PR DESCRIPTION
'make protogen' was failing because the variable BUF_BREAKING_AGAINST_BRANCH was pointing to the wrong branch