### PR TITLE
new: move exportDirectory to non tmpfs folder

### DIFF
--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -17,6 +17,8 @@ Depending on your setup, changes listed here might require a manual intervention
   directory containing the socket passed to `tetragon.cri.socketHostPath`.
 * `tetragon.gops.enabled` now defaults to `false`. To re-enable the gops debug
   interface, set `--set tetragon.gops.enabled=true` at install or upgrade time.
+* `exportDirectory` default value has been updated to `/var/log/tetragon` from 
+  `/var/run/cilium/tetragon/` to avoid writing to tmpfs.
 
 ### TracingPolicy (k8s CRD)
 

--- a/docs/content/en/docs/concepts/events.md
+++ b/docs/content/en/docs/concepts/events.md
@@ -114,7 +114,7 @@ in a Kubernetes cluster  `process_exec.process.pod`. The binary and args being e
 the event here `process_exec.process.binary` and `process_exec.process.args`. Finally, a `node_name`
 and `time` provide the location and time for the event and will be present in all event types.
 
-A default deployment writes the JSON log to `/var/run/cilium/tetragon/tetragon.log` where it can
+A default deployment writes the JSON log to `/var/log/tetragon/tetragon.log` where it can
 be exported through normal log collection tooling, e.g. fluentd, logstash, etc. The file will
 be rotated and compressed by default. See [Helm Options] for details on how to customize this location.
 

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -47,7 +47,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | export.stdout.envFromSecrets | list | `[]` | A simplified way to add secret references to envFrom. Can be specified either as a string (just the secret name) or as an object with additional parameters. Example: envFromSecrets:   - my-simple-secret   - name: my-optional-secret     optional: true |
 | export.stdout.extraEnv | list | `[]` | Extra environment variables to add to the export-stdout container. Example: extraEnv:   - name: FOO     value: bar   - name: SECRET_KEY     valueFrom:       secretKeyRef:         name: my-secret         key: secret-key |
 | export.stdout.extraEnvFrom | list | `[]` | Extra envFrom sources to add to the export-stdout container. This allows adding any type of envFrom source (configMapRef, secretRef, etc.). Example: extraEnvFrom:   - configMapRef:       name: my-config-map   - secretRef:       name: my-secret       optional: true |
-| exportDirectory | string | `"/var/run/cilium/tetragon"` | Directory to put Tetragon JSON export files. |
+| exportDirectory | string | `"/var/log/tetragon"` | Directory to put Tetragon JSON export files. |
 | extraConfigmapMounts | list | `[]` |  |
 | extraHostPathMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -29,7 +29,7 @@ Helm chart for Tetragon
 | export.stdout.envFromSecrets | list | `[]` | A simplified way to add secret references to envFrom. Can be specified either as a string (just the secret name) or as an object with additional parameters. Example: envFromSecrets:   - my-simple-secret   - name: my-optional-secret     optional: true |
 | export.stdout.extraEnv | list | `[]` | Extra environment variables to add to the export-stdout container. Example: extraEnv:   - name: FOO     value: bar   - name: SECRET_KEY     valueFrom:       secretKeyRef:         name: my-secret         key: secret-key |
 | export.stdout.extraEnvFrom | list | `[]` | Extra envFrom sources to add to the export-stdout container. This allows adding any type of envFrom source (configMapRef, secretRef, etc.). Example: extraEnvFrom:   - configMapRef:       name: my-config-map   - secretRef:       name: my-secret       optional: true |
-| exportDirectory | string | `"/var/run/cilium/tetragon"` | Directory to put Tetragon JSON export files. |
+| exportDirectory | string | `"/var/log/tetragon"` | Directory to put Tetragon JSON export files. |
 | extraConfigmapMounts | list | `[]` |  |
 | extraHostPathMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -31,7 +31,7 @@ serviceLabelsOverride: {}
 # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 dnsPolicy: Default
 # -- Directory to put Tetragon JSON export files.
-exportDirectory: "/var/run/cilium/tetragon"
+exportDirectory: "/var/log/tetragon"
 # -- Configures whether Tetragon pods run on the host network.
 #
 # IMPORTANT: Tetragon must be on the host network for the process visibility to

--- a/tests/e2e/helpers/dumpinfo.go
+++ b/tests/e2e/helpers/dumpinfo.go
@@ -35,7 +35,7 @@ import (
 var (
 	TetragonContainerName         = "tetragon"
 	TetragonOperatorContainerName = "tetragon-operator"
-	TetragonJsonPathname          = "/var/run/cilium/tetragon/tetragon.log"
+	TetragonJsonPathname          = "/var/log/tetragon/tetragon.log"
 )
 
 type TestEnvFunc = func(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error)


### PR DESCRIPTION
### Description

Since `tetragon.log` could grow indefinitely, we'd better avoid using a tmpfs-backed location for it.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
new: move exportDirectory to non tmpfs folder
```
