### PR TITLE
add flag to disable event metrics

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -393,7 +393,10 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 
 		reg := metricsconfig.GetRegistry()
 		metricsconfig.InitHealthMetrics(reg)
-		metricsconfig.InitEventsMetrics(reg)
+
+		if option.Config.EnableEventMetrics {
+			metricsconfig.InitEventsMetrics(reg)
+		}
 
 		initK8sMetrics()
 	}

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -390,7 +390,11 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 
 	if option.Config.MetricsServer != "" {
 		go metricsconfig.EnableMetrics(option.Config.MetricsServer)
-		metricsconfig.InitAllMetrics(metricsconfig.GetRegistry())
+
+		reg := metricsconfig.GetRegistry()
+		metricsconfig.InitHealthMetrics(reg)
+		metricsconfig.InitEventsMetrics(reg)
+
 		initK8sMetrics()
 	}
 

--- a/docs/content/en/docs/installation/metrics.md
+++ b/docs/content/en/docs/installation/metrics.md
@@ -10,6 +10,12 @@ Tetragon exposes a number of Prometheus metrics that can be used for two main pu
 1. Monitoring the health of Tetragon itself
 2. Monitoring the activity of processes observed by Tetragon
 
+{{< note >}}
+  When the metrics server is started, Tetragon exposes both health and event
+  metrics by default. You can disable event metrics while keeping health metrics
+  by passing the `--enable-event-metrics=false` flag.
+{{< /note >}}
+
 For the full list, refer to [metrics reference]({{< ref "/docs/reference/metrics" >}}).
 
 ## Enable/Disable Metrics

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -52,6 +52,10 @@ options:
     - name: enable-deprecated-tracingpolicy-grpc
       default_value: "false"
       usage: Enable deprecated gRPC TracingPolicy APIs
+    - name: enable-event-metrics
+      default_value: "true"
+      usage: |
+        Enable per-event metrics. Enabled by default. Health and resource metrics are always available when --metrics-server is set.
     - name: enable-export-aggregation
       default_value: "false"
       usage: Enable JSON export aggregation

--- a/pkg/metrics/metricwithpod_test.go
+++ b/pkg/metrics/metricwithpod_test.go
@@ -26,16 +26,59 @@ var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
 	PolicyName: "fake-policy",
 }
 
-func TestPodDelete(t *testing.T) {
+func TestMetricsWithPod(t *testing.T) {
+	eventMetrics := []string{"tetragon_events_total", "tetragon_policy_events_total", "tetragon_syscalls_total"}
+	healthMetrics := []string{"tetragon_build_info", "tetragon_data_events_total"}
+
 	reg := metricsconfig.GetRegistry()
-	metricsconfig.InitHealthMetrics(reg)
-	metricsconfig.InitEventsMetrics(reg)
+
+	// Only health metrics should be present
+	// * tetragon_build_info
+	// * tetragon_data_events_total
+	t.Run("TestPodDeleteHealthMetricsOnly", func(t *testing.T) {
+		metricsconfig.InitHealthMetrics(reg)
+
+		deletePod()
+		metricSeries := getMetricSeries(t, reg)
+
+		for _, metric := range healthMetrics {
+			require.NotNil(t, metricSeries[metric])
+		}
+
+		// Event metrics should be nil, even though the pod was deleted
+		for _, metric := range eventMetrics {
+			require.Nil(t, metricSeries[metric])
+		}
+
+	})
 
 	// Process four events, each one with different combination of pod/namespace.
 	// These events should be counted by multiple metrics with a "pod" label:
 	// * tetragon_events_total
 	// * tetragon_policy_events_total
 	// * tetragon_syscalls_total
+	t.Run("TestPodDeleteHealthAndEventMetrics", func(t *testing.T) {
+		metricsconfig.InitEventsMetrics(reg)
+
+		deletePod()
+		metricSeries := getMetricSeries(t, reg)
+		checkMetricSeriesCount(t, metricSeries, eventMetrics, 4)
+
+		// Exactly one timeseries should be deleted for each metric (matching both
+		// pod name and namespace).
+		metrics.DeleteMetricsForPod(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake-pod",
+				Namespace: "fake-namespace",
+			},
+		})
+
+		metricSeries = getMetricSeries(t, reg)
+		checkMetricSeriesCount(t, metricSeries, eventMetrics, 3)
+	})
+}
+
+func deletePod() {
 	for _, namespace := range []string{"fake-namespace", "other-namespace"} {
 		for _, pod := range []string{"fake-pod", "other-pod"} {
 			event := tetragon.GetEventsResponse{
@@ -62,20 +105,9 @@ func TestPodDelete(t *testing.T) {
 			eventmetrics.ProcessEvent(&sampleMsgGenericTracepointUnix, &event)
 		}
 	}
-	checkMetricSeriesCount(t, reg, 4)
-
-	// Exactly one timeseries should be deleted for each metric (matching both
-	// pod name and namespace).
-	metrics.DeleteMetricsForPod(&corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "fake-pod",
-			Namespace: "fake-namespace",
-		},
-	})
-	checkMetricSeriesCount(t, reg, 3)
 }
 
-func checkMetricSeriesCount(t *testing.T, registry *prometheus.Registry, seriesCount int) {
+func getMetricSeries(t *testing.T, registry *prometheus.Registry) map[string]*io_prometheus_client.MetricFamily {
 	metricFamilies, err := registry.Gather()
 	require.NoError(t, err)
 
@@ -83,8 +115,12 @@ func checkMetricSeriesCount(t *testing.T, registry *prometheus.Registry, seriesC
 	for _, metricFamily := range metricFamilies {
 		metricNameToSeries[*metricFamily.Name] = metricFamily
 	}
-	for _, metric := range []string{"tetragon_events_total", "tetragon_policy_events_total", "tetragon_syscalls_total"} {
-		metricFamily := metricNameToSeries[metric]
+	return metricNameToSeries
+}
+
+func checkMetricSeriesCount(t *testing.T, metricSeries map[string]*io_prometheus_client.MetricFamily, metrics []string, seriesCount int) {
+	for _, metric := range metrics {
+		metricFamily := metricSeries[metric]
 		require.NotNil(t, metricFamily)
 		assert.Len(t, metricFamily.Metric, seriesCount)
 	}

--- a/pkg/metrics/metricwithpod_test.go
+++ b/pkg/metrics/metricwithpod_test.go
@@ -28,7 +28,8 @@ var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
 
 func TestPodDelete(t *testing.T) {
 	reg := metricsconfig.GetRegistry()
-	metricsconfig.InitAllMetrics(reg)
+	metricsconfig.InitHealthMetrics(reg)
+	metricsconfig.InitEventsMetrics(reg)
 
 	// Process four events, each one with different combination of pod/namespace.
 	// These events should be counted by multiple metrics with a "pod" label:

--- a/pkg/metricsconfig/initmetrics.go
+++ b/pkg/metricsconfig/initmetrics.go
@@ -30,7 +30,7 @@ func InitResourcesMetricsForDocs(registry *prometheus.Registry) {
 	initResourcesMetrics(registry)
 }
 
-func initAllEventsMetrics(registry *prometheus.Registry) {
+func InitEventsMetrics(registry *prometheus.Registry) {
 	eventmetrics.InitEventsMetrics(registry)
 	syscallmetrics.InitMetrics(registry)
 }
@@ -40,9 +40,8 @@ func InitEventsMetricsForDocs(registry *prometheus.Registry) {
 	syscallmetrics.InitMetricsForDocs(registry)
 }
 
-func InitAllMetrics(registry *prometheus.Registry) {
+func InitHealthMetrics(registry *prometheus.Registry) {
 	healthMetrics := EnableHealthMetrics(registry)
 	healthMetrics.Init()
 	initAllResourcesMetrics(registry)
-	initAllEventsMetrics(registry)
 }

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -246,7 +246,8 @@ func getDefaultObserver(tb testing.TB, ctx context.Context, initialSensor *senso
 	// a lot of code changes in a lot of a files.
 	metricsEnableOnce.Do(func() {
 		go metricsconfig.EnableMetrics(metricsAddr)
-		metricsconfig.InitAllMetrics(metricsconfig.GetRegistry())
+		metricsconfig.InitHealthMetrics(metricsconfig.GetRegistry())
+		metricsconfig.InitEventsMetrics(metricsconfig.GetRegistry())
 	})
 
 	tb.Cleanup(func() {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -70,6 +70,7 @@ type config struct {
 	ProcessCacheGCInterval time.Duration
 
 	MetricsServer      string
+	EnableEventMetrics bool
 	MetricsLabelFilter metrics.LabelFilter
 	ServerAddress      string
 	TracingPolicy      string

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -48,6 +48,7 @@ const (
 	KeyEnablePodAnnotations = "enable-pod-annotations"
 
 	KeyMetricsServer      = "metrics-server"
+	KeyEnableEventMetrics = "enable-event-metrics"
 	KeyMetricsLabelFilter = "metrics-label-filter"
 	KeyServerAddress      = "server-address"
 	KeyGopsAddr           = "gops-address"
@@ -234,6 +235,7 @@ func ReadAndSetFlags() error {
 	}
 
 	Config.MetricsServer = viper.GetString(KeyMetricsServer)
+	Config.EnableEventMetrics = viper.GetBool(KeyEnableEventMetrics)
 	Config.MetricsLabelFilter = DefaultLabelFilter().WithEnabledLabels(ParseMetricsLabelFilter(viper.GetString(KeyMetricsLabelFilter)))
 	Config.ServerAddress = viper.GetString(KeyServerAddress)
 
@@ -409,6 +411,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.String(KeyK8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	flags.Int(KeyK8sControlPlaneRetry, 1, "Number of attempts for Kubernetes control plane connection (negative for infinite, zero is invalid, positive for max attempts)")
 	flags.String(KeyMetricsServer, "", "Metrics server address (e.g. ':2112'). Disabled by default")
+	flags.Bool(KeyEnableEventMetrics, true, fmt.Sprintf("Enable per-event metrics. Enabled by default. Health and resource metrics are always available when --%s is set.", KeyMetricsServer))
 	flags.String(KeyMetricsLabelFilter, "namespace,workload,pod,binary", "Comma-separated list of enabled metrics labels. Unknown labels will be ignored.")
 	flags.String(KeyServerAddress, "localhost:54321", "gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock'). An empty address disables the gRPC server")
 	flags.String(KeyGopsAddr, "", "gops server address (e.g. 'localhost:8118'). Disabled by default")


### PR DESCRIPTION
## Description

Add --enable-event-metrics flag (default: true) to allow disabling event metrics while keeping health and resource metrics available.

Split InitAllMetrics into InitHealthMetrics and InitEventsMetrics. Health metrics and resource metrics are always initialized when --metrics-server is set.

Unit tests for metrics config added in 'pkg/metrics/metricwithpod_test.go' also manually tested in a no-k8s environment.

### Changelog

```release-note
metrics: add agent flag to disable event metrics while keeping health metrics
```
