### PR TITLE
exporter: fix data race on exporterStartErr in Start()

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -438,7 +438,7 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 
 	// The "defer cleanupWg.Wait()" above, might introduce deadlocks if an error happens.
 	// This is because cancel() will not be called until cleanupWg.Wait() returns.
-	// But, the code in server/server.go:GetEventsWG() will only call cleanupWg.Done() if ctx.Done()
+	// But, the code in server/server.go:GetEventsListener() will only call cleanupWg.Done() if ctx is done
 	// Which causes a deadlock. To fix this, we add a new ctx and we pass that to the rest of the
 	// initialization functions. This means that we can cancel them without causing a deadlock
 	// using cancel2.

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/cilium/lumberjack/v2"
@@ -30,15 +31,18 @@ type ExportEncoder interface {
 }
 
 type Exporter struct {
-	ctx              context.Context
-	request          *tetragon.GetEventsRequest
-	server           *server.Server
-	encoder          ExportEncoder
-	closer           io.Closer
-	rateLimiter      *ratelimit.RateLimiter
+	ctx         context.Context
+	request     *tetragon.GetEventsRequest
+	server      *server.Server
+	encoder     ExportEncoder
+	closer      io.Closer
+	rateLimiter *ratelimit.RateLimiter
+	logFile     string
+	logsDir     string
+
+	// mu protects rotateTimer and rotationInterval for concurrent access.
+	mu               sync.Mutex
 	rotateTimer      *time.Timer
-	logFile          string
-	logsDir          string
 	rotationInterval time.Duration
 }
 
@@ -79,14 +83,17 @@ func NewExporter(
 }
 
 func (e *Exporter) Start() error {
-	// Start the rotation timer if needed
+	// Start the rotation timer if needed. Hold mu to honor the invariant that
+	// rotateTimer and rotationInterval are only accessed while holding it.
+	e.mu.Lock()
 	if e.rotationInterval > 0 {
-		_, ok := e.closer.(*lumberjack.Logger)
-		if !ok {
+		if _, ok := e.closer.(*lumberjack.Logger); !ok {
+			e.mu.Unlock()
 			return fmt.Errorf("writer must be of type lumberjack.Logger but got %T", e.closer)
 		}
 		e.rotateTimer = time.AfterFunc(e.rotationInterval, e.rotate)
 	}
+	e.mu.Unlock()
 
 	run, err := e.server.GetEventsListener(e.request, e, e.closer)
 	if err != nil {
@@ -96,6 +103,14 @@ func (e *Exporter) Start() error {
 		if err := run(); err != nil {
 			logger.GetLogger().Warn("JSON exporter terminated with error", logfields.Error, err)
 		}
+	}()
+
+	// Stop the self-rescheduling rotation timer once the exporter context is
+	// cancelled. Otherwise rotate() keeps rescheduling itself forever, leaking
+	// a timer (and, under virtual time, firing rotations unboundedly).
+	go func() {
+		<-e.ctx.Done()
+		e.stopRotateTimer()
 	}()
 	return nil
 }
@@ -107,7 +122,22 @@ func (e *Exporter) rotate() {
 	if rotationErr := writer.Rotate(); rotationErr != nil {
 		logger.GetLogger().Warn("Failed to rotate JSON export file", "file", option.Config.ExportFilename, logfields.Error, rotationErr)
 	}
-	e.rotateTimer = time.AfterFunc(e.rotationInterval, e.rotate)
+	// Do not reschedule once the context is cancelled, otherwise the timer
+	// keeps rescheduling itself forever even after the exporter is stopped.
+	e.mu.Lock()
+	if e.ctx.Err() == nil {
+		e.rotateTimer = time.AfterFunc(e.rotationInterval, e.rotate)
+	}
+	e.mu.Unlock()
+}
+
+// stopRotateTimer stops the self-rescheduling rotation timer, if any.
+func (e *Exporter) stopRotateTimer() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.rotateTimer != nil {
+		e.rotateTimer.Stop()
+	}
 }
 
 func (e *Exporter) Send(event *tetragon.GetEventsResponse) error {
@@ -165,14 +195,20 @@ func (e *Exporter) SetLogParams(params eventlog.Params) error {
 	}
 
 	if params.RotationInterval != nil {
+		e.mu.Lock()
 		if e.rotateTimer != nil {
 			e.rotateTimer.Stop()
 		}
 		e.rotationInterval = *params.RotationInterval
-		e.rotateTimer = time.AfterFunc(
-			e.rotationInterval,
-			e.rotate,
-		)
+		// Do not install a new timer once the context is cancelled, otherwise
+		// it would outlive shutdown (see rotate() and stopRotateTimer()).
+		if e.ctx.Err() == nil {
+			e.rotateTimer = time.AfterFunc(
+				e.rotationInterval,
+				e.rotate,
+			)
+		}
+		e.mu.Unlock()
 	}
 
 	return nil

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/cilium/lumberjack/v2"
@@ -89,18 +88,16 @@ func (e *Exporter) Start() error {
 		e.rotateTimer = time.AfterFunc(e.rotationInterval, e.rotate)
 	}
 
-	// Start the events processor
-	var readyWG sync.WaitGroup
-	var exporterStartErr error
-	readyWG.Add(1)
+	run, err := e.server.GetEventsListener(e.request, e, e.closer)
+	if err != nil {
+		return fmt.Errorf("error starting JSON exporter: %w", err)
+	}
 	go func() {
-		if err := e.server.GetEventsWG(e.request, e, e.closer, &readyWG); err != nil {
-			exporterStartErr = fmt.Errorf("error starting JSON exporter: %w", err)
+		if err := run(); err != nil {
+			logger.GetLogger().Warn("JSON exporter terminated with error", logfields.Error, err)
 		}
 	}()
-	readyWG.Wait()
-
-	return exporterStartErr
+	return nil
 }
 
 func (e *Exporter) rotate() {

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -66,7 +66,9 @@ type fakeNotifier struct {
 func newFakeNotifier() *fakeNotifier {
 	return &fakeNotifier{
 		listeners: make(map[server.Listener]struct{}),
-		removed:   make(chan bool),
+		// Buffered so RemoveListener never blocks the producer goroutine if nobody
+		// is currently waiting on removed (e.g. after a polling loop breaks).
+		removed: make(chan bool, 1),
 	}
 }
 
@@ -79,8 +81,8 @@ func (f *fakeNotifier) AddListener(listener server.Listener) {
 func (f *fakeNotifier) RemoveListener(listener server.Listener) {
 	f.mux.Lock()
 	delete(f.listeners, listener)
-	f.removed <- true
 	f.mux.Unlock()
+	f.removed <- true
 }
 
 func (f *fakeNotifier) NotifyListener(_ any, processed *tetragon.GetEventsResponse) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -122,99 +122,103 @@ func (s *Server) removeNotifierAndDrain(l *getEventsListener) {
 		}
 	}
 }
+
+// ListenerFunc is the event-loop function returned by GetEventsListener. It
+// blocks until the event loop terminates, returning nil on graceful shutdown or
+// an error if the loop exits unexpectedly.
+type ListenerFunc func() error
+
 func (s *Server) GetEvents(request *tetragon.GetEventsRequest, server tetragon.FineGuidanceSensors_GetEventsServer) error {
-	return s.GetEventsWG(request, server, nil, nil)
+	run, err := s.GetEventsListener(request, server, nil)
+	if err != nil {
+		return err
+	}
+	return run()
 }
 
-func (s *Server) GetEventsWG(request *tetragon.GetEventsRequest, server tetragon.FineGuidanceSensors_GetEventsServer, closer io.Closer, readyWG *sync.WaitGroup) error {
+// GetEventsListener builds the filter and aggregation setup for a GetEvents
+// request, registers the event listener with the notifier and returns a run
+// function that drives the event loop. Registering synchronously ensures that
+// events delivered between the call to GetEventsListener and the start of the
+// returned function are not lost. Separating setup from execution lets callers
+// distinguish setup errors (bad filter config, invalid aggregation options)
+// from runtime errors (send failures, context cancellation). Callers must
+// invoke the returned ListenerFunc to drain events and clean up the listener.
+func (s *Server) GetEventsListener(request *tetragon.GetEventsRequest, server tetragon.FineGuidanceSensors_GetEventsServer, closer io.Closer) (ListenerFunc, error) {
 	logger.GetLogger().Debug("Received a GetEvents request",
 		"events.allow_list", request.GetAllowList(),
 		"events.deny_list", request.GetDenyList(),
 		"events.field_filters", request.GetFieldFilters(),
 		"events.aggregation_options", request.GetAggregationOptions())
+
 	allowList, err := filters.BuildFilterList(s.ctx, request.AllowList, filters.Filters)
 	if err != nil {
-		if readyWG != nil {
-			readyWG.Done()
-		}
-		return err
+		return nil, err
 	}
 	denyList, err := filters.BuildFilterList(s.ctx, request.DenyList, filters.Filters)
 	if err != nil {
-		if readyWG != nil {
-			readyWG.Done()
-		}
-		return err
+		return nil, err
 	}
-	aggregator, err := aggregator.NewAggregator(server, request.AggregationOptions)
+	agg, err := aggregator.NewAggregator(server, request.AggregationOptions)
 	if err != nil {
-		if readyWG != nil {
-			readyWG.Done()
-		}
-		return err
-	}
-	if aggregator != nil {
-		go aggregator.Start()
+		return nil, err
 	}
 
 	l := newListener()
 	s.notifier.AddListener(l)
-	defer s.removeNotifierAndDrain(l)
-	if readyWG != nil {
-		readyWG.Done()
-	}
 	s.ctxCleanupWG.Add(1)
-	defer s.ctxCleanupWG.Done()
-	for {
-		select {
-		case event := <-l.events:
-			if !filters.Apply(allowList, denyList, &pkgEvent.Event{Event: event}) {
-				// Event is filtered out. Nothing to do here. Continue.
-				continue
-			}
 
-			// Get field filters
-			filters, err := fieldfilters.FieldFiltersFromGetEventsRequest(request)
-			if err != nil {
-				return fmt.Errorf("failed to create field filters: %w", err)
-			}
-
-			// Apply field filters
-			for _, filter := range filters {
-				ev, err := filter.Filter(event)
-				if err != nil {
-					logger.GetLogger().Warn("Failed to apply field filter", "filter", filter, logfields.Error, err)
+	return func() error {
+		defer s.ctxCleanupWG.Done()
+		defer s.removeNotifierAndDrain(l)
+		if agg != nil {
+			go agg.Start()
+		}
+		for {
+			select {
+			case event := <-l.events:
+				if !filters.Apply(allowList, denyList, &pkgEvent.Event{Event: event}) {
 					continue
 				}
-				event = ev
-			}
 
-			if aggregator != nil {
-				// Send event to aggregator.
-				select {
-				case aggregator.GetEventChannel() <- event:
-				default:
-					logger.GetLogger().Warn("Aggregator buffer is full. Consider increasing AggregatorOptions.channel_buffer_size.",
-						"request", request)
+				fieldFilters, err := fieldfilters.FieldFiltersFromGetEventsRequest(request)
+				if err != nil {
+					return fmt.Errorf("failed to create field filters: %w", err)
 				}
-			} else {
-				// No need to aggregate. Directly send out the response.
-				if err = server.Send(event); err != nil {
-					return err
+				for _, filter := range fieldFilters {
+					ev, err := filter.Filter(event)
+					if err != nil {
+						logger.GetLogger().Warn("Failed to apply field filter", "filter", filter, logfields.Error, err)
+						continue
+					}
+					event = ev
 				}
+
+				if agg != nil {
+					select {
+					case agg.GetEventChannel() <- event:
+					default:
+						logger.GetLogger().Warn("Aggregator buffer is full. Consider increasing AggregatorOptions.channel_buffer_size.",
+							"request", request)
+					}
+				} else {
+					if err = server.Send(event); err != nil {
+						return err
+					}
+				}
+			case <-server.Context().Done():
+				if closer != nil {
+					closer.Close()
+				}
+				return server.Context().Err()
+			case <-s.ctx.Done():
+				if closer != nil {
+					closer.Close()
+				}
+				return s.ctx.Err()
 			}
-		case <-server.Context().Done():
-			if closer != nil {
-				closer.Close()
-			}
-			return server.Context().Err()
-		case <-s.ctx.Done():
-			if closer != nil {
-				closer.Close()
-			}
-			return s.ctx.Err()
 		}
-	}
+	}, nil
 }
 
 func (s *Server) GetHealth(_ context.Context, request *tetragon.GetHealthStatusRequest) (*tetragon.GetHealthStatusResponse, error) {


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Fixes <!-- #issue-number -->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
The original GetEventsWG called readyWG.Done() on its three early-error paths (filter list build, aggregator creation) and then returned the error. The goroutine in exporter.Start() captured that error and wrote exporterStartErr *after* GetEventsWG returned, but readyWG.Done() may already have unblocked the main goroutine, which reads exporterStartErr concurrently. Under the Go memory model this is a data race; in practice the error is silently lost and the daemon starts with a broken, non-exporting exporter.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
fix: race condition on GetEventsWG startup error handling
```
