### PR TITLE
fix for multiple uprobes in one policy with different targets

### DIFF
--- a/pkg/sensors/program/loader_linux.go
+++ b/pkg/sensors/program/loader_linux.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/cilium/ebpf"
@@ -369,6 +370,7 @@ func uprobeAttachMulti(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec
 		var links []link.Link
 		var lnk link.Link
 
+		idx := 0
 		for path, attach := range data.Attach {
 			exec, err := link.OpenExecutable(path)
 			if err != nil {
@@ -388,12 +390,14 @@ func uprobeAttachMulti(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec
 			if err != nil {
 				return nil, err
 			}
-			err = LinkPin(lnk, bpfDir, load, extra...)
+			pinExtra := append(extra, strconv.Itoa(idx))
+			err = LinkPin(lnk, bpfDir, load, pinExtra...)
 			if err != nil {
 				lnk.Close()
 				return nil, err
 			}
 			links = append(links, lnk)
+			idx++
 		}
 		return links, nil
 	}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -524,13 +524,22 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 	addrs := len(spec.Addrs)
 	refCtrOffsets := len(spec.RefCtrOffsets)
 
-	// uprobe definition spec usanity checks
-	if symbols == 0 && offsets == 0 && addrs == 0 {
-		return nil, errors.New("uprobe need either Symbols, Offsets or Addrs defined")
+	// uprobe definition spec sanity check
+	numAddressMethods := 0
+	if symbols != 0 {
+		numAddressMethods++
 	}
-	if symbols != 0 && offsets != 0 && addrs != 0 {
-		return nil, errors.New("uprobe is defined either only with Symbols, Offsets or Addrs")
+	if offsets != 0 {
+		numAddressMethods++
 	}
+	if addrs != 0 {
+		numAddressMethods++
+	}
+
+	if numAddressMethods != 1 {
+		return nil, errors.New("uprobe needs exactly one of either Symbols, Offsets or Addrs defined")
+	}
+
 	if refCtrOffsets != 0 {
 		if symbols != 0 && symbols != refCtrOffsets {
 			return nil, fmt.Errorf("RefCtrOffsets(%d) has different dimension than Symbols(%d)",

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -177,6 +177,10 @@ func TestUprobePclntab(t *testing.T) {
 	policytest.AllPolicyTests.DoObserverTest(t, "uprobe-pclntab", nil)
 }
 
+func TestUprobeMultipleTargets(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "uprobe-multiple-targets", nil)
+}
+
 func TestUretprobeGeneric(t *testing.T) {
 	testUretprobe := testutils.RepoRootPath("contrib/tester-progs/uretprobe")
 	uretprobeHook := `

--- a/pkg/testutils/policytest/observertest.go
+++ b/pkg/testutils/policytest/observertest.go
@@ -83,7 +83,7 @@ func (rpt *RegisteredPolicyTests) DoObserverTest(
 		scenario := s(conf)
 		err = scenario.Trigger.Trigger(ctx)
 		if err != nil {
-			t.Fatalf("failed to trigger scenario %s", scenario.Name)
+			t.Fatalf("failed to trigger scenario %s: %v", scenario.Name, err)
 		}
 
 		err = jsonchecker.JsonTestCheckExpect(t, scenario.EventChecker, scenario.ExpectCheckerFailure)

--- a/pkg/testutils/policytest/trigger.go
+++ b/pkg/testutils/policytest/trigger.go
@@ -50,6 +50,26 @@ func (c *CmdTrigger) ExpectSignal(sig syscall.Signal) *ExecTester {
 	}
 }
 
+// MultiCmdTrigger simply wraps multiple exec.CommandContext().Run() into a Trigger
+type MultiCmdTrigger struct {
+	BinToArgs map[string][]string
+}
+
+func NewMultiCmdTrigger(bin2args map[string][]string) *MultiCmdTrigger {
+	return &MultiCmdTrigger{
+		BinToArgs: bin2args,
+	}
+}
+
+func (c *MultiCmdTrigger) Trigger(ctx context.Context) error {
+	for bin, args := range c.BinToArgs {
+		if err := exec.CommandContext(ctx, bin, args...).Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type ExecTester struct {
 	CmdTrigger
 	// Execution should either terminate normally (with an exit code) or by a signal

--- a/tests/policytests/uprobes.go
+++ b/tests/policytests/uprobes.go
@@ -264,3 +264,34 @@ spec:
 		EventChecker: ec.NewUnorderedEventChecker(checker),
 	}
 }).RegisterAtInit()
+
+var _ = policytest.NewBuilder("uprobe-multiple-targets").WithLabels("uprobes").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe-multiple-targets"
+spec:
+  uprobes:
+  - path: {{ testBinary "uprobe-resolve" }}
+    symbols:
+    - "func"
+  - path: {{ testBinary "nop" }}
+    symbols:
+    - "main"
+`).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	binOne := c.TestBinary("uprobe-resolve")
+	binTwo := c.TestBinary("nop")
+	up1Checker := ec.NewProcessUprobeChecker(binOne).
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(binOne))).WithSymbol(sm.Full("func"))
+
+	up2Checker := ec.NewProcessUprobeChecker(binTwo).
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(binTwo))).WithSymbol(sm.Full("main"))
+
+	return &policytest.Scenario{
+		Name:         "check both events occur",
+		Trigger:      policytest.NewMultiCmdTrigger(map[string][]string{binOne: {"v8", "7"}, binTwo: {}}),
+		EventChecker: ec.NewUnorderedEventChecker(up1Checker, up2Checker),
+	}
+}).RegisterAtInit()


### PR DESCRIPTION
This is meant to fix an issue regarding multiple probes within a single, multi-probe enabled uprobe policy. If the probes are for different paths, then the policy will not load.

This issue was caused by the fact that we did not use a unique path when pinning the bpf links.