### PR TITLE
renovate: add dependency cooldown

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -85,6 +85,11 @@
   //   important rules override settings from earlier rules if needed.
   "packageRules": [
     {
+      // Dependency cooldown: skip versions published less than 5 days ago
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "minimumReleaseAge": "5 days"
+    },
+    {
       "groupName": "all github action dependencies",
       "groupSlug": "all-github-action",
       "matchFileNames": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -90,6 +90,15 @@
       "minimumReleaseAge": "5 days"
     },
     {
+      // Docker Hub is the only Docker registry that currently supports release
+      // timestamps, causing updates to be never proposed by Renovate for all
+      // other registries. Hence, let's enable the "timestamp-optional" option,
+      // which unfortunately effectively disables the cooldown period for them.
+      // https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-registries-support-release-timestamps
+      "matchDatasources": ["docker"],
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
+    },
+    {
       "groupName": "all github action dependencies",
       "groupSlug": "all-github-action",
       "matchFileNames": [


### PR DESCRIPTION
- adds a 5-day dependency cooldown to the Renovate config for stability and security to prevent supply chain vulnerabilities
- Vulnerability updates are exempt from this cooldown by default.
