### PR TITLE
[v1.7] backports for tetra macos build

### DIFF
--- a/Makefile.cli
+++ b/Makefile.cli
@@ -42,6 +42,7 @@ cli-local-release: $(RELEASES) ## Compile tetra CLI release binaries locally
 
 $(RELEASE_FOLDER)/$(TARGET)-%.tar.gz: cli-clean
 	@{ \
+		set -e; \
 		OS=$(word 1,$(subst -, ,$*)); \
 		ARCH=$(word 2,$(subst -, ,$*)); \
 		EXT=""; if [ "$$OS" = "windows" ]; then EXT=".exe"; fi; \

--- a/pkg/tetragoninfo/info_darwin.go
+++ b/pkg/tetragoninfo/info_darwin.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+package tetragoninfo
+
+import (
+	"github.com/cilium/tetragon/api/v1/tetragon"
+)
+
+func bpfProbes() []*tetragon.GetInfoResponse_Probe {
+	return nil
+}


### PR DESCRIPTION
### Description
Fixing build tetra for macos build in `v1.7`

### Changelog
```release-note
tetragoninfo: add darwin stub for bpfProbes
```
