### PR TITLE
ci: bump go test job timeout to 60m

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -71,7 +71,7 @@ jobs:
         sudo -E echo "run go tests: " `uname -a`
         sudo -E go mod verify
         export TETRAGON_LIB=$(realpath "bpf/objs/")
-        make test GO_TEST_TIMEOUT=40m
+        make test GO_TEST_TIMEOUT=60m
 
     # Run some somple nok8s tests in packages where there is meaningful differentiation
     - name: Run nok8s go tests


### PR DESCRIPTION
### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

ARM runner exceeds the 40m job limit; raise timeout-minutes and GO_TEST_TIMEOUT to 60m.

Relates: https://github.com/cilium/tetragon/actions/runs/26885930800/job/79298025651?pr=5098

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
ci: bump go test job timeout to 60m
```
