### PR TITLE
Fix null spec.{pod, container, host}Selectors

### DIFF
--- a/pkg/watcher/crdwatcher/lastapplied.go
+++ b/pkg/watcher/crdwatcher/lastapplied.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !nok8s
+
+package crdwatcher
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+)
+
+type Tp[T any] interface {
+	TpSpec() *v1alpha1.TracingPolicySpec
+	DeepCopy() T
+	GetAnnotations() map[string]string
+}
+
+func restoreNullSelectors[T Tp[T]](tp T) T {
+	ret := tp.DeepCopy()
+	restoreNullSelectorsFromLastApplied(ret.GetAnnotations(), ret.TpSpec())
+	return ret
+}
+
+// restoreNullSelectorsFromLastApplied recovers explicit null selectors from the
+// kubectl last-applied annotation. This is needed because client-side
+// `kubectl apply` removes the distinction between explicit null and omitted
+// fields for CRD defaults before the object reaches Tetragon.
+func restoreNullSelectorsFromLastApplied(annotations map[string]string, spec *v1alpha1.TracingPolicySpec) {
+	lastApplied, ok := annotations[corev1.LastAppliedConfigAnnotation]
+	if !ok {
+		return
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(lastApplied), &obj); err != nil {
+		return
+	}
+
+	specMap, ok := obj["spec"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	if val, ok := specMap["hostSelector"]; ok && val == nil {
+		spec.HostSelector = nil
+	}
+
+	if val, ok := specMap["podSelector"]; ok && val == nil {
+		spec.PodSelector = nil
+	}
+
+	if val, ok := specMap["containerSelector"]; ok && val == nil {
+		spec.ContainerSelector = nil
+	}
+}

--- a/pkg/watcher/crdwatcher/tracingpolicy.go
+++ b/pkg/watcher/crdwatcher/tracingpolicy.go
@@ -55,9 +55,11 @@ func addTracingPolicy(ctx context.Context, log logger.FieldLogger, s *sensors.Ma
 	var err error
 	switch tp := obj.(type) {
 	case *v1alpha1.TracingPolicy:
+		tp = restoreNullSelectors(tp)
 		log.Info("adding tracing policy", "name", tp.TpName(), "info", tp.TpInfo())
 		err = s.AddTracingPolicy(ctx, tp)
 	case *v1alpha1.TracingPolicyNamespaced:
+		tp = restoreNullSelectors(tp)
 		log.Info("adding namespaced tracing policy", "name", tp.TpName(), "info", tp.TpInfo(), "namespace", tp.TpNamespace())
 		err = s.AddTracingPolicy(ctx, tp)
 	default:
@@ -128,7 +130,7 @@ func updateTracingPolicy(ctx context.Context, log logger.FieldLogger, s *sensors
 		}
 
 		log.Info("updating tracing policy", "old", oldTp.TpName(), "new", newTp.TpName())
-		update(oldTp, newTp)
+		update(oldTp, restoreNullSelectors(newTp))
 
 	case *v1alpha1.TracingPolicyNamespaced:
 		newTp, ok := newObj.(*v1alpha1.TracingPolicyNamespaced)
@@ -144,7 +146,7 @@ func updateTracingPolicy(ctx context.Context, log logger.FieldLogger, s *sensors
 		}
 
 		log.Info("updating namespaced tracing policy", "old", oldTp.TpName(), "new", newTp.TpName())
-		update(oldTp, newTp)
+		update(oldTp, restoreNullSelectors(newTp))
 	}
 
 	if err != nil {


### PR DESCRIPTION
After https://github.com/cilium/tetragon/pull/4814 when a user applies a policy similar to the following

```
spec:
  hostSelector: null
  kprobes:
```

we expect that hostSelector is null and podSelector to be {}. This is the case when we run:
kubectl create -f pol.yaml
kubectl apply --server-size=true -f pol.yaml
and in all cases outside of k8s.

When a user loads such a policy with kubectl apply -f pol.yaml it seems that the client side of k8s sees hostSelector to be null and thus it is applying the default value which is {}.

A way to fix that without changing the user API, we use the "last-applied-configuration" annotation which keeps the original policy that the user applies. If we find out that spec.{pod, container, host}Selectors was null, we override that value to be nul again. It seems that in that in the client-side apply we cannot affect the order of when defaults are applied.

Tested manually and this seems to work as expected in all cases.