### PR TITLE
feat: add support for nodeSelector in tracing policy

### DIFF
--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -3609,6 +3609,61 @@ spec:
                   - hook
                   type: object
                 type: array
+              nodeSelector:
+                description: NodeSelector selects nodes that this policy applies to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               options:
                 description: A list of overloaded options
                 items:

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -3609,6 +3609,61 @@ spec:
                   - hook
                   type: object
                 type: array
+              nodeSelector:
+                description: NodeSelector selects nodes that this policy applies to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               options:
                 description: A list of overloaded options
                 items:

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -3609,6 +3609,61 @@ spec:
                   - hook
                   type: object
                 type: array
+              nodeSelector:
+                description: NodeSelector selects nodes that this policy applies to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               options:
                 description: A list of overloaded options
                 items:

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -3609,6 +3609,61 @@ spec:
                   - hook
                   type: object
                 type: array
+              nodeSelector:
+                description: NodeSelector selects nodes that this policy applies to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               options:
                 description: A list of overloaded options
                 items:

--- a/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -121,6 +121,10 @@ type TracingPolicySpec struct {
 	HostSelector *slimv1.LabelSelector `json:"hostSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// NodeSelector selects nodes that this policy applies to.
+	NodeSelector *slimv1.LabelSelector `json:"nodeSelector,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// A list of list specs.
 	Lists []ListSpec `json:"lists,omitempty"`
 

--- a/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
@@ -759,6 +759,11 @@ func (in *TracingPolicySpec) DeepCopyInto(out *TracingPolicySpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Lists != nil {
 		in, out := &in.Lists, &out.Lists
 		*out = make([]ListSpec, len(*in))

--- a/pkg/watcher/crdwatcher/tracingpolicy.go
+++ b/pkg/watcher/crdwatcher/tracingpolicy.go
@@ -12,12 +12,15 @@ import (
 	"strings"
 	"sync"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/tetragon/pkg/logger/logfields"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	slimlabels "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/labels"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
 
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/manager"
@@ -49,15 +52,33 @@ func k8sErrorHandler(_ context.Context, e error, _ string, _ ...any) {
 	}
 }
 
-func addTracingPolicy(ctx context.Context, log logger.FieldLogger, s *sensors.Manager,
+func addTracingPolicy(ctx context.Context, log logger.FieldLogger, m *manager.ControllerManager, s *sensors.Manager,
 	obj any,
 ) {
 	var err error
 	switch tp := obj.(type) {
 	case *v1alpha1.TracingPolicy:
+		applies, applyErr := tracingPolicyAppliesToLocalNode(m, tp)
+		if applyErr != nil {
+			log.Warn("failed to evaluate tracing policy nodeSelector", "name", tp.TpName(), "namespace", tp.TpNamespace(), logfields.Error, applyErr)
+			return
+		}
+		if !applies {
+			log.Info("skipping tracing policy due to nodeSelector", "name", tp.TpName(), "info", tp.TpInfo())
+			return
+		}
 		log.Info("adding tracing policy", "name", tp.TpName(), "info", tp.TpInfo())
 		err = s.AddTracingPolicy(ctx, tp)
 	case *v1alpha1.TracingPolicyNamespaced:
+		applies, applyErr := tracingPolicyAppliesToLocalNode(m, tp)
+		if applyErr != nil {
+			log.Warn("failed to evaluate namespaced tracing policy nodeSelector", "name", tp.TpName(), "namespace", tp.TpNamespace(), logfields.Error, applyErr)
+			return
+		}
+		if !applies {
+			log.Info("skipping namespaced tracing policy due to nodeSelector", "name", tp.TpName(), "info", tp.TpInfo(), "namespace", tp.TpNamespace())
+			return
+		}
 		log.Info("adding namespaced tracing policy", "name", tp.TpName(), "info", tp.TpInfo(), "namespace", tp.TpNamespace())
 		err = s.AddTracingPolicy(ctx, tp)
 	default:
@@ -67,6 +88,83 @@ func addTracingPolicy(ctx context.Context, log logger.FieldLogger, s *sensors.Ma
 
 	if err != nil {
 		log.Warn("adding tracing policy failed", logfields.Error, err)
+	}
+}
+
+func nodeSelectorMatches(nodeSelector *slimv1.LabelSelector, nodeLabels map[string]string) (bool, error) {
+	if nodeSelector == nil {
+		return true, nil
+	}
+	selector, err := slimv1.LabelSelectorAsSelector(nodeSelector)
+	if err != nil {
+		return false, err
+	}
+	return selector.Matches(slimlabels.Set(nodeLabels)), nil
+}
+
+func tracingPolicyNodeSelector(tp tracingpolicy.TracingPolicy) *slimv1.LabelSelector {
+	if tp == nil || tp.TpSpec() == nil {
+		return nil
+	}
+	return tp.TpSpec().NodeSelector
+}
+
+func tracingPolicyAppliesToNode(tp tracingpolicy.TracingPolicy, node *corev1.Node) (bool, error) {
+	if node == nil {
+		return false, nil
+	}
+	return nodeSelectorMatches(tracingPolicyNodeSelector(tp), node.Labels)
+}
+
+func tracingPolicyAppliesToLocalNode(m *manager.ControllerManager, tp tracingpolicy.TracingPolicy) (bool, error) {
+	if tracingPolicyNodeSelector(tp) == nil {
+		return true, nil
+	}
+	node, err := m.GetNode()
+	if err != nil {
+		return false, err
+	}
+	return tracingPolicyAppliesToNode(tp, node)
+}
+
+func reconcileTracingPolicyNodeSelector(ctx context.Context, log logger.FieldLogger, s *sensors.Manager,
+	oldNode *corev1.Node, newNode *corev1.Node, obj any,
+) {
+	var tp tracingpolicy.TracingPolicy
+	switch policy := obj.(type) {
+	case *v1alpha1.TracingPolicy:
+		tp = policy
+	case *v1alpha1.TracingPolicyNamespaced:
+		tp = policy
+	default:
+		log.Warn("reconcileTracingPolicyNodeSelector: invalid type", "obj", obj, "obj-type", fmt.Sprintf("%T", obj))
+		return
+	}
+
+	oldApplies, err := tracingPolicyAppliesToNode(tp, oldNode)
+	if err != nil {
+		log.Warn("failed to evaluate old local node labels for tracing policy nodeSelector", "name", tp.TpName(), "namespace", tp.TpNamespace(), logfields.Error, err)
+		return
+	}
+	newApplies, err := tracingPolicyAppliesToNode(tp, newNode)
+	if err != nil {
+		log.Warn("failed to evaluate new local node labels for tracing policy nodeSelector", "name", tp.TpName(), "namespace", tp.TpNamespace(), logfields.Error, err)
+		return
+	}
+
+	switch {
+	case oldApplies == newApplies:
+		return
+	case newApplies:
+		log.Info("adding tracing policy due to nodeSelector match", "name", tp.TpName(), "namespace", tp.TpNamespace(), "info", tp.TpInfo())
+		if err := s.AddTracingPolicy(ctx, tp); err != nil {
+			log.Warn("failed to add tracing policy after nodeSelector match", "name", tp.TpName(), "namespace", tp.TpNamespace(), logfields.Error, err)
+		}
+	default:
+		log.Info("deleting tracing policy due to nodeSelector mismatch", "name", tp.TpName(), "namespace", tp.TpNamespace(), "info", tp.TpInfo())
+		if err := s.DeleteTracingPolicy(ctx, tp.TpName(), tp.TpNamespace(), tp.TpDomain()); err != nil {
+			log.Warn("failed to delete tracing policy after nodeSelector mismatch", "name", tp.TpName(), "namespace", tp.TpNamespace(), logfields.Error, err)
+		}
 	}
 }
 
@@ -93,11 +191,36 @@ func deleteTracingPolicy(ctx context.Context, log logger.FieldLogger, s *sensors
 	}
 }
 
-func updateTracingPolicy(ctx context.Context, log logger.FieldLogger, s *sensors.Manager,
+func updateTracingPolicy(ctx context.Context, log logger.FieldLogger, m *manager.ControllerManager, s *sensors.Manager,
 	oldObj any, newObj any) {
 
 	update := func(oldTp, newTp tracingpolicy.TracingPolicy) {
 		namespace := oldTp.TpNamespace()
+		oldApplies, err := tracingPolicyAppliesToLocalNode(m, oldTp)
+		if err != nil {
+			log.Warn("updateTracingPolicy: failed to evaluate old policy nodeSelector", "old-name", oldTp.TpName(), logfields.Error, err)
+			return
+		}
+		newApplies, err := tracingPolicyAppliesToLocalNode(m, newTp)
+		if err != nil {
+			log.Warn("updateTracingPolicy: failed to evaluate new policy nodeSelector", "new-name", newTp.TpName(), logfields.Error, err)
+			return
+		}
+
+		switch {
+		case !oldApplies && !newApplies:
+			return
+		case !oldApplies && newApplies:
+			if err := s.AddTracingPolicy(ctx, newTp); err != nil {
+				log.Warn("updateTracingPolicy: failed to add new policy", "new-name", newTp.TpName(), logfields.Error, err)
+			}
+			return
+		case oldApplies && !newApplies:
+			if err := s.DeleteTracingPolicy(ctx, oldTp.TpName(), namespace, oldTp.TpDomain()); err != nil {
+				log.Warn("updateTracingPolicy: failed to remove old policy", "old-name", oldTp.TpName(), logfields.Error, err)
+			}
+			return
+		}
 
 		if err := s.DeleteTracingPolicy(ctx, oldTp.TpName(), namespace, oldTp.TpDomain()); err != nil {
 			log.Warn("updateTracingPolicy: failed to remove old policy", "old-name", oldTp.TpName(), logfields.Error, err)
@@ -163,13 +286,13 @@ func AddTracingPolicyInformer(ctx context.Context, m *manager.ControllerManager,
 	_, err = tpInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
-				addTracingPolicy(ctx, log, s, obj)
+				addTracingPolicy(ctx, log, m, s, obj)
 			},
 			DeleteFunc: func(obj any) {
 				deleteTracingPolicy(ctx, log, s, obj)
 			},
 			UpdateFunc: func(oldObj any, newObj any) {
-				updateTracingPolicy(ctx, log, s, oldObj, newObj)
+				updateTracingPolicy(ctx, log, m, s, oldObj, newObj)
 			}})
 	if err != nil {
 		return err
@@ -182,14 +305,51 @@ func AddTracingPolicyInformer(ctx context.Context, m *manager.ControllerManager,
 	_, err = tpnInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
-				addTracingPolicy(ctx, log, s, obj)
+				addTracingPolicy(ctx, log, m, s, obj)
 			},
 			DeleteFunc: func(obj any) {
 				deleteTracingPolicy(ctx, log, s, obj)
 			},
 			UpdateFunc: func(oldObj any, newObj any) {
-				updateTracingPolicy(ctx, log, s, oldObj, newObj)
+				updateTracingPolicy(ctx, log, m, s, oldObj, newObj)
 			}})
+	if err != nil {
+		return err
+	}
+
+	nodeInformer, err := m.Manager.GetCache().GetInformer(ctx, &corev1.Node{})
+	if err != nil {
+		return err
+	}
+	_, err = nodeInformer.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj any, newObj any) {
+				oldNode, oldOK := oldObj.(*corev1.Node)
+				newNode, newOK := newObj.(*corev1.Node)
+				if !oldOK || !newOK {
+					log.Warn("node update: invalid type", "old-obj-type", fmt.Sprintf("%T", oldObj), "new-obj-type", fmt.Sprintf("%T", newObj))
+					return
+				}
+
+				var tpList v1alpha1.TracingPolicyList
+				if err := m.Manager.GetCache().List(ctx, &tpList); err != nil {
+					log.Warn("failed to list tracing policies for nodeSelector reconciliation", logfields.Error, err)
+					return
+				}
+				for i := range tpList.Items {
+					reconcileTracingPolicyNodeSelector(ctx, log, s, oldNode, newNode, &tpList.Items[i])
+				}
+
+				var tpnList v1alpha1.TracingPolicyNamespacedList
+				if err := m.Manager.GetCache().List(ctx, &tpnList); err != nil {
+					log.Warn("failed to list namespaced tracing policies for nodeSelector reconciliation", logfields.Error, err)
+					return
+				}
+				for i := range tpnList.Items {
+					reconcileTracingPolicyNodeSelector(ctx, log, s, oldNode, newNode, &tpnList.Items[i])
+				}
+			},
+		})
 	if err != nil {
 		return err
 	}

--- a/pkg/watcher/crdwatcher/tracingpolicy_test.go
+++ b/pkg/watcher/crdwatcher/tracingpolicy_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !nok8s
+
+package crdwatcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestTracingPolicyAppliesToNode(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"node-role.kubernetes.io/worker": "true",
+				"kubernetes.io/arch":             "amd64",
+				"tetragon.io/canary":             "enabled",
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		nodeSelector *slimv1.LabelSelector
+		want         bool
+	}{
+		{
+			name: "unset selector matches all nodes",
+			want: true,
+		},
+		{
+			name:         "empty selector matches all nodes",
+			nodeSelector: &slimv1.LabelSelector{},
+			want:         true,
+		},
+		{
+			name: "match labels selects node",
+			nodeSelector: &slimv1.LabelSelector{
+				MatchLabels: map[string]string{"kubernetes.io/arch": "amd64"},
+			},
+			want: true,
+		},
+		{
+			name: "match labels rejects node",
+			nodeSelector: &slimv1.LabelSelector{
+				MatchLabels: map[string]string{"kubernetes.io/arch": "arm64"},
+			},
+			want: false,
+		},
+		{
+			name: "match expressions select node",
+			nodeSelector: &slimv1.LabelSelector{
+				MatchExpressions: []slimv1.LabelSelectorRequirement{{
+					Key:      "tetragon.io/canary",
+					Operator: slimv1.LabelSelectorOpIn,
+					Values:   []string{"enabled", "shadow"},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "does not exist expression rejects node",
+			nodeSelector: &slimv1.LabelSelector{
+				MatchExpressions: []slimv1.LabelSelectorRequirement{{
+					Key:      "node-role.kubernetes.io/worker",
+					Operator: slimv1.LabelSelectorOpDoesNotExist,
+				}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := &v1alpha1.TracingPolicy{
+				Spec: v1alpha1.TracingPolicySpec{
+					NodeSelector: tt.nodeSelector,
+				},
+			}
+
+			got, err := tracingPolicyAppliesToNode(policy, node)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTracingPolicyAppliesToNodeReturnsSelectorError(t *testing.T) {
+	policy := &v1alpha1.TracingPolicy{
+		Spec: v1alpha1.TracingPolicySpec{
+			NodeSelector: &slimv1.LabelSelector{
+				MatchExpressions: []slimv1.LabelSelectorRequirement{{
+					Key:      "kubernetes.io/arch",
+					Operator: "Invalid",
+				}},
+			},
+		},
+	}
+	node := &corev1.Node{}
+
+	got, err := tracingPolicyAppliesToNode(policy, node)
+
+	require.Error(t, err)
+	assert.False(t, got)
+}

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -3609,6 +3609,61 @@ spec:
                   - hook
                   type: object
                 type: array
+              nodeSelector:
+                description: NodeSelector selects nodes that this policy applies to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               options:
                 description: A list of overloaded options
                 items:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -3609,6 +3609,61 @@ spec:
                   - hook
                   type: object
                 type: array
+              nodeSelector:
+                description: NodeSelector selects nodes that this policy applies to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      description: MatchLabelsValue represents the value from the
+                        MatchLabels {key,value} pair.
+                      maxLength: 63
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               options:
                 description: A list of overloaded options
                 items:

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/tracing_policy_types.go
@@ -121,6 +121,10 @@ type TracingPolicySpec struct {
 	HostSelector *slimv1.LabelSelector `json:"hostSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// NodeSelector selects nodes that this policy applies to.
+	NodeSelector *slimv1.LabelSelector `json:"nodeSelector,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// A list of list specs.
 	Lists []ListSpec `json:"lists,omitempty"`
 

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/zz_generated.deepcopy.go
@@ -759,6 +759,11 @@ func (in *TracingPolicySpec) DeepCopyInto(out *TracingPolicySpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Lists != nil {
 		in, out := &in.Lists, &out.Lists
 		*out = make([]ListSpec, len(*in))


### PR DESCRIPTION
Fixes #4935 

### Description

Add `nodeSelector` support to `TracingPolicy` so cluster-scoped tracing policies can be limited to nodes matching Kubernetes node labels.

Previously, a `TracingPolicy` was considered for all nodes. This change allows users to target policies more precisely by setting `spec.nodeSelector`, using the same label selector semantics as Kubernetes. An unset or empty selector continues to match all nodes.

This also adds unit coverage for the node matching behavior, including:

- unset selectors matching all nodes
- empty selectors matching all nodes
- `matchLabels` selecting and rejecting nodes
- `matchExpressions` selecting and rejecting nodes
- invalid selector operators returning an error

### Changelog

```release-note
Add nodeSelector support to TracingPolicy for limiting cluster-scoped tracing policies to matching Kubernetes nodes.