### PR TITLE
metrics: add missing HandlePerfEmptyData error label and initialization

### DIFF
--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -204,7 +204,7 @@ The total number of event handler errors. For internal use only.
 
 | label | values |
 | ----- | ------ |
-| `error` | `event_handler_failed, unknown_opcode` |
+| `error` | `event_handler_failed, perf_empty_data, unknown_opcode` |
 | `opcode` | `0, 13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
 
 ### `tetragon_handling_latency`

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -51,6 +51,7 @@ const (
 
 var eventHandlerErrorLabelValues = map[EventHandlerError]string{
 	HandlePerfUnknownOp:    "unknown_opcode",
+	HandlePerfEmptyData:    "perf_empty_data",
 	HandlePerfHandlerError: "event_handler_failed",
 }
 
@@ -122,6 +123,7 @@ func InitMetrics() {
 	// NB: We initialize only ops.MSG_OP_UNDEF here, but unknown_opcode can occur for any opcode
 	// that is not explicitly handled.
 	GetHandlerErrors(ops.MSG_OP_UNDEF, HandlePerfUnknownOp).Add(0)
+	GetHandlerErrors(ops.MSG_OP_UNDEF, HandlePerfEmptyData).Add(0)
 
 	for er := range debugTypeLabelValues {
 		GetDebugTotal(er).Add(0)

--- a/pkg/metrics/errormetrics/errormetrics_test.go
+++ b/pkg/metrics/errormetrics/errormetrics_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package errormetrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/tetragon/pkg/api/ops"
+)
+
+func TestHandlePerfEmptyData(t *testing.T) {
+	// verify label exists and is correct
+	assert.Equal(t, "perf_empty_data", HandlePerfEmptyData.String())
+
+	// use relative comparison to avoid depending on global state from InitMetrics()
+	// verify metric initializes to 0
+	before := testutil.ToFloat64(GetHandlerErrors(ops.MSG_OP_UNDEF, HandlePerfEmptyData))
+	HandlerErrorsInc(ops.MSG_OP_UNDEF, HandlePerfEmptyData)
+	after := testutil.ToFloat64(GetHandlerErrors(ops.MSG_OP_UNDEF, HandlePerfEmptyData))
+	assert.InDelta(t, before+1, after, 1e-9)
+}


### PR DESCRIPTION
### Description
`HandlePerfEmptyData` was defined and used in `observer.go` but was missing from `eventHandlerErrorLabelValues`, causing `String()` to return an empty label. Add the missing label and initialize the metric in `InitMetrics()` along with the other handler error types.

Add unit tests for the new label and metric initialization.

**Testing**
- `go test ./pkg/metrics/errormetrics/...`
- `go test -race ./pkg/metrics/errormetrics/...`
- `make check`

### Changelog
```release-note
Fix missing label and initialization for HandlePerfEmptyData metric.
```