### PR TITLE
cleanup: moved kprobe and uprobe validation to k8s x-validation markers.

### DIFF
--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -1332,6 +1332,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               hostSelector:
                 description: |-
@@ -2611,6 +2614,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               lists:
                 description: A list of list specs.
@@ -6687,6 +6693,13 @@ spec:
                   required:
                   - path
                   type: object
+                  x-kubernetes-validations:
+                  - message: uprobe needs at most one of symbols, addrs or offsets
+                      defined
+                    rule: '!(has(self.symbols) && has(self.addrs)) && !(has(self.symbols)
+                      && has(self.offsets)) && !(has(self.addrs) && has(self.offsets))'
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               usdts:
                 description: A list of usdt specs.

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1332,6 +1332,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               hostSelector:
                 description: |-
@@ -2611,6 +2614,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               lists:
                 description: A list of list specs.
@@ -6687,6 +6693,13 @@ spec:
                   required:
                   - path
                   type: object
+                  x-kubernetes-validations:
+                  - message: uprobe needs at most one of symbols, addrs or offsets
+                      defined
+                    rule: '!(has(self.symbols) && has(self.addrs)) && !(has(self.symbols)
+                      && has(self.offsets)) && !(has(self.addrs) && has(self.offsets))'
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               usdts:
                 description: A list of usdt specs.

--- a/pkg/build/k8s.go
+++ b/pkg/build/k8s.go
@@ -9,3 +9,7 @@ import "testing"
 
 func SkipIfK8sDisabled(_ *testing.T) {
 }
+
+func K8sEnabled() bool {
+	return true
+}

--- a/pkg/build/nok8s.go
+++ b/pkg/build/nok8s.go
@@ -11,3 +11,7 @@ func SkipIfK8sDisabled(t *testing.T) {
 	t.Helper()
 	t.Skip("no k8s build: test disabled")
 }
+
+func K8sEnabled() bool {
+	return false
+}

--- a/pkg/crdutils/crdutils_test.go
+++ b/pkg/crdutils/crdutils_test.go
@@ -202,6 +202,9 @@ spec:
       type: "string"
     - index: 4
       type: "skb"
+    returnArg:
+      index: 0
+      type: "int"
   - call: "another_func"
     return: false
     syscall: false
@@ -289,6 +292,10 @@ var expectedData = GenericTracingPolicy{
 						Index: 4,
 						Type:  "skb",
 					},
+				},
+				ReturnArg: &v1alpha1.KProbeArg{
+					Index: 0,
+					Type:  "int",
 				},
 			},
 			{

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -1332,6 +1332,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               hostSelector:
                 description: |-
@@ -2611,6 +2614,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               lists:
                 description: A list of list specs.
@@ -6687,6 +6693,13 @@ spec:
                   required:
                   - path
                   type: object
+                  x-kubernetes-validations:
+                  - message: uprobe needs at most one of symbols, addrs or offsets
+                      defined
+                    rule: '!(has(self.symbols) && has(self.addrs)) && !(has(self.symbols)
+                      && has(self.offsets)) && !(has(self.addrs) && has(self.offsets))'
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               usdts:
                 description: A list of usdt specs.

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1332,6 +1332,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               hostSelector:
                 description: |-
@@ -2611,6 +2614,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               lists:
                 description: A list of list specs.
@@ -6687,6 +6693,13 @@ spec:
                   required:
                   - path
                   type: object
+                  x-kubernetes-validations:
+                  - message: uprobe needs at most one of symbols, addrs or offsets
+                      defined
+                    rule: '!(has(self.symbols) && has(self.addrs)) && !(has(self.symbols)
+                      && has(self.offsets)) && !(has(self.addrs) && has(self.offsets))'
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               usdts:
                 description: A list of usdt specs.

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -29,6 +29,7 @@ type KprobeIgnore struct {
 	CallNotFound bool `json:"callNotFound,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!self.return || has(self.returnArg)",message="ReturnArg not specified with Return=true."
 type KProbeSpec struct {
 	// Name of the function to apply the kprobe spec to.
 	Call string `json:"call"`
@@ -364,6 +365,8 @@ type TracepointSpec struct {
 	Raw bool `json:"raw,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!(has(self.symbols) && has(self.addrs)) && !(has(self.symbols) && has(self.offsets)) && !(has(self.addrs) && has(self.offsets))",message="uprobe needs at most one of symbols, addrs or offsets defined"
+// +kubebuilder:validation:XValidation:rule="!self.return || has(self.returnArg)",message="ReturnArg not specified with Return=true."
 type UProbeSpec struct {
 	// Name of the traced binary
 	Path string `json:"path"`

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.4"
+const CustomResourceDefinitionSchemaVersion = "1.8.5"

--- a/pkg/sensors/tracing/kprobe_validation_test.go
+++ b/pkg/sensors/tracing/kprobe_validation_test.go
@@ -333,8 +333,15 @@ spec:
     syscall: true
 `
 
-	err := checkCrd(t, crd)
-	require.Error(t, err)
+	if build.K8sEnabled() {
+		// We have k8s x-validation
+		_, err := tracingpolicy.FromYAML(crd)
+		require.Error(t, err)
+	} else {
+		// We fallback at generickprobe code validation
+		err := checkCrd(t, crd)
+		require.Error(t, err)
+	}
 }
 
 func TestKprobeLTOp(t *testing.T) {

--- a/pkg/tracingpolicy/k8s_xvalidation_test.go
+++ b/pkg/tracingpolicy/k8s_xvalidation_test.go
@@ -1,0 +1,83 @@
+//go:build !nok8s
+
+package tracingpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKprobeValidationReturnWithoutArg(t *testing.T) {
+	// missing returnArg while having return: true
+	crd := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "missing-returnarg"
+spec:
+  kprobes:
+  - call: "sys_openat"
+    return: true
+    syscall: true
+`
+	_, err := FromYAML(crd)
+	require.Error(t, err)
+}
+
+func testUprobeValidationSymbolsAddrsOffsets(t *testing.T, withSymbol, withAdrr, withOff bool) {
+	crd := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe"
+spec:
+  uprobes:
+  - path: "/usr/bin/test"`
+	if withSymbol {
+		crd += "    symbols: [\"test_3\"]\n"
+	}
+	if withAdrr {
+		crd += "    addrs: [0x985256]\n"
+	}
+	if withOff {
+		crd += "    offsets: [0x9156366]\n"
+	}
+
+	_, err := FromYAML(crd)
+	require.Error(t, err)
+}
+
+func TestUprobeValidationSymbolsAddrsOffsets(t *testing.T) {
+	testUprobeValidationSymbolsAddrsOffsets(t, true, true, true)
+}
+
+func TestUprobeValidationSymbolsAddrs(t *testing.T) {
+	testUprobeValidationSymbolsAddrsOffsets(t, true, true, false)
+}
+
+func TestUprobeValidationSymbolsOffsets(t *testing.T) {
+	testUprobeValidationSymbolsAddrsOffsets(t, true, false, true)
+}
+
+func TestUprobeValidationAddrsOffsets(t *testing.T) {
+	testUprobeValidationSymbolsAddrsOffsets(t, false, true, true)
+}
+
+func TestUprobeValidationReturnWithoutArg(t *testing.T) {
+	crd := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe"
+spec:
+  uprobes:
+  - path: "/usr/bin/test"
+    symbols:
+    - "test_3"
+    return: true
+`
+
+	_, err := FromYAML(crd)
+	require.Error(t, err)
+}

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -1332,6 +1332,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               hostSelector:
                 description: |-
@@ -2611,6 +2614,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               lists:
                 description: A list of list specs.
@@ -6687,6 +6693,13 @@ spec:
                   required:
                   - path
                   type: object
+                  x-kubernetes-validations:
+                  - message: uprobe needs at most one of symbols, addrs or offsets
+                      defined
+                    rule: '!(has(self.symbols) && has(self.addrs)) && !(has(self.symbols)
+                      && has(self.offsets)) && !(has(self.addrs) && has(self.offsets))'
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               usdts:
                 description: A list of usdt specs.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1332,6 +1332,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               hostSelector:
                 description: |-
@@ -2611,6 +2614,9 @@ spec:
                   required:
                   - call
                   type: object
+                  x-kubernetes-validations:
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               lists:
                 description: A list of list specs.
@@ -6687,6 +6693,13 @@ spec:
                   required:
                   - path
                   type: object
+                  x-kubernetes-validations:
+                  - message: uprobe needs at most one of symbols, addrs or offsets
+                      defined
+                    rule: '!(has(self.symbols) && has(self.addrs)) && !(has(self.symbols)
+                      && has(self.offsets)) && !(has(self.addrs) && has(self.offsets))'
+                  - message: ReturnArg not specified with Return=true.
+                    rule: '!self.return || has(self.returnArg)'
                 type: array
               usdts:
                 description: A list of usdt specs.

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -29,6 +29,7 @@ type KprobeIgnore struct {
 	CallNotFound bool `json:"callNotFound,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!self.return || has(self.returnArg)",message="ReturnArg not specified with Return=true."
 type KProbeSpec struct {
 	// Name of the function to apply the kprobe spec to.
 	Call string `json:"call"`
@@ -364,6 +365,8 @@ type TracepointSpec struct {
 	Raw bool `json:"raw,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!(has(self.symbols) && has(self.addrs)) && !(has(self.symbols) && has(self.offsets)) && !(has(self.addrs) && has(self.offsets))",message="uprobe needs at most one of symbols, addrs or offsets defined"
+// +kubebuilder:validation:XValidation:rule="!self.return || has(self.returnArg)",message="ReturnArg not specified with Return=true."
 type UProbeSpec struct {
 	// Name of the traced binary
 	Path string `json:"path"`

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.4"
+const CustomResourceDefinitionSchemaVersion = "1.8.5"


### PR DESCRIPTION
### Description

Move to use k8s x-validation where possible.
The only field we can pre-validate are:
* kprobe `Return==true` -> requires `returnArg`
* uprobe `Return==true` -> requires `returnArg`
* uprobe -> at most one between `addrs,symbols,offsets`

### Changelog

```release-note
cleanup: moved kprobe and uprobe validation to k8s x-validation markers.
```
