### PR TITLE
Link uprobe target by file descriptor

### DIFF
--- a/pkg/sensors/collection.go
+++ b/pkg/sensors/collection.go
@@ -103,6 +103,8 @@ type collection struct {
 
 	warnedOnModeRetrievalFailure  atomic.Bool
 	warnedOnStatsRetrievalFailure atomic.Bool
+	// if non-empty, this indicates that the collection cannot be disabled, and the string is the reason why
+	disableNotAllowed string
 }
 
 type selectorStatsMetadata struct {

--- a/pkg/sensors/delayed_sensor_test.go
+++ b/pkg/sensors/delayed_sensor_test.go
@@ -47,6 +47,10 @@ func (tds *TestDelayedSensor) IsLoaded() bool {
 	return tds.loaded
 }
 
+func (tds *TestDelayedSensor) DisableNotAllowed() string {
+	return ""
+}
+
 func (tds *TestDelayedSensor) Load(_ string) error {
 	select {
 	case <-tds.ch:

--- a/pkg/sensors/handler.go
+++ b/pkg/sensors/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
@@ -117,6 +118,15 @@ func (h *handler) addTracingPolicy(op *tracingPolicyAdd) error {
 	col.sensors = append(col.sensors, sensors...)
 	col.state = LoadingState
 
+	notAllowedReasons := make([]string, 0, len(col.sensors))
+	for _, s := range col.sensors {
+		notAllowedReason := s.DisableNotAllowed()
+		if notAllowedReason != "" {
+			notAllowedReasons = append(notAllowedReasons, notAllowedReason)
+		}
+	}
+	col.disableNotAllowed = strings.Join(notAllowedReasons, "; ")
+
 	// unlock so that policyLister can access the collections (read-only) while we are loading.
 	h.collections.mu.Unlock()
 	err = h.load(&col)
@@ -160,6 +170,10 @@ func (h *handler) deleteTracingPolicy(op *tracingPolicyDelete) error {
 func (h *handler) doDisableTracingPolicy(col *collection) error {
 	if col.state != EnabledState {
 		return fmt.Errorf("tracing policy %s is not enabled", col.name)
+	}
+
+	if col.disableNotAllowed != "" {
+		return fmt.Errorf("tracing policy %s cannot be disabled: %s", col.name, col.disableNotAllowed)
 	}
 
 	col.state = UnloadingState

--- a/pkg/sensors/program/loader_linux.go
+++ b/pkg/sensors/program/loader_linux.go
@@ -358,6 +358,38 @@ func MultiUprobeAttach(load *Program, bpfDir string) AttachFunc {
 	}
 }
 
+func attachMultiUpobeLink(load *Program, prog *ebpf.Program, path string,
+	attach *MultiUprobeAttachSymbolsCookies, bpfDir string,
+	idx int, extra ...string) (link.Link, error) {
+
+	exec, err := link.OpenExecutable(path)
+	if err != nil {
+		return nil, err
+	}
+	opts := &link.UprobeMultiOptions{
+		Addresses:     attach.Addresses,
+		Offsets:       attach.Offsets,
+		RefCtrOffsets: attach.RefCtrOffsets,
+		Cookies:       attach.Cookies,
+	}
+	var lnk link.Link
+	if load.RetProbe {
+		lnk, err = exec.UretprobeMulti(attach.Symbols, prog, opts)
+	} else {
+		lnk, err = exec.UprobeMulti(attach.Symbols, prog, opts)
+	}
+	if err != nil {
+		return nil, err
+	}
+	pinExtra := append(extra, strconv.Itoa(idx))
+	err = LinkPin(lnk, bpfDir, load, pinExtra...)
+	if err != nil {
+		lnk.Close()
+		return nil, err
+	}
+	return lnk, nil
+}
+
 func uprobeAttachMulti(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec,
 	bpfDir string, extra ...string) (unloader.Unloader, error) {
 
@@ -368,32 +400,11 @@ func uprobeAttachMulti(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec
 
 	linkFn := func() ([]link.Link, error) {
 		var links []link.Link
-		var lnk link.Link
 
 		idx := 0
 		for path, attach := range data.Attach {
-			exec, err := link.OpenExecutable(path)
+			lnk, err := attachMultiUpobeLink(load, prog, path, attach, bpfDir, idx, extra...)
 			if err != nil {
-				return nil, err
-			}
-			opts := &link.UprobeMultiOptions{
-				Addresses:     attach.Addresses,
-				Offsets:       attach.Offsets,
-				RefCtrOffsets: attach.RefCtrOffsets,
-				Cookies:       attach.Cookies,
-			}
-			if load.RetProbe {
-				lnk, err = exec.UretprobeMulti(attach.Symbols, prog, opts)
-			} else {
-				lnk, err = exec.UprobeMulti(attach.Symbols, prog, opts)
-			}
-			if err != nil {
-				return nil, err
-			}
-			pinExtra := append(extra, strconv.Itoa(idx))
-			err = LinkPin(lnk, bpfDir, load, pinExtra...)
-			if err != nil {
-				lnk.Close()
 				return nil, err
 			}
 			links = append(links, lnk)

--- a/pkg/sensors/program/program.go
+++ b/pkg/sensors/program/program.go
@@ -103,7 +103,7 @@ type MultiUprobeAttachSymbolsCookies struct {
 }
 
 type MultiUprobeAttachData struct {
-	// Path -> []{Symbol,Cookie}
+	// linkPath -> []{Symbol,Cookie}
 	Attach map[string]*MultiUprobeAttachSymbolsCookies
 }
 

--- a/pkg/sensors/sensors.go
+++ b/pkg/sensors/sensors.go
@@ -72,6 +72,10 @@ type Sensor struct {
 	// when removing the sensor, sensor cannot be loaded again after this hook
 	// being triggered and must be recreated.
 	DestroyHook SensorHook
+	// DisableNotAllowedReason indicates whether the sensor cannot be disabled.
+	// If non-empty, this string is the reason why the sensor cannot be disabled.
+	// If empty, the sensor can be disabled.
+	DisableNotAllowedReason string
 }
 
 func (s *Sensor) AddPostUnloadHook(hook SensorHook) {
@@ -113,6 +117,7 @@ type SensorIface interface {
 	// the sensor's programs.
 	TotalMemlock() uint64
 	Overhead() ([]ProgOverhead, bool)
+	DisableNotAllowed() string
 }
 
 func (s *Sensor) Overhead() ([]ProgOverhead, bool) {
@@ -146,6 +151,10 @@ func (s *Sensor) GetName() string {
 
 func (s *Sensor) IsLoaded() bool {
 	return s.Loaded
+}
+
+func (s *Sensor) DisableNotAllowed() string {
+	return s.DisableNotAllowedReason
 }
 
 func (s Sensor) TotalMemlock() uint64 {

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -690,6 +690,12 @@ func createGenericUprobeSensor(
 		in.selectorStatsBase = selectorStatsBase
 		selectorStatsBase += uint32(len(uprobe.Selectors))
 
+		absPath, err := filepath.Abs(uprobe.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve absolute path for %q: %w", uprobe.Path, err)
+		}
+		uprobe.Path = absPath
+
 		var entryFile *os.File
 
 		ids, err = addUprobe(&uprobe, entryFile, ids, &in, &has)

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -12,7 +12,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -49,6 +51,8 @@ type observerUprobeSensor struct {
 	name string
 }
 
+const disableNotAllowedReasonLinkByFD = "target linked by file descriptor"
+
 var (
 	uprobeTable idtable.Table
 )
@@ -62,7 +66,8 @@ type uprobeLoadArgs struct {
 type genericUprobe struct {
 	loadArgs     uprobeLoadArgs
 	tableId      idtable.EntryID
-	path         string
+	targetPath   string
+	linkPath     string
 	symbol       string
 	address      uint64
 	refCtrOffset uint64
@@ -101,7 +106,8 @@ func (g *genericUprobe) SetID(id idtable.EntryID) {
 func (g *genericUprobe) LogAttrs(level slog.Level, msg string, attrs ...slog.Attr) {
 	attrs = append(attrs,
 		slog.Attr{Key: "policy_name", Value: slog.StringValue(g.policyName)},
-		slog.Attr{Key: "path", Value: slog.StringValue(g.path)},
+		slog.Attr{Key: "path", Value: slog.StringValue(g.targetPath)},
+
 		slog.Attr{Key: "symbol", Value: slog.StringValue(g.symbol)},
 		slog.Attr{Key: "address", Value: slog.Uint64Value(g.address)},
 	)
@@ -144,7 +150,7 @@ func handleGenericUprobe(r *bytes.Reader) ([]observer.Event, error) {
 
 	unix := &tracing.MsgGenericUprobeUnix{}
 	unix.Msg = &m
-	unix.Path = uprobeEntry.path
+	unix.Path = uprobeEntry.targetPath
 	unix.Symbol = uprobeEntry.symbol
 	unix.Offset = uprobeEntry.address
 	unix.RefCtrOffset = uprobeEntry.refCtrOffset
@@ -250,7 +256,7 @@ func loadSingleUprobeSensor(uprobeEntry *genericUprobe, args sensors.LoadProbeAr
 
 	symbol, offset := resolveSymbol(uprobeEntry.symbol)
 	attachData := &program.UprobeAttachData{
-		Path:         uprobeEntry.path,
+		Path:         uprobeEntry.linkPath,
 		Symbol:       symbol,
 		Offset:       offset,
 		Address:      uprobeEntry.address,
@@ -262,7 +268,7 @@ func loadSingleUprobeSensor(uprobeEntry *genericUprobe, args sensors.LoadProbeAr
 		return err
 	}
 
-	logger.GetLogger().Info(fmt.Sprintf("Loaded generic uprobe program: %s -> %s [%s]", args.Load.Name, uprobeEntry.path, uprobeEntry.symbol))
+	logger.GetLogger().Info(fmt.Sprintf("Loaded generic uprobe program: %s -> %s [%s]", args.Load.Name, uprobeEntry.targetPath, uprobeEntry.symbol))
 	return nil
 }
 
@@ -365,7 +371,7 @@ func loadMultiUprobeSensor(ids []idtable.EntryID, args sensors.LoadProbeArgs) er
 
 		load.MapLoad = append(load.MapLoad, mapLoad...)
 
-		attach, ok := data.Attach[uprobeEntry.path]
+		attach, ok := data.Attach[uprobeEntry.linkPath]
 		if !ok {
 			attach = &program.MultiUprobeAttachSymbolsCookies{}
 		}
@@ -384,7 +390,7 @@ func loadMultiUprobeSensor(ids []idtable.EntryID, args sensors.LoadProbeArgs) er
 
 		attach.Cookies = append(attach.Cookies, uint64(index))
 
-		data.Attach[uprobeEntry.path] = attach
+		data.Attach[uprobeEntry.linkPath] = attach
 	}
 
 	load.SetAttachData(data)
@@ -418,10 +424,11 @@ type addUprobeIn struct {
 }
 
 type uprobeHas struct {
-	sleepableOffload     bool
-	sleepablePreload     bool
-	substring            bool
-	sleepablePreloadSize int
+	sleepableOffload        bool
+	sleepablePreload        bool
+	substring               bool
+	sleepablePreloadSize    int
+	disableNotAllowedReason string
 }
 
 func validateMultiUprobeConsistency(uprobes []v1alpha1.UProbeSpec) error {
@@ -487,6 +494,8 @@ type uprobeConfigState struct {
 	argReturnPrinters []argPrinter
 
 	policyName string
+
+	entryFile *os.File
 }
 
 type uprobeArgConfig struct {
@@ -594,7 +603,7 @@ func initUprobeSelectors(spec *v1alpha1.UProbeSpec, in *addUprobeIn, state *upro
 	return nil
 }
 
-func cleanupUprobeEntries(ids []idtable.EntryID) error {
+func cleanupUprobeEntries(ids []idtable.EntryID, openedFiles []*os.File) error {
 	var errs error
 
 	for _, id := range ids {
@@ -614,6 +623,12 @@ func cleanupUprobeEntries(ids []idtable.EntryID) error {
 		_, err = uprobeTable.RemoveEntry(id)
 		if err != nil {
 			errs = errors.Join(errs, err)
+		}
+	}
+
+	for _, entryFile := range openedFiles {
+		if err := entryFile.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			errs = errors.Join(errs, fmt.Errorf("problem closing path %q: %w", entryFile.Name(), err))
 		}
 	}
 
@@ -656,9 +671,11 @@ func createGenericUprobeSensor(
 		}
 	}
 
+	var openedFiles []*os.File
+
 	defer func() {
 		if retErr != nil {
-			if cleanupErr := cleanupUprobeEntries(ids); cleanupErr != nil {
+			if cleanupErr := cleanupUprobeEntries(ids, openedFiles); cleanupErr != nil {
 				retErr = errors.Join(retErr, cleanupErr)
 			}
 		}
@@ -673,9 +690,20 @@ func createGenericUprobeSensor(
 		in.selectorStatsBase = selectorStatsBase
 		selectorStatsBase += uint32(len(uprobe.Selectors))
 
-		ids, err = addUprobe(&uprobe, ids, &in, &has)
+		var entryFile *os.File
+
+		ids, err = addUprobe(&uprobe, entryFile, ids, &in, &has)
 		if err != nil {
+			if entryFile != nil {
+				if closeErr := entryFile.Close(); closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+					err = errors.Join(err, closeErr)
+				}
+			}
 			return nil, err
+		}
+
+		if entryFile != nil {
+			openedFiles = append(openedFiles, entryFile)
 		}
 	}
 
@@ -699,13 +727,23 @@ func createGenericUprobeSensor(
 	}
 
 	return &sensors.Sensor{
-		Name:      name,
-		Progs:     progs,
-		Maps:      maps,
-		Policy:    polInfo.name,
-		Namespace: polInfo.namespace,
+		Name:                    name,
+		Progs:                   progs,
+		Maps:                    maps,
+		Policy:                  polInfo.name,
+		Namespace:               polInfo.namespace,
+		DisableNotAllowedReason: has.disableNotAllowedReason,
 		DestroyHook: func() error {
-			return cleanupUprobeEntries(ids)
+			return cleanupUprobeEntries(ids, openedFiles)
+		},
+		PostLoadHook: func() error {
+			var errs error
+			for _, entryFile := range openedFiles {
+				if err = entryFile.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+					errs = errors.Join(errs, fmt.Errorf("problem closing path %q: %w", entryFile.Name(), err))
+				}
+			}
+			return errs
 		},
 	}, nil
 }
@@ -917,7 +955,21 @@ func getUprobeReturnArg(spec *v1alpha1.UProbeSpec, argCfg uprobeArgConfig, event
 	return setRetprobe, argReturnPrinters, nil
 }
 
-func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *uprobeConfigState) ([]idtable.EntryID, error) {
+func procSelfFDPath(f *os.File) string {
+	return filepath.Join("/proc", "self", "fd", strconv.FormatUint(uint64(f.Fd()), 10))
+}
+
+// getLinkPath returns the path to use for the uprobe link. If a file is provided, it returns the /proc/self/fd path to that file.
+// Otherwise it returns the path specificed in the urpobe spec.
+// This trick allows us to avoid a TOCTOU race where the target binary is modified after we create the sensor, but before we load it.
+func getLinkPath(file *os.File, targetPath string) string {
+	if file != nil {
+		return procSelfFDPath(file)
+	}
+	return targetPath
+}
+
+func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *uprobeConfigState, has *uprobeHas) ([]idtable.EntryID, error) {
 	addUprobeEntry := func(sym string, offset uint64, idx int) error {
 		var refCtrOffset uint64
 		var err error
@@ -933,7 +985,8 @@ func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *u
 				selectors: state.selectors,
 			},
 			tableId:           idtable.UninitializedEntryID,
-			path:              spec.Path,
+			targetPath:        spec.Path,
+			linkPath:          getLinkPath(state.entryFile, spec.Path),
 			symbol:            sym,
 			address:           offset,
 			refCtrOffset:      refCtrOffset,
@@ -943,6 +996,14 @@ func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *u
 			argReturnPrinters: state.argReturnPrinters,
 			tags:              state.tags,
 			pendingEvents:     nil,
+		}
+
+		// Depending on configuration we will link via file descriptor, instead of by the path configured in the policy,
+		// in order to avoid a TOCTOU race. These files are closed after the sensor is loaded when the tracing policy is initially added,
+		// and as such their file descriptors are no longer valid after that point. So, it's not safe to load the sensor again
+		// when we re-enable a policy after it's been disabled, because the configured targetPaths would point to closed/re-used file descriptors.
+		if state.entryFile != nil {
+			has.disableNotAllowedReason = disableNotAllowedReasonLinkByFD
 		}
 
 		uprobeEntry.pendingEvents, err = lru.New[pendingEventKey, pendingEvent[*tracing.MsgGenericUprobeUnix]](option.Config.RetprobesCacheSize)
@@ -959,11 +1020,21 @@ func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *u
 		return nil
 	}
 
-	f, err := elf.OpenSafeELFFile(spec.Path)
+	var f *elf.SafeELFFile
+	var err error
+	if state.entryFile != nil {
+		f, err = elf.NewSafeELFFile(state.entryFile)
+	} else {
+		f, err = elf.OpenSafeELFFile(spec.Path)
+	}
+
 	if err != nil {
 		return ids, err
 	}
-	defer f.Close()
+
+	if state.entryFile == nil {
+		defer f.Close()
+	}
 
 	if state.symbols != 0 && f.IsStrippedPureGoBinary() {
 		tbl, err := f.Pclntab()
@@ -1016,9 +1087,10 @@ func addUprobeEntries(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, state *u
 	return ids, nil
 }
 
-func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn, has *uprobeHas) (retIDs []idtable.EntryID, retErr error) {
+func addUprobe(spec *v1alpha1.UProbeSpec, entryFile *os.File, ids []idtable.EntryID, in *addUprobeIn, has *uprobeHas) (retIDs []idtable.EntryID, retErr error) {
 	state := uprobeConfigState{
 		policyName: in.policyName,
+		entryFile:  entryFile,
 	}
 
 	defer func() {
@@ -1052,7 +1124,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 		return ids, err
 	}
 
-	return addUprobeEntries(spec, ids, &state)
+	return addUprobeEntries(spec, ids, &state, has)
 }
 
 func multiUprobePinPath(sensorPath string) string {
@@ -1206,7 +1278,7 @@ func createUprobeSensorFromEntry(polInfo *policyInfo, uprobeEntry *genericUprobe
 	pinSymbol := strings.ReplaceAll(uprobeEntry.symbol, ".", "_")
 	load := program.Builder(
 		path.Join(option.Config.HubbleLib, loadProgName),
-		fmt.Sprintf("%s %s", uprobeEntry.path, uprobeEntry.symbol),
+		fmt.Sprintf("%s %s", uprobeEntry.targetPath, uprobeEntry.symbol),
 		"uprobe/generic_uprobe",
 		fmt.Sprintf("%d-%s", uprobeEntry.tableId.ID, pinSymbol),
 		"generic_uprobe").
@@ -1254,7 +1326,7 @@ func createUprobeSensorFromEntry(polInfo *policyInfo, uprobeEntry *genericUprobe
 		pinRetProg := fmt.Sprintf("%d-%s_return", uprobeEntry.tableId.ID, pinSymbol)
 		loadret := program.Builder(
 			path.Join(option.Config.HubbleLib, loadProgRetName),
-			fmt.Sprintf("%s %s", uprobeEntry.path, uprobeEntry.symbol),
+			fmt.Sprintf("%s %s", uprobeEntry.targetPath, uprobeEntry.symbol),
 			"uprobe/generic_retuprobe",
 			pinRetProg,
 			"generic_uprobe").

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -107,11 +107,33 @@ type addUsdtIn struct {
 	selectorStatsBase uint32
 }
 
+func cleanupUsdtEntries(ids []idtable.EntryID) error {
+	var errs error
+
+	for _, id := range ids {
+		usdtEntry, err := genericUsdtTableGet(id)
+		if err != nil {
+			errs = errors.Join(errs, err)
+			continue
+		}
+		if err = selectors.CleanupKernelSelectorState(usdtEntry.selectors); err != nil {
+			errs = errors.Join(errs, err)
+		}
+
+		_, err = usdtTable.RemoveEntry(id)
+		if err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
+
+	return errs
+}
+
 func createGenericUsdtSensor(
 	spec *v1alpha1.TracingPolicySpec,
 	name string,
 	polInfo *policyInfo,
-) (*sensors.Sensor, error) {
+) (retSensor *sensors.Sensor, retError error) {
 	var (
 		progs []*program.Program
 		maps  []*program.Map
@@ -127,6 +149,14 @@ func createGenericUsdtSensor(
 	}
 
 	hasSetAction := false
+
+	defer func() {
+		if retError != nil {
+			if cleanupErr := cleanupUsdtEntries(ids); cleanupErr != nil {
+				retError = errors.Join(retError, cleanupErr)
+			}
+		}
+	}()
 
 	var selectorStatsBase uint32
 	for _, usdt := range spec.Usdts {
@@ -171,6 +201,9 @@ func createGenericUsdtSensor(
 		Maps:      maps,
 		Policy:    polInfo.name,
 		Namespace: polInfo.namespace,
+		DestroyHook: func() error {
+			return cleanupUsdtEntries(ids)
+		},
 	}, nil
 }
 
@@ -300,32 +333,42 @@ func createUsdtSensorFromEntry(polInfo *policyInfo, usdtEntry *genericUsdt,
 	return progs, maps
 }
 
-func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has *usdtHas) ([]idtable.EntryID, error) {
+func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has *usdtHas) (retIDs []idtable.EntryID, retErr error) {
+	var state *selectors.KernelSelectorState
+
+	defer func() {
+		if retErr != nil {
+			if cleanupErr := selectors.CleanupKernelSelectorState(state); cleanupErr != nil {
+				retErr = errors.Join(retErr, cleanupErr)
+			}
+		}
+	}()
+
 	se, err := elf.OpenSafeELFFile(spec.Path)
 	if err != nil {
-		return nil, err
+		return ids, err
 	}
 
 	targets, err := se.UsdtTargets()
 	if err != nil {
-		return nil, err
+		return ids, err
 	}
 
 	tagsField, err := GetPolicyTags(spec.Tags)
 	if err != nil {
-		return nil, err
+		return ids, err
 	}
 
 	msgField, err := getPolicyMessage(spec.Message)
 	if errors.Is(err, ErrMsgSyntaxShort) || errors.Is(err, ErrMsgSyntaxEscape) {
-		return nil, err
+		return ids, err
 	} else if errors.Is(err, ErrMsgSyntaxLong) {
 		logger.GetLogger().Warn(fmt.Sprintf("TracingPolicy 'message' field too long, truncated to %d characters", TpMaxMessageLen),
 			"policy-name", in.policyName)
 	}
 
 	// Parse Filters into kernel filter logic
-	state, err := selectors.InitKernelSelectorState(&selectors.KernelSelectorArgs{
+	state, err = selectors.InitKernelSelectorState(&selectors.KernelSelectorArgs{
 		Selectors: spec.Selectors,
 		Args:      spec.Args,
 		Data:      []v1alpha1.KProbeArg{},
@@ -347,7 +390,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		found = true
 
 		if len(spec.Args) > api.EventConfigMaxArgs {
-			return nil, fmt.Errorf("failed to configure usdt '%s/%s', too many arguments (%d) allowed %d",
+			return ids, fmt.Errorf("failed to configure usdt '%s/%s', too many arguments (%d) allowed %d",
 				spec.Provider, spec.Name, len(spec.Args), api.EventConfigMaxArgs)
 		}
 
@@ -355,27 +398,27 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		if ok, idx := selectors.HasSetArgIndex(spec); ok {
 			// argument index is within usdt args in spec
 			if idx > uint32(len(spec.Args)) {
-				return nil, fmt.Errorf("failed to configure usdt '%s/%s', set action argument spec index %d out of bounds",
+				return ids, fmt.Errorf("failed to configure usdt '%s/%s', set action argument spec index %d out of bounds",
 					spec.Provider, spec.Name, idx)
 			}
 
 			// usdt spec argument points to existing usdt defined in elf note
 			arg := spec.Args[idx]
 			if arg.Index > uint32(len(target.Spec.Args)) {
-				return nil, fmt.Errorf("failed to configure usdt '%s/%s', argument index %d out of bounds",
+				return ids, fmt.Errorf("failed to configure usdt '%s/%s', argument index %d out of bounds",
 					spec.Provider, spec.Name, arg.Index)
 			}
 
 			// output argument must be 'deref' type
 			tgtArg := &target.Spec.Args[arg.Index]
 			if tgtArg.Type != elf.USDT_ARG_TYPE_REG_DEREF {
-				return nil, fmt.Errorf("failed to configure usdt '%s/%s', set action argument is not 'deref' type: '%s'",
+				return ids, fmt.Errorf("failed to configure usdt '%s/%s', set action argument is not 'deref' type: '%s'",
 					spec.Provider, spec.Name, tgtArg.Str)
 			}
 
 			// output argument is only allowed to be exactly 4 bytes
 			if tgtArg.Size != 4 {
-				return nil, fmt.Errorf("failed to configure usdt '%s/%s', set action argument must have size of 4 bytes, current is: %d",
+				return ids, fmt.Errorf("failed to configure usdt '%s/%s', set action argument must have size of 4 bytes, current is: %d",
 					spec.Provider, spec.Name, tgtArg.Size)
 			}
 		}
@@ -385,7 +428,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		for cfgIdx, arg := range spec.Args {
 			tgtIdx := arg.Index
 			if tgtIdx > target.Spec.ArgsCnt {
-				return nil, fmt.Errorf("failed to configure usdt '%s/%s', argument index %d out of bounds",
+				return ids, fmt.Errorf("failed to configure usdt '%s/%s', argument index %d out of bounds",
 					spec.Provider, spec.Name, tgtIdx)
 			}
 			tgtArg := &target.Spec.Args[tgtIdx]
@@ -402,7 +445,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 			if arg.Resolve != "" {
 				lastBTFType, btfArg, err := resolveUserBTFArg(&arg, spec.BTFPath)
 				if err != nil {
-					return nil, err
+					return ids, err
 				}
 
 				allBTFArgs[cfgIdx] = btfArg
@@ -417,17 +460,17 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 
 			if argType == gt.GenericStringType {
 				if !bpf.HasKfunc("bpf_copy_from_user_str") {
-					return nil, fmt.Errorf("can't preload string for argument %d", cfgIdx)
+					return ids, fmt.Errorf("can't preload string for argument %d", cfgIdx)
 				}
 
 				if preload {
-					return nil, errors.New("preloading multiple arguments per hook point is not supported")
+					return ids, errors.New("preloading multiple arguments per hook point is not supported")
 				}
 
 				preload = true
 				argMValue, err := getUserMetaValue(&arg, true)
 				if err != nil {
-					return nil, err
+					return ids, err
 				}
 				config.ArgMeta[cfgIdx] = uint32(argMValue)
 			}
@@ -462,7 +505,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 	}
 
 	if !found {
-		return nil, fmt.Errorf("failed to configure usdt '%s/%s', not found in the binary: '%s'",
+		return ids, fmt.Errorf("failed to configure usdt '%s/%s', not found in the binary: '%s'",
 			spec.Provider, spec.Name, spec.Path)
 	}
 	return ids, nil

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"path/filepath"
 
 	"github.com/cilium/ebpf"
 
@@ -166,6 +167,12 @@ func createGenericUsdtSensor(
 
 		in.selectorStatsBase = selectorStatsBase
 		selectorStatsBase += uint32(len(usdt.Selectors))
+
+		absPath, err := filepath.Abs(usdt.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve absolute path for %q: %w", usdt.Path, err)
+		}
+		usdt.Path = absPath
 
 		ids, err = addUsdt(&usdt, &in, ids, &has)
 		if err != nil {

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/tetragon/pkg/kernels"
 	bc "github.com/cilium/tetragon/pkg/matchers/bytesmatcher"
 	"github.com/cilium/tetragon/pkg/selectors"
+	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/program"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
@@ -38,8 +39,8 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
-	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/cilium/tetragon/pkg/testutils/policytest"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
@@ -1377,4 +1378,60 @@ spec:` + opts + `
 		assert.Equal(t, "sleepable_preload", filepath.Base(m.PinPath))
 		assert.Equal(t, uint32(1024), getMaxEntries(m))
 	})
+}
+
+// Some uprobes configurations (ie digest verification) disallow disable/re-enable of a policy.
+// This test ensures that we can disable and re-enable a policy when
+// policy configuration allows it.
+func TestDisableEnablePolicyUprobe(t *testing.T) {
+	const (
+		uprobeNoopPolicyName      = "uprobe-noop"
+		uprobeNoopPolicyNamespace = ""
+		uprobeNoopPolicyPath      = "/bin/bash"
+	)
+
+	uprobeNoopPolicy := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "` + uprobeNoopPolicyName + `"
+spec:
+  uprobes:
+  - path: "` + uprobeNoopPolicyPath + `"
+    symbols:
+    - "main"
+`
+	tp, err := tracingpolicy.FromYAML(uprobeNoopPolicy)
+	require.NoError(t, err)
+	createCrdFile(t, uprobeNoopPolicy)
+
+	upChecker := ec.NewProcessUprobeChecker("UPROBE").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(uprobeNoopPolicyPath))).
+		WithSymbol(sm.Full("main"))
+	checker := ec.NewUnorderedEventChecker(upChecker)
+
+	var doneWG, readyWG sync.WaitGroup
+	defer doneWG.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	require.NoError(t, err)
+	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
+	readyWG.Wait()
+
+	err = observer.GetSensorManager().DisableTracingPolicy(ctx, uprobeNoopPolicyName, uprobeNoopPolicyNamespace, tp.TpDomain())
+	require.NoError(t, err)
+	err = observer.GetSensorManager().EnableTracingPolicy(ctx, uprobeNoopPolicyName, uprobeNoopPolicyNamespace, tp.TpDomain())
+	require.NoError(t, err)
+
+	if err := exec.Command(uprobeNoopPolicyPath).Run(); err != nil {
+		t.Fatalf("Failed to execute test binary: %s\n", err)
+	}
+
+	err = jsonchecker.JsonTestCheck(t, checker)
+	require.NoError(t, err)
+
 }


### PR DESCRIPTION
In a future PR, I will be doing uprobe target digest verification, where we support a new tracing policy configuration that allows users to supply digests, to be confirmed by tetragon before it links the target binary specified by `path`. This is useful for folks who only want to load policies for specific versions of a binary. See [this PR](https://github.com/cilium/tetragon/pull/4994) for the complete picture of where this is heading. Reviewers in that superset PR suggested that the change be broken up into multiple PRs. So, this is the first of a series of PRs.

The linux kernel tracks uprobe binary targets by inode. When you open a file, the kernel allocates a file descriptor.  That file descriptor is locked onto an inode. By linking the target via file descriptor, we ensure that the inode being linked is the same inode that was inspected for digest verification. This avoids a TOCTOU problem that would happen otherwise, where we could link a target binary that we did not check the digest of.