### PR TITLE
chore(deps): Reorder renovate post-upgrade tasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -186,7 +186,7 @@
         "gomodUpdateImportPaths",
       ],
       postUpgradeTasks: {
-        "commands": ["/tmp/install-buildx", "make protogen", "make crds", "make vendor", "make gen-docs-references"],
+        "commands": ["/tmp/install-buildx", "make vendor", "make protogen", "make crds", "make gen-docs-references"],
         "fileFilters": ["**/**"],
         "executionMode": "branch"
       }


### PR DESCRIPTION
### Description
Running 'make vendor' first in the post upgrade tasks of renovate prevents the following error:

```
  Command failed: make protogen
  go: inconsistent vendoring
```