### PR TITLE
refactor loader test

### DIFF
--- a/pkg/elf/build_id.go
+++ b/pkg/elf/build_id.go
@@ -8,7 +8,6 @@ import (
 	"debug/elf"
 	"encoding/binary"
 	"io"
-	"os"
 )
 
 // Integer represents all possible integer types.
@@ -57,13 +56,8 @@ func parseNote(dat []byte) ([]byte, bool) {
 	}
 }
 
-func ParseBuildId(file *os.File) ([]byte, error) {
-	f, err := elf.NewFile(file)
-	if err != nil {
-		return []byte{}, err
-	}
-
-	for _, ph := range f.Progs {
+func (se *SafeELFFile) ParseBuildId() ([]byte, error) {
+	for _, ph := range se.Progs {
 		if ph.Type != elf.PT_NOTE {
 			continue
 		}

--- a/pkg/elf/build_id.go
+++ b/pkg/elf/build_id.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package elf
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"io"
+	"os"
+)
+
+// Integer represents all possible integer types.
+// Remove when x/exp/constraints is moved to the standard library.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// align returns 'n' updated to 'alignment' boundary.
+func align[I Integer](n, alignment I) I {
+	return (n + alignment - 1) / alignment * alignment
+}
+
+type note struct {
+	Namesz uint32
+	Descsz uint32
+	Typ    uint32
+}
+
+func parseNote(dat []byte) ([]byte, bool) {
+	var note note
+
+	dr := bytes.NewReader(dat)
+
+	for {
+		if err := binary.Read(dr, binary.LittleEndian, &note); err != nil {
+			return []byte{}, false
+		}
+
+		name := make([]byte, align(note.Namesz, 4))
+		if err := binary.Read(dr, binary.LittleEndian, name); err != nil {
+			return []byte{}, false
+		}
+
+		desc := make([]byte, align(note.Descsz, 4))
+		if err := binary.Read(dr, binary.LittleEndian, desc); err != nil {
+			return []byte{}, false
+		}
+
+		if note.Typ == 3 &&
+			note.Namesz == 4 &&
+			bytes.Equal(name, []byte{'G', 'N', 'U', 0}) &&
+			note.Descsz > 0 {
+			return desc, true
+		}
+	}
+}
+
+func ParseBuildId(file *os.File) ([]byte, error) {
+	f, err := elf.NewFile(file)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	for _, ph := range f.Progs {
+		if ph.Type != elf.PT_NOTE {
+			continue
+		}
+		dat := make([]byte, ph.Filesz)
+		_, err := io.ReadFull(ph.Open(), dat)
+		if err != nil {
+			continue
+		}
+		bid, ok := parseNote(dat)
+		if ok {
+			return bid, nil
+		}
+	}
+	return []byte{}, nil
+}

--- a/pkg/elf/usdt_linux.go
+++ b/pkg/elf/usdt_linux.go
@@ -38,17 +38,6 @@ func getBase(se *SafeELFFile) (uint64, error) {
 	return 0, nil
 }
 
-// Integer represents all possible integer types.
-// Remove when x/exp/constraints is moved to the standard library.
-type Integer interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
-}
-
-// align returns 'n' updated to 'alignment' boundary.
-func align[I Integer](n, alignment I) I {
-	return (n + alignment - 1) / alignment * alignment
-}
-
 func (se *SafeELFFile) UsdtTargets() ([]*UsdtTarget, error) {
 	var targets []*UsdtTarget
 

--- a/pkg/sensors/tracing/loader_test.go
+++ b/pkg/sensors/tracing/loader_test.go
@@ -59,7 +59,7 @@ func parseNote(dat []byte) ([]byte, bool) {
 		if note.Typ == 3 &&
 			note.Namesz == 4 &&
 			bytes.Equal(name, []byte{'G', 'N', 'U', 0}) &&
-			note.Descsz > 0 && note.Descsz <= 20 {
+			note.Descsz > 0 {
 			return desc, true
 		}
 	}

--- a/pkg/sensors/tracing/loader_test.go
+++ b/pkg/sensors/tracing/loader_test.go
@@ -6,11 +6,8 @@
 package tracing
 
 import (
-	"bytes"
 	"context"
-	"debug/elf"
-	"encoding/binary"
-	"io"
+	"os"
 	"os/exec"
 	"sync"
 	"testing"
@@ -18,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	elfpkg "github.com/cilium/tetragon/pkg/elf"
 	"github.com/cilium/tetragon/pkg/jsonchecker"
 	"github.com/cilium/tetragon/pkg/matchers/bytesmatcher"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
@@ -25,69 +23,6 @@ import (
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 )
-
-type note struct {
-	Namesz uint32
-	Descsz uint32
-	Typ    uint32
-}
-
-func align(v, a uint32) uint32 {
-	return ((v + a - 1) / a) * a
-}
-
-func parseNote(dat []byte) ([]byte, bool) {
-	var note note
-
-	dr := bytes.NewReader(dat)
-
-	for {
-		if err := binary.Read(dr, binary.LittleEndian, &note); err != nil {
-			return []byte{}, false
-		}
-
-		name := make([]byte, align(note.Namesz, 4))
-		if err := binary.Read(dr, binary.LittleEndian, name); err != nil {
-			return []byte{}, false
-		}
-
-		desc := make([]byte, align(note.Descsz, 4))
-		if err := binary.Read(dr, binary.LittleEndian, desc); err != nil {
-			return []byte{}, false
-		}
-
-		if note.Typ == 3 &&
-			note.Namesz == 4 &&
-			bytes.Equal(name, []byte{'G', 'N', 'U', 0}) &&
-			note.Descsz > 0 {
-			return desc, true
-		}
-	}
-}
-
-func parseBuildId(filename string) ([]byte, error) {
-	f, err := elf.Open(filename)
-	if err != nil {
-		return []byte{}, err
-	}
-	defer f.Close()
-
-	for _, ph := range f.Progs {
-		if ph.Type != elf.PT_NOTE {
-			continue
-		}
-		dat := make([]byte, ph.Filesz)
-		_, err := io.ReadFull(ph.Open(), dat)
-		if err != nil {
-			continue
-		}
-		bid, ok := parseNote(dat)
-		if ok {
-			return bid, nil
-		}
-	}
-	return []byte{}, nil
-}
 
 func TestLoader(t *testing.T) {
 	if !hasLoaderEvents() {
@@ -113,7 +48,13 @@ spec:
 
 	testNop := testutils.RepoRootPath("contrib/tester-progs/nop")
 
-	id, err := parseBuildId(testNop)
+	file, err := os.Open(testNop)
+	if err != nil {
+		t.Fatalf("Failed to open test binary: %v\n", err)
+	}
+
+	id, err := elfpkg.ParseBuildId(file)
+	file.Close()
 	if err != nil {
 		t.Fatalf("Failed to ParseBuildId: %v\n", err)
 	}

--- a/pkg/sensors/tracing/loader_test.go
+++ b/pkg/sensors/tracing/loader_test.go
@@ -53,7 +53,12 @@ spec:
 		t.Fatalf("Failed to open test binary: %v\n", err)
 	}
 
-	id, err := elfpkg.ParseBuildId(file)
+	safeELF, err := elfpkg.NewSafeELFFile(file)
+	if err != nil {
+		t.Fatalf("Failed to parse ELF: %v\n", err)
+	}
+
+	id, err := safeELF.ParseBuildId()
 	file.Close()
 	if err != nil {
 		t.Fatalf("Failed to ParseBuildId: %v\n", err)

--- a/pkg/sensors/tracing/loader_test.go
+++ b/pkg/sensors/tracing/loader_test.go
@@ -33,7 +33,7 @@ type note struct {
 }
 
 func align(v, a uint32) uint32 {
-	return ((v + 1) / a) * a
+	return ((v + a - 1) / a) * a
 }
 
 func parseNote(dat []byte) ([]byte, bool) {


### PR DESCRIPTION
In a future PR, I will be doing uprobe target digest verification, where we support a new tracing policy configuration that allows users to supply digests, to be confirmed by tetragon before it links the target binary specified by path. This is useful for folks who only want to load policies for specific versions of a binary. See https://github.com/cilium/tetragon/pull/4994 for the complete picture of where this is heading. Reviewers in that superset PR suggested that the change be broken up into multiple PRs. So, this is one PR in a series of PRs.

One of the digest algorithms that will be supported is "build-id". This refactor extracts preexisting build-id parsing code, so it can be reused by a subsequent PR.