### PR TITLE
bpf: simplify copy_char_buf

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -121,18 +121,14 @@ copy_char_buf(void *ctx, long off, unsigned long arg, int argm,
 	      struct msg_generic_kprobe *e)
 {
 	int *s = (int *)args_off(e, off);
-	unsigned long meta;
-	size_t bytes = 0;
 
 	if (has_return_copy(argm)) {
-		u64 retid = retprobe_map_get_key(ctx);
+		__u64 retid = retprobe_map_get_key(ctx);
 
 		retprobe_map_set(e->func_id, retid, e->common.ktime, arg);
 		return return_error(s, char_buf_saved_for_retprobe);
 	}
-	meta = get_arg_meta(argm, e);
-	probe_read(&bytes, sizeof(bytes), &meta);
-	return __copy_char_buf(ctx, off, arg, bytes, has_max_data(argm), e);
+	return __copy_char_buf(ctx, off, arg, get_arg_meta(argm, e), has_max_data(argm), e);
 }
 
 #ifdef __LARGE_BPF_PROG


### PR DESCRIPTION


<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Thanks to @andrewstrohman for [finding this issue](https://github.com/cilium/tetragon/pull/4989#discussion_r3262416749).

### Description
This function has been largely untouched since the first Tetragon commit:
https://github.com/cilium/tetragon/blob/931b70f2c9878ba985ba6b589827bea17da6ec33/bpf/process/types/basic.h#L439

We used the `probe_read()` function to the value of meta, which in turn is read from the `msg_generic_krobe *e` value which we read from a eBPF map in `__read_arg_2`. Therefore, we can access the value directly.
