### PR TITLE
bpf: cleanup more bpf_probe_read

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -321,26 +321,26 @@ __read_arg_1(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 	case size_type:
 	case s64_ty:
 	case u64_ty:
-		probe_read(args, sizeof(__u64), &arg);
+		*(__u64 *)args = (__u64)arg;
 		size = sizeof(__u64);
 		break;
 	/* Consolidate all the types to save instructions */
 	case int_type:
 	case s32_ty:
 	case u32_ty:
-		probe_read(args, sizeof(__u32), &arg);
+		*(__u32 *)args = (__u32)arg;
 		size = sizeof(__u32);
 		break;
 	case s16_ty:
 	case u16_ty:
 		/* read 2 bytes, but send 4 to keep alignment */
-		probe_read(args, sizeof(__u16), &arg);
+		*(__u16 *)args = (__u16)arg;
 		size = sizeof(__u32);
 		break;
 	case s8_ty:
 	case u8_ty:
 		/* read 1 byte, but send 4 to keep alignment */
-		probe_read(args, sizeof(__u8), &arg);
+		*(__u8 *)args = (__u8)arg;
 		size = sizeof(__u32);
 		break;
 	case skb_type:

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -277,16 +277,13 @@ __read_arg_1(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 			asm volatile("%[bytes] &= 0xfff;\n"
 				     : [bytes] "+r"(bytes)
 				     :);
-			ret = probe_read(&args[4], bytes + 4, (char *)&val->file[0]);
+			// size + file path + flags
+			size = 4 + bytes + 4;
+			ret = probe_read(&args[4], size, (char *)&val->file[0]);
 			if (ret < 0)
 				return ret;
-			size = bytes + 4 + 4;
 
-			// flags
-			ret = probe_read(&args[size], 4,
-					 (char *)&val->file[size - 4]);
-			if (ret < 0)
-				return ret;
+			// account for fd written at args[0]
 			size += 4;
 		} else {
 			/* If filter specification is fd type then we

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -298,7 +298,7 @@ __read_arg_1(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 	case filename_ty: {
 		struct filename *file;
 
-		probe_read(&file, sizeof(file), &arg);
+		file = (struct filename *)arg;
 		probe_read(&arg, sizeof(arg), &file->name);
 	}
 		fallthrough;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -929,6 +929,7 @@ filter_char_buf(struct selector_arg_filter *filter, char *args, int value_off)
 	return is_not_operator(filter->op) ? !match : match;
 }
 
+// This struct captures the layout documented in store_path().
 struct string_buf {
 	__u32 len;
 	char buf[];
@@ -941,15 +942,18 @@ filter_file_type(struct selector_arg_filter *filter, struct string_buf *args)
 	// size + sizeof(u32) + sizeof(u16)
 	// mode is at the end, so we can access it using the length of the string
 	// plus the size of the flags.
-	u16 mode = 0;
+	__u16 mode = 0;
 	int j = 0;
 
-	// Use probe_read to avoid verifier unbounded memory access error
-	// Address is: args->buf (start of path) + args->len (end of path) + 4 (sizeof flags)
 	if (args->len > MAX_STRING)
 		return 0;
 
-	probe_read(&mode, sizeof(mode), (void *)((char *)args->buf + args->len + 4));
+	__u32 mode_off = args->len;
+	// Avoid unbounded access, needed on 4.19 only
+	asm volatile("%[mode_off] &= 0xfff;\n" : [mode_off] "+r"(mode_off));
+	// Offset from args: args->len (path) + 4 (len field) + 4 (flags)
+	mode_off += sizeof(args->len) + sizeof(__u32);
+	memcpy(&mode, (char *)args + mode_off, sizeof(mode));
 
 	/* filter->value contains the target file type constants (e.g. S_IFREG,
 	 * S_IFIFO) written by the userspace agent from the fileTypeTable.

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -939,7 +939,6 @@ FUNC_LOCAL long
 filter_file_type(struct selector_arg_filter *filter, struct string_buf *args)
 {
 	// see store_path() for memory layout
-	// size + sizeof(u32) + sizeof(u16)
 	// mode is at the end, so we can access it using the length of the string
 	// plus the size of the flags.
 	__u16 mode = 0;
@@ -2351,7 +2350,10 @@ struct fdinstall_key {
 };
 
 struct fdinstall_value {
-	char file[4104]; // 4096B paths + 4B length + 4B flags
+	// 4B length + 4096B paths + 4B flags
+	// This must align with the implementation in store_path()
+	// Note that we don't yet store the mode here.
+	char file[4104];
 };
 
 struct {


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->


### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

Follow up from this discussion: https://github.com/cilium/tetragon/pull/4989#discussion_r3264329057

I couldn't convert some of the `bpf_probe_read`s because while they were reading from e.g. eBPF map values, they had a dynamic size to be copied. For `memcpy` the size must be constexpr.

#### Questions for the reviewers
1. Did I miss any `probe_read`s, that still can be converted?
2. Did I convert `probe_read`s in place where I shouldn't?

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
bpf: replace some bpf_probe_read calls
```
