### PR TITLE
pkg/process: reset process color to inUse when reused in GC

### DIFF
--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -571,7 +571,10 @@ func (msg *MsgExitEventUnix) Retry(internal *process.ProcessInternal, ev notify.
 
 	if tetragonProcess.Pid.Value > 1 && !msg.RefCntDone[ParentRefCnt] {
 		if parent, _ := process.Get(tetragonProcess.ParentExecId); parent != nil {
-			parent.RefDec("parent")
+			if !internal.GetParentRefcntDecreased() {
+				parent.RefDec("parent")
+				internal.SetParentRefcntDecreased(true)
+			}
 			msg.RefCntDone[ParentRefCnt] = true
 		}
 	}

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -77,6 +77,7 @@ func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 					 * process a second time, but that is harmless.
 					 */
 					if p.refcnt.Load() != 0 {
+						p.color = inUse
 						continue
 					}
 					if p.color == deleteReady {

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -159,6 +159,11 @@ func NewCache(
 			// Perform parent-- for LRU-evicted entries that will never
 			// reach the exit handler.
 
+			// Skip entries whose exit path already performed parent--
+			if evicted.GetParentRefcntDecreased() {
+				return
+			}
+
 			// Skip non-inUse entries whose exit path already performed parent--
 			if evicted.color != inUse {
 				return
@@ -174,6 +179,7 @@ func NewCache(
 			}
 
 			pm.refDec(parent, "parent--")
+			evicted.SetParentRefcntDecreased(true)
 		},
 	)
 	if err != nil {

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -82,3 +82,50 @@ tetragon_process_cache_early_deletions_total 1
 		require.NoError(t, testutil.CollectAndCompare(processCacheEarlyDeletions, expected))
 	})
 }
+
+func TestProcessCacheGCLeak(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		interval := 10 * time.Millisecond
+		cache, err := NewCache(10, interval)
+		require.NoError(t, err)
+		defer cache.purge()
+
+		pid := wrapperspb.UInt32Value{Value: 1234}
+		proc := ProcessInternal{
+			process: &tetragon.Process{
+				ExecId: "process1",
+				Pid:    &pid,
+			},
+			refcntOps: make(map[string]int32),
+		}
+		proc.refcnt.Store(1)
+		cache.add(&proc)
+
+		// Trigger GC to see it, then increment refcnt while it's in the deleteQueue.
+		// The GC should drop it from the queue and reset its color to inUse.
+		cache.refDec(&proc, "test")
+		synctest.Wait()
+		assert.Equal(t, deletePending, proc.color)
+
+		cache.refInc(&proc, "test")
+		time.Sleep(interval + 1*time.Millisecond)
+		synctest.Wait()
+		assert.Equal(t, inUse, proc.color)
+
+		// Trigger refDec to 0 again and wait for GC cycles to remove it.
+		// Two GC cycles are needed because the GC moves processes from:
+		// deletePending -> deleteReady in the first tick, and
+		// deleteReady -> deleted in the second tick.
+		cache.refDec(&proc, "test")
+		synctest.Wait()
+
+		time.Sleep(interval + 1*time.Millisecond)
+		synctest.Wait()
+
+		time.Sleep(interval + 1*time.Millisecond)
+		synctest.Wait()
+
+		assert.Equal(t, deleted, proc.color)
+		assert.Equal(t, 0, cache.len())
+	})
+}

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -129,3 +129,57 @@ func TestProcessCacheGCLeak(t *testing.T) {
 		assert.Equal(t, 0, cache.len())
 	})
 }
+
+func TestProcessCacheDoubleParentDecrease(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		interval := 10 * time.Millisecond
+		cache, err := NewCache(2, interval)
+		require.NoError(t, err)
+		defer cache.purge()
+
+		parent := &ProcessInternal{
+			process:   &tetragon.Process{ExecId: "parent", Pid: &wrapperspb.UInt32Value{Value: 100}},
+			refcntOps: make(map[string]int32),
+		}
+		parent.refcnt.Store(1)
+		cache.add(parent)
+
+		child := &ProcessInternal{
+			process:   &tetragon.Process{ExecId: "child", Pid: &wrapperspb.UInt32Value{Value: 101}, ParentExecId: "parent"},
+			refcntOps: make(map[string]int32),
+		}
+		child.refcnt.Store(1)
+		cache.add(child)
+
+		cache.refInc(parent, "parent++")
+		assert.Equal(t, uint32(2), parent.refcnt.Load())
+
+		// simulate exit handler path
+		if !child.GetParentRefcntDecreased() {
+			parent.RefDec("parent")
+			child.SetParentRefcntDecreased(true)
+		}
+		assert.Equal(t, uint32(1), parent.refcnt.Load())
+
+		cache.refDec(child, "process--")
+		synctest.Wait()
+		assert.Equal(t, deletePending, child.color)
+
+		// simulate resurrection: refInc after deletePending
+		cache.refInc(child, "late-event")
+		time.Sleep(interval + 1*time.Millisecond)
+		synctest.Wait()
+		assert.Equal(t, inUse, child.color)
+
+		// trigger LRU eviction of child
+		cache.get("parent")
+		other := &ProcessInternal{
+			process:   &tetragon.Process{ExecId: "other", Pid: &wrapperspb.UInt32Value{Value: 102}},
+			refcntOps: make(map[string]int32),
+		}
+		other.refcnt.Store(1)
+		cache.add(other)
+
+		assert.Equal(t, uint32(1), parent.refcnt.Load())
+	})
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -52,6 +52,10 @@ type ProcessInternal struct {
 	// garbage collector metadata
 	color  int // Writes should happen only inside gc select channel
 	refcnt atomic.Uint32
+	// parentRefcntDecreased tracks whether the parent reference count has been
+	// decreased for this process. This is used to avoid double parent-- when
+	// a process is evicted by the LRU and then handled by the exit handler.
+	parentRefcntDecreased bool
 	// refcntOps is a map of operations to refcnt change
 	// keys can be:
 	// - "process++": process increased refcnt (i.e. this process starts)
@@ -230,6 +234,18 @@ func (pi *ProcessInternal) RefInc(reason string) {
 
 func (pi *ProcessInternal) RefGet() uint32 {
 	return pi.refcnt.Load()
+}
+
+func (pi *ProcessInternal) SetParentRefcntDecreased(val bool) {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
+	pi.parentRefcntDecreased = val
+}
+
+func (pi *ProcessInternal) GetParentRefcntDecreased() bool {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
+	return pi.parentRefcntDecreased
 }
 
 func (pi *ProcessInternal) NeededAncestors() bool {


### PR DESCRIPTION
Fixes #4698 

### Description
This PR fixes a memory leak in the process cache garbage collector. 
When a process in the `deleteQueue` is found to have a non-zero reference count (reused), it is dropped from the queue. Previously, its state (`color`) remained `deletePending`. If that process later reached a zero reference count again, the `deleteChan` handler would skip re-adding it to the queue because it was already marked as pending, leading to a permanent leak.
This change explicitly resets the process color to `inUse` when it is dropped from the `deleteQueue`.
I've added a new test that reproduces the leak and passes after fix.

### Changelog
```release-note
Fix process cache memory leak where reused processes were not being re-queued for garbage collection.
```
