### PR TITLE
renovate: Remove matchUpdateTypes for lvh for stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -340,17 +340,11 @@
       ]
     },
     {
-      // update lvh-images patch/digest for stable branches
+      // update lvh-images for stable branches
       "enabled": true,
       "matchPackageNames": [
         "quay.io/lvh-images/kernel-images",
         "quay.io/lvh-images/kind"
-      ],
-      "matchUpdateTypes": [
-        "digest",
-        "patch",
-        "pin",
-        "pinDigest"
       ],
       "matchBaseBranches": [
         "v1.5",


### PR DESCRIPTION
Otherwise, it's still disabled based on default rule.

---

Testing was done by triggering renovate from this branch 

https://github.com/cilium/tetragon/actions/runs/28434775644
