### PR TITLE
fix: skip malformed stdin events in tetra getevents

### DIFF
--- a/cmd/tetra/getevents/io_reader_client.go
+++ b/cmd/tetra/getevents/io_reader_client.go
@@ -112,8 +112,10 @@ func (i *ioReaderClient) Recv() (*tetragon.GetEventsResponse, error) {
 		res := &tetragon.GetEventsResponse{}
 		line := i.scanner.Bytes()
 		err := i.unmarshaller.Unmarshal(line, res)
-		if err != nil && i.debug {
-			fmt.Fprintf(os.Stderr, "DEBUG: failed unmarshal: %s: %s\n", line, err)
+		if err != nil {
+			if i.debug {
+				fmt.Fprintf(os.Stderr, "DEBUG: failed unmarshal: %s: %s\n", line, err)
+			}
 			continue
 		}
 		if !filters.Apply(i.allowlist, nil, &event.Event{Event: res}) {

--- a/cmd/tetra/getevents/io_reader_client_test.go
+++ b/cmd/tetra/getevents/io_reader_client_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,19 @@ func Test_ioReaderClient_GetEvents(t *testing.T) {
 		_, err := getEventsClient.Recv()
 		require.NoError(t, err)
 	}
+	_, err = getEventsClient.Recv()
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func Test_ioReaderClient_GetEventsSkipsInvalidJSON(t *testing.T) {
+	client := newIOReaderClient(strings.NewReader("not-json\n{\"process_exec\":{\"process\":{\"binary\":\"/usr/bin/netserver\"}}}\n"), false)
+	getEventsClient, err := client.GetEvents(context.Background(), &tetragon.GetEventsRequest{})
+	require.NoError(t, err)
+
+	res, err := getEventsClient.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, res.GetProcessExec())
+
 	_, err = getEventsClient.Recv()
 	require.ErrorIs(t, err, io.EOF)
 }


### PR DESCRIPTION
Fixes none

### Description
`tetra getevents` reading from stdin could turn a bad json line into an empty event and print `{}` when debug is off. Small papercut, but it can mess with pipes.

This skips lines that fail unmarshal, same as debug mode already kinda did, and adds a regression test.

Repro:
```
go build -o /tmp/tetra ./cmd/tetra
printf 'not-json\n{"process_exec":{"process":{"binary":"/usr/bin/netserver"}}}\n' | /tmp/tetra getevents
```

Before:
```
{}
{"process_exec":{"process":{"binary":"/usr/bin/netserver"}}}
```

After:
```
{"process_exec":{"process":{"binary":"/usr/bin/netserver"}}}
```

### Changelog
```release-note
tetra getevents now skips malformed JSON lines from stdin instead of emitting empty events
```
