### PR TITLE
fix: prevent nil panic on closed stdin and sort event-types error in getevents

### DIFF
--- a/cmd/tetra/getevents/getevents.go
+++ b/cmd/tetra/getevents/getevents.go
@@ -199,8 +199,8 @@ redirection of events to the stdin. Examples:
 			return nil
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
-			fi, _ := os.Stdin.Stat()
-			if fi.Mode()&os.ModeNamedPipe != 0 {
+			fi, err := os.Stdin.Stat()
+			if err == nil && fi.Mode()&os.ModeNamedPipe != 0 {
 				// read events from stdin
 				return getEvents(context.Background(), newIOReaderClient(os.Stdin, common.Debug))
 			}

--- a/cmd/tetra/getevents/getevents.go
+++ b/cmd/tetra/getevents/getevents.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -182,12 +183,12 @@ redirection of events to the stdin. Examples:
 
 			for _, v := range Options.EventTypes {
 				if _, found := tetragon.EventType_value[v]; !found {
-					var supportedEventTypes string
-					for _, v := range tetragon.EventType_name {
-						supportedEventTypes += v + ", "
+					supported := make([]string, 0, len(tetragon.EventType_value))
+					for name := range tetragon.EventType_value {
+						supported = append(supported, name)
 					}
-					supportedEventTypes = strings.TrimSuffix(supportedEventTypes, ", ")
-					return fmt.Errorf("invalid value for %q flag: %s. Supported are %s", "event-types", v, supportedEventTypes)
+					sort.Strings(supported)
+					return fmt.Errorf("invalid value for %q flag: %s. Supported are %s", "event-types", v, strings.Join(supported, ", "))
 				}
 			}
 

--- a/cmd/tetra/getevents/getevents_test.go
+++ b/cmd/tetra/getevents/getevents_test.go
@@ -6,6 +6,7 @@ package getevents
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -171,4 +172,22 @@ func Test_GetEvents_FilterFields(t *testing.T) {
 			assert.Equal(t, "deathstar", class)
 		}
 	})
+}
+
+func Test_GetEvents_ClosedStdinNoNilPanic(t *testing.T) {
+	oldStdin := os.Stdin
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	// os.NewFile with an invalid fd causes Stat() to return (nil, error).
+	// Before the fix RunE would panic on fi.Mode() when fi is nil.
+	os.Stdin = os.NewFile(^uintptr(0), "closed")
+
+	cmd := New()
+	cmd.SetArgs([]string{})
+	var buf bytes.Buffer
+	cmd.SetErr(&buf)
+	cmd.SetOut(&buf)
+
+	// Must not panic; falls through to gRPC and gets a connection error instead.
+	require.NotPanics(t, func() { cmd.Execute() })
 }

--- a/cmd/tetra/getevents/getevents_test.go
+++ b/cmd/tetra/getevents/getevents_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,24 @@ func Test_GetEvents_EventTypes(t *testing.T) {
 
 		err := cmd.Execute()
 		require.Error(t, err)
+	})
+
+	t.Run("FilterInexistentSortedError", func(t *testing.T) {
+		cmd := New()
+		cmd.SetArgs([]string{"--event-types", "INEXISTENT"})
+
+		var devNull bytes.Buffer
+		cmd.SetErr(&devNull)
+		cmd.SetOut(&devNull)
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		msg := err.Error()
+		// Supported event types must be listed in alphabetical order.
+		require.Less(t, strings.Index(msg, "PROCESS_EXEC"), strings.Index(msg, "PROCESS_EXIT"),
+			"PROCESS_EXEC should appear before PROCESS_EXIT in sorted output")
+		require.Less(t, strings.Index(msg, "PROCESS_EXIT"), strings.Index(msg, "UNDEF"),
+			"PROCESS_EXIT should appear before UNDEF in sorted output")
 	})
 }
 


### PR DESCRIPTION
### Description

Two small bugs in `tetra getevents`:

1. `os.Stdin.Stat()` error is silently dropped, so when stdin fd is closed `fi` is nil and `fi.Mode()` panics with a nil pointer dereference. Fix: check `err == nil` before touching `fi`.

2. Supported event types in the `--event-types` validation error were pulled from a map, so the order was random on every run. Fix: collect names, sort them, join - same pattern as `explain.go` already uses.

**Reproduce the panic:**
```
# close fd 0 before running tetra
bash -c 'exec 0<&-; tetra getevents'
# runtime error: invalid memory address or nil pointer dereference
```

**Reproduce the non-determinism:**
```
# run a few times with a bad event type and watch the order change
tetra getevents --event-types INVALID
```

### Changelog

```release-note
fix: `tetra getevents` no longer panics when stdin fd is closed; supported event types in error messages are now sorted alphabetically
```