### PR TITLE
bpf: use 64K ring buffer placeholder for non-4K page size compatibility

### DIFF
--- a/bpf/lib/bpf_event.h
+++ b/bpf/lib/bpf_event.h
@@ -18,10 +18,10 @@ struct {
 
 #ifdef __V511_BPF_PROG
 // The ring buffer needs to have a size that is a multiple of a page size, and is a power of 2.
-// Zero isn't acceptable, so we arbitrarily choose 4K as that is a common/default page size.
+// 65536 is valid across 4K, 16K, and 64K page sizes (ARM64). Resized in user space before use.
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4096); // This will be resized in user space.
+	__uint(max_entries, 65536); // Placeholder, resized by GetRBSize(). Must survive kernel ELF validation.
 } tg_rb_events SEC(".maps");
 #endif
 


### PR DESCRIPTION
The BPF ring buffer map tg_rb_events uses max_entries=4096 as a placeholder that gets resized by GetRBSize() in user space before actual use. However, the kernel validates the ELF object's max_entries during map creation: it must be both a power of 2 AND a multiple of the system page size.

On ARM64 systems with 16K pages (CONFIG_ARM64_16K_PAGES=y), 4096 is not page-aligned (4096 % 16384 != 0), causing EINVAL at map creation time before user space ever gets to resize it.

Change the placeholder to 65536, which is:
- A power of 2
- Divisible by 4096 (x86, ARM64 4K)
- Divisible by 16384 (ARM64 16K, Apple Silicon)
- Divisible by 65536 (ARM64 64K)

Since GetRBSize() always overrides this value, the actual runtime behavior is unchanged -- this only affects ELF validation.

Tested on Raspberry Pi 5 (Debian 13, kernel 6.12.90, 16K pages).

Fixes: #5026

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

Fixes <!-- #issue-number -->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
```
