### PR TITLE
[v1.7] pkg/sensors/tracing: skip x86 specific tests on non-x86

### DIFF
--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -1042,6 +1042,9 @@ func testUprobePtRegsPreloadSubstring(t *testing.T, str string, ignoreCase bool,
 	if !single && !bpf.HasUprobeMulti() {
 		t.Skip("skipping, can't use uprobe multi, no kernel support")
 	}
+	if runtime.GOARCH == "arm64" {
+		t.Skip("skipping, x86_64 only test")
+	}
 
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
 
@@ -1224,6 +1227,9 @@ func testUprobePtRegsPreloadSubstringOverride(t *testing.T, single bool) {
 	}
 	if !bpf.HasKfunc("bpf_strnstr") {
 		t.Skip("skipping, no bpf_strnstr kfunc in kernel")
+	}
+	if runtime.GOARCH == "arm64" {
+		t.Skip("skipping, x86_64 only test")
 	}
 
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")


### PR DESCRIPTION
v1.7 backport of https://github.com/cilium/tetragon/pull/5082
### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
pkg/sensors/tracing: skip x86 specific tests on non-x86
```
