### PR TITLE
docs: Remove reference to followForks

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -289,8 +289,7 @@ The available operators for `matchBinaries` are:
 - `Postfix`
 - `NotPostfix`
 
-The `values` field has to be a map of `strings`. The default behaviour
-is `followForks: true`, so all the child processes are followed.
+The `values` field has to be a map of `strings`.
 
 ### Follow children
 
@@ -419,8 +418,7 @@ The available operators for `matchParentBinaries` are:
 - `Postfix`
 - `NotPostfix`
 
-The `values` field has to be a map of `strings`. The default behaviour
-is `followForks: true`, so all the child processes are followed.
+The `values` field has to be a map of `strings`.
 
 ### Follow children
 


### PR DESCRIPTION
This configuration only applies to the PID selector. So, it doesn't make sense to mention it for the binary selectors.
