### PR TITLE
docs: Add fentry/fexit sensor documentation

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -4,10 +4,11 @@ weight: 2
 description: "Hook points for Tracing Policies and arguments description"
 ---
 
-Tetragon can hook into the kernel using `kprobes` and `tracepoints`, as well as in user-space
-programs using `uprobes`. Users can configure these hook points using the correspodning sections of
-the `TracingPolicy` specification (`.spec`). These hook points include arguments and return values
-that can be specified using the `args` and `returnArg` fields as detailed in the following sections.
+Tetragon can hook into the kernel using `kprobes`, `fentry/fexit`, and `tracepoints`, as well as in
+user-space programs using `uprobes`. Users can configure these hook points using the corresponding
+sections of the `TracingPolicy` specification (`.spec`). These hook points include arguments and
+return values that can be specified using the `args` and `returnArg` fields as detailed in the
+following sections.
 
 {{< warning >}}
 Hooking a system call can introduce time-of-check to time-of-use (TOCTOU)
@@ -88,6 +89,107 @@ spec:
     syscall: true
     # [...]
 ```
+
+## Fentry/Fexit
+
+Fentry (BPF fentry/fexit) programs attach to kernel functions using BTF (BPF Type Format). They
+are a modern alternative to kprobes with lower overhead. Instead of using breakpoints and
+instruction patching like kprobes, fentry programs are called directly from a trampoline, which
+makes them faster and safer.
+
+### When to use fentry vs kprobes
+
+Fentry is preferred over kprobes when the environment supports it, because:
+
+- Lower overhead: no breakpoint or instruction patching is needed; the BPF program is invoked
+  directly from a trampoline.
+- Safer: avoids the complexity and potential issues of runtime instruction patching.
+
+However, kprobes remain the better choice when:
+
+- Older kernels: fentry in Tetragon requires kernel >= 6.1.
+- No BTF support: fentry requires the kernel to be built with `CONFIG_DEBUG_INFO_BTF=y`.
+- Enforcement is needed: fentry does not yet support enforcement (override) actions.
+
+### Kernel requirements
+
+To use fentry, the following kernel requirements must be met:
+
+- Kernel version: >= 6.1 is required for Tetragon's fentry implementation.
+- BTF support: the kernel must be built with BTF enabled (`CONFIG_DEBUG_INFO_BTF=y`). You can
+  verify this with:
+
+```shell
+cat /boot/config-$(uname -r) | grep CONFIG_DEBUG_INFO_BTF
+```
+
+The output should include:
+
+```
+CONFIG_DEBUG_INFO_BTF=y
+```
+
+### Limitations
+
+- No enforcement/override support: unlike kprobes, fentry does not yet support enforcement
+  actions such as `Override` or `Signal`.
+- No multi-attach support: each fentry spec attaches to a single kernel function.
+
+### Example
+
+Here is an example of a `TracingPolicy` using the `fentries` section to trace the `tcp_connect`
+kernel function:
+
+```yaml
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "fentry-example"
+spec:
+  fentries:
+  - call: "tcp_connect"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "sock"
+    returnArg:
+      index: 0
+      type: "int"
+```
+
+{{< note >}}
+Unlike kprobes where `syscall` can be set to `true` to trace system call entry points, fentry is
+typically used for internal kernel functions and `syscall` should be set to `false`. This is
+because fentry attaches via BTF-based trampolines that are suited for tracing internal kernel
+function boundaries rather than the syscall ABI layer.
+{{< /note >}}
+
+{{< note >}}
+The `fentry` program attaches at function *entry*, while its `fexit` counterpart attaches at
+function *exit*, where the return value is available. To capture a function's return value, set
+`return: true` — this is what attaches the `fexit` program — and define `returnArg` with the
+return value's `type`, as shown in the example above. When `return` is left unset (it defaults to
+`false`), only the `fentry` program is attached and any `returnArg` is ignored. See
+[Return values](#return-values) for more details on `return` and `returnArg`.
+{{< /note >}}
+
+Similar to kprobes, you can define multiple fentry specs in the same policy:
+
+```yaml
+spec:
+  fentries:
+  - call: "tcp_connect"
+    syscall: false
+    # [...]
+  - call: "tcp_close"
+    syscall: false
+    # [...]
+```
+
+Fentry specs support the same `args`, `returnArg`, and `selectors` fields as kprobes, so you can
+use argument filtering and in-kernel selectors in the same way. For details on selectors, see the
+[Selectors]({{< ref "/docs/concepts/tracing-policy/selectors" >}}) documentation.
 
 ## Tracepoints
 

--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -4,10 +4,11 @@ weight: 2
 description: "Hook points for Tracing Policies and arguments description"
 ---
 
-Tetragon can hook into the kernel using `kprobes` and `tracepoints`, as well as in user-space
-programs using `uprobes`. Users can configure these hook points using the correspodning sections of
-the `TracingPolicy` specification (`.spec`). These hook points include arguments and return values
-that can be specified using the `args` and `returnArg` fields as detailed in the following sections.
+Tetragon can hook into the kernel using `kprobes`, `fentry/fexit`, and `tracepoints`, as well as in
+user-space programs using `uprobes`. Users can configure these hook points using the corresponding
+sections of the `TracingPolicy` specification (`.spec`). These hook points include arguments and
+return values that can be specified using the `args` and `returnArg` fields as detailed in the
+following sections.
 
 {{< warning >}}
 Hooking a system call can introduce time-of-check to time-of-use (TOCTOU)
@@ -88,6 +89,74 @@ spec:
     syscall: true
     # [...]
 ```
+
+## Fentry/Fexit
+
+Fentry/fexit programs attach to kernel functions using BTF (BPF Type Format).
+They rely on the ftrace kernel infrastructure, which calls the BPF program
+directly from a trampoline, making them a faster alternative to kprobes.
+
+Fentry in Tetragon requires a kernel >= 6.1 built with BTF enabled
+(`CONFIG_DEBUG_INFO_BTF=y`), which you can verify with:
+
+```shell
+grep CONFIG_DEBUG_INFO_BTF /boot/config-$(uname -r)
+```
+
+Compared to kprobes, fentry currently comes with the following limitations:
+
+- Enforcement actions such as `Override` or `Signal` are not supported.
+- Each fentry spec attaches to a single kernel function, there is no
+  multi-attach equivalent to multi kprobes.
+
+Here is an example of a `TracingPolicy` using the `fentries` section to trace
+the `tcp_connect` kernel function:
+
+```yaml
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "fentry-example"
+spec:
+  fentries:
+  - call: "tcp_connect"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "sock"
+    returnArg:
+      index: 0
+      type: "int"
+```
+
+The `fentry` program attaches at function entry, while its `fexit` counterpart
+attaches at function exit, where the return value is available. Setting
+`return: true` is what attaches the `fexit` program, see
+[Return values](#return-values) for more details on `return` and `returnArg`.
+
+System calls can be traced with fentry as well. As with kprobes, set the
+`syscall` field to `true` in that case, so that Tetragon knows the traced
+function uses the system call ABI and reads its arguments accordingly. The
+symbol naming rules described in the kprobes section above apply here too.
+
+Similar to kprobes, you can define multiple fentry specs in the same policy:
+
+```yaml
+spec:
+  fentries:
+  - call: "tcp_connect"
+    syscall: false
+    # [...]
+  - call: "tcp_close"
+    syscall: false
+    # [...]
+```
+
+Fentry specs support the same `args`, `returnArg`, and `selectors` fields as
+kprobes, so you can use argument filtering and in-kernel selectors in the same
+way. For details on selectors, see the
+[Selectors]({{< ref "/docs/concepts/tracing-policy/selectors" >}}) documentation.
 
 ## Tracepoints
 

--- a/docs/content/en/docs/reference/templates/tracing_policy.tmpl
+++ b/docs/content/en/docs/reference/templates/tracing_policy.tmpl
@@ -7,7 +7,8 @@ weight: 5
 A [TracingPolicy](#tracingpolicy) is a user-configurable Kubernetes custom
 resource (CR) that defines how Tetragon observes events in both the kernel
 and userspace using eBPF. It supports a variety of hook points including
-[kprobes](#tracingpolicyspeckprobesindex), [uprobes](#tracingpolicyspecuprobesindex),
+[kprobes](#tracingpolicyspeckprobesindex), [fentry/fexit](#tracingpolicyspecfentriesindex),
+[uprobes](#tracingpolicyspecuprobesindex),
 [tracepoints](#tracingpolicyspectracepointsindex), [LSM hooks](#tracingpolicyspeclsmhooksindex),
 and [USDTs](#tracingpolicyspecusdtsindex), giving users fine-grained control
 over what to trace and what actions to take. Policies consist of hook points,

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -7,7 +7,8 @@ weight: 5
 A [TracingPolicy](#tracingpolicy) is a user-configurable Kubernetes custom
 resource (CR) that defines how Tetragon observes events in both the kernel
 and userspace using eBPF. It supports a variety of hook points including
-[kprobes](#tracingpolicyspeckprobesindex), [uprobes](#tracingpolicyspecuprobesindex),
+[kprobes](#tracingpolicyspeckprobesindex), [fentry/fexit](#tracingpolicyspecfentriesindex),
+[uprobes](#tracingpolicyspecuprobesindex),
 [tracepoints](#tracingpolicyspectracepointsindex), [LSM hooks](#tracingpolicyspeclsmhooksindex),
 and [USDTs](#tracingpolicyspecusdtsindex), giving users fine-grained control
 over what to trace and what actions to take. Policies consist of hook points,

--- a/examples/tracingpolicy/fentry.yaml
+++ b/examples/tracingpolicy/fentry.yaml
@@ -1,0 +1,20 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "fentry"
+spec:
+  fentries:
+  - call: "tcp_connect"
+    syscall: false
+    return: true
+    args:
+    - index: 0
+      type: "sock"
+    returnArg:
+      index: 0
+      type: "int"
+  - call: "tcp_close"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"


### PR DESCRIPTION


<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
I was giving it a try with fentry/fexit feature, and notice that docs/example is not there.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
docs: Add fentry/fexit sensor documentation
```
