### PR TITLE
btf : Add type casting in `resolve`

### DIFF
--- a/contrib/tester-progs/.gitignore
+++ b/contrib/tester-progs/.gitignore
@@ -48,3 +48,4 @@ pclntab-unstripped
 null-mount
 resolve-nested-anon-struct
 resolve-nested-anon-struct.btf
+uprobe-stack

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -37,6 +37,7 @@ PROGS = sigkill-tester \
 	usdt-resolve \
 	uretprobe \
 	uprobe-resolve \
+	uprobe-stack \
 	regs-override \
 	usdt-args \
 	uprobe-null \
@@ -145,6 +146,9 @@ resolve-nested-anon-struct: resolve-nested-anon-struct.c
 
 regs-override: regs-override.c
 	$(GCC) -Wall -fcf-protection=none $< -o $@
+
+uprobe-stack: uprobe-stack.c
+	$(GCC) -Wall -O2 -fcf-protection=none $< -o $@
 
 uretprobe: uretprobe.c
 	$(GCC) -Wall $< -O2 -o $@

--- a/contrib/tester-progs/uprobe-resolve.c
+++ b/contrib/tester-progs/uprobe-resolve.c
@@ -29,12 +29,13 @@ struct mystruct {
 	struct mysubstruct *arr[10];
 	struct mysubstruct **dyn;
 	struct mysubstruct *subp;
+	void *subvoid;
 };
 
 void usage(char *argv0)
 {
 	fprintf(stderr, "Usage: %s <field> <val>\n", argv0);
-	fprintf(stderr, "field can be one of: v8, v16, v32, v64, enum_u32, sub.v32 arr[idx].v64 dyn[idx].v64, subp.buff, subp.v64\n");
+	fprintf(stderr, "field can be one of: v8, v16, v32, v64, enum_u32, sub.v32, ((struct mysubstruct*)subvoid).v32, arr[idx].v64, dyn[idx].v64, subp.buff, subp.v64\n");
 }
 
 // without noinline, the symbol is found, but no event fires
@@ -85,6 +86,9 @@ int main(int argc, char *argv[])
 		printf("%ld\n", s.subp->v64);
 	} else if (!strcmp(field, "sub.v32")) {
 		s.sub.v32 = val;
+	} else if (!strcmp(field, "((struct mysubstruct*)subvoid).v32")) {
+		ss.v32 = val;
+		s.subvoid = &ss;
 	} else if (!strcmp(field, "subp.buff")) {
 		ss.buff = argv[2];
 		s.subp = pageout(&ss, sizeof(ss));

--- a/contrib/tester-progs/uprobe-stack.c
+++ b/contrib/tester-progs/uprobe-stack.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static volatile uint64_t stack_source;
+
+struct mysubstruct {
+	uint64_t empty;
+	uint64_t arr[10];
+};
+
+struct mystruct {
+	struct mysubstruct *sub;
+};
+
+#if defined(__x86_64__) || defined(__amd64__)
+__attribute__((noinline, used, naked)) uint64_t mov_in_rsp(struct mystruct *ms)
+{
+	asm volatile (
+		"push   %rdi\n"            /* rsp -= 8, (rsp) = ms; return addr preserved */
+		"mov    (%rsp), %rax\n"    /* rax = ms */
+		"pop    %rdi\n"            /* rsp += 8; return addr back on top */
+		"ret\n"
+	);
+}
+#elif defined(__aarch64__)
+__attribute__((noinline, used, naked)) uint64_t mov_in_rsp(struct mystruct *ms)
+{
+	asm volatile (
+		"str    x0, [sp, #-16]!\n"   /* sp -= 16, [sp] = ms; lr holds return addr */
+		"ldr    x0, [sp]\n"          /* x0 = ms */
+		"add    sp, sp, #16\n"       /* sp += 16 */
+		"ret\n"
+	);
+}
+#else
+__attribute__((noinline, used)) uint64_t mov_in_rsp(struct mystruct *ms)
+{
+	return (uint64_t)ms;
+}
+#endif
+
+void usage(char *argv0)
+{
+	fprintf(stderr, "Usage: %s <value>\n", argv0);
+}
+
+int main(int argc, char *argv[])
+{
+	char *endptr = NULL;
+	uint64_t value;
+
+	if (argc != 2) {
+		usage(argv[0]);
+		exit(1);
+	}
+
+	value = strtoull(argv[1], &endptr, 10);
+	if (*endptr != '\0') {
+		usage(argv[0]);
+		exit(1);
+	}
+
+	struct mystruct ms = {};
+	ms.sub = malloc(sizeof(struct mysubstruct));
+	ms.sub->arr[8] = value;
+	stack_source = value;
+	printf("%" PRIu64 "\n", mov_in_rsp(&ms));
+	free(ms.sub);
+	return 0;
+}

--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -777,6 +777,47 @@ spec:
       resolve: "sin_addr.s_addr"
 ```
 
+#### Type casts in resolve paths
+
+The `resolve` path can cast an intermediate field to another BTF type before
+continuing the resolution. This is useful when a field is typed as a generic
+pointer, such as `void *`, but the policy author knows the concrete structure
+stored at runtime.
+
+Type casts use a C-style syntax:
+
+```text
+((type)field-or-subpath).next_field
+```
+
+```yaml
+args:
+- index: 1
+  btfType: "foo"
+  type: "uint32"
+  resolve: "((struct bar *)myparam).myvalue"
+```
+
+In this example, Tetragon resolves `myparam`, treats the value as a
+`struct bar *`, dereferences it, and then reads the `myvalue` field.
+
+The cast is part of the `resolve` path, so it can also be used with indexes:
+
+```yaml
+args:
+- index: 0
+  type: "uint8"
+  resolve: "((char *)buffer)[12]"
+```
+
+This resolves `buffer`, treats it as a `char *`, and reads element `12`.
+
+{{< note >}}
+For uprobes and USDT probes, type names used in casts are resolved first from
+the BTF file configured with `spec.uprobes.btfPath`. If the type is not found there, Tetragon
+falls back to the kernel vmlinux BTF.
+{{< /note >}}
+
 #### Kernel module BTF types
 
 For kprobe arguments, use `btfTypeModule` with `btfType` when the structure is

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -272,6 +272,7 @@ type btfResolver struct {
 	btfArgs     *[api.MaxBTFArgDepth]api.ConfigBTFArg
 	currentType btf.Type
 	pathToFound []string
+	spec        *btf.Spec
 }
 
 // ResolveBTFPath function recursively search in a btf structure in order to
@@ -292,11 +293,13 @@ func ResolveBTFPath(
 	btfArgs *[api.MaxBTFArgDepth]api.ConfigBTFArg,
 	currentType btf.Type,
 	pathToFound []string,
+	spec *btf.Spec,
 ) (*btf.Type, error) {
 	resolver := btfResolver{
 		btfArgs:     btfArgs,
 		currentType: currentType,
 		pathToFound: pathToFound,
+		spec:        spec,
 	}
 	return resolver.resolve(currentType, 0)
 }

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -28,6 +28,8 @@ import (
 
 var (
 	btfFile string
+
+	errNotACast = errors.New("not a cast")
 )
 
 func btfFileExists(file string) error {
@@ -309,6 +311,12 @@ func (r *btfResolver) resolve(
 	i int,
 ) (*btf.Type, error) {
 	currentType = ResolveNestedTypes(currentType)
+	if castType, err := r.parseBTFTypeCast(i); !errors.Is(err, errNotACast) {
+		if err != nil {
+			return nil, err
+		}
+		return r.resolve(castType, i)
+	}
 	switch t := currentType.(type) {
 	case *btf.Struct:
 		return r.processMembers(currentType, t.Members, i)
@@ -429,4 +437,37 @@ func (r *btfResolver) processArray(
 		r.btfArgs[i].IsPointer = uint16(1)
 	}
 	return &targetType, nil
+}
+
+func (r *btfResolver) parseBTFTypeCast(i int) (btf.Type, error) {
+	pathElem := r.pathToFind[i]
+
+	if !strings.HasPrefix(pathElem, "(") || !strings.HasSuffix(pathElem, ")") {
+		if strings.ContainsAny(pathElem, "()") {
+			return nil, fmt.Errorf("invalid BTF type cast %q (must be: \"(type)\")", pathElem)
+		}
+		return nil, errNotACast
+	}
+
+	typeExpr := strings.TrimSpace(pathElem[1 : len(pathElem)-1])
+	if typeExpr == "" {
+		return nil, errors.New("empty BTF type cast")
+	}
+
+	if r.spec == nil {
+		spec, err := NewBTF()
+		if err != nil {
+			return nil, err
+		}
+		r.spec = spec
+	}
+
+	ty, err := ParseBTFType(r.spec, typeExpr)
+	if err != nil {
+		return nil, err
+	}
+
+	r.pathToFind = append(r.pathToFind[:i], r.pathToFind[i+1:]...)
+
+	return ty, nil
 }

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -268,47 +268,63 @@ func getSizeofType(t btf.Type) uint32 {
 	return uint32(ret)
 }
 
+type btfResolver struct {
+	btfArgs     *[api.MaxBTFArgDepth]api.ConfigBTFArg
+	currentType btf.Type
+	pathToFound []string
+}
+
 // ResolveBTFPath function recursively search in a btf structure in order to
 // found a specific path until it reach the target or fail.
-
+//
 // The function also search in embedded anonymous structures or unions to cover as
 // much use cases as possible. For instance, mm_struct have 2 fields, anonymous
 // struct and another type. But you are still able to look into the anonymous
 // struct by specifying a path like "mm.pgd.pgd".
-
+//
 // @btfArgs: dest array for storing btf informations to reach the target on the
 // bpf side.
 // @currentType: The current type being proccessed, starts with root type.
 // @pathToFound: The string representation of the path to reach in the structures.
-// @i: The current depth, until last element of pathToFound.
-
+//
 // Return: The last type found matching the path, or error.
 func ResolveBTFPath(
 	btfArgs *[api.MaxBTFArgDepth]api.ConfigBTFArg,
 	currentType btf.Type,
 	pathToFound []string,
+) (*btf.Type, error) {
+	resolver := btfResolver{
+		btfArgs:     btfArgs,
+		currentType: currentType,
+		pathToFound: pathToFound,
+	}
+	return resolver.resolve(currentType, 0)
+}
+
+func (r *btfResolver) resolve(
+	currentType btf.Type,
 	i int,
 ) (*btf.Type, error) {
 	currentType = ResolveNestedTypes(currentType)
 	switch t := currentType.(type) {
 	case *btf.Struct:
-		return processMembers(btfArgs, currentType, t.Members, pathToFound, i)
+		return r.processMembers(currentType, t.Members, i)
 	case *btf.Union:
-		return processMembers(btfArgs, currentType, t.Members, pathToFound, i)
+		return r.processMembers(currentType, t.Members, i)
 	case *btf.Pointer:
 		if i > 0 {
 			// To avoid adding an extra BTFArg entry only for doing this
 			// dereferencing, we mark the previous element as pointer.
-			btfArgs[i-1].IsPointer = uint16(1)
+			r.btfArgs[i-1].IsPointer = uint16(1)
 		}
-		if idx, err := parseArrayIdxStr(pathToFound[i]); err == nil {
+		if idx, err := parseArrayIdxStr(r.pathToFound[i]); err == nil {
 			// To stay ahead on the dereferecing, we mark the current btfArg as pointer
-			btfArgs[i].IsPointer = uint16(1)
-			return processArray(btfArgs, t.Target, pathToFound, i, idx)
+			r.btfArgs[i].IsPointer = uint16(1)
+			return r.processArray(t.Target, i, idx)
 		}
-		return ResolveBTFPath(btfArgs, t.Target, pathToFound, i)
+		return r.resolve(t.Target, i)
 	case *btf.Array:
-		idx, err := parseArrayIdxStr(pathToFound[i])
+		idx, err := parseArrayIdxStr(r.pathToFound[i])
 		if err != nil {
 			return nil, fmt.Errorf("fail parsing array index : %w", err)
 		}
@@ -317,15 +333,15 @@ func ResolveBTFPath(
 		if t.Nelems != 0 && idx >= t.Nelems {
 			return nil, fmt.Errorf("array index out of bound. Nelems=%d, got=%d", t.Nelems, idx)
 		}
-		return processArray(btfArgs, t.Type, pathToFound, i, idx)
+		return r.processArray(t.Type, i, idx)
 	default:
 		ty := currentType.TypeName()
 		if len(ty) == 0 {
 			ty = reflect.TypeOf(currentType).String()
 		}
-		currentPath := pathToFound[i]
+		currentPath := r.pathToFound[i]
 		if i > 0 {
-			currentPath = pathToFound[i-1]
+			currentPath = r.pathToFound[i-1]
 		}
 		return nil, fmt.Errorf("unexpected type : %q has type %q", currentPath, ty)
 	}
@@ -340,17 +356,15 @@ func (e *resolveError) Error() string {
 	return e.str
 }
 
-func processMembers(
-	btfArgs *[api.MaxBTFArgDepth]api.ConfigBTFArg,
+func (r *btfResolver) processMembers(
 	currentType btf.Type,
 	members []btf.Member,
-	pathToFound []string,
 	i int,
 ) (*btf.Type, error) {
 	var lastError *resolveError
 	for _, member := range members {
 		if len(member.Name) == 0 { // anonymous struct/union, fallthrough
-			lastTy, err := ResolveBTFPath(btfArgs, member.Type, pathToFound, i)
+			lastTy, err := r.resolve(member.Type, i)
 			if err != nil {
 				// Propagate the deepest error for both resolve and non-resolve error.
 				if err2, ok := errors.AsType[*resolveError](err); ok {
@@ -362,24 +376,24 @@ func processMembers(
 				}
 				continue
 			}
-			btfArgs[i].Offset += member.Offset.Bytes()
+			r.btfArgs[i].Offset += member.Offset.Bytes()
 			return lastTy, nil
 		}
-		if member.Name != pathToFound[i] {
+		if member.Name != r.pathToFound[i] {
 			continue
 		}
-		btfArgs[i].Offset = member.Offset.Bytes()
-		btfArgs[i].IsInitialized = uint16(1)
-		if i < len(pathToFound)-1 && i < api.MaxBTFArgDepth {
-			return ResolveBTFPath(btfArgs, member.Type, pathToFound, i+1)
+		r.btfArgs[i].Offset = member.Offset.Bytes()
+		r.btfArgs[i].IsInitialized = uint16(1)
+		if i < len(r.pathToFound)-1 && i < api.MaxBTFArgDepth {
+			return r.resolve(member.Type, i+1)
 		}
 		memberType := ResolveNestedTypes(member.Type)
 		switch t := memberType.(type) {
 		case *btf.Pointer:
-			btfArgs[i].IsPointer = uint16(1)
+			r.btfArgs[i].IsPointer = uint16(1)
 			memberType = t.Target
 		case *btf.Int, *btf.Enum:
-			btfArgs[i].IsPointer = uint16(1)
+			r.btfArgs[i].IsPointer = uint16(1)
 		}
 		return &memberType, nil
 	}
@@ -388,30 +402,28 @@ func processMembers(
 	}
 	return nil, &resolveError{i, fmt.Sprintf(
 		"attribute %q not found in structure %q",
-		pathToFound[i],
+		r.pathToFound[i],
 		currentType.TypeName(),
 	)}
 }
 
-func processArray(
-	btfArgs *[api.MaxBTFArgDepth]api.ConfigBTFArg,
+func (r *btfResolver) processArray(
 	targetType btf.Type,
-	pathToFound []string,
 	i int,
 	idx uint32,
 ) (*btf.Type, error) {
 	targetType = ResolveNestedTypes(targetType)
-	btfArgs[i].IsInitialized = uint16(1)
-	btfArgs[i].Offset = getSizeofType(targetType) * idx
-	if len(pathToFound) > i+1 {
-		return ResolveBTFPath(btfArgs, targetType, pathToFound, i+1)
+	r.btfArgs[i].IsInitialized = uint16(1)
+	r.btfArgs[i].Offset = getSizeofType(targetType) * idx
+	if len(r.pathToFound) > i+1 {
+		return r.resolve(targetType, i+1)
 	}
 	switch t := targetType.(type) {
 	case *btf.Pointer:
-		btfArgs[i].IsPointer = uint16(1)
+		r.btfArgs[i].IsPointer = uint16(1)
 		targetType = t.Target
 	case *btf.Int, *btf.Enum:
-		btfArgs[i].IsPointer = uint16(1)
+		r.btfArgs[i].IsPointer = uint16(1)
 	}
 	return &targetType, nil
 }

--- a/pkg/btf/btf.go
+++ b/pkg/btf/btf.go
@@ -271,7 +271,7 @@ func getSizeofType(t btf.Type) uint32 {
 type btfResolver struct {
 	btfArgs     *[api.MaxBTFArgDepth]api.ConfigBTFArg
 	currentType btf.Type
-	pathToFound []string
+	pathToFind  []string
 	spec        *btf.Spec
 }
 
@@ -286,19 +286,19 @@ type btfResolver struct {
 // @btfArgs: dest array for storing btf informations to reach the target on the
 // bpf side.
 // @currentType: The current type being proccessed, starts with root type.
-// @pathToFound: The string representation of the path to reach in the structures.
+// @pathToFind: The string representation of the path to reach in the structures.
 //
 // Return: The last type found matching the path, or error.
 func ResolveBTFPath(
 	btfArgs *[api.MaxBTFArgDepth]api.ConfigBTFArg,
 	currentType btf.Type,
-	pathToFound []string,
+	pathToFind []string,
 	spec *btf.Spec,
 ) (*btf.Type, error) {
 	resolver := btfResolver{
 		btfArgs:     btfArgs,
 		currentType: currentType,
-		pathToFound: pathToFound,
+		pathToFind:  pathToFind,
 		spec:        spec,
 	}
 	return resolver.resolve(currentType, 0)
@@ -320,14 +320,14 @@ func (r *btfResolver) resolve(
 			// dereferencing, we mark the previous element as pointer.
 			r.btfArgs[i-1].IsPointer = uint16(1)
 		}
-		if idx, err := parseArrayIdxStr(r.pathToFound[i]); err == nil {
+		if idx, err := parseArrayIdxStr(r.pathToFind[i]); err == nil {
 			// To stay ahead on the dereferecing, we mark the current btfArg as pointer
 			r.btfArgs[i].IsPointer = uint16(1)
 			return r.processArray(t.Target, i, idx)
 		}
 		return r.resolve(t.Target, i)
 	case *btf.Array:
-		idx, err := parseArrayIdxStr(r.pathToFound[i])
+		idx, err := parseArrayIdxStr(r.pathToFind[i])
 		if err != nil {
 			return nil, fmt.Errorf("fail parsing array index : %w", err)
 		}
@@ -342,9 +342,9 @@ func (r *btfResolver) resolve(
 		if len(ty) == 0 {
 			ty = reflect.TypeOf(currentType).String()
 		}
-		currentPath := r.pathToFound[i]
+		currentPath := r.pathToFind[i]
 		if i > 0 {
-			currentPath = r.pathToFound[i-1]
+			currentPath = r.pathToFind[i-1]
 		}
 		return nil, fmt.Errorf("unexpected type : %q has type %q", currentPath, ty)
 	}
@@ -382,12 +382,12 @@ func (r *btfResolver) processMembers(
 			r.btfArgs[i].Offset += member.Offset.Bytes()
 			return lastTy, nil
 		}
-		if member.Name != r.pathToFound[i] {
+		if member.Name != r.pathToFind[i] {
 			continue
 		}
 		r.btfArgs[i].Offset = member.Offset.Bytes()
 		r.btfArgs[i].IsInitialized = uint16(1)
-		if i < len(r.pathToFound)-1 && i < api.MaxBTFArgDepth {
+		if i < len(r.pathToFind)-1 && i < api.MaxBTFArgDepth {
 			return r.resolve(member.Type, i+1)
 		}
 		memberType := ResolveNestedTypes(member.Type)
@@ -405,7 +405,7 @@ func (r *btfResolver) processMembers(
 	}
 	return nil, &resolveError{i, fmt.Sprintf(
 		"attribute %q not found in structure %q",
-		r.pathToFound[i],
+		r.pathToFind[i],
 		currentType.TypeName(),
 	)}
 }
@@ -418,7 +418,7 @@ func (r *btfResolver) processArray(
 	targetType = ResolveNestedTypes(targetType)
 	r.btfArgs[i].IsInitialized = uint16(1)
 	r.btfArgs[i].Offset = getSizeofType(targetType) * idx
-	if len(r.pathToFound) > i+1 {
+	if len(r.pathToFind) > i+1 {
 		return r.resolve(targetType, i+1)
 	}
 	switch t := targetType.(type) {

--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -677,6 +678,109 @@ func TestParseArrayIdxStr(t *testing.T) {
 			if !tt.wantErr && got != tt.want {
 				t.Errorf("parseArrayIdxStr() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestParseBTFTypeCast(t *testing.T) {
+	primitiveSpec := &btf.Spec{}
+
+	// parseBTFTypeCast has three distinct outcomes:
+	//   success      — returns (type, nil);        path element at idx is removed
+	//   wantNotCast  — returns (nil, errNotACast); path is unchanged (sentinel, not a real error)
+	//   wantErr      — returns (nil, someError);   path is unchanged
+	tests := []struct {
+		name        string
+		input       []string
+		idx         int
+		spec        *btf.Spec
+		wantErr     bool
+		wantNotCast bool
+	}{
+		{
+			name:  "Valid cast - char pointer",
+			input: []string{"field", "(char*)", "[1]"},
+			idx:   1,
+			spec:  primitiveSpec,
+		},
+		{
+			name:  "Valid cast - pointer to char array",
+			input: []string{"field", "(*char[64])", "[1]"},
+			idx:   1,
+			spec:  primitiveSpec,
+		},
+		{
+			name:        "Not a cast",
+			input:       []string{"field"},
+			idx:         0,
+			wantNotCast: true,
+		},
+		{
+			name:    "Invalid format - trailing token",
+			input:   []string{"field", "(char ')*"},
+			idx:     1,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid type name",
+			input:   []string{"field", "(-_char*)"},
+			idx:     1,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid format - unopened cast",
+			input:   []string{"field", "char*)"},
+			idx:     1,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid format - unclosed cast",
+			input:   []string{"field", "(char*"},
+			idx:     1,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid format - empty cast",
+			input:   []string{"field", "()"},
+			idx:     1,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid format - blank cast",
+			input:   []string{"field", "( )"},
+			idx:     1,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := btfResolver{
+				pathToFind: append([]string(nil), tt.input...),
+				spec:       tt.spec,
+			}
+
+			_, err := resolver.parseBTFTypeCast(tt.idx)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				require.NotErrorIs(t, err, errNotACast, "expected a real error, not the sentinel errNotACast")
+			case tt.wantNotCast:
+				require.ErrorIs(t, err, errNotACast)
+			default:
+				require.NoError(t, err)
+			}
+
+			// Path is modified only on success: the cast element at idx is removed.
+			// For errors and the not-a-cast sentinel the path must be unchanged.
+			var wantPath []string
+			if !tt.wantErr && !tt.wantNotCast {
+				wantPath = slices.Concat(tt.input[:tt.idx], tt.input[tt.idx+1:])
+			} else {
+				wantPath = tt.input
+			}
+			require.Equal(t, wantPath, resolver.pathToFind)
 		})
 	}
 }

--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -436,7 +436,7 @@ func buildResolveBTFConfig(t *testing.T, rootType btf.Type, pathStr string) [api
 	var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
 
 	path := buildPathFromString(t, rootType, pathStr)
-	_, err := ResolveBTFPath(&btfArgs, rootType, path)
+	_, err := ResolveBTFPath(&btfArgs, rootType, path, nil)
 	fatalOnError(t, err)
 
 	return btfArgs
@@ -451,7 +451,7 @@ func testPathIsAccessible(rootType btf.Type, strPath string) (*[api.MaxBTFArgDep
 	var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
 	path := strings.Split(strPath, ".")
 
-	lastBTFType, err := ResolveBTFPath(&btfArgs, ResolveNestedTypes(rootType), path)
+	lastBTFType, err := ResolveBTFPath(&btfArgs, ResolveNestedTypes(rootType), path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -709,7 +709,7 @@ func TestResolveBTFPathZeroLengthArray(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
 
-			ty, err := ResolveBTFPath(&btfArgs, root, []string{"sa_data", tt.path})
+			ty, err := ResolveBTFPath(&btfArgs, root, []string{"sa_data", tt.path}, nil)
 			require.NoError(t, err)
 			require.NotNil(t, ty)
 
@@ -764,7 +764,7 @@ func TestProcessMembersErrorPrecedence(t *testing.T) {
 		}
 
 		var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
-		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"})
+		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"}, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `attribute "y" not found in structure "inner"`)
 	})
@@ -801,7 +801,7 @@ func TestProcessMembersErrorPrecedence(t *testing.T) {
 		var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
 		// Two-element path: "x" is not the last child, so finding it in anon2 triggers
 		// ResolveBTFPath(int, path, 1) which returns a non-resolveError.
-		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"})
+		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"}, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `unexpected type : "x" has type "int"`)
 	})
@@ -843,7 +843,7 @@ func TestProcessMembersErrorPrecedence(t *testing.T) {
 		}
 
 		var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
-		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"})
+		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"}, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `attribute "y" not found in structure "inner"`)
 	})
@@ -876,7 +876,7 @@ func TestProcessMembersErrorPrecedence(t *testing.T) {
 		}
 
 		var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
-		ty, err := ResolveBTFPath(&btfArgs, outer, []string{"x"})
+		ty, err := ResolveBTFPath(&btfArgs, outer, []string{"x"}, nil)
 		require.NoError(t, err)
 		require.NotNil(t, ty)
 	})

--- a/pkg/btf/btf_test.go
+++ b/pkg/btf/btf_test.go
@@ -436,7 +436,7 @@ func buildResolveBTFConfig(t *testing.T, rootType btf.Type, pathStr string) [api
 	var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
 
 	path := buildPathFromString(t, rootType, pathStr)
-	_, err := ResolveBTFPath(&btfArgs, rootType, path, 0)
+	_, err := ResolveBTFPath(&btfArgs, rootType, path)
 	fatalOnError(t, err)
 
 	return btfArgs
@@ -451,7 +451,7 @@ func testPathIsAccessible(rootType btf.Type, strPath string) (*[api.MaxBTFArgDep
 	var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
 	path := strings.Split(strPath, ".")
 
-	lastBTFType, err := ResolveBTFPath(&btfArgs, ResolveNestedTypes(rootType), path, 0)
+	lastBTFType, err := ResolveBTFPath(&btfArgs, ResolveNestedTypes(rootType), path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -709,7 +709,7 @@ func TestResolveBTFPathZeroLengthArray(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
 
-			ty, err := ResolveBTFPath(&btfArgs, root, []string{"sa_data", tt.path}, 0)
+			ty, err := ResolveBTFPath(&btfArgs, root, []string{"sa_data", tt.path})
 			require.NoError(t, err)
 			require.NotNil(t, ty)
 
@@ -764,7 +764,7 @@ func TestProcessMembersErrorPrecedence(t *testing.T) {
 		}
 
 		var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
-		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"}, 0)
+		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `attribute "y" not found in structure "inner"`)
 	})
@@ -801,7 +801,7 @@ func TestProcessMembersErrorPrecedence(t *testing.T) {
 		var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
 		// Two-element path: "x" is not the last child, so finding it in anon2 triggers
 		// ResolveBTFPath(int, path, 1) which returns a non-resolveError.
-		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"}, 0)
+		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `unexpected type : "x" has type "int"`)
 	})
@@ -843,7 +843,7 @@ func TestProcessMembersErrorPrecedence(t *testing.T) {
 		}
 
 		var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
-		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"}, 0)
+		_, err := ResolveBTFPath(&btfArgs, outer, []string{"x", "y"})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `attribute "y" not found in structure "inner"`)
 	})
@@ -876,7 +876,7 @@ func TestProcessMembersErrorPrecedence(t *testing.T) {
 		}
 
 		var btfArgs [api.MaxBTFArgDepth]api.ConfigBTFArg
-		ty, err := ResolveBTFPath(&btfArgs, outer, []string{"x"}, 0)
+		ty, err := ResolveBTFPath(&btfArgs, outer, []string{"x"})
 		require.NoError(t, err)
 		require.NotNil(t, ty)
 	})

--- a/pkg/btf/type_builder.go
+++ b/pkg/btf/type_builder.go
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package btf
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/ebpf/btf"
+
+	"github.com/cilium/tetragon/pkg/cursorparser"
+)
+
+type btfTypeParser struct {
+	*cursorparser.Parser
+	spec *btf.Spec
+}
+
+// ParseBTFType builds a BTF type from a C-like type expression.
+//
+// Supported constructs are primitive types and BTF spec types. For example:
+//
+//   - "char*"
+//   - "(*char[64])"
+//   - "uint64_t[4]"
+//   - "struct task_struct *"
+func ParseBTFType(spec *btf.Spec, typeExpr string) (btf.Type, error) {
+	if spec == nil {
+		return nil, errors.New("no BTF spec provided")
+	}
+	parser := btfTypeParser{Parser: cursorparser.New(typeExpr), spec: spec}
+	ty, err := parser.parseType()
+	if err != nil {
+		return nil, err
+	}
+	if !parser.Done() {
+		return nil, parser.errorf("unexpected token %q", parser.ReadRest())
+	}
+	return ty, nil
+}
+
+func (p *btfTypeParser) parseType() (btf.Type, error) {
+	if p.Done() {
+		return nil, p.errorf("empty type expression")
+	}
+
+	prefixPointers := 0
+	for p.Consume('*') {
+		prefixPointers++
+	}
+
+	ty, err := p.parsePrimary()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		switch {
+		case p.Consume('*'):
+			ty = &btf.Pointer{Target: ty}
+		case p.Consume('['):
+			nelems, err := p.parseArraySize()
+			if err != nil {
+				return nil, err
+			}
+			ty = &btf.Array{
+				Type:   ty,
+				Index:  arrayIndexType(),
+				Nelems: nelems,
+			}
+		default:
+			for range prefixPointers {
+				ty = &btf.Pointer{Target: ty}
+			}
+			return ty, nil
+		}
+	}
+}
+
+func (p *btfTypeParser) parsePrimary() (btf.Type, error) {
+	if p.Consume('(') {
+		ty, err := p.parseType()
+		if err != nil {
+			return nil, err
+		}
+		if !p.Consume(')') {
+			return nil, p.errorf("missing closing parenthesis")
+		}
+		return ty, nil
+	}
+
+	name := p.parseScalarName()
+	if name == "" {
+		return nil, p.errorf("expected type name")
+	}
+	ty, ok := primitiveBTFType(name)
+	if ok {
+		return ty, nil
+	}
+	ty, err := p.specBTFType(name)
+	if err != nil {
+		return nil, err
+	}
+	return ty, nil
+}
+
+func (p *btfTypeParser) specBTFType(name string) (btf.Type, error) {
+	ty, err := lookupBTFTypeInSpec(p.spec, name)
+	if err != nil {
+		return nil, p.errorf("%v", err)
+	}
+	return ty, nil
+}
+
+func lookupBTFTypeInSpec(spec *btf.Spec, name string) (btf.Type, error) {
+	if spec == nil {
+		return nil, btf.ErrNotFound
+	}
+
+	if structName, ok := strings.CutPrefix(name, "struct "); ok {
+		var st *btf.Struct
+		if err := firstTypeByName(spec, structName, &st); err != nil {
+			return nil, fmt.Errorf("failed to resolve struct %q from BTF spec: %w", structName, err)
+		}
+		return st, nil
+	}
+
+	if unionName, ok := strings.CutPrefix(name, "union "); ok {
+		var union *btf.Union
+		if err := firstTypeByName(spec, unionName, &union); err != nil {
+			return nil, fmt.Errorf("failed to resolve union %q from BTF spec: %w", unionName, err)
+		}
+		return union, nil
+	}
+
+	if enumName, ok := strings.CutPrefix(name, "enum "); ok {
+		var enum *btf.Enum
+		if err := firstTypeByName(spec, enumName, &enum); err != nil {
+			return nil, fmt.Errorf("failed to resolve enum %q from BTF spec: %w", enumName, err)
+		}
+		return enum, nil
+	}
+
+	return nil, fmt.Errorf("type %q is not supported", name)
+}
+
+func primitiveBTFType(name string) (btf.Type, bool) {
+	switch name {
+	case "void":
+		return &btf.Void{}, true
+	case "bool":
+		return btfBool(), true
+	case "char":
+		return btfChar(), true
+
+	// 1 Byte
+	case "signed char", "int8", "int8_t", "s8", "__s8":
+		return btfSignedInt("signed char", 1), true
+	case "unsigned char", "uint8", "uint8_t", "u8", "__u8":
+		return btfUnsignedInt("unsigned char", 1), true
+
+	// 2 Bytes
+	case "short", "short int", "signed short", "signed short int", "int16", "int16_t", "s16", "__s16":
+		return btfSignedInt("short int", 2), true
+	case "unsigned short", "unsigned short int", "uint16", "uint16_t", "u16", "__u16":
+		return btfUnsignedInt("unsigned short int", 2), true
+
+	// 4 Bytes
+	case "int", "signed int", "signed", "int32", "int32_t", "s32", "__s32":
+		return btfSignedInt("signed int", 4), true
+	case "unsigned int", "unsigned", "uint32", "uint32_t", "u32", "__u32":
+		return btfUnsignedInt("unsigned int", 4), true
+
+	// 8 Bytes
+	case "long", "long int", "signed long", "signed long int",
+		"long long", "long long int", "signed long long", "signed long long int",
+		"int64", "int64_t", "s64", "__s64":
+		return btfSignedInt("signed long long int", 8), true
+	case "unsigned long", "unsigned long int",
+		"unsigned long long", "unsigned long long int",
+		"uint64", "uint64_t", "u64", "__u64", "size_t":
+		return btfUnsignedInt("unsigned long long int", 8), true
+
+	default:
+		return nil, false
+	}
+}
+
+func btfBool() btf.Type {
+	return &btf.Int{
+		Name:     "bool",
+		Size:     1,
+		Encoding: btf.Bool,
+	}
+}
+
+func btfChar() btf.Type {
+	return &btf.Int{
+		Name:     "char",
+		Size:     1,
+		Encoding: btf.Char,
+	}
+}
+
+func btfSignedInt(name string, size uint32) btf.Type {
+	return &btf.Int{
+		Name:     name,
+		Size:     size,
+		Encoding: btf.Signed,
+	}
+}
+
+func btfUnsignedInt(name string, size uint32) btf.Type {
+	return &btf.Int{
+		Name:     name,
+		Size:     size,
+		Encoding: btf.Unsigned,
+	}
+}
+
+func (p *btfTypeParser) parseScalarName() string {
+	raw := p.ReadUntilAny("*[]()")
+	return strings.Join(strings.Fields(strings.ToLower(raw)), " ")
+}
+
+func (p *btfTypeParser) parseArraySize() (uint32, error) {
+	sizeLiteral, ok := p.ReadUntil(']')
+	if !ok {
+		return 0, p.errorf("missing closing array bracket")
+	}
+	sizeLiteral = strings.TrimSpace(sizeLiteral)
+	if sizeLiteral == "" {
+		return 0, p.errorf("missing array size")
+	}
+	if !p.Consume(']') {
+		return 0, p.errorf("missing closing array bracket")
+	}
+	n, err := strconv.ParseUint(sizeLiteral, 10, 32)
+	if err != nil {
+		return 0, p.errorf("invalid array size %q", sizeLiteral)
+	}
+	return uint32(n), nil
+}
+
+func (p *btfTypeParser) errorf(format string, args ...any) error {
+	return fmt.Errorf("parse BTF type %q at byte %d: %s", p.Input(), p.Pos(),
+		fmt.Sprintf(format, args...))
+}
+
+func arrayIndexType() btf.Type {
+	return &btf.Int{
+		Name:     "unsigned int",
+		Size:     4,
+		Encoding: btf.Unsigned,
+	}
+}

--- a/pkg/btf/type_builder_test.go
+++ b/pkg/btf/type_builder_test.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package btf
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cilium/ebpf/btf"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBTFTypeSyntaxErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		expr        string
+		errContains string
+	}{
+		{
+			name:        "Empty type string",
+			expr:        "",
+			errContains: "empty type expression",
+		},
+		{
+			name:        "Pure whitespace string",
+			expr:        "   ",
+			errContains: "empty type expression",
+		},
+		{
+			name:        "Extreme recursive nested loop with no scalar",
+			expr:        "((((*)))",
+			errContains: "expected type name",
+		},
+		{
+			name:        "Unbalanced opening parenthesis",
+			expr:        "((int",
+			errContains: "missing closing parenthesis",
+		},
+		{
+			name:        "Unexpected trailing tokens",
+			expr:        "int)",
+			errContains: "unexpected token",
+		},
+		{
+			name:        "Trailing garbage after valid type",
+			expr:        "char* garbage",
+			errContains: "unexpected token \"garbage\"",
+		},
+		{
+			name:        "Empty array declaration",
+			expr:        "int[]",
+			errContains: "missing array size",
+		},
+		{
+			name:        "Non-numeric array size",
+			expr:        "int[sixteen]",
+			errContains: "invalid array size",
+		},
+		{
+			name:        "Unclosed array bracket",
+			expr:        "int[64",
+			errContains: "missing closing array bracket",
+		},
+	}
+
+	dummySpec := specFromBTFTypes(t, []btf.Type{btfChar()})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseBTFType(dummySpec, tt.expr)
+			require.Error(t, err)
+			if tt.errContains != "" {
+				require.ErrorContains(t, err, tt.errContains)
+			}
+		})
+	}
+	t.Run("no BTF spec provided", func(t *testing.T) {
+		_, err := ParseBTFType(nil, "int")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no BTF spec provided")
+	})
+}
+
+func TestParseBTFTypePointerArrayCombinations(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		wantType btf.Type
+	}{
+		{
+			name:     "Suffix pointer without parens",
+			expr:     "char*",
+			wantType: wantPtr(wantChar()),
+		},
+		{
+			name:     "Suffix pointer with internal space",
+			expr:     "(char *)",
+			wantType: wantPtr(wantChar()),
+		},
+		{
+			name:     "Prefix char pointer",
+			expr:     "(*char)",
+			wantType: wantPtr(wantChar()),
+		},
+		{
+			name:     "Suffix char pointer",
+			expr:     "(char*)",
+			wantType: wantPtr(wantChar()),
+		},
+		{
+			name:     "Prefix pointer to char array",
+			expr:     "(*char[64])",
+			wantType: wantPtr(wantArray(wantChar(), 64)),
+		},
+		{
+			name:     "Suffix pointer to char array",
+			expr:     "(char[64]*)",
+			wantType: wantPtr(wantArray(wantChar(), 64)),
+		},
+		{
+			name:     "Double prefix pointer to char array",
+			expr:     "(**char[64])",
+			wantType: wantPtr(wantPtr(wantArray(wantChar(), 64))),
+		},
+		{
+			name:     "Double suffix pointer to char array",
+			expr:     "(char[64]**)",
+			wantType: wantPtr(wantPtr(wantArray(wantChar(), 64))),
+		},
+		{
+			name:     "Mixed pointer to char array",
+			expr:     "(*char[64]*)",
+			wantType: wantPtr(wantPtr(wantArray(wantChar(), 64))),
+		},
+		{
+			name:     "Array of char pointers",
+			expr:     "(char*[64])",
+			wantType: wantArray(wantPtr(wantChar()), 64),
+		},
+	}
+
+	dummySpec := specFromBTFTypes(t, []btf.Type{btfChar()})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ty, err := ParseBTFType(dummySpec, tt.expr)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, ty)
+		})
+	}
+}
+func TestParseBTFTypeSpecDirectResolutions(t *testing.T) {
+	primarySpec := specFromBTFTypes(t, []btf.Type{
+		&btf.Struct{Name: "task_struct", Size: 8},
+		&btf.Union{Name: "my_union", Size: 4},
+		&btf.Enum{Name: "my_enum", Size: 4},
+	})
+
+	taskStruct, _ := primarySpec.AnyTypeByName("task_struct")
+	myUnion, _ := primarySpec.AnyTypeByName("my_union")
+	myEnum, _ := primarySpec.AnyTypeByName("my_enum")
+
+	tests := []struct {
+		name     string
+		expr     string
+		wantType btf.Type
+	}{
+		{
+			name:     "Resolve explicit struct prefix",
+			expr:     "struct task_struct *",
+			wantType: wantPtr(taskStruct),
+		},
+		{
+			name:     "Resolve explicit union prefix",
+			expr:     "union my_union *",
+			wantType: wantPtr(myUnion),
+		},
+		{
+			name:     "Resolve explicit enum prefix",
+			expr:     "enum my_enum *",
+			wantType: wantPtr(myEnum),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ty, err := ParseBTFType(primarySpec, tt.expr)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, ty)
+		})
+	}
+}
+
+func specFromBTFTypes(t *testing.T, types []btf.Type) *btf.Spec {
+	t.Helper()
+
+	builder, err := btf.NewBuilder(types, nil)
+	require.NoError(t, err)
+
+	rawSpec, err := builder.Marshal(nil, nil)
+	require.NoError(t, err)
+
+	spec, err := btf.LoadSpecFromReader(bytes.NewReader(rawSpec))
+	require.NoError(t, err)
+	return spec
+}
+
+func wantPtr(target btf.Type) btf.Type {
+	return &btf.Pointer{Target: target}
+}
+
+func wantArray(ty btf.Type, nelems uint32) btf.Type {
+	return &btf.Array{
+		Type:   ty,
+		Index:  wantUnsignedInt(),
+		Nelems: nelems,
+	}
+}
+
+func wantChar() btf.Type {
+	return &btf.Int{
+		Name:     "char",
+		Size:     1,
+		Encoding: btf.Char,
+	}
+}
+
+func wantUnsignedInt() btf.Type {
+	return &btf.Int{
+		Name:     "unsigned int",
+		Size:     4,
+		Encoding: btf.Unsigned,
+	}
+}

--- a/pkg/cursorparser/parser.go
+++ b/pkg/cursorparser/parser.go
@@ -71,6 +71,21 @@ func (p *Parser) ReadUntil(ch byte) (string, bool) {
 	return str, true
 }
 
+// ReadUntilAny returns the text from the current cursor up to the first byte
+// that appears in stopChars, leaving the cursor at that byte.
+// If no stop byte is found the rest of the string is returned and the cursor
+// advances to the end.
+func (p *Parser) ReadUntilAny(stopChars string) string {
+	start := p.pos
+	for p.pos < len(p.str) {
+		if strings.IndexByte(stopChars, p.str[p.pos]) >= 0 {
+			break
+		}
+		p.pos++
+	}
+	return p.str[start:p.pos]
+}
+
 // ReadRest returns the remaining expression text and moves the cursor
 // to the end.
 func (p *Parser) ReadRest() string {
@@ -83,4 +98,14 @@ func (p *Parser) ReadRest() string {
 func (p *Parser) Done() bool {
 	p.skipSpace()
 	return p.pos == len(p.str)
+}
+
+// Pos returns the current cursor offset within the (trimmed) input string.
+func (p *Parser) Pos() int {
+	return p.pos
+}
+
+// Input returns the trimmed string this parser was created with.
+func (p *Parser) Input() string {
+	return p.str
 }

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -15,6 +15,8 @@ import (
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
+	"github.com/cilium/tetragon/pkg/asm"
+	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/btf"
 	conf "github.com/cilium/tetragon/pkg/config"
 	"github.com/cilium/tetragon/pkg/generictypes"
@@ -142,6 +144,44 @@ func hasCurrentTaskSource(arg *v1alpha1.KProbeArg) bool {
 
 func hasPtRegsSource(arg *v1alpha1.KProbeArg) bool {
 	return arg.Source == "pt_regs"
+}
+
+func resolvePtRegsArg(resolve string) (api.ConfigRegArg, [api.MaxBTFArgDepth]api.ConfigBTFArg, bool, error) {
+	var (
+		regArg api.ConfigRegArg
+		btfArg [api.MaxBTFArgDepth]api.ConfigBTFArg
+	)
+
+	path, err := formatBTFPath(resolve)
+	if err != nil {
+		return regArg, btfArg, false, err
+	}
+	if len(path) == 0 {
+		return regArg, btfArg, false, errors.New("empty register argument resolve path")
+	}
+
+	var ok bool
+	regArg.Offset, regArg.Size, ok = asm.RegOffsetSize(path[0])
+	if !ok {
+		return regArg, btfArg, false, fmt.Errorf("failed to retrieve register argument %q", resolve)
+	}
+
+	path = path[1:]
+	if len(path) == 0 {
+		return regArg, btfArg, false, nil
+	}
+	if !bpf.HasProgramLargeSize() {
+		return regArg, btfArg, false, errors.New("resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag")
+	}
+	if len(path) > api.MaxBTFArgDepth {
+		return regArg, btfArg, false, fmt.Errorf("unable to resolve %q. The maximum depth allowed is %d", resolve, api.MaxBTFArgDepth)
+	}
+
+	_, err = btf.ResolveBTFPath(&btfArg, &ebtf.Void{}, path, nil)
+	if err != nil {
+		return regArg, btfArg, false, fmt.Errorf("failed to resolve pt_regs path %q: %w", resolve, err)
+	}
+	return regArg, btfArg, true, nil
 }
 
 func resolveBTFType(arg *v1alpha1.KProbeArg, ty ebtf.Type) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -113,7 +113,7 @@ func resolveBTFType(arg *v1alpha1.KProbeArg, ty ebtf.Type) (*ebtf.Type, [api.Max
 		return nil, btfArg, fmt.Errorf("unable to resolve %q. The maximum depth allowed is %d", arg.Resolve, api.MaxBTFArgDepth)
 	}
 
-	lastBTFType, err := resolveBTFPath(&btfArg, btf.ResolveNestedTypes(ty), path)
+	lastBTFType, err := btf.ResolveBTFPath(&btfArg, btf.ResolveNestedTypes(ty), path, nil)
 	return lastBTFType, btfArg, err
 }
 
@@ -196,10 +196,6 @@ func resolveBTFArg(hook string, arg *v1alpha1.KProbeArg, tp bool) (*ebtf.Type, [
 		}
 	}
 	return resolveBTFType(arg, ty)
-}
-
-func resolveBTFPath(btfArg *[api.MaxBTFArgDepth]api.ConfigBTFArg, rootType ebtf.Type, path []string) (*ebtf.Type, error) {
-	return btf.ResolveBTFPath(btfArg, rootType, path)
 }
 
 func findTypeFromBTFType(arg *v1alpha1.KProbeArg, btfType *ebtf.Type) int {

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -199,7 +199,7 @@ func resolveBTFArg(hook string, arg *v1alpha1.KProbeArg, tp bool) (*ebtf.Type, [
 }
 
 func resolveBTFPath(btfArg *[api.MaxBTFArgDepth]api.ConfigBTFArg, rootType ebtf.Type, path []string) (*ebtf.Type, error) {
-	return btf.ResolveBTFPath(btfArg, rootType, path, 0)
+	return btf.ResolveBTFPath(btfArg, rootType, path)
 }
 
 func findTypeFromBTFType(arg *v1alpha1.KProbeArg, btfType *ebtf.Type) int {

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -199,14 +199,9 @@ func resolveBTFType(arg *v1alpha1.KProbeArg, ty ebtf.Type) (*ebtf.Type, [api.Max
 	return lastBTFType, btfArg, err
 }
 
-func resolveUserBTFArg(arg *v1alpha1.KProbeArg, btfPath string) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {
-	spec, err := ebtf.LoadSpec(btfPath)
-	if err != nil {
-		return nil, [api.MaxBTFArgDepth]api.ConfigBTFArg{}, err
-	}
-
+func resolveUserBTFArg(arg *v1alpha1.KProbeArg, userBTFSpec *ebtf.Spec) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {
 	var st *ebtf.Struct
-	err = spec.TypeByName(arg.BTFType, &st)
+	err := userBTFSpec.TypeByName(arg.BTFType, &st)
 	if err != nil {
 		return nil, [api.MaxBTFArgDepth]api.ConfigBTFArg{}, err
 	}

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -23,55 +23,97 @@ import (
 )
 
 // Takes arg.Resolve as input and return the path in []string
-// Input   : my.super.field[123].my.sub.field
-// Output  : []string{"my", "super", "field", "[123]", "my", "sub", "field"}
+// Input   : my.super.((char*)field)[123].my.sub.field
+// Output  : []string{"my", "super", "field", "(char*)", "[123]", "my", "sub", "field"}
 func formatBTFPath(resolvePath string) ([]string, error) {
 	var path []string
-	var buffer strings.Builder
-	inBracket := false
-	invalidFormat := false
+	i := 0
+	lastWasDot := false
 
-	for i, r := range resolvePath {
-		switch r {
-		case '.':
-			if inBracket || i > 0 && resolvePath[i-1] == '.' {
-				invalidFormat = true
-				break
+	var parse func(stopAtCloseParen bool) error
+	parse = func(stopAtCloseParen bool) error {
+		for i < len(resolvePath) {
+			tail := resolvePath[i:]
+
+			switch {
+			case stopAtCloseParen && tail[0] == ')':
+				if len(path) == 0 {
+					return errors.New("empty cast expression")
+				}
+				i++ // Consume the ')'
+				return nil
+
+			case strings.HasPrefix(tail, "(("):
+				castEnd := strings.IndexByte(tail, ')')
+				if castEnd <= 2 || strings.ContainsAny(tail[2:castEnd], "()") {
+					return errors.New("invalid prefixed cast")
+				}
+				castToken := tail[1 : castEnd+1]
+
+				i += castEnd + 1 // Move the cursor after the "((cast)"
+				if err := parse(true); err != nil {
+					return err
+				}
+
+				path = append(path, castToken)
+				lastWasDot = false
+
+			case tail[0] == '[':
+				if lastWasDot {
+					return errors.New("dot followed by '['")
+				}
+				end := strings.IndexByte(tail, ']')
+				if end <= 1 || strings.ContainsAny(tail[1:end], ".[()") {
+					return errors.New("invalid index token")
+				}
+				path = append(path, tail[:end+1])
+				i += end + 1
+				lastWasDot = false
+
+			case tail[0] == '(':
+				return errors.New("type casts must use ((cast)field)")
+			case tail[0] == ')':
+				return errors.New("mismatched closing parenthesis")
+
+			case tail[0] == '.':
+				if lastWasDot {
+					return errors.New("consecutive dots")
+				}
+				lastWasDot = true
+				i++
+
+			default:
+				end := strings.IndexAny(tail, ".[()]")
+				var ident string
+				if end == -1 {
+					ident = tail
+					i += len(tail)
+				} else {
+					ident = tail[:end]
+					i += end
+				}
+
+				if ident == "" || strings.ContainsAny(ident, "])") {
+					return errors.New("invalid or mismatched identifier")
+				}
+				if i < len(resolvePath) && resolvePath[i] == '(' {
+					return errors.New("type casts must use ((cast)field)")
+				}
+				path = append(path, ident)
+				lastWasDot = false
 			}
-			if buffer.Len() > 0 {
-				path = append(path, buffer.String())
-				buffer.Reset()
-			}
-		case '[':
-			if inBracket || i > 0 && resolvePath[i-1] == '.' {
-				invalidFormat = true
-				break
-			}
-			if buffer.Len() > 0 {
-				path = append(path, buffer.String())
-				buffer.Reset()
-			}
-			inBracket = true
-			buffer.WriteRune(r)
-		case ']':
-			if !inBracket || i > 0 && resolvePath[i-1] == '[' {
-				invalidFormat = true
-				break
-			}
-			buffer.WriteRune(r)
-			inBracket = false
-			path = append(path, buffer.String())
-			buffer.Reset()
-		default:
-			buffer.WriteRune(r)
 		}
+
+		if stopAtCloseParen {
+			return errors.New("missing closing parenthesis")
+		}
+		return nil
 	}
-	if invalidFormat || inBracket {
-		return []string{}, fmt.Errorf("invalid format for resolve path: %q", resolvePath)
+
+	if err := parse(false); err != nil {
+		return nil, fmt.Errorf("invalid format for resolve path %q: %w", resolvePath, err)
 	}
-	if buffer.Len() > 0 {
-		path = append(path, buffer.String())
-	}
+
 	return path, nil
 }
 

--- a/pkg/sensors/tracing/generic.go
+++ b/pkg/sensors/tracing/generic.go
@@ -146,7 +146,7 @@ func hasPtRegsSource(arg *v1alpha1.KProbeArg) bool {
 	return arg.Source == "pt_regs"
 }
 
-func resolvePtRegsArg(resolve string) (api.ConfigRegArg, [api.MaxBTFArgDepth]api.ConfigBTFArg, bool, error) {
+func resolvePtRegsArg(resolve string, userBTFSpec *ebtf.Spec) (api.ConfigRegArg, [api.MaxBTFArgDepth]api.ConfigBTFArg, bool, error) {
 	var (
 		regArg api.ConfigRegArg
 		btfArg [api.MaxBTFArgDepth]api.ConfigBTFArg
@@ -177,14 +177,14 @@ func resolvePtRegsArg(resolve string) (api.ConfigRegArg, [api.MaxBTFArgDepth]api
 		return regArg, btfArg, false, fmt.Errorf("unable to resolve %q. The maximum depth allowed is %d", resolve, api.MaxBTFArgDepth)
 	}
 
-	_, err = btf.ResolveBTFPath(&btfArg, &ebtf.Void{}, path, nil)
+	_, err = btf.ResolveBTFPath(&btfArg, &ebtf.Void{}, path, userBTFSpec)
 	if err != nil {
 		return regArg, btfArg, false, fmt.Errorf("failed to resolve pt_regs path %q: %w", resolve, err)
 	}
 	return regArg, btfArg, true, nil
 }
 
-func resolveBTFType(arg *v1alpha1.KProbeArg, ty ebtf.Type) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {
+func resolveBTFType(arg *v1alpha1.KProbeArg, ty ebtf.Type, spec *ebtf.Spec) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {
 	btfArg := [api.MaxBTFArgDepth]api.ConfigBTFArg{}
 	pathBase, err := formatBTFPath(arg.Resolve)
 	if err != nil {
@@ -195,7 +195,7 @@ func resolveBTFType(arg *v1alpha1.KProbeArg, ty ebtf.Type) (*ebtf.Type, [api.Max
 		return nil, btfArg, fmt.Errorf("unable to resolve %q. The maximum depth allowed is %d", arg.Resolve, api.MaxBTFArgDepth)
 	}
 
-	lastBTFType, err := btf.ResolveBTFPath(&btfArg, btf.ResolveNestedTypes(ty), path, nil)
+	lastBTFType, err := btf.ResolveBTFPath(&btfArg, btf.ResolveNestedTypes(ty), path, spec)
 	return lastBTFType, btfArg, err
 }
 
@@ -206,7 +206,7 @@ func resolveUserBTFArg(arg *v1alpha1.KProbeArg, userBTFSpec *ebtf.Spec) (*ebtf.T
 		return nil, [api.MaxBTFArgDepth]api.ConfigBTFArg{}, err
 	}
 	ty := ebtf.Type(st)
-	return resolveBTFType(arg, ty)
+	return resolveBTFType(arg, ty, userBTFSpec)
 }
 
 func findBTFTypeStruct(hook string, arg *v1alpha1.KProbeArg) (*ebtf.Struct, error) {
@@ -233,7 +233,7 @@ func findBTFTypeStruct(hook string, arg *v1alpha1.KProbeArg) (*ebtf.Struct, erro
 	return nil, fmt.Errorf("failed to find BTF type %q in kernel BTF or module %q: %w", arg.BTFType, module, errors.Join(err, moduleErr))
 }
 
-func resolveBTFArg(hook string, arg *v1alpha1.KProbeArg, tp bool) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {
+func resolveBTFArg(hook string, arg *v1alpha1.KProbeArg, tp bool, spec *ebtf.Spec) (*ebtf.Type, [api.MaxBTFArgDepth]api.ConfigBTFArg, error) {
 	// tracepoints have extra first internal argument, so we need to adjust the index
 	index := int(arg.Index)
 	if tp {
@@ -272,7 +272,7 @@ func resolveBTFArg(hook string, arg *v1alpha1.KProbeArg, tp bool) (*ebtf.Type, [
 			}
 		}
 	}
-	return resolveBTFType(arg, ty)
+	return resolveBTFType(arg, ty, spec)
 }
 
 func findTypeFromBTFType(arg *v1alpha1.KProbeArg, btfType *ebtf.Type) int {

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -183,7 +183,7 @@ spec:
 	successHook := policy.TpSpec().KProbes[:3]
 	for _, hook := range successHook {
 		for _, arg := range hook.Args {
-			lastBTFType, btfArg, err := resolveBTFArg(hook.Call, &arg, false)
+			lastBTFType, btfArg, err := resolveBTFArg(hook.Call, &arg, false, nil)
 
 			if err != nil {
 				t.Fatal(hook.Call, err)
@@ -198,7 +198,7 @@ spec:
 
 	failHook := policy.TpSpec().KProbes[3]
 	for _, arg := range failHook.Args {
-		_, _, err := resolveBTFArg(failHook.Call, &arg, false)
+		_, _, err := resolveBTFArg(failHook.Call, &arg, false, nil)
 
 		require.ErrorContains(t, err, "The maximum depth allowed is", "The path %q must have len < %d", arg.Resolve, api.MaxBTFArgDepth)
 	}
@@ -266,7 +266,7 @@ spec:
 			require.True(t, ok, "missing test case for %q", arg.Label)
 
 			t.Run(arg.Label, func(t *testing.T) {
-				lastBTFType, btfArg, err := resolveBTFArg(hook.Call, &arg, false)
+				lastBTFType, btfArg, err := resolveBTFArg(hook.Call, &arg, false, nil)
 				require.NoError(t, err, hook.Call)
 				require.NotNil(t, lastBTFType)
 
@@ -294,7 +294,7 @@ func TestResolveBTFArgWithBTFTypeModule(t *testing.T) {
 		Resolve:       "sun_family",
 	}
 
-	_, _, err := resolveBTFArg("security_socket_connect", &arg, false)
+	_, _, err := resolveBTFArg("security_socket_connect", &arg, false, nil)
 	require.ErrorContains(t, err, `failed to find BTF type "sockaddr_un" in module "tetragon_test_module_that_does_not_exist"`)
 }
 

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -44,6 +44,42 @@ func TestFormatBTFPath(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "reject suffix type cast",
+			input:   "rsp(char*)[16]",
+			want:    []string{"rsp", "[16]"},
+			wantErr: true,
+		},
+		{
+			name:    "reject suffix pointer to array type cast",
+			input:   "rsp(*char[64])[16]",
+			want:    []string{"rsp", "(*char[64])", "[16]"},
+			wantErr: true,
+		},
+		{
+			name:    "prefixed type cast before indexed field path",
+			input:   "((char*)field)[123].my.sub.field",
+			want:    []string{"field", "(char*)", "[123]", "my", "sub", "field"},
+			wantErr: false,
+		},
+		{
+			name:    "prefixed struct pointer cast around indexed field",
+			input:   "((struct task_struct*)field[123]).my.sub.field",
+			want:    []string{"field", "[123]", "(struct task_struct*)", "my", "sub", "field"},
+			wantErr: false,
+		},
+		{
+			name:    "nested prefixed type casts with index",
+			input:   "((struct task_struct*)((char*)field)[123]).my.sub.field",
+			want:    []string{"field", "(char*)", "[123]", "(struct task_struct*)", "my", "sub", "field"},
+			wantErr: false,
+		},
+		{
+			name:    "reject bare type cast prefix",
+			input:   "(char*)field[123].my.sub.field",
+			want:    []string{},
+			wantErr: true,
+		},
+		{
 			name:    "dot inside bracket",
 			input:   "my.super.field[.123]",
 			want:    []string{},

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -764,7 +764,7 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 		var regArg api.ConfigRegArg
 
 		if hasPtRegsSource(a) {
-			reg, btfArg, hasBTFArg, err := resolvePtRegsArg(a.Resolve)
+			reg, btfArg, hasBTFArg, err := resolvePtRegsArg(a.Resolve, nil)
 			if err != nil {
 				return fmt.Errorf("error resolving pt_regs argument %q: %w", a.Resolve, err)
 			}
@@ -776,7 +776,7 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 			if !bpf.HasProgramLargeSize() {
 				return errors.New("error: Resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag")
 			}
-			lastBTFType, btfArg, err := resolveBTFArg(f.Call, a, false)
+			lastBTFType, btfArg, err := resolveBTFArg(f.Call, a, false, nil)
 			if err != nil {
 				return fmt.Errorf("error on hook %q for index %d : %w", f.Call, a.Index, err)
 			}

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/arch"
-	"github.com/cilium/tetragon/pkg/asm"
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/celbpf"
@@ -762,15 +761,16 @@ func addKprobe(funcName string, instance int, f *v1alpha1.KProbeSpec, in *addKpr
 			argType = gt.GenericTypeFromString(a.Type)
 		}
 
-		var (
-			regArg api.ConfigRegArg
-			ok     bool
-		)
+		var regArg api.ConfigRegArg
 
 		if hasPtRegsSource(a) {
-			regArg.Offset, regArg.Size, ok = asm.RegOffsetSize(a.Resolve)
-			if !ok {
-				return fmt.Errorf("error: Failed to retrieve register argument '%s'", a.Resolve)
+			reg, btfArg, hasBTFArg, err := resolvePtRegsArg(a.Resolve)
+			if err != nil {
+				return fmt.Errorf("error resolving pt_regs argument %q: %w", a.Resolve, err)
+			}
+			regArg = reg
+			if hasBTFArg {
+				allBTFArgs[j] = btfArg
 			}
 		} else if a.Resolve != "" && j < api.EventConfigMaxArgs {
 			if !bpf.HasProgramLargeSize() {

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -327,7 +327,7 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 			if !bpf.HasProgramLargeSize() {
 				return errFn(errors.New("error: Resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag"))
 			}
-			lastBTFType, btfArg, err := resolveBTFArg(lsmHookBTFName(f.Hook), &a, false)
+			lastBTFType, btfArg, err := resolveBTFArg(lsmHookBTFName(f.Hook), &a, false, nil)
 			if err != nil {
 				return errFn(fmt.Errorf("error on hook %q for index %d : %w", f.Hook, a.Index, err))
 			}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -369,7 +369,7 @@ func buildArgsRaw(info *tracepoint.Tracepoint, specArgs []v1alpha1.KProbeArg) ([
 			}
 			fn := "__bpf_trace_" + info.Event
 
-			lastBTFType, btfArg, err := resolveBTFArg(fn, &tpArg, true)
+			lastBTFType, btfArg, err := resolveBTFArg(fn, &tpArg, true, nil)
 			if err != nil {
 				return nil, fmt.Errorf("error on hook %q for index %d : %w", fn, tpArg.Index, err)
 			}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -768,7 +768,7 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 		if data {
 			// Data specific config
 			if hasPtRegsSource(a) {
-				reg, btfArg, hasBTFArg, err := resolvePtRegsArg(a.Resolve)
+				reg, btfArg, hasBTFArg, err := resolvePtRegsArg(a.Resolve, userBTFSpec)
 				if err != nil {
 					return fmt.Errorf("error resolving pt_regs argument %q: %w", a.Resolve, err)
 				}
@@ -792,7 +792,8 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 				if !bpf.HasProgramLargeSize() {
 					return errors.New("error: Resolve flag can't be used for your kernel version. Please update to version 5.4 or higher or disable Resolve flag")
 				}
-				lastBTFType, btfArg, err := resolveBTFArg("", a, false)
+				// Spec is nil because it's loaded later. We want kernel BTF, not userBTFSpec
+				lastBTFType, btfArg, err := resolveBTFArg("", a, false, nil)
 				if err != nil {
 					return fmt.Errorf("can't resolve current_task source: %s", a.Resolve)
 				}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -22,8 +22,6 @@ import (
 	"github.com/cilium/tetragon/pkg/celbpf"
 	"github.com/cilium/tetragon/pkg/cgtracker"
 
-	"github.com/cilium/tetragon/pkg/asm"
-
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 
 	"github.com/cilium/tetragon/pkg/api/ops"
@@ -761,11 +759,13 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 		if data {
 			// Data specific config
 			if hasPtRegsSource(a) {
-				var ok bool
-
-				cfg.regArg[i].Offset, cfg.regArg[i].Size, ok = asm.RegOffsetSize(a.Resolve)
-				if !ok {
-					return fmt.Errorf("error: Failed to retrieve register argument '%s'", a.Resolve)
+				reg, btfArg, hasBTFArg, err := resolvePtRegsArg(a.Resolve)
+				if err != nil {
+					return fmt.Errorf("error resolving pt_regs argument %q: %w", a.Resolve, err)
+				}
+				cfg.regArg[i] = reg
+				if hasBTFArg {
+					cfg.allBTFArgs[i] = btfArg
 				}
 
 				// If we are getting string type from pt_regs register we can safely assume

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/cilium/ebpf"
+	ebtf "github.com/cilium/ebpf/btf"
 	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/cilium/tetragon/pkg/celbpf"
@@ -751,6 +752,14 @@ func initUprobeArgs(spec *v1alpha1.UProbeSpec, has *uprobeHas, in *addUprobeIn, 
 
 func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgConfig, error) {
 	var cfg uprobeArgConfig
+	var userBTFSpec *ebtf.Spec
+	if spec.BTFPath != "" {
+		var err error
+		userBTFSpec, err = ebtf.LoadSpec(spec.BTFPath)
+		if err != nil {
+			return cfg, fmt.Errorf("failed to load user BTF spec %q: %w", spec.BTFPath, err)
+		}
+	}
 
 	addArg := func(i int, a *v1alpha1.KProbeArg, data bool) error {
 		var preloadArg bool
@@ -793,7 +802,7 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 		} else {
 			// Args specific config
 			if a.Resolve != "" {
-				lastBTFType, btfArg, err := resolveUserBTFArg(a, spec.BTFPath)
+				lastBTFType, btfArg, err := resolveUserBTFArg(a, userBTFSpec)
 				if err != nil {
 					return err
 				}

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -15,6 +15,7 @@ import (
 	"path"
 
 	"github.com/cilium/ebpf"
+	ebtf "github.com/cilium/ebpf/btf"
 
 	"github.com/cilium/tetragon/pkg/cgtracker"
 
@@ -380,6 +381,14 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 			}
 		}
 
+		var userBTFSpec *ebtf.Spec
+		if spec.BTFPath != "" {
+			userBTFSpec, err = ebtf.LoadSpec(spec.BTFPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load user BTF spec %q: %w", spec.BTFPath, err)
+			}
+		}
+
 		var allBTFArgs [api.EventConfigMaxArgs][api.MaxBTFArgDepth]api.ConfigBTFArg
 		var preload bool
 		for cfgIdx, arg := range spec.Args {
@@ -400,7 +409,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 
 			argType := gt.GenericTypeFromString(arg.Type)
 			if arg.Resolve != "" {
-				lastBTFType, btfArg, err := resolveUserBTFArg(&arg, spec.BTFPath)
+				lastBTFType, btfArg, err := resolveUserBTFArg(&arg, userBTFSpec)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -7,6 +7,7 @@ package tracing
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -177,6 +178,81 @@ spec:
 	require.Equal(t, 11, cmd.ProcessState.ExitCode())
 
 	err = jsonchecker.JsonTestCheck(t, checker)
+	require.NoError(t, err)
+}
+
+func TestUprobeResolveCast(t *testing.T) {
+	if !config.EnableLargeProgs() || !bpf.HasUprobeRefCtrOffset() {
+		t.Skip("Need 5.3 or newer kernel for uprobe ref_ctr_off support for this test.")
+	}
+
+	uprobe := testutils.RepoRootPath("contrib/tester-progs/uprobe-resolve")
+	uprobeBtf := testutils.RepoRootPath("contrib/tester-progs/uprobe-resolve.btf")
+
+	tt := []struct {
+		argTy     string
+		resolve   string
+		filterVal int
+		kpArgs    []*ec.KprobeArgumentChecker
+	}{
+		{"uint32", "((struct mysubstruct*)subvoid).v32", 1337, []*ec.KprobeArgumentChecker{
+			ec.NewKprobeArgumentChecker().WithUintArg(1337),
+		}},
+	}
+
+	uprobeHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe"
+spec:
+  uprobes:
+  - path: "` + uprobe + `"
+    btfPath: "` + uprobeBtf + `"
+    symbols:
+    - "func"
+    args:
+    - index: 1
+      btfType: "mystruct"
+      type: "` + tt[0].argTy + `"
+      resolve: "` + tt[0].resolve + `"
+`
+
+	createCrdFile(t, uprobeHook)
+
+	var checkers []ec.EventChecker
+	for i := range tt {
+		checkers = append(checkers, ec.NewProcessUprobeChecker("uprobe-resolve").
+			WithProcess(ec.NewProcessChecker().
+				WithBinary(sm.Full(uprobe)).
+				WithArguments(
+					sm.Suffix(fmt.Sprintf("%q %d", tt[i].resolve, tt[i].filterVal)),
+				),
+			).WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(tt[i].kpArgs...)))
+	}
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	for i := range tt {
+		cmd := exec.Command(uprobe, tt[i].resolve, strconv.Itoa(tt[i].filterVal))
+		cmdErr := testutils.RunCmdAndLogOutput(t, cmd)
+		require.NoError(t, cmdErr)
+	}
+
+	err = jsonchecker.JsonTestCheck(t, ec.NewUnorderedEventChecker(checkers...))
 	require.NoError(t, err)
 }
 

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -820,6 +820,78 @@ func TestUprobePtRegsDataNotMatch(t *testing.T) {
 	testUprobePtRegsMatch(t, 10, true)
 }
 
+func TestUprobeResolveFromStackPtr(t *testing.T) {
+	if !config.EnableLargeProgs() || !bpf.HasUprobeRefCtrOffset() {
+		t.Skip("Need 5.3 or newer kernel for uprobe ref_ctr_off support for this test.")
+	}
+
+	if runtime.GOARCH != "amd64" {
+		t.Skip("skipping, x86_64 only test")
+	}
+
+	testBinary := testutils.RepoRootPath("contrib/tester-progs/uprobe-stack")
+
+	expectedValue := uint64(1337)
+
+	//    <+0>:     push   rdi
+	//    <+1>:     mov    rax,QWORD PTR [rsp]
+	// => <+5>:     pop    rdi
+	//    <+6>:     ret
+	//    <+7>:     ud2
+
+	symbol := "mov_in_rsp+5"
+
+	pathHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe"
+spec:
+  uprobes:
+  - path: "` + testBinary + `"
+    symbols:
+    - "` + symbol + `"
+    data:
+    - index: 0
+      type: "uint64"
+      source: "pt_regs"
+      resolve: "((uint64_t***)rsp)[0][0][9]"
+`
+
+	createCrdFile(t, pathHook)
+
+	upChecker := ec.NewProcessUprobeChecker("UPROBE_DATA_MATCH").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(testBinary))).
+		WithSymbol(sm.Full(symbol)).
+		WithData(ec.NewKprobeArgumentListMatcher().
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithSizeArg(expectedValue),
+			))
+
+	checker := ec.NewUnorderedEventChecker(upChecker)
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
+	if err != nil {
+		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
+	}
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	cmd := exec.Command(testBinary, strconv.Itoa(int(expectedValue)))
+	cmdErr := testutils.RunCmdAndLogOutput(t, cmd)
+	require.NoError(t, cmdErr)
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	require.NoError(t, err)
+}
+
 func testUprobePtRegsPreload(t *testing.T, multi bool) {
 	if !bpf.HasKfunc("bpf_copy_from_user_str") {
 		t.Skip("skipping")


### PR DESCRIPTION
## Description

- Add support to cast a resolve attributes.
- Add support to use `pt_regs` along with the resolve 

It works as follow

```yaml
- index: 0
  type: "uint8"
  resolve: "((char *)buffer)[12]"
```

## Motivation

We need support to retrieve values from `rsp`. By default it's not accessible because the types are `unsigned long`. This PR allow to cast `rsp` to a `char*` and then act as an array to get the value we need.