### PR TITLE
fix(bpf): define `_MULTI_KPROBE` macro when needed.

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -207,11 +207,9 @@ $(DEPSDIR)%_$$(VAR).d: $(BPFTESTDIR)%.c
 # Define extra CFLAGS for variant objects
 CFLAGS_bpf_multi_kprobe_$$(VAR).o    = -D__MULTI_KPROBE
 CFLAGS_bpf_multi_retkprobe_$$(VAR).o = -D__MULTI_KPROBE
-ifeq (v61,$$(VAR))
 CFLAGS_bpf_multi_uprobe_$$(VAR).o    = -D__MULTI_KPROBE
 CFLAGS_bpf_multi_retuprobe_$$(VAR).o = -D__MULTI_KPROBE
 CFLAGS_bpf_multi_usdt_$$(VAR).o      = -D__MULTI_KPROBE
-endif
 endef # DEFINE_VARIANT
 
 $(eval $(call DEFINE_VARIANT,v310))


### PR DESCRIPTION
Fixes #4837 

### Description

This fixes an issue when "multi" feat (eg: uprobe_multi) is backported to older (but >=5.11) kernels, where `detect_linux` would try to enforce the usage of `multi` sections in our programs.
Given that our bpf makefile was only adding the `-D__MULTI_KPROBE` CFLAG for v61 variant (https://github.com/cilium/tetragon/blob/main/bpf/Makefile#L210), but we were loading the multi uprobe on a 5.11+ kernel, what happened is that the bpf program had the wrong sections (https://github.com/cilium/tetragon/blob/main/bpf/process/bpf_generic_uprobe.c#L56) but userspace tried to load the correct ones, ie: the multi one and did not find them!


### Changelog


```release-note
fix(bpf): define `_MULTI_KPROBE` macro when needed.
```
