### PR TITLE
usdt: unify selector state when there are multiple entries per hook

### DIFF
--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -324,16 +324,14 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 			"policy-name", in.policyName)
 	}
 
-	var (
-		argPrinters []argPrinter
-		found       bool
-	)
+	var found bool
 
 	for _, target := range targets {
 		if spec.Provider != target.Spec.Provider || spec.Name != target.Spec.Name {
 			continue
 		}
 
+		var argPrinters []argPrinter
 		config := &api.EventConfig{}
 		config.SelStatsBase = in.selectorStatsBase
 		found = true

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -324,6 +324,16 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 			"policy-name", in.policyName)
 	}
 
+	// Parse Filters into kernel filter logic
+	state, err := selectors.InitKernelSelectorState(&selectors.KernelSelectorArgs{
+		Selectors: spec.Selectors,
+		Args:      spec.Args,
+		Data:      []v1alpha1.KProbeArg{},
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	var found bool
 
 	for _, target := range targets {
@@ -339,16 +349,6 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		if len(spec.Args) > api.EventConfigMaxArgs {
 			return nil, fmt.Errorf("failed to configure usdt '%s/%s', too many arguments (%d) allowed %d",
 				spec.Provider, spec.Name, len(spec.Args), api.EventConfigMaxArgs)
-		}
-
-		// Parse Filters into kernel filter logic
-		state, err := selectors.InitKernelSelectorState(&selectors.KernelSelectorArgs{
-			Selectors: spec.Selectors,
-			Args:      spec.Args,
-			Data:      []v1alpha1.KProbeArg{},
-		})
-		if err != nil {
-			return nil, err
 		}
 
 		// Validate argument for set action


### PR DESCRIPTION
While probably a rare use-case, we support users setting multiple USDT tracepoints with the same provider/name. When this happens, we create multiple usdt entries for the hook. These entries share the same selector, because they were generated from the same hook.

We have a similar situation for uprobes, where one hook has multiple entries. In that case, we re-use the selector state. This change makes usdt like uprobes in this way. It makes sense to represent a selector with a single selector state.

While investigating this, I found that an error message was emitted when I created a binary that has multiple tracepoints with the same provider/name. This change contains a fix for that as well.