### PR TITLE
cgidmap: Add cgroupfs fallback for pod association

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -94,7 +94,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | serviceLabelsOverride | object | `{}` |  |
 | tetragon.argsOverride | list | `[]` | Override the arguments. For advanced users only. |
 | tetragon.btf | string | `""` |  |
-| tetragon.cgidmap | object | `{"enabled":false}` | Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for pod association. This feature depends on cri being enabled. |
+| tetragon.cgidmap | object | `{"enabled":false}` | Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for pod association. Without cri enabled, existing pods are associated using best-effort cgroup filesystem scanning; enabling cri provides authoritative resolution. |
 | tetragon.clusterName | string | `""` | Name of the cluster where Tetragon is installed. Tetragon uses this value to set the cluster_name field in GetEventsResponse messages. |
 | tetragon.commandOverride | list | `[]` | Override the command. For advanced users only. |
 | tetragon.cri | object | `{"enabled":false,"socketHostPath":""}` | Configure tetragon pod so that it can contact the CRI running on the host |

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -93,7 +93,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | serviceLabelsOverride | object | `{}` |  |
 | tetragon.argsOverride | list | `[]` | Override the arguments. For advanced users only. |
 | tetragon.btf | string | `""` |  |
-| tetragon.cgidmap | object | `{"enabled":false}` | Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for pod association. This feature depends on cri being enabled. |
+| tetragon.cgidmap | object | `{"enabled":false}` | Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for pod association. Without cri enabled, existing pods are associated using best-effort cgroup filesystem scanning; enabling cri provides authoritative resolution. |
 | tetragon.clusterName | string | `""` | Name of the cluster where Tetragon is installed. Tetragon uses this value to set the cluster_name field in GetEventsResponse messages. |
 | tetragon.commandOverride | list | `[]` | Override the command. For advanced users only. |
 | tetragon.cri | object | `{"enabled":false,"socketHostPath":""}` | Configure tetragon pod so that it can contact the CRI running on the host |

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -42,6 +42,14 @@ Build information about tetragon
 | `time ` | `2022-05-13T15:54:45Z` |
 | `version` | `v1.2.0` |
 
+### `tetragon_cgfs_cgidmap_resolutions_errors_total`
+
+number of cgroup id map (cgidmap) cgroupfs resolutions that failed
+
+### `tetragon_cgfs_cgidmap_resolutions_total`
+
+number of total cgroup id map (cgidmap) cgroupfs resolutions
+
 ### `tetragon_cgroup_rate_total`
 
 The total number of Tetragon cgroup rate counters. For internal use only.

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -43,6 +43,14 @@ Build information about tetragon
 | `time ` | `2022-05-13T15:54:45Z` |
 | `version` | `v1.2.0` |
 
+### `tetragon_cgfs_cgidmap_resolutions_errors_total`
+
+number of cgroup id map (cgidmap) cgroupfs resolutions that failed
+
+### `tetragon_cgfs_cgidmap_resolutions_total`
+
+number of total cgroup id map (cgidmap) cgroupfs resolutions
+
 ### `tetragon_cgroup_rate_total`
 
 The total number of Tetragon cgroup rate counters. For internal use only.

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -76,7 +76,7 @@ Helm chart for Tetragon
 | serviceLabelsOverride | object | `{}` |  |
 | tetragon.argsOverride | list | `[]` | Override the arguments. For advanced users only. |
 | tetragon.btf | string | `""` |  |
-| tetragon.cgidmap | object | `{"enabled":false}` | Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for pod association. This feature depends on cri being enabled. |
+| tetragon.cgidmap | object | `{"enabled":false}` | Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for pod association. Without cri enabled, existing pods are associated using best-effort cgroup filesystem scanning; enabling cri provides authoritative resolution. |
 | tetragon.clusterName | string | `""` | Name of the cluster where Tetragon is installed. Tetragon uses this value to set the cluster_name field in GetEventsResponse messages. |
 | tetragon.commandOverride | list | `[]` | Override the command. For advanced users only. |
 | tetragon.cri | object | `{"enabled":false,"socketHostPath":""}` | Configure tetragon pod so that it can contact the CRI running on the host |

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -75,7 +75,7 @@ Helm chart for Tetragon
 | serviceLabelsOverride | object | `{}` |  |
 | tetragon.argsOverride | list | `[]` | Override the arguments. For advanced users only. |
 | tetragon.btf | string | `""` |  |
-| tetragon.cgidmap | object | `{"enabled":false}` | Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for pod association. This feature depends on cri being enabled. |
+| tetragon.cgidmap | object | `{"enabled":false}` | Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for pod association. Without cri enabled, existing pods are associated using best-effort cgroup filesystem scanning; enabling cri provides authoritative resolution. |
 | tetragon.clusterName | string | `""` | Name of the cluster where Tetragon is installed. Tetragon uses this value to set the cluster_name field in GetEventsResponse messages. |
 | tetragon.commandOverride | list | `[]` | Override the command. For advanced users only. |
 | tetragon.cri | object | `{"enabled":false,"socketHostPath":""}` | Configure tetragon pod so that it can contact the CRI running on the host |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -299,7 +299,8 @@ tetragon:
     # "/run/containerd/containerd.sock" for containerd or "/var/run/crio/crio.sock"  for crio.
     socketHostPath: ""
   # -- Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for
-  # pod association. This feature depends on cri being enabled.
+  # pod association. Without cri enabled, existing pods are associated using best-effort cgroup
+  # filesystem scanning; enabling cri provides authoritative resolution.
   cgidmap:
     enabled: false
   usePerfRingBuffer: false

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -314,7 +314,8 @@ tetragon:
     # "/run/containerd/containerd.sock" for containerd or "/var/run/crio/crio.sock"  for crio.
     socketHostPath: ""
   # -- Enabling cgidmap instructs the Tetragon agent to use cgroup ids (instead of cgroup names) for
-  # pod association. This feature depends on cri being enabled.
+  # pod association. Without cri enabled, existing pods are associated using best-effort cgroup
+  # filesystem scanning; enabling cri provides authoritative resolution.
   cgidmap:
     enabled: false
   usePerfRingBuffer: false

--- a/pkg/cgidmap/cgidmap.go
+++ b/pkg/cgidmap/cgidmap.go
@@ -94,7 +94,8 @@ func newMap() (*cgidm, error) {
 	if option.Config.EnableCRI {
 		m.resolver = newCriResolver(m)
 	} else {
-		logger.GetLogger().Warn("cgidmap is enabled but cri is not. This means that pod association will not work for existing pods. You can enable cri using --enable-cri")
+		m.resolver = newCgfsResolver(m)
+		logger.GetLogger().Info("cgidmap is enabled but cri is not. Pod association for existing pods will use best-effort cgroupfs scanning. For authoritative resolution, enable cri using --enable-cri")
 	}
 	return m, nil
 }
@@ -226,9 +227,7 @@ func (m *cgidm) Update(podID PodID, contIDs []ContainerID) {
 			contID: id,
 		})
 	}
-	if m.resolver != nil {
-		m.resolver.enqueue(unmappedIDs)
-	}
+	m.resolver.enqueue(unmappedIDs)
 }
 
 // Global state

--- a/pkg/cgidmap/cgidmap.go
+++ b/pkg/cgidmap/cgidmap.go
@@ -77,7 +77,7 @@ type cgidm struct {
 	log logger.FieldLogger
 	*logger.DebugLogger
 
-	criResolver *criResolver
+	resolver *resolver
 }
 
 func newMap() (*cgidm, error) {
@@ -91,13 +91,11 @@ func newMap() (*cgidm, error) {
 		DebugLogger: logger.NewDebugLogger(log, option.Config.EnableCgIDmapDebug),
 	}
 
-	var criResolver *criResolver
 	if option.Config.EnableCRI {
-		criResolver = newCriResolver(m)
+		m.resolver = newCriResolver(m)
 	} else {
 		logger.GetLogger().Warn("cgidmap is enabled but cri is not. This means that pod association will not work for existing pods. You can enable cri using --enable-cri")
 	}
-	m.criResolver = criResolver
 	return m, nil
 }
 
@@ -220,7 +218,7 @@ func (m *cgidm) Update(podID PodID, contIDs []ContainerID) {
 		return
 	}
 
-	// schedule unmapped ids to be resolved by the CRI resolver
+	// schedule unmapped ids to be resolved by the async resolver
 	unmappedIDs := make([]unmappedID, 0, len(tmp))
 	for id := range tmp {
 		unmappedIDs = append(unmappedIDs, unmappedID{
@@ -228,8 +226,8 @@ func (m *cgidm) Update(podID PodID, contIDs []ContainerID) {
 			contID: id,
 		})
 	}
-	if m.criResolver != nil {
-		m.criResolver.enqeue(unmappedIDs)
+	if m.resolver != nil {
+		m.resolver.enqueue(unmappedIDs)
 	}
 }
 

--- a/pkg/cgidmap/cgidmap.go
+++ b/pkg/cgidmap/cgidmap.go
@@ -91,13 +91,12 @@ func newMap() (*cgidm, error) {
 		DebugLogger: logger.NewDebugLogger(log, option.Config.EnableCgIDmapDebug),
 	}
 
-	var resolver *resolver
 	if option.Config.EnableCRI {
-		resolver = newCriResolver(m)
+		m.resolver = newCriResolver(m)
 	} else {
-		logger.GetLogger().Warn("cgidmap is enabled but cri is not. This means that pod association will not work for existing pods. You can enable cri using --enable-cri")
+		m.resolver = newCgfsResolver(m)
+		logger.GetLogger().Info("cgidmap is enabled but cri is not. Pod association for existing pods will use best-effort cgroupfs scanning. For authoritative resolution, enable cri using --enable-cri")
 	}
-	m.resolver = resolver
 	return m, nil
 }
 
@@ -239,9 +238,7 @@ func (m *cgidm) Update(podID PodID, contIDs []ContainerID) {
 			contID: id,
 		})
 	}
-	if m.resolver != nil {
-		m.resolver.enqueue(unmappedIDs)
-	}
+	m.resolver.enqueue(unmappedIDs)
 }
 
 // Global state

--- a/pkg/cgidmap/cgidmap.go
+++ b/pkg/cgidmap/cgidmap.go
@@ -77,7 +77,7 @@ type cgidm struct {
 	log logger.FieldLogger
 	*logger.DebugLogger
 
-	criResolver *criResolver
+	resolver *resolver
 }
 
 func newMap() (*cgidm, error) {
@@ -91,13 +91,13 @@ func newMap() (*cgidm, error) {
 		DebugLogger: logger.NewDebugLogger(log, option.Config.EnableCgIDmapDebug),
 	}
 
-	var criResolver *criResolver
+	var resolver *resolver
 	if option.Config.EnableCRI {
-		criResolver = newCriResolver(m)
+		resolver = newCriResolver(m)
 	} else {
 		logger.GetLogger().Warn("cgidmap is enabled but cri is not. This means that pod association will not work for existing pods. You can enable cri using --enable-cri")
 	}
-	m.criResolver = criResolver
+	m.resolver = resolver
 	return m, nil
 }
 
@@ -220,7 +220,7 @@ func (m *cgidm) Update(podID PodID, contIDs []ContainerID) {
 		return
 	}
 
-	// schedule unmapped ids to be resolved by the CRI resolver
+	// schedule unmapped ids to be resolved by the async resolver
 	unmappedIDs := make([]unmappedID, 0, len(tmp))
 	for id := range tmp {
 		unmappedIDs = append(unmappedIDs, unmappedID{
@@ -228,8 +228,8 @@ func (m *cgidm) Update(podID PodID, contIDs []ContainerID) {
 			contID: id,
 		})
 	}
-	if m.criResolver != nil {
-		m.criResolver.enqeue(unmappedIDs)
+	if m.resolver != nil {
+		m.resolver.enqueue(unmappedIDs)
 	}
 }
 

--- a/pkg/cgidmap/cgidmap.go
+++ b/pkg/cgidmap/cgidmap.go
@@ -101,6 +101,17 @@ func newMap() (*cgidm, error) {
 	return m, nil
 }
 
+// cgTrackerAdd registers a resolved container cgroup path with the cgroup
+// tracker. The tracker map only exists when cgroup tracker ids are enabled (see
+// cgtracker.RegisterCgroupTracker), so without them registration is skipped:
+// otherwise the resolver would block on a map that is never created.
+func cgTrackerAdd(path string) error {
+	if !option.Config.EnableCgTrackerID {
+		return nil
+	}
+	return cgtracker.AddCgroupTrackerPath(path)
+}
+
 // addEntryAllocID allocates space for a new entry, adds it, and returns its id
 func (m *cgidm) addEntryAllocID(e entry) int {
 	l := len(m.entries)

--- a/pkg/cgidmap/cri.go
+++ b/pkg/cgidmap/cri.go
@@ -6,140 +6,40 @@
 package cgidmap
 
 import (
-	"container/list"
 	"context"
 	"path/filepath"
-	"sync"
 
 	"github.com/cilium/tetragon/pkg/cgroups"
-	"github.com/cilium/tetragon/pkg/cgtracker"
 	"github.com/cilium/tetragon/pkg/cri"
-	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/metrics/crimetrics"
-	"github.com/cilium/tetragon/pkg/option"
 )
 
-// code for resolving missing cgroup ids by quering the CRI
+// code for resolving missing cgroup ids by querying the CRI. Talking to the CRI
+// provides authoritative answers and is used when --enable-cri is set.
 
-const (
-	// if, for whatever reason, we cannot talk to the CRI we dont want the queue to grow
-	// unbounded. Hence, we only keep the last 128 unresolved ids added. If we manage to catch
-	// up, subsequent sync updates from the pod hooks will ensure that the ids that were dropped
-	// will be added if they are still alive.
-	maxUnmappedIDs = 128
-)
-
-type criResolver struct {
-	mu   sync.Mutex
-	cond sync.Cond
-	// unresolvedIDs implements a LIFO for unresolved IDs.
-	unresolvedIDs *list.List
+// newCriResolver returns a resolver that finds container cgroup paths via the CRI.
+func newCriResolver(m Map) *resolver {
+	return newResolver(m, criContainerPath,
+		crimetrics.CriResolutionsTotal, crimetrics.CriResolutionErrorsTotal)
 }
 
-type unmappedID struct {
-	podID  PodID
-	contID ContainerID
-}
-
-func (c *criResolver) enqeue(unmappedIDs []unmappedID) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	defer c.cond.Signal()
-
-	// unmapped ids to be enqueued are larger than our capacity. Create a new list and add as
-	// many as we  can.
-	if len(unmappedIDs) >= maxUnmappedIDs {
-		newL := list.New()
-		for _, id := range unmappedIDs[:maxUnmappedIDs] {
-			newL.PushFront(id)
-		}
-		c.unresolvedIDs = newL
-		return
-	}
-
-	// remove IDs from the end that for which we don't have the capacity
-	newCnt := len(unmappedIDs) + c.unresolvedIDs.Len()
-	if newCnt > maxUnmappedIDs {
-		for range newCnt - maxUnmappedIDs {
-			c.unresolvedIDs.Remove(c.unresolvedIDs.Back())
-		}
-	}
-
-	for _, id := range unmappedIDs {
-		c.unresolvedIDs.PushFront(id)
-	}
-}
-
-func criResolve(m Map, id unmappedID) error {
-	contID := id.contID
-
+// criContainerPath returns the absolute host cgroup path for a container by querying the CRI.
+func criContainerPath(id unmappedID) (string, error) {
 	ctx := context.Background()
 	cli, err := cri.GetClient(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	cgPath, err := cri.CgroupPath(ctx, cli, contID)
+	cgPath, err := cri.CgroupPath(ctx, cli, id.contID)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cgRoot, err := cgroups.HostCgroupRoot()
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	var getCgroupID func(string) (uint64, error)
-	if option.Config.EnableCgTrackerID {
-		getCgroupID = cgroups.GetCgroupIdFromPath
-	} else {
-		getCgroupID = cgroups.GetCgroupIDFromSubCgroup
-	}
-
-	path := filepath.Join(cgRoot, cgPath)
-	cgID, err := getCgroupID(path)
-	if err != nil {
-		return err
-	}
-
-	if err := cgtracker.AddCgroupTrackerPath(path); err != nil {
-		logger.GetLogger().Warn("failed to add path to cgroup tracker", "cri-resolve", true, logfields.Error, err)
-	}
-	m.Add(id.podID, id.contID, cgID)
-	return nil
-}
-
-func newCriResolver(m Map) *criResolver {
-	ret := &criResolver{
-		unresolvedIDs: list.New(),
-	}
-	ret.cond.L = &ret.mu
-
-	go func() {
-		ret.mu.Lock()
-		defer ret.mu.Unlock()
-
-		for {
-			for ret.unresolvedIDs.Len() == 0 {
-				ret.cond.Wait()
-			}
-
-			// grab one container id and try to resolve it
-			elem := ret.unresolvedIDs.Front()
-			ret.unresolvedIDs.Remove(elem)
-			ret.mu.Unlock()
-			id := elem.Value.(unmappedID)
-			err := criResolve(m, id)
-			if err != nil {
-				crimetrics.CriResolutionErrorsTotal.WithLabelValues().Inc()
-				logger.GetLogger().Warn("criResolve failed", logfields.Error, err)
-			}
-			crimetrics.CriResolutionsTotal.WithLabelValues().Inc()
-			ret.mu.Lock()
-		}
-
-	}()
-
-	return ret
+	return filepath.Join(cgRoot, cgPath), nil
 }

--- a/pkg/cgidmap/cri.go
+++ b/pkg/cgidmap/cri.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/tetragon/pkg/cgroups"
-	"github.com/cilium/tetragon/pkg/cgtracker"
 	"github.com/cilium/tetragon/pkg/cri"
 	"github.com/cilium/tetragon/pkg/metrics/crimetrics"
 )
@@ -20,7 +19,7 @@ import (
 
 // newCriResolver returns a resolver that finds container cgroup paths via the CRI.
 func newCriResolver(m Map) *resolver {
-	return newResolver(m, criContainerPath, cgtracker.AddCgroupTrackerPath,
+	return newResolver(m, criContainerPath, cgTrackerAdd,
 		crimetrics.CriResolutionsTotal, crimetrics.CriResolutionErrorsTotal)
 }
 

--- a/pkg/cgidmap/cri.go
+++ b/pkg/cgidmap/cri.go
@@ -6,140 +6,41 @@
 package cgidmap
 
 import (
-	"container/list"
 	"context"
 	"path/filepath"
-	"sync"
 
 	"github.com/cilium/tetragon/pkg/cgroups"
 	"github.com/cilium/tetragon/pkg/cgtracker"
 	"github.com/cilium/tetragon/pkg/cri"
-	"github.com/cilium/tetragon/pkg/logger"
-	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/metrics/crimetrics"
-	"github.com/cilium/tetragon/pkg/option"
 )
 
-// code for resolving missing cgroup ids by quering the CRI
+// code for resolving missing cgroup ids by querying the CRI. Talking to the CRI
+// provides authoritative answers and is used when --enable-cri is set.
 
-const (
-	// if, for whatever reason, we cannot talk to the CRI we dont want the queue to grow
-	// unbounded. Hence, we only keep the last 128 unresolved ids added. If we manage to catch
-	// up, subsequent sync updates from the pod hooks will ensure that the ids that were dropped
-	// will be added if they are still alive.
-	maxUnmappedIDs = 128
-)
-
-type criResolver struct {
-	mu   sync.Mutex
-	cond sync.Cond
-	// unresolvedIDs implements a LIFO for unresolved IDs.
-	unresolvedIDs *list.List
+// newCriResolver returns a resolver that finds container cgroup paths via the CRI.
+func newCriResolver(m Map) *resolver {
+	return newResolver(m, criContainerPath, cgtracker.AddCgroupTrackerPath,
+		crimetrics.CriResolutionsTotal, crimetrics.CriResolutionErrorsTotal)
 }
 
-type unmappedID struct {
-	podID  PodID
-	contID ContainerID
-}
-
-func (c *criResolver) enqeue(unmappedIDs []unmappedID) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	defer c.cond.Signal()
-
-	// unmapped ids to be enqueued are larger than our capacity. Create a new list and add as
-	// many as we  can.
-	if len(unmappedIDs) >= maxUnmappedIDs {
-		newL := list.New()
-		for _, id := range unmappedIDs[:maxUnmappedIDs] {
-			newL.PushFront(id)
-		}
-		c.unresolvedIDs = newL
-		return
-	}
-
-	// remove IDs from the end that for which we don't have the capacity
-	newCnt := len(unmappedIDs) + c.unresolvedIDs.Len()
-	if newCnt > maxUnmappedIDs {
-		for range newCnt - maxUnmappedIDs {
-			c.unresolvedIDs.Remove(c.unresolvedIDs.Back())
-		}
-	}
-
-	for _, id := range unmappedIDs {
-		c.unresolvedIDs.PushFront(id)
-	}
-}
-
-func criResolve(m Map, id unmappedID) error {
-	contID := id.contID
-
+// criContainerPath returns the absolute host cgroup path for a container by querying the CRI.
+func criContainerPath(id unmappedID) (string, error) {
 	ctx := context.Background()
 	cli, err := cri.GetClient(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	cgPath, err := cri.CgroupPath(ctx, cli, contID)
+	cgPath, err := cri.CgroupPath(ctx, cli, id.contID)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cgRoot, err := cgroups.HostCgroupRoot()
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	var getCgroupID func(string) (uint64, error)
-	if option.Config.EnableCgTrackerID {
-		getCgroupID = cgroups.GetCgroupIdFromPath
-	} else {
-		getCgroupID = cgroups.GetCgroupIDFromSubCgroup
-	}
-
-	path := filepath.Join(cgRoot, cgPath)
-	cgID, err := getCgroupID(path)
-	if err != nil {
-		return err
-	}
-
-	if err := cgtracker.AddCgroupTrackerPath(path); err != nil {
-		logger.GetLogger().Warn("failed to add path to cgroup tracker", "cri-resolve", true, logfields.Error, err)
-	}
-	m.Add(id.podID, id.contID, cgID)
-	return nil
-}
-
-func newCriResolver(m Map) *criResolver {
-	ret := &criResolver{
-		unresolvedIDs: list.New(),
-	}
-	ret.cond.L = &ret.mu
-
-	go func() {
-		ret.mu.Lock()
-		defer ret.mu.Unlock()
-
-		for {
-			for ret.unresolvedIDs.Len() == 0 {
-				ret.cond.Wait()
-			}
-
-			// grab one container id and try to resolve it
-			elem := ret.unresolvedIDs.Front()
-			ret.unresolvedIDs.Remove(elem)
-			ret.mu.Unlock()
-			id := elem.Value.(unmappedID)
-			err := criResolve(m, id)
-			if err != nil {
-				crimetrics.CriResolutionErrorsTotal.WithLabelValues().Inc()
-				logger.GetLogger().Warn("criResolve failed", logfields.Error, err)
-			}
-			crimetrics.CriResolutionsTotal.WithLabelValues().Inc()
-			ret.mu.Lock()
-		}
-
-	}()
-
-	return ret
+	return filepath.Join(cgRoot, cgPath), nil
 }

--- a/pkg/cgidmap/fsscan.go
+++ b/pkg/cgidmap/fsscan.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows && !nok8s
+
+package cgidmap
+
+import (
+	"errors"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/tetragon/pkg/cgroups/fsscan"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/metrics/crimetrics"
+)
+
+// newCgfsResolver returns a resolver that finds container cgroup paths by scanning
+// the cgroup filesystem.
+func newCgfsResolver(m Map) *resolver {
+	scanner := fsscan.New()
+	return newResolver(m, cgfsContainerPath(scanner),
+		crimetrics.CgfsResolutionsTotal, crimetrics.CgfsResolutionErrorsTotal)
+}
+
+// cgfsContainerPath returns a containerPathFn that resolves a container's cgroup
+// path by scanning the cgroup filesystem. The scanner is not safe for concurrent
+// use, but the resolver drives it from a single worker goroutine.
+func cgfsContainerPath(scanner fsscan.FsScanner) containerPathFn {
+	return func(id unmappedID) (string, error) {
+		path, err := scanner.FindContainerPath(types.UID(id.podID.String()), id.contID)
+		// The container cgroup was found but its parent pod directory did not
+		// match. Treat this as a soft hit and use the path, as policyfilter does.
+		// Warn because the match is unverified and drives pod association.
+		if errors.Is(err, fsscan.ErrContainerPathWithoutMatchingPodID) {
+			logger.GetLogger().Warn("cgidmap cgroupfs scan: found path without matching pod id, continuing",
+				"pod-id", id.podID, "container-id", id.contID)
+			return path, nil
+		}
+		return path, err
+	}
+}

--- a/pkg/cgidmap/fsscan.go
+++ b/pkg/cgidmap/fsscan.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows && !nok8s
+
+package cgidmap
+
+import (
+	"errors"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/tetragon/pkg/cgroups/fsscan"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/metrics/crimetrics"
+)
+
+// newCgfsResolver returns a resolver that finds container cgroup paths by scanning
+// the cgroup filesystem.
+func newCgfsResolver(m Map) *resolver {
+	scanner := fsscan.New()
+	return newResolver(m, cgfsContainerPath(scanner), cgTrackerAdd,
+		crimetrics.CgfsResolutionsTotal, crimetrics.CgfsResolutionErrorsTotal)
+}
+
+// cgfsContainerPath returns a containerPathFn that resolves a container's cgroup
+// path by scanning the cgroup filesystem. The scanner is not safe for concurrent
+// use, but the resolver drives it from a single worker goroutine.
+func cgfsContainerPath(scanner fsscan.FsScanner) containerPathFn {
+	return func(id unmappedID) (string, error) {
+		path, err := scanner.FindContainerPath(types.UID(id.podID.String()), id.contID)
+		// The container cgroup was found but its parent pod directory did not
+		// match. Treat this as a soft hit and use the path, as policyfilter does.
+		// Warn because the match is unverified and drives pod association.
+		if errors.Is(err, fsscan.ErrContainerPathWithoutMatchingPodID) {
+			logger.GetLogger().Warn("cgidmap cgroupfs scan: found path without matching pod id, continuing",
+				"pod-id", id.podID, "container-id", id.contID)
+			return path, nil
+		}
+		return path, err
+	}
+}

--- a/pkg/cgidmap/fsscan_test.go
+++ b/pkg/cgidmap/fsscan_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows && !nok8s
+
+package cgidmap
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/tetragon/pkg/cgroups/fsscan"
+)
+
+type mockScanner struct {
+	path string
+	err  error
+}
+
+func (m mockScanner) FindContainerPath(types.UID, string) (string, error) { return m.path, m.err }
+func (m mockScanner) FindPodPath(types.UID) (string, error)               { return "", nil }
+
+func TestCgfsContainerPath(t *testing.T) {
+	id := unmappedID{podID: uuid.New(), contID: "cont-abc"}
+
+	t.Run("found", func(t *testing.T) {
+		fn := cgfsContainerPath(mockScanner{path: "/sys/fs/cgroup/pod/cont", err: nil})
+		path, err := fn(id)
+		require.NoError(t, err)
+		require.Equal(t, "/sys/fs/cgroup/pod/cont", path)
+	})
+
+	t.Run("soft hit without matching pod id is used", func(t *testing.T) {
+		fn := cgfsContainerPath(mockScanner{path: "/sys/fs/cgroup/pod/cont", err: fsscan.ErrContainerPathWithoutMatchingPodID})
+		path, err := fn(id)
+		require.NoError(t, err)
+		require.Equal(t, "/sys/fs/cgroup/pod/cont", path)
+	})
+
+	t.Run("hard error is propagated", func(t *testing.T) {
+		wantErr := errors.New("not found")
+		fn := cgfsContainerPath(mockScanner{path: "", err: wantErr})
+		path, err := fn(id)
+		require.ErrorIs(t, err, wantErr)
+		require.Empty(t, path)
+	})
+}

--- a/pkg/cgidmap/resolver.go
+++ b/pkg/cgidmap/resolver.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows && !nok8s
+
+package cgidmap
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/cilium/tetragon/pkg/cgroups"
+	"github.com/cilium/tetragon/pkg/cgtracker"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/logger/logfields"
+	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/option"
+)
+
+// asynchronous resolution of unmapped container ids to cgroup ids. The queue and
+// worker are backend-agnostic; a backend only provides a containerPathFn (how to
+// find a container's cgroup path) and metric counters.
+
+const (
+	// if, for whatever reason, we cannot resolve ids we dont want the queue to grow
+	// unbounded. Hence, we only keep the last 128 unresolved ids added. If we manage to catch
+	// up, subsequent sync updates from the pod hooks will ensure that the ids that were dropped
+	// will be added if they are still alive.
+	maxUnmappedIDs = 128
+)
+
+type unmappedID struct {
+	podID  PodID
+	contID ContainerID
+}
+
+// containerPathFn returns the absolute host cgroup path for a container. It is the
+// only part of resolution that differs between the CRI and cgroupfs backends.
+type containerPathFn func(unmappedID) (string, error)
+
+type resolver struct {
+	mu   sync.Mutex
+	cond sync.Cond
+	// unresolvedIDs holds pending ids, oldest first; the worker pops the
+	// newest from the end (LIFO).
+	unresolvedIDs []unmappedID
+
+	m             Map
+	containerPath containerPathFn
+	// getCgroupID derives the cgroup id from a path. The choice depends only
+	// on how cgidmap keys its map (EnableCgTrackerID), not on the backend.
+	getCgroupID func(string) (uint64, error)
+	attempted   *metrics.Counter
+	errored     *metrics.Counter
+}
+
+func newResolver(m Map, containerPath containerPathFn, attempted, errored *metrics.Counter) *resolver {
+	getCgroupID := cgroups.GetCgroupIDFromSubCgroup
+	if option.Config.EnableCgTrackerID {
+		getCgroupID = cgroups.GetCgroupIdFromPath
+	}
+	ret := &resolver{
+		m:             m,
+		containerPath: containerPath,
+		getCgroupID:   getCgroupID,
+		attempted:     attempted,
+		errored:       errored,
+	}
+	ret.cond.L = &ret.mu
+
+	go func() {
+		ret.mu.Lock()
+		defer ret.mu.Unlock()
+
+		for {
+			for len(ret.unresolvedIDs) == 0 {
+				ret.cond.Wait()
+			}
+
+			// grab the most recently added id and try to resolve it
+			id := ret.unresolvedIDs[len(ret.unresolvedIDs)-1]
+			ret.unresolvedIDs = ret.unresolvedIDs[:len(ret.unresolvedIDs)-1]
+			ret.mu.Unlock()
+			if err := ret.resolve(id); err != nil {
+				ret.errored.WithLabelValues().Inc()
+				logger.GetLogger().Warn("cgidmap resolve failed",
+					"pod-id", id.podID, "container-id", id.contID, logfields.Error, err)
+			}
+			ret.attempted.WithLabelValues().Inc()
+			ret.mu.Lock()
+		}
+	}()
+
+	return ret
+}
+
+func (r *resolver) enqueue(unmappedIDs []unmappedID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	defer r.cond.Signal()
+
+	// pod updates can repeat ids that are still waiting for resolution; skip
+	// them so duplicates do not evict other pending ids.
+	for _, id := range unmappedIDs {
+		if slices.Contains(r.unresolvedIDs, id) {
+			continue
+		}
+		r.unresolvedIDs = append(r.unresolvedIDs, id)
+	}
+	// drop the oldest ids over capacity. Dropped ids that are still alive get
+	// re-added by subsequent pod hook sync updates.
+	if dropped := len(r.unresolvedIDs) - maxUnmappedIDs; dropped > 0 {
+		r.unresolvedIDs = slices.Delete(r.unresolvedIDs, 0, dropped)
+		logger.GetLogger().Debug("cgidmap resolver queue is full, dropped oldest unresolved ids", "dropped", dropped)
+	}
+}
+
+// resolve finds the cgroup id for an unmapped container and adds it to the map. The
+// backend-specific part (finding the cgroup path) is provided by containerPath.
+func (r *resolver) resolve(id unmappedID) error {
+	path, err := r.containerPath(id)
+	if err != nil {
+		return fmt.Errorf("find container path: %w", err)
+	}
+
+	cgID, err := r.getCgroupID(path)
+	if err != nil {
+		return fmt.Errorf("get cgroup id: %w", err)
+	}
+
+	if err := cgtracker.AddCgroupTrackerPath(path); err != nil {
+		logger.GetLogger().Warn("failed to add path to cgroup tracker", "cgidmap-resolve", true, logfields.Error, err)
+	}
+	r.m.Add(id.podID, id.contID, cgID)
+	return nil
+}

--- a/pkg/cgidmap/resolver.go
+++ b/pkg/cgidmap/resolver.go
@@ -6,8 +6,8 @@
 package cgidmap
 
 import (
-	"container/list"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/cilium/tetragon/pkg/cgroups"
@@ -41,9 +41,10 @@ type containerPathFn func(unmappedID) (string, error)
 type resolver struct {
 	mu   sync.Mutex
 	cond sync.Cond
-	// unresolvedIDs implements a LIFO for unresolved IDs: a recent request is
-	// more likely to still reflect the current state of the pod than an old one.
-	unresolvedIDs *list.List
+	// unresolvedIDs holds pending ids, oldest first; the worker pops the
+	// newest from the end (LIFO), because a recent request is more likely to
+	// still reflect the current state of the pod than an old one.
+	unresolvedIDs []unmappedID
 
 	m             Map
 	containerPath containerPathFn
@@ -63,7 +64,6 @@ func newResolver(m Map, containerPath containerPathFn, addCgTrackerPath func(str
 		getCgroupID = cgroups.GetCgroupIdFromPath
 	}
 	ret := &resolver{
-		unresolvedIDs:    list.New(),
 		m:                m,
 		containerPath:    containerPath,
 		getCgroupID:      getCgroupID,
@@ -78,15 +78,14 @@ func newResolver(m Map, containerPath containerPathFn, addCgTrackerPath func(str
 		defer ret.mu.Unlock()
 
 		for {
-			for ret.unresolvedIDs.Len() == 0 {
+			for len(ret.unresolvedIDs) == 0 {
 				ret.cond.Wait()
 			}
 
-			// grab one container id and try to resolve it
-			elem := ret.unresolvedIDs.Front()
-			ret.unresolvedIDs.Remove(elem)
+			// grab the most recently added id and try to resolve it
+			id := ret.unresolvedIDs[len(ret.unresolvedIDs)-1]
+			ret.unresolvedIDs = ret.unresolvedIDs[:len(ret.unresolvedIDs)-1]
 			ret.mu.Unlock()
-			id := elem.Value.(unmappedID)
 			if err := ret.resolve(id); err != nil {
 				ret.errored.WithLabelValues().Inc()
 				logger.GetLogger().Warn("cgidmap resolve failed",
@@ -105,27 +104,19 @@ func (r *resolver) enqueue(unmappedIDs []unmappedID) {
 	defer r.mu.Unlock()
 	defer r.cond.Signal()
 
-	// unmapped ids to be enqueued are larger than our capacity. Create a new list and add as
-	// many as we  can.
-	if len(unmappedIDs) >= maxUnmappedIDs {
-		newL := list.New()
-		for _, id := range unmappedIDs[:maxUnmappedIDs] {
-			newL.PushFront(id)
-		}
-		r.unresolvedIDs = newL
-		return
-	}
-
-	// remove IDs from the end that for which we don't have the capacity
-	newCnt := len(unmappedIDs) + r.unresolvedIDs.Len()
-	if newCnt > maxUnmappedIDs {
-		for range newCnt - maxUnmappedIDs {
-			r.unresolvedIDs.Remove(r.unresolvedIDs.Back())
-		}
-	}
-
+	// pod updates can repeat ids that are still waiting for resolution; skip
+	// them so duplicates do not evict other pending ids.
 	for _, id := range unmappedIDs {
-		r.unresolvedIDs.PushFront(id)
+		if slices.Contains(r.unresolvedIDs, id) {
+			continue
+		}
+		r.unresolvedIDs = append(r.unresolvedIDs, id)
+	}
+	// drop the oldest ids over capacity. Dropped ids that are still alive get
+	// re-added by subsequent pod hook sync updates.
+	if dropped := len(r.unresolvedIDs) - maxUnmappedIDs; dropped > 0 {
+		r.unresolvedIDs = slices.Delete(r.unresolvedIDs, 0, dropped)
+		logger.GetLogger().Debug("cgidmap resolver queue is full, dropped oldest unresolved ids", "dropped", dropped)
 	}
 }
 

--- a/pkg/cgidmap/resolver.go
+++ b/pkg/cgidmap/resolver.go
@@ -35,7 +35,7 @@ type unmappedID struct {
 }
 
 // containerPathFn returns the absolute host cgroup path for a container. It is the
-// only part of resolution that differs between backends.
+// only part of resolution that differs between the CRI and cgroupfs backends.
 type containerPathFn func(unmappedID) (string, error)
 
 type resolver struct {

--- a/pkg/cgidmap/resolver.go
+++ b/pkg/cgidmap/resolver.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows && !nok8s
+
+package cgidmap
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	"github.com/cilium/tetragon/pkg/cgroups"
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/logger/logfields"
+	"github.com/cilium/tetragon/pkg/metrics"
+	"github.com/cilium/tetragon/pkg/option"
+)
+
+// asynchronous resolution of unmapped container ids to cgroup ids. The queue and
+// worker are backend-agnostic; a backend only provides a containerPathFn (how to
+// find a container's cgroup path) and metric counters.
+
+const (
+	// if, for whatever reason, we cannot resolve ids we dont want the queue to grow
+	// unbounded. Hence, we only keep the last 128 unresolved ids added. If we manage to catch
+	// up, subsequent sync updates from the pod hooks will ensure that the ids that were dropped
+	// will be added if they are still alive.
+	maxUnmappedIDs = 128
+)
+
+type unmappedID struct {
+	podID  PodID
+	contID ContainerID
+}
+
+// containerPathFn returns the absolute host cgroup path for a container. It is the
+// only part of resolution that differs between backends.
+type containerPathFn func(unmappedID) (string, error)
+
+type resolver struct {
+	mu   sync.Mutex
+	cond sync.Cond
+	// unresolvedIDs implements a LIFO for unresolved IDs: a recent request is
+	// more likely to still reflect the current state of the pod than an old one.
+	unresolvedIDs *list.List
+
+	m             Map
+	containerPath containerPathFn
+	// getCgroupID derives the cgroup id from a path. The choice depends only
+	// on how cgidmap keys its map (EnableCgTrackerID), not on the backend.
+	getCgroupID func(string) (uint64, error)
+	// addCgTrackerPath registers a resolved path with the cgroup tracker.
+	addCgTrackerPath func(string) error
+	attempted        *metrics.Counter
+	errored          *metrics.Counter
+}
+
+func newResolver(m Map, containerPath containerPathFn, addCgTrackerPath func(string) error,
+	attempted, errored *metrics.Counter) *resolver {
+	getCgroupID := cgroups.GetCgroupIDFromSubCgroup
+	if option.Config.EnableCgTrackerID {
+		getCgroupID = cgroups.GetCgroupIdFromPath
+	}
+	ret := &resolver{
+		unresolvedIDs:    list.New(),
+		m:                m,
+		containerPath:    containerPath,
+		getCgroupID:      getCgroupID,
+		addCgTrackerPath: addCgTrackerPath,
+		attempted:        attempted,
+		errored:          errored,
+	}
+	ret.cond.L = &ret.mu
+
+	go func() {
+		ret.mu.Lock()
+		defer ret.mu.Unlock()
+
+		for {
+			for ret.unresolvedIDs.Len() == 0 {
+				ret.cond.Wait()
+			}
+
+			// grab one container id and try to resolve it
+			elem := ret.unresolvedIDs.Front()
+			ret.unresolvedIDs.Remove(elem)
+			ret.mu.Unlock()
+			id := elem.Value.(unmappedID)
+			if err := ret.resolve(id); err != nil {
+				ret.errored.WithLabelValues().Inc()
+				logger.GetLogger().Warn("cgidmap resolve failed",
+					"pod-id", id.podID, "container-id", id.contID, logfields.Error, err)
+			}
+			ret.attempted.WithLabelValues().Inc()
+			ret.mu.Lock()
+		}
+	}()
+
+	return ret
+}
+
+func (r *resolver) enqueue(unmappedIDs []unmappedID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	defer r.cond.Signal()
+
+	// unmapped ids to be enqueued are larger than our capacity. Create a new list and add as
+	// many as we  can.
+	if len(unmappedIDs) >= maxUnmappedIDs {
+		newL := list.New()
+		for _, id := range unmappedIDs[:maxUnmappedIDs] {
+			newL.PushFront(id)
+		}
+		r.unresolvedIDs = newL
+		return
+	}
+
+	// remove IDs from the end that for which we don't have the capacity
+	newCnt := len(unmappedIDs) + r.unresolvedIDs.Len()
+	if newCnt > maxUnmappedIDs {
+		for range newCnt - maxUnmappedIDs {
+			r.unresolvedIDs.Remove(r.unresolvedIDs.Back())
+		}
+	}
+
+	for _, id := range unmappedIDs {
+		r.unresolvedIDs.PushFront(id)
+	}
+}
+
+// resolve finds the cgroup id for an unmapped container and adds it to the map. The
+// backend-specific part (finding the cgroup path) is provided by containerPath.
+func (r *resolver) resolve(id unmappedID) error {
+	path, err := r.containerPath(id)
+	if err != nil {
+		return fmt.Errorf("find container path: %w", err)
+	}
+
+	cgID, err := r.getCgroupID(path)
+	if err != nil {
+		return fmt.Errorf("get cgroup id: %w", err)
+	}
+
+	if err := r.addCgTrackerPath(path); err != nil {
+		logger.GetLogger().Warn("failed to add path to cgroup tracker", "cgidmap-resolve", true, logfields.Error, err)
+	}
+	r.m.Add(id.podID, id.contID, cgID)
+	return nil
+}

--- a/pkg/cgidmap/resolver_test.go
+++ b/pkg/cgidmap/resolver_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows && !nok8s
+
+package cgidmap
+
+import (
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/tetragon/pkg/metrics"
+)
+
+// drain returns the queued ids in the order the worker would resolve them
+// (newest first), emptying the queue.
+func drain(r *resolver) []unmappedID {
+	got := drainOldestLast(r)
+	slices.Reverse(got)
+	return got
+}
+
+// drainOldestLast drains the queue and returns the ids in enqueue order
+// (oldest first), so it can be compared against the expected surviving window.
+func drainOldestLast(r *resolver) []unmappedID {
+	got := r.unresolvedIDs
+	r.unresolvedIDs = nil
+	return got
+}
+
+func mkIDs(n int) []unmappedID {
+	ret := make([]unmappedID, 0, n)
+	for range n {
+		ret = append(ret, unmappedID{podID: uuid.New(), contID: ContainerID(uuid.New().String())})
+	}
+	return ret
+}
+
+func TestResolverEnqueueLIFO(t *testing.T) {
+	r := &resolver{}
+	ids := mkIDs(3)
+	r.enqueue(ids)
+
+	// the worker pops the newest first, so the last id enqueued is drained first.
+	got := drain(r)
+	require.Equal(t, []unmappedID{ids[2], ids[1], ids[0]}, got)
+}
+
+func TestResolverEnqueueOverCapacity(t *testing.T) {
+	r := &resolver{}
+	// a single batch larger than capacity keeps only the most recent maxUnmappedIDs.
+	ids := mkIDs(maxUnmappedIDs + 50)
+	r.enqueue(ids)
+	require.Len(t, r.unresolvedIDs, maxUnmappedIDs)
+	require.Equal(t, ids[len(ids)-maxUnmappedIDs:], drainOldestLast(r))
+}
+
+func TestResolverEnqueueDedup(t *testing.T) {
+	r := &resolver{}
+	ids := mkIDs(3)
+	r.enqueue(ids)
+	// re-enqueueing a pending id (e.g. from a repeated pod update) must not add
+	// a duplicate that would evict other pending ids.
+	r.enqueue(ids[1:2])
+	require.Len(t, r.unresolvedIDs, len(ids))
+	require.Equal(t, ids, drainOldestLast(r))
+}
+
+func TestResolverEnqueueTrimsOldest(t *testing.T) {
+	r := &resolver{}
+	a := mkIDs(100)
+	b := mkIDs(50)
+	r.enqueue(a)
+	// 100 + 50 = 150 > capacity, so the oldest ids are trimmed to keep the newest 128.
+	r.enqueue(b)
+	require.Len(t, r.unresolvedIDs, maxUnmappedIDs)
+
+	all := append(append([]unmappedID{}, a...), b...)
+	require.Equal(t, all[len(all)-maxUnmappedIDs:], drainOldestLast(r))
+}
+
+// fakeMap records Add calls so resolve() can be exercised without a real cgidmap.
+type fakeMap struct {
+	mu    sync.Mutex
+	added []unmappedID
+	cgIDs []CgroupID
+}
+
+func (f *fakeMap) Get(CgroupID) (ContainerID, bool) { return "", false }
+func (f *fakeMap) Update(PodID, []ContainerID)      {}
+func (f *fakeMap) Add(podID PodID, contID ContainerID, cgID CgroupID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.added = append(f.added, unmappedID{podID: podID, contID: contID})
+	f.cgIDs = append(f.cgIDs, cgID)
+}
+
+// addedIDs returns a snapshot of the recorded Add calls, safe to call while a
+// resolver worker is running.
+func (f *fakeMap) addedIDs() []unmappedID {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.added)
+}
+
+func TestResolve(t *testing.T) {
+	id := unmappedID{podID: uuid.New(), contID: "cont-abc"}
+
+	t.Run("adds resolved cgroup id", func(t *testing.T) {
+		fm := &fakeMap{}
+		r := &resolver{
+			m:             fm,
+			containerPath: func(unmappedID) (string, error) { return "/sys/fs/cgroup/pod/cont", nil },
+			getCgroupID:   func(string) (uint64, error) { return 4242, nil },
+		}
+		require.NoError(t, r.resolve(id))
+		require.Equal(t, []unmappedID{id}, fm.added)
+		require.Equal(t, []CgroupID{4242}, fm.cgIDs)
+	})
+
+	t.Run("containerPath error short-circuits before Add", func(t *testing.T) {
+		wantErr := errors.New("no path")
+		fm := &fakeMap{}
+		r := &resolver{
+			m:             fm,
+			containerPath: func(unmappedID) (string, error) { return "", wantErr },
+			getCgroupID:   func(string) (uint64, error) { return 4242, nil },
+		}
+		require.ErrorIs(t, r.resolve(id), wantErr)
+		require.Empty(t, fm.added)
+	})
+
+	t.Run("getCgroupID error short-circuits before Add", func(t *testing.T) {
+		wantErr := errors.New("bad cgroup path")
+		fm := &fakeMap{}
+		r := &resolver{
+			m:             fm,
+			containerPath: func(unmappedID) (string, error) { return "/some/path", nil },
+			getCgroupID:   func(string) (uint64, error) { return 0, wantErr },
+		}
+		require.ErrorIs(t, r.resolve(id), wantErr)
+		require.Empty(t, fm.added)
+	})
+}
+
+// testCounter returns a throwaway counter so tests do not touch the global
+// metric state.
+func testCounter(name string) *metrics.Counter {
+	return metrics.MustNewCounter(
+		metrics.NewOpts("test", "cgidmap", name, name, nil, nil, nil), nil)
+}
+
+func TestResolverWorker(t *testing.T) {
+	fm := &fakeMap{}
+	r := newResolver(fm, func(id unmappedID) (string, error) { return "/sys/fs/cgroup/pod/" + id.contID, nil },
+		testCounter("resolutions_total"), testCounter("resolution_errors_total"))
+	// avoid touching the real filesystem; the worker only reads this after
+	// dequeueing, so setting it before enqueue is safe.
+	r.getCgroupID = func(string) (uint64, error) { return 4242, nil }
+
+	ids := mkIDs(2)
+	r.enqueue(ids)
+	require.Eventually(t, func() bool { return len(fm.addedIDs()) == len(ids) },
+		5*time.Second, 10*time.Millisecond)
+	require.ElementsMatch(t, ids, fm.addedIDs())
+}

--- a/pkg/cgidmap/resolver_test.go
+++ b/pkg/cgidmap/resolver_test.go
@@ -18,12 +18,71 @@ import (
 	"github.com/cilium/tetragon/pkg/metrics"
 )
 
+// drain returns the queued ids in the order the worker would resolve them
+// (newest first), emptying the queue.
+func drain(r *resolver) []unmappedID {
+	got := drainOldestLast(r)
+	slices.Reverse(got)
+	return got
+}
+
+// drainOldestLast drains the queue and returns the ids in enqueue order
+// (oldest first), so it can be compared against the expected surviving window.
+func drainOldestLast(r *resolver) []unmappedID {
+	got := r.unresolvedIDs
+	r.unresolvedIDs = nil
+	return got
+}
+
 func mkIDs(n int) []unmappedID {
 	ret := make([]unmappedID, 0, n)
 	for range n {
 		ret = append(ret, unmappedID{podID: uuid.New(), contID: ContainerID(uuid.New().String())})
 	}
 	return ret
+}
+
+func TestResolverEnqueueLIFO(t *testing.T) {
+	r := &resolver{}
+	ids := mkIDs(3)
+	r.enqueue(ids)
+
+	// the worker pops the newest first, so the last id enqueued is drained first.
+	got := drain(r)
+	require.Equal(t, []unmappedID{ids[2], ids[1], ids[0]}, got)
+}
+
+func TestResolverEnqueueOverCapacity(t *testing.T) {
+	r := &resolver{}
+	// a single batch larger than capacity keeps only the most recent maxUnmappedIDs.
+	ids := mkIDs(maxUnmappedIDs + 50)
+	r.enqueue(ids)
+	require.Len(t, r.unresolvedIDs, maxUnmappedIDs)
+	require.Equal(t, ids[len(ids)-maxUnmappedIDs:], drainOldestLast(r))
+}
+
+func TestResolverEnqueueDedup(t *testing.T) {
+	r := &resolver{}
+	ids := mkIDs(3)
+	r.enqueue(ids)
+	// re-enqueueing a pending id (e.g. from a repeated pod update) must not add
+	// a duplicate that would evict other pending ids.
+	r.enqueue(ids[1:2])
+	require.Len(t, r.unresolvedIDs, len(ids))
+	require.Equal(t, ids, drainOldestLast(r))
+}
+
+func TestResolverEnqueueTrimsOldest(t *testing.T) {
+	r := &resolver{}
+	a := mkIDs(100)
+	b := mkIDs(50)
+	r.enqueue(a)
+	// 100 + 50 = 150 > capacity, so the oldest ids are trimmed to keep the newest 128.
+	r.enqueue(b)
+	require.Len(t, r.unresolvedIDs, maxUnmappedIDs)
+
+	all := append(append([]unmappedID{}, a...), b...)
+	require.Equal(t, all[len(all)-maxUnmappedIDs:], drainOldestLast(r))
 }
 
 // fakeMap records Add calls so resolve() can be exercised without a real cgidmap.

--- a/pkg/cgidmap/resolver_test.go
+++ b/pkg/cgidmap/resolver_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows && !nok8s
+
+package cgidmap
+
+import (
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/tetragon/pkg/metrics"
+)
+
+func mkIDs(n int) []unmappedID {
+	ret := make([]unmappedID, 0, n)
+	for range n {
+		ret = append(ret, unmappedID{podID: uuid.New(), contID: ContainerID(uuid.New().String())})
+	}
+	return ret
+}
+
+// fakeMap records Add calls so resolve() can be exercised without a real cgidmap.
+type fakeMap struct {
+	mu    sync.Mutex
+	added []unmappedID
+	cgIDs []CgroupID
+}
+
+func (f *fakeMap) Get(CgroupID) (ContainerID, bool) { return "", false }
+func (f *fakeMap) Update(PodID, []ContainerID)      {}
+func (f *fakeMap) Add(podID PodID, contID ContainerID, cgID CgroupID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.added = append(f.added, unmappedID{podID: podID, contID: contID})
+	f.cgIDs = append(f.cgIDs, cgID)
+}
+
+// addedIDs returns a snapshot of the recorded Add calls, safe to call while a
+// resolver worker is running.
+func (f *fakeMap) addedIDs() []unmappedID {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.added)
+}
+
+func TestResolve(t *testing.T) {
+	id := unmappedID{podID: uuid.New(), contID: "cont-abc"}
+
+	t.Run("adds resolved cgroup id", func(t *testing.T) {
+		fm := &fakeMap{}
+		r := &resolver{
+			m:                fm,
+			containerPath:    func(unmappedID) (string, error) { return "/sys/fs/cgroup/pod/cont", nil },
+			getCgroupID:      func(string) (uint64, error) { return 4242, nil },
+			addCgTrackerPath: func(string) error { return nil },
+		}
+		require.NoError(t, r.resolve(id))
+		require.Equal(t, []unmappedID{id}, fm.added)
+		require.Equal(t, []CgroupID{4242}, fm.cgIDs)
+	})
+
+	t.Run("containerPath error short-circuits before Add", func(t *testing.T) {
+		wantErr := errors.New("no path")
+		fm := &fakeMap{}
+		r := &resolver{
+			m:                fm,
+			containerPath:    func(unmappedID) (string, error) { return "", wantErr },
+			getCgroupID:      func(string) (uint64, error) { return 4242, nil },
+			addCgTrackerPath: func(string) error { return nil },
+		}
+		require.ErrorIs(t, r.resolve(id), wantErr)
+		require.Empty(t, fm.added)
+	})
+
+	t.Run("getCgroupID error short-circuits before Add", func(t *testing.T) {
+		wantErr := errors.New("bad cgroup path")
+		fm := &fakeMap{}
+		r := &resolver{
+			m:                fm,
+			containerPath:    func(unmappedID) (string, error) { return "/some/path", nil },
+			getCgroupID:      func(string) (uint64, error) { return 0, wantErr },
+			addCgTrackerPath: func(string) error { return nil },
+		}
+		require.ErrorIs(t, r.resolve(id), wantErr)
+		require.Empty(t, fm.added)
+	})
+}
+
+// testCounter returns a throwaway counter so tests do not touch the global
+// metric state.
+func testCounter(name string) *metrics.Counter {
+	return metrics.MustNewCounter(
+		metrics.NewOpts("test", "cgidmap", name, name, nil, nil, nil), nil)
+}
+
+func TestResolverWorker(t *testing.T) {
+	fm := &fakeMap{}
+	r := newResolver(fm, func(id unmappedID) (string, error) { return "/sys/fs/cgroup/pod/" + id.contID, nil },
+		func(string) error { return nil },
+		testCounter("resolutions_total"), testCounter("resolution_errors_total"))
+	// avoid touching the real filesystem; the worker only reads this after
+	// dequeueing, so setting it before enqueue is safe.
+	r.getCgroupID = func(string) (uint64, error) { return 4242, nil }
+
+	ids := mkIDs(2)
+	r.enqueue(ids)
+	require.Eventually(t, func() bool { return len(fm.addedIDs()) == len(ids) },
+		5*time.Second, 10*time.Millisecond)
+	require.ElementsMatch(t, ids, fm.addedIDs())
+}

--- a/pkg/cgroups/fsscan/fsscan.go
+++ b/pkg/cgroups/fsscan/fsscan.go
@@ -24,7 +24,18 @@ var (
 	// special error to inidicate that fileystem scanning found a file that
 	// matches the container id, without, however, matching the pod id.
 	ErrContainerPathWithoutMatchingPodID = errors.New("found cgroup file that matches the container id, but not the pod id")
+
+	// ErrEmptyContainerID is returned for an empty container id, which would
+	// otherwise substring-match an arbitrary cgroup directory.
+	ErrEmptyContainerID = errors.New("empty container id")
 )
+
+// isConmonDir reports whether a cgroup directory belongs to crio's conmon
+// container. Conmon directories contain the container id but are not the
+// container's own cgroup.
+func isConmonDir(name string) bool {
+	return strings.Contains(name, "crio-conmon")
+}
 
 // FsScanner is a utility for scanning the filesystem to find container cgroup directories.
 type FsScanner interface {
@@ -69,6 +80,10 @@ func findContainerDirectoryFromRoot(root string, containerID string) string {
 			return nil
 		}
 		base := filepath.Base(path)
+		// skip crio's conmon container
+		if isConmonDir(base) {
+			return filepath.SkipDir
+		}
 		if strings.Contains(base, containerID) {
 			retPath = path
 			return found
@@ -80,6 +95,10 @@ func findContainerDirectoryFromRoot(root string, containerID string) string {
 
 // FindContainer implements FindContainer method from FsScanner
 func (fs *fsScannerState) FindContainerPath(podID types.UID, containerID string) (string, error) {
+	if containerID == "" {
+		return "", ErrEmptyContainerID
+	}
+
 	// first, check the known (cached) locations
 	for _, loc := range fs.knownParentPodDirs {
 		podDir, containerDir := findPodAndContainerDirectory(loc, podID, containerID)
@@ -190,7 +209,7 @@ func findContainerDirectoryFromPod(podDir string, containerID string) string {
 
 		name := dentry.Name()
 		// skip crio's conmon container
-		if strings.Contains(name, "crio-conmon") {
+		if isConmonDir(name) {
 			continue
 		}
 		if strings.Contains(name, containerID) {

--- a/pkg/cgroups/fsscan/fsscan_test.go
+++ b/pkg/cgroups/fsscan/fsscan_test.go
@@ -6,6 +6,8 @@
 package fsscan
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,4 +21,25 @@ func TestPodMatcher(t *testing.T) {
 	require.True(t, matcher("pod-1399d9c7-c86f-4371-8568-07b3d32258a4"))
 	require.True(t, matcher("kubepods-besteffort-pod1399d9c7_c86f_4371_8568_07b3d32258a4.slice/"))
 	require.False(t, matcher("pod-000000-c86f-4371-8568-07b3d32258a4"))
+}
+
+func TestFindContainerPathRejectsEmptyContainerID(t *testing.T) {
+	// an empty container id would substring-match an arbitrary cgroup
+	// directory, so it must be rejected before any scanning.
+	path, err := New().FindContainerPath("1399d9c7-c86f-4371-8568-07b3d32258a4", "")
+	require.ErrorIs(t, err, ErrEmptyContainerID)
+	require.Empty(t, path)
+}
+
+func TestFindContainerDirectoryFromRootSkipsConmon(t *testing.T) {
+	root := t.TempDir()
+	contID := "abc123"
+	// the conmon directory sorts first in the walk; it must be skipped in favor
+	// of the container's own cgroup directory.
+	conmon := filepath.Join(root, "a", "crio-conmon-"+contID+".scope")
+	cont := filepath.Join(root, "b", "crio-"+contID+".scope")
+	require.NoError(t, os.MkdirAll(conmon, 0o755))
+	require.NoError(t, os.MkdirAll(cont, 0o755))
+
+	require.Equal(t, cont, findContainerDirectoryFromRoot(root, contID))
 }

--- a/pkg/cgtracker/cgtracker.go
+++ b/pkg/cgtracker/cgtracker.go
@@ -176,9 +176,9 @@ func globalMap() (Map, error) {
 	setGlMap.Do(func() {
 		retries := 0
 		log := logger.GetLogger()
-		// NB(kkourt): the map is needed for criResolver that runs in a new goroutine
-		// started by newCriResolver. This goroutine will start before the base sensor which
-		// initialized the map and, as a result, criResolver fails. To address this, add a
+		// NB(kkourt): the map is needed for the cgidmap resolver that runs in a new
+		// goroutine. This goroutine will start before the base sensor which initialized
+		// the map and, as a result, resolution fails. To address this, add a
 		// number of retries before we start.
 		for {
 			fname := filepath.Join(bpf.MapPrefixPath(), MapName)
@@ -197,6 +197,11 @@ func globalMap() (Map, error) {
 }
 
 func AddCgroupTrackerPath(cgRoot string) error {
+	// the tracker map only exists when cgroup tracker ids are enabled (see
+	// RegisterCgroupTracker); without it, globalMap() would block forever.
+	if !option.Config.EnableCgTrackerID {
+		return nil
+	}
 	m, err := globalMap()
 	if err != nil {
 		return err

--- a/pkg/cgtracker/cgtracker.go
+++ b/pkg/cgtracker/cgtracker.go
@@ -176,9 +176,9 @@ func globalMap() (Map, error) {
 	setGlMap.Do(func() {
 		retries := 0
 		log := logger.GetLogger()
-		// NB(kkourt): the map is needed for criResolver that runs in a new goroutine
-		// started by newCriResolver. This goroutine will start before the base sensor which
-		// initialized the map and, as a result, criResolver fails. To address this, add a
+		// NB(kkourt): the map is needed for the cgidmap resolver that runs in a new
+		// goroutine. This goroutine will start before the base sensor which initialized
+		// the map and, as a result, resolution fails. To address this, add a
 		// number of retries before we start.
 		for {
 			fname := filepath.Join(bpf.MapPrefixPath(), MapName)

--- a/pkg/metrics/crimetrics/crimetrics.go
+++ b/pkg/metrics/crimetrics/crimetrics.go
@@ -22,8 +22,23 @@ var (
 			"cri_cgidmap", "resolutions_errors_total",
 			"number of cgroup id map (cgidmap) CRI resolutions that failed", nil, nil, nil),
 		nil)
+
+	CgfsResolutionsTotal = metrics.MustNewCounter(
+		metrics.NewOpts(
+			consts.MetricsNamespace,
+			"cgfs_cgidmap", "resolutions_total",
+			"number of total cgroup id map (cgidmap) cgroupfs resolutions", nil, nil, nil),
+		nil)
+
+	CgfsResolutionErrorsTotal = metrics.MustNewCounter(
+		metrics.NewOpts(
+			consts.MetricsNamespace,
+			"cgfs_cgidmap", "resolutions_errors_total",
+			"number of cgroup id map (cgidmap) cgroupfs resolutions that failed", nil, nil, nil),
+		nil)
 )
 
 func RegisterMetrics(group metrics.Group) {
-	group.MustRegister(CriResolutionsTotal, CriResolutionErrorsTotal)
+	group.MustRegister(CriResolutionsTotal, CriResolutionErrorsTotal,
+		CgfsResolutionsTotal, CgfsResolutionErrorsTotal)
 }

--- a/tests/e2e/tests/cgidmap/cgidmap_test.go
+++ b/tests/e2e/tests/cgidmap/cgidmap_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+// Package cgidmap_test verifies that with cgidmap enabled and the CRI
+// disabled, pod association for pods that pre-exist the agent comes from the
+// cgroupfs-scan fallback resolver.
+package cgidmap_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/tests/e2e/checker"
+	"github.com/cilium/tetragon/tests/e2e/helpers"
+	"github.com/cilium/tetragon/tests/e2e/install/tetragon"
+	"github.com/cilium/tetragon/tests/e2e/metricschecker"
+	"github.com/cilium/tetragon/tests/e2e/runners"
+)
+
+var runner *runners.Runner
+
+const (
+	namespace = "cgidmap-fallback"
+	podName   = "cgidmap-workload"
+)
+
+// workloadPod execs repeatedly so exec events keep arriving after the
+// fallback resolver has populated cgidmap. The container id is resolved once
+// per event, so a single exec could race the resolver and stay unassociated.
+const workloadPod = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cgidmap-workload
+  labels:
+    app: cgidmap-workload
+spec:
+  containers:
+    - name: workload
+      image: docker.io/library/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+      command: ["sh", "-c", "while true; do uname -a; sleep 2; done"]
+  restartPolicy: Never
+`
+
+func TestMain(m *testing.M) {
+	runner = runners.NewRunner().
+		// The workload pod must exist BEFORE the agent starts so that pod
+		// association can only come from the cgroupfs fallback: rthooks are
+		// disabled (and would not cover pre-existing containers anyway) and
+		// the CRI is disabled.
+		WithInstallTetragonFn(func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			ctx, _ = helpers.DeleteNamespace(namespace, true)(ctx, cfg)
+			ctx, err := helpers.CreateNamespace(namespace, true)(ctx, cfg)
+			if err != nil {
+				return ctx, fmt.Errorf("failed to create namespace: %w", err)
+			}
+			ctx, err = helpers.LoadCRDString(namespace, workloadPod, true)(ctx, cfg)
+			if err != nil {
+				return ctx, fmt.Errorf("failed to create workload pod: %w", err)
+			}
+			return tetragon.Install(
+				tetragon.WithHelmOptions(map[string]string{
+					"tetragon.exportAllowList": "",
+					"tetragon.cgidmap.enabled": "true",
+					// tetragon.cri.enabled stays false (chart default)
+				}),
+			)(ctx, cfg)
+		}).
+		Init()
+
+	runner.Run(m)
+}
+
+// TestCgidmapCgroupfsFallback verifies that exec events from the
+// pre-existing pod carry pod association. With cgidmap enabled the
+// cgroup-name association path is bypassed, so a matching event proves the
+// cgroupfs fallback resolved the container. The metrics check confirms the
+// cgfs resolver did the work.
+func TestCgidmapCgroupfsFallback(t *testing.T) {
+	execChecker := ec.NewUnorderedEventChecker(
+		ec.NewProcessExecChecker("cgidmap-fallback-exec").
+			WithProcess(
+				ec.NewProcessChecker().
+					WithPod(ec.NewPodChecker().
+						WithNamespace(sm.Full(namespace)).
+						WithName(sm.Full(podName))).
+					WithBinary(sm.Suffix("uname")),
+			),
+	)
+	rpcChecker := checker.NewRPCChecker(execChecker, "cgidmapFallbackChecker").
+		WithEventLimit(500).
+		WithTimeLimit(2 * time.Minute)
+
+	metricsChecker := metricschecker.NewMetricsChecker("cgidmapFallbackMetrics")
+
+	runEventChecker := features.New("Check pod association").
+		Assess("Exec events carry pod info", rpcChecker.CheckInNamespace(1*time.Minute, namespace)).
+		Feature()
+
+	checkMetrics := features.New("Check cgfs resolver metrics").
+		Assess("Wait for event checker", rpcChecker.Wait(60*time.Second)).
+		Assess("cgfs resolutions happened",
+			metricsChecker.Greater("tetragon_cgfs_cgidmap_resolutions_total", 0)).
+		Feature()
+
+	runner.TestInParallel(t, runEventChecker, checkMetrics)
+}

--- a/tests/e2e/tests/cgidmap/cgidmap_test.go
+++ b/tests/e2e/tests/cgidmap/cgidmap_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+// Package cgidmap_test verifies that with cgidmap enabled and the CRI
+// disabled, pod association for pods that pre-exist the agent comes from the
+// cgroupfs-scan fallback resolver.
+package cgidmap_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/tests/e2e/checker"
+	"github.com/cilium/tetragon/tests/e2e/helpers"
+	"github.com/cilium/tetragon/tests/e2e/install/tetragon"
+	"github.com/cilium/tetragon/tests/e2e/metricschecker"
+	"github.com/cilium/tetragon/tests/e2e/runners"
+)
+
+var runner *runners.Runner
+
+const (
+	namespace = "cgidmap-fallback"
+	podName   = "cgidmap-workload"
+)
+
+// workloadPod execs repeatedly so exec events keep arriving after the
+// fallback resolver has populated cgidmap. The container id is resolved once
+// per event, so a single exec could race the resolver and stay unassociated.
+const workloadPod = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cgidmap-workload
+  labels:
+    app: cgidmap-workload
+spec:
+  containers:
+    - name: workload
+      image: docker.io/library/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+      command: ["sh", "-c", "while true; do uname -a; sleep 2; done"]
+  restartPolicy: Never
+`
+
+func TestMain(m *testing.M) {
+	runner = runners.NewRunner().
+		// The workload pod must exist BEFORE the agent starts so that pod
+		// association can only come from the cgroupfs fallback: rthooks are
+		// disabled (and would not cover pre-existing containers anyway) and
+		// the CRI is disabled.
+		WithInstallTetragonFn(func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+			ctx, _ = helpers.DeleteNamespace(namespace, true)(ctx, cfg)
+			ctx, err := helpers.CreateNamespace(namespace, true)(ctx, cfg)
+			if err != nil {
+				return ctx, fmt.Errorf("failed to create namespace: %w", err)
+			}
+			ctx, err = helpers.LoadCRDString(namespace, workloadPod, true)(ctx, cfg)
+			if err != nil {
+				return ctx, fmt.Errorf("failed to create workload pod: %w", err)
+			}
+			return tetragon.Install(
+				tetragon.WithHelmOptions(map[string]string{
+					"tetragon.exportAllowList": "",
+					"tetragon.cgidmap.enabled": "true",
+					"tetragon.cri.enabled":     "false",
+				}),
+			)(ctx, cfg)
+		}).
+		Init()
+
+	runner.Run(m)
+}
+
+// TestCgidmapCgroupfsFallback verifies that exec events from the
+// pre-existing pod carry pod association. With cgidmap enabled the
+// cgroup-name association path is bypassed, so a matching event proves the
+// cgroupfs fallback resolved the container. The metrics check confirms the
+// cgfs resolver did the work.
+func TestCgidmapCgroupfsFallback(t *testing.T) {
+	execChecker := ec.NewUnorderedEventChecker(
+		ec.NewProcessExecChecker("cgidmap-fallback-exec").
+			WithProcess(
+				ec.NewProcessChecker().
+					WithPod(ec.NewPodChecker().
+						WithNamespace(sm.Full(namespace)).
+						WithName(sm.Full(podName))).
+					WithBinary(sm.Suffix("uname")),
+			),
+	)
+	rpcChecker := checker.NewRPCChecker(execChecker, "cgidmapFallbackChecker").
+		WithEventLimit(500).
+		WithTimeLimit(2 * time.Minute)
+
+	metricsChecker := metricschecker.NewMetricsChecker("cgidmapFallbackMetrics")
+
+	runEventChecker := features.New("Check pod association").
+		Assess("Exec events carry pod info", rpcChecker.CheckInNamespace(1*time.Minute, namespace)).
+		Feature()
+
+	// Run the metrics check only after the event checker has concluded, so the
+	// resolutions behind the checked events are guaranteed to be counted.
+	checkMetrics := features.New("Check cgfs resolver metrics").
+		Assess("cgfs resolutions happened",
+			metricsChecker.Greater("tetragon_cgfs_cgidmap_resolutions_total", 0)).
+		Feature()
+
+	runner.Test(t, runEventChecker)
+	runner.Test(t, checkMetrics)
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description

Without `--enable-cri`, cgidmap could not associate existing pods. Generalize the async resolver into a backend-agnostic queue/worker and add a best-effort cgroupfs-scan fallback (mirroring policyfilter), so pod association keeps working for existing pods when the CRI is disabled. Covered by a new e2e test.

Fixes #3381

### Changelog

```release-note
cgidmap: Add cgroupfs fallback for pod association when CRI is disabled
```
