### PR TITLE
tracing: improve arg read error status message

### DIFF
--- a/pkg/sensors/tracing/args_linux.go
+++ b/pkg/sensors/tracing/args_linux.go
@@ -134,9 +134,9 @@ func getArgStatus(r *bytes.Reader) (*api.MsgGenericKprobeArgError, error) {
 
 	if status != 0 {
 		if status == ^uint32(0) {
-			arg.Message = "Bad address"
+			arg.Message = "Bad address for basic type"
 		} else {
-			arg.Message = strconv.FormatUint(uint64(status), 10)
+			arg.Message = "Bad address encountered during resolve dereference at depth " + strconv.FormatUint(uint64(status-1), 10)
 		}
 		return &arg, nil
 	}

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -202,35 +202,35 @@ func TestUprobeResolve(t *testing.T) {
 			ec.NewKprobeArgumentChecker().WithSizeArg(10), // uint64(10)
 			ec.NewKprobeArgumentChecker().WithUintArg(0),
 			ec.NewKprobeArgumentChecker().WithUintArg(0),
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("3"))),
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("2"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 2"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 1"))),
 		}},
 		{"uint32", 1234, "enum_u32", []*ec.KprobeArgumentChecker{
 			ec.NewKprobeArgumentChecker().WithSizeArg(0),
 			ec.NewKprobeArgumentChecker().WithUintArg(1234), // uint32(1234)
 			ec.NewKprobeArgumentChecker().WithUintArg(0),
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("3"))),
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("2"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 2"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 1"))),
 		}},
 		{"uint32", 12, "sub.v32", []*ec.KprobeArgumentChecker{
 			ec.NewKprobeArgumentChecker().WithSizeArg(0),
 			ec.NewKprobeArgumentChecker().WithUintArg(0),
 			ec.NewKprobeArgumentChecker().WithUintArg(12), // uint32(12)
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("3"))),
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("2"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 2"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 1"))),
 		}},
 		{"uint64", 13, "arr[2].v64", []*ec.KprobeArgumentChecker{
 			ec.NewKprobeArgumentChecker().WithSizeArg(0),
 			ec.NewKprobeArgumentChecker().WithUintArg(0),
 			ec.NewKprobeArgumentChecker().WithUintArg(0),
 			ec.NewKprobeArgumentChecker().WithSizeArg(13), // uint64(13)
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("3"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 2"))),
 		}},
 		{"uint64", 14, "dyn[6].v64", []*ec.KprobeArgumentChecker{
 			ec.NewKprobeArgumentChecker().WithSizeArg(0),
 			ec.NewKprobeArgumentChecker().WithUintArg(0),
 			ec.NewKprobeArgumentChecker().WithUintArg(0),
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("3"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 2"))),
 			ec.NewKprobeArgumentChecker().WithSizeArg(14), // uint64(14)
 		}},
 	}
@@ -1336,13 +1336,13 @@ func TestUprobeResolveNull(t *testing.T) {
 		kpArgs []*ec.KprobeArgumentChecker
 	}{
 		{"first", []*ec.KprobeArgumentChecker{
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("1"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 0"))),
 		}},
 		{"second", []*ec.KprobeArgumentChecker{
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("2"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 1"))),
 		}},
 		{"third", []*ec.KprobeArgumentChecker{
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("3"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address encountered during resolve dereference at depth 2"))),
 		}},
 		{"nonull", []*ec.KprobeArgumentChecker{
 			ec.NewKprobeArgumentChecker().WithIntArg(0),

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -1254,7 +1254,7 @@ spec:
 			WithBinary(sm.Full(uprobeTest1))).WithSymbol(sm.Full("uprobe_test_lib_string_arg_null")).WithArgs(ec.NewKprobeArgumentListMatcher().
 		WithOperator(lc.Ordered).
 		WithValues(
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address for basic type"))),
 			ec.NewKprobeArgumentChecker().WithIntArg(0)),
 	)
 	checker := ec.NewUnorderedEventChecker(upChecker)

--- a/tests/policytests/kprobes.go
+++ b/tests/policytests/kprobes.go
@@ -70,7 +70,7 @@ spec:
 			WithBinary(sm.Full(myBin))).WithArgs(ec.NewKprobeArgumentListMatcher().
 		WithOperator(lc.Ordered).
 		WithValues(
-			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address"))),
+			ec.NewKprobeArgumentChecker().WithErrorArg(ec.NewKprobeErrorChecker().WithMessage(sm.Full("Bad address for basic type"))),
 		)).WithReturn(ec.NewKprobeArgumentChecker().WithIntArg(0))
 
 	return &policytest.Scenario{


### PR DESCRIPTION
Improve the messages so that the error is more understandable.

Basic types are types that we support without resolve or are the terminal type when doing resolve. They are the types that users specify as an arg's type within the policy.

For dereference issues that happen during resolve, we report the depth, or the index of the resolve configuration where the dereference failed. This change subtracts one from the status value that is reported from the bpf program because status 0 signifies the non-error case.