### PR TITLE
feat(helm): allow rthooks-specific affinity override

### DIFF
--- a/install/kubernetes/tetragon/templates/_helpers.tpl
+++ b/install/kubernetes/tetragon/templates/_helpers.tpl
@@ -128,3 +128,15 @@ Runtime-hooks
 {{- else -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+rthooks affinity: when rthooks.affinity is explicitly set (including {}),
+use it as-is. Otherwise fall back to the top-level .Values.affinity.
+*/}}
+{{- define "tetragon-rthooks.affinity" -}}
+{{- if hasKey .Values.rthooks "affinity" -}}
+{{- toYaml .Values.rthooks.affinity -}}
+{{- else -}}
+{{- toYaml .Values.affinity -}}
+{{- end -}}
+{{- end }}

--- a/install/kubernetes/tetragon/templates/rthooks-daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/rthooks-daemonset.yaml
@@ -50,7 +50,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (include "tetragon-rthooks.affinity" . | fromYaml) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -434,6 +434,10 @@ rthooks:
   #      Specific configuration for this interface can be found under "nriHook".
   #
   interface: ""
+  # -- Affinity for the Tetragon rthooks pod. If this key is omitted, the chart
+  # falls back to the top-level `affinity` value. Set it explicitly (including
+  # to `{}`) to override the top-level affinity for the rthooks DaemonSet only.
+  # affinity: {}
   # -- Annotations for the Tetragon rthooks daemonset
   annotations: {}
   # -- Extra labels for the Tetrargon rthooks daemonset


### PR DESCRIPTION
## Summary

Allow setting `rthooks.affinity` in the Helm chart `values.yaml` to override the top-level `affinity` value for the `tetragon-rthooks` DaemonSet.

Behavior:

| `rthooks.affinity` | rthooks DaemonSet uses |
|---|---|
| omitted (default) | `.Values.affinity` (top-level fallback — unchanged behavior) |
| set to a value    | the rthooks-specific value |
| explicitly `{}` | no affinity at all |

The third case is the motivating one — it lets operators schedule `tetragon-rthooks` freely while constraining the agent to a subset of nodes.

## Implementation

- New helper `tetragon-rthooks.affinity` in `templates/_helpers.tpl` uses `hasKey` to distinguish "unset" from "explicitly empty". `default` could not be used because it treats `{}` as falsy, making the third case impossible to express.
- `templates/rthooks-daemonset.yaml` consumes the helper.
- `values.yaml` documents the key (kept commented out so the default codepath is the fallback).

## Motivation

The rthooks DaemonSet currently inherits the same affinity as the main Tetragon agent, so they cannot be scheduled independently. A common deployment pattern is to schedule `tetragon-rthooks` onto a specific set of nodes first, and then schedule the Tetragon agent onto nodes where rthooks is already running. This requires distinct affinity rules for the two DaemonSets, which the current chart does not support.

## Verification

- `helm lint` passes.
- `helm template` confirms all three cases render correctly:
  - Only `affinity` set: rthooks DaemonSet uses the top-level affinity.
  - `rthooks.affinity` set to a value: rthooks uses that value, agent keeps top-level.
  - `rthooks.affinity: {}` explicitly: rthooks renders no `affinity:` block.