### PR TITLE
cmd/tetra: propagate errors correctly in CLI commands

### DIFF
--- a/cmd/tetra/cgtracker/cgtracker.go
+++ b/cmd/tetra/cgtracker/cgtracker.go
@@ -6,7 +6,6 @@
 package cgtracker
 
 import (
-	"fmt"
 	"log"
 	"path/filepath"
 
@@ -39,7 +38,7 @@ func dumpCmd() *cobra.Command {
 		Use:   "dump",
 		Short: "dump cgtracker map state",
 		Args:  cobra.ExactArgs(0),
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			m, err := cgtracker.OpenMap(mapFname)
 			if err != nil {
 				log.Fatal(err)
@@ -51,7 +50,7 @@ func dumpCmd() *cobra.Command {
 				return err
 			}
 			for tracker, tracked := range vals {
-				fmt.Printf("%d: %v\n", tracker, tracked)
+				cmd.Printf("%d: %v\n", tracker, tracked)
 			}
 			return nil
 		},

--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -58,20 +58,6 @@ func RetryPolicy(retries int) string {
 	}]}`, maxAttempt)
 }
 
-func CliRunErr(fn func(ctx context.Context, cli tetragon.FineGuidanceSensorsClient), fnErr func(err error)) {
-	c, err := NewClientWithDefaultContextAndAddress()
-	if err != nil {
-		fnErr(err)
-		return
-	}
-	defer c.Close()
-	fn(c.Ctx, c.Client)
-}
-
-func CliRun(fn func(ctx context.Context, cli tetragon.FineGuidanceSensorsClient)) {
-	CliRunErr(fn, func(_ error) {})
-}
-
 type ClientWithContext struct {
 	Client tetragon.FineGuidanceSensorsClient
 	// Ctx is a combination of the signal context and the timeout context

--- a/cmd/tetra/cri/cri.go
+++ b/cmd/tetra/cri/cri.go
@@ -54,7 +54,7 @@ func versionCmd(flagVals *criFlags) *cobra.Command {
 		Use:   "version",
 		Short: "retrieve CRI version",
 		Args:  cobra.ExactArgs(0),
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			client, err := cri.NewClient(ctx, flagVals.endpoint)
 			if err != nil {
@@ -68,13 +68,13 @@ func versionCmd(flagVals *criFlags) *cobra.Command {
 
 			switch flagVals.output {
 			case "raw":
-				fmt.Printf("%v\n", res)
+				cmd.Printf("%v\n", res)
 			case "json":
 				b, err := json.Marshal(res)
 				if err != nil {
 					return fmt.Errorf("failed to generate json: %w", err)
 				}
-				fmt.Println(string(b))
+				cmd.Println(string(b))
 			}
 			return nil
 		},
@@ -87,7 +87,7 @@ func cgroupPathCmd(flagVals *criFlags) *cobra.Command {
 		Use:   "cgroup_path",
 		Short: "retrieve cgroup path for container",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			client, err := cri.NewClient(ctx, flagVals.endpoint)
 			if err != nil {
@@ -98,7 +98,7 @@ func cgroupPathCmd(flagVals *criFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Println(ret)
+			cmd.Println(ret)
 			return nil
 		},
 	}

--- a/cmd/tetra/debug/dump.go
+++ b/cmd/tetra/debug/dump.go
@@ -94,6 +94,7 @@ func dumpExecveMap(cmd *cobra.Command, fname string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open execve map: %w", err)
 	}
+	defer m.Close()
 
 	data := make(map[execvemap.ExecveKey]execvemap.ExecveValue)
 	iter := m.Iterate()

--- a/cmd/tetra/debug/dump.go
+++ b/cmd/tetra/debug/dump.go
@@ -58,8 +58,8 @@ func execveMapCmd() *cobra.Command {
 		Use:   "execve",
 		Short: "dump execve map",
 		Args:  cobra.ExactArgs(0),
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return dumpExecveMap(mapFname)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return dumpExecveMap(cmd, mapFname)
 		},
 	}
 
@@ -76,8 +76,8 @@ func policyfilterCmd() *cobra.Command {
 		Use:   "policyfilter",
 		Short: "dump policyfilter state",
 		Args:  cobra.ExactArgs(0),
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return PolicyfilterState(mapFname)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return PolicyfilterState(cmd, mapFname)
 		},
 	}
 
@@ -87,7 +87,7 @@ func policyfilterCmd() *cobra.Command {
 	return ret
 }
 
-func dumpExecveMap(fname string) error {
+func dumpExecveMap(cmd *cobra.Command, fname string) error {
 	m, err := ebpf.LoadPinnedMap(fname, &ebpf.LoadPinOptions{
 		ReadOnly: true,
 	})
@@ -109,12 +109,12 @@ func dumpExecveMap(fname string) error {
 	}
 
 	if len(data) == 0 {
-		fmt.Printf("(empty)")
+		cmd.Print("(empty)")
 		return nil
 	}
 
 	for k, v := range data {
-		fmt.Printf("%d %+v\n", k, v)
+		cmd.Printf("%d %+v\n", k, v)
 	}
 	return nil
 }
@@ -159,7 +159,7 @@ func processCacheCmd() *cobra.Command {
 	return ret
 }
 
-func PolicyfilterState(fname string) error {
+func PolicyfilterState(cmd *cobra.Command, fname string) error {
 	m, err := policyfilter.OpenMap(fname)
 	if err != nil {
 		return fmt.Errorf("failed to open policyfilter map: %w", err)
@@ -171,10 +171,10 @@ func PolicyfilterState(fname string) error {
 		return fmt.Errorf("failed to dump policyfilter map: %w", err)
 	}
 
-	fmt.Println("--- PolicyID to CgroupIDs mapping ---")
+	cmd.Println("--- PolicyID to CgroupIDs mapping ---")
 
 	if len(data.Policy) == 0 {
-		fmt.Printf("(empty)\n")
+		cmd.Println("(empty)")
 	}
 
 	for polId, cgIDs := range data.Policy {
@@ -182,14 +182,14 @@ func PolicyfilterState(fname string) error {
 		for id := range cgIDs {
 			ids = append(ids, strconv.FormatUint(uint64(id), 10))
 		}
-		fmt.Printf("%d: %s\n", polId, strings.Join(ids, ","))
+		cmd.Printf("%d: %s\n", polId, strings.Join(ids, ","))
 	}
 
 	if data.Cgroup != nil {
-		fmt.Println("--- CgroupID to PolicyIDs mapping ---")
+		cmd.Println("--- CgroupID to PolicyIDs mapping ---")
 
 		if len(data.Cgroup) == 0 {
-			fmt.Printf("(empty)\n")
+			cmd.Println("(empty)")
 		}
 
 		for cgIDs, polIds := range data.Cgroup {
@@ -197,7 +197,7 @@ func PolicyfilterState(fname string) error {
 			for id := range polIds {
 				ids = append(ids, strconv.FormatUint(uint64(id), 10))
 			}
-			fmt.Printf("%d: %s\n", cgIDs, strings.Join(ids, ","))
+			cmd.Printf("%d: %s\n", cgIDs, strings.Join(ids, ","))
 		}
 	}
 	return nil

--- a/cmd/tetra/debug/dump.go
+++ b/cmd/tetra/debug/dump.go
@@ -58,8 +58,8 @@ func execveMapCmd() *cobra.Command {
 		Use:   "execve",
 		Short: "dump execve map",
 		Args:  cobra.ExactArgs(0),
-		Run: func(_ *cobra.Command, _ []string) {
-			dumpExecveMap(mapFname)
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return dumpExecveMap(mapFname)
 		},
 	}
 
@@ -70,15 +70,14 @@ func execveMapCmd() *cobra.Command {
 }
 
 func policyfilterCmd() *cobra.Command {
-
 	mapFname := filepath.Join(defaults.DefaultMapRoot, defaults.DefaultMapPrefix, policyfilter.MapName)
 
 	ret := &cobra.Command{
 		Use:   "policyfilter",
 		Short: "dump policyfilter state",
 		Args:  cobra.ExactArgs(0),
-		Run: func(_ *cobra.Command, _ []string) {
-			PolicyfilterState(mapFname)
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return PolicyfilterState(mapFname)
 		},
 	}
 
@@ -88,12 +87,12 @@ func policyfilterCmd() *cobra.Command {
 	return ret
 }
 
-func dumpExecveMap(fname string) {
+func dumpExecveMap(fname string) error {
 	m, err := ebpf.LoadPinnedMap(fname, &ebpf.LoadPinOptions{
 		ReadOnly: true,
 	})
 	if err != nil {
-		logger.Fatal(logger.GetLogger(), "failed to open execve map", logfields.Error, err)
+		return fmt.Errorf("failed to open execve map: %w", err)
 	}
 
 	data := make(map[execvemap.ExecveKey]execvemap.ExecveValue)
@@ -106,17 +105,18 @@ func dumpExecveMap(fname string) {
 	}
 
 	if err := iter.Err(); err != nil {
-		logger.Fatal(logger.GetLogger(), "error iterating execve map", logfields.Error, err)
+		return fmt.Errorf("error iterating execve map: %w", err)
 	}
 
 	if len(data) == 0 {
 		fmt.Printf("(empty)")
-		return
+		return nil
 	}
 
 	for k, v := range data {
 		fmt.Printf("%d %+v\n", k, v)
 	}
+	return nil
 }
 
 func processCacheCmd() *cobra.Command {
@@ -159,18 +159,16 @@ func processCacheCmd() *cobra.Command {
 	return ret
 }
 
-func PolicyfilterState(fname string) {
+func PolicyfilterState(fname string) error {
 	m, err := policyfilter.OpenMap(fname)
 	if err != nil {
-		logger.Fatal(logger.GetLogger(), "failed to open policyfilter map", logfields.Error, err)
-		return
+		return fmt.Errorf("failed to open policyfilter map: %w", err)
 	}
 	defer m.Close()
 
 	data, err := m.Dump()
 	if err != nil {
-		logger.Fatal(logger.GetLogger(), "failed to dump policyfilter map", logfields.Error, err)
-		return
+		return fmt.Errorf("failed to dump policyfilter map: %w", err)
 	}
 
 	fmt.Println("--- PolicyID to CgroupIDs mapping ---")
@@ -202,6 +200,7 @@ func PolicyfilterState(fname string) {
 			fmt.Printf("%d: %s\n", cgIDs, strings.Join(ids, ","))
 		}
 	}
+	return nil
 }
 
 func bpfErrMetricsCmd() *cobra.Command {

--- a/cmd/tetra/debug/progs.go
+++ b/cmd/tetra/debug/progs.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -120,7 +119,7 @@ Examples:
   # tetra debug progs --once --timeout 10
 `,
 
-		Run: func(_ *cobra.Command, _ []string) {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -132,7 +131,7 @@ Examples:
 
 			if cfg.bpffs == "" {
 				if cfg.bpffs, err = detectBpffs(); err != nil {
-					log.Fatal(err)
+					return err
 				}
 			}
 
@@ -146,9 +145,7 @@ Examples:
 				}
 			}
 
-			if err = runProgs(ctx); err != nil {
-				log.Fatal(err)
-			}
+			return runProgs(ctx)
 		},
 	}
 

--- a/cmd/tetra/eventlog/eventlog.go
+++ b/cmd/tetra/eventlog/eventlog.go
@@ -65,7 +65,7 @@ func getCmd() *cobra.Command {
 		Use:   "get",
 		Short: "get logging parameters",
 		Args:  cobra.ExactArgs(0),
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			c, err := NewClient()
 			if err != nil {
 				return fmt.Errorf("failed to create gRPC client: %w", err)
@@ -76,7 +76,7 @@ func getCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Current logging parameters: %+v\n", params)
+			cmd.Printf("Current logging parameters: %+v\n", params)
 			return nil
 		},
 	}

--- a/cmd/tetra/explain/explain.go
+++ b/cmd/tetra/explain/explain.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"slices"
 	"sort"
@@ -64,16 +63,13 @@ Examples:
 			}
 			return cobra.ExactArgs(1)(cmd, args)
 		},
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if listMode {
 				listResources(cmd.OutOrStdout())
-				return
+				return nil
 			}
 
-			if err := runExplain(cmd.OutOrStdout(), args[0]); err != nil {
-				fmt.Fprintf(cmd.OutOrStderr(), "Error: %v\n", err)
-				os.Exit(1)
-			}
+			return runExplain(cmd.OutOrStdout(), args[0])
 		},
 	}
 

--- a/cmd/tetra/policyfilter/policyfilter.go
+++ b/cmd/tetra/policyfilter/policyfilter.go
@@ -43,12 +43,12 @@ func cgroupGetIDCommand() *cobra.Command {
 		Use:   "cgroupid",
 		Short: "retrieve cgroup id from file",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cgID, err := cgroups.GetCgroupIdFromPath(args[0])
 			if err != nil {
 				return fmt.Errorf("failed to parse cgroup: %w", err)
 			}
-			fmt.Printf("%d\n", cgID)
+			cmd.Printf("%d\n", cgID)
 			return nil
 		},
 	}
@@ -64,8 +64,8 @@ func dumpCmd() *cobra.Command {
 		Use:   "dump",
 		Short: "dump policyfilter state",
 		Args:  cobra.ExactArgs(0),
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return debug.PolicyfilterState(mapFname)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return debug.PolicyfilterState(cmd, mapFname)
 		},
 	}
 

--- a/cmd/tetra/policyfilter/policyfilter.go
+++ b/cmd/tetra/policyfilter/policyfilter.go
@@ -13,8 +13,6 @@ import (
 	"github.com/cilium/tetragon/cmd/tetra/debug"
 	"github.com/cilium/tetragon/pkg/cgroups"
 	"github.com/cilium/tetragon/pkg/defaults"
-	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 )
 
@@ -45,12 +43,13 @@ func cgroupGetIDCommand() *cobra.Command {
 		Use:   "cgroupid",
 		Short: "retrieve cgroup id from file",
 		Args:  cobra.ExactArgs(1),
-		Run: func(_ *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, args []string) error {
 			cgID, err := cgroups.GetCgroupIdFromPath(args[0])
 			if err != nil {
-				logger.Fatal(logger.GetLogger(), "Failed to parse cgroup", logfields.Error, err)
+				return fmt.Errorf("failed to parse cgroup: %w", err)
 			}
 			fmt.Printf("%d\n", cgID)
+			return nil
 		},
 	}
 
@@ -82,10 +81,10 @@ func addCommand() *cobra.Command {
 		Use:   "add [policy id] [cgroup]",
 		Short: "add policyfilter entry",
 		Args:  cobra.ExactArgs(2),
-		Run: func(_ *cobra.Command, args []string) {
+		RunE: func(_ *cobra.Command, args []string) error {
 			x, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
-				logger.Fatal(logger.GetLogger(), "Failed to parse policy id", logfields.Error, err)
+				return fmt.Errorf("failed to parse policy id: %w", err)
 			}
 			polID := policyfilter.PolicyID(x)
 
@@ -96,14 +95,23 @@ func addCommand() *cobra.Command {
 			case "id":
 				cgID, err = strconv.ParseUint(args[1], 10, 32)
 			default:
-				logger.Fatal(logger.GetLogger(), "Unknown type", "type", argType)
+				return fmt.Errorf("unknown type: %s", argType)
 			}
 
 			if err != nil {
-				logger.Fatal(logger.GetLogger(), "Failed to parse cgroup", logfields.Error, err)
+				return fmt.Errorf("failed to parse cgroup: %w", err)
 			}
 
-			addCgroup(mapFname, polID, policyfilter.CgroupID(cgID))
+			m, err := policyfilter.OpenMap(mapFname)
+			if err != nil {
+				return fmt.Errorf("failed to open policyfilter map: %w", err)
+			}
+			defer m.Close()
+
+			if err := m.AddCgroup(polID, policyfilter.CgroupID(cgID)); err != nil {
+				return fmt.Errorf("failed to add cgroup id: %w", err)
+			}
+			return nil
 		},
 	}
 
@@ -111,19 +119,4 @@ func addCommand() *cobra.Command {
 	flags.StringVar(&argType, "arg-type", "file", "cgroup type (id,file)")
 	flags.StringVar(&mapFname, "map-fname", mapFname, "policyfilter map filename")
 	return ret
-}
-
-func addCgroup(fname string, polID policyfilter.PolicyID, cgID policyfilter.CgroupID) {
-	m, err := policyfilter.OpenMap(fname)
-	if err != nil {
-		logger.Fatal(logger.GetLogger(), "Failed to open policyfilter map", logfields.Error, err)
-		return
-	}
-	defer m.Close()
-
-	err = m.AddCgroup(polID, cgID)
-	if err != nil {
-		logger.Fatal(logger.GetLogger(), "Failed to add cgroup id", logfields.Error, err)
-	}
-
 }

--- a/cmd/tetra/policyfilter/policyfilter.go
+++ b/cmd/tetra/policyfilter/policyfilter.go
@@ -65,8 +65,8 @@ func dumpCmd() *cobra.Command {
 		Use:   "dump",
 		Short: "dump policyfilter state",
 		Args:  cobra.ExactArgs(0),
-		Run: func(_ *cobra.Command, _ []string) {
-			debug.PolicyfilterState(mapFname)
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return debug.PolicyfilterState(mapFname)
 		},
 	}
 

--- a/cmd/tetra/policytest/policytest.go
+++ b/cmd/tetra/policytest/policytest.go
@@ -40,14 +40,14 @@ func listCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "list",
 		Short: "list Tetragon policy tests",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			for i := range policytest.AllPolicyTests.Len() {
 				pt := policytest.AllPolicyTests.Get(i)
-				fmt.Printf("%s %v\n", pt.Name, pt.Labels)
+				cmd.Printf("%s %v\n", pt.Name, pt.Labels)
 				if listParams && len(pt.Params) > 0 {
-					fmt.Printf(" parameters:\n")
+					cmd.Println(" parameters:")
 					for _, param := range pt.Params {
-						fmt.Printf("    %s: %s (default:%s)\n", param.Name, param.Help, param.Default)
+						cmd.Printf("    %s: %s (default:%s)\n", param.Name, param.Help, param.Default)
 					}
 				}
 			}

--- a/cmd/tetra/rthooks/rthook.go
+++ b/cmd/tetra/rthooks/rthook.go
@@ -4,7 +4,6 @@
 package rthooks
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -31,10 +30,28 @@ func New() *cobra.Command {
 	add := &cobra.Command{
 		Use:   "create-container --container-id=<containerID> --root-dir=<rootDir>",
 		Short: "trigger create-container hook",
-		Run: func(_ *cobra.Command, _ []string) {
-			common.CliRun(func(ctx context.Context, cli tetragon.FineGuidanceSensorsClient) {
-				createContainer(ctx, cli, &cnf)
-			})
+		RunE: func(_ *cobra.Command, _ []string) error {
+			c, err := common.NewClientWithDefaultContextAndAddress()
+			if err != nil {
+				return fmt.Errorf("failed to create gRPC client: %w", err)
+			}
+			defer c.Close()
+
+			req := &tetragon.RuntimeHookRequest{
+				Event: &tetragon.RuntimeHookRequest_CreateContainer{
+					CreateContainer: &tetragon.CreateContainer{
+						CgroupsPath: cnf.containerID,
+						RootDir:     cnf.rootDir,
+						Annotations: cnf.annotations,
+					},
+				},
+			}
+
+			_, err = c.Client.RuntimeHook(c.Ctx, req)
+			if err != nil {
+				return fmt.Errorf("failed to trigger create-container hook: %w", err)
+			}
+			return nil
 		},
 	}
 
@@ -45,21 +62,4 @@ func New() *cobra.Command {
 
 	ret.AddCommand(add)
 	return ret
-}
-
-func createContainer(ctx context.Context, client tetragon.FineGuidanceSensorsClient, cnf *addContainerConf) {
-	req := &tetragon.RuntimeHookRequest{
-		Event: &tetragon.RuntimeHookRequest_CreateContainer{
-			CreateContainer: &tetragon.CreateContainer{
-				CgroupsPath: cnf.containerID,
-				RootDir:     cnf.rootDir,
-				Annotations: cnf.annotations,
-			},
-		},
-	}
-
-	_, err := client.RuntimeHook(ctx, req)
-	if err != nil {
-		fmt.Printf("triggering create-container hook failed: %s", err)
-	}
 }

--- a/cmd/tetra/sensors/sensors.go
+++ b/cmd/tetra/sensors/sensors.go
@@ -5,6 +5,7 @@ package sensors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -25,13 +26,13 @@ func New() *cobra.Command {
 	sensorsListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List available sensors",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			c, err := common.NewClientWithDefaultContextAndAddress()
 			if err != nil {
 				return err
 			}
 			defer c.Close()
-			return listSensors(c.Ctx, c.Client)
+			return listSensors(c.Ctx, cmd, c.Client)
 		},
 	}
 	sensorsCmd.AddCommand(sensorsListCmd)
@@ -40,13 +41,13 @@ func New() *cobra.Command {
 		Use:   "enable <sensor>",
 		Short: "Enable sensor",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := common.NewClientWithDefaultContextAndAddress()
 			if err != nil {
 				return err
 			}
 			defer c.Close()
-			return enableSensor(c.Ctx, c.Client, args[0])
+			return enableSensor(c.Ctx, cmd, c.Client, args[0])
 		},
 	}
 	sensorsCmd.AddCommand(sensorEnableCmd)
@@ -55,13 +56,13 @@ func New() *cobra.Command {
 		Use:   "disable <sensor>",
 		Short: "Disable sensor",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := common.NewClientWithDefaultContextAndAddress()
 			if err != nil {
 				return err
 			}
 			defer c.Close()
-			return disableSensor(c.Ctx, c.Client, args[0])
+			return disableSensor(c.Ctx, cmd, c.Client, args[0])
 		},
 	}
 	sensorsCmd.AddCommand(sensorDisableCmd)
@@ -84,7 +85,7 @@ func New() *cobra.Command {
 	return sensorsCmd
 }
 
-func listSensors(ctx context.Context, client tetragon.FineGuidanceSensorsClient) error {
+func listSensors(ctx context.Context, cmd *cobra.Command, client tetragon.FineGuidanceSensorsClient) error {
 	// ignore deprecation warnings
 	//nolint:staticcheck
 	sensors, err := client.ListSensors(ctx, &tetragon.ListSensorsRequest{})
@@ -92,7 +93,7 @@ func listSensors(ctx context.Context, client tetragon.FineGuidanceSensorsClient)
 		return fmt.Errorf("failed to list sensors: %w", err)
 	}
 	if sensors == nil {
-		return fmt.Errorf("sensors is nil")
+		return errors.New("sensors is nil")
 	}
 
 	for _, sensor := range sensors.Sensors {
@@ -102,7 +103,7 @@ func listSensors(ctx context.Context, client tetragon.FineGuidanceSensorsClient)
 		} else {
 			enabled = "(not enabled)"
 		}
-		fmt.Printf("%s %s %s\n", sensor.Name, enabled, sensor.Collection)
+		cmd.Printf("%s %s %s\n", sensor.Name, enabled, sensor.Collection)
 	}
 	return nil
 }
@@ -119,24 +120,24 @@ func removeSensor(ctx context.Context, client tetragon.FineGuidanceSensorsClient
 	return nil
 }
 
-func enableSensor(ctx context.Context, client tetragon.FineGuidanceSensorsClient, sensor string) error {
+func enableSensor(ctx context.Context, cmd *cobra.Command, client tetragon.FineGuidanceSensorsClient, sensor string) error {
 	// ignore deprecation warnings
 	//nolint:staticcheck
 	_, err := client.EnableSensor(ctx, &tetragon.EnableSensorRequest{Name: sensor})
 	if err != nil {
 		return fmt.Errorf("failed to enable sensor %s: %w", sensor, err)
 	}
-	fmt.Printf("sensor %s enabled\n", sensor)
+	cmd.Printf("sensor %s enabled\n", sensor)
 	return nil
 }
 
-func disableSensor(ctx context.Context, client tetragon.FineGuidanceSensorsClient, sensor string) error {
+func disableSensor(ctx context.Context, cmd *cobra.Command, client tetragon.FineGuidanceSensorsClient, sensor string) error {
 	// ignore deprecation warnings
 	//nolint:staticcheck
 	_, err := client.DisableSensor(ctx, &tetragon.DisableSensorRequest{Name: sensor})
 	if err != nil {
 		return fmt.Errorf("failed to disable sensor %s: %w", sensor, err)
 	}
-	fmt.Printf("sensor %s disabled\n", sensor)
+	cmd.Printf("sensor %s disabled\n", sensor)
 	return nil
 }

--- a/cmd/tetra/sensors/sensors.go
+++ b/cmd/tetra/sensors/sensors.go
@@ -25,8 +25,13 @@ func New() *cobra.Command {
 	sensorsListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List available sensors",
-		Run: func(_ *cobra.Command, _ []string) {
-			common.CliRun(listSensors)
+		RunE: func(_ *cobra.Command, _ []string) error {
+			c, err := common.NewClientWithDefaultContextAndAddress()
+			if err != nil {
+				return err
+			}
+			defer c.Close()
+			return listSensors(c.Ctx, c.Client)
 		},
 	}
 	sensorsCmd.AddCommand(sensorsListCmd)
@@ -35,11 +40,13 @@ func New() *cobra.Command {
 		Use:   "enable <sensor>",
 		Short: "Enable sensor",
 		Args:  cobra.ExactArgs(1),
-		Run: func(_ *cobra.Command, args []string) {
-			sensor := args[0]
-			common.CliRun(func(ctx context.Context, cli tetragon.FineGuidanceSensorsClient) {
-				enableSensor(ctx, cli, sensor)
-			})
+		RunE: func(_ *cobra.Command, args []string) error {
+			c, err := common.NewClientWithDefaultContextAndAddress()
+			if err != nil {
+				return err
+			}
+			defer c.Close()
+			return enableSensor(c.Ctx, c.Client, args[0])
 		},
 	}
 	sensorsCmd.AddCommand(sensorEnableCmd)
@@ -48,11 +55,13 @@ func New() *cobra.Command {
 		Use:   "disable <sensor>",
 		Short: "Disable sensor",
 		Args:  cobra.ExactArgs(1),
-		Run: func(_ *cobra.Command, args []string) {
-			sensor := args[0]
-			common.CliRun(func(ctx context.Context, cli tetragon.FineGuidanceSensorsClient) {
-				disableSensor(ctx, cli, sensor)
-			})
+		RunE: func(_ *cobra.Command, args []string) error {
+			c, err := common.NewClientWithDefaultContextAndAddress()
+			if err != nil {
+				return err
+			}
+			defer c.Close()
+			return disableSensor(c.Ctx, c.Client, args[0])
 		},
 	}
 	sensorsCmd.AddCommand(sensorDisableCmd)
@@ -61,10 +70,13 @@ func New() *cobra.Command {
 		Use:   "rm <sensor_name>",
 		Short: "remove a sensor",
 		Args:  cobra.ExactArgs(1),
-		Run: func(_ *cobra.Command, args []string) {
-			common.CliRun(func(ctx context.Context, cli tetragon.FineGuidanceSensorsClient) {
-				removeSensor(ctx, cli, args[0])
-			})
+		RunE: func(_ *cobra.Command, args []string) error {
+			c, err := common.NewClientWithDefaultContextAndAddress()
+			if err != nil {
+				return err
+			}
+			defer c.Close()
+			return removeSensor(c.Ctx, c.Client, args[0])
 		},
 	}
 	sensorsCmd.AddCommand(sensorRmCmd)
@@ -72,16 +84,15 @@ func New() *cobra.Command {
 	return sensorsCmd
 }
 
-func listSensors(ctx context.Context, client tetragon.FineGuidanceSensorsClient) {
+func listSensors(ctx context.Context, client tetragon.FineGuidanceSensorsClient) error {
 	// ignore deprecation warnings
 	//nolint:staticcheck
 	sensors, err := client.ListSensors(ctx, &tetragon.ListSensorsRequest{})
 	if err != nil {
-		fmt.Printf("error: %s\n", err)
-		return
-	} else if sensors == nil {
-		fmt.Printf("error: sensors is nil\n")
-		return
+		return fmt.Errorf("failed to list sensors: %w", err)
+	}
+	if sensors == nil {
+		return fmt.Errorf("sensors is nil")
 	}
 
 	for _, sensor := range sensors.Sensors {
@@ -93,37 +104,39 @@ func listSensors(ctx context.Context, client tetragon.FineGuidanceSensorsClient)
 		}
 		fmt.Printf("%s %s %s\n", sensor.Name, enabled, sensor.Collection)
 	}
+	return nil
 }
 
-func removeSensor(ctx context.Context, client tetragon.FineGuidanceSensorsClient, sensor string) {
+func removeSensor(ctx context.Context, client tetragon.FineGuidanceSensorsClient, sensor string) error {
 	// ignore deprecation warnings
 	//nolint:staticcheck
 	_, err := client.RemoveSensor(ctx, &tetragon.RemoveSensorRequest{
 		Name: sensor,
 	})
 	if err != nil {
-		fmt.Printf("failed to remove tracing policy: %s\n", err)
+		return fmt.Errorf("failed to remove sensor: %w", err)
 	}
+	return nil
 }
 
-func enableSensor(ctx context.Context, client tetragon.FineGuidanceSensorsClient, sensor string) {
+func enableSensor(ctx context.Context, client tetragon.FineGuidanceSensorsClient, sensor string) error {
 	// ignore deprecation warnings
 	//nolint:staticcheck
 	_, err := client.EnableSensor(ctx, &tetragon.EnableSensorRequest{Name: sensor})
-	if err == nil {
-		fmt.Printf("sensor %s enabled\n", sensor)
-	} else {
-		fmt.Printf("failed to enable sensor %s: %s\n", sensor, err)
+	if err != nil {
+		return fmt.Errorf("failed to enable sensor %s: %w", sensor, err)
 	}
+	fmt.Printf("sensor %s enabled\n", sensor)
+	return nil
 }
 
-func disableSensor(ctx context.Context, client tetragon.FineGuidanceSensorsClient, sensor string) {
+func disableSensor(ctx context.Context, client tetragon.FineGuidanceSensorsClient, sensor string) error {
 	// ignore deprecation warnings
 	//nolint:staticcheck
 	_, err := client.DisableSensor(ctx, &tetragon.DisableSensorRequest{Name: sensor})
-	if err == nil {
-		fmt.Printf("sensor %s disabled\n", sensor)
-	} else {
-		fmt.Printf("failed to disable sensor %s: %s\n", sensor, err)
+	if err != nil {
+		return fmt.Errorf("failed to disable sensor %s: %w", sensor, err)
 	}
+	fmt.Printf("sensor %s disabled\n", sensor)
+	return nil
 }

--- a/cmd/tetra/status/status.go
+++ b/cmd/tetra/status/status.go
@@ -4,7 +4,6 @@
 package status
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -13,26 +12,28 @@ import (
 	"github.com/cilium/tetragon/cmd/tetra/common"
 )
 
-func getStatus(ctx context.Context, client tetragon.FineGuidanceSensorsClient) {
-	response, err := client.GetHealth(ctx, &tetragon.GetHealthStatusRequest{})
-	if err != nil {
-		fmt.Printf("status error: %s\n", err)
-		return
-	}
-	healthStatus := response.GetHealthStatus()
-	if len(healthStatus) == 0 {
-		fmt.Println("Health Status: no status available")
-		return
-	}
-	fmt.Printf("Health Status: %s\n", healthStatus[0].Details)
-}
-
 func New() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Print health status",
-		Run: func(_ *cobra.Command, _ []string) {
-			common.CliRun(getStatus)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			c, err := common.NewClientWithDefaultContextAndAddress()
+			if err != nil {
+				return fmt.Errorf("failed to create gRPC client: %w", err)
+			}
+			defer c.Close()
+
+			response, err := c.Client.GetHealth(c.Ctx, &tetragon.GetHealthStatusRequest{})
+			if err != nil {
+				return fmt.Errorf("failed to get health status: %w", err)
+			}
+			healthStatus := response.GetHealthStatus()
+			if len(healthStatus) == 0 {
+				cmd.Println("Health Status: no status available")
+				return nil
+			}
+			cmd.Printf("Health Status: %s\n", healthStatus[0].Details)
+			return nil
 		},
 	}
 }

--- a/cmd/tetra/tracingpolicy/tracingpolicy.go
+++ b/cmd/tetra/tracingpolicy/tracingpolicy.go
@@ -273,7 +273,7 @@ func tpListDomainsCmd() *cobra.Command {
 				}
 				cmd.Println(string(b))
 			case "text":
-				fmt.Println(res.Domains)
+				cmd.Println(res.Domains)
 			}
 
 			return nil

--- a/cmd/tetra/version/version.go
+++ b/cmd/tetra/version/version.go
@@ -4,13 +4,10 @@
 package version
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/cmd/tetra/common"
-	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/version"
 
 	"github.com/spf13/cobra"
@@ -33,29 +30,28 @@ func New() *cobra.Command {
 		Short:   "Print version from CLI and server",
 		Example: examples,
 		Args:    cobra.NoArgs,
-		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Printf("CLI version: %s\n", version.Version)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.Printf("CLI version: %s\n", version.Version)
 
 			if server {
-				common.CliRunErr(
-					func(ctx context.Context, cli tetragon.FineGuidanceSensorsClient) {
-						res, err := cli.GetVersion(ctx, &tetragon.GetVersionRequest{})
-						if err != nil {
-							logger.GetLogger().Error("error retrieving server version", logfields.Error, err)
-							return
-						}
-						fmt.Printf("Server version: %s\n", res.Version)
-					},
-					func(err error) {
-						logger.GetLogger().Error("error retrieving server version", logfields.Error, err)
-					},
-				)
+				c, err := common.NewClientWithDefaultContextAndAddress()
+				if err != nil {
+					return fmt.Errorf("failed to create gRPC client: %w", err)
+				}
+				defer c.Close()
+
+				res, err := c.Client.GetVersion(c.Ctx, &tetragon.GetVersionRequest{})
+				if err != nil {
+					return fmt.Errorf("failed to retrieve server version: %w", err)
+				}
+				cmd.Printf("Server version: %s\n", res.Version)
 			}
 
 			if build {
 				info := version.ReadBuildInfo()
 				info.Print()
 			}
+			return nil
 		},
 	}
 	flags := cmd.Flags()


### PR DESCRIPTION
Based on https://github.com/cilium/tetragon/pull/5187, please merge that one first (this is the first 4 commits).

This is a cleanup to remove the common.CliRun helpers to have all commands to properly propagate failure via cobra commands error so that we don't have any commands doing `fmt.Println("failed to do blabla")` and return.

Again, Friday late afternoon type of PR, not super useful I admit but I wanted to do something light.