### PR TITLE
uprobe-test-1: have libs relative to binary

### DIFF
--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -92,7 +92,7 @@ libtester.so: tester-lib.c
 	$(GCC) -Wall -fPIC $< -o $@ -shared
 
 uprobe-test-1: uprobe-test.c tester-lib.h libuprobe.so libtester.so
-	$(GCC) -Wall $< -o $@ $(CURDIR)/libuprobe.so $(CURDIR)/libtester.so
+	$(GCC) -Wall $< -o $@ -L . -luprobe -ltester -Wl,-rpath,'$$ORIGIN'
 
 uprobe-test-2: uprobe-test-1
 	cp uprobe-test-1 uprobe-test-2


### PR DESCRIPTION
We want to be able to execute uprobe-test-1 from different directories. That is, copy the binary and the .so file in different directories and execute them from them.

From https://sourceware.org/binutils/docs/ld/Options.html

-rpath-link=dir
 ...
    The tokens $ORIGIN and $LIB can appear in these search directories.
    They will be replaced by the full path to the directory containing
    the program or shared object in the case of $ORIGIN and either ‘lib’
    - for 32-bit binaries - or ‘lib64’ - for 64-bit binaries - in the case of $LIB.

