### PR TITLE
crd: Add tetragon category to PodInfo CRD

### DIFF
--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_podinfo.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_podinfo.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - tetragon
     kind: PodInfo
     listKind: PodInfoList
     plural: podinfo

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_podinfo.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_podinfo.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - tetragon
     kind: PodInfo
     listKind: PodInfoList
     plural: podinfo

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -492,7 +492,7 @@ type WorkloadObjectMeta struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="podinfo",path="podinfo",scope="Namespaced",shortName={tgpi}
+// +kubebuilder:resource:categories={tetragon},singular="podinfo",path="podinfo",scope="Namespaced",shortName={tgpi}
 
 // PodInfo is the Scheme for the Podinfo API
 type PodInfo struct {

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.14"
+const CustomResourceDefinitionSchemaVersion = "1.7.15"

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_podinfo.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_podinfo.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: cilium.io
   names:
+    categories:
+    - tetragon
     kind: PodInfo
     listKind: PodInfoList
     plural: podinfo

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -492,7 +492,7 @@ type WorkloadObjectMeta struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:singular="podinfo",path="podinfo",scope="Namespaced",shortName={tgpi}
+// +kubebuilder:resource:categories={tetragon},singular="podinfo",path="podinfo",scope="Namespaced",shortName={tgpi}
 
 // PodInfo is the Scheme for the Podinfo API
 type PodInfo struct {

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.7.14"
+const CustomResourceDefinitionSchemaVersion = "1.7.15"


### PR DESCRIPTION
The same was already done for other resources

```release-note
crd: Add tetragon category to PodInfo CRD
```
