### PR TITLE
feat: add direct stdout export mode

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net"
@@ -72,6 +73,12 @@ import (
 var (
 	log = logger.GetLogger()
 )
+
+// writeNopCloser wraps an io.Writer with a no-op Close to satisfy io.WriteCloser.
+// Used to pass os.Stdout to the exporter without letting the exporter close fd 1 at shutdown.
+type writeNopCloser struct{ io.Writer }
+
+func (writeNopCloser) Close() error { return nil }
 
 func getExportFilters() ([]*tetragon.Filter, []*tetragon.Filter, error) {
 	allowList, err := filters.ParseFilterList(viper.GetString(option.KeyExportAllowlist), viper.GetBool(option.KeyEnablePidSetFilter))
@@ -215,8 +222,12 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
-	if err := logger.SetupLogging(option.Config.LogOpts, option.Config.Debug); err != nil {
+	// If we use stdout for event exporting, we need to make sure that logs are not interleaving with JSON events on stdout.
+	if err := logger.SetupLogging(option.Config.LogOpts, option.Config.Debug, !option.Config.ExportStdout); err != nil {
 		logger.Fatal(log, "Failed to setup logging", logfields.Error, err)
+	}
+	if option.Config.ExportStdout {
+		log.Info("Logs redirected to stderr because --export-stdout is active")
 	}
 
 	if !filepath.IsAbs(option.Config.TracingPolicyDir) {
@@ -473,8 +484,14 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 	}
 
 	// Fetch the exporter if needed
+	if option.Config.ExportFilename != "" && option.Config.ExportStdout {
+		return fmt.Errorf("--export-filename and --export-stdout are mutually exclusive")
+	}
+	if option.Config.ExportStdout && option.Config.ExportFileRotationInterval > 0 {
+		return fmt.Errorf("--export-stdout and --export-file-rotation-interval are mutually exclusive")
+	}
 	var exporter *exporter.Exporter
-	if option.Config.ExportFilename != "" {
+	if option.Config.ExportFilename != "" || option.Config.ExportStdout {
 		exporter, err = getExporter(ctx, pm.Server)
 		if err != nil {
 			return fmt.Errorf("failed to fetch json exporter: %w", err)
@@ -498,7 +515,10 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 		health.StartHealthServer(ctx, option.Config.HealthServerAddress, option.Config.HealthServerInterval)
 	}
 
-	log.Info("Exporter configuration", "enabled", option.Config.ExportFilename != "", "fileName", option.Config.ExportFilename)
+	log.Info("Exporter configuration",
+		"file", option.Config.ExportFilename != "",
+		"stdout", option.Config.ExportStdout,
+		"fileName", option.Config.ExportFilename)
 	obs.AddListener(pm)
 	saveInitInfo()
 
@@ -657,24 +677,34 @@ func getExporter(ctx context.Context, server *server.Server) (*exporter.Exporter
 	if err != nil {
 		return nil, err
 	}
-	writer := &lumberjack.Logger{
-		Filename:   option.Config.ExportFilename,
-		MaxSize:    option.Config.ExportFileMaxSizeMB,
-		MaxBackups: option.Config.ExportFileMaxBackups,
-		Compress:   option.Config.ExportFileCompress,
-	}
 
-	perms, err := fileutils.RegularFilePerms(option.Config.ExportFilePerm)
-	if err != nil {
-		log.Warn(fmt.Sprintf("Failed to parse export file permission '%s', failing back to %v",
-			option.KeyExportFilePerm, perms), logfields.Error, err)
-	}
-	writer.FileMode = perms
+	var writer io.WriteCloser
+	if option.Config.ExportStdout {
+		writer = writeNopCloser{os.Stdout}
+		log.Info("Starting JSON exporter", "logger", "stdout")
+	} else {
+		lj := &lumberjack.Logger{
+			Filename:   option.Config.ExportFilename,
+			MaxSize:    option.Config.ExportFileMaxSizeMB,
+			MaxBackups: option.Config.ExportFileMaxBackups,
+			Compress:   option.Config.ExportFileCompress,
+		}
 
-	finfo, err := os.Stat(filepath.Clean(option.Config.ExportFilename))
-	if err == nil && finfo.IsDir() {
-		// Error if exportFilename points to a directory
-		return nil, errors.New("passed export JSON logs file point to a directory")
+		perms, err := fileutils.RegularFilePerms(option.Config.ExportFilePerm)
+		if err != nil {
+			log.Warn(fmt.Sprintf("Failed to parse export file permission '%s', failing back to %v",
+				option.KeyExportFilePerm, perms), logfields.Error, err)
+		}
+		lj.FileMode = perms
+
+		finfo, err := os.Stat(filepath.Clean(option.Config.ExportFilename))
+		if err == nil && finfo.IsDir() {
+			// Error if exportFilename points to a directory
+			return nil, errors.New("passed export JSON logs file point to a directory")
+		}
+
+		writer = lj
+		log.Info("Starting JSON exporter", "logger", lj)
 	}
 
 	// Track how many bytes are written to the event export location
@@ -693,7 +723,6 @@ func getExporter(ctx context.Context, server *server.Server) (*exporter.Exporter
 	}
 	req := tetragon.GetEventsRequest{AllowList: allowList, DenyList: denyList, AggregationOptions: aggregationOptions, FieldFilters: fieldFilters}
 	log.Info("Configured field filters", "fieldFilters", fieldFilters)
-	log.Info("Starting JSON exporter", "logger", writer, "request", &req)
 	return exporter.NewExporter(ctx, &req, server, encoder, writer, rateLimiter)
 }
 

--- a/install/kubernetes/tetragon/templates/_container_tetragon.tpl
+++ b/install/kubernetes/tetragon/templates/_container_tetragon.tpl
@@ -36,8 +36,10 @@
       name: cilium-run
     - mountPath: "/var/run/tetragon"
       name: tetragon-run
+    {{- if eq .Values.export.mode "stdout" }}
     - mountPath: {{ .Values.exportDirectory }}
       name: export-logs
+    {{- end }}
     - mountPath: "/procRoot"
       name: host-proc
 {{- if and (.Values.tetragon.cri.enabled) (.Values.tetragon.cri.socketHostPath) }}

--- a/install/kubernetes/tetragon/templates/daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/daemonset.yaml
@@ -83,10 +83,12 @@ spec:
         hostPath:
           path: /var/run/tetragon
           type: DirectoryOrCreate
+      {{- if eq .Values.export.mode "stdout" }}
       - name: export-logs
         hostPath:
           path: {{ .Values.exportDirectory }}
           type: DirectoryOrCreate
+      {{- end }}
       - name: tetragon-config
         configMap:
           name: {{ include "tetragon.configMapName" . }}

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -23,12 +23,24 @@ data:
   enable-process-ns: {{ .Values.tetragon.enableProcessNs | quote }}
   enable-ancestors: {{ .Values.tetragon.processAncestors.enabled | quote }}
   process-cache-size: {{ .Values.tetragon.processCacheSize | quote }}
-{{- if .Values.tetragon.exportFilename }}
+{{- if and .Values.tetragon.exportFilename (eq .Values.export.mode "stdout") }}
   export-filename: {{ .Values.exportDirectory}}/{{ .Values.tetragon.exportFilename }}
   export-file-perm: {{ .Values.tetragon.exportFilePerm | quote }}
   export-file-max-size-mb: {{ .Values.tetragon.exportFileMaxSizeMB | quote }}
   export-file-max-backups: {{ .Values.tetragon.exportFileMaxBackups | quote }}
   export-file-compress: {{ .Values.tetragon.exportFileCompress | quote }}
+  export-allowlist: |-
+{{- .Values.tetragon.exportAllowList | trim | nindent 4 }}
+  export-denylist: |-
+{{- .Values.tetragon.exportDenyList | trim | nindent 4 }}
+  field-filters: |-
+{{- .Values.tetragon.fieldFilters | trim | nindent 4 }}
+  redaction-filters: |-
+{{- .Values.tetragon.redactionFilters | trim | nindent 4 }}
+  export-rate-limit: {{ .Values.tetragon.exportRateLimit | quote }}
+{{- end }}
+{{- if eq .Values.export.mode "direct-stdout" }}
+  export-stdout: "true"
   export-allowlist: |-
 {{- .Values.tetragon.exportAllowList | trim | nindent 4 }}
   export-denylist: |-

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -412,7 +412,10 @@ tetragonOperator:
       scrapeInterval: 60s
 # -- Tetragon events export settings
 export:
-  # "stdout". "" to disable.
+  # Selects the export mode. Supported values:
+  #   "stdout":        Events are written to a log file and a sidecar container tails it to stdout (default).
+  #   "direct-stdout": Events are written directly to the tetragon container stdout. No sidecar or volume needed.
+  #   "":              Disables event export entirely.
   mode: "stdout"
   resources: {}
   securityContext: {}

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -51,18 +51,19 @@ func NewExporter(
 	closer io.Closer,
 	rateLimiter *ratelimit.RateLimiter,
 ) (*Exporter, error) {
-	logFile := filepath.Base(option.Config.ExportFilename)
-	logsDir, err := filepath.Abs(filepath.Dir(filepath.Clean(option.Config.ExportFilename)))
-	if err != nil {
-		logger.GetLogger().Warn(fmt.Sprintf("Failed to get absolute path of exported JSON logs '%s'", option.Config.ExportFilename), logfields.Error, err)
-		// Do not fail; we let lumberjack handle this. We want to
-		// log the rotate logs operation.
-		logsDir = filepath.Dir(option.Config.ExportFilename)
+	if option.Config.ExportFileRotationInterval < 0 {
+		return nil, fmt.Errorf("frequency '%s' at which to rotate JSON export files is negative", option.Config.ExportFileRotationInterval.String())
 	}
 
-	if option.Config.ExportFileRotationInterval < 0 {
-		// Passed an invalid interval let's error out
-		return nil, fmt.Errorf("frequency '%s' at which to rotate JSON export files is negative", option.Config.ExportFileRotationInterval.String())
+	var logFile, logsDir string
+	if !option.Config.ExportStdout {
+		logFile = filepath.Base(option.Config.ExportFilename)
+		var err error
+		logsDir, err = filepath.Abs(filepath.Dir(filepath.Clean(option.Config.ExportFilename)))
+		if err != nil {
+			logger.GetLogger().Warn(fmt.Sprintf("Failed to get absolute path of exported JSON logs '%s'", option.Config.ExportFilename), logfields.Error, err)
+			logsDir = filepath.Dir(option.Config.ExportFilename)
+		}
 	}
 
 	e := &Exporter{

--- a/pkg/logger/log.go
+++ b/pkg/logger/log.go
@@ -118,11 +118,11 @@ func PopulateLogOpts(o LogOptions, level, format, file string) {
 }
 
 // SetupLogging setup logger options taking into consideration the debug flag.
-func SetupLogging(o LogOptions, debug bool) error {
+func SetupLogging(o LogOptions, debug bool, useStdout bool) error {
 	if debug {
 		o[LevelOpt] = slog.LevelDebug.String()
 	}
-	initializeSlog(o, true)
+	initializeSlog(o, useStdout)
 
 	// always suppress the default logger so libraries don't print things
 	slog.SetLogLoggerLevel(LevelPanic)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -83,6 +83,7 @@ type config struct {
 	ExportFileCompress         bool
 	ExportRateLimit            int
 	ExportFilePerm             string
+	ExportStdout               bool
 
 	// Export aggregation options
 	EnableExportAggregation     bool

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -74,6 +74,7 @@ const (
 	KeyExportFileCompress         = "export-file-compress"
 	KeyExportRateLimit            = "export-rate-limit"
 	KeyExportFilePerm             = "export-file-perm"
+	KeyExportStdout               = "export-stdout"
 
 	KeyEnableExportAggregation     = "enable-export-aggregation"
 	KeyExportAggregationWindowSize = "export-aggregation-window-size"
@@ -252,6 +253,7 @@ func ReadAndSetFlags() error {
 	Config.ExportFileCompress = viper.GetBool(KeyExportFileCompress)
 	Config.ExportRateLimit = viper.GetInt(KeyExportRateLimit)
 	Config.ExportFilePerm = viper.GetString(KeyExportFilePerm)
+	Config.ExportStdout = viper.GetBool(KeyExportStdout)
 
 	Config.EnableExportAggregation = viper.GetBool(KeyEnableExportAggregation)
 	Config.ExportAggregationWindowSize = viper.GetDuration(KeyExportAggregationWindowSize)
@@ -463,6 +465,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Bool(KeyExportFileCompress, false, "Compress rotated JSON export files")
 	flags.String(KeyExportFilePerm, defaults.DefaultLogsPermission, "Access permissions on JSON export files")
 	flags.Int(KeyExportRateLimit, -1, "Rate limit (per minute) for event export. Set to -1 to disable")
+	flags.Bool(KeyExportStdout, false, "Export events directly to stdout. Disabled by default")
 	flags.String(KeyLogLevel, "info", "Set log level")
 	flags.String(KeyLogFormat, "text", "Set log format")
 	flags.String(KeyLogFile, "", "Set log file where tetragon agent logs will be written (in addition to stdout or stderr)")

--- a/pkg/testutils/sensors/testrun_linux.go
+++ b/pkg/testutils/sensors/testrun_linux.go
@@ -50,7 +50,7 @@ func TestSensorsRun(m *testing.M, sensorName string) int {
 	flag.Parse()
 
 	if config.Debug {
-		if err := logger.SetupLogging(option.Config.LogOpts, true); err != nil {
+		if err := logger.SetupLogging(option.Config.LogOpts, true, true); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/pkg/testutils/sensors/testrun_windows.go
+++ b/pkg/testutils/sensors/testrun_windows.go
@@ -50,7 +50,7 @@ func TestSensorsRun(m *testing.M, sensorName string) int {
 	flag.Parse()
 
 	if config.Debug {
-		if err := logger.SetupLogging(option.Config.LogOpts, true); err != nil {
+		if err := logger.SetupLogging(option.Config.LogOpts, true, true); err != nil {
 			log.Fatal(err)
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [X] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Fixes #1710 

### Description

Add a new `--export-stdout` flag that writes JSON events directly to the Tetragon agent's stdout instead of a file. In Kubernetes, this is exposed as `export.mode: direct-stdout` in the Helm chart, which removes the need for a sidecar container and an export-logs host volume.
When active, agent logs are automatically redirected to stderr to avoid interleaving with the event stream. The flag is mutually exclusive with `--export-filename` and `--export-file-rotation-interval`. The existing `stdout` (sidecar-based) mode remains the Helm default for now.


### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Add a new `--export-stdout` flag that writes JSON events directly to the Tetragon agent's stdout instead of a file. In Kubernetes, this is exposed as `export.mode: direct-stdout` in the Helm chart, which removes the need for a sidecar container and an export-logs host volume.
When active, agent logs are automatically redirected to stderr to avoid interleaving with the event stream. The flag is mutually exclusive with `--export-filename` and `--export-file-rotation-interval`. The existing `stdout` (sidecar-based) mode remains the Helm default for now.
```
