### PR TITLE
nok8s: don't return an error for label filters

### DIFF
--- a/pkg/filters/nok8s.go
+++ b/pkg/filters/nok8s.go
@@ -7,7 +7,6 @@ package filters
 
 import (
 	"context"
-	"errors"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 )
@@ -15,5 +14,5 @@ import (
 type LabelsFilter struct{}
 
 func (l *LabelsFilter) OnBuildFilter(_ context.Context, _ *tetragon.Filter) ([]FilterFunc, error) {
-	return nil, errors.New("label filters not supported in nok8s build")
+	return nil, nil
 }


### PR DESCRIPTION
The current code results in:
> Error: failed to receive events: rpc error: code = Unknown desc = label filters not supported in nok8s build

When doing "tetra getevents" for the nok8s build.

Instead of return an error, just ignore the unsupported filters.

Fixes: d833af47155e ("nok8s: update pkg/filters")

