### PR TITLE
bpf: use void *ctx for fentry/fexit programs

### DIFF
--- a/bpf/process/bpf_generic_fentry.c
+++ b/bpf/process/bpf_generic_fentry.c
@@ -50,7 +50,7 @@ struct {
 #define SECTION_TAIL  "fentry/generic_fentry_tail"
 
 __attribute__((section((SECTION_ENTRY)), used)) int
-generic_fentry_event(struct pt_regs *ctx)
+generic_fentry_event(void *ctx)
 {
 	return generic_start_process_filter(ctx, (struct bpf_map_def *)&fentry_calls);
 }

--- a/bpf/process/bpf_generic_fexit.c
+++ b/bpf/process/bpf_generic_fexit.c
@@ -25,7 +25,7 @@ struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(max_entries, 6);
 	__type(key, __u32);
-	__array(values, int(struct pt_regs *));
+	__array(values, int(void *));
 } fexit_calls SEC(".maps") = {
 	.values = {
 		[TAIL_CALL_ARGS] = (void *)&generic_fexit_filter_arg,


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

fentry/fexit BPF programs don't receive a struct pt_regs * context — their context is an array of function arguments, not register state. This updates the generic fentry/fexit programs to use void
   *ctx, which more accurately reflects the actual context type:

- bpf_generic_fentry.c: change generic_fentry_event signature from struct pt_regs *ctx to void *ctx.
- bpf_generic_fexit.c: change the fexit_calls prog-array values type from int(struct pt_regs *) to int(void *) to match.

No functional change — the context pointer is passed through to generic_start_process_filter unchanged.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
bpf: use void *ctx for fentry/fexit programs
```
