### PR TITLE
pkg/sensors/tracing: skip x86 specific tests on non-x86

### DIFF
--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -1046,6 +1046,9 @@ func testUprobePtRegsPreloadSubstring(t *testing.T, str string, ignoreCase bool,
 	if !single && !bpf.HasUprobeMulti() {
 		t.Skip("skipping, can't use uprobe multi, no kernel support")
 	}
+	if runtime.GOARCH == "arm64" {
+		t.Skip("skipping, x86_64 only test")
+	}
 
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
 
@@ -1228,6 +1231,9 @@ func testUprobePtRegsPreloadSubstringOverride(t *testing.T, single bool) {
 	}
 	if !bpf.HasKfunc("bpf_strnstr") {
 		t.Skip("skipping, no bpf_strnstr kfunc in kernel")
+	}
+	if runtime.GOARCH == "arm64" {
+		t.Skip("skipping, x86_64 only test")
 	}
 
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description
GitHub upgraded the kernel in our CI to 6.17. This kernel now supports the kfuncs needed for the tests, hence they are enabled.

These tests are now failing because they use x86 specific registers in the policy.
Therefore, skip them on non-x86 platforms.
