### PR TITLE
grpc: Support mTLS for tetragon grpc server

### DIFF
--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
@@ -106,9 +107,16 @@ func NewClient(ctx context.Context, address string, timeout time.Duration) (*Cli
 	c.SignalCtx, c.signalCancel = signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	c.Ctx, c.timeoutCancel = context.WithTimeout(c.SignalCtx, timeout)
 
-	var err error
+	tlsCreds, err := TLSCredentials(TLS)
+	if err != nil {
+		return nil, fmt.Errorf("building TLS credentials: %w", err)
+	}
+	creds := credentials.TransportCredentials(insecure.NewCredentials())
+	if tlsCreds != nil {
+		creds = tlsCreds
+	}
 	c.conn, err = grpc.NewClient(address,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultServiceConfig(RetryPolicy(Retries)),
 		grpc.WithMaxCallAttempts(Retries+1), // maxAttempt includes the first call
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)),

--- a/cmd/tetra/common/tls.go
+++ b/cmd/tetra/common/tls.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package common
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/credentials"
+)
+
+// Flag keys exposed by the tetra CLI for TLS dialing.
+const (
+	KeyTLSCertFile   = "tls-cert-file"
+	KeyTLSKeyFile    = "tls-key-file"
+	KeyTLSCAFiles    = "tls-ca-cert-files"
+	KeyTLSServerName = "tls-server-name"
+	KeyTLSSkipVerify = "tls-skip-verify"
+)
+
+// TLSConfig holds the parsed TLS dial configuration captured from the tetra
+// root flags. Subcommands consume this via [TLSCredentials].
+type TLSConfig struct {
+	CertFile   string
+	KeyFile    string
+	CAFiles    []string
+	ServerName string
+	SkipVerify bool
+}
+
+// TLS is the package-level holder populated by AddTLSFlags.
+var TLS TLSConfig
+
+// Enabled reports whether the dial should switch from plaintext to TLS.
+// --tls-skip-verify and --tls-server-name only refine an already-active
+// TLS dial; on their own they don't trigger TLS mode.
+func (c TLSConfig) Enabled() bool {
+	return c.CertFile != "" || c.KeyFile != "" || len(c.CAFiles) > 0
+}
+
+// Validate enforces the minimum invariants. --tls-skip-verify with
+// --tls-ca-cert-files is rejected because crypto/tls ignores RootCAs when
+// InsecureSkipVerify is true, which would silently no-op the CA bundle.
+func (c TLSConfig) Validate() error {
+	if (c.CertFile == "") != (c.KeyFile == "") {
+		return fmt.Errorf("--%s and --%s must be set together", KeyTLSCertFile, KeyTLSKeyFile)
+	}
+	if c.SkipVerify && len(c.CAFiles) > 0 {
+		return fmt.Errorf("--%s makes --%s a no-op (crypto/tls ignores RootCAs when verification is skipped); pick one",
+			KeyTLSSkipVerify, KeyTLSCAFiles)
+	}
+	return nil
+}
+
+// AddTLSFlags wires the persistent TLS flags onto cmd. Call exactly once on
+// the tetra root command.
+func AddTLSFlags(cmd *cobra.Command) {
+	flags := cmd.PersistentFlags()
+	flags.StringVar(&TLS.CertFile, KeyTLSCertFile, "", "Path to client certificate (PEM) for mTLS")
+	flags.StringVar(&TLS.KeyFile, KeyTLSKeyFile, "", "Path to client private key (PEM) for mTLS")
+	flags.StringSliceVar(&TLS.CAFiles, KeyTLSCAFiles, nil, "Paths to PEM CA bundles used to verify the server certificate")
+	flags.StringVar(&TLS.ServerName, KeyTLSServerName, "", "Override SNI / certificate hostname when dialing the server")
+	flags.BoolVar(&TLS.SkipVerify, KeyTLSSkipVerify, false, "Disable server certificate verification (development only)")
+}
+
+// TLSCredentials returns gRPC transport credentials, or (nil, nil) when
+// cfg.Enabled() is false so callers can fall back to plaintext.
+func TLSCredentials(cfg TLSConfig) (credentials.TransportCredentials, error) {
+	if !cfg.Enabled() {
+		return nil, nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	tlsCfg := &tls.Config{
+		MinVersion:         tls.VersionTLS13,
+		ServerName:         cfg.ServerName,
+		InsecureSkipVerify: cfg.SkipVerify, //nolint:gosec // gated by --tls-skip-verify, dev-only
+	}
+	if cfg.CertFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading client cert/key: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+	if len(cfg.CAFiles) > 0 {
+		pool := x509.NewCertPool()
+		for _, p := range cfg.CAFiles {
+			pem, err := os.ReadFile(p)
+			if err != nil {
+				return nil, fmt.Errorf("reading CA bundle %q: %w", p, err)
+			}
+			if !pool.AppendCertsFromPEM(pem) {
+				return nil, fmt.Errorf("CA bundle %q contained no valid PEM certificates", p)
+			}
+		}
+		tlsCfg.RootCAs = pool
+	}
+	return credentials.NewTLS(tlsCfg), nil
+}

--- a/cmd/tetra/common/tls_test.go
+++ b/cmd/tetra/common/tls_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package common
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTLSConfigEnabled(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  TLSConfig
+		want bool
+	}{
+		{name: "zero", cfg: TLSConfig{}},
+		{name: "skip-verify alone", cfg: TLSConfig{SkipVerify: true}},
+		{name: "server-name alone", cfg: TLSConfig{ServerName: "x"}},
+		{name: "ca alone", cfg: TLSConfig{CAFiles: []string{"a"}}, want: true},
+		{name: "cert alone", cfg: TLSConfig{CertFile: "a"}, want: true},
+		{name: "key alone", cfg: TLSConfig{KeyFile: "a"}, want: true},
+		{name: "cert+key", cfg: TLSConfig{CertFile: "a", KeyFile: "b"}, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.cfg.Enabled())
+		})
+	}
+}
+
+func TestTLSConfigValidate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		cfg     TLSConfig
+		wantErr bool
+	}{
+		{name: "zero"},
+		{name: "cert+key ok", cfg: TLSConfig{CertFile: "a", KeyFile: "b"}},
+		{name: "cert without key", cfg: TLSConfig{CertFile: "a"}, wantErr: true},
+		{name: "key without cert", cfg: TLSConfig{KeyFile: "b"}, wantErr: true},
+		{name: "skip-verify+ca rejected", cfg: TLSConfig{SkipVerify: true, CAFiles: []string{"x"}}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.cfg.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestTLSCredentialsDisabledReturnsNil(t *testing.T) {
+	t.Parallel()
+	creds, err := TLSCredentials(TLSConfig{})
+	require.NoError(t, err)
+	require.Nil(t, creds)
+}
+
+func TestTLSCredentialsLoadsCAAndCert(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	caCert, caKey, caPath := writeCA(t, dir)
+	certPath, keyPath := writeLeaf(t, dir, "client", caCert, caKey)
+
+	creds, err := TLSCredentials(TLSConfig{
+		CertFile: certPath,
+		KeyFile:  keyPath,
+		CAFiles:  []string{caPath},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+}
+
+func TestTLSCredentialsRejectsMissingFiles(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  TLSConfig
+	}{
+		{name: "missing cert", cfg: TLSConfig{CertFile: "/no/such/cert", KeyFile: "/no/such/key"}},
+		{name: "missing ca", cfg: TLSConfig{CAFiles: []string{"/no/such/ca"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := TLSCredentials(tc.cfg)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestTLSCredentialsRejectsBadCABundle(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bogus := filepath.Join(dir, "bogus.pem")
+	require.NoError(t, os.WriteFile(bogus, []byte("not pem\n"), 0600))
+
+	_, err := TLSCredentials(TLSConfig{CAFiles: []string{bogus}})
+	require.Error(t, err)
+}
+
+// writeCA mints a self-signed CA and writes it to dir/ca.pem.
+func writeCA(t *testing.T, dir string) (*x509.Certificate, *ecdsa.PrivateKey, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	path := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600))
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key, path
+}
+
+// writeLeaf mints a leaf cert signed by ca and returns paths to its
+// cert and key in dir.
+func writeLeaf(t *testing.T, dir, name string, ca *x509.Certificate, caKey *ecdsa.PrivateKey) (certPath, keyPath string) {
+	t.Helper()
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	certPath = filepath.Join(dir, name+".pem")
+	keyPath = filepath.Join(dir, name+".key")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600))
+	keyDER, err := x509.MarshalECPrivateKey(leafKey)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0600))
+	return certPath, keyPath
+}

--- a/cmd/tetra/eventlog/client.go
+++ b/cmd/tetra/eventlog/client.go
@@ -5,13 +5,14 @@ package eventlog
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/cilium/tetragon/cmd/tetra/common"
-
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/cmd/tetra/common"
 )
 
 type ClientWithContext struct {
@@ -30,10 +31,17 @@ func NewClient() (*ClientWithContext, error) {
 	c := &ClientWithContext{}
 	c.ctx, c.timeoutCancel = context.WithTimeout(context.Background(), common.Timeout)
 
-	var err error
+	tlsCreds, err := common.TLSCredentials(common.TLS)
+	if err != nil {
+		return nil, fmt.Errorf("building TLS credentials: %w", err)
+	}
+	creds := credentials.TransportCredentials(insecure.NewCredentials())
+	if tlsCreds != nil {
+		creds = tlsCreds
+	}
 	c.conn, err = grpc.NewClient(
 		common.ResolveServerAddress(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(creds),
 		grpc.WithMaxCallAttempts(common.Retries+1), // maxAttempt includes the first call
 	)
 	if err != nil {

--- a/cmd/tetra/main.go
+++ b/cmd/tetra/main.go
@@ -49,5 +49,6 @@ func New() *cobra.Command {
 	flags.DurationVar(&common.Timeout, common.KeyTimeout, 30*time.Second, "Connection timeout")
 	flags.IntVar(&common.Retries, common.KeyRetries, 1, "Connection retries with exponential backoff")
 	flags.IntVar(&common.MaxRecvMsgSize, common.KeyMaxRecvMsgSize, defaults.DefaultMaxGRPCRecvMsgSize, "Maximum gRPC message size in bytes the client can receive")
+	common.AddTLSFlags(rootCmd)
 	return rootCmd
 }

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -120,15 +120,21 @@ func absPath(p string) string {
 	return ret
 }
 
-// Save daemon information so it is used by client cli but
-// also by bugtool
+// saveInitInfo writes daemon info read by tetra and bugtool. ServerAddr
+// advertises the unix listener (when one runs) so in-pod tooling
+// defaults to the trusted IPC channel rather than the TCP listener,
+// which may require TLS / mTLS.
 func saveInitInfo() error {
+	addr := ""
+	if path, ok := resolveUnixSocketPath(option.Config.ServerAddress); ok {
+		addr = "unix://" + path
+	}
 	info := bugtool.InitInfo{
 		ExportFname: absPath(option.Config.ExportFilename),
 		LibDir:      absPath(option.Config.HubbleLib),
 		BTFFname:    absPath(option.Config.BTF),
 		MetricsAddr: option.Config.MetricsServer,
-		ServerAddr:  option.Config.ServerAddress,
+		ServerAddr:  addr,
 		GopsAddr:    option.Config.GopsAddr,
 		MapDir:      absPath(bpf.MapPrefixPath()),
 		PID:         os.Getpid(),

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -63,7 +63,10 @@ import (
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/cilium/tetragon/pkg/certloader"
 )
 
 var (
@@ -688,45 +691,130 @@ func getExporter(ctx context.Context, server *server.Server) (*exporter.Exporter
 	return exporter.NewExporter(ctx, &req, server, encoder, writer, rateLimiter)
 }
 
-func Serve(ctx context.Context, listenAddr string, srv *server.Server, logSrv *eventlog.Server) error {
-	// we use an empty listen address to effectively disable the gRPC server
-	if len(listenAddr) == 0 {
+// Serve starts the Tetragon gRPC server. listenAddr drives the topology:
+// "" disables gRPC; "unix://X" runs a single plaintext listener at X;
+// on Linux, a TCP address runs that listener plus an in-pod plaintext
+// unix socket at the platform default path, with --server-tls-* gating
+// the TCP path. Windows skips the sidecar unix listener.
+//
+// extraOpts apply to every listener; callers should not pass grpc.Creds
+// here. TLS is attached to the TCP path via buildServerTLSOptions.
+func Serve(ctx context.Context, listenAddr string, srv *server.Server, logSrv *eventlog.Server, extraOpts ...grpc.ServerOption) error {
+	if listenAddr == "" {
 		return nil
 	}
-	grpcServer := grpc.NewServer()
-	tetragon.RegisterFineGuidanceSensorsServer(grpcServer, srv)
-	tetragon.RegisterEventLogServiceServer(grpcServer, logSrv)
-
+	register := func(s *grpc.Server) {
+		tetragon.RegisterFineGuidanceSensorsServer(s, srv)
+		tetragon.RegisterEventLogServiceServer(s, logSrv)
+	}
 	proto, addr, err := server.SplitListenAddr(listenAddr)
 	if err != nil {
 		return fmt.Errorf("failed to parse listen address: %w", err)
 	}
-	go func(proto, addr string) {
-		var listener net.Listener
-		var err error
-		if proto == "unix" {
-			listener, err = unixlisten.ListenWithRename(addr, 0660)
-		} else {
-			listener, err = net.Listen(proto, addr)
+
+	if proto == "unix" {
+		if err := serveOne(ctx, "unix", addr, extraOpts, register); err != nil {
+			return fmt.Errorf("starting unix gRPC listener: %w", err)
 		}
-		if err != nil {
-			logger.Fatal(log, "Failed to start gRPC server", "protocol", proto, "address", addr, logfields.Error, err)
+		return nil
+	}
+
+	if sockPath, ok := resolveUnixSocketPath(listenAddr); ok {
+		if err := serveOne(ctx, "unix", sockPath, extraOpts, register); err != nil {
+			return fmt.Errorf("starting unix gRPC listener: %w", err)
 		}
+	}
+
+	tlsOpts, tlsEnabled, err := buildServerTLSOptions(ctx)
+	if err != nil {
+		return err
+	}
+	if !tlsEnabled {
+		log.Warn("Tetragon gRPC TCP listener is exposing the API without TLS; configure --"+
+			option.KeyServerTLSCertFile+" and --"+
+			option.KeyServerTLSKeyFile+" to enable it",
+			"address", addr)
+	}
+	grpcOpts := append([]grpc.ServerOption{}, extraOpts...)
+	grpcOpts = append(grpcOpts, tlsOpts...)
+	if err := serveOne(ctx, proto, addr, grpcOpts, register); err != nil {
+		return fmt.Errorf("starting TCP gRPC listener: %w", err)
+	}
+	return nil
+}
+
+// serveOne binds the listener synchronously so bind failures surface as
+// a returned error rather than a runtime fatal.
+func serveOne(
+	ctx context.Context,
+	proto, addr string,
+	grpcOpts []grpc.ServerOption,
+	register func(*grpc.Server),
+) error {
+	var listener net.Listener
+	var err error
+	if proto == "unix" {
+		listener, err = unixlisten.ListenWithRename(addr, 0660)
+	} else {
+		listener, err = net.Listen(proto, addr)
+	}
+	if err != nil {
+		return fmt.Errorf("listen %s://%s: %w", proto, addr, err)
+	}
+	grpcServer := grpc.NewServer(grpcOpts...)
+	register(grpcServer)
+
+	go func() {
 		log.Info("Starting gRPC server", "protocol", proto, "address", addr)
-		if err = grpcServer.Serve(listener); err != nil {
-			log.Error("Failed to close gRPC server", logfields.Error, err)
+		if err := grpcServer.Serve(listener); err != nil {
+			log.Error("gRPC Serve returned", logfields.Error, err)
 		}
-	}(proto, addr)
-	go func(proto, addr string) {
+	}()
+	go func() {
 		<-ctx.Done()
 		grpcServer.Stop()
-		// if proto is unix, ListenWithRename() creates the socket
-		// then renames it, so explicitly clean it up.
 		if proto == "unix" {
 			os.Remove(addr)
 		}
-	}(proto, addr)
+	}()
 	return nil
+}
+
+// buildServerTLSOptions returns the credentials option for the TCP
+// listener (or nil when TLS is disabled). The boolean reports whether
+// TLS is actually active for logging accuracy.
+func buildServerTLSOptions(ctx context.Context) ([]grpc.ServerOption, bool, error) {
+	cfg := certloader.Config{
+		CertFile:          option.Config.ServerTLSCertFile,
+		KeyFile:           option.Config.ServerTLSKeyFile,
+		ClientCAFiles:     option.Config.ServerTLSClientCAFiles,
+		RequireClientCert: option.Config.ServerTLSRequireClientCert,
+	}
+	if !cfg.Enabled() {
+		return nil, false, nil
+	}
+	// Lazy load tolerates a provisioner (cert-manager, cilium-certgen Job)
+	// that writes the Secret after the agent starts; Watch promotes the
+	// Reloader to Ready as soon as the files appear.
+	reloader, err := certloader.NewReloaderLazy(cfg)
+	if err != nil {
+		return nil, false, fmt.Errorf("preparing gRPC TLS: %w", err)
+	}
+	certloader.Watch(ctx, reloader)
+	log.Info("gRPC TLS enabled",
+		"mtls", cfg.RequireClientCert,
+		"cert", cfg.CertFile,
+		"key", cfg.KeyFile,
+		"client-ca-files", len(cfg.ClientCAFiles),
+		"ready", reloader.Ready(),
+	)
+	if !reloader.Ready() {
+		log.Warn("gRPC TLS material not yet on disk; handshakes will fail until files appear at the configured paths",
+			"cert", cfg.CertFile,
+			"key", cfg.KeyFile,
+		)
+	}
+	return []grpc.ServerOption{grpc.Creds(credentials.NewTLS(reloader.ServerConfig()))}, true, nil
 }
 
 func startGopsServer() error {

--- a/cmd/tetragon/main_linux.go
+++ b/cmd/tetragon/main_linux.go
@@ -12,9 +12,28 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/reader/namespace"
 	"github.com/cilium/tetragon/pkg/reader/proc"
+	"github.com/cilium/tetragon/pkg/server"
 
 	"github.com/spf13/viper"
 )
+
+// resolveUnixSocketPath returns the unix socket path the agent should
+// expose for in-pod tooling and whether one should be started, derived
+// from listenAddr: a "unix://X" address yields X; a TCP address yields
+// defaults.DefaultUnixSocket; an empty or invalid address yields ("", false).
+func resolveUnixSocketPath(listenAddr string) (string, bool) {
+	if listenAddr == "" {
+		return "", false
+	}
+	proto, addr, err := server.SplitListenAddr(listenAddr)
+	if err != nil {
+		return "", false
+	}
+	if proto == "unix" {
+		return addr, true
+	}
+	return defaults.DefaultUnixSocket, true
+}
 
 func logCurrentSecurityContext() {
 	proc.LogCurrentSecurityContext()

--- a/cmd/tetragon/main_windows.go
+++ b/cmd/tetragon/main_windows.go
@@ -24,3 +24,10 @@ func checkStructAlignments() error {
 
 func setNetNSDir() {
 }
+
+// resolveUnixSocketPath is a no-op on Windows: the agent does not
+// advertise or open a unix socket sidecar listener, since the default
+// Linux path (defaults.DefaultUnixSocket) is not available there.
+func resolveUnixSocketPath(_ string) (string, bool) {
+	return "", false
+}

--- a/docs/content/en/docs/installation/configuration.md
+++ b/docs/content/en/docs/installation/configuration.md
@@ -47,6 +47,7 @@ To read more about Tetragon configuration, please check our reference pages:
 * For Kubernetes deployments, see the [Helm chart]({{< ref "/docs/reference/helm-chart" >}}) reference.
 * For Container or systemd deployments, see the [Daemon configuration]({{< ref "/docs/reference/daemon-configuration" >}})
 reference.
+* To secure the gRPC API with TLS or mTLS, see [gRPC TLS / mTLS]({{< ref "/docs/installation/grpc-tls" >}}).
 
 ## Enable Process Credentials
 

--- a/docs/content/en/docs/installation/grpc-tls.md
+++ b/docs/content/en/docs/installation/grpc-tls.md
@@ -1,0 +1,135 @@
+---
+title: "Secure the gRPC API with TLS"
+linkTitle: "gRPC TLS / mTLS"
+weight: 8
+description: "Enable TLS or mTLS on the Tetragon gRPC TCP listener"
+---
+
+Tetragon serves its gRPC API on two listeners:
+
+* An always-on unix-domain socket at `/var/run/tetragon/tetragon.sock`,
+  reserved for in-pod IPC and protected by file permissions.
+* An optional TCP listener for off-host clients. TLS only applies here.
+
+This page shows how to enable TLS, switch to mTLS, and connect with `tetra`.
+
+{{< caution >}}
+TLS settings are silently ignored when `--server-address` points at a
+`unix://` socket. Configure a TCP address (for example `0.0.0.0:54321`)
+before enabling TLS.
+{{< /caution >}}
+
+## Quick start (Helm, auto-provisioned)
+
+The chart can issue and rotate certificates for you. The default
+`auto.method=helm` is the simplest option and requires no extra components.
+
+```shell
+helm upgrade --install tetragon cilium/tetragon -n kube-system \
+  --set tetragon.grpc.address=0.0.0.0:54321 \
+  --set tetragon.grpc.tls.enabled=true
+```
+
+The chart generates a CA and a server certificate with a wildcard SAN over
+`*.tetragon-grpc.cilium.io`, and writes them to a Secret mounted at
+`/var/lib/tetragon/tls/` inside each agent pod. Clients must override SNI to
+match this domain (see [Connect with `tetra`](#connect-with-tetra)).
+
+## Enable mTLS
+
+mTLS makes the agent reject TCP connections that do not present a client
+certificate signed by the bundled CA.
+
+```shell
+helm upgrade --install tetragon cilium/tetragon -n kube-system \
+  --set tetragon.grpc.address=0.0.0.0:54321 \
+  --set tetragon.grpc.tls.enabled=true \
+  --set tetragon.grpc.tls.requireClientCert=true
+```
+
+You then mint client certificates from the same CA and pass them to `tetra`
+or your own gRPC client.
+
+## Provisioning methods
+
+Pick one method via `tetragon.grpc.tls.auto.method`:
+
+| Method        | When to use                                                                                                                      |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------|
+| `helm`        | Default. Helm renders the cert/key Secret directly. Rotation requires `helm upgrade`.                                            |
+| `cronJob`     | Periodic rotation by `cilium-certgen`. A bootstrap Job seeds the Secret on install; a CronJob refreshes it on `auto.schedule`.   |
+| `certmanager` | Hand off issuance to [cert-manager](https://cert-manager.io/). Set `auto.certManagerIssuerRef` to your `Issuer`/`ClusterIssuer`. |
+
+Tunables (`tetragon.grpc.tls.*`) are listed in the
+[Helm chart reference]({{< ref "/docs/reference/helm-chart" >}}).
+
+## Bring your own certificates
+
+Disable auto-provisioning and point at an existing Secret:
+
+```shell
+helm upgrade --install tetragon cilium/tetragon -n kube-system \
+  --set tetragon.grpc.address=0.0.0.0:54321 \
+  --set tetragon.grpc.tls.enabled=true \
+  --set tetragon.grpc.tls.auto.enabled=false \
+  --set tetragon.grpc.tls.server.existingSecret=my-tetragon-grpc-tls
+```
+
+The Secret must contain:
+
+* `tls.crt` — PEM server certificate
+* `tls.key` — matching PEM private key
+* `ca.crt` — PEM CA bundle (required when `requireClientCert=true`)
+
+## Connect with `tetra`
+
+Pass the CA bundle and, for mTLS, the client cert and key. The auto-provisioned
+server cert is wildcard, so override SNI to any hostname under
+`tetragon-grpc.cilium.io`.
+
+```shell
+tetra \
+  --server-address tetragon.example.com:54321 \
+  --tls-ca-cert-files ca.crt \
+  --tls-cert-file client.crt \
+  --tls-key-file client.key \
+  --tls-server-name node.tetragon-grpc.cilium.io \
+  getevents
+```
+
+Drop `--tls-cert-file` / `--tls-key-file` if the server is in TLS-only mode.
+
+{{< caution >}}
+`--tls-skip-verify` disables server certificate verification and is intended
+for local development only. It is mutually exclusive with `--tls-ca-cert-files`.
+{{< /caution >}}
+
+## Standalone deployments
+
+For container or systemd installs, set the daemon flags directly through
+[drop-in configuration files]({{< ref "/docs/reference/daemon-configuration#configuration-precedence" >}}):
+
+```shell
+echo "0.0.0.0:54321"                       > /etc/tetragon/tetragon.conf.d/server-address
+echo "/etc/tetragon/tls/tls.crt"           > /etc/tetragon/tetragon.conf.d/server-tls-cert-file
+echo "/etc/tetragon/tls/tls.key"           > /etc/tetragon/tetragon.conf.d/server-tls-key-file
+# For mTLS, also set:
+echo "true"                                > /etc/tetragon/tetragon.conf.d/server-tls-require-client-cert
+echo "/etc/tetragon/tls/ca.crt"            > /etc/tetragon/tetragon.conf.d/server-tls-client-ca-files
+```
+
+The full flag list is in the
+[Daemon configuration reference]({{< ref "/docs/reference/daemon-configuration" >}}).
+
+## Certificate rotation
+
+The agent watches the parent directories of every TLS file with `fsnotify`
+and reloads atomically when the contents change. No restart is required when
+a Secret or mounted file is updated in place — the next handshake uses the
+new material.
+
+## See also
+
+* [Helm chart reference]({{< ref "/docs/reference/helm-chart" >}})
+* [Daemon configuration reference]({{< ref "/docs/reference/daemon-configuration" >}})
+* [Troubleshooting gRPC TLS]({{< ref "/docs/troubleshooting/grpc-tls" >}})

--- a/docs/content/en/docs/installation/tetra-cli.md
+++ b/docs/content/en/docs/installation/tetra-cli.md
@@ -93,6 +93,23 @@ fetch precompiled binaries. You can also use it to build from sources (using the
 brew install tetra
 ```
 
+## Connect to a TLS-protected server
+
+If the Tetragon agent runs the gRPC API over TLS or mTLS, point `tetra` at the
+TCP listener and pass the matching credentials:
+
+```shell
+tetra \
+  --server-address tetragon.example.com:54321 \
+  --tls-ca-cert-files ca.crt \
+  --tls-cert-file client.crt \
+  --tls-key-file client.key \
+  getevents
+```
+
+See [gRPC TLS / mTLS]({{< ref "/docs/installation/grpc-tls" >}}) for the full
+flag list and provisioning options.
+
 ## Install a specific release
 
 You can retrieve the release of `tetra` along the release of Tetragon on GitHub

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -27,6 +27,17 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":1},"generateCA":true,"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.2.5"},"nodeSelector":{},"podLabels":{},"resources":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | cilium-certgen settings used by tetragon.grpc.tls.auto.method=cronJob. Mirrors the same block in cilium/cilium so operators familiar with the hubble TLS workflow find consistent knobs. |
+| certgen.affinity | object | `{}` | Affinity for certgen pods. |
+| certgen.annotations | object | `{"cronJob":{},"job":{}}` | Annotations applied to certgen Job/CronJob objects. |
+| certgen.cronJob.failedJobsHistoryLimit | int | `1` | Number of failed CronJob runs to retain. |
+| certgen.cronJob.successfulJobsHistoryLimit | int | `1` | Number of successful CronJob runs to retain. |
+| certgen.generateCA | bool | `true` | Whether the certgen invocation should generate a CA when one isn't found in the configured CA Secret. |
+| certgen.nodeSelector | object | `{}` | Node selector for certgen pods. |
+| certgen.podLabels | object | `{}` | Pod labels added to certgen pods. |
+| certgen.resources | object | `{}` | Resource requests/limits for the certgen container. |
+| certgen.tolerations | list | `[]` | Tolerations for certgen pods. |
+| certgen.ttlSecondsAfterFinished | int | `1800` | TTL applied to the bootstrap Job once it completes. |
 | crds.installMethod | string | `"operator"` | Method for installing CRDs. Supported values are: "operator", "helm" and "none". The "operator" method allows for fine-grained control over which CRDs are installed and by default doesn't perform CRD downgrades. These can be configured in tetragonOperator section. The "helm" method always installs all CRDs for the chart version. |
 | daemonSetAnnotations | object | `{}` |  |
 | daemonSetLabelsOverride | object | `{}` |  |
@@ -111,6 +122,23 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.gops.port | int | `8118` | The port at which to expose gops. |
 | tetragon.grpc.address | string | `"unix:///var/run/tetragon/tetragon.sock"` | The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock |
 | tetragon.grpc.enabled | bool | `true` | Whether to enable exposing Tetragon gRPC. |
+| tetragon.grpc.tls | object | `{"auto":{"certManagerIssuerRef":{},"certValidityDuration":365,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"},"ca":{"cert":"","certValidityDuration":1095,"key":""},"enabled":false,"requireClientCert":false,"server":{"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[]}}` | gRPC TLS / mTLS configuration for the optional TCP listener (tetragon.grpc.address); the always-on unix-domain listener at /var/run/tetragon/tetragon.sock is unaffected.  The auto-provisioned server cert uses a wildcard SAN over a synthetic DNS domain (*.tetragon-grpc.cilium.io) so a single Secret covers every DaemonSet pod. Clients must override SNI to <any>.tetragon-grpc.cilium.io to validate. See _helpers.tpl `tetragon.grpcTls.domain` for details; add Service-style or per-node identities via server.extraDnsNames / server.extraIpAddresses below. |
+| tetragon.grpc.tls.auto | object | `{"certManagerIssuerRef":{},"certValidityDuration":365,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"}` | Configure automatic TLS certificate generation. |
+| tetragon.grpc.tls.auto.certManagerIssuerRef | object | `{}` | cert-manager IssuerRef used when method=certmanager. [Example] certManagerIssuerRef:   group: cert-manager.io   kind: ClusterIssuer   name: ca-issuer |
+| tetragon.grpc.tls.auto.certValidityDuration | int | `365` | Generated certificate validity duration in days. Defaults to 365 (1 year). |
+| tetragon.grpc.tls.auto.enabled | bool | `true` | Auto-generate certificates. When false, you must provide a Secret yourself (see server.existingSecret). |
+| tetragon.grpc.tls.auto.method | string | `"helm"` | Method used to auto-generate certificates. Supported values: - helm:        Helm renders the cert/key Secret directly. - cronJob:     A Kubernetes CronJob runs cilium-certgen to (re)issue                the cert; a one-shot Job seeds it on install. - certmanager: cert-manager issues and rotates the cert. |
+| tetragon.grpc.tls.auto.schedule | string | `"0 0 1 */4 *"` | Schedule for certificate regeneration; only honored when method=cronJob. Empty disables the recurring CronJob, leaving only the one-shot bootstrap Job. |
+| tetragon.grpc.tls.ca | object | `{"cert":"","certValidityDuration":1095,"key":""}` | In-cluster CA used by the helm and cronJob methods. |
+| tetragon.grpc.tls.ca.cert | string | `""` | base64-encoded PEM CA certificate. When both cert and key are set, helm/cronJob reuse this CA instead of generating a fresh one. |
+| tetragon.grpc.tls.ca.certValidityDuration | int | `1095` | Validity duration in days for an auto-generated CA. Only used when ca.cert/key are unset. |
+| tetragon.grpc.tls.ca.key | string | `""` | base64-encoded PEM CA private key. Required when ca.cert is set. |
+| tetragon.grpc.tls.enabled | bool | `false` | Enable TLS on the TCP gRPC listener. When false, the listener (if any) is plaintext. |
+| tetragon.grpc.tls.requireClientCert | bool | `false` | Require and verify client certificates (mTLS). When true, the agent rejects TCP gRPC connections that don't present a valid client cert signed by one of the bundled CAs. |
+| tetragon.grpc.tls.server | object | `{"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[]}` | Server cert configuration. |
+| tetragon.grpc.tls.server.existingSecret | string | `""` | Use an existing Secret (must contain tls.crt + tls.key, plus ca.crt when requireClientCert is true) instead of provisioning one. Disables all auto-* methods when set. |
+| tetragon.grpc.tls.server.extraDnsNames | list | `[]` | Extra DNS SANs added to auto-generated certificates. |
+| tetragon.grpc.tls.server.extraIpAddresses | list | `[]` | Extra IP SANs added to auto-generated certificates. |
 | tetragon.healthGrpc.enabled | bool | `true` | Whether to enable health gRPC server. |
 | tetragon.healthGrpc.interval | int | `10` | The interval at which to check the health of the agent. |
 | tetragon.healthGrpc.port | int | `6789` | The port at which to expose health gRPC. |

--- a/docs/content/en/docs/troubleshooting/grpc-tls.md
+++ b/docs/content/en/docs/troubleshooting/grpc-tls.md
@@ -1,0 +1,56 @@
+---
+title: "Troubleshooting gRPC TLS"
+linkTitle: "gRPC TLS"
+weight: 4
+description: "Common errors when connecting to the Tetragon gRPC API over TLS"
+---
+
+The setup steps live in [gRPC TLS / mTLS]({{< ref "/docs/installation/grpc-tls" >}}).
+This page covers the three errors operators hit most often.
+
+## `x509: certificate signed by unknown authority`
+
+Seen on the client during the TLS handshake.
+
+* Cause — `tetra` does not trust the CA that signed the server certificate.
+* Fix — pass the CA bundle that issued the server cert:
+
+  ```shell
+  tetra --tls-ca-cert-files ca.crt ...
+  ```
+
+  When the chart auto-provisioned the cert, copy `ca.crt` out of the Secret:
+
+  ```shell
+  kubectl -n kube-system get secret tetragon-grpc-server-cert \
+    -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+  ```
+
+## `tls: bad certificate`
+
+Seen in the agent logs while the client sees `connection closed`.
+
+* Cause — the server runs in mTLS mode (`requireClientCert=true`) and the
+  client either presented no certificate or one signed by a CA the agent does
+  not trust.
+* Fix — issue a client certificate from the same CA, then pass both halves:
+
+  ```shell
+  tetra --tls-cert-file client.crt --tls-key-file client.key ...
+  ```
+
+## `x509: certificate is valid for *.tetragon-grpc.cilium.io, not <host>`
+
+Seen on the client when the chart auto-provisioned the server cert.
+
+* Cause — the auto-issued cert uses a wildcard SAN over a synthetic
+  domain, but the dial target is a different hostname or IP.
+* Fix — override SNI to match the wildcard:
+
+  ```shell
+  tetra --tls-server-name node.tetragon-grpc.cilium.io ...
+  ```
+
+  To use your own hostnames or IPs instead, add them through
+  `tetragon.grpc.tls.server.extraDnsNames` or `extraIpAddresses` and roll out
+  the chart.

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -254,6 +254,20 @@ options:
       default_value: localhost:54321
       usage: |
         gRPC server address (e.g. 'localhost:54321' or 'unix:///var/run/tetragon/tetragon.sock'). An empty address disables the gRPC server
+    - name: server-tls-cert-file
+      usage: |
+        Path to a PEM-encoded server certificate. When set, TLS is enabled on the TCP gRPC listener.
+    - name: server-tls-client-ca-files
+      default_value: '[]'
+      usage: |
+        Paths to PEM-encoded CA bundles used to verify client certificates. Required when --server-tls-require-client-cert is true.
+    - name: server-tls-key-file
+      usage: |
+        Path to the PEM-encoded private key matching --server-tls-cert-file. Required when --server-tls-cert-file is set.
+    - name: server-tls-require-client-cert
+      default_value: "false"
+      usage: |
+        Require and verify client certificates (mTLS). Requires --server-tls-client-ca-files.
     - name: tracing-policy
       usage: Tracing policy file to load at startup
     - name: tracing-policy-dir

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -9,6 +9,17 @@ Helm chart for Tetragon
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":1},"generateCA":true,"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.2.5"},"nodeSelector":{},"podLabels":{},"resources":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | cilium-certgen settings used by tetragon.grpc.tls.auto.method=cronJob. Mirrors the same block in cilium/cilium so operators familiar with the hubble TLS workflow find consistent knobs. |
+| certgen.affinity | object | `{}` | Affinity for certgen pods. |
+| certgen.annotations | object | `{"cronJob":{},"job":{}}` | Annotations applied to certgen Job/CronJob objects. |
+| certgen.cronJob.failedJobsHistoryLimit | int | `1` | Number of failed CronJob runs to retain. |
+| certgen.cronJob.successfulJobsHistoryLimit | int | `1` | Number of successful CronJob runs to retain. |
+| certgen.generateCA | bool | `true` | Whether the certgen invocation should generate a CA when one isn't found in the configured CA Secret. |
+| certgen.nodeSelector | object | `{}` | Node selector for certgen pods. |
+| certgen.podLabels | object | `{}` | Pod labels added to certgen pods. |
+| certgen.resources | object | `{}` | Resource requests/limits for the certgen container. |
+| certgen.tolerations | list | `[]` | Tolerations for certgen pods. |
+| certgen.ttlSecondsAfterFinished | int | `1800` | TTL applied to the bootstrap Job once it completes. |
 | crds.installMethod | string | `"operator"` | Method for installing CRDs. Supported values are: "operator", "helm" and "none". The "operator" method allows for fine-grained control over which CRDs are installed and by default doesn't perform CRD downgrades. These can be configured in tetragonOperator section. The "helm" method always installs all CRDs for the chart version. |
 | daemonSetAnnotations | object | `{}` |  |
 | daemonSetLabelsOverride | object | `{}` |  |
@@ -93,6 +104,23 @@ Helm chart for Tetragon
 | tetragon.gops.port | int | `8118` | The port at which to expose gops. |
 | tetragon.grpc.address | string | `"unix:///var/run/tetragon/tetragon.sock"` | The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock |
 | tetragon.grpc.enabled | bool | `true` | Whether to enable exposing Tetragon gRPC. |
+| tetragon.grpc.tls | object | `{"auto":{"certManagerIssuerRef":{},"certValidityDuration":365,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"},"ca":{"cert":"","certValidityDuration":1095,"key":""},"enabled":false,"requireClientCert":false,"server":{"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[]}}` | gRPC TLS / mTLS configuration for the optional TCP listener (tetragon.grpc.address); the always-on unix-domain listener at /var/run/tetragon/tetragon.sock is unaffected.  The auto-provisioned server cert uses a wildcard SAN over a synthetic DNS domain (*.tetragon-grpc.cilium.io) so a single Secret covers every DaemonSet pod. Clients must override SNI to <any>.tetragon-grpc.cilium.io to validate. See _helpers.tpl `tetragon.grpcTls.domain` for details; add Service-style or per-node identities via server.extraDnsNames / server.extraIpAddresses below. |
+| tetragon.grpc.tls.auto | object | `{"certManagerIssuerRef":{},"certValidityDuration":365,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"}` | Configure automatic TLS certificate generation. |
+| tetragon.grpc.tls.auto.certManagerIssuerRef | object | `{}` | cert-manager IssuerRef used when method=certmanager. [Example] certManagerIssuerRef:   group: cert-manager.io   kind: ClusterIssuer   name: ca-issuer |
+| tetragon.grpc.tls.auto.certValidityDuration | int | `365` | Generated certificate validity duration in days. Defaults to 365 (1 year). |
+| tetragon.grpc.tls.auto.enabled | bool | `true` | Auto-generate certificates. When false, you must provide a Secret yourself (see server.existingSecret). |
+| tetragon.grpc.tls.auto.method | string | `"helm"` | Method used to auto-generate certificates. Supported values: - helm:        Helm renders the cert/key Secret directly. - cronJob:     A Kubernetes CronJob runs cilium-certgen to (re)issue                the cert; a one-shot Job seeds it on install. - certmanager: cert-manager issues and rotates the cert. |
+| tetragon.grpc.tls.auto.schedule | string | `"0 0 1 */4 *"` | Schedule for certificate regeneration; only honored when method=cronJob. Empty disables the recurring CronJob, leaving only the one-shot bootstrap Job. |
+| tetragon.grpc.tls.ca | object | `{"cert":"","certValidityDuration":1095,"key":""}` | In-cluster CA used by the helm and cronJob methods. |
+| tetragon.grpc.tls.ca.cert | string | `""` | base64-encoded PEM CA certificate. When both cert and key are set, helm/cronJob reuse this CA instead of generating a fresh one. |
+| tetragon.grpc.tls.ca.certValidityDuration | int | `1095` | Validity duration in days for an auto-generated CA. Only used when ca.cert/key are unset. |
+| tetragon.grpc.tls.ca.key | string | `""` | base64-encoded PEM CA private key. Required when ca.cert is set. |
+| tetragon.grpc.tls.enabled | bool | `false` | Enable TLS on the TCP gRPC listener. When false, the listener (if any) is plaintext. |
+| tetragon.grpc.tls.requireClientCert | bool | `false` | Require and verify client certificates (mTLS). When true, the agent rejects TCP gRPC connections that don't present a valid client cert signed by one of the bundled CAs. |
+| tetragon.grpc.tls.server | object | `{"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[]}` | Server cert configuration. |
+| tetragon.grpc.tls.server.existingSecret | string | `""` | Use an existing Secret (must contain tls.crt + tls.key, plus ca.crt when requireClientCert is true) instead of provisioning one. Disables all auto-* methods when set. |
+| tetragon.grpc.tls.server.extraDnsNames | list | `[]` | Extra DNS SANs added to auto-generated certificates. |
+| tetragon.grpc.tls.server.extraIpAddresses | list | `[]` | Extra IP SANs added to auto-generated certificates. |
 | tetragon.healthGrpc.enabled | bool | `true` | Whether to enable health gRPC server. |
 | tetragon.healthGrpc.interval | int | `10` | The interval at which to check the health of the agent. |
 | tetragon.healthGrpc.port | int | `6789` | The port at which to expose health gRPC. |

--- a/install/kubernetes/tetragon/templates/_container_tetragon.tpl
+++ b/install/kubernetes/tetragon/templates/_container_tetragon.tpl
@@ -44,6 +44,11 @@
     - mountPath: {{ quote .Values.tetragon.cri.socketHostPath }}
       name: cri-socket
 {{- end }}
+{{- if and .Values.tetragon.grpc.enabled .Values.tetragon.grpc.tls.enabled }}
+    - mountPath: /var/lib/tetragon/tls
+      name: tetragon-grpc-tls
+      readOnly: true
+{{- end }}
 {{- range .Values.extraHostPathMounts }}
     - name: {{ .name }}
       mountPath: {{ .mountPath }}

--- a/install/kubernetes/tetragon/templates/_helpers.tpl
+++ b/install/kubernetes/tetragon/templates/_helpers.tpl
@@ -140,3 +140,67 @@ use it as-is. Otherwise fall back to the top-level .Values.affinity.
 {{- toYaml .Values.affinity -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+gRPC TLS resource names.
+*/}}
+{{- define "tetragon.grpcTlsSecretName" -}}
+{{- printf "%s-server-certs" (include "tetragon.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "tetragon.caSecretName" -}}
+{{- printf "%s-ca" (include "tetragon.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+gRPC TLS cert identity.
+
+A wildcard SAN over a synthetic DNS suffix lets one Secret cover every
+DaemonSet pod: clients dial the agent's TCP address but override SNI to a
+single-label subdomain (RFC 6125 wildcard rules) so the cert validates
+without per-node provisioning.
+
+  server SAN: *.tetragon-grpc.cilium.io
+  client SNI: <any>.tetragon-grpc.cilium.io
+*/}}
+{{- define "tetragon.grpcTls.domain" -}}
+{{- print "tetragon-grpc.cilium.io" -}}
+{{- end }}
+
+{{- define "tetragon.grpcTls.commonName" -}}
+{{- printf "*.%s" (include "tetragon.grpcTls.domain" .) -}}
+{{- end }}
+
+{{- define "tetragon.grpcTls.dnsNames" -}}
+- {{ include "tetragon.grpcTls.commonName" . | quote }}
+{{- range .Values.tetragon.grpc.tls.server.extraDnsNames }}
+- {{ . | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate / look up the in-cluster CA used by the helm-method server-cert
+Secret. Mirrors cilium.ca.setup: stash the CA on the dot via $_ so all
+templates that render in the same helm pass share one CA.
+*/}}
+{{- define "tetragon.ca.setup" }}
+  {{- if not .commonCA -}}
+    {{- $ca := "" -}}
+    {{- $secretName := include "tetragon.caSecretName" . -}}
+    {{- $crt := .Values.tetragon.grpc.tls.ca.cert -}}
+    {{- $key := .Values.tetragon.grpc.tls.ca.key -}}
+    {{- if and $crt $key }}
+      {{- $ca = buildCustomCert $crt $key -}}
+    {{- else }}
+      {{- with lookup "v1" "Secret" .Release.Namespace $secretName }}
+        {{- $crt := index .data "ca.crt" }}
+        {{- $key := index .data "ca.key" }}
+        {{- $ca = buildCustomCert $crt $key -}}
+      {{- else }}
+        {{- $validity := (.Values.tetragon.grpc.tls.ca.certValidityDuration | int) -}}
+        {{- $ca = genCA "Tetragon CA" $validity -}}
+      {{- end }}
+    {{- end -}}
+    {{- $_ := set . "commonCA" $ca -}}
+  {{- end -}}
+{{- end -}}

--- a/install/kubernetes/tetragon/templates/daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/daemonset.yaml
@@ -104,6 +104,12 @@ spec:
           path: {{ quote .Values.tetragon.cri.socketHostPath }}
           type: Socket
 {{- end }}
+{{- if and .Values.tetragon.grpc.enabled .Values.tetragon.grpc.tls.enabled }}
+      - name: tetragon-grpc-tls
+        secret:
+          secretName: {{ .Values.tetragon.grpc.tls.server.existingSecret | default (include "tetragon.grpcTlsSecretName" .) }}
+          defaultMode: 0400
+{{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -1,3 +1,9 @@
+{{- if and .Values.tetragon.grpc.tls.enabled .Values.tetragon.grpc.enabled (hasPrefix "unix://" .Values.tetragon.grpc.address) -}}
+{{- fail (printf "tetragon.grpc.tls.enabled requires tetragon.grpc.address to point at a TCP listener, got %q. TLS does not apply to the unix-domain socket." .Values.tetragon.grpc.address) -}}
+{{- end -}}
+{{- if and .Values.tetragon.grpc.tls.enabled (not .Values.tetragon.grpc.tls.auto.enabled) (not .Values.tetragon.grpc.tls.server.existingSecret) -}}
+{{- fail "tetragon.grpc.tls: auto provisioning is disabled but server.existingSecret is empty. Set server.existingSecret to a Secret containing tls.crt, tls.key, and (for mTLS) ca.crt." -}}
+{{- end -}}
 {{- if .Values.tetragon.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -48,6 +54,14 @@ data:
   server-address: {{ .Values.tetragon.grpc.address }}
 {{- else }}
   server-address: ""
+{{- end }}
+{{- if and .Values.tetragon.grpc.enabled .Values.tetragon.grpc.tls.enabled }}
+  server-tls-cert-file: "/var/lib/tetragon/tls/tls.crt"
+  server-tls-key-file: "/var/lib/tetragon/tls/tls.key"
+{{- if .Values.tetragon.grpc.tls.requireClientCert }}
+  server-tls-require-client-cert: "true"
+  server-tls-client-ca-files: "/var/lib/tetragon/tls/ca.crt"
+{{- end }}
 {{- end }}
 {{- if .Values.tetragon.healthGrpc.enabled }}
   health-server-address: :{{ .Values.tetragon.healthGrpc.port }}

--- a/install/kubernetes/tetragon/templates/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/tetragon/templates/tls-certmanager/server-secret.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.tetragon.enabled .Values.tetragon.grpc.tls.enabled .Values.tetragon.grpc.tls.auto.enabled (eq .Values.tetragon.grpc.tls.auto.method "certmanager") (not .Values.tetragon.grpc.tls.server.existingSecret) -}}
+{{- if not .Values.tetragon.grpc.tls.auto.certManagerIssuerRef -}}
+{{- fail "tetragon.grpc.tls.auto.certManagerIssuerRef must be set when auto.method is certmanager" -}}
+{{- end -}}
+{{- $cn := include "tetragon.grpcTls.commonName" . -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "tetragon.grpcTlsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon.labels" . | nindent 4 }}
+    tetragon.cilium.io/tls-method: certmanager
+spec:
+  secretName: {{ include "tetragon.grpcTlsSecretName" . }}
+  commonName: {{ $cn | quote }}
+  dnsNames:
+    {{- include "tetragon.grpcTls.dnsNames" . | nindent 4 }}
+  {{- with .Values.tetragon.grpc.tls.server.extraIpAddresses }}
+  ipAddresses:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  duration: {{ printf "%dh0m0s" (mul .Values.tetragon.grpc.tls.auto.certValidityDuration 24) | quote }}
+  privateKey:
+    rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
+    - client auth
+  issuerRef:
+    {{- toYaml .Values.tetragon.grpc.tls.auto.certManagerIssuerRef | nindent 4 }}
+{{- end }}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/_job-spec.tpl
@@ -1,0 +1,89 @@
+{{/*
+Reusable PodSpec / JobSpec body for the certgen Job and CronJob. Renders the
+cilium-certgen invocation that (re)creates the server + CA Secrets for the
+tetragon gRPC TLS listener.
+*/}}
+{{- define "tetragon.certgen.jobSpec" -}}
+{{- $validityHours := mul .Values.tetragon.grpc.tls.auto.certValidityDuration 24 -}}
+{{- $validityStr := printf "%dh" $validityHours -}}
+{{- $caValidityHours := mul .Values.tetragon.grpc.tls.ca.certValidityDuration 24 -}}
+{{- $caValidityStr := printf "%dh" $caValidityHours -}}
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "tetragon.labels" . | nindent 8 }}
+        app.kubernetes.io/component: certgen
+        {{- with .Values.certgen.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "tetragon.name" . }}-certgen
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      {{- with .Values.certgen.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.certgen.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.certgen.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: certgen
+          image: "{{ if .Values.certgen.image.override }}{{ .Values.certgen.image.override }}{{ else }}{{ .Values.certgen.image.repository }}:{{ .Values.certgen.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - "/usr/bin/cilium-certgen"
+          args:
+            - "--ca-generate={{ .Values.certgen.generateCA }}"
+            - "--ca-reuse-secret"
+            - "--ca-secret-namespace={{ .Release.Namespace }}"
+            - "--ca-secret-name={{ include "tetragon.caSecretName" . }}"
+            - "--ca-common-name=Tetragon CA"
+            - "--ca-validity-duration={{ $caValidityStr }}"
+          env:
+            - name: CILIUM_CERTGEN_CONFIG
+              value: |
+                certs:
+                  - name: {{ include "tetragon.grpcTlsSecretName" . }}
+                    namespace: {{ .Release.Namespace }}
+                    commonName: {{ include "tetragon.grpcTls.commonName" . | quote }}
+                    hosts:
+                      - {{ include "tetragon.grpcTls.commonName" . | quote }}
+                      {{- range .Values.tetragon.grpc.tls.server.extraDnsNames }}
+                      - {{ . | quote }}
+                      {{- end }}
+                      {{- range .Values.tetragon.grpc.tls.server.extraIpAddresses }}
+                      - {{ . | quote }}
+                      {{- end }}
+                    usage:
+                      - signing
+                      - key encipherment
+                      - server auth
+                      - client auth
+                    validity: {{ $validityStr }}
+          {{- with .Values.certgen.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end -}}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/cronjob.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.tetragon.enabled .Values.tetragon.grpc.tls.enabled .Values.tetragon.grpc.tls.auto.enabled (eq .Values.tetragon.grpc.tls.auto.method "cronJob") (not .Values.tetragon.grpc.tls.server.existingSecret) .Values.tetragon.grpc.tls.auto.schedule -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "tetragon.name" . }}-certgen
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certgen
+  {{- with .Values.certgen.annotations.cronJob }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ .Values.tetragon.grpc.tls.auto.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.certgen.cronJob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.certgen.cronJob.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "tetragon.labels" . | nindent 8 }}
+        app.kubernetes.io/component: certgen
+    {{- include "tetragon.certgen.jobSpec" . | nindent 4 }}
+{{- end }}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/job.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/job.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.tetragon.enabled .Values.tetragon.grpc.tls.enabled .Values.tetragon.grpc.tls.auto.enabled (eq .Values.tetragon.grpc.tls.auto.method "cronJob") (not .Values.tetragon.grpc.tls.server.existingSecret) -}}
+{{- /*
+Bootstrap Job — runs once on install/upgrade so the Secret exists before the
+recurring CronJob fires. The name is suffixed with a hash of the spec so that
+an upgrade that changes the JobSpec replaces the Job cleanly (Job specs are
+immutable).
+*/ -}}
+{{- $jobSpec := include "tetragon.certgen.jobSpec" . -}}
+{{- $jobHash := sha256sum $jobSpec | trunc 10 -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "tetragon.name" . }}-certgen-{{ $jobHash }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certgen
+  {{- with .Values.certgen.annotations.job }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ttlSecondsAfterFinished: {{ .Values.certgen.ttlSecondsAfterFinished }}
+  {{- $jobSpec | nindent 2 }}
+{{- end }}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/role.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/role.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.tetragon.enabled .Values.tetragon.grpc.tls.enabled .Values.tetragon.grpc.tls.auto.enabled (eq .Values.tetragon.grpc.tls.auto.method "cronJob") (not .Values.tetragon.grpc.tls.server.existingSecret) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tetragon.name" . }}-certgen
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certgen
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ include "tetragon.grpcTlsSecretName" . }}
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ include "tetragon.caSecretName" . }}
+    verbs: ["get", "update"]
+{{- end }}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.tetragon.enabled .Values.tetragon.grpc.tls.enabled .Values.tetragon.grpc.tls.auto.enabled (eq .Values.tetragon.grpc.tls.auto.method "cronJob") (not .Values.tetragon.grpc.tls.server.existingSecret) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tetragon.name" . }}-certgen
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certgen
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tetragon.name" . }}-certgen
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tetragon.name" . }}-certgen
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/serviceaccount.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.tetragon.enabled .Values.tetragon.grpc.tls.enabled .Values.tetragon.grpc.tls.auto.enabled (eq .Values.tetragon.grpc.tls.auto.method "cronJob") (not .Values.tetragon.grpc.tls.server.existingSecret) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tetragon.name" . }}-certgen
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certgen
+{{- end }}

--- a/install/kubernetes/tetragon/templates/tls-helm/server-secret.yaml
+++ b/install/kubernetes/tetragon/templates/tls-helm/server-secret.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.tetragon.enabled .Values.tetragon.grpc.tls.enabled .Values.tetragon.grpc.tls.auto.enabled (eq .Values.tetragon.grpc.tls.auto.method "helm") (not .Values.tetragon.grpc.tls.server.existingSecret) -}}
+{{- $_ := include "tetragon.ca.setup" . -}}
+{{- $cn := include "tetragon.grpcTls.commonName" . -}}
+{{- $ip := .Values.tetragon.grpc.tls.server.extraIpAddresses -}}
+{{- $dns := concat (list $cn) .Values.tetragon.grpc.tls.server.extraDnsNames -}}
+{{- $cert := genSignedCert $cn $ip $dns (.Values.tetragon.grpc.tls.auto.certValidityDuration | int) .commonCA -}}
+{{- $tls_crt := ($cert.Cert | b64enc) -}}
+{{- $tls_key := ($cert.Key | b64enc) -}}
+{{- /* Preserve existing cert/key across helm upgrade unless the user forces
+       rotation (e.g. by deleting the Secret). */ -}}
+{{- with lookup "v1" "Secret" .Release.Namespace (include "tetragon.grpcTlsSecretName" .) }}
+  {{- if and (index .data "tls.crt") (index .data "tls.key") }}
+    {{- $tls_crt = (index .data "tls.crt") }}
+    {{- $tls_key = (index .data "tls.key") }}
+  {{- end }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tetragon.grpcTlsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon.labels" . | nindent 4 }}
+    tetragon.cilium.io/tls-method: helm
+type: kubernetes.io/tls
+data:
+  ca.crt:  {{ .commonCA.Cert | b64enc }}
+  tls.crt: {{ $tls_crt }}
+  tls.key: {{ $tls_key }}
+---
+# CA Secret, kept so that subsequent `helm upgrade` runs reuse the same CA
+# material (see tetragon.ca.setup lookup path).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tetragon.caSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tetragon.labels" . | nindent 4 }}
+    tetragon.cilium.io/tls-method: helm
+type: Opaque
+data:
+  ca.crt: {{ .commonCA.Cert | b64enc }}
+  ca.key: {{ .commonCA.Key  | b64enc }}
+{{- end }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -186,6 +186,69 @@ tetragon:
     enabled: true
     # -- The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock
     address: "unix:///var/run/tetragon/tetragon.sock"
+    # -- gRPC TLS / mTLS configuration for the optional TCP listener
+    # (tetragon.grpc.address); the always-on unix-domain listener at
+    # /var/run/tetragon/tetragon.sock is unaffected.
+    #
+    # The auto-provisioned server cert uses a wildcard SAN over a synthetic
+    # DNS domain (*.tetragon-grpc.cilium.io) so a single Secret covers every
+    # DaemonSet pod. Clients must override SNI to <any>.tetragon-grpc.cilium.io
+    # to validate. See _helpers.tpl `tetragon.grpcTls.domain` for details;
+    # add Service-style or per-node identities via server.extraDnsNames /
+    # server.extraIpAddresses below.
+    tls:
+      # -- Enable TLS on the TCP gRPC listener. When false, the listener (if
+      # any) is plaintext.
+      enabled: false
+      # -- Require and verify client certificates (mTLS). When true, the
+      # agent rejects TCP gRPC connections that don't present a valid client
+      # cert signed by one of the bundled CAs.
+      requireClientCert: false
+      # -- Configure automatic TLS certificate generation.
+      auto:
+        # -- Auto-generate certificates. When false, you must provide a
+        # Secret yourself (see server.existingSecret).
+        enabled: true
+        # -- Method used to auto-generate certificates. Supported values:
+        # - helm:        Helm renders the cert/key Secret directly.
+        # - cronJob:     A Kubernetes CronJob runs cilium-certgen to (re)issue
+        #                the cert; a one-shot Job seeds it on install.
+        # - certmanager: cert-manager issues and rotates the cert.
+        method: helm
+        # -- Generated certificate validity duration in days.
+        # Defaults to 365 (1 year).
+        certValidityDuration: 365
+        # -- Schedule for certificate regeneration; only honored when
+        # method=cronJob. Empty disables the recurring CronJob, leaving only
+        # the one-shot bootstrap Job.
+        schedule: "0 0 1 */4 *"
+        # -- cert-manager IssuerRef used when method=certmanager.
+        # [Example]
+        # certManagerIssuerRef:
+        #   group: cert-manager.io
+        #   kind: ClusterIssuer
+        #   name: ca-issuer
+        certManagerIssuerRef: {}
+      # -- In-cluster CA used by the helm and cronJob methods.
+      ca:
+        # -- base64-encoded PEM CA certificate. When both cert and key are
+        # set, helm/cronJob reuse this CA instead of generating a fresh one.
+        cert: ""
+        # -- base64-encoded PEM CA private key. Required when ca.cert is set.
+        key: ""
+        # -- Validity duration in days for an auto-generated CA. Only used
+        # when ca.cert/key are unset.
+        certValidityDuration: 1095
+      # -- Server cert configuration.
+      server:
+        # -- Use an existing Secret (must contain tls.crt + tls.key, plus
+        # ca.crt when requireClientCert is true) instead of provisioning
+        # one. Disables all auto-* methods when set.
+        existingSecret: ""
+        # -- Extra DNS SANs added to auto-generated certificates.
+        extraDnsNames: []
+        # -- Extra IP SANs added to auto-generated certificates.
+        extraIpAddresses: []
   gops:
     # -- Whether to enable exposing gops server.
     enabled: true
@@ -481,3 +544,38 @@ rthooks:
   # -- rthooks service account.
   serviceAccount:
     name: ""
+
+# -- cilium-certgen settings used by tetragon.grpc.tls.auto.method=cronJob.
+# Mirrors the same block in cilium/cilium so operators familiar with the
+# hubble TLS workflow find consistent knobs.
+certgen:
+  image:
+    override: ~
+    repository: quay.io/cilium/certgen
+    # renovate: datasource=docker depName=quay.io/cilium/certgen
+    tag: v0.2.5
+    pullPolicy: IfNotPresent
+  # -- Whether the certgen invocation should generate a CA when one isn't
+  # found in the configured CA Secret.
+  generateCA: true
+  # -- Pod labels added to certgen pods.
+  podLabels: {}
+  # -- Annotations applied to certgen Job/CronJob objects.
+  annotations:
+    job: {}
+    cronJob: {}
+  # -- Resource requests/limits for the certgen container.
+  resources: {}
+  # -- Node selector for certgen pods.
+  nodeSelector: {}
+  # -- Tolerations for certgen pods.
+  tolerations: []
+  # -- Affinity for certgen pods.
+  affinity: {}
+  # -- TTL applied to the bootstrap Job once it completes.
+  ttlSecondsAfterFinished: 1800
+  cronJob:
+    # -- Number of successful CronJob runs to retain.
+    successfulJobsHistoryLimit: 1
+    # -- Number of failed CronJob runs to retain.
+    failedJobsHistoryLimit: 1

--- a/pkg/certloader/doc.go
+++ b/pkg/certloader/doc.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// Package certloader builds a reloadable [crypto/tls.Config] backed by files
+// on disk, so cert rotation does not require a server restart. The package
+// is transport-agnostic — the produced [crypto/tls.Config] is consumed by
+// the Tetragon gRPC server.
+//
+// The design — directory-watched material, atomic snapshot swapped on
+// reload, [crypto/tls.Config.GetConfigForClient] pinning a snapshot for the
+// duration of each handshake — is adapted from
+// [cilium/cilium/pkg/crypto/certloader] (Apache-2.0).
+//
+// [cilium/cilium/pkg/crypto/certloader]: https://github.com/cilium/cilium/tree/main/pkg/crypto/certloader
+package certloader

--- a/pkg/certloader/integration_test.go
+++ b/pkg/certloader/integration_test.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package certloader_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/cilium/tetragon/pkg/certloader"
+)
+
+const dialTimeout = 5 * time.Second
+
+type stubHealth struct {
+	healthgrpc.UnimplementedHealthServer
+}
+
+func (stubHealth) Check(_ context.Context, _ *healthgrpc.HealthCheckRequest) (*healthgrpc.HealthCheckResponse, error) {
+	return &healthgrpc.HealthCheckResponse{Status: healthgrpc.HealthCheckResponse_SERVING}, nil
+}
+
+// startServer registers a Health stub on a TLS-wrapped listener and blocks
+// teardown on the Serve goroutine to surface errors deterministically.
+func startServer(t *testing.T, creds credentials.TransportCredentials) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer(grpc.Creds(creds))
+	healthgrpc.RegisterHealthServer(srv, stubHealth{})
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+		if err := <-serveErr; err != nil {
+			t.Errorf("grpc Serve returned: %v", err)
+		}
+	})
+	return lis.Addr().String()
+}
+
+func rootPool(t *testing.T, pki *certloader.TestPKI) *x509.CertPool {
+	t.Helper()
+	pool := x509.NewCertPool()
+	caPEM, err := os.ReadFile(pki.CACertPath)
+	require.NoError(t, err)
+	require.True(t, pool.AppendCertsFromPEM(caPEM))
+	return pool
+}
+
+func loadKeyPair(t *testing.T, certPath, keyPath string) tls.Certificate {
+	t.Helper()
+	c, err := tls.LoadX509KeyPair(certPath, keyPath)
+	require.NoError(t, err)
+	return c
+}
+
+func setupServer(t *testing.T, mtls bool) (*certloader.TestPKI, string) {
+	t.Helper()
+	dir := t.TempDir()
+	pki, err := certloader.NewTestPKI(dir)
+	require.NoError(t, err)
+	server, err := pki.Issue(dir, certloader.IssueOpts{
+		CommonName: "server",
+		DNSNames:   []string{"localhost"},
+		IPs:        []net.IP{net.ParseIP("127.0.0.1")},
+		IsServer:   true,
+	})
+	require.NoError(t, err)
+	cfg := certloader.Config{CertFile: server.CertPath, KeyFile: server.KeyPath}
+	if mtls {
+		cfg.RequireClientCert = true
+		cfg.ClientCAFiles = []string{pki.CACertPath}
+	}
+	r, err := certloader.NewReloader(cfg)
+	require.NoError(t, err)
+	return pki, startServer(t, credentials.NewTLS(r.ServerConfig()))
+}
+
+// dialContext returns a context bounded by the test deadline (or
+// dialTimeout, whichever is shorter) and registers the cancel.
+func dialContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), dialTimeout)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func TestMTLSValidClient(t *testing.T) {
+	pki, addr := setupServer(t, true)
+	clientLeaf, err := pki.Issue(t.TempDir(), certloader.IssueOpts{CommonName: "client"})
+	require.NoError(t, err)
+	clientCert := loadKeyPair(t, clientLeaf.CertPath, clientLeaf.KeyPath)
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		RootCAs:      rootPool(t, pki),
+		Certificates: []tls.Certificate{clientCert},
+		ServerName:   "localhost",
+	})))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	resp, err := healthgrpc.NewHealthClient(conn).Check(dialContext(t), &healthgrpc.HealthCheckRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, healthgrpc.HealthCheckResponse_SERVING, resp.Status)
+}
+
+func TestMTLSRejectsClientWithoutCert(t *testing.T) {
+	pki, addr := setupServer(t, true)
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		MinVersion: tls.VersionTLS13,
+		RootCAs:    rootPool(t, pki),
+		ServerName: "localhost",
+	})))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = healthgrpc.NewHealthClient(conn).Check(dialContext(t), &healthgrpc.HealthCheckRequest{})
+	require.Error(t, err)
+}
+
+func TestMTLSRejectsUntrustedClient(t *testing.T) {
+	pki, addr := setupServer(t, true)
+	otherPKI, err := certloader.NewTestPKI(t.TempDir())
+	require.NoError(t, err)
+	rogue, err := otherPKI.Issue(t.TempDir(), certloader.IssueOpts{CommonName: "rogue"})
+	require.NoError(t, err)
+	rogueCert := loadKeyPair(t, rogue.CertPath, rogue.KeyPath)
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		RootCAs:      rootPool(t, pki),
+		Certificates: []tls.Certificate{rogueCert},
+		ServerName:   "localhost",
+	})))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = healthgrpc.NewHealthClient(conn).Check(dialContext(t), &healthgrpc.HealthCheckRequest{})
+	require.Error(t, err)
+}
+
+func TestServerOnlyTLSAcceptsClientWithoutCert(t *testing.T) {
+	pki, addr := setupServer(t, false)
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		MinVersion: tls.VersionTLS13,
+		RootCAs:    rootPool(t, pki),
+		ServerName: "localhost",
+	})))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = healthgrpc.NewHealthClient(conn).Check(dialContext(t), &healthgrpc.HealthCheckRequest{})
+	require.NoError(t, err)
+}
+
+func TestServerOnlyTLSRejectsPlaintextClient(t *testing.T) {
+	_, addr := setupServer(t, false)
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = healthgrpc.NewHealthClient(conn).Check(dialContext(t), &healthgrpc.HealthCheckRequest{})
+	require.Error(t, err)
+}
+
+// TestLazyReloaderRecoversWhenFilesAppear exercises the cert-manager /
+// cilium-certgen bootstrap path: the agent starts pointing at TLS file paths
+// that do not yet exist, the watcher observes their CREATE, and handshakes
+// start succeeding without a server restart.
+func TestLazyReloaderRecoversWhenFilesAppear(t *testing.T) {
+
+	mountDir := t.TempDir()
+	certPath := filepath.Join(mountDir, "tls.crt")
+	keyPath := filepath.Join(mountDir, "tls.key")
+
+	pki, err := certloader.NewTestPKI(t.TempDir())
+	require.NoError(t, err)
+	issued, err := pki.Issue(t.TempDir(), certloader.IssueOpts{
+		CommonName: "server",
+		DNSNames:   []string{"localhost"},
+		IPs:        []net.IP{net.ParseIP("127.0.0.1")},
+		IsServer:   true,
+	})
+	require.NoError(t, err)
+
+	r, err := certloader.NewReloaderLazy(certloader.Config{CertFile: certPath, KeyFile: keyPath})
+	require.NoError(t, err)
+	require.False(t, r.Ready(), "lazy reloader must not be ready before files exist")
+
+	certloader.Watch(t.Context(), r)
+	addr := startServer(t, credentials.NewTLS(r.ServerConfig()))
+
+	dial := func() (*grpc.ClientConn, error) {
+		return grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			MinVersion: tls.VersionTLS13,
+			RootCAs:    rootPool(t, pki),
+			ServerName: "localhost",
+		})))
+	}
+
+	failConn, err := dial()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = failConn.Close() })
+	_, err = healthgrpc.NewHealthClient(failConn).Check(dialContext(t), &healthgrpc.HealthCheckRequest{})
+	require.Error(t, err, "handshake must fail before TLS material is provisioned")
+
+	copyFile(t, issued.CertPath, certPath)
+	copyFile(t, issued.KeyPath, keyPath)
+
+	// 15s covers one full retryInterval before certwatcher.New succeeds,
+	// plus slack for the immediate-fire callback and TLS handshake.
+	require.Eventually(t, func() bool {
+		if !r.Ready() {
+			return false
+		}
+		conn, err := dial()
+		if err != nil {
+			return false
+		}
+		defer conn.Close()
+		_, err = healthgrpc.NewHealthClient(conn).Check(dialContext(t), &healthgrpc.HealthCheckRequest{})
+		return err == nil
+	}, 15*time.Second, 50*time.Millisecond)
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	b, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dst, b, 0600))
+}

--- a/pkg/certloader/testdata_test.go
+++ b/pkg/certloader/testdata_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package certloader
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// TestPKI is a self-contained CA + leaf factory for end-to-end TLS tests.
+type TestPKI struct {
+	CACert     *x509.Certificate
+	CAKey      *ecdsa.PrivateKey
+	CACertPEM  []byte
+	CACertPath string
+}
+
+// NewTestPKI returns a fresh self-signed CA whose certificate is also written
+// to dir/ca.pem.
+func NewTestPKI(dir string) (*TestPKI, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tetragon-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(caPath, certPEM, 0600); err != nil {
+		return nil, err
+	}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+	return &TestPKI{CACert: parsed, CAKey: key, CACertPEM: certPEM, CACertPath: caPath}, nil
+}
+
+// IssueOpts customizes a leaf certificate issued by the test CA.
+type IssueOpts struct {
+	CommonName string
+	DNSNames   []string
+	IPs        []net.IP
+	IsServer   bool
+}
+
+// LeafFiles holds the paths to a freshly-issued leaf cert + key on disk.
+type LeafFiles struct {
+	CertPath string
+	KeyPath  string
+}
+
+// Issue creates a new ECDSA key + certificate signed by the test CA and writes
+// them to dir/<commonName>.{pem,key}.
+func (p *TestPKI) Issue(dir string, opts IssueOpts) (*LeafFiles, error) {
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	usage := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+	extUsage := []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	if opts.IsServer {
+		extUsage = append(extUsage, x509.ExtKeyUsageServerAuth)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: opts.CommonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     usage,
+		ExtKeyUsage:  extUsage,
+		DNSNames:     opts.DNSNames,
+		IPAddresses:  opts.IPs,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, p.CACert, &leafKey.PublicKey, p.CAKey)
+	if err != nil {
+		return nil, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		return nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	certPath := filepath.Join(dir, opts.CommonName+".pem")
+	keyPath := filepath.Join(dir, opts.CommonName+".key")
+	if err := os.WriteFile(certPath, certPEM, 0600); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		return nil, err
+	}
+	return &LeafFiles{CertPath: certPath, KeyPath: keyPath}, nil
+}

--- a/pkg/certloader/tls.go
+++ b/pkg/certloader/tls.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package certloader
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+)
+
+// Config drives a server-side TLS configuration. Zero values disable TLS.
+type Config struct {
+	// CertFile is a PEM-encoded server cert (leaf + optional intermediates).
+	CertFile string
+	// KeyFile is the PEM-encoded private key for CertFile.
+	KeyFile string
+	// ClientCAFiles is a list of PEM CA bundles used to verify client
+	// certs. Required when RequireClientCert is true.
+	ClientCAFiles []string
+	// RequireClientCert toggles mTLS (RequireAndVerifyClientCert).
+	RequireClientCert bool
+}
+
+// Enabled reports whether a server cert is configured.
+func (c Config) Enabled() bool {
+	return c.CertFile != "" && c.KeyFile != ""
+}
+
+// Validate enforces flag-layer invariants so callers can construct a
+// Reloader without going through viper.
+func (c Config) Validate() error {
+	if c.CertFile == "" && c.KeyFile == "" && !c.RequireClientCert && len(c.ClientCAFiles) == 0 {
+		return nil
+	}
+	if c.CertFile == "" || c.KeyFile == "" {
+		return errors.New("server cert-file and key-file must be provided together")
+	}
+	if c.RequireClientCert && len(c.ClientCAFiles) == 0 {
+		return errors.New("require-client-cert demands at least one client CA bundle")
+	}
+	if !c.RequireClientCert && len(c.ClientCAFiles) > 0 {
+		return errors.New("client CA bundle is only honored when require-client-cert is true")
+	}
+	return nil
+}
+
+// Reloader holds TLS material and atomically swaps it on Reload, so a
+// rotation does not interrupt in-flight handshakes. Safe for concurrent use.
+type Reloader struct {
+	cfg     Config
+	snap    atomic.Pointer[snapshot]
+	tlsConf *tls.Config
+
+	// reloadMu serializes Reload so a slow read cannot overwrite a newer
+	// snapshot and roll the listener back to stale material.
+	reloadMu sync.Mutex
+}
+
+type snapshot struct {
+	cert    *tls.Certificate
+	caPool  *x509.CertPool
+	require bool
+}
+
+// NewReloaderLazy constructs a Reloader without requiring the TLS material
+// to exist on disk. Handshakes performed before the first successful Reload
+// fail with "certloader: no certificate loaded"; pair with [Watch] so the first
+// reload happens automatically once the files appear.
+//
+// Use this when the agent may start before its provisioner (cert-manager,
+// cilium-certgen Job) has written the Secret.
+func NewReloaderLazy(cfg Config) (*Reloader, error) {
+	if !cfg.Enabled() {
+		return nil, errors.New("TLS is not enabled: server cert and key are required")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	r := &Reloader{cfg: cfg}
+	r.tlsConf = r.buildTLSConfig()
+	_ = r.Reload() // best-effort; absence is recovered by Watch when files appear.
+	return r, nil
+}
+
+// Ready reports whether a Reload has succeeded at least once. A Reloader
+// returned by [NewReloader] is always Ready; one returned by [NewReloaderLazy]
+// becomes Ready after [Watch] observes the TLS files on disk.
+func (r *Reloader) Ready() bool {
+	return r.snap.Load() != nil
+}
+
+// Reload re-reads the cert/key and CA bundle from disk and atomically
+// replaces the active snapshot. Concurrent calls are serialized by reloadMu.
+func (r *Reloader) Reload() error {
+	r.reloadMu.Lock()
+	defer r.reloadMu.Unlock()
+	cert, err := tls.LoadX509KeyPair(r.cfg.CertFile, r.cfg.KeyFile)
+	if err != nil {
+		return fmt.Errorf("loading server cert/key: %w", err)
+	}
+	var pool *x509.CertPool
+	if r.cfg.RequireClientCert {
+		pool = x509.NewCertPool()
+		for _, p := range r.cfg.ClientCAFiles {
+			pem, err := os.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("reading client CA bundle %q: %w", p, err)
+			}
+			if !pool.AppendCertsFromPEM(pem) {
+				return fmt.Errorf("client CA bundle %q contained no valid PEM certificates", p)
+			}
+		}
+	}
+	r.snap.Store(&snapshot{
+		cert:    &cert,
+		caPool:  pool,
+		require: r.cfg.RequireClientCert,
+	})
+	return nil
+}
+
+// ServerConfig returns a [tls.Config] suitable for [credentials.NewTLS].
+// The returned value is stable across reloads.
+func (r *Reloader) ServerConfig() *tls.Config {
+	return r.tlsConf
+}
+
+func (r *Reloader) buildTLSConfig() *tls.Config {
+	// GetConfigForClient pins the snapshot (cert + CA pool) once per
+	// handshake to avoid split-brain if a Reload lands mid-handshake.
+	// The parent-config GetCertificate is unreachable when the server
+	// uses GetConfigForClient; it's kept for non-server callers and tests.
+	parentGetCert := func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		s := r.snap.Load()
+		if s == nil || s.cert == nil {
+			return nil, errors.New("certloader: no certificate loaded")
+		}
+		return s.cert, nil
+	}
+	return &tls.Config{
+		MinVersion:     tls.VersionTLS13,
+		GetCertificate: parentGetCert,
+		GetConfigForClient: func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+			s := r.snap.Load()
+			if s == nil || s.cert == nil {
+				return nil, errors.New("certloader: no certificate loaded")
+			}
+			cert := s.cert
+			caPool := s.caPool
+			require := s.require
+			out := &tls.Config{
+				MinVersion: tls.VersionTLS13,
+				GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+					return cert, nil
+				},
+			}
+			if require {
+				out.ClientCAs = caPool
+				out.ClientAuth = tls.RequireAndVerifyClientCert
+			}
+			return out, nil
+		},
+	}
+}

--- a/pkg/certloader/tls_test.go
+++ b/pkg/certloader/tls_test.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package certloader
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func NewReloader(cfg Config) (*Reloader, error) {
+	if !cfg.Enabled() {
+		return nil, errors.New("TLS is not enabled: server cert and key are required")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	r := &Reloader{cfg: cfg}
+	if err := r.Reload(); err != nil {
+		return nil, err
+	}
+	r.tlsConf = r.buildTLSConfig()
+	return r, nil
+}
+
+// snapshot exposes the current snapshot for in-package tests.
+func (r *Reloader) snapshot() (*tls.Certificate, *x509.CertPool, bool) {
+	s := r.snap.Load()
+	if s == nil {
+		return nil, nil, false
+	}
+	return s.cert, s.caPool, s.require
+}
+
+func TestConfigValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{name: "zero", cfg: Config{}},
+		{name: "cert without key", cfg: Config{CertFile: "a"}, wantErr: true},
+		{name: "key without cert", cfg: Config{KeyFile: "a"}, wantErr: true},
+		{name: "tls only", cfg: Config{CertFile: "a", KeyFile: "b"}},
+		{name: "mtls without ca", cfg: Config{CertFile: "a", KeyFile: "b", RequireClientCert: true}, wantErr: true},
+		{name: "mtls ok", cfg: Config{CertFile: "a", KeyFile: "b", RequireClientCert: true, ClientCAFiles: []string{"c"}}},
+		{name: "ca without mtls", cfg: Config{CertFile: "a", KeyFile: "b", ClientCAFiles: []string{"c"}}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewReloaderRejectsDisabled(t *testing.T) {
+	_, err := NewReloader(Config{})
+	require.Error(t, err)
+}
+
+// newServerReloader mints a fresh CA + server leaf and returns a Reloader.
+func newServerReloader(t *testing.T, mtls bool) (*Reloader, *TestPKI, *LeafFiles) {
+	t.Helper()
+	dir := t.TempDir()
+	pki, err := NewTestPKI(dir)
+	require.NoError(t, err)
+	srv, err := pki.Issue(dir, IssueOpts{
+		CommonName: "server",
+		DNSNames:   []string{"localhost"},
+		IPs:        []net.IP{net.ParseIP("127.0.0.1")},
+		IsServer:   true,
+	})
+	require.NoError(t, err)
+	cfg := Config{CertFile: srv.CertPath, KeyFile: srv.KeyPath}
+	if mtls {
+		cfg.RequireClientCert = true
+		cfg.ClientCAFiles = []string{pki.CACertPath}
+	}
+	r, err := NewReloader(cfg)
+	require.NoError(t, err)
+	return r, pki, srv
+}
+
+func TestNewReloaderLoadsCerts(t *testing.T) {
+	r, _, _ := newServerReloader(t, true)
+
+	cert, pool, mtls := r.snapshot()
+	require.NotNil(t, cert)
+	require.NotNil(t, pool)
+	require.True(t, mtls)
+
+	cfg := r.ServerConfig()
+	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+
+	clientCfg, err := cfg.GetConfigForClient(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	assert.Equal(t, tls.RequireAndVerifyClientCert, clientCfg.ClientAuth)
+	assert.NotNil(t, clientCfg.ClientCAs)
+
+	got, err := cfg.GetCertificate(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
+func TestReloadPicksUpRotation(t *testing.T) {
+	r, pki, srv := newServerReloader(t, false)
+	first, _, _ := r.snapshot()
+
+	srv2, err := pki.Issue(t.TempDir(), IssueOpts{CommonName: "server2", DNSNames: []string{"localhost"}, IsServer: true})
+	require.NoError(t, err)
+	mustCopy(t, srv2.CertPath, srv.CertPath)
+	mustCopy(t, srv2.KeyPath, srv.KeyPath)
+
+	require.NoError(t, r.Reload())
+	second, _, _ := r.snapshot()
+	require.NotEmpty(t, first.Certificate)
+	require.NotEmpty(t, second.Certificate)
+	assert.NotEqual(t, string(first.Certificate[0]), string(second.Certificate[0]))
+}
+
+// TestReloadFailsOnBadKey asserts a failed Reload preserves the prior
+// snapshot, so the server keeps serving stale-but-valid material.
+func TestReloadFailsOnBadKey(t *testing.T) {
+	r, _, srv := newServerReloader(t, false)
+
+	require.NoError(t, os.WriteFile(srv.KeyPath, []byte("not a key"), 0600))
+	prev, _, _ := r.snapshot()
+	require.Error(t, r.Reload())
+	cur, _, _ := r.snapshot()
+	assert.Equal(t, string(prev.Certificate[0]), string(cur.Certificate[0]))
+}
+
+func TestReloadFailsOnBadCABundle(t *testing.T) {
+	dir := t.TempDir()
+	pki, err := NewTestPKI(dir)
+	require.NoError(t, err)
+	srv, err := pki.Issue(dir, IssueOpts{CommonName: "server", DNSNames: []string{"localhost"}, IsServer: true})
+	require.NoError(t, err)
+
+	bogus := filepath.Join(dir, "bogus-ca.pem")
+	require.NoError(t, os.WriteFile(bogus, []byte("not pem\n"), 0600))
+
+	_, err = NewReloader(Config{
+		CertFile:          srv.CertPath,
+		KeyFile:           srv.KeyPath,
+		ClientCAFiles:     []string{bogus},
+		RequireClientCert: true,
+	})
+	require.Error(t, err)
+}
+
+// TestReloadIsSerialized asserts concurrent Reload calls leave the snapshot
+// reflecting the last completed disk read; a slow read returning after a
+// faster one must not overwrite the newer snapshot.
+func TestReloadIsSerialized(t *testing.T) {
+	r, _, srv := newServerReloader(t, false)
+
+	const goroutines = 16
+	const iterations = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				if err := r.Reload(); err != nil {
+					t.Errorf("Reload: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	cert, _, _ := r.snapshot()
+	require.NotNil(t, cert)
+	require.NotEmpty(t, cert.Certificate)
+
+	want, err := tls.LoadX509KeyPair(srv.CertPath, srv.KeyPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(want.Certificate[0]), string(cert.Certificate[0]))
+}
+
+func TestWatchTriggersReload(t *testing.T) {
+	r, pki, srv := newServerReloader(t, false)
+
+	Watch(t.Context(), r)
+	first, _, _ := r.snapshot()
+
+	srv2, err := pki.Issue(t.TempDir(), IssueOpts{CommonName: "server2", DNSNames: []string{"localhost"}, IsServer: true})
+	require.NoError(t, err)
+	mustCopy(t, srv2.CertPath, srv.CertPath)
+	mustCopy(t, srv2.KeyPath, srv.KeyPath)
+
+	// 15s gives fsnotify the fast path plus one full watchInterval poll as
+	// backstop in case the watcher arms after mustCopy under -race.
+	require.Eventually(t, func() bool {
+		cur, _, _ := r.snapshot()
+		return string(first.Certificate[0]) != string(cur.Certificate[0])
+	}, 15*time.Second, 50*time.Millisecond)
+}
+
+func mustCopy(t *testing.T, src, dst string) {
+	t.Helper()
+	b, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dst, b, 0600))
+}

--- a/pkg/certloader/watcher.go
+++ b/pkg/certloader/watcher.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package certloader
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/logger/logfields"
+)
+
+// watchInterval polls cert/key as a safety net for fsnotify events missed
+// during atomic rotations (notably Kubernetes Secret ..data symlink swaps,
+// which file-level fsnotify cannot observe).
+const watchInterval = 5 * time.Second
+
+// retryInterval governs construction retries during lazy bootstrap (cert
+// files written after the agent starts, e.g. cert-manager / cilium-certgen).
+const retryInterval = 5 * time.Second
+
+// Watch starts a background watcher that calls r.Reload whenever the cert or
+// key change on disk. Reload re-reads the client CA bundle too, so all TLS
+// material stays in sync. Runs until ctx is canceled; failures are logged.
+func Watch(ctx context.Context, r *Reloader) {
+	log := logger.GetLogger().With("component", "certloader")
+	go func() {
+		cw, err := waitForCertWatcher(ctx, r.cfg.CertFile, r.cfg.KeyFile)
+		if err != nil {
+			return
+		}
+		// RegisterCallback fires once immediately, promoting a lazy
+		// Reloader to Ready as soon as the cert can be loaded.
+		cw.RegisterCallback(func(_ tls.Certificate) {
+			if err := r.Reload(); err != nil {
+				log.Error("TLS reload failed", logfields.Error, err)
+				return
+			}
+			log.Info("TLS material reloaded")
+		})
+		if err := cw.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			log.Error("certwatcher exited", logfields.Error, err)
+		}
+	}()
+}
+
+// waitForCertWatcher retries certwatcher.New until it succeeds or ctx is
+// canceled. Construction can fail for missing files, mid-rotation cert/key
+// mismatch, bad permissions, or malformed PEM — all retried so a transient
+// bootstrap race does not crash the agent. Errors are logged so a permanent
+// misconfiguration is visible instead of silently spinning.
+func waitForCertWatcher(ctx context.Context, certPath, keyPath string) (*certwatcher.CertWatcher, error) {
+	log := logger.GetLogger().With("component", "certloader")
+	timer := time.NewTimer(retryInterval)
+	defer timer.Stop()
+	for {
+		cw, err := certwatcher.New(certPath, keyPath)
+		if err == nil {
+			return cw.WithWatchInterval(watchInterval), nil
+		}
+		log.Warn("certwatcher init failed; retrying", logfields.Error, err)
+		timer.Reset(retryInterval)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -41,6 +41,11 @@ const (
 	// Used by both client cli to guess unix socket address and by bugtool
 	InitInfoFile = DefaultRunDir + "tetragon-info.json"
 
+	// DefaultUnixSocket is the in-pod IPC socket the agent exposes when the
+	// gRPC server is listening on TCP, so co-located tooling can connect
+	// without TLS material.
+	DefaultUnixSocket = DefaultRunDir + "tetragon.sock"
+
 	// BugtoolExtraFiles is the file location for extra files to include in bugtool archives.
 	// Written by the daemon at startup, read by the CLI at bugtool time.
 	BugtoolExtraFiles = DefaultRunDir + "tetragon-bugtool-extra-files.json"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -141,6 +141,21 @@ type config struct {
 	EnableGRPCDeprecatedTP bool
 
 	KeepCollection bool
+
+	// ServerTLSCertFile is the path to the PEM-encoded server leaf certificate
+	// served on the TCP gRPC listener. Empty disables TLS.
+	ServerTLSCertFile string
+	// ServerTLSKeyFile is the path to the PEM-encoded private key corresponding
+	// to ServerTLSCertFile. Required when ServerTLSCertFile is set.
+	ServerTLSKeyFile string
+	// ServerTLSClientCAFiles is a list of PEM-encoded CA bundle files used to
+	// verify presented client certificates. Required when
+	// ServerTLSRequireClientCert is true.
+	ServerTLSClientCAFiles []string
+	// ServerTLSRequireClientCert toggles mTLS. When true, the server promotes
+	// its ClientAuth policy to RequireAndVerifyClientCert; ServerTLSClientCAFiles
+	// must be non-empty.
+	ServerTLSRequireClientCert bool
 }
 
 var (

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -145,6 +145,12 @@ const (
 	KeyRetprobesCacheSize = "retprobes-cache-size"
 
 	KeyEnableDeprecatedTPGRPC = "enable-deprecated-tracingpolicy-grpc"
+
+	// gRPC server TLS / mTLS flags.
+	KeyServerTLSCertFile          = "server-tls-cert-file"
+	KeyServerTLSKeyFile           = "server-tls-key-file"
+	KeyServerTLSClientCAFiles     = "server-tls-client-ca-files"
+	KeyServerTLSRequireClientCert = "server-tls-require-client-cert"
 )
 
 type UsernameMetadaCode int
@@ -318,7 +324,60 @@ func ReadAndSetFlags() error {
 
 	Config.EnableGRPCDeprecatedTP = viper.GetBool(KeyEnableDeprecatedTPGRPC)
 
+	Config.ServerTLSCertFile = viper.GetString(KeyServerTLSCertFile)
+	Config.ServerTLSKeyFile = viper.GetString(KeyServerTLSKeyFile)
+	Config.ServerTLSClientCAFiles = viper.GetStringSlice(KeyServerTLSClientCAFiles)
+	Config.ServerTLSRequireClientCert = viper.GetBool(KeyServerTLSRequireClientCert)
+	if err := validateServerTLSConfig(Config); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// validateServerTLSConfig enforces the server-side TLS / mTLS flag
+// preconditions:
+//   - cert-file and key-file must be set together,
+//   - require-client-cert demands at least one client CA bundle,
+//   - client CA files cannot be supplied without enabling client cert
+//     verification (otherwise the bundle is silently ignored), and
+//   - TLS only applies to the TCP listener: pairing --server-tls-* with a
+//     unix-only or empty --server-address is almost certainly a misconfig
+//     (the cert material would be quietly ignored), so reject it loudly.
+func validateServerTLSConfig(c config) error {
+	hasCert := c.ServerTLSCertFile != ""
+	hasKey := c.ServerTLSKeyFile != ""
+	if hasCert != hasKey {
+		return fmt.Errorf("--%s and --%s must be set together", KeyServerTLSCertFile, KeyServerTLSKeyFile)
+	}
+	if c.ServerTLSRequireClientCert {
+		if !hasCert {
+			return fmt.Errorf("--%s requires --%s and --%s", KeyServerTLSRequireClientCert, KeyServerTLSCertFile, KeyServerTLSKeyFile)
+		}
+		if len(c.ServerTLSClientCAFiles) == 0 {
+			return fmt.Errorf("--%s requires at least one --%s entry", KeyServerTLSRequireClientCert, KeyServerTLSClientCAFiles)
+		}
+	}
+	if !c.ServerTLSRequireClientCert && len(c.ServerTLSClientCAFiles) > 0 {
+		return fmt.Errorf("--%s only takes effect when --%s is true", KeyServerTLSClientCAFiles, KeyServerTLSRequireClientCert)
+	}
+	if hasCert && !serverAddressUsesTCP(c.ServerAddress) {
+		return fmt.Errorf("--%s requires --%s to point at a TCP address (got %q); TLS does not apply to the unix-domain listener",
+			KeyServerTLSCertFile, KeyServerAddress, c.ServerAddress)
+	}
+	return nil
+}
+
+// serverAddressUsesTCP reports whether the configured listen address
+// targets a TCP listener (the only listener type TLS applies to).
+func serverAddressUsesTCP(addr string) bool {
+	if addr == "" {
+		return false
+	}
+	// Mirror server.SplitListenAddr: an explicit unix:// scheme is the
+	// only non-TCP form we accept; everything else is treated as a host
+	// or host:port for net.Listen("tcp", ...).
+	return !strings.HasPrefix(addr, "unix://")
 }
 
 type CgroupRate struct {
@@ -524,4 +583,9 @@ func AddFlags(flags *pflag.FlagSet) {
 
 	flags.Bool(KeyEnableDeprecatedTPGRPC, false, "Enable deprecated gRPC TracingPolicy APIs")
 
+	// gRPC server TLS / mTLS flags.
+	flags.String(KeyServerTLSCertFile, "", "Path to a PEM-encoded server certificate. When set, TLS is enabled on the TCP gRPC listener.")
+	flags.String(KeyServerTLSKeyFile, "", "Path to the PEM-encoded private key matching --"+KeyServerTLSCertFile+". Required when --"+KeyServerTLSCertFile+" is set.")
+	flags.StringSlice(KeyServerTLSClientCAFiles, []string{}, "Paths to PEM-encoded CA bundles used to verify client certificates. Required when --"+KeyServerTLSRequireClientCert+" is true.")
+	flags.Bool(KeyServerTLSRequireClientCert, false, "Require and verify client certificates (mTLS). Requires --"+KeyServerTLSClientCAFiles+".")
 }

--- a/pkg/option/validate_test.go
+++ b/pkg/option/validate_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package option
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateServerTLSConfig(t *testing.T) {
+	t.Parallel()
+	const tcp = "0.0.0.0:54321"
+	cases := []struct {
+		name    string
+		c       config
+		wantErr bool
+	}{
+		{name: "disabled", c: config{}},
+		{name: "tls only", c: config{ServerAddress: tcp, ServerTLSCertFile: "a", ServerTLSKeyFile: "b"}},
+		{name: "cert without key", c: config{ServerAddress: tcp, ServerTLSCertFile: "a"}, wantErr: true},
+		{name: "key without cert", c: config{ServerAddress: tcp, ServerTLSKeyFile: "b"}, wantErr: true},
+		{name: "mtls ok", c: config{ServerAddress: tcp, ServerTLSCertFile: "a", ServerTLSKeyFile: "b", ServerTLSRequireClientCert: true, ServerTLSClientCAFiles: []string{"c"}}},
+		{name: "mtls without cert", c: config{ServerAddress: tcp, ServerTLSRequireClientCert: true, ServerTLSClientCAFiles: []string{"c"}}, wantErr: true},
+		{name: "mtls without ca", c: config{ServerAddress: tcp, ServerTLSCertFile: "a", ServerTLSKeyFile: "b", ServerTLSRequireClientCert: true}, wantErr: true},
+		{name: "ca without mtls", c: config{ServerAddress: tcp, ServerTLSCertFile: "a", ServerTLSKeyFile: "b", ServerTLSClientCAFiles: []string{"c"}}, wantErr: true},
+		{name: "tls with unix address", c: config{ServerAddress: "unix:///run/tetragon.sock", ServerTLSCertFile: "a", ServerTLSKeyFile: "b"}, wantErr: true},
+		{name: "tls with empty address", c: config{ServerAddress: "", ServerTLSCertFile: "a", ServerTLSKeyFile: "b"}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateServerTLSConfig(tc.c)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tests/e2e/tests/grpctls/grpctls_test.go
+++ b/tests/e2e/tests/grpctls/grpctls_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package grpctls_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/tests/e2e/flags"
+	"github.com/cilium/tetragon/tests/e2e/helpers"
+	tetragoninstall "github.com/cilium/tetragon/tests/e2e/install/tetragon"
+	"github.com/cilium/tetragon/tests/e2e/runners"
+	"github.com/cilium/tetragon/tests/e2e/state"
+)
+
+const agentTCPPort = 54321
+
+var runner *runners.Runner
+
+// TestMain installs Tetragon with mTLS via the helm method. The runner's
+// default plaintext auto port-forward is skipped because it would fail
+// the handshake against a TLS-required listener.
+func TestMain(m *testing.M) {
+	runner = runners.NewRunner().
+		NoPortForward().
+		WithInstallTetragon(tetragoninstall.WithHelmOptions(map[string]string{
+			"tetragon.grpc.tls.enabled":           "true",
+			"tetragon.grpc.tls.requireClientCert": "true",
+			"tetragon.grpc.tls.auto.method":       "helm",
+		})).
+		Init()
+	runner.Run(m)
+}
+
+// agentCerts loads the chart-provisioned trust root, CA cert, and CA
+// private key (the latter is needed to mint a client cert in-test).
+func agentCerts(ctx context.Context, t *testing.T, cfg *envconf.Config) (rootCAs *x509.CertPool, caCert *x509.Certificate, caKey crypto.Signer) {
+	t.Helper()
+	opts, ok := ctx.Value(state.InstallOpts).(*flags.HelmOptions)
+	require.True(t, ok, "Tetragon install opts not in context")
+
+	client, err := cfg.NewClient()
+	require.NoError(t, err)
+	r := client.Resources(opts.Namespace)
+
+	serverSecret := corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: opts.DaemonSetName + "-server-certs", Namespace: opts.Namespace}}
+	require.NoError(t, r.Get(ctx, serverSecret.Name, opts.Namespace, &serverSecret))
+
+	caSecret := corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: opts.DaemonSetName + "-ca", Namespace: opts.Namespace}}
+	require.NoError(t, r.Get(ctx, caSecret.Name, opts.Namespace, &caSecret))
+
+	rootCAs = x509.NewCertPool()
+	require.True(t, rootCAs.AppendCertsFromPEM(serverSecret.Data["ca.crt"]), "server-certs Secret has no usable ca.crt")
+
+	caBlock, _ := pem.Decode(caSecret.Data["ca.crt"])
+	require.NotNil(t, caBlock, "ca Secret missing ca.crt PEM")
+	caCert, err = x509.ParseCertificate(caBlock.Bytes)
+	require.NoError(t, err)
+
+	keyBlock, _ := pem.Decode(caSecret.Data["ca.key"])
+	require.NotNil(t, keyBlock, "ca Secret missing ca.key PEM")
+	caKey, err = parsePrivateKey(keyBlock.Bytes)
+	require.NoError(t, err)
+	return rootCAs, caCert, caKey
+}
+
+// parsePrivateKey accepts the three PEM private-key encodings the
+// chart's provisioning methods may produce: PKCS#8 (any algorithm),
+// PKCS#1 (sprig genCA's RSA default), and SEC1 (EC).
+func parsePrivateKey(der []byte) (crypto.Signer, error) {
+	if k, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		signer, ok := k.(crypto.Signer)
+		if !ok {
+			return nil, fmt.Errorf("PKCS#8 key is not a crypto.Signer (%T)", k)
+		}
+		return signer, nil
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return k, nil
+	}
+	if k, err := x509.ParseECPrivateKey(der); err == nil {
+		return k, nil
+	}
+	return nil, errors.New("unrecognized private key format (tried PKCS#8, PKCS#1, SEC1)")
+}
+
+// mintClientCert produces a tls.Certificate signed by the supplied CA.
+// The leaf key is RSA so the resulting tls.Certificate is usable
+// regardless of the CA key's algorithm.
+func mintClientCert(t *testing.T, caCert *x509.Certificate, caKey crypto.Signer) tls.Certificate {
+	t.Helper()
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "tetragon-e2e-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: leafKey}
+}
+
+// portForwardAgent forwards the first Tetragon pod's TCP gRPC port to
+// an OS-assigned loopback port and returns the local address.
+func portForwardAgent(ctx context.Context, t *testing.T, cfg *envconf.Config) string {
+	t.Helper()
+	opts, ok := ctx.Value(state.InstallOpts).(*flags.HelmOptions)
+	require.True(t, ok)
+	client, err := cfg.NewClient()
+	require.NoError(t, err)
+
+	pods := &corev1.PodList{}
+	require.NoError(t, client.Resources(opts.Namespace).List(ctx, pods,
+		resources.WithLabelSelector("app.kubernetes.io/name="+opts.DaemonSetName)))
+	require.NotEmpty(t, pods.Items, "no Tetragon pods found")
+	pod := pods.Items[0]
+
+	localPort := freeLoopbackPort(t)
+	_, err = helpers.PortForwardPod(
+		runner.Environment, &pod, nil, nil, 30, time.Second,
+		func() error {
+			conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", localPort), 2*time.Second)
+			if err != nil {
+				return err
+			}
+			_ = conn.Close()
+			return nil
+		},
+		fmt.Sprintf("%d:%d", localPort, agentTCPPort),
+	)(ctx, cfg)
+	require.NoError(t, err, "could not establish port-forward")
+	return fmt.Sprintf("127.0.0.1:%d", localPort)
+}
+
+// freeLoopbackPort asks the kernel for an unused loopback port. The
+// returned port is closed before use, so a TOCTOU race is possible but
+// far smaller than any fixed-range counter under matrix parallelism.
+func freeLoopbackPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+func dial(t *testing.T, addr string, creds credentials.TransportCredentials) *grpc.ClientConn {
+	t.Helper()
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func rpcContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// validClientCreds builds the valid-client-cert mTLS credentials reused
+// by the readiness probe and the happy-path assertion.
+func validClientCreds(t *testing.T, rootCAs *x509.CertPool, caCert *x509.Certificate, caKey crypto.Signer) credentials.TransportCredentials {
+	t.Helper()
+	return credentials.NewTLS(&tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		RootCAs:      rootCAs,
+		Certificates: []tls.Certificate{mintClientCert(t, caCert, caKey)},
+		ServerName:   "any.tetragon-grpc.cilium.io",
+	})
+}
+
+// waitForReady blocks until a valid mTLS dial + GetVersion succeeds.
+// Pod readiness only gates on the liveness probe (port 6789); the main
+// gRPC listener comes up later, after BPF setup. Without this probe a
+// rejection test can pass spuriously by dialling before the listener
+// exists (codes.Unavailable from "connection refused" is
+// indistinguishable from a TLS reject).
+func waitForReady(t *testing.T, addr string, creds credentials.TransportCredentials) string {
+	t.Helper()
+	var version string
+	require.Eventually(t, func() bool {
+		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
+		if err != nil {
+			return false
+		}
+		defer func() { _ = conn.Close() }()
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		resp, err := tetragon.NewFineGuidanceSensorsClient(conn).
+			GetVersion(ctx, &tetragon.GetVersionRequest{})
+		if err != nil || resp.GetVersion() == "" {
+			return false
+		}
+		version = resp.GetVersion()
+		return true
+	}, 90*time.Second, time.Second, "agent gRPC listener not ready")
+	return version
+}
+
+func TestMTLSHandshake(t *testing.T) {
+	feature := features.New("mTLS handshake succeeds with valid client cert").
+		Assess("GetVersion", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rootCAs, caCert, caKey := agentCerts(ctx, t, cfg)
+			addr := portForwardAgent(ctx, t, cfg)
+			version := waitForReady(t, addr, validClientCreds(t, rootCAs, caCert, caKey))
+			t.Logf("handshake succeeded, agent version: %s", version)
+			return ctx
+		}).Feature()
+	runner.Test(t, feature)
+}
+
+func TestMTLSRejectsPlaintext(t *testing.T) {
+	feature := features.New("mTLS rejects plaintext clients").
+		Assess("dial fails", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rootCAs, caCert, caKey := agentCerts(ctx, t, cfg)
+			addr := portForwardAgent(ctx, t, cfg)
+			waitForReady(t, addr, validClientCreds(t, rootCAs, caCert, caKey))
+
+			conn := dial(t, addr, insecure.NewCredentials())
+			_, err := tetragon.NewFineGuidanceSensorsClient(conn).
+				GetVersion(rpcContext(t), &tetragon.GetVersionRequest{})
+			requireUnavailable(t, err)
+			t.Logf("rejected plaintext client: %s", err)
+			return ctx
+		}).Feature()
+	runner.Test(t, feature)
+}
+
+func TestMTLSRejectsAnonymousTLS(t *testing.T) {
+	feature := features.New("mTLS rejects clients without a client cert").
+		Assess("dial fails", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			rootCAs, caCert, caKey := agentCerts(ctx, t, cfg)
+			addr := portForwardAgent(ctx, t, cfg)
+			waitForReady(t, addr, validClientCreds(t, rootCAs, caCert, caKey))
+
+			creds := credentials.NewTLS(&tls.Config{
+				MinVersion: tls.VersionTLS13,
+				RootCAs:    rootCAs,
+				ServerName: "any.tetragon-grpc.cilium.io",
+			})
+			conn := dial(t, addr, creds)
+			_, err := tetragon.NewFineGuidanceSensorsClient(conn).
+				GetVersion(rpcContext(t), &tetragon.GetVersionRequest{})
+			requireUnavailable(t, err)
+			t.Logf("handshake rejected as expected with client TLS but no cert: %s", err)
+			return ctx
+		}).Feature()
+	runner.Test(t, feature)
+}
+
+// requireUnavailable asserts the RPC failed with codes.Unavailable.
+// gRPC wraps both rejected handshakes and post-handshake resets that
+// way. A raw timeout is treated as a failure rather than a rejection
+// signal so a slow CI node cannot mask an absent server-side reject.
+func requireUnavailable(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	s, ok := status.FromError(err)
+	require.True(t, ok, "expected a gRPC status error, got: %v", err)
+	require.Equal(t, codes.Unavailable, s.Code(),
+		"expected Unavailable, got %v: %s", s.Code(), s.Message())
+}


### PR DESCRIPTION
### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

This PR is to add TLS/mTLS support for tetragon grpc server, below points worth highlighting:

- grpc TLS feature is disabled by default, mainly for upgrade scenario if existing installation is already configured with TCP (instead of unix socket)
- dual listeners if TCP + TLS combination is used i.e. unix domain socket is enabled as second listener. This is to avoid any potential issue for in-pod tetra command.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
grpc: Support mTLS for tetragon grpc server
```
