### PR TITLE
tetragon: Make the testKprobeObjectFileWriteHook spec more detailed

### DIFF
--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -2047,6 +2047,11 @@ func testKprobeObjectFileWriteHook(pidStr string) string {
           followForks: true
           values:
           - ` + pidStr + `
+        matchArgs:
+        - index: 1
+          operator: "Postfix"
+          values:
+          - "testfile"
         matchActions:
         - action: FollowFD
           argFd: 0
@@ -2066,6 +2071,11 @@ func testKprobeObjectFileWriteHook(pidStr string) string {
         - operator: In
           values:
           - ` + pidStr + `
+        matchArgs:
+        - index: 0
+          operator: "Postfix"
+          values:
+          - "testfile"
   `
 }
 


### PR DESCRIPTION
Add testfile matchArgs to the spec in testKprobeObjectFileWriteHook, to filter out unwanted sys_write traffic.

It makes the test easier to debug and prevent failures due to ring buffer lost events.