### PR TITLE
chore: go1.26 syntax updates

### DIFF
--- a/api/vendor/github.com/cilium/tetragon/pkg/matchers/timestampmatcher/timestampmatcher.go
+++ b/api/vendor/github.com/cilium/tetragon/pkg/matchers/timestampmatcher/timestampmatcher.go
@@ -325,8 +325,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkAfter(&tsTime)
+			return m.checkAfter(new(value.AsTime().UTC()))
 		}
 	case opBefore:
 		{
@@ -336,8 +335,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkBefore(&tsTime)
+			return m.checkBefore(new(value.AsTime().UTC()))
 		}
 	case opBetween:
 		{
@@ -347,8 +345,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkBetween(&tsTime)
+			return m.checkBetween(new(value.AsTime().UTC()))
 		}
 	case opDay:
 		{
@@ -358,8 +355,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkDay(&tsTime)
+			return m.checkDay(new(value.AsTime().UTC()))
 		}
 	case opFormat:
 		{
@@ -369,8 +365,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkFormat(&tsTime)
+			return m.checkFormat(new(value.AsTime().UTC()))
 		}
 	case opHour:
 		{
@@ -380,8 +375,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkHour(&tsTime)
+			return m.checkHour(new(value.AsTime().UTC()))
 		}
 	case opMinute:
 		{
@@ -391,8 +385,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkMinute(&tsTime)
+			return m.checkMinute(new(value.AsTime().UTC()))
 		}
 	case opSecond:
 		{
@@ -402,8 +395,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkSecond(&tsTime)
+			return m.checkSecond(new(value.AsTime().UTC()))
 		}
 	default:
 		return fmt.Errorf("unhandled TimestampMatcher operator %s", m.Operator)

--- a/cmd/tetra/eventlog/eventlog.go
+++ b/cmd/tetra/eventlog/eventlog.go
@@ -41,8 +41,7 @@ func setCmd() *cobra.Command {
 				maxBackups = &maxBackupsVar
 			}
 			if cmd.Flags().Lookup("rotation-interval").Changed {
-				strVal := rotationIntervalVar.String()
-				interval = &strVal
+				interval = new(rotationIntervalVar.String())
 			}
 			_, err = c.Client.SetEventLogParams(c.ctx, &tetragon.SetEventLogParamsRequest{
 				MaxSize:          maxSize,

--- a/cmd/tetra/tracingpolicy/tracingpolicy.go
+++ b/cmd/tetra/tracingpolicy/tracingpolicy.go
@@ -145,8 +145,7 @@ func tpEnableCmd() *cobra.Command {
 		Long:  "Enable a disabled tracing policy. Use disable to re-disable the tracing policy.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			enable := true
-			err := tpConfigure(args[0], namespace, &enable, nil)
+			err := tpConfigure(args[0], namespace, new(true), nil)
 			if err != nil {
 				return fmt.Errorf("failed to enable tracing policy: %w", err)
 			}
@@ -167,8 +166,7 @@ func tpDisableCmd() *cobra.Command {
 		Long:  "Disable an enabled tracing policy. Use enable to re-enable the tracing policy.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			enable := false
-			err := tpConfigure(args[0], namespace, &enable, nil)
+			err := tpConfigure(args[0], namespace, new(false), nil)
 			if err != nil {
 				return fmt.Errorf("failed to disable tracing policy: %w", err)
 			}

--- a/operator/podinfo/podinfo_controller.go
+++ b/operator/podinfo/podinfo_controller.go
@@ -90,15 +90,13 @@ func equal(pod *corev1.Pod, podInfo *ciliumiov1alpha1.PodInfo) bool {
 	}
 
 	// check if ownerReference is changed.
-	controller := true
-	blockOwnerDeletion := true
 	expectedOwnerReference := metav1.OwnerReference{
 		APIVersion:         "v1",
 		Kind:               "Pod",
 		Name:               pod.Name,
 		UID:                pod.UID,
-		Controller:         &controller,
-		BlockOwnerDeletion: &blockOwnerDeletion,
+		Controller:         new(true),
+		BlockOwnerDeletion: new(true),
 	}
 	workloadObject, workloadType := podhelpers.GetWorkloadMetaFromPod(pod)
 	return pod.Name == podInfo.Name &&
@@ -132,8 +130,6 @@ func generatePodInfo(pod *corev1.Pod) *ciliumiov1alpha1.PodInfo {
 		podIPs = append(podIPs, ciliumiov1alpha1.PodIP{IP: podIP.IP})
 	}
 	workloadObject, workloadType := podhelpers.GetWorkloadMetaFromPod(pod)
-	controller := true
-	blockOwnerDeletion := true
 	return &ciliumiov1alpha1.PodInfo{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        pod.Name,
@@ -147,8 +143,8 @@ func generatePodInfo(pod *corev1.Pod) *ciliumiov1alpha1.PodInfo {
 					Kind:               pod.Kind,
 					Name:               pod.Name,
 					UID:                pod.UID,
-					Controller:         &controller,
-					BlockOwnerDeletion: &blockOwnerDeletion,
+					Controller:         new(true),
+					BlockOwnerDeletion: new(true),
 				},
 			},
 		},

--- a/operator/podinfo/podinfo_controller_test.go
+++ b/operator/podinfo/podinfo_controller_test.go
@@ -120,8 +120,6 @@ func randomPodGenerator() *corev1.Pod {
 func TestGeneratePod(t *testing.T) {
 	t.Run("Testing Object Meta", func(t *testing.T) {
 		pod := randomPodGenerator()
-		controller := true
-		blockOwnerDeletion := true
 		// Copy the Pod IPs into the PodInfo IPs.
 		var podIPs []ciliumv1alpha1.PodIP
 		for _, podIP := range pod.Status.PodIPs {
@@ -140,8 +138,8 @@ func TestGeneratePod(t *testing.T) {
 						Kind:               pod.Kind,
 						Name:               pod.Name,
 						UID:                pod.UID,
-						Controller:         &controller,
-						BlockOwnerDeletion: &blockOwnerDeletion,
+						Controller:         new(true),
+						BlockOwnerDeletion: new(true),
 					},
 				},
 			},
@@ -274,7 +272,6 @@ func TestEqual(t *testing.T) {
 
 		t.Run("Pod owner references changed", func(t *testing.T) {
 			pod := randomPodGenerator()
-			controller, blockOwnerDeletion := true, true
 			podInfo := generatePodInfo(pod)
 			pod.GenerateName = "tetragon-"
 			pod.OwnerReferences = []metav1.OwnerReference{
@@ -283,8 +280,8 @@ func TestEqual(t *testing.T) {
 					Kind:               "DaemonSet",
 					Name:               "tetragon",
 					UID:                "00000000-0000-0000-0000-000000000000",
-					Controller:         &controller,
-					BlockOwnerDeletion: &blockOwnerDeletion,
+					Controller:         new(true),
+					BlockOwnerDeletion: new(true),
 				},
 			}
 			assert.False(t, equal(pod, podInfo), "Pod owner references changed, still returning pod not changed")
@@ -320,8 +317,7 @@ func TestReconcile(t *testing.T) {
 func TestReconcileWithDeletionTimestamp(t *testing.T) {
 	pod := randomPodGenerator()
 	pod.SetFinalizers([]string{"finalize-it"})
-	deletionTimestamp := metav1.Now()
-	pod.SetDeletionTimestamp(&deletionTimestamp)
+	pod.SetDeletionTimestamp(new(metav1.Now()))
 	client := getClientBuilder().WithObjects(pod).Build()
 	reconciler := Reconciler{client}
 	namespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}

--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -674,9 +674,7 @@ func detectMixBpfAndTailCalls() bool {
 	defer tcProg.Close()
 
 	// insert the program into the map
-	zero := uint32(0)
-	fd := int32(tcProg.FD())
-	err = tcMap.Update(&zero, &fd, 0)
+	err = tcMap.Update(new(uint32(0)), new(int32(tcProg.FD())), 0)
 	if err != nil {
 		return false
 	}

--- a/pkg/celbpf/celbpf_test.go
+++ b/pkg/celbpf/celbpf_test.go
@@ -212,8 +212,7 @@ func TestArgExprs(t *testing.T) {
 	for _, tc := range testCase {
 		data, eargs := prepareArgs(t, tc.hookArgs, tc.exprArgs)
 
-		mapKey := uint32(0)
-		err := m.Update(&mapKey, &data, 0)
+		err := m.Update(new(uint32(0)), &data, 0)
 		require.NoError(t, err, "update map value")
 
 		fnName := "myfn"
@@ -247,8 +246,7 @@ func TestArgExprs(t *testing.T) {
 			Instructions: insns,
 			License:      "Dual BSD/GPL",
 		}, ebpf.ProgramOptions{LogLevel: ebpf.LogLevelInstruction})
-		var ve *ebpf.VerifierError
-		if errors.As(err, &ve) {
+		if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 			t.Logf("verifier error: %+v", ve)
 			t.FailNow()
 		}

--- a/pkg/cgtracker/test/cgtracker_test.go
+++ b/pkg/cgtracker/test/cgtracker_test.go
@@ -96,9 +96,8 @@ func doMapTest(t *testing.T, cgfsPath string) {
 		if !strings.HasPrefix(path, "tracked") {
 			continue
 		}
-		trackedID := cgfs.cgIDs[path]
 		var val uint64
-		err = cgfs.cgTrackerMap.Lookup(&trackedID, &val)
+		err = cgfs.cgTrackerMap.Lookup(new(cgfs.cgIDs[path]), &val)
 		require.NoError(t, err)
 		require.Equal(t, trackerID, val)
 	}

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -335,9 +335,8 @@ func TestExporterSetLoggingParams(t *testing.T) {
 		assert.Len(t, files, 2)
 
 		// Set a new export file rotation interval (2s)
-		newRotationInterval := 2 * time.Second
 		err = e.SetLogParams(eventlog.Params{
-			RotationInterval: &newRotationInterval,
+			RotationInterval: new(2 * time.Second),
 		})
 		require.NoError(t, err)
 

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -291,8 +291,7 @@ func (msg *MsgExecveEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 }
 
 func (msg *MsgExecveEventUnix) Cast(o any) notify.Message {
-	t := o.(processapi.MsgExecveEventUnix)
-	return &MsgExecveEventUnix{Unix: &t}
+	return &MsgExecveEventUnix{Unix: new(o.(processapi.MsgExecveEventUnix))}
 }
 
 // finalize() is called to finalize Process of the event ExecveEvent

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -29,7 +29,6 @@ import (
 
 func TestProcessManager_getPodInfo(t *testing.T) {
 	build.SkipIfK8sDisabled(t)
-	controller := true
 	podA := corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:         "pod-a",
@@ -38,7 +37,7 @@ func TestProcessManager_getPodInfo(t *testing.T) {
 			OwnerReferences: []v1.OwnerReference{
 				{
 					Name:       "test-workload",
-					Controller: &controller,
+					Controller: new(true),
 				},
 			},
 		},
@@ -92,7 +91,6 @@ func TestProcessManager_getPodInfo(t *testing.T) {
 
 func TestProcessManager_getPodInfoMaybeExecProbe(t *testing.T) {
 	build.SkipIfK8sDisabled(t)
-	controller := true
 	var podA = corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:         "pod-a",
@@ -101,7 +99,7 @@ func TestProcessManager_getPodInfoMaybeExecProbe(t *testing.T) {
 			OwnerReferences: []v1.OwnerReference{
 				{
 					Name:       "test-workload",
-					Controller: &controller,
+					Controller: new(true),
 				},
 			},
 		},

--- a/pkg/grpc/test/test.go
+++ b/pkg/grpc/test/test.go
@@ -50,6 +50,5 @@ func (msg *MsgTestEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 }
 
 func (msg *MsgTestEventUnix) Cast(o any) notify.Message {
-	t := o.(testapi.MsgTestEvent)
-	return &MsgTestEventUnix{Msg: &t}
+	return &MsgTestEventUnix{Msg: new(o.(testapi.MsgTestEvent))}
 }

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -712,8 +712,7 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 }
 
 func (msg *MsgGenericTracepointUnix) Cast(o any) notify.Message {
-	t := o.(MsgGenericTracepointUnix)
-	return &t
+	return new(o.(MsgGenericTracepointUnix))
 }
 
 func (msg *MsgGenericTracepointUnix) PolicyInfo() tracingpolicy.PolicyInfo {
@@ -768,8 +767,7 @@ func (msg *MsgGenericKprobeUnix) HandleMessage() *tetragon.GetEventsResponse {
 }
 
 func (msg *MsgGenericKprobeUnix) Cast(o any) notify.Message {
-	t := o.(MsgGenericKprobeUnix)
-	return &t
+	return new(o.(MsgGenericKprobeUnix))
 }
 
 func (msg *MsgGenericKprobeUnix) PolicyInfo() tracingpolicy.PolicyInfo {
@@ -849,8 +847,7 @@ func (msg *MsgProcessLoaderUnix) HandleMessage() *tetragon.GetEventsResponse {
 }
 
 func (msg *MsgProcessLoaderUnix) Cast(o any) notify.Message {
-	t := o.(MsgProcessLoaderUnix)
-	return &t
+	return new(o.(MsgProcessLoaderUnix))
 }
 
 type MsgGenericUprobeUnix struct {
@@ -971,8 +968,7 @@ func (msg *MsgGenericUprobeUnix) HandleMessage() *tetragon.GetEventsResponse {
 }
 
 func (msg *MsgGenericUprobeUnix) Cast(o any) notify.Message {
-	t := o.(MsgGenericUprobeUnix)
-	return &t
+	return new(o.(MsgGenericUprobeUnix))
 }
 
 type MsgGenericUsdtUnix struct {
@@ -1077,8 +1073,7 @@ func (msg *MsgGenericUsdtUnix) HandleMessage() *tetragon.GetEventsResponse {
 }
 
 func (msg *MsgGenericUsdtUnix) Cast(o any) notify.Message {
-	t := o.(MsgGenericUsdtUnix)
-	return &t
+	return new(o.(MsgGenericUsdtUnix))
 }
 
 type MsgImaHash struct {
@@ -1120,8 +1115,7 @@ func (msg *MsgGenericLsmUnix) HandleMessage() *tetragon.GetEventsResponse {
 }
 
 func (msg *MsgGenericLsmUnix) Cast(o any) notify.Message {
-	t := o.(MsgGenericLsmUnix)
-	return &t
+	return new(o.(MsgGenericLsmUnix))
 }
 
 func (msg *MsgGenericLsmUnix) PolicyInfo() tracingpolicy.PolicyInfo {
@@ -1242,6 +1236,5 @@ func (msg *MsgProcessThrottleUnix) HandleMessage() *tetragon.GetEventsResponse {
 }
 
 func (msg *MsgProcessThrottleUnix) Cast(o any) notify.Message {
-	t := o.(MsgProcessThrottleUnix)
-	return &t
+	return new(o.(MsgProcessThrottleUnix))
 }

--- a/pkg/jsonchecker/jsonchecker.go
+++ b/pkg/jsonchecker/jsonchecker.go
@@ -76,7 +76,6 @@ func JsonCheck(jsonFile *os.File, checker ec.MultiEventChecker, log *slog.Logger
 	count := 0
 	dec := json.NewDecoder(jsonFile)
 	for dec.More() {
-		var dbgErr *DebugError
 		var ev tetragon.GetEventsResponse
 		if err := dec.Decode(&ev); err != nil {
 			if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
@@ -104,7 +103,7 @@ func JsonCheck(jsonFile *os.File, checker ec.MultiEventChecker, log *slog.Logger
 		} else if done && err != nil {
 			log.Error(fmt.Sprintf("%s => terminating error: %s", matchPrefix, err))
 			return err
-		} else if errors.As(err, &dbgErr) {
+		} else if _, ok := errors.AsType[*DebugError](err); ok {
 			log.Debug(fmt.Sprintf("%s => no match: %s, continuing", matchPrefix, err))
 		} else {
 			log.Info(fmt.Sprintf("%s => no match: %s, continuing", matchPrefix, err))

--- a/pkg/logger/slog.go
+++ b/pkg/logger/slog.go
@@ -164,8 +164,7 @@ type FieldLogger interface {
 
 func init() {
 	// Set a no-op exit handler to avoid nil dereference
-	a := func() {}
-	exitHandler.Store(&a)
+	exitHandler.Store(new(func() {}))
 }
 
 var (

--- a/pkg/matchers/durationmatcher/durationmatcher.go
+++ b/pkg/matchers/durationmatcher/durationmatcher.go
@@ -188,8 +188,7 @@ func (m *DurationMatcher) Match(value *durationpb.Duration) error {
 			if value == nil {
 				return errors.New("duration is nil")
 			}
-			dur := value.AsDuration()
-			return m.checkBetween(&dur)
+			return m.checkBetween(new(value.AsDuration()))
 		}
 	case opFull:
 		{
@@ -199,8 +198,7 @@ func (m *DurationMatcher) Match(value *durationpb.Duration) error {
 			if value == nil {
 				return errors.New("duration is nil")
 			}
-			dur := value.AsDuration()
-			return m.checkFull(&dur)
+			return m.checkFull(new(value.AsDuration()))
 		}
 	case opGreater:
 		{
@@ -210,8 +208,7 @@ func (m *DurationMatcher) Match(value *durationpb.Duration) error {
 			if value == nil {
 				return errors.New("duration is nil")
 			}
-			dur := value.AsDuration()
-			return m.checkGreater(&dur)
+			return m.checkGreater(new(value.AsDuration()))
 		}
 	case opLess:
 		{
@@ -221,8 +218,7 @@ func (m *DurationMatcher) Match(value *durationpb.Duration) error {
 			if value == nil {
 				return errors.New("duration is nil")
 			}
-			dur := value.AsDuration()
-			return m.checkLess(&dur)
+			return m.checkLess(new(value.AsDuration()))
 		}
 	default:
 		return fmt.Errorf("unhandled DurationMatcher operator %s", m.Operator)

--- a/pkg/matchers/timestampmatcher/timestampmatcher.go
+++ b/pkg/matchers/timestampmatcher/timestampmatcher.go
@@ -325,8 +325,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkAfter(&tsTime)
+			return m.checkAfter(new(value.AsTime().UTC()))
 		}
 	case opBefore:
 		{
@@ -336,8 +335,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkBefore(&tsTime)
+			return m.checkBefore(new(value.AsTime().UTC()))
 		}
 	case opBetween:
 		{
@@ -347,8 +345,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkBetween(&tsTime)
+			return m.checkBetween(new(value.AsTime().UTC()))
 		}
 	case opDay:
 		{
@@ -358,8 +355,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkDay(&tsTime)
+			return m.checkDay(new(value.AsTime().UTC()))
 		}
 	case opFormat:
 		{
@@ -369,8 +365,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkFormat(&tsTime)
+			return m.checkFormat(new(value.AsTime().UTC()))
 		}
 	case opHour:
 		{
@@ -380,8 +375,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkHour(&tsTime)
+			return m.checkHour(new(value.AsTime().UTC()))
 		}
 	case opMinute:
 		{
@@ -391,8 +385,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkMinute(&tsTime)
+			return m.checkMinute(new(value.AsTime().UTC()))
 		}
 	case opSecond:
 		{
@@ -402,8 +395,7 @@ func (m *TimestampMatcher) Match(value *timestamppb.Timestamp) error {
 			if value == nil {
 				return errors.New("timestamp is nil")
 			}
-			tsTime := value.AsTime().UTC()
-			return m.checkSecond(&tsTime)
+			return m.checkSecond(new(value.AsTime().UTC()))
 		}
 	default:
 		return fmt.Errorf("unhandled TimestampMatcher operator %s", m.Operator)

--- a/pkg/policyconf/policyconf.go
+++ b/pkg/policyconf/policyconf.go
@@ -51,8 +51,7 @@ func ModeFromBPFMap(fname string) (Mode, error) {
 	defer m.Close()
 
 	var ret PolicyConf
-	zero := uint32(0)
-	if err = m.Lookup(&zero, &ret); err != nil {
+	if err = m.Lookup(new(uint32(0)), &ret); err != nil {
 		return InvalidMode, err
 	}
 	return ret.Mode, nil
@@ -73,8 +72,7 @@ func SetModeInBPFMap(fname string, mode Mode) error {
 	conf := PolicyConf{
 		Mode: mode,
 	}
-	zero := uint32(0)
-	if err = m.Update(&zero, &conf, ebpf.UpdateExist); err != nil {
+	if err = m.Update(new(uint32(0)), &conf, ebpf.UpdateExist); err != nil {
 		return fmt.Errorf("failed to update map %q with val %v: %w", fname, conf, err)
 	}
 	return nil

--- a/pkg/policyfilter/error.go
+++ b/pkg/policyfilter/error.go
@@ -29,8 +29,7 @@ func ErrorLabel(err error) string {
 		return policyfiltermetrics.NoErr.String()
 	}
 
-	var podNamespaceConflictErr *podNamespaceConflictError
-	if errors.As(err, &podNamespaceConflictErr) {
+	if _, ok := errors.AsType[*podNamespaceConflictError](err); ok {
 		return policyfiltermetrics.PodNamespaceConflictErr.String()
 	}
 	return policyfiltermetrics.GenericErr.String()

--- a/pkg/policyfilter/map.go
+++ b/pkg/policyfilter/map.go
@@ -554,8 +554,7 @@ func (m PfMap) AddCgroup(polID PolicyID, cgID CgroupID) error {
 	}
 	defer inMap.Close()
 
-	val := uint8(0)
-	if err := inMap.Update(&cgID, &val, ebpf.UpdateAny); err != nil {
+	if err := inMap.Update(&cgID, new(uint8(0)), ebpf.UpdateAny); err != nil {
 		return fmt.Errorf("error updating inner map: %w", err)
 	}
 

--- a/pkg/policystats/policystats.go
+++ b/pkg/policystats/policystats.go
@@ -46,8 +46,7 @@ func StatsFromBPFMap(fname string) (*PolicyStats, error) {
 	defer m.Close()
 
 	var ret PolicyStats
-	zero := uint32(0)
-	if err = m.Lookup(&zero, &ret); err != nil {
+	if err = m.Lookup(new(uint32(0)), &ret); err != nil {
 		return nil, fmt.Errorf("lookup failed: %w", err)
 	}
 	return &ret, nil

--- a/pkg/process/podinfo_test.go
+++ b/pkg/process/podinfo_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestK8sWatcher_GetPodInfo(t *testing.T) {
 	build.SkipIfK8sDisabled(t)
-	controller := true
 	var pods []any
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -35,7 +34,7 @@ func TestK8sWatcher_GetPodInfo(t *testing.T) {
 				{
 					Name:       "test-workload",
 					Kind:       "Deployment",
-					Controller: &controller,
+					Controller: new(true),
 				},
 			},
 		},

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -141,14 +141,12 @@ func (h *Manager) DeleteTracingPolicy(ctx context.Context, name string, namespac
 
 func (h *Manager) EnableTracingPolicy(_ context.Context, name, namespace string) error {
 	ck := collectionKey{name, namespace}
-	var enable = true
-	return h.handler.configureTracingPolicy(ck, nil, &enable)
+	return h.handler.configureTracingPolicy(ck, nil, new(true))
 }
 
 func (h *Manager) DisableTracingPolicy(_ context.Context, name, namespace string) error {
 	ck := collectionKey{name, namespace}
-	var enable = false
-	return h.handler.configureTracingPolicy(ck, nil, &enable)
+	return h.handler.configureTracingPolicy(ck, nil, new(false))
 }
 
 func (h *Manager) ConfigureTracingPolicy(_ context.Context, conf *tetragon.ConfigureTracingPolicyRequest) error {

--- a/pkg/sensors/program/loader_linux.go
+++ b/pkg/sensors/program/loader_linux.go
@@ -1104,8 +1104,7 @@ func doLoadProgram(
 		// gets properly pretty-printed.
 		if verbose != 0 {
 			logger.GetLogger().Info("Opening collection failed, dumping verifier log.")
-			var ve *ebpf.VerifierError
-			if errors.As(err, &ve) {
+			if ve, ok := errors.AsType[*ebpf.VerifierError](err); ok {
 				// Print a truncated version if we have verbose=1, otherwise dump the
 				// full log.
 				if verbose < 2 {

--- a/pkg/sensors/tracing/enforcer_builder.go
+++ b/pkg/sensors/tracing/enforcer_builder.go
@@ -45,14 +45,12 @@ func (ksb *EnforcerSpecBuilder) WithKill(sig uint32) *EnforcerSpecBuilder {
 }
 
 func (ksb *EnforcerSpecBuilder) WithMultiKprobe() *EnforcerSpecBuilder {
-	multi := true
-	ksb.multiKprobe = &multi
+	ksb.multiKprobe = new(true)
 	return ksb
 }
 
 func (ksb *EnforcerSpecBuilder) WithoutMultiKprobe() *EnforcerSpecBuilder {
-	multi := false
-	ksb.multiKprobe = &multi
+	ksb.multiKprobe = new(false)
 	return ksb
 }
 

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -533,8 +533,7 @@ func tpValidateAndAdjustEnforcerAction(
 					for i, arg := range tp.Args {
 						// syscall id
 						if arg.Index == 4 {
-							val := uint32(i)
-							act.EnforcerNotifyActionArgIndex = &val
+							act.EnforcerNotifyActionArgIndex = new(uint32(i))
 						}
 					}
 					defaultABI, _ := syscallinfo.DefaultABI()

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -246,8 +246,7 @@ func TestNamespacedPolicies(t *testing.T) {
 					if ok {
 						// cast uint64 to int32 so that we can have a single
 						// runTest function.
-						x := int32(arg)
-						return &x
+						return new(int32(arg))
 					}
 				} else if execEvent, ok := x.(*grpcexec.MsgExecveEventUnix); ok {
 					if strings.HasSuffix(execEvent.Unix.Process.Filename, "lseek-pipe") {

--- a/pkg/testutils/policytest/runner.go
+++ b/pkg/testutils/policytest/runner.go
@@ -177,8 +177,7 @@ func (r *LocalRunner) RunTest(l *slog.Logger, test *T, testConf *TestConf) *Resu
 	}
 
 	if testConf.MonitorMode {
-		mode := tetragon.TracingPolicyMode_TP_MODE_MONITOR
-		err := polHandler.Configure(l, r.cli, nil, &mode)
+		err := polHandler.Configure(l, r.cli, nil, new(tetragon.TracingPolicyMode_TP_MODE_MONITOR))
 		if err != nil {
 			err = errors.Join(err, polHandler.Cleanup(l, r.conf, r.cli))
 			return &Result{Err: err}

--- a/pkg/testutils/sensors/testrun_linux.go
+++ b/pkg/testutils/sensors/testrun_linux.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestSensorsRun(m *testing.M, sensorName string) int {
-	c := ConfigDefaults
-	config = &c
+	config = new(ConfigDefaults)
 
 	// some tests require the name of the current binary.
 	config.SelfBinary = filepath.Base(os.Args[0])


### PR DESCRIPTION
Authored through goland new syntax updates feat: https://blog.jetbrains.com/go/2026/02/13/moving-your-codebase-to-go-1-26-with-goland-syntax-updates/

