### PR TITLE
pkg/tetragoninfo: errors.Join return value ignored

### DIFF
--- a/pkg/tetragoninfo/info.go
+++ b/pkg/tetragoninfo/info.go
@@ -124,8 +124,7 @@ func encodeConf(conf map[string]any) ([]*tetragon.GetInfoResponse_ConfVal, error
 		}
 
 		if err != nil {
-			err := fmt.Errorf("failed to wrap type key %s (with value type %T): %w", key, val, err)
-			errors.Join(retErr, err)
+			retErr = errors.Join(retErr, fmt.Errorf("failed to wrap type key %s (with value type %T): %w", key, val, err))
 		}
 		ret = append(ret, &tetragon.GetInfoResponse_ConfVal{
 			Key:   key,


### PR DESCRIPTION
Tiny bug I found using errcheck linter.

errors.Join does not modify the errors passed by argument, you need to read the return value, so this line was not doing anything and the error would have been ignored.

Fixes: 107ecdda601c ("server: export info over gRPC")

```release-note
pkg/tetragoninfo: read previously ignored value returned by errors.Join in encode configuration function.
```
