### PR TITLE
tetragon: sleepable_preload fixes

### DIFF
--- a/bpf/process/user_preload.h
+++ b/bpf/process/user_preload.h
@@ -19,6 +19,7 @@ struct {
 	__uint(max_entries, 1); // will be resized by agent when needed
 	__type(key, __u64);
 	__type(value, struct preload_data);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } sleepable_preload SEC(".maps");
 
 #if defined(GENERIC_UPROBE) || defined(GENERIC_USDT)

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -90,6 +90,8 @@ const (
 	KeyDisableKprobeMulti = "disable-kprobe-multi"
 	KeyDisableUprobeMulti = "disable-uprobe-multi"
 
+	KeySleepablePreloadSize = "sleepable-preload-size"
+
 	KeyUsePerfRingBuffer = "use-perf-ring-buffer"
 	KeyRBSize            = "rb-size"
 	KeyRBSizeTotal       = "rb-size-total"

--- a/pkg/sensors/load_linux.go
+++ b/pkg/sensors/load_linux.go
@@ -6,6 +6,7 @@ package sensors
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/cilium/ebpf"
@@ -42,6 +43,14 @@ func (s *Sensor) preLoadMaps(bpfDir string, loadedMaps []*program.Map) ([]*progr
 	return loadedMaps, nil
 }
 
+func isFirstShared(m *program.Map, pinPath string) bool {
+	if !m.IsShared() {
+		return false
+	}
+	_, err := os.Stat(pinPath)
+	return err != nil
+}
+
 // loadMap loads BPF map in the sensor.
 func (s *Sensor) loadMap(bpfDir string, loaderCache *loaderCache, m *program.Map) error {
 	l := logger.GetLogger()
@@ -67,7 +76,7 @@ func (s *Sensor) loadMap(bpfDir string, loaderCache *loaderCache, m *program.Map
 	s.setMapPinPath(m)
 	pinPath := filepath.Join(bpfDir, m.PinPath)
 
-	if m.IsOwner() {
+	if m.IsOwner() || isFirstShared(m, pinPath) {
 		// If map is the owner we set configured maximum entries
 		// directly to map spec.
 		if maximum, ok := m.GetMaxEntries(); ok {

--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -58,6 +58,11 @@
 //  Map user object object is just using the pinned map and follows its
 //  setup and will fail if the pinned map differs in spec or configured
 //  max entries value.
+//
+//  MapShared creates a shared map pinned at the global scope
+//  (/sys/fs/bpf/tetragon/<name>). The first sensor to load it creates and
+//  pins the map; subsequent sensors reuse the existing pin. The pin is
+//  removed only when the last sensor using it unloads.
 
 package program
 
@@ -103,6 +108,7 @@ type Map struct {
 	InnerEntries MaxEntries
 	Type         MapType
 	Owner        bool
+	Shared       bool
 }
 
 func (m *Map) String() string {
@@ -146,6 +152,24 @@ func DeleteGlobMap(name string) {
 	delete(globalMaps.maps, name)
 }
 
+// sharedMapRefs tracks the number of sensors currently using each shared map,
+// without locking because sensor load/unload is serialized by the sensor manager.
+var sharedMapRefs = map[string]int{}
+
+func sharedMapIncRef(pinPath string) int {
+	sharedMapRefs[pinPath]++
+	return sharedMapRefs[pinPath]
+}
+
+func sharedMapDecRef(pinPath string) bool {
+	sharedMapRefs[pinPath]--
+	last := sharedMapRefs[pinPath] <= 0
+	if last {
+		delete(sharedMapRefs, pinPath)
+	}
+	return last
+}
+
 // Map holds pointer to Program object as a source of its ebpf object
 // file. We assume all the programs sharing the map have same map
 // definition, so it's ok to use the first program if there's more.
@@ -159,12 +183,12 @@ func DeleteGlobMap(name string) {
 //	p.PinMap["map2"] = &map2
 //	...
 //	p.PinMap["mapX"] = &mapX
-func mapBuilder(name string, ty MapType, owner bool, lds ...*Program) *Map {
+func mapBuilder(name string, ty MapType, owner bool, shared bool, lds ...*Program) *Map {
 	var prog *Program
 	if len(lds) != 0 {
 		prog = lds[0]
 	}
-	m := &Map{name, "", prog, Idle(), nil, MaxEntries{0, false}, MaxEntries{0, false}, ty, owner}
+	m := &Map{name, "", prog, Idle(), nil, MaxEntries{0, false}, MaxEntries{0, false}, ty, owner, shared}
 	for _, ld := range lds {
 		ld.PinMap[name] = m
 	}
@@ -172,31 +196,35 @@ func mapBuilder(name string, ty MapType, owner bool, lds ...*Program) *Map {
 }
 
 func MapBuilder(name string, lds ...*Program) *Map {
-	return mapBuilder(name, MapTypeGlobal, true, lds...)
+	return mapBuilder(name, MapTypeGlobal, true, false, lds...)
 }
 
 func MapBuilderProgram(name string, lds ...*Program) *Map {
-	return mapBuilder(name, MapTypeProgram, true, lds...)
+	return mapBuilder(name, MapTypeProgram, true, false, lds...)
 }
 
 func MapBuilderSensor(name string, lds ...*Program) *Map {
-	return mapBuilder(name, MapTypeSensor, true, lds...)
+	return mapBuilder(name, MapTypeSensor, true, false, lds...)
 }
 
 func MapBuilderPolicy(name string, lds ...*Program) *Map {
-	return mapBuilder(name, MapTypePolicy, true, lds...)
+	return mapBuilder(name, MapTypePolicy, true, false, lds...)
 }
 
 func MapBuilderType(name string, ty MapType, lds ...*Program) *Map {
-	return mapBuilder(name, ty, true, lds...)
+	return mapBuilder(name, ty, true, false, lds...)
 }
 
 func MapBuilderOpts(name string, opts MapOpts, lds ...*Program) *Map {
-	return mapBuilder(name, opts.Type, opts.Owner, lds...)
+	return mapBuilder(name, opts.Type, opts.Owner, false, lds...)
+}
+
+func MapShared(name string, lds ...*Program) *Map {
+	return mapBuilder(name, MapTypeGlobal, false, true, lds...)
 }
 
 func mapUser(name string, ty MapType, prog *Program) *Map {
-	return &Map{name, "", prog, Idle(), nil, MaxEntries{0, false}, MaxEntries{0, false}, ty, false}
+	return &Map{name, "", prog, Idle(), nil, MaxEntries{0, false}, MaxEntries{0, false}, ty, false, false}
 }
 
 func MapUser(name string, prog *Program) *Map {
@@ -227,6 +255,10 @@ func (m *Map) IsOwner() bool {
 	return m.Owner
 }
 
+func (m *Map) IsShared() bool {
+	return m.Shared
+}
+
 func (m *Map) Unload(unpin bool) error {
 	log := logger.GetLogger().With("map", m.Name, "pin", m.PinPath)
 	if !m.PinState.IsLoaded() {
@@ -241,7 +273,10 @@ func (m *Map) Unload(unpin bool) error {
 		return nil
 	}
 	log.Debug("map was unloaded")
-	if m.IsOwner() && unpin {
+	if m.IsShared() && sharedMapDecRef(m.PinPath) && unpin {
+		m.MapHandle.Unpin()
+		DeleteGlobMap(m.Name)
+	} else if m.IsOwner() && unpin {
 		m.MapHandle.Unpin()
 		if m.Type == MapTypeGlobal {
 			DeleteGlobMap(m.Name)
@@ -289,7 +324,7 @@ func (m *Map) LoadOrCreatePinnedMap(pinPath string, mapSpec *ebpf.MapSpec) error
 		m.MapHandle.Close()
 	}
 
-	mh, err := LoadOrCreatePinnedMap(pinPath, mapSpec, m.IsOwner())
+	mh, err := LoadOrCreatePinnedMap(pinPath, mapSpec, m.IsOwner() || m.IsShared())
 	if err != nil {
 		return err
 	}
@@ -298,6 +333,9 @@ func (m *Map) LoadOrCreatePinnedMap(pinPath string, mapSpec *ebpf.MapSpec) error
 	m.PinState.RefInc()
 	if m.Type == MapTypeGlobal {
 		AddGlobalMap(m.Name)
+	}
+	if m.IsShared() {
+		sharedMapIncRef(m.PinPath)
 	}
 	return nil
 }

--- a/pkg/sensors/program/map.go
+++ b/pkg/sensors/program/map.go
@@ -237,19 +237,19 @@ func (m *Map) Unload(unpin bool) error {
 		log.Debug("Reference exists, not unloading map yet", "count", count)
 		return nil
 	}
-	log.Debug("map was unloaded")
-	if m.MapHandle != nil {
-		if m.IsOwner() && unpin {
-			m.MapHandle.Unpin()
-			if m.Type == MapTypeGlobal {
-				DeleteGlobMap(m.Name)
-			}
-		}
-		err := m.MapHandle.Close()
-		m.MapHandle = nil
-		return err
+	if m.MapHandle == nil {
+		return nil
 	}
-	return nil
+	log.Debug("map was unloaded")
+	if m.IsOwner() && unpin {
+		m.MapHandle.Unpin()
+		if m.Type == MapTypeGlobal {
+			DeleteGlobMap(m.Name)
+		}
+	}
+	err := m.MapHandle.Close()
+	m.MapHandle = nil
+	return err
 }
 
 func (m *Map) New(spec *ebpf.MapSpec) error {

--- a/pkg/sensors/test/sensors_test.go
+++ b/pkg/sensors/test/sensors_test.go
@@ -756,6 +756,78 @@ func TestCleanup(t *testing.T) {
 	})
 }
 
+func TestMapShared(t *testing.T) {
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	option.Config.Verbosity = 5
+
+	p1 := program.Builder(
+		"bpf_map_test_p1.o",
+		"wake_up_new_task",
+		"kprobe/wake_up_new_task",
+		"p1",
+		"kprobe",
+	)
+	p2 := program.Builder(
+		"bpf_map_test_p2.o",
+		"wake_up_new_task",
+		"kprobe/wake_up_new_task",
+		"p2",
+		"kprobe",
+	)
+
+	verifyExists := func(files ...string) {
+		for _, f := range files {
+			_, err := os.Stat(filepath.Join(bpf.MapPrefixPath(), f))
+			t.Logf("Exists checking path: '%s'\n", f)
+			require.NoError(t, err)
+		}
+	}
+	verifyRemoved := func(files ...string) {
+		for _, f := range files {
+			_, err := os.Stat(filepath.Join(bpf.MapPrefixPath(), f))
+			t.Logf("Removed checking path: '%s'\n", f)
+			require.Error(t, err)
+		}
+	}
+
+	// Each sensor has its own MapShared object, both naming the same map.
+	m1a := program.MapShared("m1", p1)
+	m1b := program.MapShared("m1", p2)
+
+	s1 := &sensors.Sensor{
+		Name:   "sensor1",
+		Progs:  []*program.Program{p1},
+		Maps:   []*program.Map{m1a},
+		Policy: "policy",
+	}
+	s2 := &sensors.Sensor{
+		Name:   "sensor2",
+		Progs:  []*program.Program{p2},
+		Maps:   []*program.Map{m1b},
+		Policy: "policy",
+	}
+
+	// s1 loads first — map is created and pinned, global ref = 1.
+	err := s1.Load(bpf.MapPrefixPath())
+	require.NoError(t, err)
+	verifyExists("m1")
+
+	// s2 loads — map is opened (not recreated), global ref = 2.
+	err = s2.Load(bpf.MapPrefixPath())
+	require.NoError(t, err)
+	verifyExists("m1")
+
+	// s1 unloads — global ref drops to 1, pin must survive.
+	err = s1.Unload(true)
+	require.NoError(t, err)
+	verifyExists("m1")
+
+	// s2 unloads — global ref drops to 0, pin is removed.
+	err = s2.Unload(true)
+	require.NoError(t, err)
+	verifyRemoved("m1")
+}
+
 func TestNamespace(t *testing.T) {
 	p1 := program.Builder(
 		"bpf_map_test_p1.o",

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -418,9 +418,10 @@ type addUprobeIn struct {
 }
 
 type uprobeHas struct {
-	sleepableOffload bool
-	sleepablePreload bool
-	substring        bool
+	sleepableOffload     bool
+	sleepablePreload     bool
+	substring            bool
+	sleepablePreloadSize int
 }
 
 func validateMultiUprobeConsistency(uprobes []v1alpha1.UProbeSpec) error {
@@ -635,6 +636,9 @@ func createGenericUprobeSensor(
 	// - it's not disabled by spec option
 	// - there's support detected
 	useMulti := !polInfo.specOpts.DisableUprobeMulti && bpf.HasUprobeMulti()
+
+	// user sleepable_preload override
+	has.sleepablePreloadSize = polInfo.specOpts.SleepablePreloadSize
 
 	if useMulti {
 		// if we are using multi-uprobe, CEL expressions are shared across all uprobes
@@ -1055,6 +1059,19 @@ func multiUprobePinPath(sensorPath string) string {
 	return sensors.PathJoin(sensorPath, "multi_uprobe")
 }
 
+func getSleepablePreloadMap(userSize int, load *program.Program) *program.Map {
+	var m *program.Map
+
+	if userSize != 0 {
+		m = program.MapBuilderProgram("sleepable_preload", load)
+		m.SetMaxEntries(userSize)
+	} else {
+		m = program.MapShared("sleepable_preload", load)
+		m.SetMaxEntries(sleepablePreloadMaxEntries)
+	}
+	return m
+}
+
 func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []idtable.EntryID, has uprobeHas) ([]*program.Program, []*program.Map, error) {
 	var multiRetIDs []idtable.EntryID
 	var progs []*program.Program
@@ -1115,8 +1132,7 @@ func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []
 	}
 
 	if has.sleepablePreload {
-		sleepablePreloadMap := program.MapBuilderProgram("sleepable_preload", load)
-		sleepablePreloadMap.SetMaxEntries(sleepablePreloadMaxEntries)
+		sleepablePreloadMap := getSleepablePreloadMap(has.sleepablePreloadSize, load)
 		maps = append(maps, sleepablePreloadMap)
 	}
 
@@ -1226,8 +1242,7 @@ func createUprobeSensorFromEntry(polInfo *policyInfo, uprobeEntry *genericUprobe
 	}
 
 	if has.sleepablePreload {
-		sleepablePreloadMap := program.MapBuilderProgram("sleepable_preload", load)
-		sleepablePreloadMap.SetMaxEntries(sleepablePreloadMaxEntries)
+		sleepablePreloadMap := getSleepablePreloadMap(has.sleepablePreloadSize, load)
 		maps = append(maps, sleepablePreloadMap)
 	}
 

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -215,7 +215,7 @@ func createMultiUsdtSensor(
 	}
 
 	if has.sleepablePreload {
-		sleepablePreloadMap := program.MapBuilderProgram("sleepable_preload", load)
+		sleepablePreloadMap := program.MapShared("sleepable_preload", load)
 		sleepablePreloadMap.SetMaxEntries(sleepablePreloadMaxEntries)
 		maps = append(maps, sleepablePreloadMap)
 	}
@@ -286,7 +286,7 @@ func createUsdtSensorFromEntry(polInfo *policyInfo, usdtEntry *genericUsdt,
 	}
 
 	if has.sleepablePreload {
-		sleepablePreloadMap := program.MapBuilderProgram("sleepable_preload", load)
+		sleepablePreloadMap := program.MapShared("sleepable_preload", load)
 		sleepablePreloadMap.SetMaxEntries(sleepablePreloadMaxEntries)
 		maps = append(maps, sleepablePreloadMap)
 	}

--- a/pkg/sensors/tracing/options.go
+++ b/pkg/sensors/tracing/options.go
@@ -43,10 +43,11 @@ func overrideMethodParse(s string) OverrideMethod {
 }
 
 type specOptions struct {
-	DisableKprobeMulti bool
-	DisableUprobeMulti bool
-	OverrideMethod     OverrideMethod
-	policyMode         policyconf.Mode
+	DisableKprobeMulti   bool
+	DisableUprobeMulti   bool
+	SleepablePreloadSize int
+	OverrideMethod       OverrideMethod
+	policyMode           policyconf.Mode
 }
 
 type opt struct {
@@ -91,6 +92,19 @@ var opts = map[string]opt{
 				return err
 			}
 			options.policyMode = mode
+			return nil
+		},
+	},
+	option.KeySleepablePreloadSize: {
+		set: func(str string, options *specOptions) (err error) {
+			size, err := strconv.Atoi(str)
+			if err != nil {
+				return err
+			}
+			if size <= 0 {
+				return fmt.Errorf("sleepable-preload-size must be positive, got %d", size)
+			}
+			options.SleepablePreloadSize = size
 			return nil
 		},
 	},

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -10,12 +10,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/cilium/ebpf"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -24,6 +27,7 @@ import (
 	"github.com/cilium/tetragon/pkg/kernels"
 	bc "github.com/cilium/tetragon/pkg/matchers/bytesmatcher"
 	"github.com/cilium/tetragon/pkg/selectors"
+	"github.com/cilium/tetragon/pkg/sensors/program"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
@@ -1280,4 +1284,97 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+func TestUprobeSleepablePreloadMapConfig(t *testing.T) {
+	if !bpf.HasKfunc("bpf_copy_from_user_str") {
+		t.Skip("skipping, no string preload support")
+	}
+	if runtime.GOARCH == "arm64" {
+		t.Skip("skipping, x86_64 only test")
+	}
+
+	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
+
+	// uprobe policy with a preload data argument; opts is the options block (may be empty)
+	policy := func(opts string) string {
+		return `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "preload"
+spec:` + opts + `
+  uprobes:
+  - path: "` + testBinary + `"
+    symbols:
+    - "test_3+12"
+    data:
+    - index: 0
+      type: "string"
+      source: "pt_regs"
+      resolve: "rdi"
+`
+	}
+
+	loadSensors := func(t *testing.T, config string) []*sensors.Sensor {
+		createCrdFile(t, config)
+		sens, err := observertesthelper.GetDefaultSensorsWithFile(t, testConfigFile,
+			tus.Conf().TetragonLib, observertesthelper.WithKeepCollection())
+		require.NoError(t, err)
+		return sens
+	}
+
+	unloadSensors := func(sens []*sensors.Sensor) {
+		sensi := make([]sensors.SensorIface, 0, len(sens))
+		for _, s := range sens {
+			sensi = append(sensi, s)
+		}
+		sensors.UnloadSensors(sensi)
+	}
+
+	findPreloadMap := func(sens []*sensors.Sensor) *program.Map {
+		for _, s := range sens {
+			for _, m := range s.Maps {
+				if m.Name == "sleepable_preload" {
+					return m
+				}
+			}
+		}
+		return nil
+	}
+
+	getMaxEntries := func(m *program.Map) uint32 {
+		path := filepath.Join(bpf.MapPrefixPath(), m.PinPath)
+		val, err := program.GetMaxEntriesPinnedMap(path)
+		require.NoError(t, err)
+		return val
+	}
+
+	// sleepable_preload as MapShared at global scope (/sys/fs/bpf/tetragon/sleepable_preload)
+	t.Run("shared", func(t *testing.T) {
+		sens := loadSensors(t, policy(""))
+		defer unloadSensors(sens)
+
+		m := findPreloadMap(sens)
+		require.NotNil(t, m, "sleepable_preload map not found in sensor")
+
+		assert.Equal(t, "sleepable_preload", m.PinPath)
+		assert.Equal(t, uint32(sleepablePreloadMaxEntries), getMaxEntries(m))
+	})
+
+	// sleepable_preload as MapBuilderProgram at program scope (.../policy/sensor/prog/sleepable_preload)
+	t.Run("program", func(t *testing.T) {
+		sens := loadSensors(t, policy(`
+  options:
+  - name: "sleepable-preload-size"
+    value: "1024"`))
+		defer unloadSensors(sens)
+
+		m := findPreloadMap(sens)
+		require.NotNil(t, m, "sleepable_preload map not found in sensor")
+
+		assert.NotEqual(t, "sleepable_preload", m.PinPath)
+		assert.Equal(t, "sleepable_preload", filepath.Base(m.PinPath))
+		assert.Equal(t, uint32(1024), getMaxEntries(m))
+	})
 }


### PR DESCRIPTION
make sleepable_preload bpf map marked as not preloaded in the kernel
and make it shared between all the policies by default