### PR TITLE
policyfilter: fix nok8s test build

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -77,6 +77,7 @@ jobs:
     - name: Run nok8s go tests
       run: |
         cd go/src/github.com/cilium/tetragon/
+        go vet -tags nok8s ./pkg/sensors ./pkg/policyfilter ./pkg/tracingpolicy
         go test -tags nok8s ./pkg/tracingpolicy
 
     - name: Upload Tetragon logs

--- a/pkg/policyfilter/nok8s.go
+++ b/pkg/policyfilter/nok8s.go
@@ -37,6 +37,12 @@ func GetState() (State, error) {
 	return glblState, glblError
 }
 
+// DisabledState returns an empty state for the non-k8s build, where
+// policyfilter is always disabled.
+func DisabledState() State {
+	return State{}
+}
+
 // see k8s.go
 func resetStateOnlyForTesting() {
 	glblState = State{}


### PR DESCRIPTION


### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
manager_test.go references policyfilter.DisabledState(), which only existed in the !nok8s build, so building the sensors tests with -tags nok8s failed to compile. Add a DisabledState() stub to the nok8s build.

The build-nok8s CI job only compiles the binaries and never the test files, so this went unnoticed. Add a vet step over the packages whose exported API differs between the k8s and nok8s builds to catch test-compile breakage in the future.

From current main branch 

```
$ go vet -tags nok8s ./pkg/sensors ./pkg/policyfilter ./pkg/tracingpolicy
# github.com/cilium/tetragon/pkg/sensors
# [github.com/cilium/tetragon/pkg/sensors]
vet: pkg/sensors/manager_test.go:187:56: undefined: policyfilter.DisabledState
```

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
policyfilter: fix nok8s test build
```
