### PR TITLE
usdt: configure sensor's selector maps

### DIFF
--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -200,6 +200,8 @@ func createMultiUsdtSensor(
 	filterMap.SetMaxEntries(len(multiIDs))
 	configMap.SetMaxEntries(len(multiIDs))
 
+	maps = append(maps, createSelectorMaps(load, nil)...)
+
 	if has.sleepableOffload {
 		sleepableOffloadMap := program.MapBuilderProgram("write_offload", load)
 		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
@@ -268,6 +270,8 @@ func createUsdtSensorFromEntry(polInfo *policyInfo, usdtEntry *genericUsdt,
 
 	selMatchBinariesMap := program.MapBuilderProgram("tg_mb_sel_opts", load)
 	maps = append(maps, configMap, tailCalls, filterMap, selMatchBinariesMap)
+
+	maps = append(maps, createSelectorMaps(load, usdtEntry.selectors)...)
 
 	if has.sleepableOffload {
 		sleepableOffloadMap := program.MapBuilderProgram("write_offload", load)

--- a/pkg/sensors/tracing/usdt_test.go
+++ b/pkg/sensors/tracing/usdt_test.go
@@ -534,6 +534,10 @@ func TestUsdtSet(t *testing.T) {
 	policytest.AllPolicyTests.DoObserverTest(t, "usdt-set", nil)
 }
 
+func TestUsdtLoadSelectorMaps(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "usdt-load-selector-maps", nil)
+}
+
 func TestUsdtResolve(t *testing.T) {
 	if !config.EnableLargeProgs() || !bpf.HasUprobeRefCtrOffset() {
 		t.Skip("Need 5.3 or newer kernel for usdt and uprobe ref_ctr_off support for this test.")

--- a/tests/policytests/usdts.go
+++ b/tests/policytests/usdts.go
@@ -78,3 +78,52 @@ spec:
 		},
 	}
 }).RegisterAtInit()
+
+var _ = policytest.NewBuilder("usdt-load-selector-maps").WithLabels("usdt").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: usdt-argfilter-inmap-repro
+spec:
+  usdts:
+    - path: {{ testBinary "usdt-override" }}
+      provider: "tetragon"
+      name: "test_4B"
+      args:
+        - index: 1
+          type: "int32"
+      selectors:
+        - matchArgs:
+            - index: 1
+              operator: "InMap"
+              values:
+                - "321"
+                - "7"
+
+`).WithSkip(func(si *policytest.SkipInfo) string {
+	if !si.AgentInfo.Probes[bpf.LargeProgsProbe] {
+		return "need 5.3 or newer kernel"
+	}
+	if !si.AgentInfo.Probes[bpf.UprobeRefCtrOffsetProbe] {
+		return "need uprobe ref_ctr_off support"
+	}
+	return ""
+}).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	myBin := c.TestBinary("usdt-override")
+	upChecker := ec.NewProcessUsdtChecker("USDT").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(myBin))).
+		WithProvider(sm.Full("tetragon")).
+		WithName(sm.Full("test_4B")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithIntArg(321),
+			))
+
+	return &policytest.Scenario{
+		Name:         "load selector maps",
+		Trigger:      policytest.NewCmdTrigger(myBin, "321", "123").ExpectExitCode(0),
+		EventChecker: ec.NewUnorderedEventChecker(upChecker),
+	}
+}).RegisterAtInit()


### PR DESCRIPTION
This makes USDT work the same as other hook types. Previosly, we only called selectorsMapload() without calling the corresponding createSelectorMaps() to configure the map to be apart of the sensor.

Without calling createSelectorMaps(),
1) The selector maps will not be pinned
2) The selector maps will not have an owner
3) There can be conflict regarding inner map max size at load time

## Testing

Prior to this change, the following policy:
```
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: usdt-argfilter-inmap-repro
spec:
  usdts:
    - path: /host/src/tetragon/contrib/tester-progs/usdt-override
      provider: "tetragon"
      name: "test_4B"
      args:
        - index: 1
          type: "int32"
      selectors:
        - matchArgs:
            - index: 1
              operator: "InMap"
              values:
                - "321"
                - "654"

```
Failed to load on 5.4, with:
> level=error msg="Failed to execute tetragon" error="sensor generic_usdt from collection usdt-argfilter-inmap-repro failed to load: failed prog bpf/objs/bpf_generic_usdt_v53.o kern_version 328959 loadInstance: map load for argfilter_maps failed: failed to insert argfilter_map_0: update: invalid argument"


With this change, the policy can load.