### PR TITLE
tetragon: add btfType and btfTypeModule

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -741,6 +741,81 @@ It is also possible to resolve arrays (`int arr[100]`) and dynamic arrays
   type: uint32
 ```
 
+#### Initial BTF type
+
+By default, Tetragon starts `resolve` from the BTF type of the hook argument.
+For kprobes, tracepoints, and LSM hooks, this type comes from the kernel BTF
+prototype. For uprobes and USDT probes, it comes from the BTF file configured
+with `btfPath`.
+
+Use `btfType` when the hook argument type is too generic, or when you need to
+cast the argument to a more specific structure before resolving fields. The
+`btfType` value is the BTF struct name without the `struct` prefix.
+
+The following example resolves fields from the `struct sockaddr_in` view of the
+second `security_socket_connect` argument:
+
+```yaml
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "socket-connect-address"
+spec:
+  kprobes:
+  - call: "security_socket_connect"
+    syscall: false
+    args:
+    - index: 1
+      type: "uint16"
+      label: "sockaddr_in.sin_port"
+      btfType: "sockaddr_in"
+      resolve: "sin_port"
+    - index: 1
+      type: "uint32"
+      label: "sockaddr_in.sin_addr.s_addr"
+      btfType: "sockaddr_in"
+      resolve: "sin_addr.s_addr"
+```
+
+#### Kernel module BTF types
+
+For kprobe arguments, use `btfTypeModule` with `btfType` when the structure is
+defined by a kernel module instead of the main kernel BTF. The module name
+should be the kernel module name, without a `.ko` suffix.
+
+```yaml
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "af-alg-bind"
+spec:
+  kprobes:
+  - call: "security_socket_bind"
+    syscall: false
+    args:
+    - index: 1
+      type: "uint16"
+      label: "sockaddr_alg.salg_family"
+      btfType: "sockaddr_alg_new"
+      btfTypeModule: "af_alg"
+      resolve: "salg_family"
+    - index: 1
+      type: "string"
+      label: "sockaddr_alg.salg_name"
+      btfType: "sockaddr_alg_new"
+      btfTypeModule: "af_alg"
+      resolve: "salg_name"
+```
+
+{{< caution >}}
+When `btfTypeModule` is set, Tetragon first tries to read module BTF exposed by
+the kernel in `/sys/kernel/btf/<module>`. If that is not available, Tetragon
+fails to load the policy.
+{{< /caution >}}
+
+If `btfTypeModule` is omitted, Tetragon searches the main kernel BTF first. For
+hooks that belong to a loaded module, Tetragon also tries that hook's module BTF.
+
 ## Data
 
 Kprobes allow definition of `data` fields and following `matchData` selector

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -462,9 +462,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -569,9 +577,17 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -702,9 +718,17 @@ A return argument to include in the trace output.
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1906,9 +1930,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2013,9 +2045,17 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2146,9 +2186,17 @@ A return argument to include in the trace output.
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3275,9 +3323,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5387,9 +5443,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6518,9 +6582,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6625,9 +6697,17 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6732,9 +6812,17 @@ A return argument to include in the trace output.
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7826,9 +7914,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9227,9 +9323,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9334,9 +9438,17 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9467,9 +9579,17 @@ A return argument to include in the trace output.
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10671,9 +10791,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10778,9 +10906,17 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10911,9 +11047,17 @@ A return argument to include in the trace output.
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12040,9 +12184,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14152,9 +14304,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15283,9 +15443,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15390,9 +15558,17 @@ This field is used only for char_buf and char_iovec types.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15497,9 +15673,17 @@ A return argument to include in the trace output.
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -16591,9 +16775,17 @@ Maximum of 16 Tags are supported.<br/>
         <td><b>btfType</b></td>
         <td>string</td>
         <td>
-          Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-type.<br/>
+          Type to use as the initial resolve type. For kprobe args it looks up the named struct
+from the kernel BTF, casting the argument's type before traversing the resolve path.
+For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>btfTypeModule</b></td>
+        <td>string</td>
+        <td>
+          Kernel module that contains the BTFType. This is used only for kprobe args.
+The module must already be loaded and expose BTF in /sys/kernel/btf.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -125,9 +125,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -240,9 +245,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -368,9 +378,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -1206,9 +1221,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1321,9 +1341,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1449,9 +1474,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -2259,9 +2289,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -3736,9 +3771,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4526,9 +4566,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4641,9 +4686,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4777,9 +4827,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -5550,9 +5605,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -125,9 +125,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -240,9 +245,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -368,9 +378,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -1206,9 +1221,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1321,9 +1341,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1449,9 +1474,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -2259,9 +2289,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -3736,9 +3771,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4526,9 +4566,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4641,9 +4686,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4777,9 +4827,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -5550,9 +5605,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -286,7 +286,9 @@ func ResolveBTFPath(
 		if err != nil {
 			return nil, fmt.Errorf("fail parsing array index : %w", err)
 		}
-		if idx >= t.Nelems {
+		// BTF encodes flexible array members with nr_elems=0, so there is
+		// no static upper bound to enforce for those arrays.
+		if t.Nelems != 0 && idx >= t.Nelems {
 			return nil, fmt.Errorf("array index out of bound. Nelems=%d, got=%d", t.Nelems, idx)
 		}
 		return processArray(btfArgs, t.Type, pathToFound, i, idx)

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -106,14 +106,40 @@ func GetCachedBTFFile() string {
 }
 
 func FindBTFStruct(name string) (*btf.Struct, error) {
-	var ty *btf.Struct
-
 	spec, err := NewBTF()
 	if err != nil {
 		return nil, err
 	}
+	return findBTFStructInSpec(spec, name)
+}
 
-	err = firstTypeByName(spec, name, &ty)
+func FindBTFStructInModule(name, module string) (*btf.Struct, error) {
+	spec, err := btf.LoadKernelModuleSpec(module)
+	if err != nil {
+		return nil, err
+	}
+	return findBTFStructInSpec(spec, name)
+}
+
+func FindBTFStructInHookModule(hook, name string) (*btf.Struct, string, error) {
+	ks, err := ksyms.KernelSymbols()
+	if err != nil {
+		return nil, "", err
+	}
+
+	kmod, err := ks.GetKmod(hook)
+	if err != nil {
+		return nil, "", err
+	}
+
+	st, err := FindBTFStructInModule(name, kmod)
+	return st, kmod, err
+}
+
+func findBTFStructInSpec(spec *btf.Spec, name string) (*btf.Struct, error) {
+	var ty *btf.Struct
+
+	err := firstTypeByName(spec, name, &ty)
 	return ty, err
 }
 

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -380,5 +380,12 @@ func processArray(
 	if len(pathToFound) > i+1 {
 		return ResolveBTFPath(btfArgs, targetType, pathToFound, i+1)
 	}
+	switch t := targetType.(type) {
+	case *btf.Pointer:
+		btfArgs[i].IsPointer = uint16(1)
+		targetType = t.Target
+	case *btf.Int, *btf.Enum:
+		btfArgs[i].IsPointer = uint16(1)
+	}
 	return &targetType, nil
 }

--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -720,6 +720,7 @@ func TestResolveBTFPathZeroLengthArray(t *testing.T) {
 			assert.Equal(t, uint32(2), btfArgs[0].Offset)
 			// [X]
 			assert.Equal(t, uint16(1), btfArgs[1].IsInitialized)
+			assert.Equal(t, uint16(1), btfArgs[1].IsPointer)
 			assert.Equal(t, tt.offset, btfArgs[1].Offset)
 		})
 	}

--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -681,6 +681,50 @@ func TestParseArrayIdxStr(t *testing.T) {
 	}
 }
 
+func TestResolveBTFPathZeroLengthArray(t *testing.T) {
+	u8Ty := &btf.Int{Name: "unsigned char", Size: 1}
+	root := &btf.Struct{
+		Name: "sockaddr",
+		Size: 2,
+		Members: []btf.Member{
+			{
+				Name: "sa_data",
+				Type: &btf.Array{
+					Type:   u8Ty,
+					Index:  &btf.Int{Name: "int", Size: 4},
+					Nelems: 0,
+				},
+				Offset: btf.Bits(16),
+			},
+		},
+	}
+
+	for _, tt := range []struct {
+		path   string
+		offset uint32
+	}{
+		{path: "[0]", offset: 0},
+		{path: "[13]", offset: 13},
+	} {
+		t.Run(tt.path, func(t *testing.T) {
+			var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
+
+			ty, err := ResolveBTFPath(&btfArgs, root, []string{"sa_data", tt.path}, 0)
+			require.NoError(t, err)
+			require.NotNil(t, ty)
+
+			assert.Equal(t, btf.Type(u8Ty), *ty)
+
+			// sa_data
+			assert.Equal(t, uint16(1), btfArgs[0].IsInitialized)
+			assert.Equal(t, uint32(2), btfArgs[0].Offset)
+			// [X]
+			assert.Equal(t, uint16(1), btfArgs[1].IsInitialized)
+			assert.Equal(t, tt.offset, btfArgs[1].Offset)
+		})
+	}
+}
+
 func TestProcessMembersErrorPrecedence(t *testing.T) {
 	intTy := &btf.Int{Name: "int", Size: 4}
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -125,9 +125,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -240,9 +245,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -368,9 +378,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -1206,9 +1221,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1321,9 +1341,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1449,9 +1474,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -2259,9 +2289,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -3736,9 +3771,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4526,9 +4566,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4641,9 +4686,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4777,9 +4827,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -5550,9 +5605,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -125,9 +125,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -240,9 +245,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -368,9 +378,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -1206,9 +1221,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1321,9 +1341,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1449,9 +1474,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -2259,9 +2289,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -3736,9 +3771,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4526,9 +4566,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4641,9 +4686,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4777,9 +4827,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -5550,9 +5605,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -113,6 +113,10 @@ type KProbeArg struct {
 	// from the kernel BTF, casting the argument's type before traversing the resolve path.
 	// For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
 	BTFType string `json:"btfType,omitempty"`
+	// +kubebuilder:validation:Optional
+	// Kernel module that contains the BTFType. This is used only for kprobe args.
+	// The module must already be loaded and expose BTF in /sys/kernel/btf.
+	BTFTypeModule string `json:"btfTypeModule,omitempty"`
 }
 
 type BinarySelector struct {

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -109,9 +109,9 @@ type KProbeArg struct {
 	// Source of the data, if missing the default if function arguments
 	Source string `json:"source"`
 	// +kubebuilder:validation:Optional
-	// Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-	// the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-	// type.
+	// Type to use as the initial resolve type. For kprobe args it looks up the named struct
+	// from the kernel BTF, casting the argument's type before traversing the resolve path.
+	// For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
 	BTFType string `json:"btfType,omitempty"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.2"
+const CustomResourceDefinitionSchemaVersion = "1.8.3"

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -150,6 +150,12 @@ func resolveBTFArg(hook string, arg *v1alpha1.KProbeArg, tp bool) (*ebtf.Type, [
 			return nil, [api.MaxBTFArgDepth]api.ConfigBTFArg{}, err
 		}
 		ty = ebtf.Type(st)
+	} else if arg.BTFType != "" {
+		st, err := btf.FindBTFStruct(arg.BTFType)
+		if err != nil {
+			return nil, [api.MaxBTFArgDepth]api.ConfigBTFArg{}, err
+		}
+		ty = ebtf.Type(st)
 	} else {
 		param, err := btf.FindBTFFuncParamFromHook(hook, index)
 		if err != nil {

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -132,6 +132,30 @@ func resolveUserBTFArg(arg *v1alpha1.KProbeArg, btfPath string) (*ebtf.Type, [ap
 	return resolveBTFType(arg, ty)
 }
 
+func findBTFTypeStruct(hook string, arg *v1alpha1.KProbeArg) (*ebtf.Struct, error) {
+	if arg.BTFTypeModule != "" {
+		st, err := btf.FindBTFStructInModule(arg.BTFType, arg.BTFTypeModule)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find BTF type %q in module %q: %w", arg.BTFType, arg.BTFTypeModule, err)
+		}
+		return st, nil
+	}
+
+	st, err := btf.FindBTFStruct(arg.BTFType)
+	if err == nil || !errors.Is(err, ebtf.ErrNotFound) {
+		return st, err
+	}
+
+	st, module, moduleErr := btf.FindBTFStructInHookModule(hook, arg.BTFType)
+	if moduleErr == nil {
+		return st, nil
+	}
+	if module == "" {
+		return nil, err
+	}
+	return nil, fmt.Errorf("failed to find BTF type %q in kernel BTF or module %q: %w", arg.BTFType, module, errors.Join(err, moduleErr))
+}
+
 func resolveBTFArg(hook string, arg *v1alpha1.KProbeArg, tp bool) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {
 	// tracepoints have extra first internal argument, so we need to adjust the index
 	index := int(arg.Index)
@@ -151,7 +175,7 @@ func resolveBTFArg(hook string, arg *v1alpha1.KProbeArg, tp bool) (*ebtf.Type, [
 		}
 		ty = ebtf.Type(st)
 	} else if arg.BTFType != "" {
-		st, err := btf.FindBTFStruct(arg.BTFType)
+		st, err := findBTFTypeStruct(hook, arg)
 		if err != nil {
 			return nil, [api.MaxBTFArgDepth]api.ConfigBTFArg{}, err
 		}

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -168,6 +168,87 @@ spec:
 	}
 }
 
+func TestResolveBTFArgWithBTFType(t *testing.T) {
+	rawPolicy := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "kprobes"
+spec:
+  kprobes:
+  - call: "security_socket_connect"
+    args:
+    - index: 1
+      type: "uint16"
+      label: "sockaddr.sa_family"
+      btfType: "sockaddr"
+      resolve: "sa_family"
+    - index: 1
+      type: "uint8"
+      label: "sockaddr.sa_data[0]"
+      btfType: "sockaddr"
+      resolve: "sa_data[0]"
+    - index: 1
+      type: "uint16"
+      label: "sockaddr_in.sin_port"
+      btfType: "sockaddr_in"
+      resolve: "sin_port"
+    - index: 1
+      type: "uint32"
+      label: "sockaddr_in.sin_addr.s_addr"
+      btfType: "sockaddr_in"
+      resolve: "sin_addr.s_addr"
+    - index: 1
+      type: "uint8"
+      label: "sockaddr_un.sun_path[0]"
+      btfType: "sockaddr_un"
+      resolve: "sun_path[0]"
+    - index: 1
+      type: "uint16"
+      label: "sockaddr_un.sun_family"
+      btfType: "sockaddr_un"
+      resolve: "sun_family"
+  `
+	policy, err := tracingpolicy.FromYAML(rawPolicy)
+	require.NoError(t, err, "FromYAML rawPolicy error %q", err)
+
+	tests := map[string]struct {
+		wantType  int
+		wantDepth int
+	}{
+		"sockaddr.sa_family":          {gt.GenericU16Type, 1},
+		"sockaddr.sa_data[0]":         {gt.GenericU8Type, 2},
+		"sockaddr_in.sin_port":        {gt.GenericU16Type, 1},
+		"sockaddr_in.sin_addr.s_addr": {gt.GenericU32Type, 2},
+		"sockaddr_un.sun_path[0]":     {gt.GenericU8Type, 2},
+		"sockaddr_un.sun_family":      {gt.GenericU16Type, 1},
+	}
+
+	for _, hook := range policy.TpSpec().KProbes {
+		for _, arg := range hook.Args {
+			test, ok := tests[arg.Label]
+			require.True(t, ok, "missing test case for %q", arg.Label)
+
+			t.Run(arg.Label, func(t *testing.T) {
+				lastBTFType, btfArg, err := resolveBTFArg(hook.Call, &arg, false)
+				require.NoError(t, err, hook.Call)
+				require.NotNil(t, lastBTFType)
+
+				argType := findTypeFromBTFType(&arg, lastBTFType)
+				require.Equal(t, test.wantType, argType, "Type %q is not supported", (*lastBTFType).TypeName())
+
+				for i, entry := range btfArg {
+					if i < test.wantDepth {
+						require.Equal(t, uint16(1), entry.IsInitialized, "BTF arg depth %d", i)
+						continue
+					}
+					require.Zero(t, entry.IsInitialized, "BTF arg depth %d", i)
+				}
+			})
+		}
+	}
+}
+
 func TestAppendMacrosSelectors(t *testing.T) {
 	tests := map[string]struct {
 		selectors         []v1alpha1.KProbeSelector

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -249,6 +249,19 @@ spec:
 	}
 }
 
+func TestResolveBTFArgWithBTFTypeModule(t *testing.T) {
+	arg := v1alpha1.KProbeArg{
+		Index:         1,
+		Type:          "uint16",
+		BTFType:       "sockaddr_un",
+		BTFTypeModule: "tetragon_test_module_that_does_not_exist",
+		Resolve:       "sun_family",
+	}
+
+	_, _, err := resolveBTFArg("security_socket_connect", &arg, false)
+	require.ErrorContains(t, err, `failed to find BTF type "sockaddr_un" in module "tetragon_test_module_that_does_not_exist"`)
+}
+
 func TestAppendMacrosSelectors(t *testing.T) {
 	tests := map[string]struct {
 		selectors         []v1alpha1.KProbeSelector

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -73,6 +73,7 @@ import (
 	"github.com/cilium/tetragon/pkg/sensors/base"
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
 	testsensor "github.com/cilium/tetragon/pkg/sensors/test"
+	_ "github.com/cilium/tetragon/tests/policytests"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,6 +143,10 @@ func TestKprobeObjectLoad(t *testing.T) {
 // debug because we can write things on stdout which will not generate events.
 func TestKprobeLseek(t *testing.T) {
 	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-lseek", nil)
+}
+
+func TestKprobeBTFTypeModuleAFAlgBind(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-btf-type-module-af-alg-bind", nil)
 }
 
 func getTestKprobeObjectWRChecker(t *testing.T) ec.MultiEventChecker {

--- a/tests/policytests/kprobes.go
+++ b/tests/policytests/kprobes.go
@@ -6,10 +6,18 @@
 package tests
 
 import (
+	"context"
+	"fmt"
+
+	ebtf "github.com/cilium/ebpf/btf"
+	"golang.org/x/sys/unix"
+
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/bpf"
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/testutils/policytest"
+	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 )
 
 // This file contains tests on kernel functions.
@@ -79,3 +87,109 @@ spec:
 		EventChecker: ec.NewUnorderedEventChecker(argChecker),
 	}
 }).RegisterAtInit()
+
+const (
+	afAlgModuleName = "af_alg"
+	afAlgType       = "hash"
+	afAlgName       = "sha1"
+)
+
+type afAlgBindTrigger struct{}
+
+func (afAlgBindTrigger) Trigger(_ context.Context) error {
+	return triggerAFAlgBind()
+}
+
+func triggerAFAlgBind() error {
+	fd, err := unix.Socket(unix.AF_ALG, unix.SOCK_SEQPACKET, 0)
+	if err != nil {
+		return fmt.Errorf("socket(AF_ALG): %w", err)
+	}
+	defer unix.Close(fd)
+
+	if err := unix.Bind(fd, &unix.SockaddrALG{
+		Type: afAlgType,
+		Name: afAlgName,
+	}); err != nil {
+		return fmt.Errorf("bind(AF_ALG, %s/%s): %w", afAlgType, afAlgName, err)
+	}
+	return nil
+}
+
+func skipAFAlgBTFTypeModule(_ *policytest.SkipInfo) string {
+	if !bpf.HasProgramLargeSize() {
+		return "BTF resolve requires large BPF programs"
+	}
+	if err := triggerAFAlgBind(); err != nil {
+		return err.Error()
+	}
+
+	spec, err := ebtf.LoadKernelModuleSpec(afAlgModuleName)
+	if err != nil {
+		return fmt.Sprintf("kernel module BTF for %s is not available: %s", afAlgModuleName, err)
+	}
+
+	var st *ebtf.Struct
+	if err := spec.TypeByName("sockaddr_alg_new", &st); err != nil {
+		return fmt.Sprintf("kernel module BTF type sockaddr_alg_new is not available: %s", err)
+	}
+	return ""
+}
+
+var _ = policytest.NewBuilder("kprobe-btf-type-module-af-alg-bind").
+	WithLabels("kprobes").
+	WithSkip(skipAFAlgBTFTypeModule).
+	WithPolicyTemplate(fmt.Sprintf(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "btf-type-module-af-alg"
+spec:
+  kprobes:
+  - call: "security_socket_bind"
+    syscall: false
+    args:
+    - index: 1
+      type: "uint16"
+      label: "sockaddr_alg.salg_family"
+      btfType: "sockaddr_alg_new"
+      btfTypeModule: "%s"
+      resolve: "salg_family"
+    - index: 1
+      type: "string"
+      label: "sockaddr_alg.salg_type"
+      btfType: "sockaddr_alg_new"
+      btfTypeModule: "%s"
+      resolve: "salg_type"
+    - index: 1
+      type: "string"
+      label: "sockaddr_alg.salg_name"
+      btfType: "sockaddr_alg_new"
+      btfTypeModule: "%s"
+      resolve: "salg_name"
+`, afAlgModuleName, afAlgModuleName, afAlgModuleName)).
+	AddScenario(func(_ *policytest.Conf) *policytest.Scenario {
+		checker := ec.NewProcessKprobeChecker("").
+			WithFunctionName(sm.Full("security_socket_bind")).
+			WithProcess(ec.NewProcessChecker().
+				WithBinary(sm.Suffix(tus.Conf().SelfBinary))).
+			WithArgs(ec.NewKprobeArgumentListMatcher().
+				WithOperator(lc.Ordered).
+				WithValues(
+					ec.NewKprobeArgumentChecker().
+						WithUintArg(unix.AF_ALG).
+						WithLabel(sm.Full("sockaddr_alg.salg_family")),
+					ec.NewKprobeArgumentChecker().
+						WithStringArg(sm.Full(afAlgType)).
+						WithLabel(sm.Full("sockaddr_alg.salg_type")),
+					ec.NewKprobeArgumentChecker().
+						WithStringArg(sm.Full(afAlgName)).
+						WithLabel(sm.Full("sockaddr_alg.salg_name")),
+				))
+
+		return &policytest.Scenario{
+			Name:         "bind AF_ALG socket and check sockaddr_alg BTF module fields",
+			Trigger:      afAlgBindTrigger{},
+			EventChecker: ec.NewUnorderedEventChecker(checker),
+		}
+	}).RegisterAtInit()

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -125,9 +125,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -240,9 +245,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -368,9 +378,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -1206,9 +1221,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1321,9 +1341,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1449,9 +1474,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -2259,9 +2289,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -3736,9 +3771,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4526,9 +4566,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4641,9 +4686,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4777,9 +4827,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -5550,9 +5605,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -125,9 +125,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -240,9 +245,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -368,9 +378,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -1206,9 +1221,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1321,9 +1341,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -1449,9 +1474,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -2259,9 +2289,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -3736,9 +3771,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4526,9 +4566,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4641,9 +4686,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.
@@ -4777,9 +4827,14 @@ spec:
                       properties:
                         btfType:
                           description: |-
-                            Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                            the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                            type.
+                            Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                            from the kernel BTF, casting the argument's type before traversing the resolve path.
+                            For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                          type: string
+                        btfTypeModule:
+                          description: |-
+                            Kernel module that contains the BTFType. This is used only for kprobe args.
+                            The module must already be loaded and expose BTF in /sys/kernel/btf.
                           type: string
                         index:
                           description: Position of the argument.
@@ -5550,9 +5605,14 @@ spec:
                         properties:
                           btfType:
                             description: |-
-                              Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-                              the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-                              type.
+                              Type to use as the initial resolve type. For kprobe args it looks up the named struct
+                              from the kernel BTF, casting the argument's type before traversing the resolve path.
+                              For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
+                            type: string
+                          btfTypeModule:
+                            description: |-
+                              Kernel module that contains the BTFType. This is used only for kprobe args.
+                              The module must already be loaded and expose BTF in /sys/kernel/btf.
                             type: string
                           index:
                             description: Position of the argument.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -113,6 +113,10 @@ type KProbeArg struct {
 	// from the kernel BTF, casting the argument's type before traversing the resolve path.
 	// For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
 	BTFType string `json:"btfType,omitempty"`
+	// +kubebuilder:validation:Optional
+	// Kernel module that contains the BTFType. This is used only for kprobe args.
+	// The module must already be loaded and expose BTF in /sys/kernel/btf.
+	BTFTypeModule string `json:"btfTypeModule,omitempty"`
 }
 
 type BinarySelector struct {

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -109,9 +109,9 @@ type KProbeArg struct {
 	// Source of the data, if missing the default if function arguments
 	Source string `json:"source"`
 	// +kubebuilder:validation:Optional
-	// Type of original argument. This is currently only used in UsdtSpecs and UprobeSpecs for arguments with
-	// the Resolve attribute set. It relies on the BTF file defined by BTFPath to extract the
-	// type.
+	// Type to use as the initial resolve type. For kprobe args it looks up the named struct
+	// from the kernel BTF, casting the argument's type before traversing the resolve path.
+	// For UprobeSpecs and UsdtSpecs it looks up the type from the BTF file defined by BTFPath.
 	BTFType string `json:"btfType,omitempty"`
 }
 

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.2"
+const CustomResourceDefinitionSchemaVersion = "1.8.3"


### PR DESCRIPTION
- allow to change base resolve type with `btfType`
- allow to specify kernel module with `btfTypeModule` as source of the `btfType` type

example:
```
args:
- index: 1
  type: "uint16"
  label: "sockaddr_alg.salg_family"
  btfType: "sockaddr_alg_new"
  btfTypeModule: "af_alg"
  resolve: "salg_family"
- index: 1
  type: "string"
  label: "sockaddr_alg.salg_name"
  btfType: "sockaddr_alg_new"
  btfTypeModule: "salg_family"
  resolve: "salg_name"
```