### PR TITLE
ci: bump go test job timeout to 60m

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -71,7 +71,7 @@ jobs:
         sudo -E echo "run go tests: " `uname -a`
         sudo -E go mod verify
         export TETRAGON_LIB=$(realpath "bpf/objs/")
-        make test GO_TEST_TIMEOUT=40m
+        make test GO_TEST_TIMEOUT=60m
 
     - name: Upload Tetragon logs
       if: failure()


### PR DESCRIPTION
[ upstream commit 32f5861e3d981f5ea0a7aea2b637f131f3bd3e8d ]

ARM runner exceeds the 40m job limit; raise timeout-minutes and GO_TEST_TIMEOUT to 60m.

Relates: https://github.com/cilium/tetragon/actions/runs/26885930800/job/79298025651?pr=5098

