### PR TITLE
uprobe: check for consistency among probes

### DIFF
--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -424,6 +424,52 @@ type uprobeHas struct {
 	substring        bool
 }
 
+func validateMultiUprobeConsistency(uprobes []v1alpha1.UProbeSpec) error {
+	if len(uprobes) < 2 {
+		return nil
+	}
+
+	type pathState struct {
+		idx    int
+		method string
+	}
+
+	pathStates := make(map[string]pathState)
+
+	for i, curr := range uprobes {
+		method := ""
+		if len(curr.Symbols) != 0 {
+			method = "symbols"
+		} else if len(curr.Offsets) != 0 {
+			method = "offsets"
+		} else if len(curr.Addrs) != 0 {
+			method = "addrs"
+		}
+
+		state, ok := pathStates[curr.Path]
+		if !ok {
+			pathStates[curr.Path] = pathState{
+				idx:    i,
+				method: method,
+			}
+			continue
+		}
+
+		if method != state.method {
+			return fmt.Errorf(
+				"multi-uprobe requires uprobes for the same hook path to use the same addressing method, but uprobe[%d] uses %s while uprobe[%d] uses %s for path %q; disable multiprobe with spec.options: [{name: disable-uprobe-multi, value: \"true\"}]",
+				i,
+				method,
+				state.idx,
+				state.method,
+				curr.Path,
+			)
+		}
+	}
+
+	return nil
+}
+
 func createGenericUprobeSensor(
 	spec *v1alpha1.TracingPolicySpec,
 	name string,
@@ -452,6 +498,12 @@ func createGenericUprobeSensor(
 
 		useMulti: useMulti,
 		celExprs: celExprs,
+	}
+
+	if in.useMulti {
+		if err = validateMultiUprobeConsistency(spec.UProbes); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, uprobe := range spec.UProbes {


### PR DESCRIPTION
This validation prevents currently unsupported combinations of uprobe configurations within a policy when multi-uprobe is enabled. If unsupported configuration is detected, the policy is rejected with an error message that directs the user to disable multi-probe, where this problem does not apply.

This limitation only exist because of tetragon design choices. The intention is to remove this verification once we support policies that mix address configuration methods across the same target path.

This is related to #5005. Since this is meant to be stopgap, I don't consider this to fix that issue.