### PR TITLE
helm: Disable gops debug interface by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ e2e-test: image image-operator
 else
 e2e-test:
 endif
-	$(GO) list $(E2E_TESTS) | xargs -Ipkg $(GO) test $(GOFLAGS) -gcflags=$(GO_BUILD_GCFLAGS) -timeout $(E2E_TEST_TIMEOUT) -failfast -cover pkg ${EXTRA_TESTFLAGS} -fail-fast -tetragon.helm.set tetragon.image.override="$(E2E_AGENT)" -tetragon.helm.set tetragonOperator.image.override="$(E2E_OPERATOR)" -tetragon.helm.set tetragon.grpc.address="localhost:54321" -tetragon.helm.url="" -tetragon.helm.chart="$(realpath ./install/kubernetes/tetragon)" $(E2E_BTF_FLAGS)
+	$(GO) list $(E2E_TESTS) | xargs -Ipkg $(GO) test $(GOFLAGS) -gcflags=$(GO_BUILD_GCFLAGS) -timeout $(E2E_TEST_TIMEOUT) -failfast -cover pkg ${EXTRA_TESTFLAGS} -fail-fast -tetragon.helm.set tetragon.image.override="$(E2E_AGENT)" -tetragon.helm.set tetragonOperator.image.override="$(E2E_OPERATOR)" -tetragon.helm.set tetragon.grpc.address="localhost:54321" -tetragon.helm.set tetragon.gops.enabled=true -tetragon.helm.url="" -tetragon.helm.chart="$(realpath ./install/kubernetes/tetragon)" $(E2E_BTF_FLAGS)
 
 ##@ Development
 

--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -15,6 +15,8 @@ Depending on your setup, changes listed here might require a manual intervention
   If your systems are running Kyverno/OPA/Gatekeeper rules that allow hostPath mounts
   only by explicit paths, then you will need to extend your allowlist with the
   directory containing the socket passed to `tetragon.cri.socketHostPath`.
+* `tetragon.gops.enabled` now defaults to `false`. To re-enable the gops debug
+  interface, set `--set tetragon.gops.enabled=true` at install or upgrade time.
 
 ### TracingPolicy (k8s CRD)
 

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -120,7 +120,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.extraVolumeMounts | list | `[]` |  |
 | tetragon.fieldFilters | string | `""` | Filters to include or exclude fields from Tetragon events. Without any filters, all fields are included by default. The presence of at least one inclusion filter implies default-exclude (i.e. any fields that don't match an inclusion filter will be excluded). Field paths are expressed using dot notation like "a.b.c" and multiple field paths can be separated by commas like "a.b.c,d,e.f". An optional "event_set" may be specified to apply the field filter to a specific set of events.  For example, to exclude the "parent" field from all events and include the "process" field in PROCESS_KPROBE events while excluding all others:  fieldFilters: |   {"fields": "parent", "action": "EXCLUDE"}   {"event_set": ["PROCESS_KPROBE"], "fields": "process", "action": "INCLUDE"}  |
 | tetragon.gops.address | string | `"localhost"` | The address at which to expose gops. |
-| tetragon.gops.enabled | bool | `true` | Whether to enable exposing gops server. |
+| tetragon.gops.enabled | bool | `false` | Whether to enable exposing gops server. |
 | tetragon.gops.port | int | `8118` | The port at which to expose gops. |
 | tetragon.grpc.address | string | `"unix:///var/run/tetragon/tetragon.sock"` | The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock |
 | tetragon.grpc.enabled | bool | `true` | Whether to enable exposing Tetragon gRPC. |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -102,7 +102,7 @@ Helm chart for Tetragon
 | tetragon.extraVolumeMounts | list | `[]` |  |
 | tetragon.fieldFilters | string | `""` | Filters to include or exclude fields from Tetragon events. Without any filters, all fields are included by default. The presence of at least one inclusion filter implies default-exclude (i.e. any fields that don't match an inclusion filter will be excluded). Field paths are expressed using dot notation like "a.b.c" and multiple field paths can be separated by commas like "a.b.c,d,e.f". An optional "event_set" may be specified to apply the field filter to a specific set of events.  For example, to exclude the "parent" field from all events and include the "process" field in PROCESS_KPROBE events while excluding all others:  fieldFilters: |   {"fields": "parent", "action": "EXCLUDE"}   {"event_set": ["PROCESS_KPROBE"], "fields": "process", "action": "INCLUDE"}  |
 | tetragon.gops.address | string | `"localhost"` | The address at which to expose gops. |
-| tetragon.gops.enabled | bool | `true` | Whether to enable exposing gops server. |
+| tetragon.gops.enabled | bool | `false` | Whether to enable exposing gops server. |
 | tetragon.gops.port | int | `8118` | The port at which to expose gops. |
 | tetragon.grpc.address | string | `"unix:///var/run/tetragon/tetragon.sock"` | The address at which to expose gRPC. Examples: localhost:54321, unix:///var/run/tetragon/tetragon.sock |
 | tetragon.grpc.enabled | bool | `true` | Whether to enable exposing Tetragon gRPC. |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -253,7 +253,7 @@ tetragon:
         extraIpAddresses: []
   gops:
     # -- Whether to enable exposing gops server.
-    enabled: true
+    enabled: false
     # -- The address at which to expose gops.
     address: "localhost"
     # -- The port at which to expose gops.


### PR DESCRIPTION
The gops listener is unauthenticated and reachable by any hostNetwork pod on the same node, exposing runtime internals without authentication.  It can be re-enabled during install.

Reported-by: Banh Do <<bangdo.dxb2@gmail.com>>