### PR TITLE
ci: Move to cosign v3

### DIFF
--- a/.github/actions/cosign/action.yaml
+++ b/.github/actions/cosign/action.yaml
@@ -1,0 +1,66 @@
+name: 'Generate SBOM and Sign with Cosign'
+description: 'Generate SBOM, sign container images, and publish SBOM attestations'
+inputs:
+  image:
+    description: 'Container image to sign (format: "quay.io/org/image@digest")'
+    required: true
+  image_tag:
+    description: 'Container image tag for SBOM generation (format: "quay.io/org/image:tag")'
+    required: false
+  sbom_name:
+    description: 'Name for the SBOM artifact and file (e.g., "tetragon_v1.2.3")'
+    required: false
+  generate_sbom:
+    description: 'Generate SBOM'
+    required: false
+    default: 'true'
+  install_cosign:
+    description: 'Whether to install cosign (set to false if already installed)'
+    required: false
+    default: 'true'
+  upload_sbom_release_assets:
+    description: 'Upload SBOM as a release asset'
+    required: false
+    default: 'true'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Cosign
+      if: ${{ inputs.install_cosign == 'true' }}
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+    - name: Generate SBOM
+      if: ${{ inputs.generate_sbom == 'true' }}
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        artifact-name: sbom_${{ inputs.sbom_name }}.spdx.json
+        output-file: ./sbom_${{ inputs.sbom_name }}.spdx.json
+        image: ${{ inputs.image_tag }}
+        upload-release-assets: ${{ inputs.upload_sbom_release_assets }}
+
+    - name: Sign image and publish SBOM attestation
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        SBOM_FILE: ./sbom_${{ inputs.sbom_name }}.spdx.json
+      run: |
+        # Cosign signing/attestation can hit transient registry errors;
+        # retry the given command with exponential backoff.
+        retry() {
+          local max_attempts=5 delay=10 attempt
+          for attempt in $(seq 1 "$max_attempts"); do
+            "$@" && return 0
+            echo "Attempt $attempt/$max_attempts failed: $*"
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "Waiting ${delay}s before retry..."
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
+          done
+          echo "ERROR: '$*' failed after $max_attempts attempts" >&2
+          return 1
+        }
+
+        retry cosign sign -y "$IMAGE"
+        retry cosign attest -y --predicate "$SBOM_FILE" --type spdxjson "$IMAGE"

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -20,4 +20,13 @@ exclude = [
   # this a parsing error from index.html, it uses the {{< latest-version >}}
   # shortcode which is not detected
   '^https://github.com/cilium/tetragon/releases/download/$',
+  # cosign keyless OIDC token endpoint: only responds to authenticated requests
+  '^https://token\.actions\.githubusercontent\.com',
+  # SPDX namespace URI used as the predicate-type identifier — not a fetchable resource
+  '^https://spdx\.dev/Document',
+  # lychee's URL extractor stops at the first `\` in the
+  # `--certificate-identity-regexp` argument value used in cosign examples,
+  # leaving it with the meaningless prefix `https://github` (normalised to
+  # `https://github/`). Exclude it so the spurious URL doesn't fail the check.
+  '^https?://github/?$',
 ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -400,12 +400,6 @@
       "matchUpdateTypes": ["digest"],
     },
     {
-      // do not update sigstore/cosign-installer as it breaks CI
-      "matchPackageNames": ["sigstore/cosign-installer"],
-      "matchManagers": ["github-actions"],
-      "enabled": false
-    },
-    {
       // do not update docker.io/library/ubuntu container image in utility images
       "matchPackageNames": ["docker.io/library/ubuntu"],
       "matchManagers": ["dockerfile"],

--- a/.github/workflows/build-clang-image.yaml
+++ b/.github/workflows/build-clang-image.yaml
@@ -60,7 +60,7 @@ jobs:
     permissions:
       # To be able to access the repository with `actions/checkout`
       contents: read
-      # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+      # Required to generate OIDC tokens for cosign keyless signing
       id-token: write
     steps:
       # https://github.com/docker/setup-qemu-action
@@ -107,51 +107,13 @@ jobs:
           tags: |
             quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}
 
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
-
-      - name: Sign Container Image
-        if: steps.tag-in-repositories.outputs.exists == 'false'
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          cosign sign -y quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
-
-      - name: Install Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Sign image and publish SBOM attestation
+        uses: ./.github/actions/cosign
         with:
-          # renovate: datasource=golang-version depName=go
-          go-version: '1.26.4'
-
-      - name: Install Bom
-        shell: bash
-        env:
-          # renovate: datasource=github-releases depName=kubernetes-sigs/bom
-          BOM_VERSION: v0.7.1
-        run: |
-          go install sigs.k8s.io/bom/cmd/bom@${{ env.BOM_VERSION }}
-
-      - name: Generate SBOM
-        shell: bash
-        # To-Do: Format SBOM output to JSON after a new version of cosign is released after v1.13.1. Ref: https://github.com/sigstore/cosign/pull/2479
-        run: |
-          bom generate -o sbom_clang_${{ steps.tag.outputs.tag }}.spdx \
-          --dirs= . \
-          --image=quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}
-
-      - name: Attach SBOM to container image
-        run: |
-          cosign attach sbom --sbom sbom_clang_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
-
-      - name: Sign SBOM Image
-        if: steps.tag-in-repositories.outputs.exists == 'false'
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          docker_build_release_digest="${{ steps.docker_build_release.outputs.digest }}"
-          image_name="quay.io/${{ github.repository_owner }}/clang:${docker_build_release_digest/:/-}.sbom"
-          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign -y "quay.io/${{ github.repository_owner }}/clang@${docker_build_release_sbom_digest}"
+          image: quay.io/${{ github.repository_owner }}/clang@${{ steps.docker_build_release.outputs.digest }}
+          image_tag: quay.io/${{ github.repository_owner }}/clang:${{ steps.tag.outputs.tag }}
+          sbom_name: clang_${{ steps.tag.outputs.tag }}
+          upload_sbom_release_assets: 'false'
 
       - name: Image Release Digest
         shell: bash

--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -11,7 +11,7 @@ on:
 permissions:
   # To be able to access the repository with `actions/checkout` and upload release artifacts
   contents: write
-  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  # Required to generate OIDC tokens for cosign keyless signing
   id-token: write
 
 jobs:
@@ -77,61 +77,23 @@ jobs:
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
 
-      - name: Install Cosign
+      - name: Sign image and publish SBOM attestation (${{ matrix.name }})
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
-
-      - name: Sign Container Image
-        if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          cosign sign -y quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
-          cosign sign -y quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
-
-      - name: Install Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/cosign
         with:
-          # renovate: datasource=golang-version depName=go
-          go-version: '1.26.4'
+          image: quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
+          image_tag: quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+          sbom_name: ${{ matrix.name }}_${{ steps.tag.outputs.tag }}
 
-      - name: Install Bom
+      - name: Sign image and attach SBOM attestation (${{ matrix.name }}-ci)
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        shell: bash
-        env:
-          # renovate: datasource=github-releases depName=kubernetes-sigs/bom
-          BOM_VERSION: v0.7.1
-        run: |
-          go install sigs.k8s.io/bom/cmd/bom@${{ env.BOM_VERSION }}
-
-      - name: Generate SBOM
-        if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        shell: bash
-        # To-Do: Format SBOM output to JSON after a new version of cosign is released after v1.13.1. Ref: https://github.com/sigstore/cosign/pull/2479
-        run: |
-          bom generate -o sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx \
-          --dirs= . \
-          --image=quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
-
-      - name: Attach SBOM to container image
-        if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        run: |
-          cosign attach sbom --sbom sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
-          cosign attach sbom --sbom sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
-
-      - name: Sign SBOM Image
-        if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          docker_build_release_digest="${{ steps.docker_build_release.outputs.digest }}"
-          image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${docker_build_release_digest/:/-}.sbom"
-          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign -y "quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${docker_build_release_sbom_digest}"
-
-          image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_release_digest/:/-}.sbom"
-          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign -y "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_release_sbom_digest}"
+        uses: ./.github/actions/cosign
+        with:
+          image: quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
+          sbom_name: ${{ matrix.name }}_${{ steps.tag.outputs.tag }}
+          install_cosign: 'false'
+          generate_sbom: 'false'
+          upload_sbom_release_assets: 'false'
 
       - name: Image Release Digest
         shell: bash

--- a/.github/workflows/build-rthooks-images-releases.yml
+++ b/.github/workflows/build-rthooks-images-releases.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   # To be able to access the repository with `actions/checkout` and upload release artifacts
   contents: write
-  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  # Required to generate OIDC tokens for cosign keyless signing
   id-token: write
 
 jobs:
@@ -65,61 +65,23 @@ jobs:
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
             quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
 
-      - name: Install Cosign
+      - name: Sign image and publish SBOM attestation (${{ matrix.name }})
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
-
-      - name: Sign Container Image
-        if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          cosign sign -y quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
-          cosign sign -y quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
-
-      - name: Install Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/cosign
         with:
-          # renovate: datasource=golang-version depName=go
-          go-version: '1.26.4'
+          image: quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
+          image_tag: quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+          sbom_name: ${{ matrix.name }}_${{ steps.tag.outputs.tag }}
 
-      - name: Install Bom
+      - name: Sign image and attach SBOM attestation (${{ matrix.name }}-ci)
         if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        shell: bash
-        env:
-          # renovate: datasource=github-releases depName=kubernetes-sigs/bom
-          BOM_VERSION: v0.7.1
-        run: |
-          go install sigs.k8s.io/bom/cmd/bom@${{ env.BOM_VERSION }}
-
-      - name: Generate SBOM
-        if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        shell: bash
-        # To-Do: Format SBOM output to JSON after a new version of cosign is released after v1.13.1. Ref: https://github.com/sigstore/cosign/pull/2479
-        run: |
-          bom generate -o sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx \
-          --dirs= . \
-          --image=quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
-
-      - name: Attach SBOM to container image
-        if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        run: |
-          cosign attach sbom --sbom sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${{ steps.docker_build_release.outputs.digest }}
-          cosign attach sbom --sbom sbom_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
-
-      - name: Sign SBOM Image
-        if: ${{ startsWith(steps.tag.outputs.tag, 'v') }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          docker_build_release_digest="${{ steps.docker_build_release.outputs.digest }}"
-          image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${docker_build_release_digest/:/-}.sbom"
-          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign -y "quay.io/${{ github.repository_owner }}/${{ matrix.name }}@${docker_build_release_sbom_digest}"
-
-          image_name="quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${docker_build_release_digest/:/-}.sbom"
-          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign -y "quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${docker_build_release_sbom_digest}"
+        uses: ./.github/actions/cosign
+        with:
+          image: quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci@${{ steps.docker_build_release.outputs.digest }}
+          sbom_name: ${{ matrix.name }}_${{ steps.tag.outputs.tag }}
+          install_cosign: 'false'
+          generate_sbom: 'false'
+          upload_sbom_release_assets: 'false'
 
       - name: Image Release Digest
         shell: bash

--- a/docs/content/en/docs/installation/verify.md
+++ b/docs/content/en/docs/installation/verify.md
@@ -20,7 +20,11 @@ Since version 0.8.4, all Tetragon container images are signed using cosign.
 Let's verify a Tetragon image's signature using the `cosign verify` command:
 
 ```shell
-cosign verify --certificate-github-workflow-repository cilium/tetragon --certificate-oidc-issuer https://token.actions.githubusercontent.com <Image URL> | jq
+cosign verify \
+  --certificate-github-workflow-repository cilium/tetragon \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'https://github\.com/cilium/tetragon/\.github/workflows/.+' \
+  <Image URL> | jq
 ```
 
 {{< note >}}
@@ -39,27 +43,47 @@ insight into the software supply chain and any potential concerns related to
 license compliance and security that might exist.
 
 Starting with version 0.8.4, all Tetragon images include an SBOM. The SBOM is
-generated in [SPDX](https://spdx.dev/) format using the
-[bom](https://github.com/kubernetes-sigs/bom) tool. If you are new to the
-concept of SBOM, see [what an SBOM can do for you](https://www.chainguard.dev/unchained/what-an-sbom-can-do-for-you).
+generated in [SPDX JSON](https://spdx.dev/) format and published as a cosign
+[attestation](https://docs.sigstore.dev/cosign/verifying/attestation/)
+alongside the image. If you are new to the concept of SBOM, see
+[what an SBOM can do for you](https://www.chainguard.dev/unchained/what-an-sbom-can-do-for-you).
+
+{{< note >}}
+**Upgrade note:** Releases prior to v1.8 published the SBOM as a separate
+`.sbom` artifact attached with `cosign attach sbom`. Starting with v1.8, the
+SBOM is published as an SPDX JSON attestation via `cosign attest --type
+spdxjson`. The legacy commands below no longer apply to images built from v1.8
+onward; use the attestation-based commands instead.
+
+```shell
+# Legacy (pre-v1.8) — no longer applicable
+cosign download sbom <Image URL>
+cosign verify --attachment sbom <Image URL>
+```
+{{< /note >}}
 
 ### Download SBOM
 
-The SBOM can be downloaded from the supplied Tetragon image using the `cosign
-download sbom` command.
+The SBOM can be extracted from the attestation using `cosign download
+attestation` and decoding the base64-encoded payload:
 
 ```shell
-cosign download sbom --output-file sbom.spdx <Image URL>
+cosign download attestation --predicate-type=https://spdx.dev/Document <Image URL> \
+  | jq -r .dsseEnvelope.payload | base64 -d | jq .predicate > sbom.spdx.json
 ```
 
-### Verify SBOM Image Signature
+### Verify SBOM Attestation
 
-To ensure the SBOM is tamper-proof, its signature can be verified using the
-`cosign verify` command.
+To ensure the SBOM is tamper-proof, its attestation can be verified using the
+`cosign verify-attestation` command.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign verify --certificate-github-workflow-repository cilium/tetragon --certificate-oidc-issuer https://token.actions.githubusercontent.com --attachment sbom <Image URL> | jq
+cosign verify-attestation --type spdxjson \
+  --certificate-github-workflow-repository cilium/tetragon \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'https://github\.com/cilium/tetragon/\.github/workflows/.+' \
+  <Image URL> | jq
 ```
 
-It can be validated that the SBOM image was signed using Github Actions in the
-Cilium repository from the `Issuer` and `Subject` fields of the output.
+It can be validated that the SBOM attestation was signed using GitHub Actions
+in the Cilium repository from the `Issuer` and `Subject` fields of the output.


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->


### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

The current cosign-installer v3.x.x was the last release for cosign v2, it's better to transition to v3 with more recent cosign-installer. 

https://github.com/sigstore/cosign-installer/releases/tag/v3.10.1
> Note: This is planned to be the final release of Cosign v2, though we will cut new releases for any critical security or bug fixes. We recommend transitioning to [Cosign v3](https://blog.sigstore.dev/cosign-3-0-available/).


### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
ci: Move to cosign v3
```
