### PR TITLE
tracing: add native DNS query parsing for UDP kprobes

### DIFF
--- a/api/v1/tetragon/tetragon.proto
+++ b/api/v1/tetragon/tetragon.proto
@@ -459,6 +459,18 @@ message SyscallId {
   string abi = 2;
 }
 
+message KprobeDns {
+  string query_name = 1;
+  uint32 query_type = 2;
+  string query_type_str = 3;
+  uint32 query_class = 4;
+  uint32 tx_id = 5;
+  uint32 flags = 6;
+  bool response = 7;
+  bool truncated = 8;
+  bool parsed = 9;
+}
+
 message KprobeArgument {
   oneof arg {
     string string_arg = 1;
@@ -493,6 +505,7 @@ message KprobeArgument {
     KprobeBpfProg bpf_prog_arg = 31;
     KprobeError error_arg = 32;
     KprobeSockaddrUn sockaddrun_arg = 33;
+    KprobeDns dns_arg = 34;
   }
   string label = 18;
 }

--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -356,6 +356,11 @@ __read_arg_1(void *ctx, int type, long orig_off, unsigned long arg, int argm, ch
 		size = copy_sockaddr_un(args, arg);
 		break;
 #endif
+#ifdef __LARGE_BPF_PROG
+	case dns_type:
+		size = copy_dns(args, arg);
+		break;
+#endif
 	default:
 		size = 0;
 		break;

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -14,6 +14,7 @@
 #include "sockaddr_un.h"
 #endif
 #include "socket.h"
+#include "dns.h"
 #include "net_device.h"
 #include "../bpf_process_event.h"
 #include "bpfattr.h"
@@ -101,6 +102,8 @@ enum {
 	bpf_prog_type = 43,
 
 	sockaddr_un_type = 44,
+
+	dns_type = 45,
 
 	nop_s64_ty = -10,
 	nop_u64_ty = -11,
@@ -436,6 +439,16 @@ FUNC_INLINE long copy_socket(char *args, unsigned long arg)
 	set_event_from_socket(sk_event, sock);
 
 	return sizeof(struct sk_type);
+}
+
+FUNC_INLINE long copy_dns(char *args, unsigned long arg)
+{
+	struct msghdr *msg = (struct msghdr *)arg;
+	struct dns_type *ev = (struct dns_type *)args;
+
+	set_event_from_msghdr(ev, msg);
+
+	return sizeof(struct dns_type);
 }
 
 FUNC_INLINE long copy_user_ns(char *args, unsigned long arg)
@@ -1297,6 +1310,55 @@ filter_sockaddr_un(struct selector_arg_filter *filter, char *args)
 }
 #endif
 
+#ifdef __LARGE_BPF_PROG
+FUNC_LOCAL long
+filter_dns(struct selector_arg_filter *filter, char *args)
+{
+	struct dns_type *ev = (struct dns_type *)args;
+	char *name = ev->name;
+	__u8 name_len = ev->name_len;
+
+	switch (filter->op) {
+	case op_substring_igncase:
+		if (bpf_ksym_exists(bpf_strncasestr))
+			return filter_char_substring(filter, name, name_len, true);
+		break;
+	case op_substring:
+		if (bpf_ksym_exists(bpf_strnstr))
+			return filter_char_substring(filter, name, name_len, false);
+		break;
+	case op_filter_str_prefix:
+	case op_filter_str_notprefix: {
+		long match = filter_char_buf_prefix(filter, name, name_len);
+
+		if (is_not_operator(filter->op))
+			return !match;
+		return match;
+	}
+	case op_filter_str_postfix:
+	case op_filter_str_notpostfix: {
+		long match = filter_char_buf_postfix(filter, name, name_len);
+
+		if (is_not_operator(filter->op))
+			return !match;
+		return match;
+	}
+	case op_filter_eq:
+	case op_filter_neq: {
+		long match = filter_char_buf_equal(filter, name, name_len);
+
+		if (is_not_operator(filter->op))
+			return !match;
+		return match;
+	}
+	default:
+		break;
+	}
+
+	return 0;
+}
+#endif
+
 FUNC_INLINE long
 __copy_char_iovec(long off, unsigned long arg, unsigned long cnt,
 		  unsigned long max, struct msg_generic_kprobe *e)
@@ -1974,6 +2036,8 @@ FUNC_INLINE size_t type_to_min_size(int type, int argm)
 	case sockaddr_un_type:
 		return sizeof(struct sockaddr_un_type);
 #endif
+	case dns_type:
+		return sizeof(struct dns_type);
 	case cred_type:
 		return sizeof(struct msg_cred);
 	case size_type:
@@ -2266,6 +2330,10 @@ filter_arg_2(struct msg_generic_kprobe *e, struct selector_arg_filter *filter, c
 #if defined(__V511_BPF_PROG)
 	case sockaddr_un_type:
 		return filter_sockaddr_un(filter, args);
+#endif
+#ifdef __LARGE_BPF_PROG
+	case dns_type:
+		return filter_dns(filter, args);
 #endif
 	default:
 		return 1;

--- a/bpf/process/types/dns.h
+++ b/bpf/process/types/dns.h
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#ifndef __DNS_H__
+#define __DNS_H__
+
+#define DNS_MAX_NAME	    255
+#define DNS_HEADER_LEN	    12
+/* RFC 1035 cap; EDNS0 is not supported in v1. */
+#define DNS_UDP_PAYLOAD_MAX 512
+#define DNS_MAX_LABEL	    63
+#define DNS_WALK_MAX	    270
+
+enum {
+	dns_ok = 0,
+	dns_err_short = -1,
+	dns_err_not_query = -2,
+	dns_err_opcode = -3,
+	dns_err_qdcount = -4,
+	dns_err_label = -5,
+	dns_err_compression = -6,
+	dns_err_truncated = -7,
+	dns_err_iter = -8,
+	dns_err_read = -9,
+};
+
+/* Keep in sync with MsgGenericKprobeDns in pkg/api/tracingapi/client_kprobe.go */
+struct dns_type {
+	__u16 tx_id;
+	__u16 flags;
+	__u16 qtype;
+	__u16 qclass;
+	__u8 qr;
+	__u8 name_len;
+	__u8 truncated;
+	__u8 ok;
+	char name[DNS_MAX_NAME + 1];
+};
+
+#ifdef __LARGE_BPF_PROG
+struct dns_scratch {
+	__u8 buf[DNS_UDP_PAYLOAD_MAX];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct dns_scratch);
+} dns_scratch_map SEC(".maps");
+#endif
+
+FUNC_INLINE __u8 dns_to_lower(__u8 c)
+{
+	if (c >= 'A' && c <= 'Z')
+		return c + ('a' - 'A');
+	return c;
+}
+
+FUNC_INLINE int parse_dns_payload(const __u8 *buf, __u16 len, struct dns_type *ev)
+{
+	__u16 qdcount, pos, out_pos = 0;
+	__u16 flags, txid;
+	__u8 opcode;
+	__u8 in_label = 0;
+	__u8 remaining = 0;
+	__u8 done = 0;
+	__u16 i;
+
+	if (len < DNS_HEADER_LEN)
+		return dns_err_short;
+
+	txid = ((__u16)buf[0] << 8) | buf[1];
+	flags = ((__u16)buf[2] << 8) | buf[3];
+	qdcount = ((__u16)buf[4] << 8) | buf[5];
+
+	ev->tx_id = txid;
+	ev->flags = flags;
+	ev->qr = (flags >> 15) & 0x1;
+	opcode = (flags >> 11) & 0xf;
+
+	if (opcode != 0)
+		return dns_err_opcode;
+	if (qdcount < 1)
+		return dns_err_qdcount;
+
+	pos = DNS_HEADER_LEN;
+
+	/* Single bounded loop (no nesting) keeps verifier complexity linear. */
+#pragma unroll
+	for (i = 0; i < DNS_WALK_MAX; i++) {
+		__u8 b;
+
+		if (done)
+			break;
+		if (pos >= len || pos >= DNS_UDP_PAYLOAD_MAX)
+			return dns_err_short;
+
+		b = buf[pos & (DNS_UDP_PAYLOAD_MAX - 1)];
+		pos++;
+
+		if (!in_label) {
+			if (b == 0) {
+				done = 1;
+				continue;
+			}
+			/* RFC 1035 §4.1.4: top two bits 11 = compression pointer,
+			 * illegal in the question section.
+			 */
+			if ((b & 0xc0) == 0xc0)
+				return dns_err_compression;
+			if (b > DNS_MAX_LABEL)
+				return dns_err_label;
+			if (out_pos > 0) {
+				if (out_pos >= DNS_MAX_NAME) {
+					ev->truncated = 1;
+					return dns_err_truncated;
+				}
+				ev->name[out_pos & (DNS_MAX_NAME - 1)] = '.';
+				out_pos++;
+			}
+			remaining = b;
+			in_label = 1;
+		} else {
+			if (out_pos >= DNS_MAX_NAME) {
+				ev->truncated = 1;
+				return dns_err_truncated;
+			}
+			ev->name[out_pos & (DNS_MAX_NAME - 1)] = dns_to_lower(b);
+			out_pos++;
+			remaining--;
+			if (remaining == 0)
+				in_label = 0;
+		}
+	}
+
+	if (!done)
+		return dns_err_label;
+
+	ev->name_len = (__u8)out_pos;
+	if (out_pos <= DNS_MAX_NAME)
+		ev->name[out_pos] = '\0';
+
+	if (pos + 4 > len)
+		return dns_err_short;
+	ev->qtype = ((__u16)buf[pos & (DNS_UDP_PAYLOAD_MAX - 1)] << 8) |
+		    buf[(pos + 1) & (DNS_UDP_PAYLOAD_MAX - 1)];
+	ev->qclass = ((__u16)buf[(pos + 2) & (DNS_UDP_PAYLOAD_MAX - 1)] << 8) |
+		     buf[(pos + 3) & (DNS_UDP_PAYLOAD_MAX - 1)];
+
+	ev->ok = 1;
+	return dns_ok;
+}
+
+#ifdef __LARGE_BPF_PROG
+FUNC_INLINE int read_msghdr_payload(struct msghdr *msg, const char **out_buf,
+				    size_t *out_len)
+{
+	long iter_iovec = -1, iter_ubuf __maybe_unused = -1;
+	struct iov_iter *iter = _(&msg->msg_iter);
+	struct kvec *kvec;
+	const char *buf = NULL;
+	size_t count = 0;
+	u8 iter_type;
+	void *tmp;
+
+	if (!bpf_core_field_exists(iter->iter_type))
+		return dns_err_iter;
+
+	tmp = _(&iter->iter_type);
+	if (probe_read(&iter_type, sizeof(iter_type), tmp) < 0)
+		return dns_err_read;
+
+	if (bpf_core_enum_value_exists(enum iter_type, ITER_IOVEC))
+		iter_iovec = bpf_core_enum_value(enum iter_type, ITER_IOVEC);
+#ifdef __V61_BPF_PROG
+	if (bpf_core_enum_value_exists(enum iter_type, ITER_UBUF))
+		iter_ubuf = bpf_core_enum_value(enum iter_type, ITER_UBUF);
+#endif
+
+	if (iter_type == iter_iovec) {
+		tmp = _(&iter->kvec);
+		if (probe_read(&kvec, sizeof(kvec), tmp) < 0)
+			return dns_err_read;
+		tmp = _(&kvec->iov_base);
+		if (probe_read(&buf, sizeof(buf), tmp) < 0)
+			return dns_err_read;
+		tmp = _(&kvec->iov_len);
+		if (probe_read(&count, sizeof(count), tmp) < 0)
+			return dns_err_read;
+	}
+#ifdef __V61_BPF_PROG
+	else if (iter_type == iter_ubuf) {
+		tmp = _(&iter->ubuf);
+		if (probe_read(&buf, sizeof(buf), tmp) < 0)
+			return dns_err_read;
+		tmp = _(&iter->count);
+		if (probe_read(&count, sizeof(count), tmp) < 0)
+			return dns_err_read;
+	}
+#endif
+	else {
+		return dns_err_iter;
+	}
+
+	if (!buf || count == 0)
+		return dns_err_iter;
+
+	*out_buf = buf;
+	*out_len = count;
+	return 0;
+}
+
+FUNC_INLINE void
+set_event_from_msghdr(struct dns_type *ev, struct msghdr *msg)
+{
+	const char *iov_buf = NULL;
+	size_t iov_len = 0;
+	__u16 read_len;
+	__u32 zero = 0;
+	struct dns_scratch *scratch;
+
+	memset(ev, 0, sizeof(*ev));
+
+	scratch = map_lookup_elem(&dns_scratch_map, &zero);
+	if (!scratch)
+		return;
+
+	if (read_msghdr_payload(msg, &iov_buf, &iov_len) < 0)
+		return;
+
+	read_len = iov_len > DNS_UDP_PAYLOAD_MAX ? DNS_UDP_PAYLOAD_MAX
+						 : (__u16)iov_len;
+
+	if (bpf_probe_read_user(scratch->buf, read_len, iov_buf) < 0)
+		return;
+
+	parse_dns_payload(scratch->buf, read_len, ev);
+}
+#else
+FUNC_INLINE void
+set_event_from_msghdr(struct dns_type *ev, struct msghdr *msg)
+{
+	memset(ev, 0, sizeof(*ev));
+}
+#endif
+
+#endif /* __DNS_H__ */

--- a/docs/content/en/docs/concepts/tracing-policy/argument_types.md
+++ b/docs/content/en/docs/concepts/tracing-policy/argument_types.md
@@ -48,6 +48,7 @@ List of described data types:
 - [`sockaddr`](#sockaddr)
 - [`sockaddr_un`](#sockaddr_un)
 - [`socket`](#socket)
+- [`dns`](#dns)
 - [`file`](#file)
 - [`dentry`](#dentry)
 - [`path`](#path)
@@ -306,6 +307,43 @@ layer), as opposed to `struct sock` (network layer).
 
 In `matchArgs` or `matchData`, use network operators: `SAddr`, `DAddr`, `SPort`, `DPort`,
 `Protocol`, `Family`, or `State`.
+
+## `dns`
+
+The `dns` data type parses the first question of a DNS-over-UDP message out
+of a kernel `struct msghdr *` argument. It is intended to be attached to
+kprobes on `udp_sendmsg`, `udp_recvmsg`, and their IPv6 variants, paired
+with a `sock` arg filtered on `DPort 53` (egress) or `SPort 53` (ingress).
+The parser runs entirely in BPF and exposes the following fields on the
+event:
+
+- `query_name` — lowercased, dot-separated FQDN (no trailing dot)
+- `query_type` / `query_type_str` — IANA QTYPE (e.g. `1`/`"A"`, `28`/`"AAAA"`,
+  `5`/`"CNAME"`, `12`/`"PTR"`); unknown values are reported as `"TYPEn"` per
+  RFC 3597
+- `query_class` — typically `1` (`IN`)
+- `tx_id`, `flags`, `response`, `truncated`, `parsed`
+
+In `matchArgs` or `matchData`, `query_name` supports `Equal`, `NotEqual`,
+`Prefix`, `NotPrefix`, `Postfix`, `NotPostfix`, `SubString` (v6.17+) and
+`SubStringIgnoreCase` (v6.19+). Suffix matching with `Postfix` is the
+natural way to match a whole zone (e.g. `Postfix example.com` matches both
+`example.com` and `www.example.com`). Matching on `query_type` and other
+DNS fields is currently only available through CEL on the userspace event.
+
+Example policy: see [examples/tracingpolicy/dns-egress.yaml](https://github.com/cilium/tetragon/blob/main/examples/tracingpolicy/dns-egress.yaml).
+
+{{< caution >}}
+v1 limitations:
+- UDP only — TCP, DoT and DoH are out of scope.
+- Only the first question is decoded; messages with `QDCOUNT > 1` set the
+  `truncated` flag.
+- EDNS0 is not supported; payloads are clamped to the RFC 1035 512-byte cap.
+- Compression pointers in the *question* section (illegal per RFC 1035
+  §4.1.4) cause the parser to emit an event with `parsed = false`.
+- Requires kernel features gated behind Tetragon's `__LARGE_BPF_PROG` build
+  variant. On older kernels the policy loads but the `dns` arg is empty.
+{{< /caution >}}
 
 ## `file`
 

--- a/examples/tracingpolicy/dns-egress.yaml
+++ b/examples/tracingpolicy/dns-egress.yaml
@@ -1,0 +1,43 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "dns-egress"
+spec:
+  kprobes:
+  - call: "udp_sendmsg"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    - index: 1
+      type: "dns"
+      label: "dns"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DPort"
+        values:
+        - "53"
+      - index: 1
+        operator: "Postfix"
+        values:
+        - "example.com"
+
+  - call: "udpv6_sendmsg"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    - index: 1
+      type: "dns"
+      label: "dns"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DPort"
+        values:
+        - "53"
+      - index: 1
+        operator: "Postfix"
+        values:
+        - "example.com"

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -323,6 +323,43 @@ func (m MsgGenericKprobeArgSockaddrUn) IsReturnArg() bool {
 	return m.Index == ReturnArgIndex
 }
 
+const DnsMaxName = 255
+
+// MsgGenericKprobeDns must match struct dns_type in bpf/process/types/dns.h.
+type MsgGenericKprobeDns struct {
+	TxId      uint16
+	Flags     uint16
+	QType     uint16
+	QClass    uint16
+	QR        uint8
+	NameLen   uint8
+	Truncated uint8
+	Ok        uint8
+	Name      [DnsMaxName + 1]byte
+}
+
+type MsgGenericKprobeArgDns struct {
+	Index     uint64
+	Name      string
+	Type      uint16
+	TypeStr   string
+	Class     uint16
+	TxId      uint16
+	Flags     uint16
+	Response  bool
+	Truncated bool
+	Parsed    bool
+	Label     string
+}
+
+func (m MsgGenericKprobeArgDns) GetIndex() uint64 {
+	return m.Index
+}
+
+func (m MsgGenericKprobeArgDns) IsReturnArg() bool {
+	return m.Index == ReturnArgIndex
+}
+
 type MsgGenericSyscallID struct {
 	ID  uint32
 	ABI string

--- a/pkg/dns/parser.go
+++ b/pkg/dns/parser.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+// Package dns provides DNS helpers and a pure-Go reference parser that mirrors
+// the on-path BPF parser at bpf/process/types/dns.h.
+package dns
+
+import "errors"
+
+type Parsed struct {
+	TxId      uint16
+	Flags     uint16
+	QType     uint16
+	QClass    uint16
+	Response  bool
+	QName     string
+	Truncated bool
+}
+
+var (
+	ErrShort       = errors.New("dns: message shorter than header")
+	ErrOpcode      = errors.New("dns: non-standard opcode")
+	ErrNoQuestion  = errors.New("dns: qdcount < 1")
+	ErrLabel       = errors.New("dns: invalid label length")
+	ErrCompression = errors.New("dns: compression pointer in question section")
+	ErrTruncated   = errors.New("dns: qname exceeded maximum length")
+)
+
+const (
+	maxName     = 255
+	maxLabel    = 63
+	headerLen   = 12
+	maxUDPBytes = 512
+)
+
+func Parse(buf []byte) (Parsed, error) {
+	var p Parsed
+	if len(buf) > maxUDPBytes {
+		buf = buf[:maxUDPBytes]
+	}
+	if len(buf) < headerLen {
+		return p, ErrShort
+	}
+
+	p.TxId = uint16(buf[0])<<8 | uint16(buf[1])
+	p.Flags = uint16(buf[2])<<8 | uint16(buf[3])
+	qdcount := uint16(buf[4])<<8 | uint16(buf[5])
+	p.Response = p.Flags&0x8000 != 0
+	opcode := (p.Flags >> 11) & 0xf
+	if opcode != 0 {
+		return p, ErrOpcode
+	}
+	if qdcount < 1 {
+		return p, ErrNoQuestion
+	}
+
+	name := make([]byte, 0, 64)
+	pos := headerLen
+	for {
+		if pos >= len(buf) {
+			return p, ErrShort
+		}
+		labelLen := int(buf[pos])
+		pos++
+		if labelLen == 0 {
+			break
+		}
+		// RFC 1035 §4.1.4: top two bits 11 = compression pointer.
+		if labelLen&0xc0 == 0xc0 {
+			return p, ErrCompression
+		}
+		if labelLen > maxLabel {
+			return p, ErrLabel
+		}
+		if len(name) > 0 {
+			if len(name)+1 > maxName {
+				p.Truncated = true
+				return p, ErrTruncated
+			}
+			name = append(name, '.')
+		}
+		if pos+labelLen > len(buf) {
+			return p, ErrShort
+		}
+		for i := 0; i < labelLen; i++ {
+			if len(name) >= maxName {
+				p.Truncated = true
+				return p, ErrTruncated
+			}
+			c := buf[pos+i]
+			if c >= 'A' && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+			name = append(name, c)
+		}
+		pos += labelLen
+	}
+	p.QName = string(name)
+
+	if pos+4 > len(buf) {
+		return p, ErrShort
+	}
+	p.QType = uint16(buf[pos])<<8 | uint16(buf[pos+1])
+	p.QClass = uint16(buf[pos+2])<<8 | uint16(buf[pos+3])
+	return p, nil
+}

--- a/pkg/dns/parser_test.go
+++ b/pkg/dns/parser_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package dns
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func buildQuery(t *testing.T, name string, qtype uint16, flags uint16) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	b.Write([]byte{0x12, 0x34, byte(flags >> 8), byte(flags), 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+	if name != "" {
+		for _, l := range bytes.Split([]byte(name), []byte{'.'}) {
+			if len(l) > 63 {
+				t.Fatalf("test bug: label too long: %q", l)
+			}
+			b.WriteByte(byte(len(l)))
+			b.Write(l)
+		}
+	}
+	b.WriteByte(0)
+	b.Write([]byte{byte(qtype >> 8), byte(qtype)})
+	b.Write([]byte{0x00, 0x01})
+	return b.Bytes()
+}
+
+func TestParseStandardQueries(t *testing.T) {
+	cases := []struct {
+		name   string
+		qname  string
+		qtype  uint16
+		flags  uint16
+		expect string
+		isResp bool
+	}{
+		{"A example.com", "example.com", 1, 0x0100, "example.com", false},
+		{"AAAA example.com", "example.com", 28, 0x0100, "example.com", false},
+		{"CNAME www.example.com", "www.example.com", 5, 0x0100, "www.example.com", false},
+		{"PTR 1.in-addr.arpa", "1.in-addr.arpa", 12, 0x0100, "1.in-addr.arpa", false},
+		{"response bit set", "x.test", 1, 0x8180, "x.test", true},
+		{"uppercase lowercased", "WWW.EXAMPLE.COM", 1, 0x0100, "www.example.com", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p, err := Parse(buildQuery(t, c.qname, c.qtype, c.flags))
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if p.QName != c.expect {
+				t.Errorf("qname = %q, want %q", p.QName, c.expect)
+			}
+			if p.QType != c.qtype {
+				t.Errorf("qtype = %d, want %d", p.QType, c.qtype)
+			}
+			if p.Response != c.isResp {
+				t.Errorf("response = %v, want %v", p.Response, c.isResp)
+			}
+			if p.TxId != 0x1234 {
+				t.Errorf("txid = %#x, want 0x1234", p.TxId)
+			}
+		})
+	}
+}
+
+func TestParseMalformedRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  []byte
+		want error
+	}{
+		{"empty", []byte{}, ErrShort},
+		{"header-with-qdcount-zero", make([]byte, 12), ErrNoQuestion},
+		{"truncated-after-qdcount-one", []byte{0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}, ErrShort},
+		{"label-length-64", func() []byte {
+			b := []byte{0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+			b = append(b, 64)
+			b = append(b, bytes.Repeat([]byte{'a'}, 64)...)
+			b = append(b, 0, 0, 1, 0, 1)
+			return b
+		}(), ErrLabel},
+		{"compression-in-question", func() []byte {
+			b := []byte{0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+			b = append(b, 0xc0, 0x0c, 0, 1, 0, 1)
+			return b
+		}(), ErrCompression},
+		{"non-standard-opcode", func() []byte {
+			b := []byte{0x00, 0x01, 0x08, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+			b = append(b, 1, 'a', 0, 0, 1, 0, 1)
+			return b
+		}(), ErrOpcode},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := Parse(c.buf); !errors.Is(err, c.want) {
+				t.Fatalf("err = %v, want %v", err, c.want)
+			}
+		})
+	}
+}
+
+func FuzzParse(f *testing.F) {
+	seeds := [][]byte{
+		buildQuery(&testing.T{}, "example.com", 1, 0x0100),
+		buildQuery(&testing.T{}, "a", 28, 0x0100),
+		{0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0, 0xc0, 0x0c, 0, 1, 0, 1},
+		make([]byte, 0),
+		make([]byte, 4096),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, b []byte) {
+		_, _ = Parse(b)
+	})
+}
+
+func TestQTypeString(t *testing.T) {
+	cases := map[uint16]string{
+		1:    "A",
+		5:    "CNAME",
+		28:   "AAAA",
+		257:  "CAA",
+		9999: "TYPE9999",
+	}
+	for in, want := range cases {
+		if got := QTypeString(in); got != want {
+			t.Errorf("QTypeString(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/dns/qtype.go
+++ b/pkg/dns/qtype.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package dns
+
+import "strconv"
+
+var qtypeNames = map[uint16]string{
+	1:   "A",
+	2:   "NS",
+	5:   "CNAME",
+	6:   "SOA",
+	12:  "PTR",
+	13:  "HINFO",
+	15:  "MX",
+	16:  "TXT",
+	17:  "RP",
+	18:  "AFSDB",
+	24:  "SIG",
+	25:  "KEY",
+	28:  "AAAA",
+	29:  "LOC",
+	33:  "SRV",
+	35:  "NAPTR",
+	37:  "CERT",
+	39:  "DNAME",
+	41:  "OPT",
+	43:  "DS",
+	44:  "SSHFP",
+	46:  "RRSIG",
+	47:  "NSEC",
+	48:  "DNSKEY",
+	50:  "NSEC3",
+	51:  "NSEC3PARAM",
+	52:  "TLSA",
+	53:  "SMIMEA",
+	59:  "CDS",
+	60:  "CDNSKEY",
+	61:  "OPENPGPKEY",
+	64:  "SVCB",
+	65:  "HTTPS",
+	257: "CAA",
+}
+
+// QTypeString returns the IANA mnemonic, or "TYPEn" per RFC 3597 for unknowns.
+func QTypeString(t uint16) string {
+	if name, ok := qtypeNames[t]; ok {
+		return name
+	}
+	return "TYPE" + strconv.FormatUint(uint64(t), 10)
+}

--- a/pkg/generictypes/generictypes.go
+++ b/pkg/generictypes/generictypes.go
@@ -70,6 +70,8 @@ const (
 	GenericBpfProgType    = 43
 	GenericSockaddrUnType = 44
 
+	GenericDnsType = 45
+
 	GenericUnsetType = 0
 
 	GenericNopType     = -1
@@ -133,6 +135,7 @@ var genericStringToType = map[string]int{
 	"socket":          GenericSocketType,
 	"dentry":          GenericDentryType,
 	"bpf_prog":        GenericBpfProgType,
+	"dns":             GenericDnsType,
 }
 
 var genericTypeToStringTable = map[int]string{
@@ -180,6 +183,7 @@ var genericTypeToStringTable = map[int]string{
 	GenericSocketType:      "socket",
 	GenericDentryType:      "dentry",
 	GenericBpfProgType:     "bpf_prog",
+	GenericDnsType:         "dns",
 	GenericInvalidType:     "",
 }
 

--- a/pkg/grpc/tracing/tracing.go
+++ b/pkg/grpc/tracing/tracing.go
@@ -187,6 +187,19 @@ func getKprobeArgument(arg tracingapi.MsgGenericKprobeArg) *tetragon.KprobeArgum
 		}
 		a.Arg = &tetragon.KprobeArgument_SockaddrunArg{SockaddrunArg: sockaddrUnArg}
 		a.Label = e.Label
+	case tracingapi.MsgGenericKprobeArgDns:
+		a.Arg = &tetragon.KprobeArgument_DnsArg{DnsArg: &tetragon.KprobeDns{
+			QueryName:    e.Name,
+			QueryType:    uint32(e.Type),
+			QueryTypeStr: e.TypeStr,
+			QueryClass:   uint32(e.Class),
+			TxId:         uint32(e.TxId),
+			Flags:        uint32(e.Flags),
+			Response:     e.Response,
+			Truncated:    e.Truncated,
+			Parsed:       e.Parsed,
+		}}
+		a.Label = e.Label
 	case tracingapi.MsgGenericKprobeArgCred:
 		credArg := &tetragon.ProcessCredentials{
 			Uid:        &wrapperspb.UInt32Value{Value: e.Uid},
@@ -651,6 +664,21 @@ func (msg *MsgGenericTracepointUnix) HandleMessage() *tetragon.GetEventsResponse
 
 			tetragonArgs = append(tetragonArgs, &tetragon.KprobeArgument{Arg: &tetragon.KprobeArgument_SockaddrunArg{
 				SockaddrunArg: &address,
+			}})
+
+		case tracingapi.MsgGenericKprobeArgDns:
+			tetragonArgs = append(tetragonArgs, &tetragon.KprobeArgument{Arg: &tetragon.KprobeArgument_DnsArg{
+				DnsArg: &tetragon.KprobeDns{
+					QueryName:    v.Name,
+					QueryType:    uint32(v.Type),
+					QueryTypeStr: v.TypeStr,
+					QueryClass:   uint32(v.Class),
+					TxId:         uint32(v.TxId),
+					Flags:        uint32(v.Flags),
+					Response:     v.Response,
+					Truncated:    v.Truncated,
+					Parsed:       v.Parsed,
+				},
 			}})
 
 		case tracingapi.MsgGenericSyscallID:

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -75,7 +75,7 @@ type KProbeArg struct {
 	// +kubebuilder:validation:Minimum=0
 	// Position of the argument.
 	Index uint32 `json:"index"`
-	// +kubebuilder:validation:Enum=auto;int;sint8;int8;uint8;sint16;int16;uint16;uint32;sint32;int32;ulong;uint64;size_t;long;sint64;int64;char_buf;char_iovec;skb;sock;sockaddr;socket;sockaddr_un;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;const_buf;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd;dentry;bpf_prog;
+	// +kubebuilder:validation:Enum=auto;int;sint8;int8;uint8;sint16;int16;uint16;uint32;sint32;int32;ulong;uint64;size_t;long;sint64;int64;char_buf;char_iovec;skb;sock;sockaddr;socket;sockaddr_un;string;fd;file;filename;path;nop;bpf_attr;perf_event;bpf_map;user_namespace;capability;kiocb;iov_iter;cred;const_buf;load_info;module;syscall64;kernel_cap_t;cap_inheritable;cap_permitted;cap_effective;linux_binprm;data_loc;net_device;bpf_cmd;dentry;bpf_prog;dns;
 	// +kubebuilder:default=auto
 	// Argument type.
 	Type string `json:"type"`

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -995,14 +995,14 @@ func parseMatchArg(k *KernelSelectorState, arg *v1alpha1.ArgSelector, sig []v1al
 		}
 	case SelectorOpSubStringIgnCase, SelectorOpSubString:
 		switch ty {
-		case gt.GenericFdType, gt.GenericFileType, gt.GenericPathType, gt.GenericDentryType, gt.GenericStringType, gt.GenericCharBuffer, gt.GenericLinuxBinprmType, gt.GenericDataLoc, gt.GenericNetDev, gt.GenericSockaddrUnType:
+		case gt.GenericFdType, gt.GenericFileType, gt.GenericPathType, gt.GenericDentryType, gt.GenericStringType, gt.GenericCharBuffer, gt.GenericLinuxBinprmType, gt.GenericDataLoc, gt.GenericNetDev, gt.GenericSockaddrUnType, gt.GenericDnsType:
 			if err := writeMatchSubString(k, arg.Values); err != nil {
 				return fmt.Errorf("writeMatchSubString error: %w", err)
 			}
 		}
 	case SelectorOpEQ, SelectorOpNEQ:
 		switch ty {
-		case gt.GenericFdType, gt.GenericFileType, gt.GenericPathType, gt.GenericDentryType, gt.GenericStringType, gt.GenericCharBuffer, gt.GenericLinuxBinprmType, gt.GenericDataLoc, gt.GenericNetDev, gt.GenericSockaddrUnType:
+		case gt.GenericFdType, gt.GenericFileType, gt.GenericPathType, gt.GenericDentryType, gt.GenericStringType, gt.GenericCharBuffer, gt.GenericLinuxBinprmType, gt.GenericDataLoc, gt.GenericNetDev, gt.GenericSockaddrUnType, gt.GenericDnsType:
 			err := writeMatchStrings(k, arg.Values, ty)
 			if err != nil {
 				return fmt.Errorf("writeMatchStrings error: %w", err)

--- a/pkg/sensors/tracing/args_linux.go
+++ b/pkg/sensors/tracing/args_linux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/tetragon/pkg/api/dataapi"
 	processapi "github.com/cilium/tetragon/pkg/api/processapi"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
+	"github.com/cilium/tetragon/pkg/dns"
 	gt "github.com/cilium/tetragon/pkg/generictypes"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger/logfields"
@@ -371,6 +372,33 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Index = uint64(a.index)
 		arg.Family = sockaddr.Family
 		arg.Path = decodeSockaddrUnPath(sockaddr.Path[:], sockaddr.PathLen, sockaddr.IsAbstract)
+		return arg
+	case gt.GenericDnsType:
+		var dnsEv api.MsgGenericKprobeDns
+		var arg api.MsgGenericKprobeArgDns
+
+		err := binary.Read(r, binary.LittleEndian, &dnsEv)
+		if err != nil {
+			l.LogAttrs(slog.LevelWarn, "dns type err", slog.Any(logfields.Error, err))
+		}
+
+		arg.Index = uint64(a.index)
+		arg.Label = a.label
+		arg.Parsed = dnsEv.Ok != 0
+		if arg.Parsed {
+			n := int(dnsEv.NameLen)
+			if n > len(dnsEv.Name) {
+				n = len(dnsEv.Name)
+			}
+			arg.Name = strutils.UTF8FromBPFBytes(dnsEv.Name[:n])
+			arg.Type = dnsEv.QType
+			arg.TypeStr = dns.QTypeString(dnsEv.QType)
+			arg.Class = dnsEv.QClass
+			arg.TxId = dnsEv.TxId
+			arg.Flags = dnsEv.Flags
+			arg.Response = dnsEv.QR != 0
+			arg.Truncated = dnsEv.Truncated != 0
+		}
 		return arg
 	case gt.GenericS64Type:
 		var output int64

--- a/pkg/sensors/tracing/kprobe_dns_test.go
+++ b/pkg/sensors/tracing/kprobe_dns_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package tracing
+
+import (
+	"net"
+
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/config"
+	"github.com/cilium/tetragon/pkg/jsonchecker"
+	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+)
+
+func dnsRawQuery() []byte {
+	hdr := []byte{0x42, 0x42, 0x01, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+	q := []byte{7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 4, 't', 'e', 's', 't', 0}
+	tail := []byte{0, 1, 0, 1}
+	return append(append(hdr, q...), tail...)
+}
+
+func (suite *KprobeNet) TestKprobeDnsExample() {
+	if !config.EnableLargeProgs() {
+		suite.T().Skip("DNS parser requires __LARGE_BPF_PROG")
+	}
+
+	hook := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "udp-dns-egress"
+spec:
+  kprobes:
+  - call: "udp_sendmsg"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    - index: 1
+      type: "dns"
+      label: "dns"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DPort"
+        values:
+        - "53"
+      - index: 1
+        operator: "Postfix"
+        values:
+        - "example.test"
+`
+
+	suite.readyWG.Wait()
+	tp := suite.addTracingPolicy(hook)
+	defer suite.deleteTracingPolicy(tp)
+
+	conn, err := net.Dial("udp4", "127.0.0.1:53")
+	suite.Require().NoError(err)
+	defer conn.Close()
+	_, err = conn.Write(dnsRawQuery())
+	suite.Require().NoError(err)
+
+	kp := ec.NewProcessKprobeChecker("udp-dns-egress").
+		WithFunctionName(sm.Full("udp_sendmsg")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithSockArg(
+					ec.NewKprobeSockChecker().WithDport(53),
+				),
+				ec.NewKprobeArgumentChecker().WithDnsArg(
+					ec.NewKprobeDnsChecker().
+						WithQueryName(sm.Full("example.test")).
+						WithQueryTypeStr(sm.Full("A")).
+						WithParsed(true).
+						WithResponse(false),
+				).WithLabel(sm.Full("dns")),
+			))
+
+	err = jsonchecker.JsonTestCheckExpectWithKeep(suite.T(), ec.NewUnorderedEventChecker(kp), false, false)
+	suite.Require().NoError(err)
+}
+
+func (suite *KprobeNet) TestKprobeDnsPostfixNoMatch() {
+	if !config.EnableLargeProgs() {
+		suite.T().Skip("DNS parser requires __LARGE_BPF_PROG")
+	}
+
+	hook := `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "udp-dns-egress-strict"
+spec:
+  kprobes:
+  - call: "udp_sendmsg"
+    syscall: false
+    args:
+    - index: 0
+      type: "sock"
+    - index: 1
+      type: "dns"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "DPort"
+        values:
+        - "53"
+      - index: 1
+        operator: "Postfix"
+        values:
+        - "example.test"
+`
+
+	suite.readyWG.Wait()
+	tp := suite.addTracingPolicy(hook)
+	defer suite.deleteTracingPolicy(tp)
+
+	pkt := []byte{0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+	pkt = append(pkt, 5, 'o', 't', 'h', 'e', 'r', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0)
+	pkt = append(pkt, 0, 1, 0, 1)
+
+	conn, err := net.Dial("udp4", "127.0.0.1:53")
+	suite.Require().NoError(err)
+	defer conn.Close()
+	_, err = conn.Write(pkt)
+	suite.Require().NoError(err)
+
+	err = jsonchecker.JsonTestCheckExpectWithKeep(suite.T(), ec.NewUnorderedEventChecker(), false, false)
+	suite.Require().NoError(err)
+}


### PR DESCRIPTION
Introduce a new `dns` KProbeArg type that decodes the first question of DNS-over-UDP messages directly in BPF when attached to udp_sendmsg / udp_recvmsg (and IPv6 variants). The parsed query name, type, class, flags, and tx_id are exposed as a new KprobeDns argument on ProcessKprobe events, and dns_query_name can be matched with the existing string operators (Equal, NotEqual, Prefix, Postfix, SubString). The on-path parser lives in bpf/process/types/dns.h. It validates the DNS header (opcode, qdcount), walks the QNAME with a single bounded loop sized for verifier complexity, and lowercases labels as it writes.

Fixes: #4948 

```release-note
Add a new `dns` kprobe argument type for TracingPolicy that decodes DNS-over-UDP queries directly in BPF, exposing `query_name`/`query_type` and supporting Equal/Prefix/Postfix/SubString selectors on the queried domain.
```
