### PR TITLE
pkg/process: use atomic for color field in ProcessInternal

### DIFF
--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -28,15 +28,19 @@ type Cache struct {
 	stopChan   chan bool
 }
 
+// processColor tracks the garbage collection state of a process. It is stored
+// in ProcessInternal as an atomic and accessed via getColor/setColor.
+type processColor int32
+
 // garbage collection states
 const (
-	inUse = iota
+	inUse processColor = iota
 	deletePending
 	deleteReady
 	deleted
 )
 
-var colorStr = map[int]string{
+var colorStr = map[processColor]string{
 	inUse:         "inUse",
 	deletePending: "deletePending",
 	deleteReady:   "deleteReady",
@@ -77,15 +81,15 @@ func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 					 * process a second time, but that is harmless.
 					 */
 					if p.refcnt.Load() != 0 {
-						p.color = inUse
+						p.setColor(inUse)
 						continue
 					}
-					if p.color == deleteReady {
-						p.color = deleted
+					if p.getColor() == deleteReady {
+						p.setColor(deleted)
 						pc.remove(p.process)
 					} else {
 						newQueue = append(newQueue, p)
-						p.color = deleteReady
+						p.setColor(deleteReady)
 					}
 				}
 				deleteQueue = newQueue
@@ -93,21 +97,18 @@ func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 				// The object has already been deleted let if fall of
 				// the edge of the world. Hitting this could mean our
 				// GC logic deleted a process too early.
-				if p.color == deleted {
+				if p.getColor() == deleted {
 					processCacheEarlyDeletions.Inc()
 					continue
 				}
 				// duplicate deletes can happen, if they do reset
 				// color to pending and move along. This will cause
 				// the GC to keep it alive for at least another pass.
-				// Notice color is only ever touched inside GC behind
-				// select channel logic so should be safe to work on
-				// and assume its visible everywhere.
-				if p.color != inUse {
-					p.color = deletePending
+				if p.getColor() != inUse {
+					p.setColor(deletePending)
 					continue
 				}
-				p.color = deletePending
+				p.setColor(deletePending)
 				deleteQueue = append(deleteQueue, p)
 			}
 		}
@@ -165,7 +166,7 @@ func NewCache(
 			}
 
 			// Skip non-inUse entries whose exit path already performed parent--
-			if evicted.color != inUse {
+			if evicted.getColor() != inUse {
 				return
 			}
 
@@ -257,7 +258,7 @@ func (pc *Cache) dump(opts *tetragon.DumpProcessCacheReqArgs) []*tetragon.Proces
 			Process:   proto.Clone(v.process).(*tetragon.Process),
 			Refcnt:    &wrapperspb.UInt32Value{Value: ref},
 			RefcntOps: maps.Clone(v.refcntOps),
-			Color:     colorStr[v.color],
+			Color:     colorStr[v.getColor()],
 		})
 	}
 	return processes
@@ -270,7 +271,7 @@ func (pc *Cache) getEntries() []*tetragon.ProcessInternal {
 			Process:   v.process,
 			Refcnt:    &wrapperspb.UInt32Value{Value: v.refcnt.Load()},
 			RefcntOps: v.refcntOps,
-			Color:     colorStr[v.color],
+			Color:     colorStr[v.getColor()],
 		})
 	}
 	return processes

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -4,7 +4,9 @@
 package process
 
 import (
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -68,7 +70,7 @@ func TestProcessCacheGCEarlyDeletion(t *testing.T) {
 		}
 		cache.add(&proc)
 
-		proc.color = deleted
+		proc.setColor(deleted)
 		cache.deletePending(&proc)
 
 		// Wait for the GC goroutine to drain deleteChan and return to its
@@ -105,12 +107,12 @@ func TestProcessCacheGCLeak(t *testing.T) {
 		// The GC should drop it from the queue and reset its color to inUse.
 		cache.refDec(&proc, "test")
 		synctest.Wait()
-		assert.Equal(t, deletePending, proc.color)
+		assert.Equal(t, deletePending, proc.getColor())
 
 		cache.refInc(&proc, "test")
 		time.Sleep(interval + 1*time.Millisecond)
 		synctest.Wait()
-		assert.Equal(t, inUse, proc.color)
+		assert.Equal(t, inUse, proc.getColor())
 
 		// Trigger refDec to 0 again and wait for GC cycles to remove it.
 		// Two GC cycles are needed because the GC moves processes from:
@@ -125,9 +127,73 @@ func TestProcessCacheGCLeak(t *testing.T) {
 		time.Sleep(interval + 1*time.Millisecond)
 		synctest.Wait()
 
-		assert.Equal(t, deleted, proc.color)
+		assert.Equal(t, deleted, proc.getColor())
 		assert.Equal(t, 0, cache.len())
 	})
+}
+
+// TestProcessCacheColorDataRace exercises the GC goroutine writing the color
+// field concurrently with another goroutine reading it via getEntries (the same
+// read path used by dump). Before color was made atomic this test reports a data
+// race under -race. It must stay clean now that color uses atomic access.
+func TestProcessCacheColorDataRace(t *testing.T) {
+	interval := 1 * time.Millisecond
+	cache, err := NewCache(100, interval)
+	require.NoError(t, err)
+	defer cache.purge()
+
+	procs := make([]*ProcessInternal, 0, 50)
+	for i := 0; i < 50; i++ {
+		p := &ProcessInternal{
+			process: &tetragon.Process{
+				ExecId: "proc" + strconv.Itoa(i),
+				Pid:    &wrapperspb.UInt32Value{Value: uint32(1000 + i)},
+			},
+			refcntOps: make(map[string]int32),
+		}
+		p.refcnt.Store(1)
+		cache.add(p)
+		procs = append(procs, p)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Reader goroutine: reads color via the getEntries path repeatedly.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				cache.getEntries()
+			}
+		}
+	}()
+
+	// Writer goroutine: churns refcnt so the GC goroutine keeps writing color
+	// (inUse -> deletePending -> deleteReady -> inUse ...).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for _, p := range procs {
+					cache.refDec(p, "race")
+					cache.refInc(p, "race")
+				}
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }
 
 func TestProcessCacheDoubleParentDecrease(t *testing.T) {
@@ -163,13 +229,13 @@ func TestProcessCacheDoubleParentDecrease(t *testing.T) {
 
 		cache.refDec(child, "process--")
 		synctest.Wait()
-		assert.Equal(t, deletePending, child.color)
+		assert.Equal(t, deletePending, child.getColor())
 
 		// simulate resurrection: refInc after deletePending
 		cache.refInc(child, "late-event")
 		time.Sleep(interval + 1*time.Millisecond)
 		synctest.Wait()
-		assert.Equal(t, inUse, child.color)
+		assert.Equal(t, inUse, child.getColor())
 
 		// trigger LRU eviction of child
 		cache.get("parent")

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -143,7 +143,7 @@ func TestProcessCacheColorDataRace(t *testing.T) {
 	defer cache.purge()
 
 	procs := make([]*ProcessInternal, 0, 50)
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		p := &ProcessInternal{
 			process: &tetragon.Process{
 				ExecId: "proc" + strconv.Itoa(i),
@@ -160,9 +160,7 @@ func TestProcessCacheColorDataRace(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Reader goroutine: reads color via the getEntries path repeatedly.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -171,13 +169,11 @@ func TestProcessCacheColorDataRace(t *testing.T) {
 				cache.getEntries()
 			}
 		}
-	}()
+	})
 
 	// Writer goroutine: churns refcnt so the GC goroutine keeps writing color
 	// (inUse -> deletePending -> deleteReady -> inUse ...).
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -189,7 +185,7 @@ func TestProcessCacheColorDataRace(t *testing.T) {
 				}
 			}
 		}
-	}()
+	})
 
 	time.Sleep(200 * time.Millisecond)
 	close(stop)

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -49,8 +49,10 @@ type ProcessInternal struct {
 	// will be constructed on the fly when returning these extra fields
 	// about the binary during the corresponding ProcessExec only.
 	apiBinaryProp *tetragon.BinaryProperties
-	// garbage collector metadata
-	color  int // Writes should happen only inside gc select channel
+	// garbage collector metadata. color is accessed from the GC goroutine and
+	// concurrently read by dump()/getEntries() and the LRU eviction callback, so
+	// it is stored as an atomic and must only be touched via getColor/setColor.
+	color  atomic.Int32
 	refcnt atomic.Uint32
 	// parentRefcntDecreased tracks whether the parent reference count has been
 	// decreased for this process. This is used to avoid double parent-- when
@@ -246,6 +248,14 @@ func (pi *ProcessInternal) GetParentRefcntDecreased() bool {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
 	return pi.parentRefcntDecreased
+}
+
+func (pi *ProcessInternal) getColor() processColor {
+	return processColor(pi.color.Load())
+}
+
+func (pi *ProcessInternal) setColor(c processColor) {
+	pi.color.Store(int32(c))
 }
 
 func (pi *ProcessInternal) NeededAncestors() bool {


### PR DESCRIPTION
## Description

The `color` field in `ProcessInternal` (`pkg/process/process.go`) tracks the garbage collection state of a process. It is written by the `cacheGarbageCollector` goroutine, but it is also read concurrently from other goroutines:

- `dump()` and `getEntries()` read `v.color` when building the API response for a process-cache dump.
- the LRU eviction callback in `NewCache` reads `evicted.color` to decide whether to perform the parent refcount decrement.

None of this access was synchronized. This was raised during the review of #5057: once GC could transition a process back to `inUse` (the fix in that PR), the unsynchronized access became a correctness concern, not just a memory-visibility one, because eviction can incorrectly skip or apply parent refcount adjustments depending on a torn or stale read of `color`. Reviewers (@kevsecurity, @tpapagian, @will-isovalent) agreed that switching `color` to an atomic in a follow-up made sense, and that follow-up is tracked in #5089.

## Changes

- Store `color` as `atomic.Int32` in `ProcessInternal` and route every read/write through two small helpers, `getColor()` and `setColor()`, so all access is synchronized. The GC state machine and its transitions are unchanged.
- Introduce a named `processColor` type for the state constants (`inUse`, `deletePending`, `deleteReady`, `deleted`) so the colors are constrained to the valid set instead of plain `int`. This also picks up the suggestion in #5089 to make the color enum a real type.

All `color` access sites were updated: the GC loop in `cacheGarbageCollector` (the `<-ticker.C` and `<-pc.deleteChan` cases), the LRU eviction callback, and the `dump()` / `getEntries()` read paths.

## Testing

Added `TestProcessCacheColorDataRace`, which runs the GC writing `color` (driven by a refcnt-churn goroutine) concurrently with a goroutine reading `color` through `getEntries()`, the same read path used by `dump()`.

Before the change, the race detector flags the conflict:

```
WARNING: DATA RACE
Write at 0x... by goroutine 27:
  pkg/process.(*Cache).cacheGarbageCollector.func1()
      pkg/process/cache.go:110

Previous read at 0x... by goroutine 28:
  pkg/process.(*Cache).getEntries()
      pkg/process/cache.go:273
```

After the change:

```
$ go test -race -count=1 ./pkg/process/...
ok  	github.com/cilium/tetragon/pkg/process
```

`go test -race ./pkg/process/...` is clean, `go build ./...` passes, and `go vet ./pkg/process/...` is clean. Reverting only the source change (keeping the new test) makes the race reappear, which confirms the test guards against a regression.

Fixes: #5089
