### PR TITLE
Handle NULL pointers for string args

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -276,8 +276,7 @@ __read_arg_1(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 			size += 4;
 		} else {
 			/* If filter specification is fd type then we
-			 * expect the fd has been previously followed
-			 * otherwise drop the event.
+			 * prevent the filter from matching
 			 */
 			return -1;
 		}
@@ -345,7 +344,7 @@ __read_arg_1(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 		size = 0;
 		break;
 	}
-	return size + sizeof(arg_status_t);
+	return size;
 }
 
 FUNC_INLINE long
@@ -423,7 +422,7 @@ __read_arg_2(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 		size = 0;
 		break;
 	}
-	return size + sizeof(arg_status_t);
+	return size;
 }
 
 /**
@@ -450,6 +449,7 @@ read_arg(void *ctx, int index, int type, long orig_off, unsigned long arg, int a
 	const struct path *path_arg = 0;
 	struct path path_buf;
 	int zero = 0;
+	int ret;
 
 	e = map_lookup_elem(&process_call_heap, &zero);
 	if (!e)
@@ -467,22 +467,32 @@ read_arg(void *ctx, int index, int type, long orig_off, unsigned long arg, int a
 	args = args_off(e, orig_off);
 
 	path_arg = get_path(type, arg, &path_buf);
-	if (path_arg)
-		return copy_path(args, path_arg) + sizeof(arg_status_t);
 	/*
-	 * Separate argument processing based on the process const
-	 * for 4.19 kernels..
+	 * If not path_ag, separate argument processing based on the process
+	 * const for 4.19 kernels..
 	 */
-	if (process == __READ_ARG_1)
-		return __read_arg_1(ctx, type, orig_off, arg, argm, args);
-	if (process == __READ_ARG_2)
-		return __read_arg_2(ctx, type, orig_off, arg, argm, args);
+	if (path_arg) {
+		ret = copy_path(args, path_arg);
+	} else if (process == __READ_ARG_1) {
+		ret = __read_arg_1(ctx, type, orig_off, arg, argm, args);
+	} else if (process == __READ_ARG_2) {
+		ret = __read_arg_2(ctx, type, orig_off, arg, argm, args);
+	} else {
+		/* .. and the rest of the world */
+		if (is_read_arg_1(type))
+			ret = __read_arg_1(ctx, type, orig_off, arg, argm, args);
+		else
+			ret = __read_arg_2(ctx, type, orig_off, arg, argm, args);
+	}
 
-	/* .. and the rest of the world */
-	if (is_read_arg_1(type))
-		return __read_arg_1(ctx, type, orig_off, arg, argm, args);
-	else
-		return __read_arg_2(ctx, type, orig_off, arg, argm, args);
+	if (ret < 0) {
+		e->arg_status[index & MAX_POSSIBLE_ARGS_MASK] = -1;
+		/* update the arg status to reflect the detected fault */
+		write_arg_status(e, orig_off - sizeof(arg_status_t), e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
+		return sizeof(arg_status_t);
+	}
+
+	return ret + sizeof(arg_status_t);
 }
 
 FUNC_INLINE long get_pt_regs_arg_syscall(struct pt_regs *ctx, __u16 offset, __u8 shift)
@@ -657,13 +667,6 @@ generic_process_event(void *ctx, struct bpf_map_def *tailcals, int process)
 		errv = generic_read_arg(ctx, index, total, tailcals, process);
 		if (errv > 0)
 			total += errv;
-		/* Follow filter lookup failed so lets abort the event.
-		 * From high-level this is a filter and should be in the
-		 * filter block, but its just easier to do here so lets
-		 * do it where it makes most sense.
-		 */
-		if (errv < 0)
-			return filter_args_reject(e->func_id);
 	}
 	e->common.size = total;
 	/* Continue to process other arguments. */

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -1240,6 +1240,7 @@ FUNC_INLINE int generic_retprobe(void *ctx, struct bpf_map_def *calls, unsigned 
 	ty_arg = config->argreturn;
 	do_copy = config->argreturncopy;
 	if (ty_arg) {
+		e->arg_status[0] = 0;
 		size += read_arg(ctx, 0, ty_arg, size, ret, 0, __READ_ARG_ALL);
 #if defined(__LARGE_BPF_PROG) && (defined(GENERIC_KRETPROBE) || defined(GENERIC_FEXIT))
 		struct socket_owner owner;

--- a/bpf/process/generic_path.h
+++ b/bpf/process/generic_path.h
@@ -177,6 +177,7 @@ FUNC_INLINE long generic_path_offload(void *ctx, long ty, unsigned long arg,
 	const struct path *path;
 	char *args, *buffer, *buf;
 	int zero = 0;
+	int ret;
 
 	e = map_lookup_elem(&process_call_heap, &zero);
 	if (!e)
@@ -207,7 +208,15 @@ FUNC_INLINE long generic_path_offload(void *ctx, long ty, unsigned long arg,
 
 	args = args_off(e, orig_off);
 	buf = get_buf(buffer, gp->off);
-	return store_path(args, buf, gp->path, MAX_BUF_LEN - gp->off - 1, 0) + sizeof(arg_status_t);
+	ret = store_path(args, buf, gp->path, MAX_BUF_LEN - gp->off - 1, 0);
+	if (ret < 0) {
+		/* update the arg status to reflect the detected fault */
+		e->arg_status[index & MAX_POSSIBLE_ARGS_MASK] = -1;
+		write_arg_status(e, orig_off - sizeof(arg_status_t), e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
+		return sizeof(arg_status_t);
+	} else {
+		return ret + sizeof(arg_status_t);
+	}
 }
 
 FUNC_INLINE bool should_offload_path(long type)

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -365,8 +365,8 @@ FUNC_INLINE long copy_strings(char *args, char *arg, int max_size)
 	// So add one to the length to allow for it. This should
 	// result in us honouring our max_size correctly.
 	size = probe_read_str(&args[4], max_size + 1, arg);
-	if (size <= 0)
-		return invalid_ty;
+	if (size < 0)
+		return size;
 	// Remove the nul character from end.
 	size--;
 	*s = size;

--- a/bpf/process/user_preload.h
+++ b/bpf/process/user_preload.h
@@ -140,7 +140,7 @@ try_preload_arg(int idx, struct preload_arg_data *data)
 {
 	asm volatile("%[idx] &= %1 ;\n"
 		     : [idx] "+r"(idx)
-		     : "i"(MAX_POSSIBLE_ARGS));
+		     : "i"(MAX_POSSIBLE_ARGS_MASK));
 
 	if (data->config->arm[idx] & ARGM_PRELOAD) {
 		if (data->config->arm[idx] & ARGM_PT_REGS)

--- a/bpf/process/user_preload.h
+++ b/bpf/process/user_preload.h
@@ -41,9 +41,14 @@ preload_string_type(struct pt_regs *ctx, struct event_config *config, unsigned l
 	if (!data)
 		return 0;
 
+	if (!status) {
+		if (bpf_copy_from_user_str(data->data, sizeof(data->data), (const void *)val, 0) < 0) {
+			data->status = -1;
+			return 0;
+		}
+	}
+
 	data->status = status;
-	if (!status)
-		bpf_copy_from_user_str(data->data, sizeof(data->data), (const void *)val, 0);
 	return 0;
 }
 

--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -45,3 +45,4 @@ uprobe-null.btf
 /uprobe-simple
 pclntab-stripped
 pclntab-unstripped
+null-mount

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -42,7 +42,8 @@ PROGS = sigkill-tester \
 	uprobe-null \
 	uprobe-simple \
 	pclntab-unstripped \
-	pclntab-stripped
+	pclntab-stripped \
+	null-mount
 
 LIBS =	libuprobe.so \
 	libtester.so

--- a/contrib/tester-progs/null-mount.c
+++ b/contrib/tester-progs/null-mount.c
@@ -1,0 +1,41 @@
+#include <sys/mount.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main() {
+    char mount_template[] = "/tmp/mnt.XXXXXX";
+    char *mount_point = NULL;
+    int status = 0;
+
+    // Create a unique mount point directory under /tmp for this run.
+    mount_point = mkdtemp(mount_template);
+    if (mount_point == NULL) {
+        perror("mkdtemp failed");
+        return 1;
+    }
+
+    // Passing NULL as the first argument (source)
+    if (mount(NULL, mount_point, "tmpfs", 0, NULL) == 0) {
+        printf("Mount successful\n");
+
+        if (umount(mount_point) == 0) {
+            printf("Unmount successful\n");
+        } else {
+            perror("Unmount failed");
+            status = 1;
+        }
+    } else {
+        perror("Mount failed");
+        status = 1;
+    }
+
+    if (rmdir(mount_point) == 0) {
+        printf("Removed mount point\n");
+    } else {
+        perror("rmdir failed");
+        status = 1;
+    }
+
+    return status;
+}

--- a/contrib/tester-progs/uprobe-lib.c
+++ b/contrib/tester-progs/uprobe-lib.c
@@ -48,6 +48,12 @@ int uprobe_test_lib_string_arg_empty(char *str)
 	return 0;
 }
 
+int uprobe_test_lib_string_arg_null(char *str)
+{
+	printf("uprobe_test_lib_string_arg_null called\n");
+	return 0;
+}
+
 int uprobe_test_lib_string_arg_substring(char *str)
 {
 	printf("uprobe_test_lib_string_arg_substring called\n");

--- a/contrib/tester-progs/uprobe-lib.c
+++ b/contrib/tester-progs/uprobe-lib.c
@@ -42,6 +42,36 @@ int uprobe_test_lib_string_arg(char *str)
 	return 0;
 }
 
+int uprobe_test_lib_string_arg0(char *str, int two, int three, int four, int five)
+{
+	printf("uprobe_test_lib_string_arg0 called\n");
+	return 0;
+}
+
+int uprobe_test_lib_string_arg1(int one, char *str, int three, int four, int five)
+{
+	printf("uprobe_test_lib_string_arg1 called\n");
+	return 0;
+}
+
+int uprobe_test_lib_string_arg2(int one, int two, char *str, int four, int five)
+{
+	printf("uprobe_test_lib_string_arg2 called\n");
+	return 0;
+}
+
+int uprobe_test_lib_string_arg3(int one, int two, int three, char *str, int five)
+{
+	printf("uprobe_test_lib_string_arg3 called\n");
+	return 0;
+}
+
+int uprobe_test_lib_string_arg4(int one, int two, int three, int four, char *str)
+{
+	printf("uprobe_test_lib_string_arg4 called\n");
+	return 0;
+}
+
 int uprobe_test_lib_string_arg_empty(char *str)
 {
 	printf("uprobe_test_lib_string_arg_empty called\n");

--- a/contrib/tester-progs/uprobe-test.c
+++ b/contrib/tester-progs/uprobe-test.c
@@ -17,6 +17,11 @@ int uprobe_test_lib_string_arg(char *str);
 int uprobe_test_lib_string_arg_empty(char *str);
 int uprobe_test_lib_string_arg_null(char *str);
 int uprobe_test_lib_string_arg_substring(char *str);
+int uprobe_test_lib_string_arg0(char *str, int two, int three, int four, int five);
+int uprobe_test_lib_string_arg1(int one, char *str, int three, int four, int five);
+int uprobe_test_lib_string_arg2(int one, int two, char *str, int four, int five);
+int uprobe_test_lib_string_arg3(int one, int two, int three, char *str, int five);
+int uprobe_test_lib_string_arg4(int one, int two, int three, int four, char *str);
 
 int main(void)
 {
@@ -32,4 +37,9 @@ int main(void)
 	uprobe_test_lib_string_arg_empty("");
 	uprobe_test_lib_string_arg_null(NULL);
 	uprobe_test_lib_string_arg_substring("test");
+	uprobe_test_lib_string_arg0("one", 2, 3, 4, 5);
+	uprobe_test_lib_string_arg1(1, "two", 3, 4, 5);
+	uprobe_test_lib_string_arg2(1, 2, "three", 4, 5);
+	uprobe_test_lib_string_arg3(1, 2, 3, "four", 5);
+	uprobe_test_lib_string_arg4(1, 2, 3, 4, "five");
 }

--- a/contrib/tester-progs/uprobe-test.c
+++ b/contrib/tester-progs/uprobe-test.c
@@ -15,6 +15,7 @@ int uprobe_test_lib_arg4(long a1, int a2, char a3, void *a4);
 int uprobe_test_lib_arg5(int a1, char a2, unsigned long a3, short a4, void *a5);
 int uprobe_test_lib_string_arg(char *str);
 int uprobe_test_lib_string_arg_empty(char *str);
+int uprobe_test_lib_string_arg_null(char *str);
 int uprobe_test_lib_string_arg_substring(char *str);
 
 int main(void)
@@ -29,5 +30,6 @@ int main(void)
 	uprobe_test_lib_arg5(1, 'c', 0xcafe, 1234, (void *) 2);
 	uprobe_test_lib_string_arg(pageout(str_arg, strlen(str_arg) + 1));
 	uprobe_test_lib_string_arg_empty("");
+	uprobe_test_lib_string_arg_null(NULL);
 	uprobe_test_lib_string_arg_substring("test");
 }

--- a/contrib/tetragon-rthooks/docs/demo.md
+++ b/contrib/tetragon-rthooks/docs/demo.md
@@ -1,4 +1,4 @@
-This is a dev demo of how to install the teragon OCI hook on a CRI-O runtime.
+This is a dev demo of how to install the tetragon OCI hook on a CRI-O runtime.
 
 Note: we should move this to the documentation once the PR is merged and `tetragon-oci-hook` and
 `tetragon-oci-hook-setup` are part of the tetragon development image.

--- a/contrib/tetragon-rthooks/scripts/minikube-install-hook.sh
+++ b/contrib/tetragon-rthooks/scripts/minikube-install-hook.sh
@@ -126,7 +126,7 @@ install_containerd() {
 install_crio() {
 	echo "Installing CRIO OCI hook"
 	$SETUPBIN print-config --interface=oci-hooks --binary=$HOOKNAME > $xdir/hook.json
-	minikube cp $xdir/hook.json /usr/share/containers/oci/hooks.d/teragon-oci-hook.json
+	minikube cp $xdir/hook.json /usr/share/containers/oci/hooks.d/tetragon-oci-hook.json
 }
 
 

--- a/pkg/sensors/tracing/args_linux.go
+++ b/pkg/sensors/tracing/args_linux.go
@@ -112,7 +112,11 @@ func getArgStatus(r *bytes.Reader) (*api.MsgGenericKprobeArgError, error) {
 	}
 
 	if status != 0 {
-		arg.Message = strconv.FormatUint(uint64(status), 10)
+		if status == ^uint32(0) {
+			arg.Message = "Bad address"
+		} else {
+			arg.Message = strconv.FormatUint(uint64(status), 10)
+		}
 		return &arg, nil
 	}
 	return nil, nil

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -8348,3 +8348,7 @@ spec:
 func TestKprobeNotEqualMultipleValues(t *testing.T) {
 	testKprobeNotEqualMultipleValues(t, false)
 }
+
+func TestKprobeNULLStringAndReturnArg(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-null-string", nil)
+}

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -479,7 +479,7 @@ func TestLoadTracepointSensor(t *testing.T) {
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 6, 7}})
 
 		// all but generic_tracepoint_event,generic_tracepoint_filter
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 6, 7}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 6, 7}})
 
 		// all kprobe but generic_tracepoint_filter
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 2, 6}})

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -1127,3 +1127,63 @@ spec:
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
 }
+
+func TestUprobeNULLStringAndReturnArg(t *testing.T) {
+
+	if !bpf.HasKfunc("bpf_copy_from_user_str") {
+		t.Skip("this test requires bpf_copy_from_user_str kfunc support")
+	}
+
+	testutils.CaptureLog(t, logger.GetLogger())
+	uprobeTest1 := testutils.RepoRootPath("contrib/tester-progs/uprobe-test-1")
+	libUprobe := testutils.RepoRootPath("contrib/tester-progs/libuprobe.so")
+
+	uprobeHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "null-string-arg-uprobe"
+spec:
+  uprobes:
+  - path: "` + libUprobe + `"
+    symbols:
+    - "uprobe_test_lib_string_arg_null"
+    args:
+    - index: 0
+      type: "string"
+    return: true
+    returnArg:
+      index: 0
+      type: "int"
+`
+
+	createCrdFile(t, uprobeHook)
+
+	upChecker := ec.NewProcessUprobeChecker("null-string-arg-uprobe").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(uprobeTest1))).WithSymbol(sm.Full("uprobe_test_lib_string_arg_null")).WithArgs(ec.NewKprobeArgumentListMatcher().
+		WithOperator(lc.Ordered).
+		WithValues(
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address"))),
+			ec.NewKprobeArgumentChecker().WithIntArg(0)),
+	)
+	checker := ec.NewUnorderedEventChecker(upChecker)
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	require.NoError(t, err)
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	if err := exec.Command(uprobeTest1).Run(); err != nil {
+		t.Fatalf("Failed to execute test binary: %s\n", err)
+	}
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	require.NoError(t, err)
+}

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -789,6 +789,96 @@ func TestUprobeArgsWithAddress(t *testing.T) {
 	testUprobeArgs(t, checkers, tp)
 }
 
+func uprobePreloadArgs(t *testing.T, arg_idx int, arg_value string) {
+	if !bpf.HasKfunc("bpf_copy_from_user_str") {
+		t.Skip("this test requires bpf_copy_from_user_str kfunc support")
+	}
+
+	symbol := "uprobe_test_lib_string_arg" + strconv.Itoa(arg_idx)
+
+	uprobeTest1 := testutils.RepoRootPath("contrib/tester-progs/uprobe-test-1")
+	libUprobe := testutils.RepoRootPath("contrib/tester-progs/libuprobe.so")
+
+	var pathHook strings.Builder
+	pathHook.WriteString(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe"
+spec:
+  uprobes:
+  - path: "` + libUprobe + `"
+    symbols:
+    - "` + symbol + `"
+    args:`)
+
+	for i := range 5 {
+		arg_type := "int"
+		if i == arg_idx {
+			arg_type = "string"
+		}
+		pathHook.WriteString(`
+    - index: ` + strconv.Itoa(i) + `
+      type: "` + arg_type + `"`)
+	}
+
+	createCrdFile(t, pathHook.String())
+
+	values := []*ec.KprobeArgumentChecker{ec.NewKprobeArgumentChecker().WithIntArg(1),
+		ec.NewKprobeArgumentChecker().WithIntArg(2),
+		ec.NewKprobeArgumentChecker().WithIntArg(3),
+		ec.NewKprobeArgumentChecker().WithIntArg(4),
+		ec.NewKprobeArgumentChecker().WithIntArg(5),
+	}
+
+	values[arg_idx] = ec.NewKprobeArgumentChecker().WithStringArg(sm.Full(arg_value))
+
+	upChecker := ec.NewProcessUprobeChecker("UPROBE_PRELOAD_ARGS").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(uprobeTest1))).
+		WithSymbol(sm.Full(symbol)).WithArgs(ec.NewKprobeArgumentListMatcher().
+		WithOperator(lc.Ordered).
+		WithValues(values...))
+
+	checker := ec.NewUnorderedEventChecker(upChecker)
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	if err := exec.Command(uprobeTest1).Run(); err != nil {
+		t.Fatalf("Failed to execute test binary: %s\n", err)
+	}
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	require.NoError(t, err)
+}
+
+func TestUprobePreloadArg0(t *testing.T) {
+	uprobePreloadArgs(t, 0, "one")
+}
+func TestUprobePreloadArg1(t *testing.T) {
+	uprobePreloadArgs(t, 1, "two")
+}
+func TestUprobePreloadArg2(t *testing.T) {
+	uprobePreloadArgs(t, 2, "three")
+}
+func TestUprobePreloadArg3(t *testing.T) {
+	uprobePreloadArgs(t, 3, "four")
+}
+func TestUprobePreloadArg4(t *testing.T) {
+	uprobePreloadArgs(t, 4, "five")
+}
+
 func uprobeArgsMatch(t *testing.T, symbol string, arg_type string, op string, values []string, expectCheckerFailure bool) error {
 	uprobeTest1 := testutils.RepoRootPath("contrib/tester-progs/uprobe-test-1")
 	libUprobe := testutils.RepoRootPath("contrib/tester-progs/libuprobe.so")

--- a/pkg/testutils/policytest/observertest.go
+++ b/pkg/testutils/policytest/observertest.go
@@ -63,7 +63,7 @@ func (rpt *RegisteredPolicyTests) DoObserverTest(
 		t.Fatalf("failed to generate policy: %s", err)
 	}
 
-	policyFile, err := os.CreateTemp("", "teragon-policy-"+t.Name()+"-*.txt")
+	policyFile, err := os.CreateTemp("", "tetragon-policy-"+t.Name()+"-*.txt")
 	if err != nil {
 		t.Fatalf("failed to create polcy file: %s", err)
 	}

--- a/pkg/testutils/sensors/testrun_linux.go
+++ b/pkg/testutils/sensors/testrun_linux.go
@@ -37,7 +37,7 @@ func TestSensorsRun(m *testing.M, sensorName string) int {
 		&config.DisableTetragonLogs,
 		"disable-tetragon-logs",
 		ConfigDefaults.DisableTetragonLogs,
-		"do not output teragon log")
+		"do not output tetragon log")
 	flag.BoolVar(
 		&config.Debug,
 		"debug",

--- a/pkg/testutils/sensors/testrun_windows.go
+++ b/pkg/testutils/sensors/testrun_windows.go
@@ -36,7 +36,7 @@ func TestSensorsRun(m *testing.M, sensorName string) int {
 		&config.DisableTetragonLogs,
 		"disable-tetragon-logs",
 		ConfigDefaults.DisableTetragonLogs,
-		"do not output teragon log")
+		"do not output tetragon log")
 	flag.BoolVar(
 		&config.Debug,
 		"debug",

--- a/tests/policytests/kprobes.go
+++ b/tests/policytests/kprobes.go
@@ -7,6 +7,7 @@ package tests
 
 import (
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/testutils/policytest"
 )
@@ -43,5 +44,38 @@ spec:
 		Name:         "execute lseek and check events",
 		Trigger:      policytest.NewCmdTrigger(lseek, "-1", "0", "4444"),
 		EventChecker: ec.NewUnorderedEventChecker(lseekChecker),
+	}
+}).RegisterAtInit()
+
+var _ = policytest.NewBuilder("kprobe-null-string").WithLabels("kprobes").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "kprobe-null-string"
+spec:
+  kprobes:
+  - call: "security_sb_mount"
+    syscall: false
+    return: true
+    args:
+      - index: 0 # dev_name
+        type: "string"
+    returnArg:
+      index: 0
+      type: "int"
+`).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	myBin := c.TestBinary("null-mount")
+	argChecker := ec.NewProcessKprobeChecker("kprobe-null-string").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(myBin))).WithArgs(ec.NewKprobeArgumentListMatcher().
+		WithOperator(lc.Ordered).
+		WithValues(
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address"))),
+		)).WithReturn(ec.NewKprobeArgumentChecker().WithIntArg(0))
+
+	return &policytest.Scenario{
+		Name:         "check null pointer passed for string argument",
+		Trigger:      policytest.NewCmdTrigger(myBin).ExpectExitCode(0),
+		EventChecker: ec.NewUnorderedEventChecker(argChecker),
 	}
 }).RegisterAtInit()


### PR DESCRIPTION
This change lays the ground work for addressing https://github.com/cilium/tetragon/issues/4579. After I created the error arg type with [this change](https://github.com/cilium/tetragon/pull/4327), the problem described in that issue mutated such that we send events, but they are corrupted.

While looking into that problem, I found another issue with https://github.com/cilium/tetragon/pull/4327 where returnArgs can be overwritten when the first configured arg read results in an error arg.

Userspace probes have different string reading logic than kprobes. While events were not dropped in the uprobe case when NULL pointers are passed, empty strings were being reported in the event. So, I made uprobes consistent with kprobes in this regard, by returning an error arg when a NULL pointer is passed. This way, we can distinguish between empty strings and NULL pointers.

While creating the uprobe test I noticed a bug where I was masking against a macro that was not actually a mask. I corrected this as well.

I wanted to make the uprobe tests policytests, but I couldn't because there is no way to determine kfunc availability for policy tests yet.