### PR TITLE
ci: remove azure apt mirrors

### DIFF
--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -96,6 +96,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+    - name: Remove slow Azure apt mirrors
+      run: |
+        # The default 'azure.archive.ubuntu.com' mirrors can be really slow.
+        # Removing azure.archive will pioritize the official Ubuntu mirrors.
+        if [ -f /etc/apt/apt-mirrors.txt ]; then
+          sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt
+          echo "Using mirrors:"
+          cat /etc/apt/apt-mirrors.txt
+        fi
+
     - name: Install VM test dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
### Description

From https://github.com/actions/runner-images/issues/12949

> Package downloads from http://azure.archive.ubuntu.com/ubuntu on
GitHub-hosted runners can sometimes be slow. This happens due to performance issues with the Azure Ubuntu archive mirror, not with the GitHub Actions runner images.

This change removes the azure.archive mirrors so the apt-get update uses other mirrors.

Fixes https://github.com/cilium/tetragon/issues/4860

