### PR TITLE
renovate: fix pattern of LVH images to include rhel8.10

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -272,7 +272,7 @@
       // - rhel8.10-20260206.193128
       // - 5.15-20230912.232842
       // - 5.19-20230912.232842@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
-      "versioning": "regex:^((?<compatibility>[a-z0-9-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
+      "versioning": "regex:^((?<compatibility>[a-z0-9.-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
       "groupName": "all lvh-images main",


### PR DESCRIPTION
### Description

The rhel8.10 image in `.github/workflows/vmtests.ym` has not been updated by renovate for a while because the regex breaks with the dot in the `compatibility` section of the image. This fix includes the dot so this image in vmtest.yml should be updated in the next renovate PR.

See the difference in versions: https://github.com/cilium/tetragon/blob/d64bc9af69ba4fa5fb888b89a6adace5b4895e23/.github/workflows/vmtests.yml#L68-L72

### Testing

Running renovate locally, before the fix

```json
{
  "depName": "quay.io/lvh-images/kernel-images",
  "currentValue": "rhel8.10-20260206.193128",
  "datasource": "docker",
  "replaceString": "# renovate: datasource=docker depName=quay.io/lvh-images/kernel-images\n              - 'rhel8.10-20260206.193128",
  "updates": [],
  "packageName": "quay.io/lvh-images/kernel-images",
  "versioning": "regex:^((?<compatibility>[a-z0-9-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$",
  "warnings": [],
  "skipReason": "invalid-value"
}
```

After the fix

```json
{
  "depName": "quay.io/lvh-images/kernel-images",
  "currentValue": "rhel8.10-20260206.193128",
  "datasource": "docker",
  "replaceString": "# renovate: datasource=docker depName=quay.io/lvh-images/kernel-images\n              - 'rhel8.10-20260206.193128",
  "updates": [
    {
      "bucket": "patch",
      "newVersion": "rhel8.10-20260504.013701",
      "newValue": "rhel8.10-20260504.013701",
      "newMajor": 0,
      "newMinor": 0,
      "newPatch": 20260504,
      "updateType": "patch",
      "isBreaking": false,
      "branchName": "renovate/patch-all-lvh-images-main"
    }
  ],
  "packageName": "quay.io/lvh-images/kernel-images",
  "versioning": "regex:^((?<compatibility>[a-z0-9.-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$",
  "warnings": [],
  "registryUrl": "https://quay.io",
  "lookupName": "lvh-images/kernel-images",
  "currentVersion": "rhel8.10-20260206.193128",
  "isSingleVersion": true,
  "fixedVersion": "rhel8.10-20260206.193128"
}
```
