### PR TITLE
CODEOWNERS: adjust tetragon-docs md file rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@
 
 # Request a review from the tetragon-docs team on any doc changes
 /docs/ @cilium/tetragon-docs
-*.md @cilium/tetragon-docs
+/*.md @cilium/tetragon-docs
 # Exclude some docs generated files from specific tetragon-docs ownership
 /docs/content/en/docs/reference/helm-chart.md @cilium/tetragon-reviewers
 /docs/content/en/docs/reference/grpc-api.md @cilium/tetragon-reviewers


### PR DESCRIPTION
The *.md is too broad, it got triggered by files under vendor during dependencies update because it contained markdown files. Let's restrict to every markdown file under the root directory.

See https://github.com/cilium/tetragon/pull/5009