### PR TITLE
sensors: add support for fd type to retrieve file*

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -251,7 +251,6 @@ __read_arg_1(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 {
 	struct msg_generic_kprobe *e;
 	long size = -1;
-	long ret = 0;
 	int zero = 0;
 
 	e = map_lookup_elem(&process_call_heap, &zero);
@@ -262,36 +261,6 @@ __read_arg_1(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 	case iov_iter_type:
 		size = copy_iov_iter(ctx, orig_off, arg, argm, e);
 		break;
-	case fd_ty: {
-		struct fdinstall_key key = { 0 };
-		struct fdinstall_value *val;
-
-		key.tid = get_current_pid_tgid() >> 32;
-		key.fd = arg;
-
-		val = map_lookup_elem(&fdinstall_map, &key);
-		if (val) {
-			__u32 bytes = *((__u32 *)&val->file[0]);
-
-			memcpy(&args[0], &key.fd, sizeof(key.fd));
-			asm volatile("%[bytes] &= 0xfff;\n"
-				     : [bytes] "+r"(bytes)
-				     :);
-			// size + file path + flags
-			size = 4 + bytes + 4;
-			ret = probe_read(&args[4], size, (char *)&val->file[0]);
-			if (ret < 0)
-				return ret;
-
-			// account for fd written at args[0]
-			size += 4;
-		} else {
-			/* If filter specification is fd type then we
-			 * prevent the filter from matching
-			 */
-			return -1;
-		}
-	} break;
 	case filename_ty: {
 		struct filename *file;
 
@@ -502,9 +471,9 @@ read_arg(void *ctx, int index, int type, long orig_off, unsigned long arg, int a
 	}
 
 	if (ret < 0) {
-		/* fd_ty returns -1 when the fd is not in the fdinstall_map,
-		 * meaning the filter should not match (event should be dropped).
-		 * This is a filter decision, not a fault.
+		/* fd_ty returns -1 when the fd cannot be resolved, meaning the
+		 * filter should not match (event should be dropped). This is a
+		 * filter decision, not a fault.
 		 */
 		if (type == fd_ty)
 			return -1;

--- a/bpf/process/generic_path.h
+++ b/bpf/process/generic_path.h
@@ -227,6 +227,7 @@ FUNC_INLINE bool should_offload_path(long type)
 	case path_ty:
 	case dentry_type:
 	case linux_binprm_type:
+	case fd_ty:
 		return true;
 	}
 	return false;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -2238,9 +2238,6 @@ filter_arg_2(struct msg_generic_kprobe *e, struct selector_arg_filter *filter, c
 {
 	switch (filter->type) {
 	case fd_ty:
-		/* Advance args past fd */
-		args += 4;
-		fallthrough;
 	case file_ty:
 	case path_ty:
 	case dentry_type:
@@ -2766,6 +2763,38 @@ FUNC_INLINE void path_from_dentry(struct dentry *dentry, struct path *path_buf)
 	path_buf->dentry = dentry;
 }
 
+FUNC_INLINE const struct path *path_from_fd(unsigned long fd)
+{
+	struct task_struct *task = (struct task_struct *)get_current_task();
+	struct files_struct *files = NULL;
+	struct fdtable *fdt = NULL;
+	struct file **fd_array = NULL;
+	struct file *file = NULL;
+	__u32 fd_idx;
+	__u32 max_fds;
+
+	if (fd > 0xffffffff)
+		return NULL;
+	fd_idx = (__u32)fd;
+
+	if (BPF_CORE_READ_INTO(&files, task, files) != 0 || !files)
+		return NULL;
+	if (BPF_CORE_READ_INTO(&fdt, files, fdt) != 0 || !fdt)
+		return NULL;
+	if (BPF_CORE_READ_INTO(&max_fds, fdt, max_fds) != 0)
+		return NULL;
+	if (fd_idx >= max_fds)
+		return NULL;
+	if (BPF_CORE_READ_INTO(&fd_array, fdt, fd) != 0 || !fd_array)
+		return NULL;
+
+	probe_read(&file, sizeof(file), &fd_array[fd_idx]);
+	if (!file)
+		return NULL;
+
+	return _(&file->f_path);
+}
+
 FUNC_INLINE const struct path *get_path(long type, unsigned long arg, struct path *path_buf)
 {
 	const struct path *path_arg = 0;
@@ -2789,6 +2818,9 @@ FUNC_INLINE const struct path *get_path(long type, unsigned long arg, struct pat
 	case dentry_type:
 		path_from_dentry((struct dentry *)arg, path_buf);
 		path_arg = path_buf;
+		break;
+	case fd_ty:
+		path_arg = path_from_fd(arg);
 		break;
 #ifdef __LARGE_BPF_PROG
 	case linux_binprm_type: {

--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -25,6 +25,9 @@ Depending on your setup, changes listed here might require a manual intervention
   behavior. Only `TrackSock` and `UntrackSock` are supported. Existing policies
   that set `returnArgAction: "Post"` should remove the field.
 
+* `fd` type no longer needs the pre `FollowFD` and post `UnfollowFD` actions to resolve the
+  path and works on its own. Existing policies that used `fd` type should be updated to remove the hooks associated with the `FollowFD` and `UnfollowFD` actions. The structure around the use of `fd` hasn't changed and no update should be necessary to the hook that used the type. 
+
 ### Events (protobuf API)
 
 * TBD

--- a/pkg/sensors/tracing/args_linux.go
+++ b/pkg/sensors/tracing/args_linux.go
@@ -182,13 +182,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 	case gt.GenericFileType, gt.GenericFdType, gt.GenericKiocb:
 		var arg api.MsgGenericKprobeArgFile
 		var flags uint32
-		var b int32
 		var mode uint16
-
-		/* Eat file descriptor its not used in userland */
-		if a.ty == gt.GenericFdType {
-			binary.Read(r, binary.LittleEndian, &b)
-		}
 
 		arg.Index = uint64(a.index)
 		arg.Value, err = parseString(r)
@@ -211,7 +205,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 			flags = 0
 		}
 
-		if a.ty == gt.GenericFileType || a.ty == gt.GenericKiocb {
+		if a.ty == gt.GenericFileType || a.ty == gt.GenericFdType || a.ty == gt.GenericKiocb {
 			err := binary.Read(r, binary.LittleEndian, &mode)
 			if err != nil {
 				mode = 0

--- a/pkg/sensors/tracing/fentry_test.go
+++ b/pkg/sensors/tracing/fentry_test.go
@@ -535,3 +535,10 @@ func TestSubStringPathFentry(t *testing.T) {
 		"Hook": "fentries",
 	})
 }
+
+func TestFdRetrivalFentry(t *testing.T) {
+	checkFentry(t)
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-fd-arg", map[string]any{
+		"Hook": "fentries",
+	})
+}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -1156,14 +1156,8 @@ func handleMsgGenericTracepoint(
 		case gt.GenericFileType, gt.GenericFdType, gt.GenericKiocb:
 			var arg tracingapi.MsgGenericKprobeArgFile
 			var flags uint32
-			var b int32
 			var mode uint16
 			var err error
-
-			/* Eat file descriptor its not used in userland */
-			if out.genericTypeId == gt.GenericFdType {
-				binary.Read(r, binary.LittleEndian, &b)
-			}
 
 			arg.Value, err = parseString(r)
 			if err != nil {
@@ -1185,7 +1179,7 @@ func handleMsgGenericTracepoint(
 				flags = 0
 			}
 
-			if out.genericTypeId == gt.GenericFileType || out.genericTypeId == gt.GenericKiocb {
+			if out.genericTypeId == gt.GenericFileType || out.genericTypeId == gt.GenericFdType || out.genericTypeId == gt.GenericKiocb {
 				err = binary.Read(r, binary.LittleEndian, &mode)
 				if err != nil {
 					mode = 0

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -5774,6 +5774,12 @@ func TestSubStringPath(t *testing.T) {
 	})
 }
 
+func TestFdRetrival(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "kprobe-fd-arg", map[string]any{
+		"Hook": "kprobes",
+	})
+}
+
 // Test module loading/unloading on Ubuntu
 func testTraceKernelModule(t *testing.T, fentry bool) {
 	_, err := ftrace.ReadAvailFuncs("^find_module_sections$")

--- a/tests/policytests/kprobes.go
+++ b/tests/policytests/kprobes.go
@@ -9,14 +9,18 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"syscall"
 
 	ebtf "github.com/cilium/ebpf/btf"
 	"golang.org/x/sys/unix"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/bpf"
+	bc "github.com/cilium/tetragon/pkg/matchers/bytesmatcher"
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	tpath "github.com/cilium/tetragon/pkg/reader/path"
 	"github.com/cilium/tetragon/pkg/testutils/policytest"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 )
@@ -86,6 +90,101 @@ spec:
 		Name:         "check null pointer passed for string argument",
 		Trigger:      policytest.NewCmdTrigger(myBin).ExpectExitCode(0),
 		EventChecker: ec.NewUnorderedEventChecker(argChecker),
+	}
+}).RegisterAtInit()
+
+type fdWriteTrigger struct {
+	dir  string
+	path string
+}
+
+func (t *fdWriteTrigger) Trigger(_ context.Context) error {
+	defer os.RemoveAll(t.dir)
+
+	file, err := os.OpenFile(t.path, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		return fmt.Errorf("open fd target: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString("hello fd\n"); err != nil {
+		return fmt.Errorf("write fd target: %w", err)
+	}
+	return nil
+}
+
+var _ = policytest.NewBuilder("kprobe-fd-arg").
+	WithLabels("kprobes").
+	WithParameter(policytest.Parameter{
+		Name:    "Hook",
+		Default: "kprobes",
+		Help:    "type of hook to use in the policy",
+	}).WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "kprobe-fd-arg"
+spec:
+  {{ .Hook }}:
+  - call: "sys_write"
+    syscall: true
+    args:
+    - index: 0
+      type: "fd"
+    - index: 1
+      type: "char_buf"
+      sizeArgIndex: 3
+    - index: 2
+      type: "size_t"
+    selectors:
+    - matchArgs:
+      - operator: Postfix
+        index: 0
+        values:
+        - "/target"
+`).AddScenario(func(_ *policytest.Conf) *policytest.Scenario {
+	dir, err := os.MkdirTemp("", "kprobe-fd-arg")
+	if err != nil {
+		return &policytest.Scenario{
+			Name:    "failed to create temp dir",
+			Trigger: policytest.NewCmdTrigger("/usr/bin/false"),
+		}
+	}
+	filePath := filepath.Join(dir, "target")
+	if err := os.WriteFile(filePath, []byte{}, 0644); err != nil {
+		os.RemoveAll(dir)
+		return &policytest.Scenario{
+			Name:    "failed to create temp file",
+			Trigger: policytest.NewCmdTrigger("/usr/bin/false"),
+		}
+	}
+	st, err := os.Stat(filePath)
+	if err != nil {
+		os.RemoveAll(dir)
+		return &policytest.Scenario{
+			Name:    "failed to stat temp file",
+			Trigger: policytest.NewCmdTrigger("/usr/bin/false"),
+		}
+	}
+	permission := tpath.FilePathModeToStr(uint16(st.Mode() | syscall.S_IFREG))
+
+	checker := ec.NewProcessKprobeChecker("").
+		WithFunctionName(sm.Suffix("sys_write")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithFileArg(ec.NewKprobeFileChecker().
+					WithPath(sm.Full(filePath)).
+					WithPermission(sm.Full(permission)),
+				),
+				ec.NewKprobeArgumentChecker().WithBytesArg(bc.Full([]byte("hello fd\n"))),
+				ec.NewKprobeArgumentChecker().WithSizeArg(9),
+			))
+
+	return &policytest.Scenario{
+		Name:         "file retrieval through fd type",
+		Trigger:      &fdWriteTrigger{dir: dir, path: filePath},
+		EventChecker: ec.NewUnorderedEventChecker(checker),
 	}
 }).RegisterAtInit()
 


### PR DESCRIPTION
Currently, `fd` type would only be populated through the deprecated FollowFD feature. 
We can instead resolve the `fd` directly against the current_task (`files->fdt->fd[n]`) and get the file* pointer.

Add tests for the feature too.


Example event generated:

```yaml
{
  "process_kprobe": {
    "process": {
      "exec_id": "dWJ1bnR1MjQwNDoxNjQ4MjkxNTAwMDAwMDA6MzIxNzQ=",
      "pid": 32174,
      "uid": 1000,
      "cwd": "/home/litios",
      "binary": "/usr/bin/zsh",
      "flags": "procFS",
      "start_time": "2026-06-05T09:17:06.837726801Z",
      "auid": 1000,
      "parent_exec_id": "dWJ1bnR1MjQwNDoxNjQ4MjkxMDAwMDAwMDA6MzIxNzM=",
      "refcnt": 1,
      "tid": 32174,
      "in_init_tree": false
    },
    "parent": {
      "exec_id": "dWJ1bnR1MjQwNDoxNjQ4MjkxMDAwMDAwMDA6MzIxNzM=",
      "pid": 32173,
      "uid": 1000,
      "cwd": "/",
      "binary": "/usr/sbin/sshd",
      "flags": "procFS rootcwd",
      "start_time": "2026-06-05T09:17:06.787726790Z",
      "auid": 1000,
      "parent_exec_id": "dWJ1bnR1MjQwNDoxNjQ4MjgwNzAwMDAwMDA6MzIwNzQ=",
      "tid": 32173,
      "in_init_tree": false
    },
    "function_name": "__x64_sys_write",
    "args": [
      {
        "file_arg": {
          "path": "/tmp/target",
          "permission": "-rw-rw-r--"
        }
      },
      {
        "bytes_arg": "QUFvQQo="
      },
      {
        "size_arg": "5"
      }
    ],
    "action": "KPROBE_ACTION_POST",
    "policy_name": "kprobe-fd-arg-live-file",
    "return_action": "KPROBE_ACTION_POST"
  },
  "node_name": "ubuntu2404",
  "time": "2026-06-05T09:36:41.053843626Z"
}
```