### PR TITLE
[v1.7] pkg/bugtool: bug fixes to tetra debug maps output

### DIFF
--- a/cmd/tetra/common/utils.go
+++ b/cmd/tetra/common/utils.go
@@ -15,7 +15,7 @@ import (
 // HumanizeByteCount transforms bytes count into a quickly-readable version, for
 // example it transforms 4458824 into "4.46 MB". I copied this code from
 // https://yourbasic.org/golang/formatting-byte-size-to-human-readable-format/
-func HumanizeByteCount(b int) string {
+func HumanizeByteCount(b uint64) string {
 	const unit = 1000
 	if b < unit {
 		return fmt.Sprintf("%d B", b)
@@ -79,7 +79,7 @@ func PrintTracingPolicies(output io.Writer, policies []*tetragon.TracingPolicySt
 			pol.FilterId,
 			namespace,
 			sensors,
-			HumanizeByteCount(int(pol.KernelMemoryBytes)),
+			HumanizeByteCount(pol.KernelMemoryBytes),
 			strings.TrimPrefix(strings.ToLower(pol.Mode.String()), "tp_mode_"),
 			counters.GetPost(),
 			counters.GetSignal()+counters.GetOverride()+counters.GetNotifyEnforcer()+counters.GetSet(),

--- a/cmd/tetra/common/utils_test.go
+++ b/cmd/tetra/common/utils_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestHumanizeByteCount(t *testing.T) {
 	tests := []struct {
-		input int
+		input uint64
 		want  string
 	}{
 		{0, "0 B"},
@@ -25,7 +25,7 @@ func TestHumanizeByteCount(t *testing.T) {
 		{12970000000000, "12.97 TB"},
 	}
 	for _, tt := range tests {
-		t.Run(strconv.Itoa(tt.input), func(t *testing.T) {
+		t.Run(strconv.FormatUint(tt.input, 10), func(t *testing.T) {
 			if got := HumanizeByteCount(tt.input); got != tt.want {
 				t.Errorf("HumanizeByteCount(%d) = %v, want %v", tt.input, got, tt.want)
 			}

--- a/cmd/tetra/debug/maps.go
+++ b/cmd/tetra/debug/maps.go
@@ -106,18 +106,19 @@ adjust the number of item in the table.
 
 				if len(out.AggregatedMaps) != 0 {
 					w = tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', 0)
-					fmt.Fprintln(w, "Name\tType\tKeySize\tValueSize\tMaxEntries\tCount\tTotalMemlock\tPercentOfTotal")
+					fmt.Fprintln(w, "Name\tType\tKeySize\tValueSize\tMaxEntries\tCount\tMemlock\tTotalMemlock\tPercentOfTotal")
 					for i, d := range out.AggregatedMaps {
 						if lines != 0 && i+1 > lines {
 							break
 						}
-						fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%d\t%s\t%0.1f%%\n",
+						fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%d\t%s\t%s\t%0.1f%%\n",
 							d.Name,
 							d.Type,
 							d.KeySize,
 							d.ValueSize,
 							d.MaxEntries,
 							d.Count,
+							common.HumanizeByteCount(d.MemlockBytes),
 							common.HumanizeByteCount(d.TotalMemlockBytes),
 							d.PercentOfTotal,
 						)

--- a/pkg/bpf/maps.go
+++ b/pkg/bpf/maps.go
@@ -17,7 +17,7 @@ import (
 
 type ExtendedMapInfo struct {
 	ebpf.MapInfo
-	Memlock int
+	Memlock uint64
 }
 
 func ExtendedInfoFromMapID(id int) (ExtendedMapInfo, error) {
@@ -72,7 +72,7 @@ func MemlockInfoFromMapID(id int) (ExtendedMapInfo, error) {
 	}, nil
 }
 
-func ParseMemlockFromFDInfo(fd int) (int, error) {
+func ParseMemlockFromFDInfo(fd int) (uint64, error) {
 	path := fmt.Sprintf("/proc/self/fdinfo/%d", fd)
 	file, err := os.Open(path)
 	if err != nil {
@@ -82,12 +82,12 @@ func ParseMemlockFromFDInfo(fd int) (int, error) {
 	return parseMemlockFromFDInfoReader(file)
 }
 
-func parseMemlockFromFDInfoReader(r io.Reader) (int, error) {
+func parseMemlockFromFDInfoReader(r io.Reader) (uint64, error) {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
 		if len(fields) > 1 && fields[0] == "memlock:" {
-			memlock, err := strconv.Atoi(fields[1])
+			memlock, err := strconv.ParseUint(fields[1], 10, 64)
 			if err != nil {
 				return 0, fmt.Errorf("failed converting memlock to int: %w", err)
 			}

--- a/pkg/bpf/maps_test.go
+++ b/pkg/bpf/maps_test.go
@@ -31,7 +31,7 @@ func Test_parseMemlockFromFDInfoReader(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    io.Reader
-		want    int
+		want    uint64
 		wantErr bool
 	}{
 		{

--- a/pkg/bugtool/maps.go
+++ b/pkg/bugtool/maps.go
@@ -20,8 +20,8 @@ import (
 )
 
 // TotalMemlockBytes iterates over the extend map info and sums the memlock field.
-func TotalMemlockBytes(infos []bpf.ExtendedMapInfo) int {
-	var sum int
+func TotalMemlockBytes(infos []bpf.ExtendedMapInfo) uint64 {
+	var sum uint64
 	for _, info := range infos {
 		sum += info.Memlock
 	}
@@ -206,28 +206,28 @@ type DiffMap struct {
 	ID           int    `json:"id,omitempty"`
 	Name         string `json:"name,omitempty"`
 	Type         string `json:"type,omitempty"`
-	KeySize      int    `json:"key_size,omitempty"`
-	ValueSize    int    `json:"value_size,omitempty"`
-	MaxEntries   int    `json:"max_entries,omitempty"`
-	MemlockBytes int    `json:"memlock_bytes,omitempty"`
+	KeySize      uint32 `json:"key_size,omitempty"`
+	ValueSize    uint32 `json:"value_size,omitempty"`
+	MaxEntries   uint32 `json:"max_entries,omitempty"`
+	MemlockBytes uint64 `json:"memlock_bytes,omitempty"`
 }
 
 type AggregatedMap struct {
 	Name              string  `json:"name,omitempty"`
 	Type              string  `json:"type,omitempty"`
-	KeySize           int     `json:"key_size,omitempty"`
-	ValueSize         int     `json:"value_size,omitempty"`
-	MaxEntries        int     `json:"max_entries,omitempty"`
-	Count             int     `json:"count,omitempty"`
-	TotalMemlockBytes int     `json:"total_memlock_bytes,omitempty"`
+	KeySize           uint32  `json:"key_size,omitempty"`
+	ValueSize         uint32  `json:"value_size,omitempty"`
+	MaxEntries        uint32  `json:"max_entries,omitempty"`
+	Count             uint64  `json:"count,omitempty"`
+	TotalMemlockBytes uint64  `json:"total_memlock_bytes,omitempty"`
 	PercentOfTotal    float64 `json:"percent_of_total,omitempty"`
 }
 
 type MapsChecksOutput struct {
 	TotalMemlockBytes struct {
-		AllMaps         int `json:"all_maps,omitempty"`
-		PinnedProgsMaps int `json:"pinned_progs_maps,omitempty"`
-		PinnedMaps      int `json:"pinned_maps,omitempty"`
+		AllMaps         uint64 `json:"all_maps,omitempty"`
+		PinnedProgsMaps uint64 `json:"pinned_progs_maps,omitempty"`
+		PinnedMaps      uint64 `json:"pinned_maps,omitempty"`
 	} `json:"total_memlock_bytes"`
 
 	MapsStats struct {
@@ -311,9 +311,9 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 			ID:           int(id),
 			Name:         d.Name,
 			Type:         d.Type.String(),
-			KeySize:      int(d.KeySize),
-			ValueSize:    int(d.ValueSize),
-			MaxEntries:   int(d.MaxEntries),
+			KeySize:      d.KeySize,
+			ValueSize:    d.ValueSize,
+			MaxEntries:   d.MaxEntries,
 			MemlockBytes: d.Memlock,
 		})
 	}
@@ -321,9 +321,9 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 	// aggregates maps total memory use
 	aggregatedMapsSet := map[string]struct {
 		bpf.ExtendedMapInfo
-		count int
+		count uint64
 	}{}
-	var total int
+	var total uint64
 	for _, m := range union {
 		total += m.Memlock
 		if e, exist := aggregatedMapsSet[m.Name]; exist {
@@ -333,7 +333,7 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 		} else {
 			aggregatedMapsSet[m.Name] = struct {
 				bpf.ExtendedMapInfo
-				count int
+				count uint64
 			}{m, 1}
 		}
 	}
@@ -346,9 +346,9 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 		out.AggregatedMaps = append(out.AggregatedMaps, AggregatedMap{
 			Name:              m.Name,
 			Type:              m.Type.String(),
-			KeySize:           int(m.KeySize),
-			ValueSize:         int(m.ValueSize),
-			MaxEntries:        int(m.MaxEntries),
+			KeySize:           m.KeySize,
+			ValueSize:         m.ValueSize,
+			MaxEntries:        m.MaxEntries,
 			Count:             m.count,
 			TotalMemlockBytes: m.Memlock,
 			PercentOfTotal:    float64(m.Memlock) / float64(total) * 100,

--- a/pkg/bugtool/maps.go
+++ b/pkg/bugtool/maps.go
@@ -9,7 +9,6 @@ import (
 	"iter"
 	"maps"
 	"os"
-	"slices"
 	"sort"
 	"syscall"
 
@@ -338,12 +337,8 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 			}{m, 1}
 		}
 	}
-	aggregatedMaps := slices.Collect(maps.Values(aggregatedMapsSet))
-	sort.Slice(aggregatedMaps, func(i, j int) bool {
-		return aggregatedMaps[i].Memlock > aggregatedMaps[j].Memlock
-	})
 
-	for _, m := range aggregatedMaps {
+	for m := range maps.Values(aggregatedMapsSet) {
 		out.AggregatedMaps = append(out.AggregatedMaps, AggregatedMap{
 			Name:              m.Name,
 			Type:              m.Type.String(),
@@ -356,6 +351,10 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 			PercentOfTotal:    float64(m.Memlock*m.count) / float64(total) * 100,
 		})
 	}
+
+	sort.Slice(out.AggregatedMaps, func(i, j int) bool {
+		return out.AggregatedMaps[i].TotalMemlockBytes > out.AggregatedMaps[j].TotalMemlockBytes
+	})
 
 	return &out, nil
 }

--- a/pkg/bugtool/maps.go
+++ b/pkg/bugtool/maps.go
@@ -302,6 +302,7 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 	out.MapsStats.Diff = len(diff)
 
 	// details on diff maps
+	out.DiffMaps = make([]DiffMap, 0, len(diff))
 	for _, d := range diff {
 		id, ok := d.ID()
 		if !ok {
@@ -338,6 +339,7 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 		}
 	}
 
+	out.AggregatedMaps = make([]AggregatedMap, 0, len(aggregatedMapsSet))
 	for m := range maps.Values(aggregatedMapsSet) {
 		out.AggregatedMaps = append(out.AggregatedMaps, AggregatedMap{
 			Name:              m.Name,

--- a/pkg/bugtool/maps.go
+++ b/pkg/bugtool/maps.go
@@ -219,6 +219,7 @@ type AggregatedMap struct {
 	ValueSize         uint32  `json:"value_size,omitempty"`
 	MaxEntries        uint32  `json:"max_entries,omitempty"`
 	Count             uint64  `json:"count,omitempty"`
+	MemlockBytes      uint64  `json:"memlock_bytes,omitempty"`
 	TotalMemlockBytes uint64  `json:"total_memlock_bytes,omitempty"`
 	PercentOfTotal    float64 `json:"percent_of_total,omitempty"`
 }
@@ -350,8 +351,9 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 			ValueSize:         m.ValueSize,
 			MaxEntries:        m.MaxEntries,
 			Count:             m.count,
-			TotalMemlockBytes: m.Memlock,
-			PercentOfTotal:    float64(m.Memlock) / float64(total) * 100,
+			MemlockBytes:      m.Memlock,
+			TotalMemlockBytes: m.Memlock * m.count,
+			PercentOfTotal:    float64(m.Memlock*m.count) / float64(total) * 100,
 		})
 	}
 

--- a/pkg/bugtool/maps_test.go
+++ b/pkg/bugtool/maps_test.go
@@ -33,8 +33,8 @@ func TestFindMaps(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	sumMemlock := func(mapInfos []bpf.ExtendedMapInfo) int {
-		sumMemlock := 0
+	sumMemlock := func(mapInfos []bpf.ExtendedMapInfo) uint64 {
+		sumMemlock := uint64(0)
 		for _, mapInfo := range mapInfos {
 			sumMemlock += mapInfo.Memlock
 		}

--- a/pkg/sensors/delayed_sensor_test.go
+++ b/pkg/sensors/delayed_sensor_test.go
@@ -35,7 +35,7 @@ func (tds TestDelayedSensor) Overhead() ([]ProgOverhead, bool) {
 	return []ProgOverhead{}, false
 }
 
-func (tds TestDelayedSensor) TotalMemlock() int {
+func (tds TestDelayedSensor) TotalMemlock() uint64 {
 	return 0
 }
 

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -112,7 +112,7 @@ type SensorIface interface {
 	Destroy(unpin bool) error
 	// TotalMemlock is the total amount of memlock bytes for BPF maps used by
 	// the sensor's programs.
-	TotalMemlock() int
+	TotalMemlock() uint64
 	Overhead() ([]ProgOverhead, bool)
 }
 
@@ -149,7 +149,7 @@ func (s *Sensor) IsLoaded() bool {
 	return s.Loaded
 }
 
-func (s Sensor) TotalMemlock() int {
+func (s Sensor) TotalMemlock() uint64 {
 	uniqueMap := map[int]bpf.ExtendedMapInfo{}
 	for _, p := range s.Progs {
 		// we could first check that it exist then write but all maps with
@@ -157,7 +157,7 @@ func (s Sensor) TotalMemlock() int {
 		maps.Copy(uniqueMap, p.LoadedMapsInfo)
 	}
 
-	var total int
+	var total uint64
 	for _, info := range uniqueMap {
 		// we are using info.Name that is truncated to 15 chars to exclude
 		// global maps, a more resilient implementation could use ID but this


### PR DESCRIPTION
v.17 backport for https://github.com/cilium/tetragon/pull/5029

```release-note
Fixed incorrect total memlock reporting for aggregated maps in Bugtool and tetra debug maps, where only a single instance’s memlock usage was previously shown.
```
