### PR TITLE
helm: Adjust mounting of socket to survive daemon restarts for consistent metadata collection

### DIFF
--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -11,7 +11,10 @@ Depending on your setup, changes listed here might require a manual intervention
 
 ### Helm Values
 
-* TBD
+* CRI users: Mounting of the Container Runtime socket is moving to a directory path.
+  If your systems are running Kyverno/OPA/Gatekeeper rules that allow hostPath mounts
+  only by explicit paths, then you will need to extend your allowlist with the
+  directory containing the socket passed to `tetragon.cri.socketHostPath`.
 
 ### TracingPolicy (k8s CRD)
 

--- a/install/kubernetes/tetragon/templates/_container_tetragon.tpl
+++ b/install/kubernetes/tetragon/templates/_container_tetragon.tpl
@@ -41,7 +41,7 @@
     - mountPath: "/procRoot"
       name: host-proc
 {{- if and (.Values.tetragon.cri.enabled) (.Values.tetragon.cri.socketHostPath) }}
-    - mountPath: {{ quote .Values.tetragon.cri.socketHostPath }}
+    - mountPath: {{ dir .Values.tetragon.cri.socketHostPath | quote }}
       name: cri-socket
 {{- end }}
 {{- range .Values.extraHostPathMounts }}

--- a/install/kubernetes/tetragon/templates/daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/daemonset.yaml
@@ -101,8 +101,8 @@ spec:
 {{- if and (.Values.tetragon.cri.enabled) (.Values.tetragon.cri.socketHostPath) }}
       - name: cri-socket
         hostPath:
-          path: {{ quote .Values.tetragon.cri.socketHostPath }}
-          type: Socket
+          path: {{ dir .Values.tetragon.cri.socketHostPath | quote }}
+          type: Directory
 {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [X] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [X] All code is covered by unit and/or end-to-end tests where feasible.
- [X] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [X] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [X] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [X] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description

If/when a containerd or cri daemon restarts without completely restarting the node it breaks the mounted socket into the daemonset. This happens because linux bind mounts on inode, not the path itself.

When the disconnect happens, metadata is no longer collected to be submitted.

This implements the similar socket mount setup as cilium-agent for spire-agent and envoy.

* [volumes](https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml#L931-L943)
* [volumeMounts](https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml#L312-L321)

Worth noting:
1. Any orgs running Kyverno/OPA/Gatekeeper rules that allow hostPath mounts by explicit path (/run/containerd/containerd.sock) need their allowlist updated to the directory path.

2. `type: Socket` → `type: Directory` removes a kubelet-side integrity check. With `Socket`, kubelet refuses to start the pod unless the file is a unix socket at that exact path. With `Directory`, kubelet only checks that a directory exists.
   a. For CRI socket, this seems the safer choice because it would be better to fail loudly if the runtime path is wrong rather than silently creating an empty directory and not collecting metadata which leads to other failure scenarios.
   b. Security-wise this is a small reduction in defense-in-depth (you could conceivably bind-mount a directory whose containerd.sock was a regular file pointing somewhere unexpected, which requires host root already).

3. Mounting the directory does open access such as an easy path log/stdio scraping if tetragon itself is compromised, however, as procfs is already mounted the access already exists.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
helm: Adjust mounting of socket to survive daemon restarts for consistent metadata collection
```
