### PR TITLE
tetragon: Add missing setup for matchParentBinaries selector

### DIFF
--- a/bpf/process/pfilter.h
+++ b/bpf/process/pfilter.h
@@ -439,10 +439,9 @@ selector_process_filter(__u32 *f, __u32 index, struct execve_map_value *enter,
 	if (PARENTS_MAP_ENABLED) {
 		struct binary *parent_bin = map_lookup_elem(&tg_parents_bin, &enter->key.pid);
 
-		if (parent_bin)
-			/* matchParentBinaries key is in range [MAX_SELECTORS; MAX_SELECTORS * 2) */
-			if (!match_binaries(index + MAX_SELECTORS, enter, parent_bin))
-				return 0;
+		/* matchParentBinaries key is in range [MAX_SELECTORS; MAX_SELECTORS * 2) */
+		if (!match_binaries(index + MAX_SELECTORS, enter, parent_bin))
+			return 0;
 	}
 #endif
 

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -2051,7 +2051,7 @@ FUNC_INLINE int match_binaries(__u32 key, struct execve_map_value *current, stru
 {
 	bool match = 0;
 	void *path_map;
-	__u8 *found_key;
+	__u8 *found_key = NULL;
 #ifdef __LARGE_BPF_PROG
 	struct string_prefix_lpm_trie *prefix_key;
 	struct string_postfix_lpm_trie *postfix_key;
@@ -2098,7 +2098,7 @@ FUNC_INLINE int match_binaries(__u32 key, struct execve_map_value *current, stru
 
 			path_map = map_lookup_elem(&tg_mb_paths, &key);
 			if (!path_map)
-				return 0;
+				break;
 			found_key = map_lookup_elem(path_map, bin->path);
 			break;
 #ifdef __LARGE_BPF_PROG
@@ -2106,35 +2106,36 @@ FUNC_INLINE int match_binaries(__u32 key, struct execve_map_value *current, stru
 		case op_filter_str_notprefix:
 			path_map = map_lookup_elem(&string_prefix_maps, &selector_options->map_id);
 			if (!path_map)
-				return 0;
+				break;
 			// prepare the key to perform lookup in the LPM_TRIE
 			prefix_key = (struct string_prefix_lpm_trie *)map_lookup_elem(&string_maps_heap, &zero);
 			if (!prefix_key)
-				return 0;
+				break;
 			memset(prefix_key, 0, sizeof(*prefix_key));
 			prefix_key->prefixlen = bin->path_length * 8; // prefixlen is in bits
 			if (probe_read(prefix_key->data, bin->path_length & (STRING_PREFIX_MAX_LENGTH - 1), bin->path) < 0)
-				return 0;
+				break;
 			found_key = map_lookup_elem(path_map, prefix_key);
 			break;
 		case op_filter_str_postfix:
 		case op_filter_str_notpostfix:
 			path_map = map_lookup_elem(&string_postfix_maps, &selector_options->map_id);
 			if (!path_map)
-				return 0;
+				break;
 			if (bin->path_length < STRING_POSTFIX_MAX_MATCH_LENGTH)
 				postfix_len = bin->path_length;
 			postfix_key = (struct string_postfix_lpm_trie *)map_lookup_elem(&string_postfix_maps_heap, &zero);
 			if (!postfix_key)
-				return 0;
+				break;
 			postfix_key->prefixlen = postfix_len * 8; // prefixlen is in bits
 			if (!bin->reversed) {
 				file_copy_reverse((__u8 *)bin->end_r, postfix_len, (__u8 *)bin->end, bin->path_length - postfix_len);
 				bin->reversed = true;
 			}
-			if (postfix_len < STRING_POSTFIX_MAX_MATCH_LENGTH)
+			if (postfix_len < STRING_POSTFIX_MAX_MATCH_LENGTH) {
 				if (probe_read(postfix_key->data, postfix_len, bin->end_r) < 0)
-					return 0;
+					break;
+			}
 			found_key = map_lookup_elem(path_map, postfix_key);
 			break;
 #endif /* __LARGE_BPF_PROG */

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1916,6 +1916,15 @@ func HasNotifyEnforcerAction(selectors []v1alpha1.KProbeSelector) bool {
 	return false
 }
 
+func HasMatchParentBinaries(selectors []v1alpha1.KProbeSelector) bool {
+	for _, s := range selectors {
+		if len(s.MatchParentBinaries) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func HasRateLimit(selectors []v1alpha1.KProbeSelector) bool {
 	for _, selector := range selectors {
 		for _, matchAction := range selector.MatchActions {

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -19,7 +19,10 @@ import (
 	conf "github.com/cilium/tetragon/pkg/config"
 	"github.com/cilium/tetragon/pkg/generictypes"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/selectors"
+	"github.com/cilium/tetragon/pkg/sensors/base"
+	"github.com/cilium/tetragon/pkg/sensors/program"
 )
 
 // Takes arg.Resolve as input and return the path in []string
@@ -337,4 +340,16 @@ func (d *DupInstance) GetID(name string) InstanceID {
 	}
 	d.dups[name] = instance
 	return instance
+}
+
+func setParentsMap(progs []*program.Program, maps []*program.Map, hasSelector bool) []*program.Map {
+	if option.Config.ParentsMapEnabled {
+		maps = append(maps, program.MapUserFrom(base.ParentBinariesMap))
+		if hasSelector {
+			for _, p := range progs {
+				p.RewriteConstants["PARENTS_MAP_ENABLED"] = uint8(1)
+			}
+		}
+	}
+	return maps
 }

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -504,13 +504,14 @@ type addKprobeIn struct {
 }
 
 type hasMaps struct {
-	stackTrace bool
-	rateLimit  bool
-	enforcer   bool
-	override   bool
-	sockTrack  bool
-	selector   bool
-	fentry     bool
+	stackTrace     bool
+	rateLimit      bool
+	enforcer       bool
+	override       bool
+	sockTrack      bool
+	selector       bool
+	fentry         bool
+	parentBinaries bool
 }
 
 // hasMapsSetup setups the has maps for the per policy maps. The per kprobe maps
@@ -523,6 +524,7 @@ func hasMapsSetup(spec *v1alpha1.TracingPolicySpec, kprobes []v1alpha1.KProbeSpe
 		has.sockTrack = has.sockTrack || selectors.HasSockTrack(&kprobe)
 		has.override = has.override || selectors.HasOverride(kprobe.Selectors)
 		has.selector = has.selector || selectors.HasSelector(&kprobe)
+		has.parentBinaries = has.parentBinaries || selectors.HasMatchParentBinaries(kprobe.Selectors)
 	}
 	return has
 }
@@ -644,9 +646,7 @@ func createGenericKprobeSensor(
 		maps = append(maps, program.MapUserFrom(base.RingBufEvents))
 	}
 
-	if option.Config.ParentsMapEnabled {
-		maps = append(maps, program.MapUserFrom(base.ParentBinariesMap))
-	}
+	maps = setParentsMap(progs, maps, has.parentBinaries)
 
 	return &sensors.Sensor{
 		Name:      name,

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -421,6 +421,7 @@ func createGenericLsmSensor(
 	var maps []*program.Map
 	var ids []idtable.EntryID
 	var selMaps *selectors.KernelSelectorMaps
+	var hasParentBinaries bool
 
 	if !bpf.HasLSMPrograms() || !config.EnableLargeProgs() {
 		return nil, errors.New("does you kernel support the bpf LSM? You can enable LSM BPF by modifying" +
@@ -446,6 +447,8 @@ func createGenericLsmSensor(
 		in.selectorStatsBase = selectorStatsBase
 		selectorStatsBase += uint32(len(hook.Selectors))
 
+		hasParentBinaries = hasParentBinaries || selectors.HasMatchParentBinaries(hook.Selectors)
+
 		id, err := addLsm(&hook, dups.GetID(hook.Hook), &in)
 		if err != nil {
 			return nil, err
@@ -466,9 +469,7 @@ func createGenericLsmSensor(
 		maps = append(maps, program.MapUserFrom(base.RingBufEvents))
 	}
 
-	if option.Config.ParentsMapEnabled {
-		maps = append(maps, program.MapUserFrom(base.ParentBinariesMap))
-	}
+	maps = setParentsMap(progs, maps, hasParentBinaries)
 
 	return &sensors.Sensor{
 		Name:  name,

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -617,6 +617,7 @@ func createGenericTracepointSensor(
 		if err := appendMacrosSelectors(tp.Spec.Selectors, spec.SelectorsMacros); err != nil {
 			return nil, fmt.Errorf("append macros selectos: %w", err)
 		}
+		has.parentBinaries = has.parentBinaries || selectors.HasMatchParentBinaries(tp.Spec.Selectors)
 
 		pinProg := sensors.PathJoin(fmt.Sprintf("%s:%s", tp.Info.Subsys, tp.Info.Event))
 		attach := fmt.Sprintf("%s/%s", tp.Info.Subsys, tp.Info.Event)
@@ -670,9 +671,7 @@ func createGenericTracepointSensor(
 		maps = append(maps, program.MapUserFrom(base.RingBufEvents))
 	}
 
-	if option.Config.ParentsMapEnabled {
-		maps = append(maps, program.MapUserFrom(base.ParentBinariesMap))
-	}
+	maps = setParentsMap(progs, maps, has.parentBinaries)
 
 	ret.Progs = progs
 	ret.Maps = maps

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -456,6 +456,7 @@ type uprobeHas struct {
 	substring               bool
 	sleepablePreloadSize    int
 	disableNotAllowedReason string
+	parentBinaries          bool
 }
 
 func validateMultiUprobeConsistency(uprobes []v1alpha1.UProbeSpec) error {
@@ -588,6 +589,8 @@ func validateUprobeFeatures(spec *v1alpha1.UProbeSpec, has *uprobeHas) error {
 		}
 		has.sleepableOffload = true
 	}
+
+	has.parentBinaries = has.parentBinaries || selectors.HasMatchParentBinaries(spec.Selectors)
 
 	if selectors.HasOperator(spec.Selectors, selectors.SelectorOpSubString) {
 		if !bpf.HasKfunc("bpf_strnstr") {
@@ -950,9 +953,7 @@ func createGenericUprobeSensor(
 		maps = append(maps, program.MapUserFrom(base.RingBufEvents))
 	}
 
-	if option.Config.ParentsMapEnabled {
-		maps = append(maps, program.MapUserFrom(base.ParentBinariesMap))
-	}
+	maps = setParentsMap(progs, maps, has.parentBinaries)
 
 	return &sensors.Sensor{
 		Name:                    name,

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -46,6 +46,7 @@ type observerUsdtSensor struct {
 type usdtHas struct {
 	sleepableOffload bool
 	sleepablePreload bool
+	parentBinaries   bool
 }
 
 var (
@@ -198,9 +199,7 @@ func createGenericUsdtSensor(
 		maps = append(maps, program.MapUserFrom(base.RingBufEvents))
 	}
 
-	if option.Config.ParentsMapEnabled {
-		maps = append(maps, program.MapUserFrom(base.ParentBinariesMap))
-	}
+	maps = setParentsMap(progs, maps, has.parentBinaries)
 
 	return &sensors.Sensor{
 		Name:      name,
@@ -489,6 +488,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 			)
 		}
 		has.sleepablePreload = has.sleepablePreload || preload
+		has.parentBinaries = has.parentBinaries || selectors.HasMatchParentBinaries(spec.Selectors)
 		config.BTFArg = allBTFArgs
 
 		usdtEntry := &genericUsdt{

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4207,6 +4207,10 @@ func TestKprobeMatchParentBinariesCombined(t *testing.T) {
 	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-match-parent-binaries-combined", nil)
 }
 
+func TestKprobeMatchParentBinariesFollowChildrenCombined(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-match-parent-binaries-followchildren-combined", nil)
+}
+
 func TestMatchParentBinariesSetParentsMap(t *testing.T) {
 	specDisabled := &v1alpha1.TracingPolicySpec{
 		KProbes: []v1alpha1.KProbeSpec{

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4203,6 +4203,10 @@ func TestKprobeMatchParentBinaries(t *testing.T) {
 	testKprobeMatchParentBinaries(t, false)
 }
 
+func TestKprobeMatchParentBinariesCombined(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-match-parent-binaries-combined", nil)
+}
+
 func TestMatchParentBinariesSetParentsMap(t *testing.T) {
 	specDisabled := &v1alpha1.TracingPolicySpec{
 		KProbes: []v1alpha1.KProbeSpec{

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -4203,6 +4203,82 @@ func TestKprobeMatchParentBinaries(t *testing.T) {
 	testKprobeMatchParentBinaries(t, false)
 }
 
+func TestMatchParentBinariesSetParentsMap(t *testing.T) {
+	specDisabled := &v1alpha1.TracingPolicySpec{
+		KProbes: []v1alpha1.KProbeSpec{
+			{
+				Call:    "test_symbol",
+				Syscall: false,
+			},
+		},
+	}
+	specEnabled := &v1alpha1.TracingPolicySpec{
+		KProbes: []v1alpha1.KProbeSpec{
+			{
+				Call:    "test_symbol",
+				Syscall: false,
+				Selectors: []v1alpha1.KProbeSelector{
+					{
+						MatchParentBinaries: []v1alpha1.BinarySelector{
+							{
+								Operator: "In",
+								Values:   []string{"test"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	createSensor := func(t *testing.T, spec *v1alpha1.TracingPolicySpec) *sensors.Sensor {
+		policyInfo, err := newPolicyInfoFromSpec("", "test_policy", policyfilter.NoFilterID, spec, nil)
+		require.NoError(t, err)
+		sensor, err := createGenericKprobeSensor(spec, "test_sensor", policyInfo, simpleValidateInfo(spec.KProbes), kprobe)
+		require.NoError(t, err)
+		t.Cleanup(func() { sensor.Destroy(true) })
+		return sensor
+	}
+
+	hasParentsMap := func(sensor *sensors.Sensor) bool {
+		for _, m := range sensor.Maps {
+			if m.Name == base.ParentBinariesMap.Name {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("disabled", func(t *testing.T) {
+		oldParentsMapEnabled := option.Config.ParentsMapEnabled
+		option.Config.ParentsMapEnabled = false
+		t.Cleanup(func() { option.Config.ParentsMapEnabled = oldParentsMapEnabled })
+
+		sensor := createSensor(t, specDisabled)
+
+		for _, p := range sensor.Progs {
+			_, ok := p.RewriteConstants["PARENTS_MAP_ENABLED"]
+			assert.False(t, ok, "PARENTS_MAP_ENABLED should not be set for prog %s", p.Name)
+		}
+		assert.False(t, hasParentsMap(sensor), "ParentBinariesMap should not be in sensor maps")
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		oldParentsMapEnabled := option.Config.ParentsMapEnabled
+		option.Config.ParentsMapEnabled = true
+		t.Cleanup(func() { option.Config.ParentsMapEnabled = oldParentsMapEnabled })
+
+		sensor := createSensor(t, specEnabled)
+
+		for _, p := range sensor.Progs {
+			val, ok := p.RewriteConstants["PARENTS_MAP_ENABLED"]
+			require.True(t, ok, "PARENTS_MAP_ENABLED should be set for prog %s", p.Name)
+			assert.Equal(t, uint8(1), val, "PARENTS_MAP_ENABLED should be 1 for prog %s", p.Name)
+		}
+		assert.True(t, hasParentsMap(sensor), "ParentBinariesMap should be in sensor maps")
+	})
+}
+
 func getMatchBinariesCrd(opStr string, vals []string) string {
 	var configHook strings.Builder
 	configHook.WriteString(`apiVersion: cilium.io/v1alpha1

--- a/pkg/testutils/filenames.go
+++ b/pkg/testutils/filenames.go
@@ -114,6 +114,23 @@ func DoneWithExportFile(t testing.TB) error {
 	return nil
 }
 
+// TruncateExportFile truncates the export file so that the next scenario
+// starts with a clean event stream.
+func TruncateExportFile(t testing.TB) error {
+	exportFilesLock.Lock()
+	defer exportFilesLock.Unlock()
+	testName := fixupTestName(t)
+	ef, ok := lookupExportFilename(testName)
+	if !ok {
+		return fmt.Errorf("file for test %s does not exist", testName)
+	}
+	if err := ef.Truncate(0); err != nil {
+		return fmt.Errorf("failed to truncate export file: %w", err)
+	}
+	_, err := ef.Seek(0, 0)
+	return err
+}
+
 // KeepExportFile: marks the export file to be kept
 func KeepExportFile(t testing.TB) error {
 	exportFilesLock.Lock()

--- a/pkg/testutils/policytest/builder.go
+++ b/pkg/testutils/policytest/builder.go
@@ -98,6 +98,13 @@ func (b *Builder) WithSetup(fn func() func()) *Builder {
 	return b
 }
 
+// WithAllEvents makes the observer test to receive all events,
+// otherwise they are filtered with observertesthelper.WithMyPid
+func (b *Builder) WithAllEvents() *Builder {
+	b.policytest.AllEvents = true
+	return b
+}
+
 // Add a scenario to the builder
 func (b *Builder) AddScenario(fn func(c *Conf) *Scenario) *Builder {
 	b.policytest.Scenarios = append(b.policytest.Scenarios, fn)

--- a/pkg/testutils/policytest/builder.go
+++ b/pkg/testutils/policytest/builder.go
@@ -91,6 +91,13 @@ func (b *Builder) WithSkip(fn func(*SkipInfo) string) *Builder {
 	return b
 }
 
+// WithSetup registers a function that runs before the observer is loaded.
+// The returned cleanup function, if non-nil, is called after the test completes.
+func (b *Builder) WithSetup(fn func() func()) *Builder {
+	b.policytest.Setup = fn
+	return b
+}
+
 // Add a scenario to the builder
 func (b *Builder) AddScenario(fn func(c *Conf) *Scenario) *Builder {
 	b.policytest.Scenarios = append(b.policytest.Scenarios, fn)

--- a/pkg/testutils/policytest/observertest.go
+++ b/pkg/testutils/policytest/observertest.go
@@ -52,6 +52,17 @@ func (rpt *RegisteredPolicyTests) DoObserverTest(
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
 
+	var cleanup func()
+
+	if pt.Setup != nil {
+		cleanup = pt.Setup()
+	}
+	defer func() {
+		if cleanup != nil {
+			cleanup()
+		}
+	}()
+
 	conf := &Conf{
 		BinsDir: testutils.RepoRootPath("contrib/tester-progs"),
 		TestConf: &TestConf{

--- a/pkg/testutils/policytest/observertest.go
+++ b/pkg/testutils/policytest/observertest.go
@@ -83,7 +83,14 @@ func (rpt *RegisteredPolicyTests) DoObserverTest(
 	policyFile.Close()
 	policyFname := policyFile.Name()
 
-	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, policyFname, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	opts := []observertesthelper.TestOption{
+		observertesthelper.WithConfig(policyFname),
+	}
+	if !pt.AllEvents {
+		opts = append(opts, observertesthelper.WithMyPid())
+	}
+
+	obs, err := observertesthelper.GetDefaultObserver(t, ctx, tus.Conf().TetragonLib, opts...)
 	if err != nil {
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}

--- a/pkg/testutils/policytest/observertest.go
+++ b/pkg/testutils/policytest/observertest.go
@@ -88,7 +88,12 @@ func (rpt *RegisteredPolicyTests) DoObserverTest(
 		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
 	}
 
-	for _, s := range pt.Scenarios {
+	for i, s := range pt.Scenarios {
+		if i > 0 {
+			if err := testutils.TruncateExportFile(t); err != nil {
+				t.Fatalf("failed to truncate export file before scenario %d: %s", i, err)
+			}
+		}
 		observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
 		readyWG.Wait()
 

--- a/pkg/testutils/policytest/policytest.go
+++ b/pkg/testutils/policytest/policytest.go
@@ -70,6 +70,10 @@ type T struct {
 	// In that case, the string contains the reason that the test was skipped.
 	ShouldSkip func(info *SkipInfo) string
 
+	// Setup is called before the observer is loaded. The returned function, if
+	// non-nil, is called as a cleanup after the test completes.
+	Setup func() func()
+
 	// Policy generates a policy for this test
 	Policy func(c *Conf) (Policy, PolicyCleanupFn, error)
 

--- a/pkg/testutils/policytest/policytest.go
+++ b/pkg/testutils/policytest/policytest.go
@@ -81,6 +81,9 @@ type T struct {
 
 	// Scenarios returns a list of scenarios to test the generated policy
 	Scenarios []func(c *Conf) *Scenario
+
+	// Do not limit events to observer's pid
+	AllEvents bool
 }
 
 type ScenarioRes struct {

--- a/pkg/testutils/policytest/runner.go
+++ b/pkg/testutils/policytest/runner.go
@@ -175,9 +175,17 @@ func (r *LocalRunner) RunTest(l *slog.Logger, test *T, testConf *TestConf) *Resu
 		}
 	}
 
+	var cleanup func()
+	if test.Setup != nil {
+		cleanup = test.Setup()
+	}
+
 	// set and clear run configuration after we are done
 	r.conf.TestConf = testConf
 	defer func() {
+		if cleanup != nil {
+			cleanup()
+		}
 		r.conf.TestConf = nil
 	}()
 

--- a/tests/policytests/kprobe_matchparentbinaries.go
+++ b/tests/policytests/kprobe_matchparentbinaries.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package tests
+
+import (
+	"fmt"
+
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/config"
+	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/testutils/policytest"
+)
+
+var _ = policytest.NewBuilder("kprobe-match-parent-binaries-combined").
+	WithLabels("kprobes").
+	WithSkip(func(_ *policytest.SkipInfo) string {
+		if !config.EnableLargeProgs() {
+			return "kernels without large progs do not support matchParentBinaries selector"
+		}
+		return ""
+	}).
+	WithSetup(func() func() {
+		option.Config.ParentsMapEnabled = true
+		return func() { option.Config.ParentsMapEnabled = false }
+	}).
+	WithAllEvents().
+	WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "match-parent-binaries-test"
+spec:
+  kprobes:
+  - call: "sys_lseek"
+    return: false
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchBinaries:
+      - operator: In
+        values:
+        - {{ testBinary "lseek-pipe" }}
+      matchParentBinaries:
+      - operator: In
+        values:
+        - /usr/bin/bash
+`).
+	AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+		lseekBin := c.TestBinary("lseek-pipe")
+		// Feeding commands to bash via piped stdin forces it to fork a child,
+		// so lseek-pipe's parent binary is /usr/bin/bash — matching the selector.
+		trigger := fmt.Sprintf("echo '%s -1 0 4444' | /usr/bin/bash", lseekBin)
+		lseekChecker := ec.NewProcessKprobeChecker("lseek-parent-checker").
+			WithFunctionName(sm.Suffix("sys_lseek")).
+			WithProcess(ec.NewProcessChecker().WithBinary(sm.Full(lseekBin)))
+		return &policytest.Scenario{
+			Name:         "execute lseek-pipe via bash parent and check events",
+			Trigger:      policytest.NewCmdTrigger("/usr/bin/bash", "-c", trigger),
+			EventChecker: ec.NewUnorderedEventChecker(lseekChecker),
+		}
+	}).
+	AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+		lseekBin := c.TestBinary("lseek-pipe")
+		// sh's parent is not /usr/bin/bash so the selector drops all events.
+		// The checker describes events that would arrive if the filter were
+		// broken; ExpectCheckerFailure: true asserts they do not.
+		lseekChecker := ec.NewProcessKprobeChecker("lseek-parent-checker").
+			WithFunctionName(sm.Suffix("sys_lseek")).
+			WithProcess(ec.NewProcessChecker().WithBinary(sm.Full(lseekBin)))
+		return &policytest.Scenario{
+			Name:                 "execute lseek-pipe via sh parent and check no events",
+			Trigger:              policytest.NewCmdTrigger("/usr/bin/sh", "-c", lseekBin+" -1 0 4444"),
+			EventChecker:         ec.NewUnorderedEventChecker(lseekChecker),
+			ExpectCheckerFailure: true,
+		}
+	}).
+	RegisterAtInit()

--- a/tests/policytests/kprobe_matchparentbinaries.go
+++ b/tests/policytests/kprobe_matchparentbinaries.go
@@ -81,3 +81,64 @@ spec:
 		}
 	}).
 	RegisterAtInit()
+
+// followChildren not firing for a descendant whose own most recent exec was
+// a same-process re-exec rather than a fork+exec).
+var _ = policytest.NewBuilder("kprobe-match-parent-binaries-followchildren-combined").
+	WithLabels("kprobes").
+	WithSkip(func(_ *policytest.SkipInfo) string {
+		if !config.EnableLargeProgs() {
+			return "kernels without large progs do not support matchParentBinaries selector"
+		}
+		return ""
+	}).
+	WithSetup(func() func() {
+		option.Config.ParentsMapEnabled = true
+		return func() { option.Config.ParentsMapEnabled = false }
+	}).
+	WithAllEvents().
+	WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "match-parent-binaries-followchildren-test"
+spec:
+  kprobes:
+  - call: "sys_lseek"
+    return: false
+    syscall: true
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchBinaries:
+      - operator: In
+        values:
+        - {{ testBinary "lseek-pipe" }}
+      matchParentBinaries:
+      - operator: In
+        values:
+        - /usr/bin/bash
+        followChildren: true
+`).
+	AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+		lseekBin := c.TestBinary("lseek-pipe")
+		// The pipe forces bash to fork a child. That child's first exec (via
+		// the "exec" builtin) replaces it with sh -- a fork+exec transition
+		// with the clone flag set. sh's own "-c" script is a single command
+		// with no pipe/redirection, so sh applies its own exec optimization
+		// and self-execs (no fork) directly into lseek-pipe. So the process
+		// that finally triggers sys_lseek had its *last* exec not preceded
+		// by a fork, several hops below the /usr/bin/bash ancestor that
+		// followChildren is supposed to keep matching against.
+		trigger := fmt.Sprintf(`echo 'exec /usr/bin/sh -c "%s -1 0 4444"' | /usr/bin/bash`, lseekBin)
+		lseekChecker := ec.NewProcessKprobeChecker("lseek-followchildren-checker").
+			WithFunctionName(sm.Suffix("sys_lseek")).
+			WithProcess(ec.NewProcessChecker().WithBinary(sm.Full(lseekBin)))
+		return &policytest.Scenario{
+			Name:         "fork+exec then self-exec descendant of bash still matches with followChildren",
+			Trigger:      policytest.NewCmdTrigger("/usr/bin/bash", "-c", trigger),
+			EventChecker: ec.NewUnorderedEventChecker(lseekChecker),
+		}
+	}).
+	RegisterAtInit()


### PR DESCRIPTION
Tracing sensors (kprobe, lsm, uprobe, usdt, tracepoint) include
pfilter.h which references the PARENTS_MAP_ENABLED rodata constant to
gate parent-binary selector matching in BPF. The constant was only set
for the execve program in pkg/sensors/base/base.go, leaving it at zero
in all tracing sensors even when --parents-map-enabled is set.