### PR TITLE
tetragon: Fix tail call program types for uprobe sensor

### DIFF
--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -42,9 +42,11 @@ struct {
 #include "generic_calls.h"
 
 #ifdef __MULTI_KPROBE
-#define MAIN "uprobe.multi/generic_uprobe"
+#define MAIN   "uprobe.multi/generic_uprobe"
+#define COMMON "uprobe.multi"
 #else
-#define MAIN "uprobe/generic_uprobe"
+#define MAIN   "uprobe/generic_uprobe"
+#define COMMON "uprobe"
 #endif
 
 __attribute__((section((MAIN)), used)) int
@@ -53,19 +55,19 @@ generic_uprobe_event(struct pt_regs *ctx)
 	return generic_start_process_filter(ctx, (struct bpf_map_def *)&uprobe_calls);
 }
 
-__attribute__((section("uprobe"), used)) int
+__attribute__((section(COMMON), used)) int
 generic_uprobe_setup_event(void *ctx)
 {
 	return generic_process_event_and_setup(ctx, (struct bpf_map_def *)&uprobe_calls);
 }
 
-__attribute__((section("uprobe"), used)) int
+__attribute__((section(COMMON), used)) int
 generic_uprobe_process_event(void *ctx)
 {
 	return generic_process_event(ctx, (struct bpf_map_def *)&uprobe_calls);
 }
 
-__attribute__((section("uprobe"), used)) int
+__attribute__((section(COMMON), used)) int
 generic_uprobe_process_filter(void *ctx)
 {
 	int ret;
@@ -81,20 +83,20 @@ generic_uprobe_process_filter(void *ctx)
 	return PFILTER_REJECT;
 }
 
-__attribute__((section("uprobe"), used)) int
+__attribute__((section(COMMON), used)) int
 generic_uprobe_filter_arg(void *ctx)
 {
 	return generic_filter_arg(ctx, (struct bpf_map_def *)&uprobe_calls, true);
 }
 
-__attribute__((section("uprobe"), used)) int
+__attribute__((section(COMMON), used)) int
 generic_uprobe_actions(void *ctx)
 {
 	generic_actions(ctx, (struct bpf_map_def *)&uprobe_calls);
 	return 0;
 }
 
-__attribute__((section("uprobe"), used)) int
+__attribute__((section(COMMON), used)) int
 generic_uprobe_output(void *ctx)
 {
 	return generic_output(ctx, MSG_OP_GENERIC_UPROBE);


### PR DESCRIPTION
[ upstream commit 156d498a5b850eaf30c2a0c5cdb412129ac6afab]

As reported by Mahe newest kernels check properly on programs using (some) maps being same type [1]. We violate that with uprobe tail called programs having just 'uprobe' type.

[1] 4540aed51b12 ("bpf: Enforce expected_attach_type for tailcall compatibility")
Reported-by: Mahe Tardy <mahe.tardy@gmail.com>