### PR TITLE
cmd/tetragon-tester: improve sysrq-trigger shutdown failure log

### DIFF
--- a/cmd/tetragon-tester/init.go
+++ b/cmd/tetragon-tester/init.go
@@ -103,7 +103,7 @@ func tester() int {
 			os.Stdout.Sync()
 			time.Sleep(100 * time.Millisecond)
 			if err := os.WriteFile("/proc/sysrq-trigger", []byte("o"), 0777); err != nil {
-				fmt.Printf("failed to use syseq-trigger to shutdown machine")
+				fmt.Printf("failed to use sysrq-trigger to shutdown machine: %v\n", err)
 				return
 			}
 			// wait for the powerdown before init is killed to avoid confusing messages from the kernel


### PR DESCRIPTION
While reading the `cmd/tetragon-tester` code, I noticed two small issues in the error log printed

1. The binary name was misspelled as `syseq-trigger` instead of `sysrq-trigger`.
2. The captured error value was not included in the log, which makes debugging harder

This PR fixes the typo and includes the error using `%v`