### PR TITLE
examples: add CVE-2021-4034 PwnKit LD_PRELOAD persistence detection policy

### DIFF
--- a/examples/tracingpolicy/cves/VALIDATION-cve-2021-4034.md
+++ b/examples/tracingpolicy/cves/VALIDATION-cve-2021-4034.md
@@ -1,0 +1,89 @@
+# Validation — CVE-2021-4034 (PwnKit) LD_PRELOAD Detection
+
+## Environment
+
+| Component | Version |
+|-----------|---------|
+| Architecture | ARM64 (aarch64) |
+| Host OS | Ubuntu 22.04 |
+| Kernel | 6.8.0-1050-oracle |
+| k3s | v1.35.4+k3s1 |
+| Cilium | v1.19.3 |
+| Tetragon | latest (main) |
+| Container runtime | containerd + overlayfs snapshotter |
+
+## Symbol verification
+
+    $ grep "__arm64_sys_openat" /proc/kallsyms
+    ffffffc0814c9754 T __arm64_sys_openat
+
+Symbol present: YES
+
+## True positive test
+
+Method: Isolated exploit-test namespace with deny-all NetworkPolicy.
+Ephemeral ubuntu:22.04 pod with no privileged flags.
+
+Trigger command:
+
+    kubectl exec -n exploit-test exploit-runner -- \
+      bash -c "echo /tmp/evil.so > /etc/ld.so.preload"
+
+Tetragon event captured:
+
+    {
+      "policy": "cve-2021-4034-pwnkit-ld-preload",
+      "args": [
+        {"string_arg": "/etc/ld.so.preload"},
+        {"int_arg": 577}
+      ],
+      "action": "KPROBE_ACTION_POST"
+    }
+
+int_arg 577 = O_WRONLY|O_CREAT|O_TRUNC (decimal) - confirmed write open.
+
+Dynamic linker response (confirms real attack chain):
+
+    ERROR: ld.so: object '/tmp/evil.so' from /etc/ld.so.preload cannot be preloaded
+
+The linker immediately attempted to load the registered library on the next exec.
+
+## False positive baseline
+
+Duration: 24h across production k3s cluster
+Workloads monitored: khoj, llama.cpp, fastapi quiz engine,
+telegram bot, threat-intel-harvester, splunk bridge, IoT demo pods
+Policy hits on legitimate workloads: 0
+
+## Path resolution in containers (overlayfs)
+
+Initial hypothesis: Tetragon kprobe sees overlay upperdir path, not container path.
+
+Disproved by debug policy. Using a filter-free debug-openat-bash policy
+confirmed Tetragon resolves filenames through the container mount namespace:
+
+    {"string_arg": "/etc/ld.so.preload", "int_arg": 577}
+
+Not the host upperdir path. Path matching with Equal or Postfix works
+correctly in containerised environments.
+
+## Important: single action per selector
+
+During validation, a policy with two actions in one selector was tested:
+
+    matchActions:
+    - action: Post
+    - action: Sigkill
+
+This silently disabled the selector - zero kprobe events were generated
+despite the hook firing (confirmed by debug policy). Using a single
+action: Post per selector restored correct behaviour immediately.
+
+Rule: Each selector must contain exactly one matchActions entry.
+Multiple actions require separate kprobe entries.
+
+## x86_64 compatibility note
+
+This policy uses __arm64_sys_openat. For x86_64 deployments, replace with
+__x64_sys_openat. Both syscall symbols hook the same openat(2) call with
+identical argument layout (index 1 = filename, index 2 = flags).

--- a/examples/tracingpolicy/cves/cve-2021-4034-pwnkit-ld-preload.yaml
+++ b/examples/tracingpolicy/cves/cve-2021-4034-pwnkit-ld-preload.yaml
@@ -1,0 +1,131 @@
+# https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4034
+#
+# Description
+#  CVE-2021-4034 (PwnKit): A local privilege escalation vulnerability in
+#  polkit's pkexec. The exploit writes a malicious shared library and registers
+#  it via /etc/ld.so.preload to hijack execution flow and gain root privileges.
+#  This technique is also used by Lazarus Group BeaverTail malware and generic
+#  Linux rootkits for persistence (T1574.006 - Hijack Execution Flow: LD_PRELOAD).
+#
+# Affected versions:
+#  polkit < 0.120 on all major Linux distributions
+#  Also covers generic LD_PRELOAD rootkit persistence on any Linux kernel
+#
+# Detection:
+#  Detects writes to /etc/ld.so.preload and /etc/ld.so.conf.d/ by any binary
+#  not in the package manager allowlist. Alerts on reads of /etc/ld.so.preload
+#  by non-linker binaries (indicating a preloaded library is being inspected
+#  or a new process is starting with a malicious preload active).
+#
+# Tested:
+#  ARM64 (aarch64), k3s v1.35.4+k3s1, Cilium v1.19.3, Ubuntu 22.04
+#  Kernel: 6.8.0-1050-oracle
+#  Confirmed: kprobe fires on openat("/etc/ld.so.preload", O_WRONLY|O_CREAT|O_TRUNC)
+#  flags=577 (decimal), policy_name=detect-ld-preload-hijack, action=KPROBE_ACTION_POST
+#
+# Note on matchActions:
+#  Each selector must contain only ONE action. Specifying multiple actions
+#  (e.g. Post + Sigkill) in a single selector silently disables the selector.
+#  Use separate kprobe entries for separate actions.
+#
+# Note on path matching in containers:
+#  Tetragon resolves filenames through the container mount namespace, so
+#  /etc/ld.so.preload is seen correctly regardless of overlay filesystem
+#  upperdir paths (verified on k3s + containerd + overlayfs).
+#
+# Prerequisites:
+#  __arm64_sys_openat present in /proc/kallsyms (ARM64)
+#  __x64_sys_openat present in /proc/kallsyms (x86_64)
+#
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "cve-2021-4034-pwnkit-ld-preload"
+  annotations:
+    url: "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4034"
+    description: "Detects LD_PRELOAD persistence via writes to /etc/ld.so.preload (PwnKit/T1574.006)"
+    author: "Clyde Coutinho"
+spec:
+  kprobes:
+  # Kprobe 1: Detect writes to /etc/ld.so.preload
+  - call: "__arm64_sys_openat"
+    syscall: true
+    args:
+    - index: 1
+      type: "string"
+    - index: 2
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Postfix"
+        values:
+        - "/etc/ld.so.preload"
+      - index: 2
+        operator: "GT"
+        values:
+        - "0"
+      matchBinaries:
+      - operator: "NotIn"
+        values:
+        - "/usr/bin/dpkg"
+        - "/usr/bin/apt"
+        - "/usr/bin/apt-get"
+        - "/usr/bin/rpm"
+        - "/usr/bin/dnf"
+        - "/usr/bin/yum"
+      matchActions:
+      - action: Post
+  # Kprobe 2: Alert on reads of /etc/ld.so.preload by non-linker binaries
+  - call: "__arm64_sys_openat"
+    syscall: true
+    args:
+    - index: 1
+      type: "string"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Postfix"
+        values:
+        - "/etc/ld.so.preload"
+      matchBinaries:
+      - operator: "NotIn"
+        values:
+        - "/lib/ld-linux-aarch64.so.1"
+        - "/lib64/ld-linux-x86-64.so.2"
+        - "/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1"
+        - "/usr/bin/ldd"
+        - "/usr/bin/ldconfig"
+      matchActions:
+      - action: Post
+        rateLimit: "5/minute"
+  # Kprobe 3: Detect writes to /etc/ld.so.conf.d/
+  - call: "__arm64_sys_openat"
+    syscall: true
+    args:
+    - index: 1
+      type: "string"
+    - index: 2
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 1
+        operator: "Postfix"
+        values:
+        - "/etc/ld.so.conf.d/"
+      - index: 2
+        operator: "GT"
+        values:
+        - "0"
+      matchBinaries:
+      - operator: "NotIn"
+        values:
+        - "/usr/bin/dpkg"
+        - "/usr/bin/apt"
+        - "/usr/bin/apt-get"
+        - "/usr/bin/rpm"
+        - "/usr/bin/dnf"
+        - "/usr/bin/yum"
+        - "/usr/sbin/ldconfig"
+      matchActions:
+      - action: Post


### PR DESCRIPTION
## Summary

Adds a TracingPolicy detecting writes to `/etc/ld.so.preload` and `/etc/ld.so.conf.d/` as used by CVE-2021-4034 (PwnKit) and generic LD_PRELOAD rootkit persistence (T1574.006 - Hijack Execution Flow).

Three kprobes on `__arm64_sys_openat`:
- Write detection on `/etc/ld.so.preload` (package managers allowlisted)
- Read detection by non-linker binaries (rate limited 5/min)
- Write detection on `/etc/ld.so.conf.d/`

Validated on ARM64 (aarch64), k3s v1.35.4, Cilium v1.19.3, Ubuntu 22.04, kernel 6.8.0-1050-oracle. True positive confirmed: kprobe fires on `openat("/etc/ld.so.preload", O_WRONLY|O_CREAT|O_TRUNC, flags=577)`. Dynamic linker immediately attempted to load the registered library on next exec. Zero false positives over 24h baseline across production workloads.

Includes VALIDATION doc covering: true positive evidence, false positive baseline, overlayfs path resolution behaviour, and a finding that multiple `matchActions` in one selector silently disables detection.

Fixes #1947

### Checklist
- [x] All commits contain a well written commit message and are signed-off
- [x] All code is covered by the policy example itself
- [ ] Unit and end-to-end tests where feasible (N/A - policy example)
- [x] Documentation and upgrade notes updated
- [ ] Add yourself to USERS.md if you are a user of Tetragon

### Description
Adds a validated TracingPolicy example for CVE-2021-4034 (PwnKit) LD_PRELOAD persistence. Policy detects the exact syscall-level write pattern used by the exploit and generic Linux rootkits to hijack dynamic linker execution flow.

### Changelog
No changelog entry required for policy examples.

```release-note
Add TracingPolicy example for CVE-2021-4034 (PwnKit) LD_PRELOAD persistence detection (T1574.006, ARM64 validated)
```
