### PR TITLE
docs: fix typo in rthooks demo

### DIFF
--- a/contrib/tetragon-rthooks/docs/demo.md
+++ b/contrib/tetragon-rthooks/docs/demo.md
@@ -49,7 +49,7 @@ helm uninstall -n kube-system tetragon
 ```
 
 In many situations, you would want the hook to keep running even if tetragon is
-not. Doing so, will allow you to configure a class of pods that can only run if tetragon is availble.
+not. Doing so, will allow you to configure a class of pods that can only run if tetragon is available.
 
 
 To uninstall the hook, you can install the following daemonset:


### PR DESCRIPTION
Fixes a small typo in the rthooks demo documentation: `availble` → `available`.

This is a documentation-only change.