### PR TITLE
e2e/policyfilter: watch custom files for matchWorkloads test

### DIFF
--- a/tests/e2e/tests/policyfilter/policyfilter_test.go
+++ b/tests/e2e/tests/policyfilter/policyfilter_test.go
@@ -669,7 +669,7 @@ spec:
       - index: 0
         operator: "Prefix"
         values:
-        - "/etc/passwd"
+        - "/etc/myshadow"
       - index: 1
         operator: "Equal"
         values:
@@ -680,12 +680,12 @@ spec:
           - key: "name"
             operator: In
             values:
-            - "passwd"
+            - "myshadow"
     - matchArgs:
       - index: 0
         operator: "Prefix"
         values:
-        - "/etc/shadow"
+        - "/etc/mypasswd"
       - index: 1
         operator: "Equal"
         values:
@@ -696,9 +696,12 @@ spec:
           - key: "name"
             operator: In
             values:
-            - "shadow"
+            - "mypasswd"
 `
 
+// This Deployment has two containers. Both create and try to read two files: /etc/myshadow and /etc/mypasswd.
+// The policy above should match the container named myshadow only when it reads /etc/myshadow and the container
+// named mypasswd only when it reads /etc/mypasswd, and not the other way around.
 const ubuntuFilePod = `
 kind: Deployment
 apiVersion: apps/v1
@@ -715,16 +718,16 @@ spec:
         app: "ubuntu-file"
     spec:
       containers:
-      - name: passwd
-        image: ubuntu:20.04
+      - name: myshadow
+        image: ` + ubuntuImage + `
         imagePullPolicy: IfNotPresent
         command: ["bash"]
-        args: ["-c", "while sleep 1; do cat /etc/passwd; done"]
-      - name: shadow
-        image: ubuntu:20.04
+        args: ["-c", "touch /etc/myshadow; touch /etc/mypasswd; while sleep 1; do cat /etc/myshadow && cat /etc/mypasswd; done"]
+      - name: mypasswd
+        image: ` + ubuntuImage + `
         imagePullPolicy: IfNotPresent
         command: ["bash"]
-        args: ["-c", "while sleep 1; do cat /etc/shadow; done"]
+        args: ["-c", "touch /etc/mypasswd; touch /etc/myshadow; while sleep 1; do cat /etc/mypasswd && cat /etc/myshadow; done"]
 `
 
 func matchWorkloadsChecker() *checker.RPCChecker {
@@ -732,12 +735,12 @@ func matchWorkloadsChecker() *checker.RPCChecker {
 }
 
 type matchWorkloadsFileChecker struct {
-	matchesShadow int
-	matchesPasswd int
+	matchesWatchme    int
+	matchesWatchmetoo int
 }
 
 func (cfc *matchWorkloadsFileChecker) Done() bool {
-	return cfc.matchesPasswd > 0 && cfc.matchesShadow > 0
+	return cfc.matchesWatchme > 0 && cfc.matchesWatchmetoo > 0
 }
 
 func (cfc *matchWorkloadsFileChecker) NextEventCheck(event ec.Event, _ *slog.Logger) (bool, error) {
@@ -767,18 +770,18 @@ func (cfc *matchWorkloadsFileChecker) NextEventCheck(event ec.Event, _ *slog.Log
 	container := ev.GetProcess().GetPod().GetContainer()
 
 	switch arg.Path {
-	case "/etc/passwd":
-		if container.Name == "passwd" {
-			cfc.matchesPasswd++
+	case "/etc/myshadow":
+		if container.Name == "myshadow" {
+			cfc.matchesWatchme++
 			return cfc.Done(), nil
 		}
-		return true, fmt.Errorf("unexpected event %+v for /etc/passwd from a container with a different name than passwd", ev)
-	case "/etc/shadow":
-		if container.Name == "shadow" {
-			cfc.matchesShadow++
+		return true, fmt.Errorf("unexpected event %+v for /etc/myshadow from a container with a different name than myshadow", ev)
+	case "/etc/mypasswd":
+		if container.Name == "mypasswd" {
+			cfc.matchesWatchmetoo++
 			return cfc.Done(), nil
 		}
-		return true, fmt.Errorf("unexpected event %+v for /etc/shadow from a container with a different name than shadow", ev)
+		return true, fmt.Errorf("unexpected event %+v for /etc/mypasswd from a container with a different name than mypasswd", ev)
 	default:
 		return false, nil
 	}
@@ -788,7 +791,7 @@ func (cfc *matchWorkloadsFileChecker) FinalCheck(_ *slog.Logger) error {
 	if cfc.Done() {
 		return nil
 	}
-	return fmt.Errorf("match-workloads checker failed, had %d matches for /etc/passwd and %d matches for /etc/shadow", cfc.matchesPasswd, cfc.matchesShadow)
+	return fmt.Errorf("match-workloads checker failed, had %d matches for /etc/myshadow and %d matches for /etc/mypasswd", cfc.matchesWatchme, cfc.matchesWatchmetoo)
 }
 
 func TestMatchWorkloadsSelector(t *testing.T) {

--- a/tests/e2e/tests/policyfilter/policyfilter_test.go
+++ b/tests/e2e/tests/policyfilter/policyfilter_test.go
@@ -73,6 +73,10 @@ var (
 	testNamespaces = []string{otherNamespace, policyNamespace, podlblNamespace, containerSelectorNamespace, fileNamespace}
 )
 
+const (
+	ubuntuImage = "ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54"
+)
+
 func TestMain(m *testing.M) {
 	runner = runners.NewRunner().WithInstallTetragon(e2e.WithHelmOptions(map[string]string{
 		"tetragon.exportAllowList":    "",
@@ -188,7 +192,7 @@ spec:
     spec:
       containers:
       - name: ubuntu
-        image: ubuntu:20.04
+        image: ` + ubuntuImage + `
         imagePullPolicy: Always
         command: ["bash"]
         args: ["-c", "while sleep 1; do cat /etc/hostname; done"]
@@ -320,7 +324,7 @@ spec:
     spec:
       containers:
       - name: ubuntu
-        image: ubuntu:20.04
+        image: ` + ubuntuImage + `
         imagePullPolicy: Always
         command: ["bash"]
         args: ["-c", "while sleep 1; do cat /etc/hostname; done"]
@@ -343,7 +347,7 @@ spec:
     spec:
       containers:
       - name: ubuntu
-        image: ubuntu:20.04
+        image: ` + ubuntuImage + `
         imagePullPolicy: Always
         command: ["bash"]
         args: ["-c", "while sleep 1; do cat /etc/hostname; done"]
@@ -493,12 +497,12 @@ spec:
     spec:
       containers:
       - name: main
-        image: ubuntu:20.04
+        image: ` + ubuntuImage + `
         imagePullPolicy: IfNotPresent
         command: ["bash"]
         args: ["-c", "while sleep 1; do cat /etc/hostname; done"]
       - name: sidecar
-        image: ubuntu:20.04
+        image: ` + ubuntuImage + `
         imagePullPolicy: IfNotPresent
         command: ["bash"]
         args: ["-c", "while sleep 1; do cat /etc/hostname; done"]
@@ -588,7 +592,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: ubuntu:20.04
+        image: ` + ubuntuImage + `
         imagePullPolicy: IfNotPresent
         command: ["bash"]
         args: ["-c", "while sleep 1; do cat /etc/hostname; done"]


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->


We encountered the following error in the matchWotkloads selector e2e test:

```
level=error msg="PROCESS_KPROBE:5 => terminating error: unexpected event process:{exec_id:\"dGV0cmFnb24tY2ktNWVkMy1jb250cm9sLXBsYW5lOjExMTA3MjE1NzE0NDU6MTg4NTE=\"  pid:{value:18851}  uid:{}  cwd:\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/ea6c6afdaa3488e1e2a2e8cf91142b57d3d2c40c3af962a8ae914a216580b3fd/rootfs\"  binary:\"/kind/bin/mount-product-files.sh\"  arguments:\"/kind/bin/mount-product-files.sh\"  flags:\"execve clone inInitTree\"  start_time:{seconds:1780480931  nanos:335176792}  auid:{value:4294967295}  pod:{namespace:\"file-ns\"  name:\"ubuntu-file-b579b685-9plbx\"  uid:\"cc6ba715-71ac-4777-89a2-7a5681492ce1\"  container:{id:\"containerd://ea6c6afdaa3488e1e2a2e8cf91142b57d3d2c40c3af962a8ae914a216580b3fd\"  name:\"shadow\"  image:{id:\"docker.io/library/ubuntu@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214\"  name:\"docker.io/library/ubuntu:20.04\"}  start_time:{seconds:1780480931}  pid:{value:8}  security_context:{}}  pod_labels:{key:\"app\"  value:\"ubuntu-file\"}  pod_labels:{key:\"pod-template-hash\"  value:\"b579b685\"}  workload:\"ubuntu-file\"  workload_kind:\"Deployment\"}  docker:\"ea6c6afdaa3488e1e2a2e8cf91142b5\"  parent_exec_id:\"dGV0cmFnb24tY2ktNWVkMy1jb250cm9sLXBsYW5lOjExMTA3MDk0MTkyNDc6MTg4NDQ=\"  refcnt:6  tid:{value:18851}  in_init_tree:{value:true}}  parent:{exec_id:\"dGV0cmFnb24tY2ktNWVkMy1jb250cm9sLXBsYW5lOjExMTA3MDk0MTkyNDc6MTg4NDQ=\"  pid:{value:18844}  uid:{}  cwd:\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/00e3ac9c8f8d9594e688a1f8ad05898bca0c5070731bdd1b4ee2b8cbb31e90d1\"  binary:\"/usr/local/sbin/runc\"  arguments:\"--root /run/containerd/runc/k8s.io --log /run/containerd/io.containerd.runtime.v2.task/k8s.io/ea6c6afdaa3488e1e2a2e8cf91142b57d3d2c40c3af962a8ae914a216580b3fd/log.json --log-format json --systemd-cgroup create --bundle /run/containerd/io.containerd.runtime.v2.task/k8s.io/ea6c6afdaa3488e1e2a2e8cf91142b57d3d2c40c3af962a8ae914a216580b3fd --pid-file /run/containerd/io.containerd.runtime.v2.task/k8s.io/ea6c6afdaa3488e1e2a2e8cf91142b57d3d2c40c3af962a8ae914a216580b3fd/init.pid ea6c6afdaa3488e1e2a2e8cf91142b57d3d2c40c3af962a8ae914a216580b3fd\"  flags:\"execve inInitTree\"  start_time:{seconds:1780480931  nanos:323024644}  auid:{value:4294967295}  parent_exec_id:\"dGV0cmFnb24tY2ktNWVkMy1jb250cm9sLXBsYW5lOjExMTA2NzU0MDY1Mjc6MTg4MzE=\"  refcnt:1  tid:{value:18844}  in_init_tree:{value:true}}  function_name:\"security_file_permission\"  args:{file_arg:{path:\"/etc/passwd\"  permission:\"-rw-r--r--\"}}  args:{int_arg:4}  return:{int_arg:0}  action:KPROBE_ACTION_POST  policy_name:\"file-match-workloads\"  return_action:KPROBE_ACTION_POST for /etc/passwd from a container with a different name than passwd"
```

It seems like that during the container startup KinD calls mount ([ref](https://github.com/kubernetes-sigs/kind/blob/065f80a312bab87e130e7a316ee6dbee788262b9/images/base/files/kind/bin/mount-product-files.sh#L45)), which accesses `/etc/passwd`. 

There are 2 problems with this:
1. We access /etc/passwd from the "shadow" container, which should only generate events for the `/etc/shadow` file
2. For some reason, we get an event about this, despite the TracingPolicy stating that the "shadow" container should only generate events about `/etc/shadow` accesses. This might be because the file is accesses during container startup and we don't yet have all the necessary information (ref [rthooks](https://tetragon.io/docs/concepts/runtime-hooks/)) 

Note, this PR also contains a drive-by improvement by pinning the ubuntu docker images.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
e2e/policyfilter: watch custom files for matchWorkloads test
```
