### PR TITLE
backport: mbset: fix spurious destroy hook warning

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1725,6 +1725,9 @@ func CleanupKernelSelectorState(state *KernelSelectorState) error {
 
 	for selectorID, paths := range state.MatchBinariesPaths() {
 		sel := state.MatchBinaries()[selectorID]
+		if sel.MBSetID == mbset.InvalidID {
+			continue
+		}
 		if err := mbset.RemoveID(sel.MBSetID, paths); err != nil {
 			errs = errors.Join(errs, err)
 		}


### PR DESCRIPTION
[ upstream commit b0f5002cc4932e43937225d60f4329fb12a4a29d ]

Removing a policy with a matchBinaries selector that does not have a FollowChildren property results in the following warning:

  level=warn msg="Destroy hook failed" sensor=generic_kprobe error="failed to lookup mbset map: lookup: key does not exist"

The issue is that populateMatchBinariesPathsMaps does not insert a path entry if FollowChildren is not set (MBSetID is InvalidID), so there is nothing to remove. This commit does the same in
CleanupKernelSelectorState.

Backport of https://github.com/cilium/tetragon/pull/4954

Correct version of https://github.com/cilium/tetragon/pull/4960 which was based against `main`.
