### PR TITLE
tetragoninfo: add darwin stub for bpfProbes

### DIFF
--- a/pkg/tetragoninfo/info_darwin.go
+++ b/pkg/tetragoninfo/info_darwin.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package tetragoninfo
+
+import (
+	"github.com/cilium/tetragon/api/v1/tetragon"
+)
+
+func bpfProbes() []*tetragon.GetInfoResponse_Probe {
+	return nil
+}


### PR DESCRIPTION
Add `info_darwin.go` with a nil-returning `bpfProbes()` stub, matching the existing `info_windows.go`. Without this, the tetra CLI fails to build on macOS:

```
# github.com/cilium/tetragon/pkg/tetragoninfo
pkg/tetragoninfo/info.go:84:12: undefined: bpfProbes
```

Closes #4931
Ref: https://github.com/Homebrew/homebrew-core/pull/280098