### PR TITLE
celbpf: fix 32-bit issue by using ALU32

### DIFF
--- a/pkg/celbpf/celbpf_test.go
+++ b/pkg/celbpf/celbpf_test.go
@@ -162,6 +162,11 @@ func TestArgExprs(t *testing.T) {
 			hookArgs: []any{int32(0), uint64(0), int32(42)},
 		},
 		{
+			expr:     "arg0 == int32(-1)",
+			ret:      1,
+			hookArgs: []any{int32(-1)},
+		},
+		{
 			expr:     "arg2 == int32(0)",
 			ret:      0,
 			hookArgs: []any{int32(0), uint64(0), int32(42)},
@@ -180,6 +185,11 @@ func TestArgExprs(t *testing.T) {
 			expr:     "arg2 - int32(10) == int32(2) + arg0",
 			ret:      1,
 			hookArgs: []any{int32(30), uint64(0), int32(42)},
+		},
+		{
+			expr:     "arg2 - int32(-10) == int32(12) + arg0",
+			ret:      1,
+			hookArgs: []any{int32(30), uint64(0), int32(32)},
 		},
 	}
 
@@ -237,10 +247,10 @@ func TestArgExprs(t *testing.T) {
 		defer prog.Close()
 		val, err := prog.Run(&ebpf.RunOptions{})
 		require.NoError(t, err)
-		require.Equal(t, tc.ret, val, "result of %q was %d and not %d", tc.expr, val, tc.ret)
 		if tc.ret != val {
 			t.Logf("insns:\n%s\n", insns)
 			dumpProg(t, prog)
 		}
+		require.Equal(t, tc.ret, val, "result of %q was %d and not %d", tc.expr, val, tc.ret)
 	}
 }

--- a/pkg/celbpf/codegen.go
+++ b/pkg/celbpf/codegen.go
@@ -77,22 +77,6 @@ func (g *codeGenerator) emitPopInt64(reg asm.Register) {
 	g.stackTop += 8
 }
 
-func (g *codeGenerator) emitBranchEquals(reg0 asm.Register, reg1 asm.Register) {
-	// make space to push a boolean (8 bytes)
-	g.stackTop -= 8
-	label := g.generateLabel()
-	g.emitRaw(
-		// check reg0 vs reg1, and then use reg0 for the result so that we can save it in
-		// the stack.
-		asm.JEq.Reg(reg0, reg1, label),
-		asm.LoadImm(reg0, 0, asm.DWord),
-		asm.Instruction{OpCode: asm.Ja.Op(asm.ImmSource), Offset: 2},
-		asm.LoadImm(reg0, 1, asm.DWord).WithSymbol(label),
-		asm.StoreMem(asm.R10, g.stackTop, reg0, asm.DWord),
-	)
-
-}
-
 func (g *codeGenerator) emitPopS32(reg asm.Register) {
 	g.emitRaw(asm.LoadMem(reg, asm.R10, g.stackTop, asm.DWord))
 	g.stackTop += 8
@@ -101,10 +85,6 @@ func (g *codeGenerator) emitPopS32(reg asm.Register) {
 func (g *codeGenerator) emitS32(reg asm.Register, regTy *cgTypes.Type) error {
 	switch regTy {
 	case s64Ty:
-		g.emitRaw(
-			asm.LSh.Imm(reg, 0x20),
-			asm.ArSh.Imm(reg, 0x20),
-		)
 	default:
 		return fmt.Errorf("emitS32: unknown/unsupported type %s", regTy)
 	}
@@ -125,10 +105,6 @@ func (g *codeGenerator) emitU32(reg asm.Register, regTy *cgTypes.Type) error {
 
 	switch regTy {
 	case u64Ty:
-		g.emitRaw(
-			asm.LSh.Imm(reg, 0x20),
-			asm.RSh.Imm(reg, 0x20),
-		)
 	default:
 		return fmt.Errorf("emitU32: unknown/unsupported type %s", regTy)
 	}
@@ -186,13 +162,19 @@ func (g *codeGenerator) emitSub(
 ) error {
 	switch {
 	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName(),
-		ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
-		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName(),
-		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName():
 
 		g.stackTop -= 8
 		g.emitRaw(
 			asm.Sub.Reg(r1, r2),
+			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
+		)
+
+	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
+		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		g.stackTop -= 8
+		g.emitRaw(
+			asm.Sub.Reg32(r1, r2),
 			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
 		)
 
@@ -210,13 +192,19 @@ func (g *codeGenerator) emitAdd(
 ) error {
 	switch {
 	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName(),
-		ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
-		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName(),
-		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName():
 
 		g.stackTop -= 8
 		g.emitRaw(
 			asm.Add.Reg(r1, r2),
+			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
+		)
+
+	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
+		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		g.stackTop -= 8
+		g.emitRaw(
+			asm.Add.Reg32(r1, r2),
 			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
 		)
 
@@ -260,7 +248,7 @@ func (g *codeGenerator) emitNot(r1 asm.Register, tmp asm.Register) error {
 	return nil
 }
 
-func (g *codeGenerator) emitInequality(
+func (g *codeGenerator) emitBranch(
 	reg1 asm.Register, ty1 *cgTypes.Type,
 	reg2 asm.Register, ty2 *cgTypes.Type,
 	op string,
@@ -268,19 +256,30 @@ func (g *codeGenerator) emitInequality(
 ) error {
 
 	var signed bool
+	var alu32 bool
 	switch {
-	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
-		ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName():
+	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName():
 		signed = true
-	case ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName(),
-		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
-		signed = false
+		alu32 = true
+
+	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName():
+		signed = true
+
+	case ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		alu32 = true
+
+	case ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName():
+
+	case ty1.TypeName() == boolTy.TypeName() && ty2.TypeName() == boolTy.TypeName() && op == cgOperators.Equals:
+
 	default:
-		return fmt.Errorf("inequality (%q) between types %s and %s is not supported", op, ty1.TypeName(), ty2.TypeName())
+		return fmt.Errorf("operation (%q) between types %s and %s is not supported", op, ty1.TypeName(), ty2.TypeName())
 	}
 
 	opcode := asm.InvalidJumpOp
 	switch op {
+	case cgOperators.Equals:
+		opcode = asm.JEq
 	case cgOperators.NotEquals:
 		opcode = asm.JNE
 	case cgOperators.Less:
@@ -313,9 +312,15 @@ func (g *codeGenerator) emitInequality(
 
 	g.stackTop -= 8
 	label := g.generateLabel()
+	jmpInst := func() asm.Instruction {
+		if alu32 {
+			return opcode.Reg32(reg1, reg2, label)
+		}
+		return opcode.Reg(reg1, reg2, label)
+	}
 	g.emitRaw(
 		asm.LoadImm(tmp, 1, asm.DWord),
-		opcode.Reg(reg1, reg2, label),
+		jmpInst(),
 		asm.LoadImm(tmp, 0, asm.DWord),
 		asm.StoreMem(asm.R10, g.stackTop, tmp, asm.DWord).WithSymbol(label),
 	)

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -70,11 +70,6 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 	// setup emit call
 	var emitCall func() error
 	switch op := call.FunctionName(); op {
-	case cgOperators.Equals:
-		emitCall = func() error {
-			c.cg.emitBranchEquals(scratchRegs[0], scratchRegs[1])
-			return nil
-		}
 	case int32Fn:
 		emitCall = func() error {
 			return c.cg.emitS32(scratchRegs[0], argTypes[0])
@@ -120,11 +115,11 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 
 	case cgOperators.Less, cgOperators.LessEquals,
 		cgOperators.Greater, cgOperators.GreaterEquals,
-		cgOperators.NotEquals:
+		cgOperators.NotEquals, cgOperators.Equals:
 		emitCall = func() error {
 			// NB: scratchRegs[2] is not used but we pass it so that the implementation
 			// can use it for an intemediate value.
-			return c.cg.emitInequality(
+			return c.cg.emitBranch(
 				scratchRegs[0], argTypes[0],
 				scratchRegs[1], argTypes[1],
 				op,

--- a/pkg/celbpf/types.go
+++ b/pkg/celbpf/types.go
@@ -22,6 +22,7 @@ var (
 	u64Ty         = cgTypes.UintType
 	s32Ty         = cgTypes.NewOpaqueType("s32")
 	u32Ty         = cgTypes.NewOpaqueType("u32")
+	boolTy        = cgTypes.BoolType
 	unsupportedTy = cgTypes.NewOpaqueType("unsupported")
 
 	addS32 = "add_s32"


### PR DESCRIPTION
Previously, we used an arithmetic shift for casting 64-bit constants to 32-bit. One one hand, this allowed us to do arithmetic operations with 64-bit registers, but doing something like arg0 == int(-1) would not work as expected, because arg0 would be 0x00000000ffffffff and int(-1) would be 0xffffffffffffffff so the check would always fail.

This commit adds a test for the above issue, and, instead of clearing bits for 32-bit numbers, uses 32-bit instructions which leads to simpler code and less instructions.

As a cleanup, it also incorporates emitBranchEquals to a single function for branches named emitBranch.

```release-note
celbpf: fix issue with 32-bit arithmetic by using ALU32
```
