### PR TITLE
helm: expose Tetragon server over UDS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ e2e-test: image image-operator
 else
 e2e-test:
 endif
-	$(GO) list $(E2E_TESTS) | xargs -Ipkg $(GO) test $(GOFLAGS) -gcflags=$(GO_BUILD_GCFLAGS) -timeout $(E2E_TEST_TIMEOUT) -failfast -cover pkg ${EXTRA_TESTFLAGS} -fail-fast -tetragon.helm.set tetragon.image.override="$(E2E_AGENT)" -tetragon.helm.set tetragonOperator.image.override="$(E2E_OPERATOR)" -tetragon.helm.url="" -tetragon.helm.chart="$(realpath ./install/kubernetes/tetragon)" $(E2E_BTF_FLAGS)
+	$(GO) list $(E2E_TESTS) | xargs -Ipkg $(GO) test $(GOFLAGS) -gcflags=$(GO_BUILD_GCFLAGS) -timeout $(E2E_TEST_TIMEOUT) -failfast -cover pkg ${EXTRA_TESTFLAGS} -fail-fast -tetragon.helm.set tetragon.image.override="$(E2E_AGENT)" -tetragon.helm.set tetragonOperator.image.override="$(E2E_OPERATOR)" -tetragon.helm.set tetragon.grpc.address="localhost:54321" -tetragon.helm.url="" -tetragon.helm.chart="$(realpath ./install/kubernetes/tetragon)" $(E2E_BTF_FLAGS)
 
 ##@ Development
 

--- a/docs/content/en/docs/concepts/events.md
+++ b/docs/content/en/docs/concepts/events.md
@@ -312,8 +312,8 @@ Will filter and report just the relevant events.
 ### gRPC
 
 In addition Tetragon can expose a gRPC endpoint listeners may attach to. The
-gRPC is exposed by default helm install on `localhost:54321`, but the address
-can be configured  with the `--server-address` option. This can be
+gRPC is exposed by default helm install on `unix:///var/run/tetragon/tetragon.sock`,
+but the address can be configured  with the `--server-address` option. This can be
 set from helm with the `tetragon.grpc.address` flag or disabled completely if
 needed with `tetragon.grpc.enabled`.
 

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -108,7 +108,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.gops.address | string | `"localhost"` | The address at which to expose gops. |
 | tetragon.gops.enabled | bool | `true` | Whether to enable exposing gops server. |
 | tetragon.gops.port | int | `8118` | The port at which to expose gops. |
-| tetragon.grpc.address | string | `"localhost:54321"` | The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/cilum/tetragon/tetragon.sock |
+| tetragon.grpc.address | string | `"unix:///var/run/tetragon/tetragon.sock"` | The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock |
 | tetragon.grpc.enabled | bool | `true` | Whether to enable exposing Tetragon gRPC. |
 | tetragon.healthGrpc.enabled | bool | `true` | Whether to enable health gRPC server. |
 | tetragon.healthGrpc.interval | int | `10` | The interval at which to check the health of the agent. |

--- a/examples/configuration/tetragon.conf.d/server-address
+++ b/examples/configuration/tetragon.conf.d/server-address
@@ -1,1 +1,1 @@
-localhost:54321
+unix:///var/run/tetragon/tetragon.sock

--- a/examples/configuration/tetragon.yaml
+++ b/examples/configuration/tetragon.yaml
@@ -45,5 +45,5 @@ procfs: /proc/
 rb-size: 0
 rb-size-total: 0
 release-pinned-bpf: false
-server-address: localhost:54321
+server-address: unix:///var/run/tetragon/tetragon.sock
 verbose: 0

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -90,7 +90,7 @@ Helm chart for Tetragon
 | tetragon.gops.address | string | `"localhost"` | The address at which to expose gops. |
 | tetragon.gops.enabled | bool | `true` | Whether to enable exposing gops server. |
 | tetragon.gops.port | int | `8118` | The port at which to expose gops. |
-| tetragon.grpc.address | string | `"localhost:54321"` | The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/cilum/tetragon/tetragon.sock |
+| tetragon.grpc.address | string | `"unix:///var/run/tetragon/tetragon.sock"` | The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock |
 | tetragon.grpc.enabled | bool | `true` | Whether to enable exposing Tetragon gRPC. |
 | tetragon.healthGrpc.enabled | bool | `true` | Whether to enable health gRPC server. |
 | tetragon.healthGrpc.interval | int | `10` | The interval at which to check the health of the agent. |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -184,8 +184,8 @@ tetragon:
   grpc:
     # -- Whether to enable exposing Tetragon gRPC.
     enabled: true
-    # -- The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/cilum/tetragon/tetragon.sock
-    address: "localhost:54321"
+    # -- The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock
+    address: "unix:///var/run/tetragon/tetragon.sock"
   gops:
     # -- Whether to enable exposing gops server.
     enabled: true


### PR DESCRIPTION

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Restrict access to the Tetragon grpv server by exposing it over a UNIX domain socket instead of binding it to localhost.

The e2e tests override this back to localhost for now as we use Kubernete's port-forward mechanism to talk to the server in the e2e test.



### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Expose Tetragon Agent over UNIX domain socket instead of localhost
```
