### PR TITLE
Fix drop-privileges

### DIFF
--- a/contrib/tester-progs/drop-privileges.c
+++ b/contrib/tester-progs/drop-privileges.c
@@ -25,6 +25,6 @@ int main(int argc, char *argv[])
 	if (setreuid(1879048188, 1879048188) < 0)
 		errExit("setreuid()");
 
-	execve(argv[1], argv, NULL);
+	execve(argv[1], &argv[1], NULL);
 	errExit("execve()");
 }


### PR DESCRIPTION
It seems that drop-privileges tester program has some issue in some kernels.

This patch changes the execve call inside drop-privileges.c from execve(argv[1], argv, NULL); to execve(argv[1], &argv[1], NULL); because this seems to be the proper thing to do.

Assuming that we call
```
contrib/tester-progs/drop-privileges /usr/bin/su --help
```
as we do in one of our tests.

In the previous version it passes to su:
```
argv[0] = "contrib/tester-progs/drop-privileges"
argv[1] = "/usr/bin/su"
argv[2] = "--help"
```

where in the new version it passes
```
argv[0] = "/usr/bin/su"
argv[1] = "--help"

```
which sounds like the correct thing to do.