### PR TITLE
lsm: fixing bug with multiple lsm hook entries

### DIFF
--- a/cmd/tetra/policytest/policytest.go
+++ b/cmd/tetra/policytest/policytest.go
@@ -104,11 +104,12 @@ func dumpPolicyCmd() *cobra.Command {
 			}
 
 			for _, t := range tests {
-				pol, err := t.Policy(&conf)
+				pol, cleanup, err := t.Policy(&conf)
 				if err != nil {
 					return err
 				}
 				cmd.OutOrStdout().Write([]byte(pol))
+				cleanup()
 			}
 			return nil
 		},

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -74,6 +74,8 @@ type genericLsm struct {
 	tags []string
 	// is IMA hash collector program needed to load
 	imaProgLoad bool
+	// instance identifier to mitigate duplicate hooks at same location
+	instance int
 }
 
 func (g *genericLsm) SetID(id idtable.EntryID) {
@@ -290,7 +292,7 @@ type addLsmIn struct {
 	selectorStatsBase uint32
 }
 
-func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err error) {
+func addLsm(f *v1alpha1.LsmHookSpec, instance int, in *addLsmIn) (id idtable.EntryID, err error) {
 	var argSigPrinters []argPrinter
 	var argsBTFSet [api.MaxArgsSupported]bool
 	var allBTFArgs [api.EventConfigMaxArgs][api.MaxBTFArgDepth]api.ConfigBTFArg
@@ -379,6 +381,7 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 		message:     msgField,
 		tags:        tagsField,
 		imaProgLoad: false,
+		instance:    instance,
 	}
 
 	for _, sel := range f.Selectors {
@@ -434,6 +437,7 @@ func createGenericLsmSensor(
 	}
 
 	var selectorStatsBase uint32
+	dups := make(map[string]int)
 	for _, hook := range lsmHooks {
 		if err := appendMacrosSelectors(hook.Selectors, spec.SelectorsMacros); err != nil {
 			return nil, fmt.Errorf("append macros selectors: %w", err)
@@ -442,7 +446,13 @@ func createGenericLsmSensor(
 		in.selectorStatsBase = selectorStatsBase
 		selectorStatsBase += uint32(len(hook.Selectors))
 
-		id, err := addLsm(&hook, &in)
+		instance, ok := dups[hook.Hook]
+		if ok {
+			instance++
+		}
+		dups[hook.Hook] = instance
+
+		id, err := addLsm(&hook, instance, &in)
 		if err != nil {
 			return nil, err
 		}
@@ -537,6 +547,10 @@ func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 	progs []*program.Program, maps []*program.Map) ([]*program.Program, []*program.Map) {
 
 	loadProgCoreName, loadProgOutputName := config.GenericLsmObjs()
+	pinName := lsmEntry.hook
+	if lsmEntry.instance != 0 {
+		pinName = fmt.Sprintf("%s:%d", lsmEntry.hook, lsmEntry.instance)
+	}
 
 	/* We need to load LSM programs in the following order:
 	   1. bpf_generic_lsm_output
@@ -547,7 +561,7 @@ func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 		path.Join(option.Config.HubbleLib, loadProgOutputName),
 		lsmEntry.hook,
 		"lsm/generic_lsm_output",
-		lsmEntry.hook,
+		pinName,
 		"generic_lsm").
 		SetLoaderData(lsmEntry.tableId).
 		SetPolicy(lsmEntry.policyName)
@@ -557,7 +571,7 @@ func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 		path.Join(option.Config.HubbleLib, loadProgCoreName),
 		lsmEntry.hook,
 		"lsm/generic_lsm_core",
-		lsmEntry.hook,
+		pinName,
 		"generic_lsm").
 		SetLoaderData(lsmEntry.tableId).
 		SetPolicy(lsmEntry.policyName)
@@ -571,7 +585,7 @@ func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 				path.Join(option.Config.HubbleLib, loadProgImaName),
 				lsmEntry.hook,
 				"lsm.s/generic_lsm_ima_"+loadProgImaType,
-				lsmEntry.hook,
+				pinName,
 				"generic_lsm").
 				SetLoaderData(lsmEntry.tableId).
 				SetPolicy(lsmEntry.policyName)

--- a/pkg/sensors/tracing/lsm_test.go
+++ b/pkg/sensors/tracing/lsm_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/testutils"
+	"github.com/cilium/tetragon/pkg/testutils/policytest"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 )
 
@@ -453,4 +454,8 @@ spec:
 		return true
 	}
 	require.Condition(t, checkFunc)
+}
+
+func TestLSMDuplicateHooks(t *testing.T) {
+	policytest.AllPolicyTests.DoObserverTest(t, "lsm-dup-hooks", nil)
 }

--- a/pkg/testutils/policytest/builder.go
+++ b/pkg/testutils/policytest/builder.go
@@ -39,17 +39,31 @@ func (b *Builder) WithParameter(p Parameter) *Builder {
 //
 // In the template, the following functions are supported
 //   - testBinary: generate a test binary path from the binary name (Conf.TestBinary())
+//   - tempFile: generate a temporary file and save it in the conf
 func (b *Builder) WithPolicyTemplate(tmpl string) *Builder {
 	policyTest := b.policytest
-	policyTest.Policy = func(c *Conf) (Policy, error) {
+	policyTest.Policy = func(c *Conf) (Policy, PolicyCleanupFn, error) {
 		funcMap := template.FuncMap{
 			"testBinary": func(s string) string {
 				return c.TestBinary(s)
 			},
+			"tempFile": func(key string) (string, error) {
+				return c.TempFile(key)
+			},
 		}
+
 		t, err := template.New("testpolicy").Funcs(funcMap).Parse(tmpl)
+
+		// Clean up any temp files created if this function returns due to an
+		// error
+		defer func() {
+			if err != nil {
+				c.CleanupTempFiles()
+			}
+		}()
+
 		if err != nil {
-			return Policy(""), fmt.Errorf("failed to parse template: %w", err)
+			return Policy(""), nil, fmt.Errorf("failed to parse template: %w", err)
 		}
 
 		// fill in params
@@ -65,9 +79,9 @@ func (b *Builder) WithPolicyTemplate(tmpl string) *Builder {
 		var buf bytes.Buffer
 		err = t.Execute(&buf, params)
 		if err != nil {
-			return Policy(""), fmt.Errorf("failed to execute template: %w", err)
+			return Policy(""), nil, fmt.Errorf("failed to execute template: %w", err)
 		}
-		return Policy(buf.String()), nil
+		return Policy(buf.String()), c.CleanupTempFiles, nil
 	}
 	return b
 }

--- a/pkg/testutils/policytest/conf.go
+++ b/pkg/testutils/policytest/conf.go
@@ -7,8 +7,10 @@ package policytest
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 type ParamVals map[string]any
@@ -43,8 +45,54 @@ type Conf struct {
 
 	// Path to save the generated policy
 	DumpPolicyPath string
+
+	// Map of temporary files generated for this generated policy. Key is
+	// unique identifier for the temp file, value is the generated temp
+	// filename
+	tempFiles   map[string]string
+	tempFilesMu sync.Mutex
 }
 
 func (c *Conf) TestBinary(s string) string {
 	return filepath.Join(c.BinsDir, s)
+}
+
+func (c *Conf) TempFile(key string) (string, error) {
+	c.tempFilesMu.Lock()
+	defer c.tempFilesMu.Unlock()
+
+	if c.tempFiles == nil {
+		c.tempFiles = make(map[string]string)
+	} else if path, ok := c.tempFiles[key]; ok {
+		return path, nil // already created — return cached path
+	}
+	tempFile, err := os.CreateTemp("", "tetragon-testfile-*")
+	if err != nil {
+		return "", err
+	}
+	tempFile.Close()
+	path := tempFile.Name()
+	c.tempFiles[key] = path
+	return path, nil
+}
+
+func (c *Conf) TempFileMust(key string) string {
+	ret, err := c.TempFile(key)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+func (c *Conf) CleanupTempFiles() {
+	c.tempFilesMu.Lock()
+	defer c.tempFilesMu.Unlock()
+
+	if c.tempFiles == nil {
+		return
+	}
+	for _, tempFile := range c.tempFiles {
+		os.Remove(tempFile)
+	}
+	c.tempFiles = nil
 }

--- a/pkg/testutils/policytest/observertest.go
+++ b/pkg/testutils/policytest/observertest.go
@@ -58,10 +58,11 @@ func (rpt *RegisteredPolicyTests) DoObserverTest(
 			ParamValues: params,
 		},
 	}
-	policyStr, err := pt.Policy(conf)
+	policyStr, cleanupFn, err := pt.Policy(conf)
 	if err != nil {
 		t.Fatalf("failed to generate policy: %s", err)
 	}
+	t.Cleanup(cleanupFn)
 
 	policyFile, err := os.CreateTemp("", "tetragon-policy-"+t.Name()+"-*.txt")
 	if err != nil {

--- a/pkg/testutils/policytest/policytest.go
+++ b/pkg/testutils/policytest/policytest.go
@@ -31,6 +31,8 @@ type Scenario struct {
 // Policies are represented as strings, because that's how they are loaded via gRPC
 type Policy string
 
+type PolicyCleanupFn func()
+
 type Label string
 
 type SkipInfo struct {
@@ -69,7 +71,7 @@ type T struct {
 	ShouldSkip func(info *SkipInfo) string
 
 	// Policy generates a policy for this test
-	Policy func(c *Conf) (Policy, error)
+	Policy func(c *Conf) (Policy, PolicyCleanupFn, error)
 
 	Params []Parameter
 

--- a/pkg/testutils/policytest/runner.go
+++ b/pkg/testutils/policytest/runner.go
@@ -115,11 +115,20 @@ func (r *LocalRunner) Close() {
 
 func (r *LocalRunner) AddPolicy(l *slog.Logger, test *T) (*PolicyHandler, error) {
 	// generate policy
-	pol, err := test.Policy(r.conf)
+	pol, cleanup, err := test.Policy(r.conf)
 	if err != nil {
 		err = fmt.Errorf("failed to create policy for test %q: %w", test.Name, err)
 		return nil, err
 	}
+
+	// call cleanup if we're returning due to an error. Note that this won't
+	// run if the test doesn't have a policy but there should be nothing to
+	// clean up in this case
+	defer func() {
+		if err != nil {
+			cleanup()
+		}
+	}()
 
 	// allow for tests that do not have a policy
 	if len(pol) == 0 {
@@ -154,6 +163,7 @@ func (r *LocalRunner) AddPolicy(l *slog.Logger, test *T) (*PolicyHandler, error)
 	return &PolicyHandler{
 		tpName:      tpName,
 		tpNamespace: "", // TODO: change this when we add support for namespaced policies
+		cleanup:     cleanup,
 	}, nil
 }
 
@@ -385,9 +395,15 @@ func runFwd(
 type PolicyHandler struct {
 	tpName      string
 	tpNamespace string
+	cleanup     PolicyCleanupFn
 }
 
 func (ph *PolicyHandler) Cleanup(l *slog.Logger, conf *Conf, client *cli.ClientWithContext) error {
+
+	// call policy cleanup after we are done
+	if ph.cleanup != nil {
+		defer ph.cleanup()
+	}
 
 	_, err := client.Client.DeleteTracingPolicy(client.Ctx, &tetragon.DeleteTracingPolicyRequest{
 		Name:      ph.tpName,

--- a/tests/policytests/lsm.go
+++ b/tests/policytests/lsm.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package tests
+
+import (
+	"os/exec"
+
+	"github.com/cilium/tetragon/pkg/bpf"
+
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
+	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/testutils/policytest"
+)
+
+// This file contains tests on lsm hooks
+
+var _ = policytest.NewBuilder("lsm-dup-hooks").WithLabels("lsm").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "lsm-dup-hooks"
+spec:
+  lsmhooks:
+  - hook: "file_open"
+    args:
+      - index: 0
+        type: "file"
+    selectors:
+    - matchArgs:
+      - args: [0]
+        operator: "Equal"
+        values: [{{ tempFile "file1"}}]
+      matchActions:
+        - action: Post
+  - hook: "file_open"
+    args:
+      - index: 0
+        type: "file"
+    selectors:
+    - matchArgs:
+      - args: [0]
+        operator: "Equal"
+        values: [{{ tempFile "file2" }}]
+      matchActions:
+        - action: Post
+`).WithSkip(func(si *policytest.SkipInfo) string {
+	if !si.AgentInfo.Probes[bpf.LargeProgsProbe] {
+		return "need 5.3 or newer kernel"
+	}
+	if !si.AgentInfo.Probes[bpf.LsmProbe] {
+		return "Need LSM Support"
+	}
+	return ""
+}).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	catBin, err := exec.LookPath("cat")
+	if err != nil {
+		panic(err)
+	}
+	tempFile := c.TempFileMust("file1")
+	fileChecker := ec.NewProcessLsmChecker("lsm-file1-checker").
+		WithFunctionName(sm.Suffix("file_open")).
+		WithProcess(ec.NewProcessChecker().WithBinary(sm.Full(catBin))).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithFileArg(ec.NewKprobeFileChecker().WithPath(sm.Full(tempFile)))))
+
+	return &policytest.Scenario{
+		Name:         "checking first lsm hook event fired for duplicate hook policy",
+		Trigger:      policytest.NewCmdTrigger(catBin, tempFile).ExpectExitCode(0),
+		EventChecker: ec.NewUnorderedEventChecker(fileChecker),
+	}
+}).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	catBin, err := exec.LookPath("cat")
+	if err != nil {
+		panic(err)
+	}
+	tempFile := c.TempFileMust("file2")
+	fileChecker := ec.NewProcessLsmChecker("lsm-file2-checker").
+		WithFunctionName(sm.Suffix("file_open")).
+		WithProcess(ec.NewProcessChecker().WithBinary(sm.Full(catBin))).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithFileArg(ec.NewKprobeFileChecker().WithPath(sm.Full(tempFile)))))
+
+	return &policytest.Scenario{
+		Name:         "checking second lsm hook event fired for duplicate hook policy",
+		Trigger:      policytest.NewCmdTrigger(catBin, tempFile).ExpectExitCode(0),
+		EventChecker: ec.NewUnorderedEventChecker(fileChecker),
+	}
+}).RegisterAtInit()


### PR DESCRIPTION
Fixing bug with multiple lsm hook entries

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Fixes #4578

### Description
This commit fixes a bug where events were not being emitted when multiple entries were configured for the same lsm hook


### Changelog

```
lsm: fix bug with duplicate hooked functions
```