### PR TITLE
tetragon: Fix readArg handling for fd_ty type

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -502,6 +502,12 @@ read_arg(void *ctx, int index, int type, long orig_off, unsigned long arg, int a
 	}
 
 	if (ret < 0) {
+		/* fd_ty returns -1 when the fd is not in the fdinstall_map,
+		 * meaning the filter should not match (event should be dropped).
+		 * This is a filter decision, not a fault.
+		 */
+		if (type == fd_ty)
+			return -1;
 		e->arg_status[index & MAX_POSSIBLE_ARGS_MASK] = -1;
 		/* update the arg status to reflect the detected fault */
 		write_arg_status(e, orig_off - sizeof(arg_status_t), e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
@@ -683,6 +689,13 @@ generic_process_event(void *ctx, struct bpf_map_def *tailcals, int process)
 		errv = generic_read_arg(ctx, index, total, tailcals, process);
 		if (errv > 0)
 			total += errv;
+		/* Follow filter lookup failed so lets abort the event.
+		 * From high-level this is a filter and should be in the
+		 * filter block, but its just easier to do here so lets
+		 * do it where it makes most sense.
+		 */
+		else if (errv < 0)
+			return filter_args_reject(e->func_id);
 	}
 	e->common.size = total;
 	/* Continue to process other arguments. */

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -479,7 +479,7 @@ func TestLoadTracepointSensor(t *testing.T) {
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "tp_calls", Progs: []uint{0, 1, 2, 3, 4, 6, 7}})
 
 		// all but generic_tracepoint_event,generic_tracepoint_filter
-		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 6, 7}})
+		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "retprobe_map", Progs: []uint{1, 2, 6, 7}})
 
 		// all kprobe but generic_tracepoint_filter
 		sensorMaps = append(sensorMaps, tus.SensorMap{Name: "config_map", Progs: []uint{0, 2, 6}})


### PR DESCRIPTION
Added a check for fd_ty before the generic fault-handling.

When fd_ty returns -1, it means the fd was not found in the
fdinstall_map — this is a filter decision (don't emit the event),
not a fault. We propagate -1 so the caller knows to reject.

Fixes: https://github.com/cilium/tetragon/commit/e6a89ab2b8c9012a2c22d1fbd7010f7a1153e69f ("bpf: detect faults for basic types")