### PR TITLE
tetragon: Fail properly in OffsetFromAddr function

### DIFF
--- a/pkg/elf/file.go
+++ b/pkg/elf/file.go
@@ -148,6 +148,9 @@ func (se *SafeELFFile) OffsetFromAddr(addr uint64) (uint64, error) {
 			break
 		}
 	}
+	if offset == 0 {
+		return 0, fmt.Errorf("failed to find offset for address %x", addr)
+	}
 	return offset, nil
 }
 


### PR DESCRIPTION
At the moment we don't fail OffsetFromAddr function in case we don't find proper offset for address.

Adding following error for that:

level=error msg="Failed to execute tetragon" error="policy handler 'tracing' \ failed loading policy 'test': failed to find offset for address 40049c0"