### PR TITLE
celbpf: remove arg indirection

### DIFF
--- a/pkg/celbpf/celbpf.go
+++ b/pkg/celbpf/celbpf.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/config"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 )
 
 type Env struct{}
@@ -38,38 +39,29 @@ func Supported() bool {
 	return bpf.DetectMixBpfAndTailCalls()
 }
 
-func Compile(celExpr string, args []ExprArg, labelPrefix string) (asm.Instructions, error) {
+func Compile(celExpr string, sig []v1alpha1.KProbeArg, labelPrefix string) (asm.Instructions, []uint16, error) {
 	source := cgCommon.NewTextSource(celExpr)
 	parser, err := cgParser.NewParser()
 	if err != nil {
-		return nil, fmt.Errorf("failed initialize CEL parser: %w", err)
+		return nil, nil, fmt.Errorf("failed initialize CEL parser: %w", err)
 	}
 
 	ast, errs := parser.Parse(source)
 	if len(errs.GetErrors()) > 0 {
-		return nil, fmt.Errorf("failed to parse CEL expresion %q: %s", celExpr, errs.ToDisplayString())
+		return nil, nil, fmt.Errorf("failed to parse CEL expresion %q: %s", celExpr, errs.ToDisplayString())
 	}
 
-	eargs := make([]exprArg, 0, len(args))
-	for i := range args {
-		earg, err := newExprArg(args[i])
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert argument %d: %w", i, err)
-		}
-		eargs = append(eargs, earg)
-	}
-
-	checkerEnv, err := newCheckerEnv(eargs)
+	checkerEnv, err := newCheckerEnv(sig)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	ast, errs = cgChecker.Check(ast, source, checkerEnv)
 	if len(errs.GetErrors()) > 0 {
-		return nil, fmt.Errorf("check failed on CEL expresion %q: %s", celExpr, errs.ToDisplayString())
+		return nil, nil, fmt.Errorf("check failed on CEL expresion %q: %s", celExpr, errs.ToDisplayString())
 	}
 
-	compiler := newCompiler(ast, source, eargs, labelPrefix)
+	compiler := newCompiler(ast, source, sig, labelPrefix)
 	return compiler.compile()
 }
 
@@ -106,12 +98,12 @@ func CompileEmptyFunction(fnName string) asm.Instructions {
 	return insns
 }
 
-func CompileFn(fnName, celExpr string, args []ExprArg) (asm.Instructions, error) {
-	insns, err := Compile(celExpr, args, fnName)
+func CompileFn(fnName, celExpr string, sig []v1alpha1.KProbeArg) (asm.Instructions, []uint16, error) {
+	insns, arg_indexes, err := Compile(celExpr, sig, fnName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compile CEL expression %q: %w", celExpr, err)
+		return nil, nil, fmt.Errorf("failed to compile CEL expression %q: %w", celExpr, err)
 	}
 	fnTy := btfCelExprTy(fnName)
 	insns[0] = btf.WithFuncMetadata(insns[0].WithSymbol(fnTy.Name), fnTy).WithSource(s{celExpr})
-	return insns, nil
+	return insns, arg_indexes, nil
 }

--- a/pkg/celbpf/celbpf_test.go
+++ b/pkg/celbpf/celbpf_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/ebpf/btf"
 	"github.com/stretchr/testify/require"
 
-	gt "github.com/cilium/tetragon/pkg/generictypes"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 )
 
 func dumpProg(t *testing.T, prog *ebpf.Program) {
@@ -50,8 +50,8 @@ type DummyMsg struct {
 	args    [24000]uint8
 }
 
-func prepareArgs(t *testing.T, hookArgs []any, exprArgs []int) (DummyMsg, []ExprArg) {
-	var eargs []ExprArg
+func prepareArgs(t *testing.T, hookArgs []any) (DummyMsg, []v1alpha1.KProbeArg) {
+	var args []v1alpha1.KProbeArg
 	var msg DummyMsg
 	argsOff := 0
 	for i := range 5 {
@@ -68,35 +68,30 @@ func prepareArgs(t *testing.T, hookArgs []any, exprArgs []int) (DummyMsg, []Expr
 		}
 	}
 
-	for _, eArg := range exprArgs {
-		hArg := hookArgs[eArg]
+	for _, hArg := range hookArgs {
 		switch hArg.(type) {
 		case int32:
-			eargs = append(eargs, ExprArg{
-				GenTy:     gt.GenericS32Type,
-				ArgOffset: eArg,
+			args = append(args, v1alpha1.KProbeArg{
+				Type: "int32",
 			})
 		case uint64:
-			eargs = append(eargs, ExprArg{
-				GenTy:     gt.GenericU64Type,
-				ArgOffset: eArg,
+			args = append(args, v1alpha1.KProbeArg{
+				Type: "uint64",
 			})
 		case uint32:
-			eargs = append(eargs, ExprArg{
-				GenTy:     gt.GenericU32Type,
-				ArgOffset: eArg,
+			args = append(args, v1alpha1.KProbeArg{
+				Type: "uint32",
 			})
 		case int64:
-			eargs = append(eargs, ExprArg{
-				GenTy:     gt.GenericS64Type,
-				ArgOffset: eArg,
+			args = append(args, v1alpha1.KProbeArg{
+				Type: "int64",
 			})
 		default:
 			t.Fatalf("unknown type %T", hArg)
 		}
 	}
 
-	return msg, eargs
+	return msg, args
 }
 
 func btfTestArgExprFnTy(fnName string) *btf.Func {
@@ -130,73 +125,61 @@ func TestArgExprs(t *testing.T) {
 		expr     string
 		ret      uint32
 		hookArgs []any
-		exprArgs []int
 	}{
 		{
 			expr:     "arg0 == 42u",
 			ret:      1,
 			hookArgs: []any{uint64(42)},
-			exprArgs: []int{0},
 		},
 		{
 			expr:     "arg0 == 43u",
 			ret:      0,
 			hookArgs: []any{uint64(42)},
-			exprArgs: []int{0},
 		},
 		{
 			expr:     "arg0 == 0xaaaaaaaaaaaaaaaau",
 			ret:      1,
 			hookArgs: []any{uint64(0xaaaaaaaaaaaaaaaa)},
-			exprArgs: []int{0},
 		},
 		{
 			expr:     "arg0 == 0xaaaaaaaaaaaaaaaau",
 			ret:      0,
 			hookArgs: []any{uint64(0xbaaaaaaaaaaaaaab)},
-			exprArgs: []int{0},
 		},
 		{
 			expr:     "arg0 == uint32(42u)",
 			ret:      1,
 			hookArgs: []any{uint32(42)},
-			exprArgs: []int{0},
 		},
 		{
 			expr:     "arg0 == uint32(43u)",
 			ret:      0,
 			hookArgs: []any{uint32(42)},
-			exprArgs: []int{0},
 		},
 		{
-			expr:     "arg0 == int32(42)",
+			expr:     "arg2 == int32(42)",
 			ret:      1,
 			hookArgs: []any{int32(0), uint64(0), int32(42)},
-			exprArgs: []int{2},
 		},
 		{
-			expr:     "arg0 == int32(0)",
+			expr:     "arg2 == int32(0)",
 			ret:      0,
 			hookArgs: []any{int32(0), uint64(0), int32(42)},
-			exprArgs: []int{2},
 		},
 		{
-			expr:     "arg0 == arg1",
+			expr:     "arg2 == arg0",
 			ret:      1,
 			hookArgs: []any{int32(42), uint64(0), int32(42)},
-			exprArgs: []int{2, 0},
 		},
 		{
-			expr:     "arg0 - int32(10) == int32(32)",
+			expr:     "arg2 - int32(10) == int32(32)",
 			ret:      1,
 			hookArgs: []any{int32(30), uint64(0), int32(42)},
-			exprArgs: []int{2},
 		},
 		{
-			expr:     "arg0 - int32(10) == int32(2) + arg1",
+			expr:     "arg2 - int32(10) == int32(2) + arg0",
 			ret:      1,
 			hookArgs: []any{int32(30), uint64(0), int32(42)},
-			exprArgs: []int{2, 0},
 		},
 	}
 
@@ -210,13 +193,13 @@ func TestArgExprs(t *testing.T) {
 	defer m.Close()
 
 	for _, tc := range testCase {
-		data, eargs := prepareArgs(t, tc.hookArgs, tc.exprArgs)
+		data, args := prepareArgs(t, tc.hookArgs)
 
 		err := m.Update(new(uint32(0)), &data, 0)
 		require.NoError(t, err, "update map value")
 
 		fnName := "myfn"
-		insns, err := CompileFn(fnName, tc.expr, eargs)
+		insns, _, err := CompileFn(fnName, tc.expr, args)
 		require.NoError(t, err)
 		prelude := asm.Instructions{
 			// R1 map

--- a/pkg/celbpf/celbpfexpr_test.go
+++ b/pkg/celbpf/celbpfexpr_test.go
@@ -123,7 +123,7 @@ func TestExprs(t *testing.T) {
 	testCases = append(testCases, testComparisons()...)
 
 	for _, tc := range testCases {
-		insts, err := Compile(tc.expr, nil, "tc")
+		insts, _, err := Compile(tc.expr, nil, "tc")
 		require.NoError(t, err, "Compiling expression %q failed", tc.expr)
 		insts[0] = insts[0].WithSource(s{tc.expr})
 		// t.Logf("expr:%q\ninsts[%d]:\n%s", tc.expr, len(insts), insts)

--- a/pkg/celbpf/codegen.go
+++ b/pkg/celbpf/codegen.go
@@ -140,8 +140,8 @@ func (g *codeGenerator) emitU32(reg asm.Register, regTy *cgTypes.Type) error {
 	return nil
 }
 
-func (g *codeGenerator) pushArg(argTy *cgTypes.Type, argOffset int, tmp1, tmp2 asm.Register) error {
-	off := argOffset * 8
+func (g *codeGenerator) pushArg(argTy *cgTypes.Type, argOffset uint16, tmp1, tmp2 asm.Register) error {
+	off := int(argOffset * 8)
 	if off > math.MaxInt16 {
 		return fmt.Errorf("offset %d overflows 16-bits", off)
 	}

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -8,6 +8,7 @@ package celbpf
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -17,16 +18,19 @@ import (
 	cgOperators "github.com/google/cel-go/common/operators"
 	cgTypes "github.com/google/cel-go/common/types"
 	cgRef "github.com/google/cel-go/common/types/ref"
+
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 )
 
 type compiler struct {
-	ast  *cgAst.AST
-	src  cgCommon.Source
-	cg   *codeGenerator
-	args []exprArg
+	ast         *cgAst.AST
+	src         cgCommon.Source
+	cg          *codeGenerator
+	args        []v1alpha1.KProbeArg
+	arg_indexes []uint16
 }
 
-func newCompiler(ast *cgAst.AST, src cgCommon.Source, args []exprArg, labelPrefix string) *compiler {
+func newCompiler(ast *cgAst.AST, src cgCommon.Source, args []v1alpha1.KProbeArg, labelPrefix string) *compiler {
 	return &compiler{
 		ast:  ast,
 		src:  src,
@@ -163,13 +167,24 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 	return emitCall()
 }
 
-func (c *compiler) compileArg(argIdx int) error {
-	if argIdx >= len(c.args) {
+func (c *compiler) compileArg(argIdx uint16) error {
+	if int(argIdx) >= len(c.args) {
 		return fmt.Errorf("invalid argument (arg%d): undefined", argIdx)
 	}
 
 	arg := c.args[argIdx]
-	if err := c.cg.pushArg(arg.ty, arg.argOffset, scratchRegs[0], scratchRegs[1]); err != nil {
+
+	if !slices.Contains(c.arg_indexes, argIdx) {
+		c.arg_indexes = append(c.arg_indexes, argIdx)
+	}
+
+	converted_type := convertType(arg)
+
+	if converted_type == unsupportedTy {
+		return fmt.Errorf("arg%d has unsupported type", argIdx)
+	}
+
+	if err := c.cg.pushArg(converted_type, argIdx, scratchRegs[0], scratchRegs[1]); err != nil {
 		return fmt.Errorf("invalid argument (arg%d): %w", argIdx, err)
 	}
 	return nil
@@ -177,11 +192,11 @@ func (c *compiler) compileArg(argIdx int) error {
 
 func (c *compiler) compileIdent(s string) error {
 	if strings.HasPrefix(s, "arg") {
-		idx, err := strconv.Atoi(s[3:])
+		idx, err := strconv.ParseUint(s[3:], 10, 16)
 		if err != nil {
 			return fmt.Errorf("invalid argument (%s): %w", s, err)
 		}
-		return c.compileArg(idx)
+		return c.compileArg(uint16(idx))
 	}
 	return fmt.Errorf("BUG: ident %q unknown", s)
 }
@@ -209,16 +224,16 @@ func (c *compiler) compileExpr(expr cgAst.Expr) error {
 	return fmt.Errorf("unsupported CEL expr: %d (%+v)", expr.Kind(), expr)
 }
 
-func (c *compiler) compile() (asm.Instructions, error) {
+func (c *compiler) compile() (asm.Instructions, []uint16, error) {
 	expr := c.ast.Expr()
 	if cgAst.NavigateExpr(c.ast, expr).Type().Kind() != cgTypes.BoolKind {
-		return nil, errors.New("expecting CEL expression to return bool")
+		return nil, nil, errors.New("expecting CEL expression to return bool")
 	}
 	if err := c.compileExpr(expr); err != nil {
-		return nil, fmt.Errorf("failed to compile CEL expression: %w", err)
+		return nil, nil, fmt.Errorf("failed to compile CEL expression: %w", err)
 	}
 	c.cg.emitPopBool(asm.R0)
 	c.cg.emitRaw(asm.Return())
 
-	return c.cg.instructions(), nil
+	return c.cg.instructions(), c.arg_indexes, nil
 }

--- a/pkg/celbpf/env.go
+++ b/pkg/celbpf/env.go
@@ -15,6 +15,9 @@ import (
 	cgOperators "github.com/google/cel-go/common/operators"
 	cgOverloads "github.com/google/cel-go/common/overloads"
 	cgTypes "github.com/google/cel-go/common/types"
+
+	gt "github.com/cilium/tetragon/pkg/generictypes"
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 )
 
 var (
@@ -121,16 +124,24 @@ func checkerAddFunctions(env *cgChecker.Env) error {
 	return env.AddFunctions(fns...)
 }
 
-func checkerAddArguments(checkerEnv *cgChecker.Env, args []exprArg) error {
+func convertType(conf_arg v1alpha1.KProbeArg) *cgTypes.Type {
+	t, err := typeFromGenTy(gt.GenericTypeFromString(conf_arg.Type))
+	if err != nil {
+		t = unsupportedTy
+	}
+	return t
+}
+
+func checkerAddArguments(checkerEnv *cgChecker.Env, args []v1alpha1.KProbeArg) error {
 	// add argument identifiers
-	for i := range args {
-		arg := cgDecls.NewVariable("arg"+strconv.Itoa(i), args[i].ty)
+	for i, a := range args {
+		arg := cgDecls.NewVariable("arg"+strconv.Itoa(i), convertType(a))
 		checkerEnv.AddIdents(arg)
 	}
 	return nil
 }
 
-func newCheckerEnv(args []exprArg) (*cgChecker.Env, error) {
+func newCheckerEnv(args []v1alpha1.KProbeArg) (*cgChecker.Env, error) {
 	tyProvider, err := NewProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize type provider: %w", err)

--- a/pkg/celbpf/types.go
+++ b/pkg/celbpf/types.go
@@ -18,10 +18,11 @@ import (
 )
 
 var (
-	s64Ty = cgTypes.IntType
-	u64Ty = cgTypes.UintType
-	s32Ty = cgTypes.NewOpaqueType("s32")
-	u32Ty = cgTypes.NewOpaqueType("u32")
+	s64Ty         = cgTypes.IntType
+	u64Ty         = cgTypes.UintType
+	s32Ty         = cgTypes.NewOpaqueType("s32")
+	u32Ty         = cgTypes.NewOpaqueType("u32")
+	unsupportedTy = cgTypes.NewOpaqueType("unsupported")
 
 	addS32 = "add_s32"
 	addU32 = "add_u32"
@@ -73,11 +74,6 @@ func subOperatorFunctionOpts() []cgDecls.FunctionOpt {
 	return ret
 }
 
-type exprArg struct {
-	ty        *cgTypes.Type
-	argOffset int
-}
-
 func typeFromGenTy(genTy int) (*cgTypes.Type, error) {
 	switch genTy {
 	case gt.GenericS64Type:
@@ -93,15 +89,4 @@ func typeFromGenTy(genTy int) (*cgTypes.Type, error) {
 	}
 
 	return nil, fmt.Errorf("unhandled generic type: %d (%s)", genTy, gt.GenericTypeString(genTy))
-}
-
-func newExprArg(arg ExprArg) (exprArg, error) {
-	ty, err := typeFromGenTy(arg.GenTy)
-	if err != nil {
-		return exprArg{}, err
-	}
-	return exprArg{
-		ty:        ty,
-		argOffset: arg.ArgOffset,
-	}, nil
 }

--- a/pkg/selectors/celexpr.go
+++ b/pkg/selectors/celexpr.go
@@ -32,36 +32,27 @@ func addMatchCelExpr(
 	exprs *CelExprFunctions,
 	arg *v1alpha1.ArgSelector,
 	sig []v1alpha1.KProbeArg,
-) error {
+) ([]uint16, error) {
 
 	if len(arg.Values) != 1 {
-		return errors.New("addMatchCelExpr: only a single CelExpr value is supported")
+		return nil, errors.New("addMatchCelExpr: only a single CelExpr value is supported")
 	}
 
 	nExprs := len(*exprs)
 	if nExprs >= MaxCelExprFunctions {
-		return fmt.Errorf("addMatchCelExpr: cannot allocate new cel expression function. No more than %d CelExpr allowed per policy", MaxCelExprFunctions)
+		return nil, fmt.Errorf("addMatchCelExpr: cannot allocate new cel expression function. No more than %d CelExpr allowed per policy", MaxCelExprFunctions)
 	}
 
 	idx := nExprs
 	celExpr := arg.Values[0]
 
-	args := make([]celbpf.ExprArg, 0, len(arg.Args))
-	for i := range arg.Args {
-		argIdx, ty, err := argIndexTypeFromArgs(arg, i, sig)
-		if err != nil {
-			return nil
-		}
-		args = append(args, celbpf.ExprArg{GenTy: int(ty), ArgOffset: int(argIdx)})
-	}
-
-	insts, err := celbpf.CompileFn(CelExprFuncName(idx), celExpr, args)
+	insts, arg_indexes, err := celbpf.CompileFn(CelExprFuncName(idx), celExpr, sig)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	*exprs = append(*exprs, insts)
-	return nil
+	return arg_indexes, nil
 }
 
 func parseMatchCelExpr(
@@ -73,7 +64,7 @@ func parseMatchCelExpr(
 		return errors.New("celbpf not supported in this kernel")
 	}
 
-	err := addMatchCelExpr(k.celExprFunctions, arg, sig)
+	arg_indexes, err := addMatchCelExpr(k.celExprFunctions, arg, sig)
 	if err != nil {
 		return err
 	}
@@ -83,13 +74,8 @@ func parseMatchCelExpr(
 	WriteSelectorUint32(&k.data, SelectorOpCelExpr)
 	moff := AdvanceSelectorLength(&k.data)
 	WriteSelectorUint32(&k.data, 0)
-
-	for i := range arg.Args {
-		idx, _, err := argIndexTypeFromArgs(arg, i, sig)
-		if err != nil {
-			return err
-		}
-		WriteSelectorUint32(&k.data, idx)
+	for _, idx := range arg_indexes {
+		WriteSelectorUint32(&k.data, uint32(idx))
 	}
 	WriteSelectorLength(&k.data, moff)
 	return nil

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -349,8 +349,6 @@ spec:
     selectors:
       - matchArgs:
         - operator: CelExpr
-          args:
-            - 2
           values:
           - "` + expression + `"
 `
@@ -398,19 +396,19 @@ spec:
 }
 
 func TestUprobeResolveCELMatch(t *testing.T) {
-	testUprobeResolveCEL(t, "arg0 == 7u", []string{"subp.v64", "7"}, false)
+	testUprobeResolveCEL(t, "arg2 == 7u", []string{"subp.v64", "7"}, false)
 }
 
 func TestUprobeResolveCELMatchFail(t *testing.T) {
-	testUprobeResolveCEL(t, "arg0 == 8u", []string{"subp.v64", "7"}, true)
+	testUprobeResolveCEL(t, "arg2 == 8u", []string{"subp.v64", "7"}, true)
 }
 
 func TestUprobeResolveCELMatchNotEqual(t *testing.T) {
-	testUprobeResolveCEL(t, "arg0 != 8u", []string{"subp.v64", "7"}, false)
+	testUprobeResolveCEL(t, "arg2 != 8u", []string{"subp.v64", "7"}, false)
 }
 
 func TestUprobeResolveCELNoMatchOnArgReadFailure(t *testing.T) {
-	testUprobeResolveCEL(t, "arg0 != 8u", []string{"v8", "7"}, true)
+	testUprobeResolveCEL(t, "arg2 != 8u", []string{"v8", "7"}, true)
 }
 
 func TestCelExprMultiUprobeOneMatch(t *testing.T) {


### PR DESCRIPTION
Prior to this change, the user was required to declare the args that
they referenced within their CelExpr operator matchArgs selector. Within
the "args" section of the matchArgs selector, they would list indexes
that signified the offset within the "args" section of the tracing
policy.

This is inconvenient and redundant, as the referenced args can be
determined directly by parsing the CEL expressing itself.

This also created an unneeded layer of indirection. Ultimately, we need
a way to understand which arg within the "args" section of the hooked
function is being referenced. This change makes it so the numeric suffix
of the args in the CEL expression signify the offset within the args
configuration of the hooked function.

Previously, the numeric suffix of the args referenced in the CEL
expression were used as an offset into the "args" section of the
matchArgs selector. The index located at this offset, was then used as
the offset into the "args" section of the hook point.