### PR TITLE
fix(ci): fail on errors for macOS builds

### DIFF
--- a/Makefile.cli
+++ b/Makefile.cli
@@ -42,6 +42,7 @@ cli-local-release: $(RELEASES) ## Compile tetra CLI release binaries locally
 
 $(RELEASE_FOLDER)/$(TARGET)-%.tar.gz: cli-clean
 	@{ \
+		set -e; \
 		OS=$(word 1,$(subst -, ,$*)); \
 		ARCH=$(word 2,$(subst -, ,$*)); \
 		EXT=""; if [ "$$OS" = "windows" ]; then EXT=".exe"; fi; \


### PR DESCRIPTION
## Description

The macOS builds were failing and we didn't catch the issue because the errors didn't make the job fail. This fix will make the ci job fail when an errors in triggered during the cli-release target execution.

Fixes: https://github.com/cilium/tetragon/issues/4934
