### PR TITLE
Add a method to remove a single pod from the fake watcher

### DIFF
--- a/pkg/watcher/fake.go
+++ b/pkg/watcher/fake.go
@@ -50,6 +50,16 @@ func (watcher *FakeK8sWatcher) AddPod(pod *corev1.Pod) {
 	watcher.pods = append(watcher.pods, pod)
 }
 
+func (watcher *FakeK8sWatcher) RemovePod(rem *corev1.Pod) {
+	for i, p := range watcher.pods {
+		pod := p.(*corev1.Pod)
+		if pod.Name == rem.Name && pod.Namespace == rem.Namespace {
+			watcher.pods = append(watcher.pods[:i], watcher.pods[i+1:]...)
+			break
+		}
+	}
+}
+
 // ClearPods() removes all pods from the fake watcher. This is intended for testing.
 func (watcher *FakeK8sWatcher) ClearAllPods() {
 	watcher.pods = nil

--- a/pkg/watcher/fake_test.go
+++ b/pkg/watcher/fake_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestFakeK8sWatcher_AddService(t *testing.T) {
@@ -34,4 +35,33 @@ func TestFakeK8sWatcher_ClearAllServices(t *testing.T) {
 	assert.Len(t, fakeWatcher.services, 3)
 	fakeWatcher.ClearAllServices()
 	assert.Empty(t, fakeWatcher.services)
+}
+
+func TestFakeK8sWatcher_DeletePod(t *testing.T) {
+	pods := []any{
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "default"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: "default"}},
+	}
+	fakeWatcher := NewFakeK8sWatcherWithPodsAndServices(pods, nil)
+	assert.Len(t, fakeWatcher.pods, 3)
+	fakeWatcher.RemovePod(pods[1].(*corev1.Pod))
+	assert.Len(t, fakeWatcher.pods, 2)
+	for _, p := range fakeWatcher.pods {
+		pod := p.(*corev1.Pod)
+		assert.NotEqual(t, "pod2", pod.Name)
+	}
+}
+
+func TestFakeK8sWatcher_DeletePodNamespaceMismatch(t *testing.T) {
+	pods := []any{
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "default"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "default"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: "default"}},
+	}
+	fakeWatcher := NewFakeK8sWatcherWithPodsAndServices(pods, nil)
+	assert.Len(t, fakeWatcher.pods, 3)
+	rem := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "other"}}
+	fakeWatcher.RemovePod(rem)
+	assert.Len(t, fakeWatcher.pods, 3)
 }


### PR DESCRIPTION
This is useful for frameworks utilizing FakeK8sWatcher that need to remove individual pods.

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
Add a method to the fake watcher `watcher.RemovePod` that can be used to remove a single previously added pod. This is useful for frameworks using fake watcher that need to change the set of pods.

### Changelog

```
Add a method `(watcher *FakeK8sWatcher) RemovePod` that can be used to remove a previously added pod. This is useful for frameworks using fake watcher that need to change the set of pods.
```
