### PR TITLE
linters: add sloglint settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,15 @@ linters:
         - "on"
         - at
         - from
+    sloglint:
+      no-mixed-args: true
+      kv-only: true
+      no-global: "default"
+      forbidden-keys:
+        - time
+        - level
+        - msg
+        - source
     goheader:
       values:
         regexp:

--- a/cmd/dump-syscalls-info/main.go
+++ b/cmd/dump-syscalls-info/main.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
+
+	"github.com/cilium/tetragon/pkg/logger"
 )
 
 type cli struct {
@@ -228,7 +230,7 @@ func updateInfo(
 
 	ret := make(map[string][]SyscallArg)
 	for k, v := range allSyscalls {
-		sl := slog.With("syscall", k)
+		sl := slog.New(slog.NewTextHandler(os.Stdout, nil)).With("syscall", k)
 		if v.inOld && v.inNew {
 			ret[k] = updateArgs(sl, oldInfo[k], newInfo[k])
 		} else if v.inOld {
@@ -347,13 +349,13 @@ func (c *SyscallsIDsCmd) Run() error {
 	for _, abi := range c.ABI {
 		glibcLoc, ok := glibcLocation[abi]
 		if !ok {
-			slog.Warn("unknown abi, ignoring", "abi", abi)
+			logger.GetLogger().Warn("unknown abi, ignoring", "abi", abi)
 			continue
 		}
 
 		abiTmpDir := filepath.Join(tmpDir, abi)
 		if err := os.Mkdir(abiTmpDir, 0755); err != nil {
-			slog.Warn("error creationg dir", "dir", abiTmpDir, "err", err)
+			logger.GetLogger().Warn("error creationg dir", "dir", abiTmpDir, "err", err)
 			continue
 		}
 
@@ -426,7 +428,7 @@ func main() {
 	cliCtx := kong.Parse(cliCnf)
 	err := cliCtx.Run()
 	if err != nil {
-		slog.Error("failed to run", "error", err)
+		logger.GetLogger().Error("failed to run", "error", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/tetragon-metrics-docs/metricsmd/metricsmd.go
+++ b/cmd/tetragon-metrics-docs/metricsmd/metricsmd.go
@@ -9,6 +9,8 @@ import (
 	"github.com/isovalent/metricstool/pkg/metricsmd"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
+
+	"github.com/cilium/tetragon/pkg/logger"
 )
 
 type initMetricsFunc func(string, *prometheus.Registry, *slog.Logger) error
@@ -64,7 +66,7 @@ func New(targets map[string]string, init initMetricsFunc) *cobra.Command {
 
 	cmd, err := metricsmd.NewCmd(nil, nil, config)
 	if err != nil {
-		slog.Error("failed to create metrics-docs command", "error", err)
+		logger.GetLogger().Error("failed to create metrics-docs command", "error", err)
 	}
 	return cmd
 }


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Configure sloglint to enforce e.g. not re-using the built-in key names.
Also, enforce that the slog.DefaultLogger is not used directly. I replaced those invocations with our logger package. If we don't initialize the logger we fall back to the same behavior by using the slog.DefaultLogger.