### PR TITLE
[v1.7] fix(ci): fix windows CI.

### DIFF
--- a/.github/workflows/windows-build-smoke-test.yml
+++ b/.github/workflows/windows-build-smoke-test.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   windows-ebpf-prog-build:
     name: Build Windows ebpf programs
-    runs-on: windows-2025
+    runs-on: windows-2022
     timeout-minutes: 25
 
     permissions:


### PR DESCRIPTION
[ upstream commit f63680525153e17d75f4a59857c61e3e9e2e0d8f ]

`windows-2025` runners are now defaulting to vs2026: https://github.com/actions/runner-images/issues/14017.
But `microsoft/ntosebpfext` action, leveraged in our CI, still needs vs2022: https://github.com/microsoft/ntosebpfext/blob/main/scripts/initialize_repo.ps1

Fallback at using `windows-2022` runner.


## Notes

See [here](https://github.com/cilium/tetragon/actions/runs/27741496793/job/82069527518?pr=5150) for an example of why this backport is needed.