### PR TITLE
process/cache: add metric and fix early deletion detection in GC

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -343,6 +343,10 @@ Number of policy filter operations.
 
 The capacity of the process cache. Expected to be constant.
 
+### `tetragon_process_cache_early_deletions_total`
+
+Number of times the GC attempted to delete a process already marked as deleted. May indicate the GC is deleting processes too early.
+
 ### `tetragon_process_cache_evictions_total`
 
 Number of process cache LRU evictions. This includes all evictions: both explicit and capacity (implicit).

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -89,6 +89,13 @@ func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 				}
 				deleteQueue = newQueue
 			case p := <-pc.deleteChan:
+				// The object has already been deleted let if fall of
+				// the edge of the world. Hitting this could mean our
+				// GC logic deleted a process too early.
+				if p.color == deleted {
+					processCacheEarlyDeletions.Inc()
+					continue
+				}
 				// duplicate deletes can happen, if they do reset
 				// color to pending and move along. This will cause
 				// the GC to keep it alive for at least another pass.
@@ -97,13 +104,6 @@ func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 				// and assume its visible everywhere.
 				if p.color != inUse {
 					p.color = deletePending
-					continue
-				}
-				// The object has already been deleted let if fall of
-				// the edge of the world. Hitting this could mean our
-				// GC logic deleted a process too early.
-				// TBD add a counter around this to alert on it.
-				if p.color == deleted {
 					continue
 				}
 				p.color = deletePending

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -4,11 +4,15 @@
 package process
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/defaults"
@@ -18,6 +22,7 @@ func TestProcessCache(t *testing.T) {
 	// add a process to the cache.
 	cache, err := NewCache(10, defaults.DefaultProcessCacheGCInterval)
 	require.NoError(t, err)
+	defer cache.purge()
 	pid := wrapperspb.UInt32Value{Value: 1234}
 	execID := "process1"
 	proc := ProcessInternal{
@@ -45,4 +50,30 @@ func TestProcessCache(t *testing.T) {
 	assert.Equal(t, 0, cache.len())
 	_, err = cache.get(proc.process.ExecId)
 	require.Error(t, err)
+}
+
+func TestProcessCacheGCEarlyDeletion(t *testing.T) {
+	cache, err := NewCache(10, 10*time.Millisecond)
+	require.NoError(t, err)
+	defer cache.purge()
+
+	pid := wrapperspb.UInt32Value{Value: 1234}
+	proc := ProcessInternal{
+		process: &tetragon.Process{
+			ExecId: "process1",
+			Pid:    &pid,
+		},
+	}
+	cache.add(&proc)
+
+	proc.color = deleted
+	cache.deletePending(&proc)
+
+	time.Sleep(50 * time.Millisecond)
+
+	expected := strings.NewReader(`# HELP tetragon_process_cache_early_deletions_total Number of times the GC attempted to delete a process already marked as deleted. May indicate the GC is deleting processes too early.
+# TYPE tetragon_process_cache_early_deletions_total counter
+tetragon_process_cache_early_deletions_total 1
+`)
+	require.NoError(t, testutil.CollectAndCompare(processCacheEarlyDeletions, expected))
 }

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -39,6 +39,11 @@ var (
 		Name:      "process_cache_capacity_evictions_total",
 		Help:      "Number of process cache capacity (implicit) LRU evictions.",
 	})
+	processCacheEarlyDeletions = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: consts.MetricsNamespace,
+		Name:      "process_cache_early_deletions_total",
+		Help:      "Number of times the GC attempted to delete a process already marked as deleted. May indicate the GC is deleting processes too early.",
+	})
 	processCacheMisses = metrics.MustNewCounter(metrics.NewOpts(
 		consts.MetricsNamespace, "", "process_cache_misses_total",
 		"Number of process cache misses.",
@@ -65,6 +70,7 @@ func RegisterMetrics(group metrics.Group) {
 		processCacheTotal,
 		processCacheEvictions,
 		processCacheMisses,
+		processCacheEarlyDeletions,
 	)
 	group.MustRegister(newCacheCollector())
 }


### PR DESCRIPTION
### Description
This PR adds a new metric tetragon_process_cache_early_deletions_total to track cases where the process cache GC attempts to delete a process that was already marked as deleted.
While adding the metric, a bug was found: the deleted color check in the deleteChan handler was unreachable because color == deleted also satisfies color != inUse, causing the handler to exit early. The fix moves the deleted check before the inUse check so the metric is actually reachable.
Previously this case only had a silent TODO comment.

**Testing**
go test ./pkg/process -run TestProcessCache -v
go test ./pkg/process/...
go test -race ./pkg/process/...

### Changelog
```release-note
Add `tetragon_process_cache_early_deletions_total` metric to improve observability of process cache GC early deletions.
```