### PR TITLE
Use kubebuilder XValidation for spec.hostSelector

### DIFF
--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -129,6 +129,8 @@ Currently, only the "name" field is supported.<br/>
         <td>
           HostSelector selects hosts that this policy applies to.
 For now only ~ (none) and {} (all) is supported.<br/>
+          <br/>
+            <i>Validations</i>:<li>!has(self.matchLabels) && !has(self.matchExpressions): The hostSelector should be either null or {}.</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8892,6 +8894,8 @@ Currently, only the "name" field is supported.<br/>
         <td>
           HostSelector selects hosts that this policy applies to.
 For now only ~ (none) and {} (all) is supported.<br/>
+          <br/>
+            <i>Validations</i>:<li>!has(self.matchLabels) && !has(self.matchExpressions): The hostSelector should be either null or {}.</li>
         </td>
         <td>false</td>
       </tr><tr>

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -1192,6 +1192,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: The hostSelector should be either null or {}.
+                  rule: '!has(self.matchLabels) && !has(self.matchExpressions)'
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1192,6 +1192,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: The hostSelector should be either null or {}.
+                  rule: '!has(self.matchLabels) && !has(self.matchExpressions)'
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -1192,6 +1192,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: The hostSelector should be either null or {}.
+                  rule: '!has(self.matchLabels) && !has(self.matchExpressions)'
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1192,6 +1192,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: The hostSelector should be either null or {}.
+                  rule: '!has(self.matchLabels) && !has(self.matchExpressions)'
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -109,6 +109,7 @@ type TracingPolicySpec struct {
 	ContainerSelector *slimv1.LabelSelector `json:"containerSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="!has(self.matchLabels) && !has(self.matchExpressions)",message="The hostSelector should be either null or {}."
 	// HostSelector selects hosts that this policy applies to.
 	// For now only ~ (none) and {} (all) is supported.
 	HostSelector *slimv1.LabelSelector `json:"hostSelector,omitempty"`

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.0"
+const CustomResourceDefinitionSchemaVersion = "1.8.1"

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -1192,6 +1192,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: The hostSelector should be either null or {}.
+                  rule: '!has(self.matchLabels) && !has(self.matchExpressions)'
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1192,6 +1192,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: The hostSelector should be either null or {}.
+                  rule: '!has(self.matchLabels) && !has(self.matchExpressions)'
               kprobes:
                 description: A list of kprobe specs.
                 items:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -109,6 +109,7 @@ type TracingPolicySpec struct {
 	ContainerSelector *slimv1.LabelSelector `json:"containerSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="!has(self.matchLabels) && !has(self.matchExpressions)",message="The hostSelector should be either null or {}."
 	// HostSelector selects hosts that this policy applies to.
 	// For now only ~ (none) and {} (all) is supported.
 	HostSelector *slimv1.LabelSelector `json:"hostSelector,omitempty"`

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.0"
+const CustomResourceDefinitionSchemaVersion = "1.8.1"


### PR DESCRIPTION
As we already described in the documentation, spec.hostSelector only supports null and {} as values and this is checked in the agent as well.

This patch adds a kubebuilder validation as well.
