### PR TITLE
tetragon: factor register override parsing

### DIFF
--- a/pkg/asm/assignment_linux.go
+++ b/pkg/asm/assignment_linux.go
@@ -129,24 +129,40 @@ func parseReg(str string, ass *Assignment) error {
 	return nil
 }
 
+// parseConst parses constant assignment forms such as "1" and "-1".
+// Constants keep base-0 parsing, so 0x and leading-zero forms are accepted.
+// Examples: "1", "-1", "0x20", "010".
 func parseConst(str string, ass *Assignment) error {
-
-	var (
-		uoff uint64
-		soff int64
-		err  error
-	)
-
-	if uoff, err = strconv.ParseUint(str, 0, 64); err != nil {
-		if soff, err = strconv.ParseInt(str, 0, 64); err != nil {
-			return errNext
-		}
-		uoff = uint64(soff)
+	uoff, err := parseOffset(strings.TrimSpace(str))
+	if err != nil {
+		return errNext
 	}
 
 	ass.Type = ASM_ASSIGNMENT_TYPE_CONST
 	ass.Off = uoff
 	return nil
+}
+
+// parseOffset parses decimal, hex, octal, signed, and full-width unsigned
+// offsets. It intentionally uses strconv base 0, so offsets accept "0x20",
+// "010", "-1", and "0xffffffffffffffff" forms.
+func parseOffset(str string) (uint64, error) {
+	if str == "" {
+		return 0, strconv.ErrSyntax
+	}
+
+	// Parse negative numbers as int64 first because ParseUint rejects the
+	// leading minus sign. The uint64 conversion preserves the two's-complement
+	// representation used by the assignment format.
+	if strings.HasPrefix(str, "-") {
+		off, err := strconv.ParseInt(str, 0, 64)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(off), nil
+	}
+
+	return strconv.ParseUint(str, 0, 64)
 }
 
 func ParseAssignment(str string) (*Assignment, error) {

--- a/pkg/asm/assignment_linux.go
+++ b/pkg/asm/assignment_linux.go
@@ -6,7 +6,6 @@ package asm
 import (
 	"errors"
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 	"unicode"
@@ -36,56 +35,62 @@ type Assignment struct {
 
 type fn func(str string, ass *Assignment) error
 
-type RegScanner struct {
-	name string
-}
-
-func (sc *RegScanner) Reset() *RegScanner {
-	sc.name = ""
-	return sc
-}
-
-func (sc *RegScanner) Scan(state fmt.ScanState, _ rune) error {
-
-	for {
-		r, _, err := state.ReadRune()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		if r == ',' || r == ' ' || r == ')' {
-			state.UnreadRune()
-			break
-		}
-		sc.name = sc.name + string(r)
-	}
-	return nil
-}
-
+// parseRegDeref parses dereference forms "(%reg)" and "off(%reg)".
+// Examples: "(%rsp)", "0x20(%rsp)", "0x20 ( %rsp )".
 func parseRegDeref(str string, ass *Assignment) error {
 	var (
-		off int64
-		reg RegScanner
-		n   int
+		off uint64
+		err error
 		ok  bool
 	)
 
-	if n, _ = fmt.Sscanf(str, "0x%x(%%%s)", &off, &reg); n != 2 {
-		if n, _ = fmt.Sscanf(str, "%d(%%%s)", &off, &reg); n != 2 {
-			if n, _ = fmt.Sscanf(str, "(%%%s)", reg.Reset()); n != 1 {
-				return errNext
-			}
+	p := cursorparser.New(str)
+
+	// Split "off(%reg)" at the opening parenthesis. The left side is the
+	// optional offset; the text between '(' and ')' must be a register ref.
+	offStr, ok := p.ReadUntil('(')
+	if !ok {
+		return errNext
+	}
+
+	// Everything before '(' is the optional offset. No prefix means zero
+	// offset, so "(%rsp)" and "0(%rsp)" produce the same dereference base.
+	if offStr = strings.TrimSpace(offStr); offStr != "" {
+		off, err = parseOffset(offStr)
+		if err != nil {
+			return errNext
 		}
 	}
 
-	ass.Type = ASM_ASSIGNMENT_TYPE_REG_DEREF
-	ass.Off = uint64(off)
-	ass.Src, ass.SrcSize, ok = RegOffsetSize(reg.name)
-	if !ok {
-		return fmt.Errorf("failed to parse register '%s'", reg.name)
+	if !p.Consume('(') {
+		return errNext
 	}
+
+	if !p.Consume('%') {
+		return errNext
+	}
+
+	// Reading the register up to ')' leaves the cursor at the closing
+	// delimiter. Consuming it below rejects missing parentheses and junk
+	// suffixes.
+	reg, ok := p.ReadUntil(')')
+	if !ok {
+		return errNext
+	}
+	reg = strings.TrimRightFunc(reg, unicode.IsSpace)
+	if reg == "" || !p.Consume(')') || !p.Done() {
+		return errNext
+	}
+
+	src, srcSize, ok := RegOffsetSize(reg)
+	if !ok {
+		return fmt.Errorf("failed to parse register '%s'", reg)
+	}
+
+	ass.Type = ASM_ASSIGNMENT_TYPE_REG_DEREF
+	ass.Off = off
+	ass.Src = src
+	ass.SrcSize = srcSize
 	return nil
 }
 

--- a/pkg/asm/assignment_linux.go
+++ b/pkg/asm/assignment_linux.go
@@ -9,6 +9,9 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"unicode"
+
+	"github.com/cilium/tetragon/pkg/cursorparser"
 )
 
 const (
@@ -109,23 +112,31 @@ func parseRegOff(str string, ass *Assignment) error {
 	return nil
 }
 
+// parseReg parses register assignment forms "%reg".
+// Example: "%rax".
 func parseReg(str string, ass *Assignment) error {
-	var (
-		reg RegScanner
-		n   int
-		ok  bool
-	)
+	p := cursorparser.New(str)
 
-	if n, _ = fmt.Sscanf(str, "%%%s", &reg); n != 1 {
+	// Register assignments must start with a percent marker.
+	if !p.Consume('%') {
 		return errNext
+	}
+
+	// Everything after '%' is the source register.
+	reg := strings.TrimRightFunc(p.ReadRest(), unicode.IsSpace)
+	if reg == "" {
+		return errNext
+	}
+
+	src, srcSize, ok := RegOffsetSize(reg)
+	if !ok {
+		return fmt.Errorf("failed to parse register '%s'", reg)
 	}
 
 	ass.Type = ASM_ASSIGNMENT_TYPE_REG
 	ass.Off = 0
-	ass.Src, ass.SrcSize, ok = RegOffsetSize(reg.name)
-	if !ok {
-		return fmt.Errorf("failed to parse register '%s'", reg.name)
-	}
+	ass.Src = src
+	ass.SrcSize = srcSize
 	return nil
 }
 

--- a/pkg/asm/assignment_linux.go
+++ b/pkg/asm/assignment_linux.go
@@ -89,26 +89,39 @@ func parseRegDeref(str string, ass *Assignment) error {
 	return nil
 }
 
+// parseRegOff parses register-offset forms "off%reg".
+// Examples: "8%rsp", "0x20%rsp", "0x20 %rsp".
 func parseRegOff(str string, ass *Assignment) error {
-	var (
-		reg RegScanner
-		n   int
-		ok  bool
-		off int
-	)
+	// Split "off%reg" at the percent marker. There must be a non-empty
+	// offset before it and a non-empty register name after it.
+	offStr, reg, ok := strings.Cut(str, "%")
+	if !ok {
+		return errNext
+	}
 
-	if n, _ = fmt.Sscanf(str, "0x%x%%%s", &off, &reg); n != 2 {
-		if n, _ = fmt.Sscanf(str, "%d%%%s", &off, reg.Reset()); n != 2 {
-			return errNext
-		}
+	offStr = strings.TrimSpace(offStr)
+	if offStr == "" {
+		return errNext
+	}
+	off, err := parseOffset(offStr)
+	if err != nil {
+		return errNext
+	}
+
+	reg = strings.TrimRightFunc(reg, unicode.IsSpace)
+	if reg == "" {
+		return errNext
+	}
+
+	src, srcSize, ok := RegOffsetSize(reg)
+	if !ok {
+		return fmt.Errorf("failed to parse register '%s'", reg)
 	}
 
 	ass.Type = ASM_ASSIGNMENT_TYPE_REG_OFF
-	ass.Off = uint64(off)
-	ass.Src, ass.SrcSize, ok = RegOffsetSize(reg.name)
-	if !ok {
-		return fmt.Errorf("failed to parse register '%s'", reg.name)
-	}
+	ass.Off = off
+	ass.Src = src
+	ass.SrcSize = srcSize
 	return nil
 }
 

--- a/pkg/asm/assignment_linux.go
+++ b/pkg/asm/assignment_linux.go
@@ -204,20 +204,23 @@ func ParseAssignment(str string) (*Assignment, error) {
 
 	ass := &Assignment{}
 
-	s := strings.Split(str, "=")
-	if len(s) != 2 {
+	var ok bool
+
+	// Split on one assignment delimiter, then trim only around the two sides.
+	dst, src, cutOK := strings.Cut(str, "=")
+	dst = strings.TrimSpace(dst)
+	src = strings.TrimSpace(src)
+	if !cutOK || dst == "" || src == "" || strings.Contains(src, "=") {
 		return nil, fmt.Errorf("failed to parse assignment '%s'", str)
 	}
 
-	var ok bool
-
-	ass.Dst, ass.DstSize, ok = RegOffsetSize(s[0] /* dst */)
+	ass.Dst, ass.DstSize, ok = RegOffsetSize(dst)
 	if !ok {
-		return nil, fmt.Errorf("failed to parse register '%s'", s[0])
+		return nil, fmt.Errorf("failed to parse register '%s'", dst)
 	}
 
 	for _, parse := range parsers {
-		err := parse(s[1] /* src */, ass)
+		err := parse(src, ass)
 		if err == nil {
 			return ass, nil
 		}

--- a/pkg/asm/assignment_linux_amd64_test.go
+++ b/pkg/asm/assignment_linux_amd64_test.go
@@ -29,6 +29,14 @@ func TestAssignment(t *testing.T) {
 		err error
 	)
 
+	// constants — octal form
+	ass, err = ParseAssignment("rax=010")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_CONST, ass.Type)
+	assert.Equal(t, uint64(8), ass.Off)
+	assert.Equal(t, uint16(0x50), ass.Dst)
+	assert.Equal(t, uint16(0x0), ass.Src)
+
 	// constants
 	ass, err = ParseAssignment("rax=1")
 	require.NoError(t, err)
@@ -80,6 +88,13 @@ func TestAssignment(t *testing.T) {
 	assert.Equal(t, uint16(0x50), ass.Src)
 	assert.Equal(t, uint64(0), ass.Off)
 
+	ass, err = ParseAssignment("rsp = %rax")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG, ass.Type)
+	assert.Equal(t, uint16(0x98), ass.Dst)
+	assert.Equal(t, uint16(0x50), ass.Src)
+	assert.Equal(t, uint64(0), ass.Off)
+
 	// register + offset
 	ass, err = ParseAssignment("rbp=128%rax")
 	require.NoError(t, err)
@@ -88,12 +103,27 @@ func TestAssignment(t *testing.T) {
 	assert.Equal(t, uint16(0x50), ass.Src)
 	assert.Equal(t, uint64(128), ass.Off)
 
+	ass, err = ParseAssignment("rbp = 010 %rax")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_OFF, ass.Type)
+	assert.Equal(t, uint16(0x20), ass.Dst)
+	assert.Equal(t, uint16(0x50), ass.Src)
+	assert.Equal(t, uint64(8), ass.Off)
+
 	ass, err = ParseAssignment("rax=0x80%rax")
 	require.NoError(t, err)
 	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_OFF, ass.Type)
 	assert.Equal(t, uint16(0x50), ass.Dst)
 	assert.Equal(t, uint16(0x50), ass.Src)
 	assert.Equal(t, uint64(0x80), ass.Off)
+
+	// register deref — no-offset form
+	ass, err = ParseAssignment("rbp=(%rsp)")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_DEREF, ass.Type)
+	assert.Equal(t, uint16(0x20), ass.Dst)
+	assert.Equal(t, uint16(0x98), ass.Src)
+	assert.Equal(t, uint64(0), ass.Off)
 
 	// register deref
 	ass, err = ParseAssignment("rsp=-1372(%rbp)")
@@ -109,4 +139,49 @@ func TestAssignment(t *testing.T) {
 	assert.Equal(t, uint16(0x20), ass.Dst)
 	assert.Equal(t, uint16(0x98), ass.Src)
 	assert.Equal(t, uint64(0x20), ass.Off)
+
+	ass, err = ParseAssignment("rbp = 0x20 ( %rsp )")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_DEREF, ass.Type)
+	assert.Equal(t, uint16(0x20), ass.Dst)
+	assert.Equal(t, uint16(0x98), ass.Src)
+	assert.Equal(t, uint64(0x20), ass.Off)
+
+	ass, err = ParseAssignment("rsp=010(%rbp)")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_DEREF, ass.Type)
+	assert.Equal(t, uint16(0x98), ass.Dst)
+	assert.Equal(t, uint16(0x20), ass.Src)
+	assert.Equal(t, uint64(8), ass.Off)
+}
+
+func TestAssignmentInvalid(t *testing.T) {
+	tests := []string{
+		"rax=",
+		"=1",
+		"rax=1=2",
+		"ra x=1",
+		"rax=1 2",
+		"rax=abc",
+		"rbp=0x2 0(%rsp)",
+		"rbp=0x20(%rsp",
+		"rbp=0x20(%rsp)junk",
+		"rbp=0x20(% rsp)",
+		"rsp=%rax)",
+		"rsp=% rax",
+		"rsp=%r ax",
+		"rsp=8% rax",
+		"rsp=8%rax garbage",
+		"rsp=8%r ax",
+		"rax=0x20()",
+		"rax=0x20(%notareg)",
+	}
+
+	for _, exp := range tests {
+		t.Run(exp, func(t *testing.T) {
+			ass, err := ParseAssignment(exp)
+			require.Error(t, err)
+			assert.Nil(t, ass)
+		})
+	}
 }

--- a/pkg/asm/assignment_linux_arm64_test.go
+++ b/pkg/asm/assignment_linux_arm64_test.go
@@ -29,6 +29,14 @@ func TestAssignment(t *testing.T) {
 		err error
 	)
 
+	// constants — octal form
+	ass, err = ParseAssignment("x0=010")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_CONST, ass.Type)
+	assert.Equal(t, uint64(8), ass.Off)
+	assert.Equal(t, uint16(0x0), ass.Dst)
+	assert.Equal(t, uint16(0x0), ass.Src)
+
 	// constants
 	ass, err = ParseAssignment("x0=1")
 	require.NoError(t, err)
@@ -59,6 +67,13 @@ func TestAssignment(t *testing.T) {
 	assert.Equal(t, uint16(0x0), ass.Src)
 	assert.Equal(t, uint64(0), ass.Off)
 
+	ass, err = ParseAssignment("sp = %x0")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG, ass.Type)
+	assert.Equal(t, uint16(0xf8), ass.Dst)
+	assert.Equal(t, uint16(0x0), ass.Src)
+	assert.Equal(t, uint64(0), ass.Off)
+
 	// register + offset
 	ass, err = ParseAssignment("x29=128%x0")
 	require.NoError(t, err)
@@ -67,12 +82,27 @@ func TestAssignment(t *testing.T) {
 	assert.Equal(t, uint16(0x0), ass.Src)
 	assert.Equal(t, uint64(128), ass.Off)
 
+	ass, err = ParseAssignment("x29 = 010 %x0")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_OFF, ass.Type)
+	assert.Equal(t, uint16(0xe8), ass.Dst)
+	assert.Equal(t, uint16(0x0), ass.Src)
+	assert.Equal(t, uint64(8), ass.Off)
+
 	ass, err = ParseAssignment("x1=0x80%x1")
 	require.NoError(t, err)
 	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_OFF, ass.Type)
 	assert.Equal(t, uint16(0x8), ass.Dst)
 	assert.Equal(t, uint16(0x8), ass.Src)
 	assert.Equal(t, uint64(0x80), ass.Off)
+
+	// register deref — no-offset form
+	ass, err = ParseAssignment("x29=(%sp)")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_DEREF, ass.Type)
+	assert.Equal(t, uint16(0xe8), ass.Dst)
+	assert.Equal(t, uint16(0xf8), ass.Src)
+	assert.Equal(t, uint64(0), ass.Off)
 
 	// register deref
 	ass, err = ParseAssignment("sp=-1372(%x29)")
@@ -88,4 +118,50 @@ func TestAssignment(t *testing.T) {
 	assert.Equal(t, uint16(0xe8), ass.Dst)
 	assert.Equal(t, uint16(0xf8), ass.Src)
 	assert.Equal(t, uint64(0x20), ass.Off)
+
+	ass, err = ParseAssignment("x29 = 0x20 ( %sp )")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_DEREF, ass.Type)
+	assert.Equal(t, uint16(0xe8), ass.Dst)
+	assert.Equal(t, uint16(0xf8), ass.Src)
+	assert.Equal(t, uint64(0x20), ass.Off)
+
+	ass, err = ParseAssignment("sp=010(%x29)")
+	require.NoError(t, err)
+	assert.Equal(t, ASM_ASSIGNMENT_TYPE_REG_DEREF, ass.Type)
+	assert.Equal(t, uint16(0xf8), ass.Dst)
+	assert.Equal(t, uint16(0xe8), ass.Src)
+	assert.Equal(t, uint64(8), ass.Off)
+}
+
+func TestAssignmentInvalid(t *testing.T) {
+	tests := []string{
+		"x0=",
+		"=1",
+		"x0=1=2",
+		"x 0=1",
+		"x0=1 2",
+		"x0=abc",
+		"x29=0x2 0(%sp)",
+		"x29=0x20(%sp",
+		"x29=0x20(%sp)junk",
+		"x29=0x20(% sp)",
+		"sp=%x0)",
+		"sp=% x0",
+		"sp=%x 0",
+		"sp=%x0junk",
+		"sp=8% x0",
+		"sp=8%x0 garbage",
+		"sp=8%x 0",
+		"x0=0x20()",
+		"x0=0x20(%notareg)",
+	}
+
+	for _, exp := range tests {
+		t.Run(exp, func(t *testing.T) {
+			ass, err := ParseAssignment(exp)
+			require.Error(t, err)
+			assert.Nil(t, ass)
+		})
+	}
 }

--- a/pkg/asm/regoffset_linux_arm64.go
+++ b/pkg/asm/regoffset_linux_arm64.go
@@ -4,13 +4,36 @@
 package asm
 
 import (
-	"fmt"
+	"strconv"
+	"strings"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
 var ptregs unix.PtraceRegs
+
+// parseArmRegisterIndex parses arm64 register names with a numeric suffix.
+// The full suffix must be decimal digits and fit within the provided maximum.
+func parseArmRegisterIndex(name, prefix string, max int) (int, bool) {
+	idxStr, ok := strings.CutPrefix(name, prefix)
+	if !ok || idxStr == "" {
+		return 0, false
+	}
+
+	for _, ch := range idxStr {
+		if ch < '0' || ch > '9' {
+			return 0, false
+		}
+	}
+
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx > max {
+		return 0, false
+	}
+
+	return idx, true
+}
 
 func RegOffset(name string) (uint16, bool) {
 	switch name {
@@ -19,9 +42,8 @@ func RegOffset(name string) (uint16, bool) {
 	case "pc":
 		return uint16(unsafe.Offsetof(ptregs.Pc)), true
 	}
-	var idx int
-	_, err := fmt.Sscanf(name, "x%d", &idx)
-	if err == nil && idx >= 0 && idx <= 31 {
+	idx, ok := parseArmRegisterIndex(name, "x", 31)
+	if ok {
 		if idx == 31 {
 			return RegOffset("sp")
 		}
@@ -30,8 +52,8 @@ func RegOffset(name string) (uint16, bool) {
 		return uint16(baseOff + shift), true
 	}
 
-	_, err = fmt.Sscanf(name, "w%d", &idx)
-	if err == nil && idx >= 0 && idx <= 30 {
+	idx, ok = parseArmRegisterIndex(name, "w", 30)
+	if ok {
 		baseOff := unsafe.Offsetof(ptregs.Regs)
 		shift := unsafe.Sizeof(ptregs.Regs[0]) * uintptr(idx)
 		return uint16(baseOff + shift), true
@@ -46,9 +68,8 @@ func RegOffsetSize(name string) (uint16, uint8, bool) {
 		return 0, 0, false
 	}
 
-	var idx int
-	_, err := fmt.Sscanf(name, "w%d", &idx)
-	if err == nil {
+	_, isWReg := parseArmRegisterIndex(name, "w", 30)
+	if isWReg {
 		return off, 4, true
 	}
 

--- a/pkg/cursorparser/parser.go
+++ b/pkg/cursorparser/parser.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// Package cursorparser provides a small cursor-based helper for parsing short,
+// delimiter-oriented strings.
+//
+// Use it when a grammar is simple enough to parse left-to-right but still needs
+// to distinguish missing delimiters from trailing junk.
+// It trims outer whitespace once, skips token-edge whitespace before Consume calls,
+// and leaves text returned by ReadUntil and ReadRest for callers to validate.
+//
+// Examples of suitable inputs:
+//   - assembly register dereferences such as "(%rsp)", "0x20(%rsp)", and
+//     "0x20 ( %rsp )": read the offset until '(', consume '(', consume '%',
+//     read the register until ')', consume ')', then require Done.
+//   - register offsets such as "8%rsp" or "0x20 %rsp": read the offset until
+//     '%', consume '%', then ReadRest for the register.
+//   - prefixed tokens such as "%rax": consume '%', then ReadRest for the
+//     payload.
+//
+// It is not a full expression parser; callers own token validation and numeric
+// conversion after each cursor step.
+package cursorparser
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type Parser struct {
+	str string
+	pos int
+}
+
+func New(str string) *Parser {
+	return &Parser{str: strings.TrimSpace(str)}
+}
+
+func (p *Parser) skipSpace() {
+	for p.pos < len(p.str) {
+		r, size := utf8.DecodeRuneInString(p.str[p.pos:])
+		if !unicode.IsSpace(r) {
+			return
+		}
+		p.pos += size
+	}
+}
+
+// Consume skips token-edge whitespace and consumes ch if it is next.
+// The cursor advances only on a match, so callers can probe for
+// delimiters without losing their position on failure.
+func (p *Parser) Consume(ch byte) bool {
+	p.skipSpace()
+	if p.pos >= len(p.str) || p.str[p.pos] != ch {
+		return false
+	}
+	p.pos++
+	return true
+}
+
+// ReadUntil returns the text from the current cursor up to ch and
+// leaves the cursor at ch.
+func (p *Parser) ReadUntil(ch byte) (string, bool) {
+	idx := strings.IndexByte(p.str[p.pos:], ch)
+	if idx < 0 {
+		return "", false
+	}
+	str := p.str[p.pos : p.pos+idx]
+	p.pos += idx
+	return str, true
+}
+
+// ReadRest returns the remaining expression text and moves the cursor
+// to the end.
+func (p *Parser) ReadRest() string {
+	str := p.str[p.pos:]
+	p.pos = len(p.str)
+	return str
+}
+
+// Done reports whether only whitespace remains after the current cursor.
+func (p *Parser) Done() bool {
+	p.skipSpace()
+	return p.pos == len(p.str)
+}


### PR DESCRIPTION
change register assignment parsign to use small cursor parsing
instead of fmt.Sscanf which can't handle trailing input properly