### PR TITLE
renovate: add rule for mikefarah/yq updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -466,6 +466,16 @@
       ],
       "automerge": true
     },
+    {
+      // Group all yq updates into a single branch. Refresh once every 3 months
+      "groupName": "yq",
+      "groupSlug": "mikefarah-yq",
+      "matchDepNames": [
+        "mikefarah/yq",
+        "docker.io/mikefarah/yq",
+      ],
+      "schedule": ["* * 1 */3 *"],
+    }
   ],
   // Those regexes manage version strings in variousfiles, similar to the
   // examples shown here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture


### PR DESCRIPTION
### Description

Updates for yq image are happening quite often, and besides security updates we don't need to bump the version so frequently.

This commit sets the schedule for updating yq once every 3 months.