### PR TITLE
go.mod: pin controller-runtime to latest commit instead of replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,9 +53,9 @@ require (
 	k8s.io/code-generator v0.36.0
 	k8s.io/cri-api v0.36.0
 	k8s.io/klog/v2 v2.140.0
-	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/controller-runtime v0.23.1-0.20260424122448-c8b4b9d61fbd
 	sigs.k8s.io/controller-tools v0.20.1
-	sigs.k8s.io/e2e-framework v0.7.0
+	sigs.k8s.io/e2e-framework v0.6.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -164,8 +164,4 @@ replace (
 	// Use local version of API
 	github.com/cilium/tetragon/api => ./api
 	github.com/cilium/tetragon/pkg/k8s => ./pkg/k8s
-
-	// Pin controller-runtime to a main-branch commit that supports k8s.io v0.36.0.
-	// The latest release (v0.23.3) only supports v0.35.x. Remove once v0.24.0 ships.
-	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.23.1-0.20260424122448-c8b4b9d61fbd
 )

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ sigs.k8s.io/controller-runtime v0.23.1-0.20260424122448-c8b4b9d61fbd h1:GFs6wqtA
 sigs.k8s.io/controller-runtime v0.23.1-0.20260424122448-c8b4b9d61fbd/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5GYxs=
 sigs.k8s.io/controller-tools v0.20.1/go.mod h1:b4qPmjGU3iZwqn34alUU5tILhNa9+VXK+J3QV0fT/uU=
-sigs.k8s.io/e2e-framework v0.7.0 h1:AHkySTC6MvnnMbVSxaO4z1m2MhQKNFP+2Ihs5pRNLlM=
-sigs.k8s.io/e2e-framework v0.7.0/go.mod h1:1ZgXkUSjmnf18/JgHZNEATWjv48O5lJm9aI1QIsRdbw=
+sigs.k8s.io/e2e-framework v0.6.0 h1:p7hFzHnLKO7eNsWGI2AbC1Mo2IYxidg49BiT4njxkrM=
+sigs.k8s.io/e2e-framework v0.6.0/go.mod h1:IREnCHnKgRCioLRmNi0hxSJ1kJ+aAdjEKK/gokcZu4k=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1351,7 +1351,7 @@ k8s.io/utils/net
 k8s.io/utils/ptr
 k8s.io/utils/third_party/forked/golang/btree
 k8s.io/utils/trace
-# sigs.k8s.io/controller-runtime v0.23.3 => sigs.k8s.io/controller-runtime v0.23.1-0.20260424122448-c8b4b9d61fbd
+# sigs.k8s.io/controller-runtime v0.23.1-0.20260424122448-c8b4b9d61fbd
 ## explicit; go 1.26.0
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
@@ -1424,8 +1424,8 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/e2e-framework v0.7.0
-## explicit; go 1.25.7
+# sigs.k8s.io/e2e-framework v0.6.0
+## explicit; go 1.23.0
 sigs.k8s.io/e2e-framework/klient
 sigs.k8s.io/e2e-framework/klient/conf
 sigs.k8s.io/e2e-framework/klient/decoder
@@ -1466,4 +1466,3 @@ sigs.k8s.io/structured-merge-diff/v6/value
 sigs.k8s.io/yaml
 # github.com/cilium/tetragon/api => ./api
 # github.com/cilium/tetragon/pkg/k8s => ./pkg/k8s
-# sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.23.1-0.20260424122448-c8b4b9d61fbd

--- a/vendor/sigs.k8s.io/e2e-framework/klient/conf/config.go
+++ b/vendor/sigs.k8s.io/e2e-framework/klient/conf/config.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"path/filepath"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -98,15 +97,7 @@ func ResolveKubeConfigFile() string {
 	// if KUBECONFIG env is defined then use that
 	kubeConfigPath = os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 	if kubeConfigPath != "" {
-		// handle the variable as a path list, similar to client-go.
-		filePaths := filepath.SplitList(kubeConfigPath)
-		for _, filename := range filePaths {
-			if _, err := os.Stat(filename); err == nil {
-				return filename
-			}
-		}
-		// return the last path in the list if none exist yet.
-		return filePaths[len(filePaths)-1]
+		return kubeConfigPath
 	}
 
 	var (

--- a/vendor/sigs.k8s.io/e2e-framework/klient/decoder/decoder.go
+++ b/vendor/sigs.k8s.io/e2e-framework/klient/decoder/decoder.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/vladimirvivien/gexe/http"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -84,7 +83,7 @@ func DecodeEachFile(ctx context.Context, fsys fs.FS, pattern string, handlerFn H
 	return nil
 }
 
-// DecodeAllFiles resolves files at the filesystem matching the pattern, decoding JSON or YAML files. Supports multi-document files.
+// DecodeAllFiles  resolves files at the filesystem matching the pattern, decoding JSON or YAML files. Supports multi-document files.
 // Falls back to the unstructured.Unstructured type if a matching type cannot be found for the Kind.
 // Options may be provided to configure the behavior of the decoder.
 func DecodeAllFiles(ctx context.Context, fsys fs.FS, pattern string, options ...DecodeOption) ([]k8s.Object, error) {
@@ -141,7 +140,7 @@ func DecodeEach(ctx context.Context, manifest io.Reader, handlerFn HandlerFunc, 
 	return nil
 }
 
-// DecodeAll is a stream of documents of any Kind using either the innate typing of the scheme.
+// DecodeAll is a stream of  documents of any Kind using either the innate typing of the scheme.
 // Falls back to the unstructured.Unstructured type if a matching type cannot be found for the Kind.
 // Options may be provided to configure the behavior of the decoder.
 func DecodeAll(ctx context.Context, manifest io.Reader, options ...DecodeOption) ([]k8s.Object, error) {
@@ -216,18 +215,6 @@ func DecodeFile(fsys fs.FS, manifestPath string, obj k8s.Object, options ...Deco
 	}
 	defer f.Close()
 	return Decode(f, obj, options...)
-}
-
-// DecodeURL decodes a document from the URL of any Kind using either the innate typing of the scheme.
-// Falls back to the unstructured.Unstructured type if a matching type cannot be found for the Kind.
-func DecodeURL(ctx context.Context, url string, handlerFn HandlerFunc, options ...DecodeOption) error {
-	resp := http.Get(url).Do()
-	if resp.Err() != nil {
-		return resp.Err()
-	}
-	defer resp.Body().Close()
-
-	return DecodeEach(ctx, resp.Body(), handlerFn, options...)
 }
 
 // DecodeString decodes a single-document YAML or JSON string into the provided object. Patches are applied

--- a/vendor/sigs.k8s.io/e2e-framework/klient/k8s/resources/resources.go
+++ b/vendor/sigs.k8s.io/e2e-framework/klient/k8s/resources/resources.go
@@ -20,10 +20,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -161,7 +159,7 @@ func (r *Resources) Delete(ctx context.Context, obj k8s.Object, opts ...DeleteOp
 }
 
 func WithGracePeriod(gpt time.Duration) DeleteOption {
-	t := int64(gpt.Seconds())
+	t := gpt.Milliseconds()
 	return func(do *metav1.DeleteOptions) { do.GracePeriodSeconds = &t }
 }
 
@@ -211,7 +209,7 @@ func WithFieldSelector(sel string) ListOption {
 }
 
 func WithTimeout(to time.Duration) ListOption {
-	t := int64(to.Seconds())
+	t := to.Milliseconds()
 	return func(lo *metav1.ListOptions) { lo.TimeoutSeconds = &t }
 }
 
@@ -329,125 +327,6 @@ func (r *Resources) ExecInPod(ctx context.Context, namespaceName, podName, conta
 	}
 
 	return nil
-}
-
-type matcher[T any] func([]T) (T, error)
-
-type predicate[T any] func(T) bool
-
-func match[T any](pred predicate[T], err error) matcher[T] {
-	return func(values []T) (T, error) {
-		for _, value := range values {
-			if pred(value) {
-				return value, nil
-			}
-		}
-
-		var notFound T
-		return notFound, err
-	}
-}
-
-func matchByIndex[T any](idx int, err error) matcher[T] {
-	return func(items []T) (T, error) {
-		if idx >= len(items) {
-			var notFound T
-			return notFound, fmt.Errorf("%w: index %d is out of range with length %d", err, idx, len(items))
-		}
-
-		return items[idx], nil
-	}
-}
-
-var (
-	errPodNotFound       = errors.New("pod not found")
-	errContainerNotFound = errors.New("container not found")
-)
-
-type deploymentOptions struct {
-	podMatcher       matcher[v1.Pod]
-	containerMatcher matcher[v1.Container]
-}
-
-// DeploymentOption extends the default behavior of [ExecInDeployment].
-type DeploymentOption func(*deploymentOptions)
-
-// WithDeploymentPod selects the pod that matches the given condition.
-func WithDeploymentPod(pred predicate[v1.Pod]) DeploymentOption {
-	return func(opts *deploymentOptions) {
-		opts.podMatcher = match(pred, errPodNotFound)
-	}
-}
-
-// WithDeploymentPodIndex selects the pod at the given index.
-func WithDeploymentPodIndex(idx int) DeploymentOption {
-	return func(opts *deploymentOptions) {
-		opts.podMatcher = matchByIndex[v1.Pod](idx, errPodNotFound)
-	}
-}
-
-// WithDeploymentContainer selects the container that matches the given condition.
-func WithDeploymentContainer(pred predicate[v1.Container]) DeploymentOption {
-	return func(opts *deploymentOptions) {
-		opts.containerMatcher = match(pred, errContainerNotFound)
-	}
-}
-
-// WithDeploymentContainerIndex selects the container at the given index.
-func WithDeploymentContainerIndex(idx int) DeploymentOption {
-	return func(opts *deploymentOptions) {
-		opts.containerMatcher = matchByIndex[v1.Container](idx, errContainerNotFound)
-	}
-}
-
-// WithDeploymentContainerName selects the container with the given name.
-func WithDeploymentContainerName(name string) DeploymentOption {
-	return func(opts *deploymentOptions) {
-		opts.containerMatcher = match(
-			func(c v1.Container) bool { return c.Name == name },
-			fmt.Errorf("%w: name %q", errContainerNotFound, name),
-		)
-	}
-}
-
-// ExecInDeployment runs the given command in a container belonging to the deployment with the given name.
-// By default, it selects the first container of the first pod.
-//
-// Pod and container selection can be customized using [WithDeploymentPod], [WithDeploymentContainer],
-// or related functions.
-func (r *Resources) ExecInDeployment(ctx context.Context, namespaceName, deploymentName string, command []string, stdout, stderr *bytes.Buffer, opts ...DeploymentOption) error {
-	options := deploymentOptions{}
-	defaultOpts := []DeploymentOption{WithDeploymentPodIndex(0), WithDeploymentContainerIndex(0)}
-	for _, fn := range append(defaultOpts, opts...) {
-		fn(&options)
-	}
-
-	var deployment appsv1.Deployment
-	if err := r.Get(ctx, deploymentName, namespaceName, &deployment); err != nil {
-		return err
-	}
-
-	sel, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
-	if err != nil {
-		return err
-	}
-
-	var pods v1.PodList
-	if err := r.client.List(ctx, &pods, cr.InNamespace(namespaceName), cr.MatchingLabelsSelector{Selector: sel}); err != nil {
-		return err
-	}
-
-	pod, err := options.podMatcher(pods.Items)
-	if err != nil {
-		return err
-	}
-
-	container, err := options.containerMatcher(pod.Spec.Containers)
-	if err != nil {
-		return err
-	}
-
-	return r.ExecInPod(ctx, namespaceName, pod.Name, container.Name, command, stdout, stderr)
 }
 
 func init() {

--- a/vendor/sigs.k8s.io/e2e-framework/klient/wait/conditions/conditions.go
+++ b/vendor/sigs.k8s.io/e2e-framework/klient/wait/conditions/conditions.go
@@ -304,15 +304,14 @@ func (c *Condition) DeploymentAvailable(name, namespace string) apimachinerywait
 	)
 }
 
-// DaemonSetReady is a helper function used to check if a daemonset's pods are scheduled, ready and rolled out completely
+// DaemonSetReady is a helper function used to check if a daemonset's pods are scheduled and ready
 func (c *Condition) DaemonSetReady(daemonset k8s.Object) apimachinerywait.ConditionWithContextFunc {
 	return func(ctx context.Context) (done bool, err error) {
 		if err := c.resources.Get(ctx, daemonset.GetName(), daemonset.GetNamespace(), daemonset); err != nil {
 			return false, err
 		}
-		ds := daemonset.(*appsv1.DaemonSet) // nolint: errcheck
-		if ds.Status.NumberReady == ds.Status.DesiredNumberScheduled &&
-			ds.Status.UpdatedNumberScheduled == ds.Status.DesiredNumberScheduled {
+		status := daemonset.(*appsv1.DaemonSet).Status // nolint: errcheck
+		if status.NumberReady == status.DesiredNumberScheduled && status.NumberUnavailable == 0 {
 			done = true
 		}
 		return

--- a/vendor/sigs.k8s.io/e2e-framework/pkg/env/env.go
+++ b/vendor/sigs.k8s.io/e2e-framework/pkg/env/env.go
@@ -224,22 +224,18 @@ func (e *testEnv) processTestActions(ctx context.Context, t *testing.T, actions 
 // AfterEachFeature.
 func (e *testEnv) processTestFeature(ctx context.Context, t *testing.T, featureName string, feature types.Feature) context.Context {
 	t.Helper()
-	t.Run(featureName, func(newT *testing.T) {
-		newT.Helper()
-		skipped, message := e.requireFeatureProcessing(feature)
-		if skipped {
-			newT.Skip(message)
-		}
-		// execute beforeEachFeature actions
-		ctx = e.processFeatureActions(ctx, t, feature, e.getBeforeFeatureActions())
+	skipped, message := e.requireFeatureProcessing(feature)
+	if skipped {
+		t.Skip(message)
+	}
+	// execute beforeEachFeature actions
+	ctx = e.processFeatureActions(ctx, t, feature, e.getBeforeFeatureActions())
 
-		// execute feature test
-		ctx = e.execFeature(ctx, newT, feature)
+	// execute feature test
+	ctx = e.execFeature(ctx, t, featureName, feature)
 
-		// execute afterEachFeature actions
-		ctx = e.processFeatureActions(ctx, t, feature, e.getAfterFeatureActions())
-	})
-	return ctx
+	// execute afterEachFeature actions
+	return e.processFeatureActions(ctx, t, feature, e.getAfterFeatureActions())
 }
 
 // processFeatureActions is used to run a series of feature action that were configured as
@@ -481,70 +477,72 @@ func (e *testEnv) executeSteps(ctx context.Context, t *testing.T, steps []types.
 	return ctx
 }
 
-func (e *testEnv) execFeature(ctx context.Context, t *testing.T, f types.Feature) context.Context {
+func (e *testEnv) execFeature(ctx context.Context, t *testing.T, featName string, f types.Feature) context.Context {
 	t.Helper()
+	// feature-level subtest
+	t.Run(featName, func(newT *testing.T) {
+		newT.Helper()
 
-	if fDescription, ok := f.(types.DescribableFeature); ok && fDescription.Description() != "" {
-		t.Logf("Processing Feature: %s", fDescription.Description())
-	}
-
-	// setups run at feature-level
-	setups := features.GetStepsByLevel(f.Steps(), types.LevelSetup)
-	ctx = e.executeSteps(ctx, t, setups)
-
-	// assessments run as feature/assessment sub level
-	assessments := features.GetStepsByLevel(f.Steps(), types.LevelAssess)
-
-	failed := false
-	for i, assess := range assessments {
-		assessName := assess.Name()
-		if dAssess, ok := assess.(types.DescribableStep); ok && dAssess.Description() != "" {
-			t.Logf("Processing Assessment: %s", dAssess.Description())
+		if fDescription, ok := f.(types.DescribableFeature); ok && fDescription.Description() != "" {
+			t.Logf("Processing Feature: %s", fDescription.Description())
 		}
-		if assessName == "" {
-			assessName = fmt.Sprintf("Assessment-%d", i+1)
-		}
-		// shouldFailNow catches whether t.FailNow() is called in the assessment.
-		// If it is, we won't proceed with the next assessment.
-		var shouldFailNow bool
-		var wasSkipped bool
-		t.Run(assessName, func(internalT *testing.T) {
-			internalT.Helper()
-			defer func() {
-				wasSkipped = internalT.Skipped()
-			}()
-			skipped, message := e.requireAssessmentProcessing(assess, i+1)
-			if skipped {
-				internalT.Skip(message)
+
+		// setups run at feature-level
+		setups := features.GetStepsByLevel(f.Steps(), types.LevelSetup)
+		ctx = e.executeSteps(ctx, newT, setups)
+
+		// assessments run as feature/assessment sub level
+		assessments := features.GetStepsByLevel(f.Steps(), types.LevelAssess)
+
+		failed := false
+		for i, assess := range assessments {
+			assessName := assess.Name()
+			if dAssess, ok := assess.(types.DescribableStep); ok && dAssess.Description() != "" {
+				t.Logf("Processing Assessment: %s", dAssess.Description())
 			}
-			// Set shouldFailNow to true before actually running the assessment, because if the assessment
-			// calls t.FailNow(), the function will be abruptly stopped in the middle of `e.executeSteps()`.
-			shouldFailNow = true
-			ctx = e.executeSteps(ctx, internalT, []types.Step{assess})
-			// If we reach this point, it means the assessment did not call t.FailNow().
-			shouldFailNow = false
-		})
-		// Check if the Test assessment under question performed either 2 things:
-		// - a t.FailNow() invocation
-		// - a `t.Fail()` or `t.Failed()` invocation
-		// In one of those cases, we need to track that and stop the next set of assessment in the feature
-		// under test from getting executed. Skipped tests should not trigger this.
-		if !wasSkipped && (shouldFailNow || (e.cfg.FailFast() && t.Failed())) {
-			failed = true
-			break
+			if assessName == "" {
+				assessName = fmt.Sprintf("Assessment-%d", i+1)
+			}
+			// shouldFailNow catches whether t.FailNow() is called in the assessment.
+			// If it is, we won't proceed with the next assessment.
+			var shouldFailNow bool
+			newT.Run(assessName, func(internalT *testing.T) {
+				internalT.Helper()
+				skipped, message := e.requireAssessmentProcessing(assess, i+1)
+				if skipped {
+					internalT.Skip(message)
+				}
+				// Set shouldFailNow to true before actually running the assessment, because if the assessment
+				// calls t.FailNow(), the function will be abruptly stopped in the middle of `e.executeSteps()`.
+				shouldFailNow = true
+				ctx = e.executeSteps(ctx, internalT, []types.Step{assess})
+				// If we reach this point, it means the assessment did not call t.FailNow().
+				shouldFailNow = false
+			})
+			// Check if the Test assessment under question performed either 2 things:
+			// - a t.FailNow() invocation
+			// - a `t.Fail()` or `t.Failed()` invocation
+			// In one of those cases, we need to track that and stop the next set of assessment in the feature
+			// under test from getting executed.
+			if shouldFailNow || (e.cfg.FailFast() && newT.Failed()) {
+				failed = true
+				break
+			}
 		}
-	}
 
-	// Let us fail the test fast and not run the teardown in case if the framework specific fail-fast mode is
-	// invoked to make sure we leave the traces of the failed test behind to enable better debugging for the
-	// test developers
-	if e.cfg.FailFast() && failed {
-		t.FailNow()
-	}
+		// Let us fail the test fast and not run the teardown in case if the framework specific fail-fast mode is
+		// invoked to make sure we leave the traces of the failed test behind to enable better debugging for the
+		// test developers
+		if e.cfg.FailFast() && failed {
+			newT.FailNow()
+		}
 
-	// teardowns run at feature-level
-	teardowns := features.GetStepsByLevel(f.Steps(), types.LevelTeardown)
-	return e.executeSteps(ctx, t, teardowns)
+		// teardowns run at feature-level
+		teardowns := features.GetStepsByLevel(f.Steps(), types.LevelTeardown)
+		ctx = e.executeSteps(ctx, newT, teardowns)
+	})
+
+	return ctx
 }
 
 // requireFeatureProcessing is a wrapper around the requireProcessing function to process the feature level validation
@@ -651,7 +649,7 @@ func (e *testEnv) deepCopyConfig() *envconf.Config {
 
 	labels := make(map[string][]string, len(e.cfg.Labels()))
 	for k, vals := range e.cfg.Labels() {
-		copyVals := make([]string, 0, len(vals))
+		copyVals := make([]string, len(vals))
 		copyVals = append(copyVals, vals...)
 		labels[k] = copyVals
 	}
@@ -659,7 +657,7 @@ func (e *testEnv) deepCopyConfig() *envconf.Config {
 
 	skipLabels := make(map[string][]string, len(e.cfg.SkipLabels()))
 	for k, vals := range e.cfg.SkipLabels() {
-		copyVals := make([]string, 0, len(vals))
+		copyVals := make([]string, len(vals))
 		copyVals = append(copyVals, vals...)
 		skipLabels[k] = copyVals
 	}

--- a/vendor/sigs.k8s.io/e2e-framework/pkg/envconf/config.go
+++ b/vendor/sigs.k8s.io/e2e-framework/pkg/envconf/config.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/flags"
 )
 
-// Config represents the environment configuration
+// Config represents and environment configuration
 type Config struct {
 	client                  klient.Client
 	kubeconfig              string
@@ -100,7 +100,7 @@ func (c *Config) KubeconfigFile() string {
 	return c.kubeconfig
 }
 
-// WithClient updates the environment klient.Client
+// WithClient used to update the environment klient.Client
 func (c *Config) WithClient(client klient.Client) *Config {
 	c.client = client
 	return c
@@ -112,7 +112,7 @@ func (c *Config) GetClient() klient.Client {
 }
 
 // NewClient is a constructor function that returns a previously
-// created klient.Client or creates a new one based on configuration
+// created klient.Client or create a new one based on configuration
 // previously set. Will return an error if unable to do so.
 func (c *Config) NewClient() (klient.Client, error) {
 	if c.client != nil {
@@ -258,7 +258,7 @@ func (c *Config) WithFailFast() *Config {
 	return c
 }
 
-// FailFast indicates if the framework is running in fail fast mode. This
+// FailFast indicate if the framework is running in fail fast mode. This
 // controls the behavior of how the assessments and features are handled
 // if a test encounters a failure result
 func (c *Config) FailFast() bool {

--- a/vendor/sigs.k8s.io/e2e-framework/pkg/types/types.go
+++ b/vendor/sigs.k8s.io/e2e-framework/pkg/types/types.go
@@ -196,11 +196,6 @@ type E2EClusterProvider interface {
 	// using the cluster provider native way
 	GetKubeconfig() string
 
-	// GenerateKubeconfig provides a way to extract the kubeconfig file associated with the cluster in question.
-	// Different from GetKubeconfig, this method is used to extract the kubeconfig using provider native way, where the GetKubeconfig is cached.
-	// It is useful in cases where the kubeconfig file is required to be extracted multiple times during the test run with different arguments.
-	GenerateKubeconfig(args ...string) (string, error)
-
 	// GetKubectlContext is used to extract the kubectl context to be used while performing the operation
 	GetKubectlContext() string
 

--- a/vendor/sigs.k8s.io/e2e-framework/pkg/utils/command.go
+++ b/vendor/sigs.k8s.io/e2e-framework/pkg/utils/command.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 
@@ -94,33 +93,15 @@ func FindOrInstallGoBasedProvider(pPath, provider, module, version string) (stri
 	return "", fmt.Errorf("%s not available even after installation", provider)
 }
 
-// RunCommand runs the command and returns an *exec.Proc with information about the executed process.
-//
-// Deprecated: Please use RunCommandContext instead and provide a context to
-// make sure the command execution can be cancelled if needed.
+// RunCommand run command and returns an *exec.Proc with information about the executed process.
 func RunCommand(command string) *exec.Proc {
-	ctx := context.Background()
-	return RunCommandContext(ctx, command)
-}
-
-// RunCommand runs the command with the provided context and returns an
-// *exec.Proc with information about the executed process.
-func RunCommandContext(ctx context.Context, command string) *exec.Proc {
-	return commandRunner.RunProcWithContext(ctx, command)
+	return commandRunner.RunProc(command)
 }
 
 // RunCommandWithSeperatedOutput run command and returns the results to the provided
 // stdout and stderr io.Writer.
-//
-// Deprecated: Use RunCommandWithSeperatedOutputContext instead and provide a context to.
 func RunCommandWithSeperatedOutput(command string, stdout, stderr io.Writer) error {
-	return RunCommandWithSeperatedOutputContext(context.Background(), command, stdout, stderr)
-}
-
-// RunCommandWithSeperatedOutputContext run command with the provided context
-// and returns the results to the provided stdout and stderr io.Writer.
-func RunCommandWithSeperatedOutputContext(ctx context.Context, command string, stdout, stderr io.Writer) error {
-	p := commandRunner.NewProcWithContext(ctx, command)
+	p := commandRunner.NewProc(command)
 	p.SetStdout(stdout)
 	p.SetStderr(stderr)
 	result := p.Run()
@@ -128,19 +109,10 @@ func RunCommandWithSeperatedOutputContext(ctx context.Context, command string, s
 	return result.Err()
 }
 
-// RunCommandWithCustomWriterContext run command and returns an *exec.Proc with information about the executed process.
+// RunCommandWithCustomWriter run command and returns an *exec.Proc with information about the executed process.
 // This helps map the STDOUT/STDERR to custom writer to extract data from the output.
-//
-// Deprecated: Use RunCommandWithCustomWriterContext instead and provide a
-// context to make sure the command execution can be cancelled if needed.
 func RunCommandWithCustomWriter(command string, stdout, stderr io.Writer) *exec.Proc {
-	return RunCommandWithCustomWriterContext(context.Background(), command, stdout, stderr)
-}
-
-// RunCommandWithCustomWriterContext run command and returns an *exec.Proc with information about the executed process.
-// This helps map the STDOUT/STDERR to custom writer to extract data from the output.
-func RunCommandWithCustomWriterContext(ctx context.Context, command string, stdout, stderr io.Writer) *exec.Proc {
-	p := commandRunner.NewProcWithContext(ctx, command)
+	p := commandRunner.NewProc(command)
 	p.SetStdout(stdout)
 	p.SetStderr(stderr)
 	return p.Run()

--- a/vendor/sigs.k8s.io/e2e-framework/third_party/helm/helm.go
+++ b/vendor/sigs.k8s.io/e2e-framework/third_party/helm/helm.go
@@ -18,7 +18,6 @@ package helm
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -57,8 +56,6 @@ type Opts struct {
 	Wait bool
 	// Timeout is used to indicate the time to wait for any individual Kubernetes ops
 	Timeout string
-	// Context is used to indicate the context to be used for running helm commands.
-	Context context.Context
 }
 
 type Manager struct {
@@ -140,12 +137,6 @@ func WithWait() Option {
 func WithTimeout(timeout string) Option {
 	return func(opts *Opts) {
 		opts.Timeout = timeout
-	}
-}
-
-func WithContext(ctx context.Context) Option {
-	return func(opts *Opts) {
-		opts.Context = ctx
 	}
 }
 
@@ -242,11 +233,6 @@ func (m *Manager) RunTest(opts ...Option) error {
 // run method is used to invoke a helm command to perform a suitable operation.
 // Please make sure to configure the right Opts using the Option helpers
 func (m *Manager) run(opts *Opts) (err error) {
-	ctx := opts.Context
-	// Fallback to background context in case if the context is not provided as part of the options
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if m.path == "" {
 		m.path = "helm"
 	}
@@ -260,7 +246,7 @@ func (m *Manager) run(opts *Opts) (err error) {
 		return
 	}
 	log.V(4).InfoS("Running Helm Operation", "command", command)
-	proc := m.e.NewProcWithContext(ctx, command)
+	proc := m.e.NewProc(command)
 
 	var stderr bytes.Buffer
 	proc.SetStderr(&stderr)

--- a/vendor/sigs.k8s.io/e2e-framework/third_party/kind/kind.go
+++ b/vendor/sigs.k8s.io/e2e-framework/third_party/kind/kind.go
@@ -107,11 +107,11 @@ func (k *Cluster) WithOpts(opts ...support.ClusterOpts) support.E2EClusterProvid
 	return k
 }
 
-func (k *Cluster) getKubeconfig(ctx context.Context, args ...string) (string, error) {
+func (k *Cluster) getKubeconfig() (string, error) {
 	kubecfg := fmt.Sprintf("%s-kubecfg", k.name)
 
 	var stdout, stderr bytes.Buffer
-	err := utils.RunCommandWithSeperatedOutputContext(ctx, fmt.Sprintf(`%s get kubeconfig %s --name %s`, k.path, strings.Join(args, " "), k.name), &stdout, &stderr)
+	err := utils.RunCommandWithSeperatedOutput(fmt.Sprintf(`%s get kubeconfig --name %s`, k.path, k.name), &stdout, &stderr)
 	if err != nil {
 		return "", fmt.Errorf("kind get kubeconfig: stderr: %s: %w", stderr.String(), err)
 	}
@@ -158,7 +158,7 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 
 	if _, ok := k.clusterExists(k.name); ok {
 		log.V(4).Info("Skipping Kind Cluster.Create: cluster already created: ", k.name)
-		kConfig, err := k.getKubeconfig(ctx)
+		kConfig, err := k.getKubeconfig()
 		if err != nil {
 			return "", err
 		}
@@ -174,7 +174,7 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 		command = fmt.Sprintf("%s %s", command, strings.Join(args, " "))
 	}
 	log.V(4).Info("Launching:", command)
-	p := utils.RunCommandContext(ctx, command)
+	p := utils.RunCommand(command)
 	if p.Err() != nil {
 		outBytes, err := io.ReadAll(p.Out())
 		if err != nil {
@@ -188,7 +188,7 @@ func (k *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 	}
 	log.V(4).Info("kind clusters available: ", clusters)
 
-	kConfig, err := k.getKubeconfig(ctx)
+	kConfig, err := k.getKubeconfig()
 	if err != nil {
 		return "", err
 	}
@@ -219,7 +219,7 @@ func (k *Cluster) ExportLogs(ctx context.Context, dest string) error {
 		return err
 	}
 
-	p := utils.RunCommandContext(ctx, fmt.Sprintf(`%s export logs %s --name %s`, k.path, dest, k.name))
+	p := utils.RunCommand(fmt.Sprintf(`%s export logs %s --name %s`, k.path, dest, k.name))
 	if p.Err() != nil {
 		return fmt.Errorf("kind: export cluster %v logs failed: %s: %s", k.name, p.Err(), p.Result())
 	}
@@ -233,7 +233,7 @@ func (k *Cluster) Destroy(ctx context.Context) error {
 		return err
 	}
 
-	p := utils.RunCommandContext(ctx, fmt.Sprintf(`%s delete cluster --name %s`, k.path, k.name))
+	p := utils.RunCommand(fmt.Sprintf(`%s delete cluster --name %s`, k.path, k.name))
 	if p.Err() != nil {
 		outBytes, err := io.ReadAll(p.Out())
 		if err != nil {
@@ -262,7 +262,7 @@ func (k *Cluster) findOrInstallKind() error {
 }
 
 func (k *Cluster) LoadImage(ctx context.Context, image string, args ...string) error {
-	p := utils.RunCommandContext(ctx, fmt.Sprintf(`%s load docker-image --name %s %s`, k.path, k.name, image))
+	p := utils.RunCommand(fmt.Sprintf(`%s load docker-image --name %s %s`, k.path, k.name, image))
 	if p.Err() != nil {
 		return fmt.Errorf("kind: load docker-image %v failed: %s: %s", image, p.Err(), p.Result())
 	}
@@ -270,7 +270,7 @@ func (k *Cluster) LoadImage(ctx context.Context, image string, args ...string) e
 }
 
 func (k *Cluster) LoadImageArchive(ctx context.Context, imageArchive string, args ...string) error {
-	p := utils.RunCommandContext(ctx, fmt.Sprintf(`%s load image-archive --name %s %s`, k.path, k.name, imageArchive))
+	p := utils.RunCommand(fmt.Sprintf(`%s load image-archive --name %s %s`, k.path, k.name, imageArchive))
 	if p.Err() != nil {
 		return fmt.Errorf("kind: load image-archive %v failed: %s: %s", imageArchive, p.Err(), p.Result())
 	}
@@ -306,8 +306,4 @@ func (k *Cluster) WaitForControlPlane(ctx context.Context, client klient.Client)
 
 func (k *Cluster) KubernetesRestConfig() *rest.Config {
 	return k.rc
-}
-
-func (k *Cluster) GenerateKubeconfig(args ...string) (string, error) {
-	return k.getKubeconfig(context.Background(), args...)
 }


### PR DESCRIPTION
We need this version for supporting the new k8s v0.36.0, that has a wrong commit tag, this pin is more recent than v0.23.3 while it's very confusingly named v0.23.1-0.20260424122448-c8b4b9d61fbd.

This way renovate will automatically try to bump and we don't have to remember about the replace. Also replace can be a bit confusing as version is not what you expect from the go.mod, here it's explicit.