### PR TITLE
pkg/sensors: Add arm64 policies for uprobe regs tests

### DIFF
--- a/contrib/tester-progs/regs-override.c
+++ b/contrib/tester-progs/regs-override.c
@@ -60,9 +60,9 @@ __asm__ (
 );
 #endif
 
-#if defined(__x86_64__)
-static const char *test_3_string = "test_3_string_CASE";
+static const char *test_3_string __attribute__((used)) = "test_3_string_CASE";
 
+#if defined(__x86_64__)
 static __naked unsigned long test_3()
 {
 	asm volatile (
@@ -77,6 +77,20 @@ static __naked unsigned long test_3()
 		: [str] "m" (test_3_string)
 	);
 }
+#elif defined(__aarch64__)
+unsigned long test_3();
+__asm__ (
+    ".text\n"                                        /* asm follows a .data definition, force back to .text */
+    ".global test_3\n"
+    ".type test_3, %function\n"
+    "test_3:\n"
+	"adrp	x1, test_3_string\n"                 /* +0  load the string pointer into x1 */
+	"ldr	x1, [x1, #:lo12:test_3_string]\n"    /* +4                                  */
+	"mov	x0, #0x0\n"                          /* +8                                  */
+	"mov	x0, #0xff\n"                         /* +12                                 */
+	"ret\n"                                      /* +16                                 */
+    ".size test_3, .-test_3\n"
+);
 #else
 static unsigned long test_3()
 {

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -825,10 +825,6 @@ func testUprobePtRegsPreload(t *testing.T, multi bool) {
 		t.Skip("skipping")
 	}
 
-	if runtime.GOARCH == "arm64" {
-		t.Skip("skipping, x86_64 only test")
-	}
-
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
 
 	disableUprobeMulti := ""
@@ -840,22 +836,41 @@ func testUprobePtRegsPreload(t *testing.T, multi bool) {
       value: "1"`
 	}
 
-	// Put uprobe in test_3 function at:
-	//
-	//      static const char *test_3_string = "test_3_string_CASE";
-	//
-	//      "push   %%rbp\n"          /* +0  55                            */
-	//      "mov    %%rsp, %%rbp\n"   /* +1  48 89 e5                      */
-	//      "mov    %[str], %%rdi\n"  /* +4  48 8b 3d 96 2e 00 00          */
-	//      "pop    %%rbp\n"          /* +11 5d                            */
-	// -->  "mov    $0x0,%%rax\n"     /* +12 48 c7 c0 00 00 00 00          */
-	//      "mov    $0xff,%%rax\n"    /* +19 48 c7 c0 ff 00 00 00          */
-	//      "ret\n"                   /* +26 c3                            */
-	//      :
-	//      : [str] "m" (test_3_string)
-	//
-	// Make sure we retrieve data with eax value (1) as int argument
-	// and match the expected value via matchData.
+	var symbol, resolveReg string
+	switch runtime.GOARCH {
+	case "amd64":
+		// Put uprobe in test_3 function at:
+		//
+		//      static const char *test_3_string = "test_3_string_CASE";
+		//
+		//      "push   %%rbp\n"          /* +0  55                            */
+		//      "mov    %%rsp, %%rbp\n"   /* +1  48 89 e5                      */
+		//      "mov    %[str], %%rdi\n"  /* +4  48 8b 3d 96 2e 00 00          */
+		//      "pop    %%rbp\n"          /* +11 5d                            */
+		// -->  "mov    $0x0,%%rax\n"     /* +12 48 c7 c0 00 00 00 00          */
+		//      "mov    $0xff,%%rax\n"    /* +19 48 c7 c0 ff 00 00 00          */
+		//      "ret\n"                   /* +26 c3                            */
+		//      :
+		//      : [str] "m" (test_3_string)
+		//
+		// Make sure we retrieve data with eax value (1) as int argument
+		// and match the expected value via matchData.
+		symbol, resolveReg = "test_3+12", "rdi"
+	case "arm64":
+		// Put uprobe in test_3 function at:
+		//
+		//      static const char *test_3_string = "test_3_string_CASE";
+		//
+		//      "adrp x1, test_3_string\n"               /* +0  load string page             */
+		//      "ldr  x1, [x1, #:lo12:test_3_string]\n"  /* +4  string pointer now in x1      */
+		// -->  "mov  x0, #0x0\n"                         /* +8                                */
+		//      "mov  x0, #0xff\n"                        /* +12                               */
+		//      "ret\n"                                   /* +16                               */
+		//
+		// Make sure we retrieve data with x1 holding the string pointer
+		// and match the expected value via matchData.
+		symbol, resolveReg = "test_3+8", "x1"
+	}
 
 	pathHook := `
 apiVersion: cilium.io/v1alpha1
@@ -866,12 +881,12 @@ spec: ` + disableUprobeMulti + `
   uprobes:
   - path: "` + testBinary + `"
     symbols:
-    - "test_3+12"
+    - "` + symbol + `"
     data:
     - index: 0
       type: "string"
       source: "pt_regs"
-      resolve: "rdi"
+      resolve: "` + resolveReg + `"
 `
 
 	createCrdFile(t, pathHook)
@@ -879,7 +894,7 @@ spec: ` + disableUprobeMulti + `
 	upChecker := ec.NewProcessUprobeChecker("UPROBE_DATA_MATCH").
 		WithProcess(ec.NewProcessChecker().
 			WithBinary(sm.Full(testBinary))).
-		WithSymbol(sm.Full("test_3+12")).
+		WithSymbol(sm.Full(symbol)).
 		WithData(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(
@@ -926,10 +941,6 @@ func testUprobePtRegsPreloadDouble(t *testing.T, multi bool) {
 		t.Skip("skipping")
 	}
 
-	if runtime.GOARCH == "arm64" {
-		t.Skip("skipping, x86_64 only test")
-	}
-
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
 
 	disableUprobeMulti := ""
@@ -941,26 +952,44 @@ func testUprobePtRegsPreloadDouble(t *testing.T, multi bool) {
       value: "1"`
 	}
 
-	// Put uprobe in test_3 function at:
-	//
-	//      static const char *test_3_string = "test_3_string_CASE";
-	//
-	//      "push   %%rbp\n"          /* +0  55                            */
-	//      "mov    %%rsp, %%rbp\n"   /* +1  48 89 e5                      */
-	//      "mov    %[str], %%rdi\n"  /* +4  48 8b 3d 96 2e 00 00          */
-	//      "pop    %%rbp\n"          /* +11 5d                            */
-	// -->  "mov    $0x0,%%rax\n"     /* +12 48 c7 c0 00 00 00 00          */
-	//      "mov    $0xff,%%rax\n"    /* +19 48 c7 c0 ff 00 00 00          */
-	//      "ret\n"                   /* +26 c3                            */
-	//      :
-	//      : [str] "m" (test_3_string)
-	//
-	// Make sure we retrieve data with eax value (1) as int argument
-	// and match the expected value via matchData.
-	//
 	// This test does the same thing as testUprobePtRegsPreload but instead
 	// of single uprobe with preload argument it adds two uprobes with preload
 	// argument.
+	var symbol, resolveReg string
+	switch runtime.GOARCH {
+	case "amd64":
+		// Put uprobe in test_3 function at:
+		//
+		//      static const char *test_3_string = "test_3_string_CASE";
+		//
+		//      "push   %%rbp\n"          /* +0  55                            */
+		//      "mov    %%rsp, %%rbp\n"   /* +1  48 89 e5                      */
+		//      "mov    %[str], %%rdi\n"  /* +4  48 8b 3d 96 2e 00 00          */
+		//      "pop    %%rbp\n"          /* +11 5d                            */
+		// -->  "mov    $0x0,%%rax\n"     /* +12 48 c7 c0 00 00 00 00          */
+		//      "mov    $0xff,%%rax\n"    /* +19 48 c7 c0 ff 00 00 00          */
+		//      "ret\n"                   /* +26 c3                            */
+		//      :
+		//      : [str] "m" (test_3_string)
+		//
+		// Make sure we retrieve data with eax value (1) as int argument
+		// and match the expected value via matchData.
+		symbol, resolveReg = "test_3+12", "rdi"
+	case "arm64":
+		// Put uprobe in test_3 function at:
+		//
+		//      static const char *test_3_string = "test_3_string_CASE";
+		//
+		//      "adrp x1, test_3_string\n"               /* +0  load string page             */
+		//      "ldr  x1, [x1, #:lo12:test_3_string]\n"  /* +4  string pointer now in x1      */
+		// -->  "mov  x0, #0x0\n"                         /* +8                                */
+		//      "mov  x0, #0xff\n"                        /* +12                               */
+		//      "ret\n"                                   /* +16                               */
+		//
+		// Make sure we retrieve data with x1 holding the string pointer
+		// and match the expected value via matchData.
+		symbol, resolveReg = "test_3+8", "x1"
+	}
 
 	pathHook := `
 apiVersion: cilium.io/v1alpha1
@@ -971,20 +1000,20 @@ spec: ` + disableUprobeMulti + `
   uprobes:
   - path: "` + testBinary + `"
     symbols:
-    - "test_3+12"
+    - "` + symbol + `"
     data:
     - index: 0
       type: "string"
       source: "pt_regs"
-      resolve: "rdi"
+      resolve: "` + resolveReg + `"
   - path: "` + testBinary + `"
     symbols:
-    - "test_3+12"
+    - "` + symbol + `"
     data:
     - index: 0
       type: "string"
       source: "pt_regs"
-      resolve: "rdi"
+      resolve: "` + resolveReg + `"
 `
 
 	createCrdFile(t, pathHook)
@@ -992,7 +1021,7 @@ spec: ` + disableUprobeMulti + `
 	upChecker := ec.NewProcessUprobeChecker("UPROBE_DATA_MATCH").
 		WithProcess(ec.NewProcessChecker().
 			WithBinary(sm.Full(testBinary))).
-		WithSymbol(sm.Full("test_3+12")).
+		WithSymbol(sm.Full(symbol)).
 		WithData(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(
@@ -1046,9 +1075,6 @@ func testUprobePtRegsPreloadSubstring(t *testing.T, str string, ignoreCase bool,
 	if !single && !bpf.HasUprobeMulti() {
 		t.Skip("skipping, can't use uprobe multi, no kernel support")
 	}
-	if runtime.GOARCH == "arm64" {
-		t.Skip("skipping, x86_64 only test")
-	}
 
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
 
@@ -1064,22 +1090,41 @@ func testUprobePtRegsPreloadSubstring(t *testing.T, str string, ignoreCase bool,
     value: "1"`
 	}
 
-	// Put uprobe in test_3 function at:
-	//
-	//      static const char *test_3_string = "test_3_string";
-	//
-	//      "push   %%rbp\n"          /* +0  55                            */
-	//      "mov    %%rsp, %%rbp\n"   /* +1  48 89 e5                      */
-	//      "mov    %[str], %%rdi\n"  /* +4  48 8b 3d 96 2e 00 00          */
-	//      "pop    %%rbp\n"          /* +11 5d                            */
-	// -->  "mov    $0x0,%%rax\n"     /* +12 48 c7 c0 00 00 00 00          */
-	//      "mov    $0xff,%%rax\n"    /* +19 48 c7 c0 ff 00 00 00          */
-	//      "ret\n"                   /* +26 c3                            */
-	//      :
-	//      : [str] "m" (test_3_string)
-	//
-	// Make sure we retrieve data with eax value (1) as int argument
-	// and match the expected value via matchData.
+	var symbol, resolveReg string
+	switch runtime.GOARCH {
+	case "amd64":
+		// Put uprobe in test_3 function at:
+		//
+		//      static const char *test_3_string = "test_3_string";
+		//
+		//      "push   %%rbp\n"          /* +0  55                            */
+		//      "mov    %%rsp, %%rbp\n"   /* +1  48 89 e5                      */
+		//      "mov    %[str], %%rdi\n"  /* +4  48 8b 3d 96 2e 00 00          */
+		//      "pop    %%rbp\n"          /* +11 5d                            */
+		// -->  "mov    $0x0,%%rax\n"     /* +12 48 c7 c0 00 00 00 00          */
+		//      "mov    $0xff,%%rax\n"    /* +19 48 c7 c0 ff 00 00 00          */
+		//      "ret\n"                   /* +26 c3                            */
+		//      :
+		//      : [str] "m" (test_3_string)
+		//
+		// Make sure we retrieve data with eax value (1) as int argument
+		// and match the expected value via matchData.
+		symbol, resolveReg = "test_3+12", "rdi"
+	case "arm64":
+		// Put uprobe in test_3 function at:
+		//
+		//      static const char *test_3_string = "test_3_string";
+		//
+		//      "adrp x1, test_3_string\n"               /* +0  load string page             */
+		//      "ldr  x1, [x1, #:lo12:test_3_string]\n"  /* +4  string pointer now in x1      */
+		// -->  "mov  x0, #0x0\n"                         /* +8                                */
+		//      "mov  x0, #0xff\n"                        /* +12                               */
+		//      "ret\n"                                   /* +16                               */
+		//
+		// Make sure we retrieve data with x1 holding the string pointer
+		// and match the expected value via matchData.
+		symbol, resolveReg = "test_3+8", "x1"
+	}
 
 	pathHook := `
 apiVersion: cilium.io/v1alpha1
@@ -1091,12 +1136,12 @@ spec:
   uprobes:
   - path: "` + testBinary + `"
     symbols:
-    - "test_3+12"
+    - "` + symbol + `"
     data:
     - index: 0
       type: "string"
       source: "pt_regs"
-      resolve: "rdi"
+      resolve: "` + resolveReg + `"
     selectors:
     - matchData:
       - index: 0
@@ -1110,7 +1155,7 @@ spec:
 	upChecker := ec.NewProcessUprobeChecker("UPROBE_DATA_MATCH").
 		WithProcess(ec.NewProcessChecker().
 			WithBinary(sm.Full(testBinary))).
-		WithSymbol(sm.Full("test_3+12")).
+		WithSymbol(sm.Full(symbol)).
 		WithData(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(
@@ -1232,28 +1277,46 @@ func testUprobePtRegsPreloadSubstringOverride(t *testing.T, single bool) {
 	if !bpf.HasKfunc("bpf_strnstr") {
 		t.Skip("skipping, no bpf_strnstr kfunc in kernel")
 	}
-	if runtime.GOARCH == "arm64" {
-		t.Skip("skipping, x86_64 only test")
-	}
 
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
 
-	// Put uprobe in test_3 function at:
-	//
-	//      static const char *test_3_string = "test_3_string";
-	//
-	//      "push   %%rbp\n"          /* +0  55                            */
-	//      "mov    %%rsp, %%rbp\n"   /* +1  48 89 e5                      */
-	//      "mov    %[str], %%rdi\n"  /* +4  48 8b 3d 96 2e 00 00          */
-	//      "pop    %%rbp\n"          /* +11 5d                            */
-	//      "mov    $0x0,%%rax\n"     /* +12 48 c7 c0 00 00 00 00          */
-	// -->  "mov    $0xff,%%rax\n"    /* +19 48 c7 c0 ff 00 00 00          */
-	//      "ret\n"                   /* +26 c3                            */
-	//      :
-	//      : [str] "m" (test_3_string)
-	//
-	// Make sure we retrieve data with eax value (1) as int argument
-	// and match the expected value via matchData.
+	var symbol, resolveReg, overrideReg string
+	switch runtime.GOARCH {
+	case "amd64":
+		// Put uprobe in test_3 function at:
+		//
+		//      static const char *test_3_string = "test_3_string";
+		//
+		//      "push   %%rbp\n"          /* +0  55                            */
+		//      "mov    %%rsp, %%rbp\n"   /* +1  48 89 e5                      */
+		//      "mov    %[str], %%rdi\n"  /* +4  48 8b 3d 96 2e 00 00          */
+		//      "pop    %%rbp\n"          /* +11 5d                            */
+		//      "mov    $0x0,%%rax\n"     /* +12 48 c7 c0 00 00 00 00          */
+		// -->  "mov    $0xff,%%rax\n"    /* +19 48 c7 c0 ff 00 00 00          */
+		//      "ret\n"                   /* +26 c3                            */
+		//      :
+		//      : [str] "m" (test_3_string)
+		//
+		// We attach on the "mov $0xff" instruction and override the program
+		// counter to skip over it (rip += 7), so test_3 returns 0 instead of
+		// 0xff.
+		symbol, resolveReg, overrideReg = "test_3+19", "rdi", "rip=7%rip"
+	case "arm64":
+		// Put uprobe in test_3 function at:
+		//
+		//      static const char *test_3_string = "test_3_string";
+		//
+		//      "adrp x1, test_3_string\n"               /* +0  load string page             */
+		//      "ldr  x1, [x1, #:lo12:test_3_string]\n"  /* +4  string pointer now in x1      */
+		//      "mov  x0, #0x0\n"                         /* +8                                */
+		// -->  "mov  x0, #0xff\n"                        /* +12                               */
+		//      "ret\n"                                   /* +16                               */
+		//
+		// We attach on the "mov x0, #0xff" instruction and override the
+		// program counter to skip over it (pc += 4), so test_3 returns 0
+		// instead of 0xff.
+		symbol, resolveReg, overrideReg = "test_3+12", "x1", "pc=4%pc"
+	}
 
 	options := ""
 	if single {
@@ -1272,12 +1335,12 @@ spec:
   uprobes:
   - path: "` + testBinary + `"
     symbols:
-    - "test_3+19"
+    - "` + symbol + `"
     data:
     - index: 0
       type: "string"
       source: "pt_regs"
-      resolve: "rdi"
+      resolve: "` + resolveReg + `"
     selectors:
     - matchData:
       - index: 0
@@ -1287,7 +1350,7 @@ spec:
       matchActions:
       - action: Override
         argRegs:
-        - "rip=7%rip"
+        - "` + overrideReg + `"
 `
 
 	createCrdFile(t, pathHook)
@@ -1295,7 +1358,7 @@ spec:
 	upChecker := ec.NewProcessUprobeChecker("UPROBE_DATA_MATCH").
 		WithProcess(ec.NewProcessChecker().
 			WithBinary(sm.Full(testBinary))).
-		WithSymbol(sm.Full("test_3+19")).
+		WithSymbol(sm.Full(symbol)).
 		WithData(ec.NewKprobeArgumentListMatcher().
 			WithOperator(lc.Ordered).
 			WithValues(


### PR DESCRIPTION


### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

PR #5082 skipped four uprobe register tests on arm64 because their policies referenced x86-specific registers. The deeper issue was that they all rely on test_3, which only had a real x86 implementation (arm64 got a stub returning 0).

Add an aarch64 test_3 that loads the string pointer into x1 and returns 0xff, then provide arm64 policy variants (symbol offsets, resolve and override registers) for the four tests so they run instead of skipping.

Fixes: https://github.com/cilium/tetragon/issues/5083

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
pkg/sensors: Add arm64 policies for uprobe regs tests
```
