### PR TITLE
selectors: Add SubString support for more types

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -996,6 +996,16 @@ filter_file_buf(struct selector_arg_filter *filter, struct string_buf *args)
 		return 0;
 
 	switch (filter->op) {
+#ifdef __LARGE_BPF_PROG
+	case op_substring_igncase:
+		if (bpf_ksym_exists(bpf_strncasestr))
+			match = filter_char_substring(filter, args->buf, args->len, true);
+		break;
+	case op_substring:
+		if (bpf_ksym_exists(bpf_strnstr))
+			match = filter_char_substring(filter, args->buf, args->len, false);
+		break;
+#endif
 	case op_filter_eq:
 	case op_filter_neq:
 		match = filter_char_buf_equal(filter, args->buf, args->len);
@@ -1185,6 +1195,16 @@ filter_sockaddr_un(struct selector_arg_filter *filter, char *args)
 	__u8 path_len = address->path_len;
 
 	switch (filter->op) {
+#ifdef __LARGE_BPF_PROG
+	case op_substring_igncase:
+		if (bpf_ksym_exists(bpf_strncasestr))
+			return filter_char_substring(filter, path, path_len, true);
+		break;
+	case op_substring:
+		if (bpf_ksym_exists(bpf_strnstr))
+			return filter_char_substring(filter, path, path_len, false);
+		break;
+#endif
 	case op_filter_str_prefix:
 	case op_filter_str_notprefix: {
 		long match = filter_char_buf_prefix(filter, path, path_len);

--- a/docs/content/en/docs/concepts/tracing-policy/argument_types.md
+++ b/docs/content/en/docs/concepts/tracing-policy/argument_types.md
@@ -103,7 +103,8 @@ The data type extracts 64-bit unsigned value.
 
 The data type extracts string terminated with zero byte.
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators.
 
 ## `skb`
 
@@ -130,7 +131,8 @@ The `char_buf` data type represents a character buffer. When using this type,
 specify the buffer size using `sizeArgIndex` (referencing another argument)
 or `returnCopy` (using the return value).
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators.
 
 ## `char_iovec`
 
@@ -144,16 +146,16 @@ In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` o
 The `filename` data type represents kernel `struct filename` object and
 retrieves the user-provided filename string.
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
-with path strings.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators with path strings.
 
 ## `fd`
 
 The `fd` data type represents a file descriptor. Tetragon resolves the
 file descriptor to retrieve the associated file path.
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
-with path strings.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators with path strings.
 
 ## `cred`
 
@@ -258,8 +260,8 @@ from a process's credentials (`struct cred`).
 The `linux_binprm` data type represents kernel `struct linux_binprm` object
 and retrieves the `struct linux_binprm::file` full path.
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
-with path strings.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators with path strings.
 
 See general path limitations in [path retrieval limits](#pathlimits).
 
@@ -268,15 +270,16 @@ See general path limitations in [path retrieval limits](#pathlimits).
 The `data_loc` data type is used with tracepoints to extract dynamically
 located string data using the kernel's `__data_loc` mechanism.
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators.
 
 ## `net_device`
 
 The `net_device` data type represents kernel `struct net_device` object.
 It extracts the network device name (e.g., `eth0`, `lo`).
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
-with device name strings.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators with device name strings.
 
 ## `sockaddr`
 
@@ -309,8 +312,8 @@ In `matchArgs` or `matchData`, use network operators: `SAddr`, `DAddr`, `SPort`,
 The `file` data type represents kernel `struct file` object and retrieves
 the file's full path.
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
-with path strings.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators with path strings.
 
 See general path limitations in [path retrieval limits](#pathlimits).
 Support for [file type filtering]({{< ref "selectors.md#file-type-filtering" >}}) is also available for this type.
@@ -324,8 +327,8 @@ This stems from the fact that with just `struct dentry` tetragon does not have
 mount information and does not have enough data to pass through main point within
 the path.
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
-with path strings.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators with path strings.
 
 See general path limitations in [path retrieval limits](#pathlimits).
 
@@ -335,8 +338,8 @@ The `path` data type represents kernel `struct path` object retrieves
 the related path.
 Support for [file type filtering]({{< ref "selectors.md#file-type-filtering" >}}) is also available for this type.
 
-In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, or `Postfix` operators
-with path strings.
+In `matchArgs` or `matchData`, use `Equal`, `NotEqual`, `Prefix`, `Postfix`, `SubString` (v6.17+),
+or `SubStringIgnoreCase` (v6.19+) operators with path strings.
 
 <a name="pathlimits"></a>
 

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -1971,6 +1971,8 @@ There are different types supported for each operator. In case of `matchArgs`:
 * State
 * InRange - In interval range
 * NotInRange - Not in interval range
+* SubString - Substring match (v6.17+, requires the `bpf_strnstr` kfunc)
+* SubStringIgnoreCase - Substring match case-insensitive (v6.19+, requires the `bpf_strncasestr` kfunc)
 
 The operator types `Equal` and `NotEqual` are used to test whether the certain
 argument of a system call is equal to the defined value in the CR.

--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -693,6 +693,12 @@ func HasKfunc(name string) bool {
 	return detected
 }
 
+// HasSubStringKfunc returns true if the kernel supports the bpf_strnstr kfunc
+// which is required for the SubString operator.
+func HasSubStringKfunc() bool {
+	return HasProgramLargeSize() && HasKfunc("bpf_strnstr")
+}
+
 func detectMixBpfAndTailCalls() bool {
 	// create a tail call map
 	tcMap, err := ebpf.NewMap(&ebpf.MapSpec{
@@ -823,4 +829,5 @@ var FeatureProbes = []FeatureProbe{
 	{MixBPFAndTailCallsProbe, DetectMixBpfAndTailCalls},
 	{Fentry, HasFentryProgram},
 	{GetFuncRet, HasGetFuncRetHelper},
+	{SubStringKfuncProbe, HasSubStringKfunc},
 }

--- a/pkg/bpf/probes.go
+++ b/pkg/bpf/probes.go
@@ -24,4 +24,5 @@ const (
 	MixBPFAndTailCallsProbe     = "mix_bpf_and_tail_calls"
 	Fentry                      = "fentry"
 	GetFuncRet                  = "get_func_ret"
+	SubStringKfuncProbe         = "substring_kfunc"
 )

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -995,7 +995,7 @@ func parseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 		}
 	case SelectorOpSubStringIgnCase, SelectorOpSubString:
 		switch ty {
-		case gt.GenericStringType, gt.GenericCharBuffer:
+		case gt.GenericFdType, gt.GenericFileType, gt.GenericPathType, gt.GenericDentryType, gt.GenericStringType, gt.GenericCharBuffer, gt.GenericLinuxBinprmType, gt.GenericDataLoc, gt.GenericNetDev, gt.GenericSockaddrUnType:
 			if err := writeMatchSubString(k, arg.Values); err != nil {
 				return fmt.Errorf("writeMatchSubString error: %w", err)
 			}

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -1437,6 +1437,51 @@ func TestParseAddr(t *testing.T) {
 	}
 }
 
+func TestParseMatchArgSubString(t *testing.T) {
+	tests := []struct {
+		name   string
+		tyName string
+		tyVal  uint32
+	}{
+		{"fd", "fd", gt.GenericFdType},
+		{"dentry", "dentry", gt.GenericDentryType},
+		{"file", "file", gt.GenericFileType},
+		{"path", "path", gt.GenericPathType},
+		{"string", "string", gt.GenericStringType},
+		{"char_buf", "char_buf", gt.GenericCharBuffer},
+		{"linux_binprm", "linux_binprm", gt.GenericLinuxBinprmType},
+		{"data_loc", "data_loc", gt.GenericDataLoc},
+		{"net_device", "net_device", gt.GenericNetDev},
+		{"sockaddr_un", "sockaddr_un", gt.GenericSockaddrUnType},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sig := []v1alpha1.KProbeArg{
+				{Index: 1, Type: tc.tyName, SizeArgIndex: 0, ReturnCopy: false},
+			}
+
+			arg := &v1alpha1.ArgSelector{Index: 1, Operator: "SubString", Values: []string{"test"}}
+			k := NewKernelSelectorState(nil, nil, false, nil)
+			d := &k.data
+
+			expected := []byte{
+				0x00, 0x00, 0x00, 0x00, // Index == 0
+				0x21, 0x00, 0x00, 0x00, // operator == SubString (33)
+				0x0c, 0x00, 0x00, 0x00, // length == 12
+				0x00, 0x00, 0x00, 0x00, // value type (placeholder)
+				0x00, 0x00, 0x00, 0x00, // substring id == 0
+			}
+			binary.LittleEndian.PutUint32(expected[12:16], tc.tyVal)
+
+			err := ParseMatchArg(k, arg, sig)
+			require.NoError(t, err)
+			require.Equal(t, expected, d.e[0:d.off])
+			require.Equal(t, []string{"test"}, k.SubStrings())
+		})
+	}
+}
+
 func TestParseCapabilityMask(t *testing.T) {
 	v, err := parseCapabilitiesMask("100")
 	require.NoError(t, err)

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -514,3 +514,24 @@ func TestFentryNotEqualMultipleValues(t *testing.T) {
 	checkFentry(t)
 	testKprobeNotEqualMultipleValues(t, true)
 }
+
+func TestSubStringLinuxBinprmFentry(t *testing.T) {
+	checkFentry(t)
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-substring-linux-binprm", map[string]any{
+		"Hook": "fentries",
+	})
+}
+
+func TestSubStringFileFentry(t *testing.T) {
+	checkFentry(t)
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-substring-file", map[string]any{
+		"Hook": "fentries",
+	})
+}
+
+func TestSubStringPathFentry(t *testing.T) {
+	checkFentry(t)
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-substring-path", map[string]any{
+		"Hook": "fentries",
+	})
+}

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5746,6 +5746,24 @@ func TestLinuxBinprmExtractPath(t *testing.T) {
 	testLinuxBinprmExtractPath(t, false)
 }
 
+func TestSubStringLinuxBinprm(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-substring-linux-binprm", map[string]any{
+		"Hook": "kprobes",
+	})
+}
+
+func TestSubStringFile(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-substring-file", map[string]any{
+		"Hook": "kprobes",
+	})
+}
+
+func TestSubStringPath(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-substring-path", map[string]any{
+		"Hook": "kprobes",
+	})
+}
+
 // Test module loading/unloading on Ubuntu
 func testTraceKernelModule(t *testing.T, fentry bool) {
 	_, err := ftrace.ReadAvailFuncs("^find_module_sections$")

--- a/tests/policytests/kprobes.go
+++ b/tests/policytests/kprobes.go
@@ -8,6 +8,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"os"
 
 	ebtf "github.com/cilium/ebpf/btf"
 	"golang.org/x/sys/unix"
@@ -193,3 +194,148 @@ spec:
 			EventChecker: ec.NewUnorderedEventChecker(checker),
 		}
 	}).RegisterAtInit()
+
+func skipSubStringKfunc(si *policytest.SkipInfo) string {
+	if !si.AgentInfo.Probes[bpf.SubStringKfuncProbe] {
+		return "SubString operator requires bpf_strnstr kfunc and large BPF programs"
+	}
+	return ""
+}
+
+var _ = policytest.NewBuilder("kprobe-substring-linux-binprm").
+	WithLabels("kprobes").
+	WithSkip(skipSubStringKfunc).
+	WithParameter(policytest.Parameter{
+		Name:    "Hook",
+		Default: "kprobes",
+		Help:    "type of hook to use in the policy",
+	}).
+	WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "substring-linux-binprm"
+spec:
+  {{ .Hook }}:
+  - call: "security_bprm_check"
+    syscall: false
+    args:
+    - index: 0
+      type: "linux_binprm"
+    selectors:
+    - matchArgs:
+      - operator: SubString
+        index: 0
+        values:
+        - "/i"
+`).AddScenario(func(_ *policytest.Conf) *policytest.Scenario {
+	checker := ec.NewProcessKprobeChecker("").
+		WithFunctionName(sm.Full("security_bprm_check")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithLinuxBinprmArg(ec.NewKprobeLinuxBinprmChecker().WithPath(sm.Suffix("/id"))),
+			))
+
+	return &policytest.Scenario{
+		Name:         "SubString filter on linux_binprm matches /usr/bin/id",
+		Trigger:      policytest.NewCmdTrigger("/usr/bin/id"),
+		EventChecker: ec.NewUnorderedEventChecker(checker),
+	}
+}).RegisterAtInit()
+
+var _ = policytest.NewBuilder("kprobe-substring-file").
+	WithLabels("kprobes").
+	WithSkip(skipSubStringKfunc).
+	WithParameter(policytest.Parameter{
+		Name:    "Hook",
+		Default: "kprobes",
+		Help:    "type of hook to use in the policy",
+	}).
+	WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "substring-file"
+spec:
+  {{ .Hook }}:
+  - call: "security_file_open"
+    syscall: false
+    args:
+    - index: 0
+      type: "file"
+    selectors:
+    - matchArgs:
+      - operator: SubString
+        index: 0
+        values:
+        - "/i"
+`).AddScenario(func(_ *policytest.Conf) *policytest.Scenario {
+	checker := ec.NewProcessKprobeChecker("").
+		WithFunctionName(sm.Full("security_file_open")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithFileArg(ec.NewKprobeFileChecker().WithPath(sm.Suffix("/id"))),
+			))
+
+	return &policytest.Scenario{
+		Name:         "SubString filter on file type matches /usr/bin/id",
+		Trigger:      policytest.NewCmdTrigger("/usr/bin/id"),
+		EventChecker: ec.NewUnorderedEventChecker(checker),
+	}
+}).RegisterAtInit()
+
+type triggerSubStringPath struct{}
+
+func (t *triggerSubStringPath) Trigger(context context.Context) error {
+	tmpDir, err := os.MkdirTemp("", "substring-path-test")
+	if err != nil {
+		return nil
+	}
+	defer os.RemoveAll(tmpDir)
+	testDir := tmpDir + "/match_id_test/inner_dir"
+	return policytest.NewCmdTrigger("/usr/bin/mkdir", "-p", testDir).Trigger(context)
+}
+
+var _ = policytest.NewBuilder("kprobe-substring-path").
+	WithLabels("kprobes").
+	WithSkip(skipSubStringKfunc).
+	WithParameter(policytest.Parameter{
+		Name:    "Hook",
+		Default: "kprobes",
+		Help:    "type of hook to use in the policy",
+	}).
+	WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "substring-path"
+spec:
+  {{ .Hook }}:
+  - call: "security_path_mkdir"
+    syscall: false
+    args:
+    - index: 0
+      type: "path"
+    selectors:
+    - matchArgs:
+      - operator: SubString
+        index: 0
+        values:
+        - "_id_"
+`).AddScenario(func(_ *policytest.Conf) *policytest.Scenario {
+	checker := ec.NewProcessKprobeChecker("").
+		WithFunctionName(sm.Full("security_path_mkdir")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithPathArg(ec.NewKprobePathChecker().WithPath(sm.Suffix("match_id_test"))),
+			))
+
+	return &policytest.Scenario{
+		Name:         "SubString filter on path type matches directory with _id_ in name",
+		Trigger:      &triggerSubStringPath{},
+		EventChecker: ec.NewUnorderedEventChecker(checker),
+	}
+}).RegisterAtInit()


### PR DESCRIPTION
Other string-related types support SubString operator at policy level but then silently fail to use it.

Add support for all the other types, same coverage as for `Equal`.
