### PR TITLE
1.7 backports

### DIFF
--- a/pkg/celbpf/celbpf_test.go
+++ b/pkg/celbpf/celbpf_test.go
@@ -162,6 +162,11 @@ func TestArgExprs(t *testing.T) {
 			hookArgs: []any{int32(0), uint64(0), int32(42)},
 		},
 		{
+			expr:     "arg0 == int32(-1)",
+			ret:      1,
+			hookArgs: []any{int32(-1)},
+		},
+		{
 			expr:     "arg2 == int32(0)",
 			ret:      0,
 			hookArgs: []any{int32(0), uint64(0), int32(42)},
@@ -180,6 +185,11 @@ func TestArgExprs(t *testing.T) {
 			expr:     "arg2 - int32(10) == int32(2) + arg0",
 			ret:      1,
 			hookArgs: []any{int32(30), uint64(0), int32(42)},
+		},
+		{
+			expr:     "arg2 - int32(-10) == int32(12) + arg0",
+			ret:      1,
+			hookArgs: []any{int32(30), uint64(0), int32(32)},
 		},
 	}
 
@@ -237,10 +247,10 @@ func TestArgExprs(t *testing.T) {
 		defer prog.Close()
 		val, err := prog.Run(&ebpf.RunOptions{})
 		require.NoError(t, err)
-		require.Equal(t, tc.ret, val, "result of %q was %d and not %d", tc.expr, val, tc.ret)
 		if tc.ret != val {
 			t.Logf("insns:\n%s\n", insns)
 			dumpProg(t, prog)
 		}
+		require.Equal(t, tc.ret, val, "result of %q was %d and not %d", tc.expr, val, tc.ret)
 	}
 }

--- a/pkg/celbpf/codegen.go
+++ b/pkg/celbpf/codegen.go
@@ -77,22 +77,6 @@ func (g *codeGenerator) emitPopInt64(reg asm.Register) {
 	g.stackTop += 8
 }
 
-func (g *codeGenerator) emitBranchEquals(reg0 asm.Register, reg1 asm.Register) {
-	// make space to push a boolean (8 bytes)
-	g.stackTop -= 8
-	label := g.generateLabel()
-	g.emitRaw(
-		// check reg0 vs reg1, and then use reg0 for the result so that we can save it in
-		// the stack.
-		asm.JEq.Reg(reg0, reg1, label),
-		asm.LoadImm(reg0, 0, asm.DWord),
-		asm.Instruction{OpCode: asm.Ja.Op(asm.ImmSource), Offset: 2},
-		asm.LoadImm(reg0, 1, asm.DWord).WithSymbol(label),
-		asm.StoreMem(asm.R10, g.stackTop, reg0, asm.DWord),
-	)
-
-}
-
 func (g *codeGenerator) emitPopS32(reg asm.Register) {
 	g.emitRaw(asm.LoadMem(reg, asm.R10, g.stackTop, asm.DWord))
 	g.stackTop += 8
@@ -101,10 +85,6 @@ func (g *codeGenerator) emitPopS32(reg asm.Register) {
 func (g *codeGenerator) emitS32(reg asm.Register, regTy *cgTypes.Type) error {
 	switch regTy {
 	case s64Ty:
-		g.emitRaw(
-			asm.LSh.Imm(reg, 0x20),
-			asm.ArSh.Imm(reg, 0x20),
-		)
 	default:
 		return fmt.Errorf("emitS32: unknown/unsupported type %s", regTy)
 	}
@@ -125,10 +105,6 @@ func (g *codeGenerator) emitU32(reg asm.Register, regTy *cgTypes.Type) error {
 
 	switch regTy {
 	case u64Ty:
-		g.emitRaw(
-			asm.LSh.Imm(reg, 0x20),
-			asm.RSh.Imm(reg, 0x20),
-		)
 	default:
 		return fmt.Errorf("emitU32: unknown/unsupported type %s", regTy)
 	}
@@ -186,13 +162,19 @@ func (g *codeGenerator) emitSub(
 ) error {
 	switch {
 	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName(),
-		ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
-		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName(),
-		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName():
 
 		g.stackTop -= 8
 		g.emitRaw(
 			asm.Sub.Reg(r1, r2),
+			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
+		)
+
+	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
+		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		g.stackTop -= 8
+		g.emitRaw(
+			asm.Sub.Reg32(r1, r2),
 			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
 		)
 
@@ -210,13 +192,19 @@ func (g *codeGenerator) emitAdd(
 ) error {
 	switch {
 	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName(),
-		ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
-		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName(),
-		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName():
 
 		g.stackTop -= 8
 		g.emitRaw(
 			asm.Add.Reg(r1, r2),
+			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
+		)
+
+	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
+		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		g.stackTop -= 8
+		g.emitRaw(
+			asm.Add.Reg32(r1, r2),
 			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
 		)
 
@@ -260,7 +248,7 @@ func (g *codeGenerator) emitNot(r1 asm.Register, tmp asm.Register) error {
 	return nil
 }
 
-func (g *codeGenerator) emitInequality(
+func (g *codeGenerator) emitBranch(
 	reg1 asm.Register, ty1 *cgTypes.Type,
 	reg2 asm.Register, ty2 *cgTypes.Type,
 	op string,
@@ -268,19 +256,30 @@ func (g *codeGenerator) emitInequality(
 ) error {
 
 	var signed bool
+	var alu32 bool
 	switch {
-	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
-		ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName():
+	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName():
 		signed = true
-	case ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName(),
-		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
-		signed = false
+		alu32 = true
+
+	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName():
+		signed = true
+
+	case ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		alu32 = true
+
+	case ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName():
+
+	case ty1.TypeName() == boolTy.TypeName() && ty2.TypeName() == boolTy.TypeName() && op == cgOperators.Equals:
+
 	default:
-		return fmt.Errorf("inequality (%q) between types %s and %s is not supported", op, ty1.TypeName(), ty2.TypeName())
+		return fmt.Errorf("operation (%q) between types %s and %s is not supported", op, ty1.TypeName(), ty2.TypeName())
 	}
 
 	opcode := asm.InvalidJumpOp
 	switch op {
+	case cgOperators.Equals:
+		opcode = asm.JEq
 	case cgOperators.NotEquals:
 		opcode = asm.JNE
 	case cgOperators.Less:
@@ -313,9 +312,15 @@ func (g *codeGenerator) emitInequality(
 
 	g.stackTop -= 8
 	label := g.generateLabel()
+	jmpInst := func() asm.Instruction {
+		if alu32 {
+			return opcode.Reg32(reg1, reg2, label)
+		}
+		return opcode.Reg(reg1, reg2, label)
+	}
 	g.emitRaw(
 		asm.LoadImm(tmp, 1, asm.DWord),
-		opcode.Reg(reg1, reg2, label),
+		jmpInst(),
 		asm.LoadImm(tmp, 0, asm.DWord),
 		asm.StoreMem(asm.R10, g.stackTop, tmp, asm.DWord).WithSymbol(label),
 	)

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -70,11 +70,6 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 	// setup emit call
 	var emitCall func() error
 	switch op := call.FunctionName(); op {
-	case cgOperators.Equals:
-		emitCall = func() error {
-			c.cg.emitBranchEquals(scratchRegs[0], scratchRegs[1])
-			return nil
-		}
 	case int32Fn:
 		emitCall = func() error {
 			return c.cg.emitS32(scratchRegs[0], argTypes[0])
@@ -120,11 +115,11 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 
 	case cgOperators.Less, cgOperators.LessEquals,
 		cgOperators.Greater, cgOperators.GreaterEquals,
-		cgOperators.NotEquals:
+		cgOperators.NotEquals, cgOperators.Equals:
 		emitCall = func() error {
 			// NB: scratchRegs[2] is not used but we pass it so that the implementation
 			// can use it for an intemediate value.
-			return c.cg.emitInequality(
+			return c.cg.emitBranch(
 				scratchRegs[0], argTypes[0],
 				scratchRegs[1], argTypes[1],
 				op,

--- a/pkg/celbpf/types.go
+++ b/pkg/celbpf/types.go
@@ -22,6 +22,7 @@ var (
 	u64Ty         = cgTypes.UintType
 	s32Ty         = cgTypes.NewOpaqueType("s32")
 	u32Ty         = cgTypes.NewOpaqueType("u32")
+	boolTy        = cgTypes.BoolType
 	unsupportedTy = cgTypes.NewOpaqueType("unsupported")
 
 	addS32 = "add_s32"

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -571,7 +571,10 @@ func (msg *MsgExitEventUnix) Retry(internal *process.ProcessInternal, ev notify.
 
 	if tetragonProcess.Pid.Value > 1 && !msg.RefCntDone[ParentRefCnt] {
 		if parent, _ := process.Get(tetragonProcess.ParentExecId); parent != nil {
-			parent.RefDec("parent")
+			if !internal.GetParentRefcntDecreased() {
+				parent.RefDec("parent")
+				internal.SetParentRefcntDecreased(true)
+			}
 			msg.RefCntDone[ParentRefCnt] = true
 		}
 	}

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -77,6 +77,7 @@ func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 					 * process a second time, but that is harmless.
 					 */
 					if p.refcnt.Load() != 0 {
+						p.color = inUse
 						continue
 					}
 					if p.color == deleteReady {

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -159,6 +159,11 @@ func NewCache(
 			// Perform parent-- for LRU-evicted entries that will never
 			// reach the exit handler.
 
+			// Skip entries whose exit path already performed parent--
+			if evicted.GetParentRefcntDecreased() {
+				return
+			}
+
 			// Skip non-inUse entries whose exit path already performed parent--
 			if evicted.color != inUse {
 				return
@@ -174,6 +179,7 @@ func NewCache(
 			}
 
 			pm.refDec(parent, "parent--")
+			evicted.SetParentRefcntDecreased(true)
 		},
 	)
 	if err != nil {

--- a/pkg/process/cache.go
+++ b/pkg/process/cache.go
@@ -28,15 +28,19 @@ type Cache struct {
 	stopChan   chan bool
 }
 
+// processColor tracks the garbage collection state of a process. It is stored
+// in ProcessInternal as an atomic and accessed via getColor/setColor.
+type processColor int32
+
 // garbage collection states
 const (
-	inUse = iota
+	inUse processColor = iota
 	deletePending
 	deleteReady
 	deleted
 )
 
-var colorStr = map[int]string{
+var colorStr = map[processColor]string{
 	inUse:         "inUse",
 	deletePending: "deletePending",
 	deleteReady:   "deleteReady",
@@ -77,15 +81,15 @@ func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 					 * process a second time, but that is harmless.
 					 */
 					if p.refcnt.Load() != 0 {
-						p.color = inUse
+						p.setColor(inUse)
 						continue
 					}
-					if p.color == deleteReady {
-						p.color = deleted
+					if p.getColor() == deleteReady {
+						p.setColor(deleted)
 						pc.remove(p.process)
 					} else {
 						newQueue = append(newQueue, p)
-						p.color = deleteReady
+						p.setColor(deleteReady)
 					}
 				}
 				deleteQueue = newQueue
@@ -93,21 +97,18 @@ func (pc *Cache) cacheGarbageCollector(intervalGC time.Duration) {
 				// The object has already been deleted let if fall of
 				// the edge of the world. Hitting this could mean our
 				// GC logic deleted a process too early.
-				if p.color == deleted {
+				if p.getColor() == deleted {
 					processCacheEarlyDeletions.Inc()
 					continue
 				}
 				// duplicate deletes can happen, if they do reset
 				// color to pending and move along. This will cause
 				// the GC to keep it alive for at least another pass.
-				// Notice color is only ever touched inside GC behind
-				// select channel logic so should be safe to work on
-				// and assume its visible everywhere.
-				if p.color != inUse {
-					p.color = deletePending
+				if p.getColor() != inUse {
+					p.setColor(deletePending)
 					continue
 				}
-				p.color = deletePending
+				p.setColor(deletePending)
 				deleteQueue = append(deleteQueue, p)
 			}
 		}
@@ -165,7 +166,7 @@ func NewCache(
 			}
 
 			// Skip non-inUse entries whose exit path already performed parent--
-			if evicted.color != inUse {
+			if evicted.getColor() != inUse {
 				return
 			}
 
@@ -257,7 +258,7 @@ func (pc *Cache) dump(opts *tetragon.DumpProcessCacheReqArgs) []*tetragon.Proces
 			Process:   proto.Clone(v.process).(*tetragon.Process),
 			Refcnt:    &wrapperspb.UInt32Value{Value: ref},
 			RefcntOps: maps.Clone(v.refcntOps),
-			Color:     colorStr[v.color],
+			Color:     colorStr[v.getColor()],
 		})
 	}
 	return processes
@@ -270,7 +271,7 @@ func (pc *Cache) getEntries() []*tetragon.ProcessInternal {
 			Process:   v.process,
 			Refcnt:    &wrapperspb.UInt32Value{Value: v.refcnt.Load()},
 			RefcntOps: v.refcntOps,
-			Color:     colorStr[v.color],
+			Color:     colorStr[v.getColor()],
 		})
 	}
 	return processes

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -6,6 +6,7 @@ package process
 import (
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -76,4 +77,51 @@ func TestProcessCacheGCEarlyDeletion(t *testing.T) {
 tetragon_process_cache_early_deletions_total 1
 `)
 	require.NoError(t, testutil.CollectAndCompare(processCacheEarlyDeletions, expected))
+}
+
+func TestProcessCacheGCLeak(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		interval := 10 * time.Millisecond
+		cache, err := NewCache(10, interval)
+		require.NoError(t, err)
+		defer cache.purge()
+
+		pid := wrapperspb.UInt32Value{Value: 1234}
+		proc := ProcessInternal{
+			process: &tetragon.Process{
+				ExecId: "process1",
+				Pid:    &pid,
+			},
+			refcntOps: make(map[string]int32),
+		}
+		proc.refcnt.Store(1)
+		cache.add(&proc)
+
+		// Trigger GC to see it, then increment refcnt while it's in the deleteQueue.
+		// The GC should drop it from the queue and reset its color to inUse.
+		cache.refDec(&proc, "test")
+		synctest.Wait()
+		assert.Equal(t, deletePending, proc.color)
+
+		cache.refInc(&proc, "test")
+		time.Sleep(interval + 1*time.Millisecond)
+		synctest.Wait()
+		assert.Equal(t, inUse, proc.color)
+
+		// Trigger refDec to 0 again and wait for GC cycles to remove it.
+		// Two GC cycles are needed because the GC moves processes from:
+		// deletePending -> deleteReady in the first tick, and
+		// deleteReady -> deleted in the second tick.
+		cache.refDec(&proc, "test")
+		synctest.Wait()
+
+		time.Sleep(interval + 1*time.Millisecond)
+		synctest.Wait()
+
+		time.Sleep(interval + 1*time.Millisecond)
+		synctest.Wait()
+
+		assert.Equal(t, deleted, proc.color)
+		assert.Equal(t, 0, cache.len())
+	})
 }

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -125,3 +125,57 @@ func TestProcessCacheGCLeak(t *testing.T) {
 		assert.Equal(t, 0, cache.len())
 	})
 }
+
+func TestProcessCacheDoubleParentDecrease(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		interval := 10 * time.Millisecond
+		cache, err := NewCache(2, interval)
+		require.NoError(t, err)
+		defer cache.purge()
+
+		parent := &ProcessInternal{
+			process:   &tetragon.Process{ExecId: "parent", Pid: &wrapperspb.UInt32Value{Value: 100}},
+			refcntOps: make(map[string]int32),
+		}
+		parent.refcnt.Store(1)
+		cache.add(parent)
+
+		child := &ProcessInternal{
+			process:   &tetragon.Process{ExecId: "child", Pid: &wrapperspb.UInt32Value{Value: 101}, ParentExecId: "parent"},
+			refcntOps: make(map[string]int32),
+		}
+		child.refcnt.Store(1)
+		cache.add(child)
+
+		cache.refInc(parent, "parent++")
+		assert.Equal(t, uint32(2), parent.refcnt.Load())
+
+		// simulate exit handler path
+		if !child.GetParentRefcntDecreased() {
+			parent.RefDec("parent")
+			child.SetParentRefcntDecreased(true)
+		}
+		assert.Equal(t, uint32(1), parent.refcnt.Load())
+
+		cache.refDec(child, "process--")
+		synctest.Wait()
+		assert.Equal(t, deletePending, child.color)
+
+		// simulate resurrection: refInc after deletePending
+		cache.refInc(child, "late-event")
+		time.Sleep(interval + 1*time.Millisecond)
+		synctest.Wait()
+		assert.Equal(t, inUse, child.color)
+
+		// trigger LRU eviction of child
+		cache.get("parent")
+		other := &ProcessInternal{
+			process:   &tetragon.Process{ExecId: "other", Pid: &wrapperspb.UInt32Value{Value: 102}},
+			refcntOps: make(map[string]int32),
+		}
+		other.refcnt.Store(1)
+		cache.add(other)
+
+		assert.Equal(t, uint32(1), parent.refcnt.Load())
+	})
+}

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -4,7 +4,9 @@
 package process
 
 import (
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -67,7 +69,7 @@ func TestProcessCacheGCEarlyDeletion(t *testing.T) {
 	}
 	cache.add(&proc)
 
-	proc.color = deleted
+	proc.setColor(deleted)
 	cache.deletePending(&proc)
 
 	time.Sleep(50 * time.Millisecond)
@@ -101,12 +103,12 @@ func TestProcessCacheGCLeak(t *testing.T) {
 		// The GC should drop it from the queue and reset its color to inUse.
 		cache.refDec(&proc, "test")
 		synctest.Wait()
-		assert.Equal(t, deletePending, proc.color)
+		assert.Equal(t, deletePending, proc.getColor())
 
 		cache.refInc(&proc, "test")
 		time.Sleep(interval + 1*time.Millisecond)
 		synctest.Wait()
-		assert.Equal(t, inUse, proc.color)
+		assert.Equal(t, inUse, proc.getColor())
 
 		// Trigger refDec to 0 again and wait for GC cycles to remove it.
 		// Two GC cycles are needed because the GC moves processes from:
@@ -121,9 +123,73 @@ func TestProcessCacheGCLeak(t *testing.T) {
 		time.Sleep(interval + 1*time.Millisecond)
 		synctest.Wait()
 
-		assert.Equal(t, deleted, proc.color)
+		assert.Equal(t, deleted, proc.getColor())
 		assert.Equal(t, 0, cache.len())
 	})
+}
+
+// TestProcessCacheColorDataRace exercises the GC goroutine writing the color
+// field concurrently with another goroutine reading it via getEntries (the same
+// read path used by dump). Before color was made atomic this test reports a data
+// race under -race. It must stay clean now that color uses atomic access.
+func TestProcessCacheColorDataRace(t *testing.T) {
+	interval := 1 * time.Millisecond
+	cache, err := NewCache(100, interval)
+	require.NoError(t, err)
+	defer cache.purge()
+
+	procs := make([]*ProcessInternal, 0, 50)
+	for i := 0; i < 50; i++ {
+		p := &ProcessInternal{
+			process: &tetragon.Process{
+				ExecId: "proc" + strconv.Itoa(i),
+				Pid:    &wrapperspb.UInt32Value{Value: uint32(1000 + i)},
+			},
+			refcntOps: make(map[string]int32),
+		}
+		p.refcnt.Store(1)
+		cache.add(p)
+		procs = append(procs, p)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Reader goroutine: reads color via the getEntries path repeatedly.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				cache.getEntries()
+			}
+		}
+	}()
+
+	// Writer goroutine: churns refcnt so the GC goroutine keeps writing color
+	// (inUse -> deletePending -> deleteReady -> inUse ...).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for _, p := range procs {
+					cache.refDec(p, "race")
+					cache.refInc(p, "race")
+				}
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }
 
 func TestProcessCacheDoubleParentDecrease(t *testing.T) {
@@ -159,13 +225,13 @@ func TestProcessCacheDoubleParentDecrease(t *testing.T) {
 
 		cache.refDec(child, "process--")
 		synctest.Wait()
-		assert.Equal(t, deletePending, child.color)
+		assert.Equal(t, deletePending, child.getColor())
 
 		// simulate resurrection: refInc after deletePending
 		cache.refInc(child, "late-event")
 		time.Sleep(interval + 1*time.Millisecond)
 		synctest.Wait()
-		assert.Equal(t, inUse, child.color)
+		assert.Equal(t, inUse, child.getColor())
 
 		// trigger LRU eviction of child
 		cache.get("parent")

--- a/pkg/process/cache_test.go
+++ b/pkg/process/cache_test.go
@@ -139,7 +139,7 @@ func TestProcessCacheColorDataRace(t *testing.T) {
 	defer cache.purge()
 
 	procs := make([]*ProcessInternal, 0, 50)
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		p := &ProcessInternal{
 			process: &tetragon.Process{
 				ExecId: "proc" + strconv.Itoa(i),
@@ -156,9 +156,7 @@ func TestProcessCacheColorDataRace(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Reader goroutine: reads color via the getEntries path repeatedly.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -167,13 +165,11 @@ func TestProcessCacheColorDataRace(t *testing.T) {
 				cache.getEntries()
 			}
 		}
-	}()
+	})
 
 	// Writer goroutine: churns refcnt so the GC goroutine keeps writing color
 	// (inUse -> deletePending -> deleteReady -> inUse ...).
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -185,7 +181,7 @@ func TestProcessCacheColorDataRace(t *testing.T) {
 				}
 			}
 		}
-	}()
+	})
 
 	time.Sleep(200 * time.Millisecond)
 	close(stop)

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -49,8 +49,10 @@ type ProcessInternal struct {
 	// will be constructed on the fly when returning these extra fields
 	// about the binary during the corresponding ProcessExec only.
 	apiBinaryProp *tetragon.BinaryProperties
-	// garbage collector metadata
-	color  int // Writes should happen only inside gc select channel
+	// garbage collector metadata. color is accessed from the GC goroutine and
+	// concurrently read by dump()/getEntries() and the LRU eviction callback, so
+	// it is stored as an atomic and must only be touched via getColor/setColor.
+	color  atomic.Int32
 	refcnt atomic.Uint32
 	// parentRefcntDecreased tracks whether the parent reference count has been
 	// decreased for this process. This is used to avoid double parent-- when
@@ -246,6 +248,14 @@ func (pi *ProcessInternal) GetParentRefcntDecreased() bool {
 	pi.mu.Lock()
 	defer pi.mu.Unlock()
 	return pi.parentRefcntDecreased
+}
+
+func (pi *ProcessInternal) getColor() processColor {
+	return processColor(pi.color.Load())
+}
+
+func (pi *ProcessInternal) setColor(c processColor) {
+	pi.color.Store(int32(c))
 }
 
 func (pi *ProcessInternal) NeededAncestors() bool {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -52,6 +52,10 @@ type ProcessInternal struct {
 	// garbage collector metadata
 	color  int // Writes should happen only inside gc select channel
 	refcnt atomic.Uint32
+	// parentRefcntDecreased tracks whether the parent reference count has been
+	// decreased for this process. This is used to avoid double parent-- when
+	// a process is evicted by the LRU and then handled by the exit handler.
+	parentRefcntDecreased bool
 	// refcntOps is a map of operations to refcnt change
 	// keys can be:
 	// - "process++": process increased refcnt (i.e. this process starts)
@@ -230,6 +234,18 @@ func (pi *ProcessInternal) RefInc(reason string) {
 
 func (pi *ProcessInternal) RefGet() uint32 {
 	return pi.refcnt.Load()
+}
+
+func (pi *ProcessInternal) SetParentRefcntDecreased(val bool) {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
+	pi.parentRefcntDecreased = val
+}
+
+func (pi *ProcessInternal) GetParentRefcntDecreased() bool {
+	pi.mu.Lock()
+	defer pi.mu.Unlock()
+	return pi.parentRefcntDecreased
 }
 
 func (pi *ProcessInternal) NeededAncestors() bool {


### PR DESCRIPTION
Backported PRs

  * https://github.com/cilium/tetragon/pull/5057
       * [pkg/process: reset process color to inUse when reused in GC](https://github.com/cilium/tetragon/commit/3b9a2d9cbd901c2933bacf484946cc485856bb89)
       * [pkg/process: avoid double parent refcnt decrease on LRU eviction](https://github.com/cilium/tetragon/commit/0426843d046398af6ebf76a9eccace27b50f3955)
  * https://github.com/cilium/tetragon/pull/5106
       * [pkg/process: use atomic for color field in ProcessInternal](https://github.com/cilium/tetragon/commit/f794e6c137933a7e5733b02594c76013d9833e0d)
       * [test: modernize color race test (range-over-int and WaitGroup.Go)](https://github.com/cilium/tetragon/commit/8f6a9f6fb1e0c753b4f76295818091c905bbd031)
  * https://github.com/cilium/tetragon/pull/5138
       * [celbpf: fix 32-bit issue by using ALU32](https://github.com/cilium/tetragon/commit/6a9303fcf05c275235ad88b6850b0727376f15c1)
