### PR TITLE
cmd/tetra: return bugtool command errors

### DIFF
--- a/cmd/tetra/bugtool/bugtool.go
+++ b/cmd/tetra/bugtool/bugtool.go
@@ -43,8 +43,8 @@ func New() *Command {
 	bugtoolCmd.command = &cobra.Command{
 		Use:   "bugtool",
 		Short: "Produce a tar archive with debug information",
-		Run: func(_ *cobra.Command, _ []string) {
-			bugtool.Bugtool(outFile, bpfTool, gops, common.MaxRecvMsgSize, bugtoolCmd.CommandActions, bugtoolCmd.GRPCActions)
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return bugtool.Bugtool(outFile, bpfTool, gops, common.MaxRecvMsgSize, bugtoolCmd.CommandActions, bugtoolCmd.GRPCActions)
 		},
 	}
 


### PR DESCRIPTION
Fixes

### Description
`tetra bugtool` was swallowing `bugtool.Bugtool(...)` errors and still exiting 0.
That is kinda rough for scripts and CI.

This switches the command to `RunE` and returns the error.
Added a small test for the fail path and the ok path.

Repro:
1. Run `go run ./cmd/tetra bugtool -o /proc/1/tetragon-bugtool.tar.gz`
2. Before this patch it exits 0, even though no archive is created.
3. With this patch it exits 1 and prints `failed to create bugtool archive: ...`

### Changelog
```release-note
Fix `tetra bugtool` to return a non-zero exit code when archive creation fails
```
