### PR TITLE
cmd/tetra: enable TLS for all TLS-related client flags

### DIFF
--- a/cmd/tetra/common/tls.go
+++ b/cmd/tetra/common/tls.go
@@ -36,10 +36,11 @@ type TLSConfig struct {
 var TLS TLSConfig
 
 // Enabled reports whether the dial should switch from plaintext to TLS.
-// --tls-skip-verify and --tls-server-name only refine an already-active
-// TLS dial; on their own they don't trigger TLS mode.
+// Any TLS-related flag should activate a TLS dial so callers don't silently
+// fall back to plaintext when users request server-name overrides, dev-only
+// verification skipping, or the system CA bundle.
 func (c TLSConfig) Enabled() bool {
-	return c.CertFile != "" || c.KeyFile != "" || len(c.CAFiles) > 0
+	return c.CertFile != "" || c.KeyFile != "" || len(c.CAFiles) > 0 || c.ServerName != "" || c.SkipVerify
 }
 
 // Validate enforces the minimum invariants. --tls-skip-verify with

--- a/cmd/tetra/common/tls_test.go
+++ b/cmd/tetra/common/tls_test.go
@@ -27,8 +27,8 @@ func TestTLSConfigEnabled(t *testing.T) {
 		want bool
 	}{
 		{name: "zero", cfg: TLSConfig{}},
-		{name: "skip-verify alone", cfg: TLSConfig{SkipVerify: true}},
-		{name: "server-name alone", cfg: TLSConfig{ServerName: "x"}},
+		{name: "skip-verify alone", cfg: TLSConfig{SkipVerify: true}, want: true},
+		{name: "server-name alone", cfg: TLSConfig{ServerName: "x"}, want: true},
 		{name: "ca alone", cfg: TLSConfig{CAFiles: []string{"a"}}, want: true},
 		{name: "cert alone", cfg: TLSConfig{CertFile: "a"}, want: true},
 		{name: "key alone", cfg: TLSConfig{KeyFile: "a"}, want: true},
@@ -88,6 +88,25 @@ func TestTLSCredentialsLoadsCAAndCert(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, creds)
+}
+
+func TestTLSCredentialsBuildsForTLSOnlyFlags(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  TLSConfig
+	}{
+		{name: "skip-verify only", cfg: TLSConfig{SkipVerify: true}},
+		{name: "server-name only", cfg: TLSConfig{ServerName: "node.tetragon-grpc.cilium.io"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			creds, err := TLSCredentials(tc.cfg)
+			require.NoError(t, err)
+			require.NotNil(t, creds)
+		})
+	}
 }
 
 func TestTLSCredentialsRejectsMissingFiles(t *testing.T) {

--- a/docs/content/en/docs/installation/grpc-tls.md
+++ b/docs/content/en/docs/installation/grpc-tls.md
@@ -98,6 +98,9 @@ tetra \
 ```
 
 Drop `--tls-cert-file` / `--tls-key-file` if the server is in TLS-only mode.
+If the server certificate chains to the host OS trust store, you can also omit
+`--tls-ca-cert-files`; for example, `--tls-server-name` alone is enough to
+switch `tetra` to a TLS connection that uses the system CA bundle.
 
 {{< caution >}}
 `--tls-skip-verify` disables server certificate verification and is intended


### PR DESCRIPTION
### Description

Small fix for a TLS client footgun in `tetra`.

PR #4950 says any `--tls-*` flag should switch the client to TLS. In practice, `--tls-server-name` or `--tls-skip-verify` alone still kept insecure creds, so `tetra` could talk plaintext by accident. Kinda sneaky.

This makes any TLS-related client flag enable TLS, keeps the zero-flag plaintext path as-is, and adds tests plus docs.

### Repro

1. Start a TLS gRPC listener.
2. Dial it with one of these:
   - `tetra --server-address 127.0.0.1:54321 --tls-skip-verify getevents`
   - `tetra --server-address 127.0.0.1:54321 --tls-server-name node.tetragon-grpc.cilium.io getevents`
3. Before this patch, TLS is not enabled in those modes, so the client falls back to plaintext and the TLS connection cant work.

I re-checked it with a local TLS gRPC server too. After this patch, `--tls-skip-verify` alone reaches `READY`.

### Changelog

```release-note
Fix tetra TLS client flag handling for TLS-only connections
```
