### PR TITLE
pkg/crdutils: validate XValidation CEL rules in standalone

### DIFF
--- a/pkg/crdutils/crdutils.go
+++ b/pkg/crdutils/crdutils.go
@@ -9,6 +9,7 @@
 package crdutils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -17,6 +18,7 @@ import (
 	ext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apischema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
 	structuraldefaulting "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
 	structurallisttype "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/listtype"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
@@ -24,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
 	"sigs.k8s.io/yaml"
 )
 
@@ -39,6 +42,7 @@ type CRDContext[P CRDObject] struct {
 	crd              *extv1.CustomResourceDefinition
 	structuralSchema *apischema.Structural
 	validator        validation.SchemaValidator
+	celValidator     *cel.Validator
 }
 
 // NewCRDContext creates a new CRDContext from extv1.CustomResourceDefinition.
@@ -60,10 +64,13 @@ func NewCRDContext[P CRDObject](crd *extv1.CustomResourceDefinition) (*CRDContex
 		return nil, fmt.Errorf("failed to create schema validator: %w", err)
 	}
 
+	celValidator := cel.NewValidator(structural, true, celconfig.PerCallLimit)
+
 	return &CRDContext[P]{
 		crd:              crd,
 		structuralSchema: structural,
 		validator:        validator,
+		celValidator:     celValidator,
 	}, nil
 }
 
@@ -115,6 +122,19 @@ func (c *CRDContext[P]) Validate(obj CRDObject, unstr *unstructured.Unstructured
 		unstr.Object,
 	)
 
+	// validate CEL rules (XValidations)
+	var celErrs field.ErrorList
+	if c.celValidator != nil {
+		celErrs, _ = c.celValidator.Validate(
+			context.Background(),
+			field.NewPath(""),
+			nil, // unused, already set at validator construction
+			unstr.Object,
+			nil,
+			celconfig.RuntimeCELCostBudget,
+		)
+	}
+
 	// merge errors
 	var errs []error
 	for _, err := range metaErrs {
@@ -122,6 +142,9 @@ func (c *CRDContext[P]) Validate(obj CRDObject, unstr *unstructured.Unstructured
 	}
 	errs = append(errs, validationResult.Errors...)
 	for _, err := range listErrs {
+		errs = append(errs, err)
+	}
+	for _, err := range celErrs {
 		errs = append(errs, err)
 	}
 

--- a/pkg/crdutils/crdutils_test.go
+++ b/pkg/crdutils/crdutils_test.go
@@ -455,3 +455,36 @@ func TestTracingPolicyNotCoveredBySpec(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to unmarshal into typed object: error unmarshaling JSON: while decoding JSON: json: unknown field \"some_field\"")
 }
+
+// TestXValidationHostSelector tests that XValidation rules work using the
+// hostSelector field
+func TestXValidationHostSelector(t *testing.T) {
+	tpWithHostSelectorMatchLabels := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "test-policy"
+spec:
+  hostSelector:
+    matchLabels:
+      foo: bar
+  kprobes:
+  - call: "security_file_permission"
+    syscall: false
+`
+	_, err := TPContext.FromYAML(tpWithHostSelectorMatchLabels)
+	require.Error(t, err, "TracingPolicy with hostSelector.matchLabels should fail XValidation")
+	assert.Contains(t, err.Error(), "hostSelector should be either null or {}")
+
+	tpWithEmptyHostSelector := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "test-policy"
+spec:
+  hostSelector: {}
+  kprobes:
+  - call: "security_file_permission"
+    syscall: false
+`
+	_, err = TPContext.FromYAML(tpWithEmptyHostSelector)
+	assert.NoError(t, err, "TracingPolicy with empty hostSelector should pass")
+}


### PR DESCRIPTION
Previously, XValidation rules added in the CRDs were only checked from the k8s API server, this addition now run them in standalone (i.e. when passing a policy via --tracing-policy, or through the gRPC API for example).

```release-note
Fixed XValidation CEL rules not being enforced when loading tracing policies in standalone mode outside Kubernetes.
```
