### PR TITLE
tetragon: add sleepable uprobe sensor

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -108,6 +108,9 @@ PROCESS += bpf_generic_lsm_core_v61.o bpf_generic_lsm_output_v61.o \
 PROCESS += bpf_execve_map_update_v61.o bpf_execve_map_update_v511.o \
 	   bpf_execve_map_update_v53.o bpf_execve_map_update.o
 
+# sleepable uprobes
+PROCESS += bpf_generic_uprobe_sleepable.o bpf_multi_uprobe_sleepable.o \
+	   bpf_generic_retuprobe_sleepable.o bpf_multi_retuprobe_sleepable.o
 
 CGROUP = bpf_cgroup_mkdir.o bpf_cgroup_rmdir.o bpf_cgroup_release.o bpf_cgtracker.o
 CGROUP += bpf_cgroup_mkdir_v511.o bpf_cgroup_rmdir_v511.o bpf_cgroup_release_v511.o
@@ -153,6 +156,11 @@ CFLAGS_bpf_enforcer.o           = -D__BPF_OVERRIDE_RETURN
 CFLAGS_bpf_multi_enforcer.o     = -D__BPF_OVERRIDE_RETURN -D__MULTI_KPROBE
 CFLAGS_bpf_generic_lsm_core.o   = -D__LARGE_BPF_PROG
 CFLAGS_bpf_generic_lsm_output.o = -D__LARGE_BPF_PROG
+
+CFLAGS_bpf_generic_uprobe_sleepable.o    = -D__SLEEPABLE $(CFLAGS_v61)
+CFLAGS_bpf_multi_uprobe_sleepable.o      = -D__SLEEPABLE $(CFLAGS_v61) -D__MULTI_KPROBE
+CFLAGS_bpf_generic_retuprobe_sleepable.o = -D__SLEEPABLE $(CFLAGS_v61)
+CFLAGS_bpf_multi_retuprobe_sleepable.o   = -D__SLEEPABLE $(CFLAGS_v61) -D__MULTI_KPROBE
 
 # Rules
 MTARGET_o  = $(patsubst $(DEPSDIR)%.d,$(OBJSDIR)%.o,$@)
@@ -230,6 +238,10 @@ objs/%.ll:
 # Generic dependency files
 $(DEPSDIR)bpf_multi_enforcer.d: $(PROCESSDIR)bpf_enforcer.c
 $(DEPSDIR)bpf_fmodret_enforcer.d: $(PROCESSDIR)bpf_enforcer.c
+$(DEPSDIR)bpf_generic_uprobe_sleepable.d: $(PROCESSDIR)bpf_generic_uprobe.c
+$(DEPSDIR)bpf_multi_uprobe_sleepable.d: $(PROCESSDIR)bpf_generic_uprobe.c
+$(DEPSDIR)bpf_generic_retuprobe_sleepable.d: $(PROCESSDIR)bpf_generic_retuprobe.c
+$(DEPSDIR)bpf_multi_retuprobe_sleepable.d: $(PROCESSDIR)bpf_generic_retuprobe.c
 
 $(DEPSDIR)%.d: $(ALIGNCHECKERDIR)%.c
 	$(rule_d)

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -643,6 +643,27 @@ perf_event_output_metric(void *ctx, u8 msg_op, void *map, u64 flags, void *data,
 }
 
 #ifdef __V511_BPF_PROG
+#ifdef __NO_PERF_RINGBUFFER
+FUNC_INLINE long
+event_output(void *ctx, void *data, u64 size)
+{
+	return ringbuf_output(&tg_rb_events, data, size, 0);
+}
+
+FUNC_INLINE void
+event_output_metric(void *ctx, u8 msg_op, void *data, u64 size)
+{
+	long err;
+
+	err = ringbuf_output(&tg_rb_events, data, size, 0);
+	if (err < 0) {
+		event_output_update_error_metric(msg_op, err);
+		return;
+	}
+
+	policy_stats_update(POLICY_POST);
+}
+#else
 FUNC_INLINE long
 event_output(void *ctx, void *data, u64 size)
 {
@@ -677,6 +698,7 @@ event_output_metric(void *ctx, u8 msg_op, void *data, u64 size)
 
 	policy_stats_update(POLICY_POST);
 }
+#endif /* __NO_PERF_RINGBUFFER */
 #else
 FUNC_INLINE long
 event_output(void *ctx, void *data, u64 size)

--- a/bpf/process/bpf_generic_retuprobe.c
+++ b/bpf/process/bpf_generic_retuprobe.c
@@ -6,6 +6,12 @@
 
 #define GENERIC_URETPROBE
 
+#ifdef __SLEEPABLE
+#define __NO_PERF_RINGBUFFER
+#define __NO_STACKTRACE
+#define __NO_PRELOAD
+#endif
+
 #include "compiler.h"
 #include "bpf_tracing.h"
 #include "bpf_event.h"
@@ -40,11 +46,21 @@ struct {
 #include "generic_calls.h"
 
 #ifdef __MULTI_KPROBE
+#ifdef __SLEEPABLE
+#define MAIN   "uprobe.multi.s/generic_retuprobe"
+#define COMMON "uprobe.multi.s"
+#else
 #define MAIN   "uprobe.multi/generic_retuprobe"
 #define COMMON "uprobe.multi"
+#endif
+#else
+#ifdef __SLEEPABLE
+#define MAIN   "uprobe.s/generic_retuprobe"
+#define COMMON "uprobe.s"
 #else
 #define MAIN   "uprobe/generic_retuprobe"
 #define COMMON "uprobe"
+#endif
 #endif
 
 __attribute__((section((MAIN)), used)) int

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -155,6 +155,7 @@ generic_uprobe_path(void *ctx)
 }
 #endif
 
+#ifndef __NO_PRELOAD
 __attribute__((section(OFFLOAD), used)) int
 generic_sleepable_preload(struct pt_regs *ctx)
 {
@@ -166,6 +167,7 @@ generic_sleepable_preload_cleanup(struct pt_regs *ctx)
 {
 	return user_preload_cleanup(ctx);
 }
+#endif /* __NO_PRELOAD */
 
 __attribute__((section(OFFLOAD), used)) int
 generic_sleepable_offload(struct pt_regs *ctx)

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -6,6 +6,12 @@
 
 #define GENERIC_UPROBE
 
+#ifdef __SLEEPABLE
+#define __NO_PERF_RINGBUFFER
+#define __NO_STACKTRACE
+#define __NO_PRELOAD
+#endif
+
 #include "compiler.h"
 #include "bpf_event.h"
 #include "bpf_task.h"
@@ -54,14 +60,24 @@ struct {
 #include "generic_calls.h"
 
 #ifdef __MULTI_KPROBE
-#define MAIN	"uprobe.multi/generic_uprobe"
-#define COMMON	"uprobe.multi"
+#ifdef __SLEEPABLE
+#define MAIN   "uprobe.multi.s/generic_uprobe"
+#define COMMON "uprobe.multi.s"
+#else
+#define MAIN   "uprobe.multi/generic_uprobe"
+#define COMMON "uprobe.multi"
+#endif /* __SLEEPABLE */
 #define OFFLOAD "uprobe.multi.s"
 #else
-#define MAIN	"uprobe/generic_uprobe"
-#define COMMON	"uprobe"
+#ifdef __SLEEPABLE
+#define MAIN   "uprobe.s/generic_uprobe"
+#define COMMON "uprobe.s"
+#else
+#define MAIN   "uprobe/generic_uprobe"
+#define COMMON "uprobe"
+#endif /* __SLEEPABLE */
 #define OFFLOAD "uprobe.s"
-#endif
+#endif /* __MULTI_KPROBE */
 
 __attribute__((section((MAIN)), used)) int
 generic_uprobe_event(struct pt_regs *ctx)

--- a/bpf/process/bpf_generic_uprobe.c
+++ b/bpf/process/bpf_generic_uprobe.c
@@ -56,11 +56,11 @@ struct {
 #ifdef __MULTI_KPROBE
 #define MAIN	"uprobe.multi/generic_uprobe"
 #define COMMON	"uprobe.multi"
-#define OFFLOAD "uprobe.multi.s/generic_uprobe"
+#define OFFLOAD "uprobe.multi.s"
 #else
 #define MAIN	"uprobe/generic_uprobe"
 #define COMMON	"uprobe"
-#define OFFLOAD "uprobe.s/generic_uprobe"
+#define OFFLOAD "uprobe.s"
 #endif
 
 __attribute__((section((MAIN)), used)) int

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -289,10 +289,14 @@ __read_arg_1(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 
 		probe_read(&file, sizeof(file), &arg);
 		probe_read(&arg, sizeof(arg), &file->name);
-	}
-		fallthrough;
-	case string_type:
 		size = copy_strings(args, (char *)arg, MAX_STRING);
+		break;
+	}
+	case string_type:
+		if (argm & ARGM_USER)
+			size = copy_strings_user(args, (char *)arg, MAX_STRING);
+		else
+			size = copy_strings(args, (char *)arg, MAX_STRING);
 		break;
 	case net_dev_ty: {
 		struct net_device *dev = (struct net_device *)arg;
@@ -575,6 +579,14 @@ FUNC_INLINE long get_preload_arg(struct pt_regs *ctx, long ty, arg_status_t *sta
 }
 #endif
 
+__maybe_unused static bool get_can_sleep(void)
+{
+#ifdef __SLEEPABLE
+	return true;
+#endif
+	return false;
+}
+
 FUNC_INLINE long generic_read_arg(void *ctx, int index, long off, struct bpf_map_def *tailcals,
 				  int process)
 {
@@ -633,6 +645,12 @@ FUNC_INLINE long generic_read_arg(void *ctx, int index, long off, struct bpf_map
 	if (am & ARGM_PRELOAD) {
 		a = get_preload_arg(ctx, ty, &e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
 	} else {
+		/*
+		 * can_sleep is true if the sensor can sleep and reliably read data
+		 * from user space.
+		 */
+		bool can_sleep = get_can_sleep();
+
 		asm volatile("%[index] &= %1 ;\n"
 			     : [index] "+r"(index)
 			     : "i"(MAX_POSSIBLE_ARGS_MASK));
@@ -640,11 +658,16 @@ FUNC_INLINE long generic_read_arg(void *ctx, int index, long off, struct bpf_map
 			a = get_pt_regs_arg(ctx, config, index);
 		} else if (am & ARGM_CURRENT_TASK) {
 			a = get_current_task();
+			/*
+			 * We are getting data from kernel current object, we don't
+			 * need to sleep and need to use bpf_probe_read.
+			 */
+			can_sleep = false;
 		} else {
 			arg_index = config->idx[index & MAX_POSSIBLE_ARGS_MASK];
 			a = (&e->a0)[arg_index & MAX_ACCESSIBLE_ARGS_MASK];
 		}
-		extract_arg(config, index, &a, false, &e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
+		extract_arg(config, index, &a, can_sleep, &e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
 	}
 
 	if (should_offload_path(ty))

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -974,8 +974,9 @@ do_action(void *ctx, __u32 i, struct selector_action *actions, bool *post, bool 
 		if (rate_limit(ratelimit_interval, ratelimit_scope, e))
 			*post = false;
 #endif /* __LARGE_BPF_PROG */
-		__u32 kernel_stack_trace = actions->act[++i];
+		__u32 kernel_stack_trace __maybe_unused = actions->act[++i];
 
+#ifndef __NO_STACKTRACE
 		if (kernel_stack_trace) {
 			// Stack id 0 is valid so we need a flag.
 			e->common.flags |= MSG_COMMON_FLAG_KERNEL_STACKTRACE;
@@ -987,13 +988,16 @@ do_action(void *ctx, __u32 i, struct selector_action *actions, bool *post, bool 
 			// Here we just signal that there was a collision returning -EEXIST.
 			e->kernel_stack_id = get_stackid(ctx, &stack_trace_map, 0);
 		}
+#endif /* __NO_STACKTRACE */
 
-		__u32 user_stack_trace = actions->act[++i];
+		__u32 user_stack_trace __maybe_unused = actions->act[++i];
 
+#ifndef __NO_STACKTRACE
 		if (user_stack_trace) {
 			e->common.flags |= MSG_COMMON_FLAG_USER_STACKTRACE;
 			e->user_stack_id = get_stackid(ctx, &stack_trace_map, BPF_F_USER_STACK);
 		}
+#endif /* __NO_STACKTRACE */
 #ifdef __V511_BPF_PROG
 		__u32 ima_hash = actions->act[++i];
 

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -543,7 +543,7 @@ FUNC_INLINE long get_pt_regs_arg(struct pt_regs *ctx, struct event_config *confi
 }
 #endif /* __TARGET_ARCH_x86 && (GENERIC_KPROBE || GENERIC_UPROBE) */
 
-#if defined(GENERIC_UPROBE) || defined(GENERIC_USDT)
+#if !defined(__NO_PRELOAD) && (defined(GENERIC_UPROBE) || defined(GENERIC_USDT))
 FUNC_INLINE unsigned long get_preload_arg(struct pt_regs *ctx, long ty, arg_status_t *status)
 {
 	unsigned long arg = 0;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -379,6 +379,28 @@ FUNC_INLINE long copy_strings(char *args, char *arg, int max_size)
 	return size + 4;
 }
 
+#ifdef __SLEEPABLE
+FUNC_INLINE long copy_strings_user(char *args, char *arg, int max_size)
+{
+	int *s = (int *)args;
+	long size;
+
+	size = bpf_copy_from_user_str(&args[4], max_size + 1, (const void *)arg, 0);
+	if (size <= 0)
+		return invalid_ty;
+	// Remove the nul character from end.
+	size--;
+	*s = size;
+	// Initial 4 bytes hold string length
+	return size + 4;
+}
+#else
+FUNC_INLINE long copy_strings_user(char *args, char *arg, int max_size)
+{
+	return 0;
+}
+#endif
+
 FUNC_INLINE long copy_skb(char *args, unsigned long arg)
 {
 	struct sk_buff *skb = (struct sk_buff *)arg;
@@ -548,6 +570,7 @@ FUNC_INLINE long copy_kernel_module(char *args, unsigned long arg)
 #define ARGM_CURRENT_TASK BIT(6)
 #define ARGM_PT_REGS	  BIT(7)
 #define ARGM_PRELOAD	  BIT(8)
+#define ARGM_USER	  BIT(9)
 
 FUNC_INLINE bool has_return_copy(unsigned long argm)
 {

--- a/bpf/process/user_preload.h
+++ b/bpf/process/user_preload.h
@@ -14,14 +14,16 @@ struct preload_data {
 	unsigned char data[4096];
 };
 
+#ifndef __NO_PRELOAD
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1); // will be resized by agent when needed
 	__type(key, __u64);
 	__type(value, struct preload_data);
 } sleepable_preload SEC(".maps");
+#endif /* __NO_PRELOAD */
 
-#if defined(GENERIC_UPROBE) || defined(GENERIC_USDT)
+#if !defined(__NO_PRELOAD) && (defined(GENERIC_UPROBE) || defined(GENERIC_USDT))
 
 FUNC_INLINE int
 preload_string_type(struct pt_regs *ctx, struct event_config *config, unsigned long val,
@@ -183,8 +185,9 @@ user_preload(struct pt_regs *ctx)
 	return 0;
 }
 
-#endif /* GENERIC_UPROBE || GENERIC_USDT*/
+#endif /* !__NO_PRELOAD && (GENERIC_UPROBE || GENERIC_USDT) */
 
+#ifndef __NO_PRELOAD
 FUNC_INLINE int
 user_preload_cleanup(struct pt_regs *ctx)
 {
@@ -193,5 +196,6 @@ user_preload_cleanup(struct pt_regs *ctx)
 	map_delete_elem(&sleepable_preload, &id);
 	return 0;
 }
+#endif /* __NO_PRELOAD */
 
 #endif /* __USER_PRELOAD_H__ */

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -117,6 +117,11 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 			continue
 		}
 
+		// Skip sleepable objects if there's no sleepable tail call support.
+		if strings.Contains(fileName, "sleepable") && !bpf.DetectSleepableTailCalls() {
+			continue
+		}
+
 		spec, err := ebpf.LoadCollectionSpec(tetragonDir + "/" + fileName)
 		require.NoError(t, err, "failed to parse elf file into collection spec")
 		require.NotNil(t, spec, "collection spec should not be nil")

--- a/docs/content/en/docs/concepts/tracing-policy/options.md
+++ b/docs/content/en/docs/concepts/tracing-policy/options.md
@@ -44,6 +44,7 @@ Example:
 ## Uprobe options
 
 - [`disable-uprobe-multi`](#disable-uprobe-multi): disable uprobe multi link
+- [`disable-sleepable`](#disable-sleepable): disable sleepable uprobe programs
 
 ### disable-uprobe-multi
 
@@ -58,5 +59,21 @@ Example:
 ```yaml
   options:
     - name: "disable-uprobe-multi"
+      value: "1"
+```
+
+### disable-sleepable
+
+This option disables sleepable uprobe programs for all the uprobes defined in
+the spec file. If enabled, uprobes will use the standard non-sleepable uprobe
+programs even when sleepable uprobes are supported.
+
+It takes boolean as value, by default it's false.
+
+Example:
+
+```yaml
+  options:
+    - name: "disable-sleepable"
       value: "1"
 ```

--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -58,6 +58,7 @@ var (
 	kfuncs                 FeatureKfuncs
 	mixBpfAndTailCalls     Feature
 	getFuncRetHelper       Feature
+	sleepableTailCalls     Feature
 )
 
 func HasOverrideHelper() bool {
@@ -663,7 +664,6 @@ func detectMixBpfAndTailCalls() bool {
 		MaxEntries: 1,
 	})
 	if err != nil {
-		fmt.Printf("#0 err=%+v\n", err)
 		return false
 	}
 	defer tcMap.Close()
@@ -734,6 +734,45 @@ func HasGetFuncRetHelper() bool {
 	return getFuncRetHelper.detected
 }
 
+func detectSleepableTailCalls() bool {
+	// create a tail call map
+	tcMap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.ProgramArray,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+	})
+	if err != nil {
+		return false
+	}
+	defer tcMap.Close()
+
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Instructions: asm.Instructions{
+			asm.LoadMapPtr(asm.R2, tcMap.FD()),
+			asm.Mov.Imm(asm.R3, 0),
+			asm.FnTailCall.Call(),
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		Type:    ebpf.Kprobe,
+		Flags:   unix.BPF_F_SLEEPABLE,
+		License: "Dual BSD/GPL",
+	})
+	if err != nil {
+		return false
+	}
+	defer prog.Close()
+	return true
+}
+
+func DetectSleepableTailCalls() bool {
+	sleepableTailCalls.init.Do(func() {
+		sleepableTailCalls.detected = detectSleepableTailCalls()
+	})
+	return sleepableTailCalls.detected
+}
+
 func LogFeatures() string {
 	// once we have detected all features, flush the BTF spec
 	// we cache all values so calling again a Has* function will
@@ -784,4 +823,5 @@ var FeatureProbes = []FeatureProbe{
 	{MixBPFAndTailCallsProbe, DetectMixBpfAndTailCalls},
 	{Fentry, HasFentryProgram},
 	{GetFuncRet, HasGetFuncRetHelper},
+	{SleepableTailCallsProbe, DetectSleepableTailCalls},
 }

--- a/pkg/bpf/probes.go
+++ b/pkg/bpf/probes.go
@@ -24,4 +24,5 @@ const (
 	MixBPFAndTailCallsProbe     = "mix_bpf_and_tail_calls"
 	Fentry                      = "fentry"
 	GetFuncRet                  = "get_func_ret"
+	SleepableTailCallsProbe     = "sleepable_tail_calls"
 )

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -89,7 +89,13 @@ func GenericTracingObjs() (string, string) {
 }
 
 // GenericUprobeObjs returns the generic uprobe and generic uretprobe objects
-func GenericUprobeObjs(multi bool) (string, string) {
+func GenericUprobeObjs(multi, sleepable bool) (string, string) {
+	if sleepable {
+		if multi {
+			return "bpf_multi_uprobe_sleepable.o", "bpf_multi_retuprobe_sleepable.o"
+		}
+		return "bpf_generic_uprobe_sleepable.o", "bpf_generic_retuprobe_sleepable.o"
+	}
 	if multi {
 		if EnableV61Progs() {
 			return "bpf_multi_uprobe_v61.o", "bpf_multi_retuprobe_v61.o"

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -25,7 +25,7 @@ func GenericKprobeObjs(_ bool) (string, string) {
 	return "", ""
 }
 
-func GenericUprobeObjs(_ bool) (string, string) {
+func GenericUprobeObjs(_, _ bool) (string, string) {
 	return "", ""
 }
 

--- a/pkg/sensors/program/loader_linux.go
+++ b/pkg/sensors/program/loader_linux.go
@@ -1046,7 +1046,12 @@ func doLoadProgram(
 	refMaps := make(map[string]bool)
 	for _, prog := range spec.Programs {
 		if prog.SectionName == load.Label {
-			progSpec = prog
+			if progSpec == nil {
+				progSpec = prog
+			} else {
+				return nil, fmt.Errorf("multiple main sections found (%s) for object %s",
+					load.Label, load.Name)
+			}
 		}
 		for _, inst := range prog.Instructions {
 			if inst.Reference() != "" {

--- a/pkg/sensors/tracing/args_linux.go
+++ b/pkg/sensors/tracing/args_linux.go
@@ -59,6 +59,7 @@ const (
 	argCurrentTaskBit = 1 << 6
 	argPtRegsBit      = 1 << 7
 	argPreloadBit     = 1 << 8
+	argUserBit        = 1 << 9
 )
 
 func argReturnCopy(meta int) bool {
@@ -74,6 +75,7 @@ func argReturnCopy(meta int) bool {
 //	  6 : CurrentTask
 //	  7 : PtRegs
 //	  8 : PtRegsPreload
+//	  9 : User
 func getMetaValue(arg *v1alpha1.KProbeArg) (int, error) {
 	var meta int
 
@@ -98,7 +100,7 @@ func getMetaValue(arg *v1alpha1.KProbeArg) (int, error) {
 	return meta, nil
 }
 
-func getUserMetaValue(arg *v1alpha1.KProbeArg, preload bool) (int, error) {
+func getUserMetaValue(arg *v1alpha1.KProbeArg, preload, user bool) (int, error) {
 	// common meta bits
 	meta, err := getMetaValue(arg)
 	if err != nil {
@@ -108,7 +110,9 @@ func getUserMetaValue(arg *v1alpha1.KProbeArg, preload bool) (int, error) {
 	if preload {
 		meta = meta | argPreloadBit
 	}
-
+	if user {
+		meta = meta | argUserBit
+	}
 	return meta, nil
 }
 

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -425,14 +425,14 @@ type uprobeHas struct {
 	sleepable        bool
 }
 
-func uprobeHasSetup(uprobes []v1alpha1.UProbeSpec) uprobeHas {
+func uprobeHasSetup(uprobes []v1alpha1.UProbeSpec, opts *specOptions) uprobeHas {
 	hasStackTrace := false
 	has := uprobeHas{}
 
 	for _, uprobe := range uprobes {
 		hasStackTrace = hasStackTrace || selectors.HasStackTrace(uprobe.Selectors)
 	}
-	has.sleepable = bpf.DetectSleepableTailCalls() && !hasStackTrace
+	has.sleepable = bpf.DetectSleepableTailCalls() && !hasStackTrace && !opts.DisableSleepable
 
 	return has
 }
@@ -473,7 +473,7 @@ func createGenericUprobeSensor(
 		}
 	}
 
-	has := uprobeHasSetup(uprobes)
+	has := uprobeHasSetup(uprobes, polInfo.specOpts)
 
 	for _, uprobe := range uprobes {
 		ids, err = addUprobe(&uprobe, ids, &in, &has)

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -422,6 +422,19 @@ type uprobeHas struct {
 	sleepableOffload bool
 	sleepablePreload bool
 	substring        bool
+	sleepable        bool
+}
+
+func uprobeHasSetup(uprobes []v1alpha1.UProbeSpec) uprobeHas {
+	hasStackTrace := false
+	has := uprobeHas{}
+
+	for _, uprobe := range uprobes {
+		hasStackTrace = hasStackTrace || selectors.HasStackTrace(uprobe.Selectors)
+	}
+	has.sleepable = bpf.DetectSleepableTailCalls() && !hasStackTrace
+
+	return has
 }
 
 func createGenericUprobeSensor(
@@ -433,7 +446,6 @@ func createGenericUprobeSensor(
 	var maps []*program.Map
 	var ids []idtable.EntryID
 	var err error
-	var has uprobeHas
 	var celExprs *selectors.CelExprFunctions
 
 	// use multi uprobe only if:
@@ -454,11 +466,16 @@ func createGenericUprobeSensor(
 		celExprs: celExprs,
 	}
 
-	for _, uprobe := range spec.UProbes {
+	uprobes := spec.UProbes
+	for _, uprobe := range uprobes {
 		if err = appendMacrosSelectors(uprobe.Selectors, spec.SelectorsMacros); err != nil {
 			return nil, fmt.Errorf("append macros selectors: %w", err)
 		}
+	}
 
+	has := uprobeHasSetup(uprobes)
+
+	for _, uprobe := range uprobes {
 		ids, err = addUprobe(&uprobe, ids, &in, &has)
 		if err != nil {
 			return nil, err
@@ -877,6 +894,19 @@ func multiUprobePinPath(sensorPath string) string {
 	return sensors.PathJoin(sensorPath, "multi_uprobe")
 }
 
+func uprobeLabel(multi, sleepable bool) (string, string) {
+	if multi {
+		if sleepable {
+			return "uprobe.multi.s/generic_uprobe", "uprobe.multi.s/generic_retuprobe"
+		}
+		return "uprobe.multi/generic_uprobe", "uprobe.multi/generic_retuprobe"
+	}
+	if sleepable {
+		return "uprobe.s/generic_uprobe", "uprobe.s/generic_retuprobe"
+	}
+	return "uprobe/generic_uprobe", "uprobe/generic_retuprobe"
+}
+
 func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []idtable.EntryID, has uprobeHas) ([]*program.Program, []*program.Map, error) {
 	var multiRetIDs []idtable.EntryID
 	var progs []*program.Program
@@ -897,14 +927,16 @@ func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []
 		}
 	}
 
-	loadProgName, loadProgRetName := config.GenericUprobeObjs(true)
+	loadProgName, loadProgRetName := config.GenericUprobeObjs(true, has.sleepable)
+
+	label, labelRet := uprobeLabel(true, has.sleepable)
 
 	pinPath := multiUprobePinPath(sensorPath)
 
 	load := program.Builder(
 		path.Join(option.Config.HubbleLib, loadProgName),
 		fmt.Sprintf("uprobe_multi (%d functions)", len(multiIDs)),
-		"uprobe.multi/generic_uprobe",
+		label,
 		pinPath,
 		"generic_uprobe").
 		SetLoaderData(multiIDs).
@@ -955,7 +987,7 @@ func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []
 		loadret := program.Builder(
 			path.Join(option.Config.HubbleLib, loadProgRetName),
 			fmt.Sprintf("%d retuprobes", len(multiIDs)),
-			"uprobe.multi/generic_retuprobe",
+			labelRet,
 			"multi_retuprobe",
 			"generic_uprobe").
 			SetRetProbe(true).
@@ -1007,13 +1039,15 @@ func createUprobeSensorFromEntry(polInfo *policyInfo, uprobeEntry *genericUprobe
 		substringMapEntries = len(uprobeEntry.loadArgs.selectors.entry.SubStrings())
 	}
 
-	loadProgName, loadProgRetName := config.GenericUprobeObjs(false)
+	loadProgName, loadProgRetName := config.GenericUprobeObjs(false, has.sleepable)
+
+	label, labelRet := uprobeLabel(false, has.sleepable)
 
 	pinSymbol := strings.ReplaceAll(uprobeEntry.symbol, ".", "_")
 	load := program.Builder(
 		path.Join(option.Config.HubbleLib, loadProgName),
 		fmt.Sprintf("%s %s", uprobeEntry.path, uprobeEntry.symbol),
-		"uprobe/generic_uprobe",
+		label,
 		fmt.Sprintf("%d-%s", uprobeEntry.tableId.ID, pinSymbol),
 		"generic_uprobe").
 		SetLoaderData(uprobeEntry).
@@ -1061,7 +1095,7 @@ func createUprobeSensorFromEntry(polInfo *policyInfo, uprobeEntry *genericUprobe
 		loadret := program.Builder(
 			path.Join(option.Config.HubbleLib, loadProgRetName),
 			fmt.Sprintf("%s %s", uprobeEntry.path, uprobeEntry.symbol),
-			"uprobe/generic_retuprobe",
+			labelRet,
 			pinRetProg,
 			"generic_uprobe").
 			SetRetProbe(true).

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -629,7 +629,23 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 	var preload bool
 
 	addArg := func(i int, a *v1alpha1.KProbeArg, data bool) error {
-		var preloadArg bool
+		var preloadArg, user bool
+
+		setStringRead := func() error {
+			if !bpf.HasKfunc("bpf_copy_from_user_str") {
+				return fmt.Errorf("can't read string for argument %d: missing bpf_copy_from_user_str", i)
+			}
+			if !has.sleepable {
+				if preload {
+					return errors.New("error: can't preload more than one argument")
+				}
+				preloadArg = true
+				return nil
+			}
+			user = true
+			return nil
+		}
+
 		argType := gt.GenericTypeFromString(a.Type)
 
 		if data {
@@ -643,15 +659,12 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 				}
 
 				// If we are getting string type from pt_regs register we can safely assume
-				// it's from user address, so we need to read it through preload.
+				// it's from user address; in sleepable context we read it directly,
+				// otherwise we need to read it through preload.
 				if argType == gt.GenericStringType {
-					if !bpf.HasKfunc("bpf_copy_from_user_str") {
-						return fmt.Errorf("can't preload string for argument %d", i)
+					if err := setStringRead(); err != nil {
+						return err
 					}
-					if preload {
-						return errors.New("error: can't preload more than one argument")
-					}
-					preloadArg = true
 				}
 			} else if hasCurrentTaskSource(a) {
 				if !bpf.HasProgramLargeSize() {
@@ -677,13 +690,9 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 			}
 
 			if argType == gt.GenericStringType {
-				if !bpf.HasKfunc("bpf_copy_from_user_str") {
-					return fmt.Errorf("can't preload string for argument %d", i)
+				if err := setStringRead(); err != nil {
+					return err
 				}
-				if preload {
-					return errors.New("error: can't preload more than one argument")
-				}
-				preloadArg = true
 			}
 		}
 
@@ -694,7 +703,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 		if argType == gt.GenericInvalidType {
 			return fmt.Errorf("Arg(%d) type '%s' unsupported", i, a.Type)
 		}
-		argMValue, err := getUserMetaValue(a, preloadArg)
+		argMValue, err := getUserMetaValue(a, preloadArg, user)
 		if err != nil {
 			return err
 		}

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -420,7 +420,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 				}
 
 				preload = true
-				argMValue, err := getUserMetaValue(&arg, true)
+				argMValue, err := getUserMetaValue(&arg, true, false)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sensors/tracing/options.go
+++ b/pkg/sensors/tracing/options.go
@@ -18,10 +18,11 @@ import (
 type OverrideMethod int
 
 const (
-	keyOverrideMethod = "override-method"
-	valFmodRet        = "fmod-ret"
-	valOverrideReturn = "override-return"
-	keyPolicyMode     = "policy-mode"
+	keyOverrideMethod   = "override-method"
+	valFmodRet          = "fmod-ret"
+	valOverrideReturn   = "override-return"
+	keyPolicyMode       = "policy-mode"
+	keyDisableSleepable = "disable-sleepable"
 )
 
 const (
@@ -45,6 +46,7 @@ func overrideMethodParse(s string) OverrideMethod {
 type specOptions struct {
 	DisableKprobeMulti bool
 	DisableUprobeMulti bool
+	DisableSleepable   bool
 	OverrideMethod     OverrideMethod
 	policyMode         policyconf.Mode
 }
@@ -71,6 +73,12 @@ var opts = map[string]opt{
 	option.KeyDisableUprobeMulti: {
 		set: func(str string, options *specOptions) (err error) {
 			options.DisableUprobeMulti, err = strconv.ParseBool(str)
+			return err
+		},
+	},
+	keyDisableSleepable: {
+		set: func(str string, options *specOptions) (err error) {
+			options.DisableSleepable, err = strconv.ParseBool(str)
 			return err
 		},
 	},

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -143,6 +143,9 @@ kind: TracingPolicy
 metadata:
   name: "uprobe"
 spec:
+  options:
+  - name: "disable-sleepable"
+    value: "1"
   uprobes:
   - path: "/bin/bash"
     symbols:

--- a/pkg/sensors/tracing/uprobe_validation_test.go
+++ b/pkg/sensors/tracing/uprobe_validation_test.go
@@ -24,6 +24,9 @@ kind: TracingPolicy
 metadata:
   name: "uprobe"
 spec:
+  options:
+  - name: "disable-sleepable"
+    value: "true"
   uprobes:
   - path: "` + uprobe + `"
     symbols:


### PR DESCRIPTION
adding new uprobe sleepable sensors in following objects:
```
      bpf_generic_uprobe_sleepable.o
      bpf_generic_retuprobe_sleepable.o
      bpf_multi_uprobe_sleepable.o
      bpf_multi_retuprobe_sleepable.o
```

now we can retrieve user space data directly from sensor and do not
need preload probes (extra 2 probes on same target)

it's available from kernel v6.19 and the policy can't have stacktrace atm