### PR TITLE
fix: reject malformed field filter JSON

### DIFF
--- a/pkg/fieldfilters/fields.go
+++ b/pkg/fieldfilters/fields.go
@@ -26,7 +26,10 @@ func ParseFieldFilterList(filters string) ([]*tetragon.FieldFilter, error) {
 	// fields is in snake_case and we don't want to create confusion. So we can use a JSON
 	// marshalling hack to convert the field names to their camelCase representation
 	// before unmarshalling here.
-	filters = fixupFieldFilterString(filters)
+	filters, err := fixupFieldFilterString(filters)
+	if err != nil {
+		return nil, err
+	}
 	dec := json.NewDecoder(strings.NewReader(filters))
 	var results []*tetragon.FieldFilter
 	for {
@@ -64,7 +67,7 @@ func fixupSnakeCaseString(s string, upper bool) string {
 
 // Fixes up a field filter's string representation so that protobuf can unmarshal it from
 // JSON.
-func fixupFieldFilterString(s string) string {
+func fixupFieldFilterString(s string) (string, error) {
 	builder := &strings.Builder{}
 	dec := json.NewDecoder(strings.NewReader(s))
 	enc := json.NewEncoder(builder)
@@ -73,7 +76,10 @@ func fixupFieldFilterString(s string) string {
 		var dat map[string]any
 		err := dec.Decode(&dat)
 		if err != nil {
-			break
+			if err == io.EOF {
+				break
+			}
+			return "", err
 		}
 
 		var fields string
@@ -81,14 +87,14 @@ func fixupFieldFilterString(s string) string {
 
 		fields, ok = dat["fields"].(string)
 		if !ok {
-			return s
+			return s, nil
 		}
 
 		dat["fields"] = fixupSnakeCaseString(fields, false)
 		enc.Encode(&dat)
 	}
 
-	return builder.String()
+	return builder.String(), nil
 }
 
 // FieldFilter is a helper for filtering fields in events

--- a/pkg/fieldfilters/parse_test.go
+++ b/pkg/fieldfilters/parse_test.go
@@ -23,3 +23,8 @@ func TestParseFieldFilterList(t *testing.T) {
 	require.NoError(t, err, "must parse")
 	assert.Equal(t, "process.start_time", filters[0].Fields.Paths[0])
 }
+
+func TestParseFieldFilterListRejectsMalformedJSON(t *testing.T) {
+	_, err := ParseFieldFilterList(`{"fields":"process.pid","action":"INCLUDE"`)
+	require.Error(t, err, "must reject malformed JSON")
+}


### PR DESCRIPTION
Fixes

### Description
Malformed `fieldFilters` JSON was getting swallowed in the snake_case fixup path, so Tetragon ended up acting like no field filters were set. Kinda rough, bad config should fail loud not fail open.

This makes `ParseFieldFilterList` return the JSON decode error instead, and adds a small regression test.

Repro:
`go test ./pkg/fieldfilters/...`

or with a tiny snippet:
```go
_, err := fieldfilters.ParseFieldFilterList("{\"fields\":\"process.pid\",\"action\":\"INCLUDE\"")
fmt.Println(err)
```

Before: `nil`
After: `unexpected EOF`

### Changelog
```release-note
Fix malformed field filter JSON being silently ignored.
```
