### PR TITLE
new: argNew{Symbol,Addr,Offset} support in uprobe override action

### DIFF
--- a/contrib/tester-progs/uprobe-lib.c
+++ b/contrib/tester-progs/uprobe-lib.c
@@ -42,6 +42,13 @@ int uprobe_test_lib_string_arg(char *str)
 	return 0;
 }
 
+// This will be used for Override argNewSymbol test
+int uprobe_test_lib_string_arg__(char *str)
+{
+	printf("uprobe_test_lib_string_arg__ called\n");
+	return 1; // fixed return code to be used by tests
+}
+
 int uprobe_test_lib_string_arg0(char *str, int two, int three, int four, int five)
 {
 	printf("uprobe_test_lib_string_arg0 called\n");

--- a/contrib/tester-progs/uprobe-test.c
+++ b/contrib/tester-progs/uprobe-test.c
@@ -34,7 +34,11 @@ int main(void)
 	uprobe_test_lib_arg4(-321, -2, 'b', (void *) 1);
 	uprobe_test_lib_arg5(1, 'c', 0xcafe, 1234, (void *) 2);
 	uprobe_test_lib_string_arg(pageout(str_arg, strlen(str_arg) + 1));
-	uprobe_test_lib_string_arg_empty("");
+	if (uprobe_test_lib_string_arg_empty("") != 0) {
+		// we are testing the override argNewSymbol for uprobe
+		// return 100 to signal that the symbol was indeed overridden.
+		return 100;
+	}
 	uprobe_test_lib_string_arg_null(NULL);
 	uprobe_test_lib_string_arg_substring("test");
 	uprobe_test_lib_string_arg0("one", 2, 3, 4, 5);

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -911,13 +911,19 @@ this action for enforcement.
 
 ### Override action
 
-Override action is defined for kprobe and uprobe selectors.
+Override action is defined for kprobe, uprobe and lsmhooks selectors, each one
+of them supporting different arguments:
+| Hook   | Arguments |
+| ------ | --------- |
+| kprobe | `argError` |
+| uprobe | `argError,argRegs,argNewSymbol,argNewAddr,argNewOffset` |
+| lsmhooks | `argError` |
 
-#### Override action for kprobe
+#### Override action for kprobe and lsmhooks
 
 `Override` action allows to modify the return value of call. While `Sigkill`
 will terminate the entire process responsible for making the call, `Override`
-will run in place of the original kprobed function and return the value
+will run in place of the original probed function and return the value
 specified in the `argError` field. It's then up to the code path or the user
 space process handling the returned value to whether stop or proceed with the
 execution.
@@ -971,8 +977,6 @@ ensure they properly follow the [Error Injectable Functions](https://docs.kernel
 Beware, here be dragons!!! Use with caution, it could easily crash traced application.
 {{< /warning >}}
 
-Note that `Override` action can be used only on `x86_64` architecture.
-
 Similar to kprobe, the uprobe `Override` action allows to modify the return value
 of user space call with `argError` argument, like:
 
@@ -988,9 +992,57 @@ uprobes:
 ```
 
 Note that it can be successfully used only when following conditions are met:
-- uprobe is attached to the beggining of the user space function;
+- uprobe is attached to the beginning of the user space function;
 - user space function is called via `call` instruction;
-- user space function returns `int` type.
+- user space function returns `int` type;
+- kernel support to manipulate raw registers is available (6.18+).
+
+It's also possible to override the traced symbol with a new symbol call, like:
+```yaml
+uprobes:
+- path: "test"
+  symbols:
+  - "malloc"
+  selectors:
+  - matchActions:
+    - action: Override
+      argNewSymbol: "malloc_patched"
+```
+
+or even with a new symbol offset or address, eg:
+```yaml
+uprobes:
+- path: "test"
+  symbols:
+  - "malloc"
+  selectors:
+  - matchActions:
+    - action: Override
+      argNewOffset: "0x0000115c"
+```
+
+or:
+
+```yaml
+uprobes:
+- path: "test"
+  symbols:
+  - "malloc"
+  selectors:
+  - matchActions:
+    - action: Override
+      argNewAddr: "0x00001137"
+```
+
+There are, however, some restrictions:
+- kernel support to manipulate raw registers is required (6.18+);
+- new symbol must be already present in the binary;
+- new symbol must have the same signature as the original symbol.
+
+{{< warning >}}
+Since tetragon enforces no verification for the last point, this can lead to
+crashing the traced application.
+{{< /warning >}}
 
 It's possible to override specific registers with arbitrary value with `argRegs`
 argument, like:

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -955,7 +955,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -986,10 +999,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1524,7 +1568,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -1555,10 +1612,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2693,7 +2781,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -2724,10 +2825,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3262,7 +3394,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -3293,10 +3438,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4100,7 +4276,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -4131,10 +4320,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4669,7 +4889,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -4700,10 +4933,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5486,7 +5750,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -5517,10 +5794,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6055,7 +6363,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -6086,10 +6407,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6851,7 +7203,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -6882,10 +7247,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7420,7 +7816,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -7451,10 +7860,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8500,7 +8940,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -8531,10 +8984,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9069,7 +9553,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -9100,10 +9597,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9872,7 +10400,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -9903,10 +10444,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10441,7 +11013,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -10472,10 +11057,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -11823,7 +12439,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -11854,10 +12483,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12392,7 +13052,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -12423,10 +13096,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13561,7 +14265,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -13592,10 +14309,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14130,7 +14878,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -14161,10 +14922,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14968,7 +15760,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -14999,10 +15804,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15537,7 +16373,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -15568,10 +16417,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -16354,7 +17234,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -16385,10 +17278,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -16923,7 +17847,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -16954,10 +17891,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -17719,7 +18687,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -17750,10 +18731,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -18288,7 +19300,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -18319,10 +19344,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -19368,7 +20424,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -19399,10 +20468,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -19937,7 +21037,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -19968,10 +21081,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -20740,7 +21884,20 @@ Filters specified in macros will be appended to corresponding filters of the sel
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -20771,10 +21928,41 @@ Filters specified in macros will be appended to corresponding filters of the sel
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -21309,7 +22497,20 @@ Only valid with the post action and with a rateLimit specified.<br/>
         <td><b>action</b></td>
         <td>enum</td>
         <td>
-          Action to execute.<br/>
+          Action to execute.
+The Override action has three variants, depending on what arguments are set
+  1. Override the return value of function
+       Supported hooks: kprobes, uprobes, lsm
+       Arguments: ArgError (return value)
+  2. Override the value of a register
+       Supported hooks: uprobes
+       Arguments: ArgRegs
+  3. Override a function call
+       Supported hooks: uprobes
+       Arguments: One of:
+       - ArgNewSymbol: override call to a new symbol (in the binary)
+	      - ArgNewAddr: override call to a new address (in the binary)
+	      - ArgNewOffset: override call to an offset (in the binary)<br/>
           <br/>
             <i>Enum</i>: Post, Sigkill, Override, GetUrl, DnsLookup, NoPost, Signal, TrackSock, UntrackSock, NotifyEnforcer, CleanupEnforcerNotification, Set<br/>
         </td>
@@ -21340,10 +22541,41 @@ Only valid with the post action and with a rateLimit specified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>argNewAddr</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's address.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewOffset</b></td>
+        <td>integer</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol's offset.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>argNewSymbol</b></td>
+        <td>string</td>
+        <td>
+          An arg value for the override action, uprobe only.
+The new symbol name.
+Beware that the symbol MUST be binary compatible with the traced uprobe symbol.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>argRegs</b></td>
         <td>[]string</td>
         <td>
-          An arg value for the regs action<br/>
+          An arg value for the override action, uprobe only.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -519,7 +519,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -546,8 +558,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -598,6 +631,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -956,7 +995,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -983,8 +1034,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1035,6 +1107,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -1773,7 +1851,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -1800,8 +1890,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1852,6 +1963,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -2210,7 +2327,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2237,8 +2366,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2289,6 +2439,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -2749,7 +2905,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2776,8 +2944,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2828,6 +3017,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -3186,7 +3381,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -3213,8 +3420,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -3265,6 +3493,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -3688,7 +3922,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -3714,8 +3959,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -3766,6 +4032,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchArgs:
                       description: A list of argument filters. MatchArgs are ANDed.
@@ -4119,7 +4391,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -4145,8 +4428,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -4197,6 +4501,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchReturnArgs:
                       description: A list of argument filters. MatchReturnArgs are
@@ -4608,7 +4918,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -4635,8 +4957,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -4687,6 +5030,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -5045,7 +5394,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5072,8 +5433,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5124,6 +5506,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -5816,7 +6204,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5843,8 +6243,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5895,6 +6316,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -6253,7 +6680,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6280,8 +6719,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6332,6 +6792,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -6774,7 +7240,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6801,8 +7279,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6853,6 +7352,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -7211,7 +7716,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -7238,8 +7755,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -7290,6 +7828,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -519,7 +519,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -546,8 +558,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -598,6 +631,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -956,7 +995,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -983,8 +1034,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1035,6 +1107,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -1773,7 +1851,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -1800,8 +1890,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1852,6 +1963,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -2210,7 +2327,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2237,8 +2366,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2289,6 +2439,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -2749,7 +2905,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2776,8 +2944,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2828,6 +3017,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -3186,7 +3381,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -3213,8 +3420,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -3265,6 +3493,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -3688,7 +3922,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -3714,8 +3959,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -3766,6 +4032,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchArgs:
                       description: A list of argument filters. MatchArgs are ANDed.
@@ -4119,7 +4391,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -4145,8 +4428,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -4197,6 +4501,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchReturnArgs:
                       description: A list of argument filters. MatchReturnArgs are
@@ -4608,7 +4918,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -4635,8 +4957,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -4687,6 +5030,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -5045,7 +5394,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5072,8 +5433,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5124,6 +5506,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -5816,7 +6204,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5843,8 +6243,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5895,6 +6316,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -6253,7 +6680,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6280,8 +6719,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6332,6 +6792,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -6774,7 +7240,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6801,8 +7279,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6853,6 +7352,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -7211,7 +7716,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -7238,8 +7755,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -7290,6 +7828,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs

--- a/pkg/elf/file.go
+++ b/pkg/elf/file.go
@@ -101,25 +101,9 @@ func (se *SafeELFFile) Offset(name string) (uint64, error) {
 			continue
 		}
 
-		offset := sym.Value
-
-		// Loop over ELF segments.
-		for _, prog := range se.Progs {
-			// Skip uninteresting segments.
-			if prog.Type != elf.PT_LOAD || (prog.Flags&elf.PF_X) == 0 {
-				continue
-			}
-
-			if prog.Vaddr <= sym.Value && sym.Value < (prog.Vaddr+prog.Memsz) {
-				// If the symbol value is contained in the segment, calculate
-				// the symbol offset.
-				//
-				// fn symbol offset = fn symbol VA - .text VA + .text offset
-				//
-				// stackoverflow.com/a/40249502
-				offset = sym.Value - prog.Vaddr + prog.Off
-				break
-			}
+		offset, err := se.OffsetFromAddr(sym.Value)
+		if err != nil {
+			offset = sym.Value
 		}
 		return offset, nil
 	}

--- a/pkg/elf/file.go
+++ b/pkg/elf/file.go
@@ -128,8 +128,6 @@ func (se *SafeELFFile) Offset(name string) (uint64, error) {
 }
 
 func (se *SafeELFFile) OffsetFromAddr(addr uint64) (uint64, error) {
-	offset := uint64(0)
-
 	// Loop over ELF segments.
 	for _, prog := range se.Progs {
 		// Skip uninteresting segments.
@@ -144,14 +142,27 @@ func (se *SafeELFFile) OffsetFromAddr(addr uint64) (uint64, error) {
 			// fn address offset = fn address VA - .text VA + .text offset
 			//
 			// stackoverflow.com/a/40249502
-			offset = addr - prog.Vaddr + prog.Off
-			break
+			return addr - prog.Vaddr + prog.Off, nil
 		}
 	}
-	if offset == 0 {
-		return 0, fmt.Errorf("failed to find offset for address %x", addr)
+	return 0, fmt.Errorf("failed to find offset for address %x", addr)
+}
+
+func (se *SafeELFFile) AddrFromOffset(offset uint64) (uint64, error) {
+	// Loop over ELF segments.
+	for _, prog := range se.Progs {
+		// Skip uninteresting segments.
+		if prog.Type != elf.PT_LOAD || (prog.Flags&elf.PF_X) == 0 {
+			continue
+		}
+
+		if prog.Off <= offset && offset < (prog.Off+prog.Filesz) {
+			// Inverse of OffsetFromAddr:
+			// addr = offset - segment file offset + segment virtual address
+			return offset - prog.Off + prog.Vaddr, nil
+		}
 	}
-	return offset, nil
+	return 0, fmt.Errorf("failed to find address for offset %x", offset)
 }
 
 // SectionsByType returns all sections in the file with the specified section type.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -519,7 +519,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -546,8 +558,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -598,6 +631,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -956,7 +995,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -983,8 +1034,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1035,6 +1107,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -1773,7 +1851,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -1800,8 +1890,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1852,6 +1963,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -2210,7 +2327,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2237,8 +2366,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2289,6 +2439,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -2749,7 +2905,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2776,8 +2944,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2828,6 +3017,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -3186,7 +3381,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -3213,8 +3420,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -3265,6 +3493,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -3688,7 +3922,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -3714,8 +3959,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -3766,6 +4032,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchArgs:
                       description: A list of argument filters. MatchArgs are ANDed.
@@ -4119,7 +4391,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -4145,8 +4428,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -4197,6 +4501,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchReturnArgs:
                       description: A list of argument filters. MatchReturnArgs are
@@ -4608,7 +4918,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -4635,8 +4957,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -4687,6 +5030,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -5045,7 +5394,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5072,8 +5433,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5124,6 +5506,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -5816,7 +6204,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5843,8 +6243,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5895,6 +6316,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -6253,7 +6680,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6280,8 +6719,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6332,6 +6792,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -6774,7 +7240,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6801,8 +7279,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6853,6 +7352,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -7211,7 +7716,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -7238,8 +7755,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -7290,6 +7828,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -519,7 +519,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -546,8 +558,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -598,6 +631,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -956,7 +995,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -983,8 +1034,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1035,6 +1107,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -1773,7 +1851,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -1800,8 +1890,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1852,6 +1963,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -2210,7 +2327,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2237,8 +2366,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2289,6 +2439,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -2749,7 +2905,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2776,8 +2944,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2828,6 +3017,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -3186,7 +3381,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -3213,8 +3420,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -3265,6 +3493,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -3688,7 +3922,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -3714,8 +3959,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -3766,6 +4032,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchArgs:
                       description: A list of argument filters. MatchArgs are ANDed.
@@ -4119,7 +4391,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -4145,8 +4428,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -4197,6 +4501,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchReturnArgs:
                       description: A list of argument filters. MatchReturnArgs are
@@ -4608,7 +4918,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -4635,8 +4957,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -4687,6 +5030,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -5045,7 +5394,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5072,8 +5433,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5124,6 +5506,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -5816,7 +6204,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5843,8 +6243,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5895,6 +6316,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -6253,7 +6680,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6280,8 +6719,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6332,6 +6792,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -6774,7 +7240,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6801,8 +7279,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6853,6 +7352,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -7211,7 +7716,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -7238,8 +7755,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -7290,6 +7828,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -271,9 +271,23 @@ type ArgSelector struct {
 	Values []string `json:"values,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!(has(self.argNewSymbol) && has(self.argNewAddr)) && !(has(self.argNewSymbol) && has(self.argNewOffset)) && !(has(self.argNewAddr) && has(self.argNewOffset))",message="override action needs at most one of argNewSymbol, argNewAddr or argNewOffset defined"
 type ActionSelector struct {
 	// +kubebuilder:validation:Enum=Post;Sigkill;Override;GetUrl;DnsLookup;NoPost;Signal;TrackSock;UntrackSock;NotifyEnforcer;CleanupEnforcerNotification;Set
 	// Action to execute.
+	// The Override action has three variants, depending on what arguments are set
+	//   1. Override the return value of function
+	//        Supported hooks: kprobes, uprobes, lsm
+	//        Arguments: ArgError (return value)
+	//   2. Override the value of a register
+	//        Supported hooks: uprobes
+	//        Arguments: ArgRegs
+	//   3. Override a function call
+	//        Supported hooks: uprobes
+	//        Arguments: One of:
+	//        - ArgNewSymbol: override call to a new symbol (in the binary)
+	//	      - ArgNewAddr: override call to a new address (in the binary)
+	//	      - ArgNewOffset: override call to an offset (in the binary)
 	Action string `json:"action"`
 	// +kubebuilder:validation:Optional
 	// A URL for the getUrl action
@@ -297,8 +311,23 @@ type ActionSelector struct {
 	// An arg value for the set action
 	ArgValue uint32 `json:"argValue"`
 	// +kubebuilder:validation:Optional
-	// An arg value for the regs action
+	// An arg value for the override action, uprobe only.
 	ArgRegs []string `json:"argRegs,omitempty"`
+	// +kubebuilder:validation:Optional
+	// An arg value for the override action, uprobe only.
+	// The new symbol name.
+	// Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+	ArgNewSymbol string `json:"argNewSymbol,omitempty"`
+	// +kubebuilder:validation:Optional
+	// An arg value for the override action, uprobe only.
+	// The new symbol's address.
+	// Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+	ArgNewAddr uint64 `json:"argNewAddr,omitempty"`
+	// +kubebuilder:validation:Optional
+	// An arg value for the override action, uprobe only.
+	// The new symbol's offset.
+	// Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+	ArgNewOffset int64 `json:"argNewOffset,omitempty"`
 	// +kubebuilder:validation:Optional
 	// A time period within which repeated messages will not be posted. Can be
 	// specified in seconds (default or with 's' suffix), minutes ('m' suffix)

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.9"
+const CustomResourceDefinitionSchemaVersion = "1.8.10"

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1809,6 +1809,28 @@ func HasOverride(selectors []v1alpha1.KProbeSelector) bool {
 	return false
 }
 
+func CountOverrideArgNewSymbolAddrOffset(selectors []v1alpha1.KProbeSelector) int {
+	for _, s := range selectors {
+		for _, action := range s.MatchActions {
+			numArgNewArgs := 0
+			act := actionTypeTable[strings.ToLower(action.Action)]
+			if act == ActionTypeOverride {
+				if action.ArgNewSymbol != "" {
+					numArgNewArgs++
+				}
+				if action.ArgNewAddr != 0 {
+					numArgNewArgs++
+				}
+				if action.ArgNewOffset != 0 {
+					numArgNewArgs++
+				}
+				return numArgNewArgs
+			}
+		}
+	}
+	return 0
+}
+
 func HasOperator(selectors []v1alpha1.KProbeSelector, op uint32) bool {
 	for _, s := range selectors {
 		for _, a := range slices.Concat(s.MatchArgs, s.MatchData, s.MatchReturnArgs) {

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1187,7 +1187,7 @@ func ParseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, a
 	switch act {
 	case ActionTypeOverride:
 		if k.isUprobe {
-			id, err := parseOverrideRegs(k, action.ArgRegs, uint64(action.ArgError))
+			id, err := parseOverrideRegs(k, action.ArgRegs, uint64(action.ArgError), k.overrideActionIPDelta)
 			if err != nil {
 				return err
 			}
@@ -1621,7 +1621,11 @@ type KernelSelectorArgs struct {
 	Maps           *KernelSelectorMaps
 	IsUprobe       bool
 	UprobeID       int
-	CelExprs       *CelExprFunctions
+	// For Override argNew{Symbol,Addr,Offset} this will hold
+	// the instruction pointer delta that will be stored
+	// by ParseMatchAction().
+	OverrideActionIPDelta int64
+	CelExprs              *CelExprFunctions
 }
 
 // The byte array storing the selector configuration has the following format
@@ -1686,13 +1690,14 @@ func createKernelSelectorState(
 	maps *KernelSelectorMaps,
 	isUprobe bool,
 	uprobeID int,
+	overrideActionIPDelta int64,
 	celExprs *CelExprFunctions,
 	parseSelector func(k *KernelSelectorState, selectors *v1alpha1.KProbeSelector, selIdx int) error,
 ) (*KernelSelectorState, error) {
 	if len(selectors) > MaxSelectors {
 		return nil, fmt.Errorf("no more than %d selectors supported (%d provided)", MaxSelectors, len(selectors))
 	}
-	state := NewKernelSelectorState(listReader, maps, isUprobe, uprobeID, celExprs)
+	state := NewKernelSelectorState(listReader, maps, isUprobe, uprobeID, overrideActionIPDelta, celExprs)
 
 	WriteSelectorUint32(&state.data, uint32(len(selectors)))
 	soff := make([]uint32, len(selectors))
@@ -1746,7 +1751,7 @@ func InitKernelSelectorState(args *KernelSelectorArgs) (*KernelSelectorState, er
 		return nil
 	}
 
-	return createKernelSelectorState(args.Selectors, args.ListReader, args.Maps, args.IsUprobe, args.UprobeID, args.CelExprs, parse)
+	return createKernelSelectorState(args.Selectors, args.ListReader, args.Maps, args.IsUprobe, args.UprobeID, args.OverrideActionIPDelta, args.CelExprs, parse)
 }
 
 func InitKernelReturnSelectorState(selectors []v1alpha1.KProbeSelector, returnArg *v1alpha1.KProbeArg,
@@ -1762,7 +1767,7 @@ func InitKernelReturnSelectorState(selectors []v1alpha1.KProbeSelector, returnAr
 		return nil
 	}
 
-	return createKernelSelectorState(selectors, listReader, maps, false, 0, nil, parse)
+	return createKernelSelectorState(selectors, listReader, maps, false, 0, 0, nil, parse)
 }
 
 func CleanupKernelSelectorState(state *KernelSelectorState) error {

--- a/pkg/selectors/kernel_regs_amd64.go
+++ b/pkg/selectors/kernel_regs_amd64.go
@@ -13,12 +13,16 @@ import (
 	"github.com/cilium/tetragon/pkg/asm"
 )
 
-func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64) (uint32, error) {
+func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64, newOffset int64) (uint32, error) {
 	if len(k.regs) > 0 {
 		return uint32(0xffffffff), errors.New("only single instance of regs action is allowed")
 	}
 
 	regs := []processapi.RegAssignment{}
+
+	if newOffset != 0 {
+		values = append(values, fmt.Sprintf("rip=%d%%rip", newOffset))
+	}
 
 	// If no registers were specified go with the default for override
 	// at the top of the user space function.

--- a/pkg/selectors/kernel_regs_arm64.go
+++ b/pkg/selectors/kernel_regs_arm64.go
@@ -13,12 +13,16 @@ import (
 	"github.com/cilium/tetragon/pkg/asm"
 )
 
-func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64) (uint32, error) {
+func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64, newOffset int64) (uint32, error) {
 	if len(k.regs) > 0 {
 		return uint32(0xffffffff), errors.New("only single instance of regs action is allowed")
 	}
 
 	regs := []processapi.RegAssignment{}
+
+	if newOffset != 0 {
+		values = append(values, fmt.Sprintf("pc=%d%%pc", newOffset))
+	}
 
 	// If no registers were specified go with the default for override
 	// at the top of the user space function.

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -318,7 +318,7 @@ func TestParseMatchArgs(t *testing.T) {
 	expected = append(expected, data1Expected[:]...)
 	expected = append(expected, data2Expected[:]...)
 
-	ks := NewKernelSelectorState(nil, nil, false, 0, nil)
+	ks := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 	d := &ks.data
 	if err := ParseMatchArgs(ks, argsSel, dataSel, args, data); err != nil || bytes.Equal(expected, d.e[0:d.off]) == false {
 		t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\n", err, expected, d.e[0:d.off])
@@ -345,7 +345,7 @@ func TestParseMatchData(t *testing.T) {
 	}
 
 	arg1 := &v1alpha1.ArgSelector{Index: 0, Operator: "Equal", Values: []string{"ex"}}
-	k := NewKernelSelectorState(nil, nil, false, 0, nil)
+	k := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 	d := &k.data
 
 	expected1 := []byte{
@@ -516,7 +516,7 @@ func TestParseMatchArg(t *testing.T) {
 	}
 
 	arg1 := &v1alpha1.ArgSelector{Index: 1, Operator: "Equal", Values: []string{"foobar"}}
-	k := NewKernelSelectorState(nil, nil, false, 0, nil)
+	k := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 	d := &k.data
 
 	expected1 := []byte{
@@ -676,7 +676,7 @@ func TestParseMatchArg(t *testing.T) {
 		expected3 := append(length, expected1[:]...)
 		expected3 = append(expected3, expected2[:]...)
 		arg12 := []v1alpha1.ArgSelector{*arg1, *arg2}
-		ks := NewKernelSelectorState(nil, nil, false, 0, nil)
+		ks := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 		d = &ks.data
 		if err := ParseMatchArgs(ks, arg12, []v1alpha1.ArgSelector{}, sig, []v1alpha1.KProbeArg{}); err != nil || bytes.Equal(expected3, d.e[0:d.off]) == false {
 			t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected3, d.e[0:d.off], arg3)
@@ -703,7 +703,7 @@ func TestParseMatchArg(t *testing.T) {
 			{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}: {},
 		}
 
-		ks = NewKernelSelectorState(nil, nil, false, 0, nil)
+		ks = NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 		d = &ks.data
 		if err := ParseMatchArg(ks, arg13, sig); err != nil ||
 			bytes.Equal(expected12, d.e[0:d.off]) == false ||
@@ -1400,7 +1400,7 @@ func TestParseMatchArgSubString(t *testing.T) {
 			}
 
 			arg := &v1alpha1.ArgSelector{Index: 1, Operator: "SubString", Values: []string{"test"}}
-			k := NewKernelSelectorState(nil, nil, false, 0, nil)
+			k := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 			d := &k.data
 
 			expected := []byte{

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -132,8 +132,9 @@ type KernelSelectorState struct {
 
 	maps *KernelSelectorMaps
 
-	isUprobe bool
-	uprobeID int
+	isUprobe              bool
+	uprobeID              int
+	overrideActionIPDelta int64
 
 	regs []processapi.RegAssignment
 
@@ -151,6 +152,7 @@ func NewKernelSelectorState(
 	maps *KernelSelectorMaps,
 	isUprobe bool,
 	uprobeID int,
+	overrideActionIPDelta int64,
 	celExprs *CelExprFunctions,
 ) *KernelSelectorState {
 	if maps == nil {
@@ -160,14 +162,15 @@ func NewKernelSelectorState(
 		celExprs = &CelExprFunctions{}
 	}
 	return &KernelSelectorState{
-		matchBinaries:      make(map[int]MatchBinariesSelectorOptions),
-		matchBinariesPaths: make(map[int][][processapi.BINARY_PATH_MAX_LEN]byte),
-		listReader:         listReader,
-		maps:               maps,
-		isUprobe:           isUprobe,
-		uprobeID:           uprobeID,
-		celExprFunctions:   celExprs,
-		matchWorkloadIDs:   make(map[int]policyfilter.PolicyID),
+		matchBinaries:         make(map[int]MatchBinariesSelectorOptions),
+		matchBinariesPaths:    make(map[int][][processapi.BINARY_PATH_MAX_LEN]byte),
+		listReader:            listReader,
+		maps:                  maps,
+		isUprobe:              isUprobe,
+		uprobeID:              uprobeID,
+		overrideActionIPDelta: overrideActionIPDelta,
+		celExprFunctions:      celExprs,
+		matchWorkloadIDs:      make(map[int]policyfilter.PolicyID),
 	}
 }
 

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -505,10 +505,11 @@ func validateMultiUprobeConsistency(uprobes []v1alpha1.UProbeSpec) error {
 }
 
 type uprobeConfigState struct {
-	symbols       int
-	offsets       int
-	addrs         int
-	refCtrOffsets int
+	symbols        int
+	offsets        int
+	addrs          int
+	refCtrOffsets  int
+	overrideSymbol bool
 
 	selectors kprobeSelectors
 
@@ -572,6 +573,11 @@ func validateUprobeSpec(spec *v1alpha1.UProbeSpec, state *uprobeConfigState) err
 		}
 	}
 
+	numArgNewArgs := selectors.CountOverrideArgNewSymbolAddrOffset(spec.Selectors)
+	if numArgNewArgs > 1 {
+		return fmt.Errorf("uprobe Override action needs exactly one of either argNewSymbol, argNewOffset or argNewAddr defined; %d found", numArgNewArgs)
+	}
+	state.overrideSymbol = numArgNewArgs == 1
 	return nil
 }
 
@@ -600,14 +606,74 @@ func validateUprobeFeatures(spec *v1alpha1.UProbeSpec, has *uprobeHas) error {
 	return nil
 }
 
-func initUprobeSelectors(spec *v1alpha1.UProbeSpec, in *addUprobeIn, state *uprobeConfigState, nextIdx int) error {
+func computeArgNewOffset(spec *v1alpha1.UProbeSpec, f *elf.SafeELFFile, symbolAddr uint64) (int64, error) {
+	var err error
+	for _, sel := range spec.Selectors {
+		for _, matchAct := range sel.MatchActions {
+			if matchAct.Action == "Override" {
+				// Load override-symbol VA
+				var overrideSymbAddr uint64
+				if matchAct.ArgNewSymbol != "" {
+					overrideSymbAddr, err = f.Address(matchAct.ArgNewSymbol)
+				} else if matchAct.ArgNewAddr != 0 {
+					overrideSymbAddr = matchAct.ArgNewAddr
+				} else {
+					overrideSymbAddr, err = f.AddrFromOffset(uint64(matchAct.ArgNewOffset))
+				}
+				if err != nil {
+					return 0, err
+				}
+
+				// Store the relative-to-traced-symbol delta.
+				// This is computed based on virtual address for both symbols.
+				// Since ASLR just changes the base address,
+				// the relative delta are stable.
+				// In bpf, we will compute the override symbol address as:
+				// * curr_ip = PT_REGS_IP(ctx);
+				// * next_ip = curr_ip + delta
+				return int64(overrideSymbAddr - symbolAddr), nil
+			}
+		}
+	}
+	return 0, errors.New("state.overrideSymbol is true but no corresponding Override action found in spec.Selectors")
+}
+
+func initOverrideSymbolOffset(spec *v1alpha1.UProbeSpec, state *uprobeConfigState, f *elf.SafeELFFile) (int64, error) {
+	if !state.overrideSymbol {
+		return 0, nil
+	}
+
+	// Load probed symbol offset
+	var (
+		symbolAddr uint64
+		err        error
+	)
+	if state.symbols > 0 {
+		symbolAddr, err = f.Address(spec.Symbols[0])
+	} else if state.addrs > 0 {
+		symbolAddr = spec.Addrs[0]
+	} else {
+		symbolAddr, err = f.AddrFromOffset(spec.Offsets[0])
+	}
+	if err != nil {
+		return 0, err
+	}
+	return computeArgNewOffset(spec, f, symbolAddr)
+}
+
+func initUprobeSelectors(spec *v1alpha1.UProbeSpec, in *addUprobeIn, state *uprobeConfigState, f *elf.SafeELFFile, nextIdx int) error {
+	ipDelta, err := initOverrideSymbolOffset(spec, state, f)
+	if err != nil {
+		return err
+	}
 	entry, err := selectors.InitKernelSelectorState(&selectors.KernelSelectorArgs{
-		Selectors: spec.Selectors,
-		Args:      spec.Args,
-		Data:      spec.Data,
-		IsUprobe:  true,
-		UprobeID:  nextIdx,
-		CelExprs:  in.celExprs,
+		Selectors:             spec.Selectors,
+		Args:                  spec.Args,
+		Data:                  spec.Data,
+		IsUprobe:              true,
+		UprobeID:              nextIdx,
+		OverrideActionIPDelta: ipDelta,
+		CelExprs:              in.celExprs,
 	})
 	if err != nil {
 		return err
@@ -1131,7 +1197,7 @@ func getLinkPath(file *os.File, targetPath string) string {
 	return targetPath
 }
 
-func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *uprobeConfigState, has *uprobeHas) ([]idtable.EntryID, error) {
+func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *uprobeConfigState, has *uprobeHas, f *elf.SafeELFFile) ([]idtable.EntryID, error) {
 	addUprobeEntry := func(sym string, offset uint64, idx int) error {
 		var refCtrOffset uint64
 		var err error
@@ -1182,22 +1248,6 @@ func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *u
 		return nil
 	}
 
-	var f *elf.SafeELFFile
-	var err error
-	if state.entryFile != nil {
-		f, err = elf.NewSafeELFFile(state.entryFile)
-	} else {
-		f, err = elf.OpenSafeELFFile(spec.Path)
-	}
-
-	if err != nil {
-		return ids, err
-	}
-
-	if state.entryFile == nil {
-		defer f.Close()
-	}
-
 	if state.symbols != 0 && f.IsStrippedPureGoBinary() {
 		tbl, err := f.Pclntab()
 		if err != nil {
@@ -1221,14 +1271,14 @@ func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *u
 			if err := checkSymbol(sym); err != nil {
 				return ids, fmt.Errorf("failed to parse symbol: %w", err)
 			}
-			err = addUprobeEntry(sym, 0, idx)
+			err := addUprobeEntry(sym, 0, idx)
 			if err != nil {
 				return ids, err
 			}
 		}
 	} else if state.offsets != 0 {
 		for idx, off := range spec.Offsets {
-			err = addUprobeEntry("", off, idx)
+			err := addUprobeEntry("", off, idx)
 			if err != nil {
 				return ids, err
 			}
@@ -1266,6 +1316,22 @@ func addUprobe(spec *v1alpha1.UProbeSpec, entryFile *os.File, ids []idtable.Entr
 		}
 	}()
 
+	var f *elf.SafeELFFile
+	var err error
+	if state.entryFile != nil {
+		f, err = elf.NewSafeELFFile(state.entryFile)
+	} else {
+		f, err = elf.OpenSafeELFFile(spec.Path)
+	}
+
+	if err != nil {
+		return ids, err
+	}
+
+	if state.entryFile == nil {
+		defer f.Close()
+	}
+
 	if err := validateUprobeSpec(spec, &state); err != nil {
 		return ids, err
 	}
@@ -1274,7 +1340,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, entryFile *os.File, ids []idtable.Entr
 		return ids, err
 	}
 
-	if err := initUprobeSelectors(spec, in, &state, len(ids)); err != nil {
+	if err := initUprobeSelectors(spec, in, &state, f, len(ids)); err != nil {
 		return ids, err
 	}
 
@@ -1286,7 +1352,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, entryFile *os.File, ids []idtable.Entr
 		return ids, err
 	}
 
-	return addUprobeEntries(spec, ids, &state, has)
+	return addUprobeEntries(spec, ids, &state, has, f)
 }
 
 func multiUprobePinPath(sensorPath string) string {

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -7,6 +7,7 @@ package tracing
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -16,6 +17,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/tetragon/pkg/elf"
+	"github.com/cilium/tetragon/pkg/logger"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/bpf"
@@ -196,6 +200,98 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func testUprobeOverrideNewSymbolAddrOffsetAction(t *testing.T, symbol string, offset, addr uint64) {
+	if !bpf.HasUprobeRegsChange() {
+		t.Skip("this test requires writing to regs kernel support")
+	}
+
+	testutils.CaptureLog(t, logger.GetLogger())
+	uprobeTest1 := testutils.RepoRootPath("contrib/tester-progs/uprobe-test-1")
+	libUprobe := testutils.RepoRootPath("contrib/tester-progs/libuprobe.so")
+
+	f, _ := elf.OpenSafeELFFile(libUprobe)
+	defer f.Close()
+
+	uprobeHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe-selector"
+spec:
+  uprobes:
+  - path: "` + libUprobe + `"
+    symbols:
+    - "uprobe_test_lib_string_arg_empty"
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchBinaries:
+      - operator: "In"
+        values:
+        - "` + uprobeTest1 + `"
+      matchActions:
+      - action: Override
+        argNew%s: %s`
+
+	if symbol != "" {
+		uprobeHook = fmt.Sprintf(uprobeHook, "Symbol", symbol)
+	} else if offset != 0 {
+		uprobeHook = fmt.Sprintf(uprobeHook, "Offset", strconv.FormatUint(offset, 10))
+	} else {
+		uprobeHook = fmt.Sprintf(uprobeHook, "Addr", strconv.FormatUint(addr, 10))
+	}
+
+	createCrdFile(t, uprobeHook)
+
+	upChecker := ec.NewProcessUprobeChecker("UPROBE_SELECTOR_MATCH").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(uprobeTest1))).
+		WithSymbol(sm.Full("uprobe_test_lib_string_arg_empty"))
+	checker := ec.NewUnorderedEventChecker(upChecker)
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	require.NoError(t, err)
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	cmd := exec.Command(uprobeTest1)
+	// See uprobe-lib.c/uprobe-test.c return code for uprobe_test_lib_string_arg__().
+	// It will return 100 when the symbol is overridden.
+	// It will be considered an error by `cmd.Run()`.
+	require.Error(t, cmd.Run())
+	require.Equal(t, 100, cmd.ProcessState.ExitCode())
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	require.NoError(t, err)
+}
+
+func TestUprobeOverrideNewSymbolAddrOffsetAction(t *testing.T) {
+	libUprobe := testutils.RepoRootPath("contrib/tester-progs/libuprobe.so")
+	f, _ := elf.OpenSafeELFFile(libUprobe)
+	t.Cleanup(func() {
+		f.Close()
+	})
+
+	t.Run("symbol", func(t *testing.T) {
+		testUprobeOverrideNewSymbolAddrOffsetAction(t, "uprobe_test_lib_string_arg__", 0, 0)
+	})
+	t.Run("offset", func(t *testing.T) {
+		off, _ := f.Offset("uprobe_test_lib_string_arg__")
+		testUprobeOverrideNewSymbolAddrOffsetAction(t, "", off, 0)
+	})
+	t.Run("addr", func(t *testing.T) {
+		addr, _ := f.Address("uprobe_test_lib_string_arg__")
+		testUprobeOverrideNewSymbolAddrOffsetAction(t, "", 0, addr)
+	})
 }
 
 func TestUprobeResolve(t *testing.T) {

--- a/pkg/tracingpolicy/k8s_xvalidation_test.go
+++ b/pkg/tracingpolicy/k8s_xvalidation_test.go
@@ -33,7 +33,8 @@ metadata:
   name: "uprobe"
 spec:
   uprobes:
-  - path: "/usr/bin/test"`
+  - path: "/usr/bin/test"
+`
 	if withSymbol {
 		crd += "    symbols: [\"test_3\"]\n"
 	}
@@ -46,22 +47,25 @@ spec:
 
 	_, err := FromYAML(crd)
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "symbols, addrs or offsets defined")
 }
 
 func TestUprobeValidationSymbolsAddrsOffsets(t *testing.T) {
-	testUprobeValidationSymbolsAddrsOffsets(t, true, true, true)
-}
+	t.Run("SymbolAddrOffset", func(t *testing.T) {
+		testUprobeValidationSymbolsAddrsOffsets(t, true, true, true)
+	})
 
-func TestUprobeValidationSymbolsAddrs(t *testing.T) {
-	testUprobeValidationSymbolsAddrsOffsets(t, true, true, false)
-}
+	t.Run("SymbolAddr", func(t *testing.T) {
+		testUprobeValidationSymbolsAddrsOffsets(t, true, true, false)
+	})
 
-func TestUprobeValidationSymbolsOffsets(t *testing.T) {
-	testUprobeValidationSymbolsAddrsOffsets(t, true, false, true)
-}
+	t.Run("SymbolOffset", func(t *testing.T) {
+		testUprobeValidationSymbolsAddrsOffsets(t, true, false, true)
+	})
 
-func TestUprobeValidationAddrsOffsets(t *testing.T) {
-	testUprobeValidationSymbolsAddrsOffsets(t, false, true, true)
+	t.Run("AddrOffset", func(t *testing.T) {
+		testUprobeValidationSymbolsAddrsOffsets(t, false, true, true)
+	})
 }
 
 func TestUprobeValidationReturnWithoutArg(t *testing.T) {
@@ -80,4 +84,52 @@ spec:
 
 	_, err := FromYAML(crd)
 	require.Error(t, err)
+}
+
+func testUprobeValidationOverrideArgNewSymbolAddrOffset(t *testing.T, withSymbol, withAdrr, withOff bool) {
+	crd := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe"
+spec:
+  uprobes:
+  - path: "/usr/bin/test"
+    symbols:
+    - "test_1"
+    selectors:
+    - matchActions:
+      - action: Override
+`
+	if withSymbol {
+		crd += "        argNewSymbol: \"test_3\"\n"
+	}
+	if withAdrr {
+		crd += "        argNewAddr: 0x985256\n"
+	}
+	if withOff {
+		crd += "        argNewOffset: 0x9156366\n"
+	}
+
+	_, err := FromYAML(crd)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "argNewSymbol, argNewAddr or argNewOffset defined")
+}
+
+func TestUprobeValidationOverrideArgNewSymbolAddrOffset(t *testing.T) {
+	t.Run("NewSymbolAddrOffset", func(t *testing.T) {
+		testUprobeValidationOverrideArgNewSymbolAddrOffset(t, true, true, true)
+	})
+
+	t.Run("NewSymbolAddr", func(t *testing.T) {
+		testUprobeValidationOverrideArgNewSymbolAddrOffset(t, true, true, false)
+	})
+
+	t.Run("NewSymbolOffset", func(t *testing.T) {
+		testUprobeValidationOverrideArgNewSymbolAddrOffset(t, true, false, true)
+	})
+
+	t.Run("NewAddrOffset", func(t *testing.T) {
+		testUprobeValidationOverrideArgNewSymbolAddrOffset(t, false, true, true)
+	})
 }

--- a/tests/policytests/uprobes.go
+++ b/tests/policytests/uprobes.go
@@ -295,3 +295,41 @@ spec:
 		EventChecker: ec.NewUnorderedEventChecker(up1Checker, up2Checker),
 	}
 }).RegisterAtInit()
+
+var _ = policytest.NewBuilder("uprobe-override-new-symbol").WithLabels("uprobes").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe-selector"
+spec:
+  uprobes:
+  - path: {{ testBinary "libuprobe.so" }}
+    symbols:
+    - "uprobe_test_lib_string_arg_empty"
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchBinaries:
+      - operator: "In"
+        values:
+        - {{ testBinary "uprobe-test-1" }}
+      matchActions:
+      - action: Override
+        argNewSymbol: "uprobe_test_lib_string_arg__"
+`).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	bin := c.TestBinary("uprobe-test-1")
+	upChecker := ec.NewProcessUprobeChecker("UPROBE_SELECTOR_MATCH").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(bin))).
+		WithSymbol(sm.Full("uprobe_test_lib_string_arg_empty"))
+
+	return &policytest.Scenario{
+		Name: "check call was overridden",
+		// See uprobe-lib.c/uprobe-test.c return code for uprobe_test_lib_string_arg__().
+		// It will return 100 when the symbol is overridden.
+		// It will be considered an error by `cmd.Run()`.
+		Trigger:      policytest.NewCmdTrigger(bin).ExpectExitCode(100),
+		EventChecker: ec.NewUnorderedEventChecker(upChecker),
+	}
+}).RegisterAtInit()

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -519,7 +519,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -546,8 +558,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -598,6 +631,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -956,7 +995,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -983,8 +1034,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1035,6 +1107,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -1773,7 +1851,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -1800,8 +1890,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1852,6 +1963,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -2210,7 +2327,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2237,8 +2366,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2289,6 +2439,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -2749,7 +2905,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2776,8 +2944,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2828,6 +3017,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -3186,7 +3381,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -3213,8 +3420,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -3265,6 +3493,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -3688,7 +3922,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -3714,8 +3959,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -3766,6 +4032,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchArgs:
                       description: A list of argument filters. MatchArgs are ANDed.
@@ -4119,7 +4391,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -4145,8 +4428,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -4197,6 +4501,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchReturnArgs:
                       description: A list of argument filters. MatchReturnArgs are
@@ -4608,7 +4918,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -4635,8 +4957,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -4687,6 +5030,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -5045,7 +5394,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5072,8 +5433,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5124,6 +5506,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -5816,7 +6204,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5843,8 +6243,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5895,6 +6316,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -6253,7 +6680,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6280,8 +6719,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6332,6 +6792,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -6774,7 +7240,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6801,8 +7279,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6853,6 +7352,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -7211,7 +7716,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -7238,8 +7755,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -7290,6 +7828,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -519,7 +519,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -546,8 +558,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -598,6 +631,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -956,7 +995,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -983,8 +1034,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1035,6 +1107,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -1773,7 +1851,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -1800,8 +1890,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -1852,6 +1963,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -2210,7 +2327,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2237,8 +2366,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2289,6 +2439,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -2749,7 +2905,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -2776,8 +2944,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -2828,6 +3017,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -3186,7 +3381,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -3213,8 +3420,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -3265,6 +3493,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -3688,7 +3922,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -3714,8 +3959,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -3766,6 +4032,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchArgs:
                       description: A list of argument filters. MatchArgs are ANDed.
@@ -4119,7 +4391,18 @@ spec:
                       items:
                         properties:
                           action:
-                            description: Action to execute.
+                            description: "Action to execute.\nThe Override action
+                              has three variants, depending on what arguments are
+                              set\n  1. Override the return value of function\n       Supported
+                              hooks: kprobes, uprobes, lsm\n       Arguments: ArgError
+                              (return value)\n  2. Override the value of a register\n
+                              \      Supported hooks: uprobes\n       Arguments: ArgRegs\n
+                              \ 3. Override a function call\n       Supported hooks:
+                              uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                              override call to a new symbol (in the binary)\n\t      -
+                              ArgNewAddr: override call to a new address (in the binary)\n\t
+                              \     - ArgNewOffset: override call to an offset (in
+                              the binary)"
                             enum:
                             - Post
                             - Sigkill
@@ -4145,8 +4428,29 @@ spec:
                             description: An arg index for the set action
                             format: int32
                             type: integer
+                          argNewAddr:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's address.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewOffset:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol's offset.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            format: int64
+                            type: integer
+                          argNewSymbol:
+                            description: |-
+                              An arg value for the override action, uprobe only.
+                              The new symbol name.
+                              Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                            type: string
                           argRegs:
-                            description: An arg value for the regs action
+                            description: An arg value for the override action, uprobe
+                              only.
                             items:
                               type: string
                             type: array
@@ -4197,6 +4501,12 @@ spec:
                         required:
                         - action
                         type: object
+                        x-kubernetes-validations:
+                        - message: override action needs at most one of argNewSymbol,
+                            argNewAddr or argNewOffset defined
+                          rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                            && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                            && !(has(self.argNewAddr) && has(self.argNewOffset))'
                       type: array
                     matchReturnArgs:
                       description: A list of argument filters. MatchReturnArgs are
@@ -4608,7 +4918,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -4635,8 +4957,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -4687,6 +5030,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -5045,7 +5394,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5072,8 +5433,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5124,6 +5506,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -5816,7 +6204,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -5843,8 +6243,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -5895,6 +6316,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -6253,7 +6680,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6280,8 +6719,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6332,6 +6792,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs
@@ -6774,7 +7240,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -6801,8 +7279,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -6853,6 +7352,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchArgs:
                             description: A list of argument filters. MatchArgs are
@@ -7211,7 +7716,19 @@ spec:
                             items:
                               properties:
                                 action:
-                                  description: Action to execute.
+                                  description: "Action to execute.\nThe Override action
+                                    has three variants, depending on what arguments
+                                    are set\n  1. Override the return value of function\n
+                                    \      Supported hooks: kprobes, uprobes, lsm\n
+                                    \      Arguments: ArgError (return value)\n  2.
+                                    Override the value of a register\n       Supported
+                                    hooks: uprobes\n       Arguments: ArgRegs\n  3.
+                                    Override a function call\n       Supported hooks:
+                                    uprobes\n       Arguments: One of:\n       - ArgNewSymbol:
+                                    override call to a new symbol (in the binary)\n\t
+                                    \     - ArgNewAddr: override call to a new address
+                                    (in the binary)\n\t      - ArgNewOffset: override
+                                    call to an offset (in the binary)"
                                   enum:
                                   - Post
                                   - Sigkill
@@ -7238,8 +7755,29 @@ spec:
                                   description: An arg index for the set action
                                   format: int32
                                   type: integer
+                                argNewAddr:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's address.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewOffset:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol's offset.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  format: int64
+                                  type: integer
+                                argNewSymbol:
+                                  description: |-
+                                    An arg value for the override action, uprobe only.
+                                    The new symbol name.
+                                    Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+                                  type: string
                                 argRegs:
-                                  description: An arg value for the regs action
+                                  description: An arg value for the override action,
+                                    uprobe only.
                                   items:
                                     type: string
                                   type: array
@@ -7290,6 +7828,12 @@ spec:
                               required:
                               - action
                               type: object
+                              x-kubernetes-validations:
+                              - message: override action needs at most one of argNewSymbol,
+                                  argNewAddr or argNewOffset defined
+                                rule: '!(has(self.argNewSymbol) && has(self.argNewAddr))
+                                  && !(has(self.argNewSymbol) && has(self.argNewOffset))
+                                  && !(has(self.argNewAddr) && has(self.argNewOffset))'
                             type: array
                           matchReturnArgs:
                             description: A list of argument filters. MatchReturnArgs

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -271,9 +271,23 @@ type ArgSelector struct {
 	Values []string `json:"values,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!(has(self.argNewSymbol) && has(self.argNewAddr)) && !(has(self.argNewSymbol) && has(self.argNewOffset)) && !(has(self.argNewAddr) && has(self.argNewOffset))",message="override action needs at most one of argNewSymbol, argNewAddr or argNewOffset defined"
 type ActionSelector struct {
 	// +kubebuilder:validation:Enum=Post;Sigkill;Override;GetUrl;DnsLookup;NoPost;Signal;TrackSock;UntrackSock;NotifyEnforcer;CleanupEnforcerNotification;Set
 	// Action to execute.
+	// The Override action has three variants, depending on what arguments are set
+	//   1. Override the return value of function
+	//        Supported hooks: kprobes, uprobes, lsm
+	//        Arguments: ArgError (return value)
+	//   2. Override the value of a register
+	//        Supported hooks: uprobes
+	//        Arguments: ArgRegs
+	//   3. Override a function call
+	//        Supported hooks: uprobes
+	//        Arguments: One of:
+	//        - ArgNewSymbol: override call to a new symbol (in the binary)
+	//	      - ArgNewAddr: override call to a new address (in the binary)
+	//	      - ArgNewOffset: override call to an offset (in the binary)
 	Action string `json:"action"`
 	// +kubebuilder:validation:Optional
 	// A URL for the getUrl action
@@ -297,8 +311,23 @@ type ActionSelector struct {
 	// An arg value for the set action
 	ArgValue uint32 `json:"argValue"`
 	// +kubebuilder:validation:Optional
-	// An arg value for the regs action
+	// An arg value for the override action, uprobe only.
 	ArgRegs []string `json:"argRegs,omitempty"`
+	// +kubebuilder:validation:Optional
+	// An arg value for the override action, uprobe only.
+	// The new symbol name.
+	// Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+	ArgNewSymbol string `json:"argNewSymbol,omitempty"`
+	// +kubebuilder:validation:Optional
+	// An arg value for the override action, uprobe only.
+	// The new symbol's address.
+	// Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+	ArgNewAddr uint64 `json:"argNewAddr,omitempty"`
+	// +kubebuilder:validation:Optional
+	// An arg value for the override action, uprobe only.
+	// The new symbol's offset.
+	// Beware that the symbol MUST be binary compatible with the traced uprobe symbol.
+	ArgNewOffset int64 `json:"argNewOffset,omitempty"`
 	// +kubebuilder:validation:Optional
 	// A time period within which repeated messages will not be posted. Can be
 	// specified in seconds (default or with 's' suffix), minutes ('m' suffix)

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.9"
+const CustomResourceDefinitionSchemaVersion = "1.8.10"


### PR DESCRIPTION
### Description

This PR introduces new arguments for `Override` action for uprobes.
They allow to redirect the `symbol` call to a new symbol.
```yaml
uprobes:
- path: "test"
  symbols:
  - "malloc"
  selectors:
  - matchActions:
    - action: Override
      argNewSymbol: "malloc_patched"
```

Shortcomings:
* **the new symbol must be binary-compatible with the hooked one! (no check is in place!)**
* the new symbol must be already present in the binary
* uprobe only
* only one uprobe hook symbol/addr/offset is supported when using the new action
* kernel support to mess with raw regs is needed

### Changelog

```release-note
new: argNew{Symbol,Addr,Offset} support in uprobe override action
```
