### PR TITLE
cleanup(ci): avoid x-compilation in packages-e2e-tests CI.

### DIFF
--- a/.github/workflows/packages-e2e-tests.yaml
+++ b/.github/workflows/packages-e2e-tests.yaml
@@ -8,28 +8,12 @@ on:
 
 jobs:
   standalone-tarball-builds:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # We use the native arch build
-          - os: ubuntu-22.04
-            arch: amd64
-            match_arch: x86-64
-            cross_compile: no
-            upload_path: upload/
-          - os: ubuntu-22.04
-            arch: arm64
-            match_arch: arm64
-            cross_compile: yes
-            upload_path: upload-cross-compile/
-
+        arch: [amd64, arm64]
     steps:
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
       - name: Checkout Source Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -38,50 +22,32 @@ jobs:
         run: echo "tag=$(make version)" >> $GITHUB_OUTPUT
 
       - name: Generate Tetragon Tarball
-        if: ${{ matrix.cross_compile == 'no' }}
-        id: tetragon-tarball
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
           make tarball
-          mkdir ${{ matrix.upload_path }}
-          mv ./build/${{ matrix.arch }}/linux-tarball/tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz ./${{ matrix.upload_path }}
-
-      - name: Generate Cross Compiled Tetragon Tarball
-        if: ${{ matrix.cross_compile == 'yes' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu qemu-user-static binfmt-support
-          sudo update-binfmts --display
-          make TARGET_ARCH=${{ matrix.arch }} tarball
-          mkdir ${{ matrix.upload_path }}
-          mv ./build/${{ matrix.arch }}/linux-tarball/tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz ./${{ matrix.upload_path }}
+          mkdir upload/
+          mv ./build/${{ matrix.arch }}/linux-tarball/tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz ./upload/
 
       # Cache tarball releases for later
       - name: Save tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz Tarball
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}
-          path: ${{ matrix.upload_path }}
+          path: upload/
           retention-days: 1
 
   standalone-tarball-tests:
     needs: [standalone-tarball-builds]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
     strategy:
       matrix:
+        arch: [amd64, arm64]
         include:
-          - os: ubuntu-22.04
-            arch: amd64
+          - arch: amd64
             match_arch: x86-64
-            cross_compile: no
-            upload_path: upload/
-          - os: ubuntu-22.04-arm64
-            arch: arm64
+          - arch: arm64
             match_arch: arm64
-            cross_compile: yes
-            upload_path: upload-cross-compile/
-
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -94,12 +60,12 @@ jobs:
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}
-          path: ${{ matrix.upload_path }}
+          path: ./download
 
       - name: Move tetragon-${{ steps.tag.outputs.tag }}-${{ matrix.arch }}.tar.gz to build
         run: |
           mkdir -p ./build/${{ matrix.arch }}/
-          mv ${{ matrix.upload_path }} ./build/${{ matrix.arch }}/linux-tarball
+          mv ./download ./build/${{ matrix.arch }}/linux-tarball
 
       - name: Copy bpf.yaml tracing policy to /etc/tetragon/tetragon.tp.d/
         run: |


### PR DESCRIPTION
Fixes: #4693

Not 100% sure whether it fixes the issue but seems to help (and it's also a nice cleanup):
<img width="335" height="940" alt="immagine" src="https://github.com/user-attachments/assets/fe7a9a79-c467-4f18-ae76-68b7aff12f5b" />
