### PR TITLE
pkg/selectors: fix CPU hangs

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -2113,8 +2113,17 @@ exist.
 - String prefix max length: 256 chars
 - String postfix max length: 128 chars
 
-For an unlimited number of values, consider using the `InMap` or `NotInMap`
+For larger sets of values, consider using the `InMap` or `NotInMap`
 operators which store values in a BPF map.
+These are limited only by the amount of available memory.
+
+{{< caution >}} 
+The `InMap` and `NotInMap` operators also support the range notation described
+for the `InRange` operator. However, using range notation with `InMap` or
+`NotInMap` consumes more memory, because each value in the range is added
+individually to the map. For large ranges, prefer the `InRange` operator
+instead.
+{{< /caution >}}
 
 
 ## Return Actions filter

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -466,20 +466,26 @@ func writeRangeInMap(v string, ty uint32, op uint32, m *ValueMap) error {
 		if sRangeVal[0] > sRangeVal[1] {
 			sRangeVal[0], sRangeVal[1] = sRangeVal[1], sRangeVal[0]
 		}
-		for val := sRangeVal[0]; val <= sRangeVal[1]; val++ {
+		for val := sRangeVal[0]; ; val++ {
 			var valByte [8]byte
 			binary.LittleEndian.PutUint64(valByte[:], uint64(val))
 			m.Data[valByte] = struct{}{}
+			if val >= sRangeVal[1] {
+				break
+			}
 		}
 
 	case gt.GenericU64Type, gt.GenericU32Type, gt.GenericU16Type, gt.GenericU8Type:
 		if uRangeVal[0] > uRangeVal[1] {
 			uRangeVal[0], uRangeVal[1] = uRangeVal[1], uRangeVal[0]
 		}
-		for val := uRangeVal[0]; val <= uRangeVal[1]; val++ {
+		for val := uRangeVal[0]; ; val++ {
 			var valByte [8]byte
 			binary.LittleEndian.PutUint64(valByte[:], val)
 			m.Data[valByte] = struct{}{}
+			if val >= uRangeVal[1] {
+				break
+			}
 		}
 	}
 	return nil

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -12,6 +12,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"maps"
+	"math"
 	"strings"
 	"syscall"
 	"testing"
@@ -677,6 +680,36 @@ func TestParseMatchArg(t *testing.T) {
 		d = &ks.data
 		if err := ParseMatchArgs(ks, arg12, []v1alpha1.ArgSelector{}, sig, []v1alpha1.KProbeArg{}); err != nil || bytes.Equal(expected3, d.e[0:d.off]) == false {
 			t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected3, d.e[0:d.off], arg3)
+		}
+
+		// Regression test for https://github.com/cilium/tetragon/issues/4699
+		rangeLower := uint64(math.MaxUint64 - 5)
+		rangeUpper := uint64(math.MaxUint64)
+
+		arg13 := &v1alpha1.ArgSelector{Index: 11, Operator: "InMap", Values: []string{fmt.Sprintf("%d:%d", rangeLower, rangeUpper)}}
+		expected12 := []byte{
+			0x0a, 0x00, 0x00, 0x00, // Index == 10
+			0x0a, 0x00, 0x00, 0x00, // operator == InMap
+			0x0c, 0x00, 0x00, 0x00, // length == 12
+			0x1e, 0x00, 0x00, 0x00, // value type == 30 == GenericU16Type
+			0x00, 0x00, 0x00, 0x00, // map idx == 0
+		}
+		expectMap := map[[8]byte]struct{}{
+			{0xfa, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}: {},
+			{0xfb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}: {},
+			{0xfc, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}: {},
+			{0xfd, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}: {},
+			{0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}: {},
+			{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}: {},
+		}
+
+		ks = NewKernelSelectorState(nil, nil, false, nil)
+		d = &ks.data
+		if err := ParseMatchArg(ks, arg13, sig); err != nil ||
+			bytes.Equal(expected12, d.e[0:d.off]) == false ||
+			maps.Equal(ks.valueMaps[0].Data, expectMap) == false {
+			t.Errorf("parseMatchArg: error %v expected %v bytes %v expected map %v got %v parsing %v\n",
+				err, expected12, d.e[0:d.off], expectMap, ks.valueMaps[0].Data, arg13)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes #4699

### Description
Fixes an infinite loop for ranges with `math.MaxUint64` as upper bound.

Also documents that using range notation with the `InMap` operator is memory intensive. See the commit message for details.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Fix a infinite loop when using range notation with math.MaxUint64 as upper bound
```
