### PR TITLE
Check for images tags when updated in helm values

### DIFF
--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -61,6 +61,8 @@ jobs:
         run: |
           set -ex
           make -C install/kubernetes lint
+      - name: Check images tags exists
+        run: make -C install/kubernetes check-images-tags
       - name: Run Kubeconform with minimum supported K8s version
         if: success() || steps.validate_openapi2jsonschema_script.outcome == 'failure'
         id: kubeconform_min_k8s_version

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -84,6 +84,18 @@ openapi2jsonschema.py: ## openapi2jsonschema.py script generating JSON schema fr
 lint: ## Lint the Helm chart
 	$(HELM) lint . --with-subcharts
 
+.PHONY: check-images-tags
+check-images-tags: ## Verify all image:tag references in values.yaml exist in their registries
+	@set -e; \
+	IMAGES=$$(yq -e '.. | select(has("repository") and has("tag")) | .repository + ":" + .tag' tetragon/values.yaml); \
+	for img in $$IMAGES; do \
+		echo "Checking $$img"; \
+		if ! docker buildx imagetools inspect "$$img" >/dev/null 2>&1; then \
+			echo "  MISSING: $$img" >&2; \
+			exit 1; \
+		fi; \
+	done;
+
 .PHONY: kubeconform
 # Run kubeconform Helm chart validation checks to validate the templated
 # Kubernetes (custom) resources against their spec.


### PR DESCRIPTION
### Description
Adds check to run when the kubernetes `values.yaml` is updated. This verifies that all images tags in the file are published in their registry.

Fixes #5020


### Testing

This is a successful run:
```
make -C install/kubernetes check-images-tags                                                                      
Checking quay.io/cilium/tetragon:v1.7.0
Checking quay.io/cilium/tetragon-operator:v1.7.0
Checking quay.io/cilium/hubble-export-stdout:v1.1.1
Checking quay.io/cilium/tetragon-rthooks:v0.9
Checking quay.io/cilium/certgen:v0.4.5
```

This is a run when there is a non existing image:

```
make -C install/kubernetes check-images-tags
Checking quay.io/cilium/tetragon:v1.7.0
Checking quay.io/cilium/tetragon-operator:v1.7.0
Checking quay.io/cilium/hubble-export-stdout:v1.1.1
Checking quay.io/cilium/tetragon-rthooks:v0.10
  MISSING: quay.io/cilium/tetragon-rthooks:v0.10
make: *** [check-images-tags] Error 1
```
Here an example run https://github.com/cilium/tetragon/actions/runs/26846697582/job/79168054353?pr=5088#step:6:13
