### PR TITLE
fix(ci): fix windows ebpf CI

### DIFF
--- a/.github/workflows/windows-build-smoke-test.yml
+++ b/.github/workflows/windows-build-smoke-test.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   windows-ebpf-prog-build:
     name: Build Windows ebpf programs
-    runs-on: windows-2025
+    runs-on: windows-2022
     timeout-minutes: 25
 
     permissions:


### PR DESCRIPTION
Since june, `windows-2025` github runner defaults at visual studio 2026: https://github.com/actions/runner-images/issues/14017

But the `microsoft/ntosebpfext` github action still wants visual studio 2022 (see the script we use: https://github.com/microsoft/ntosebpfext/blob/main/scripts/initialize_repo.ps1); the proposed workaround is the one highlighted in the aforementioned runner-images issue:
> Customers needing Visual Studio 2022 must migrate to the windows-2022 image.