### PR TITLE
v1.6: fix: incorrect default logger configuration

### DIFF
--- a/pkg/logger/slog.go
+++ b/pkg/logger/slog.go
@@ -71,18 +71,22 @@ func initializeSlog(logOpts LogOptions, useStdout bool) {
 		writer = os.Stdout
 	}
 
+	var newDefaultLogger = DefaultSlogLogger
 	switch logFormat {
 	case logFormatJSON, logFormatJSONTimestamp:
-		DefaultSlogLogger = slog.New(slog.NewJSONHandler(
+		newDefaultLogger = slog.New(slog.NewJSONHandler(
 			writer,
 			&opts,
 		))
 	case logFormatText, logFormatTextTimestamp:
-		DefaultSlogLogger = slog.New(slog.NewTextHandler(
+		newDefaultLogger = slog.New(slog.NewTextHandler(
 			writer,
 			&opts,
 		))
 	}
+
+	// update in place so package-level cached logger pointers pick up the new config
+	*DefaultSlogLogger = *newDefaultLogger
 }
 
 func replaceAttrFn(_ []string, a slog.Attr) slog.Attr {


### PR DESCRIPTION
## Backport of #4734 to v1.6

This is a clean cherry-pick of commit 8b5b200d292df962bab003fd82c10f9f286bcd39 from #4734.

### Description
Update logging setup to reconfigure `DefaultSlogLogger` in place so cached logger pointers use the configured level and format.

Fixes #4733

```release-note
fix: startup logging to consistently honor configured log level and format
```