### PR TITLE
[v1.7] Do not require enable-policy-filter on hostSelector

### DIFF
--- a/pkg/cgtracker/test/cgtracker_test.go
+++ b/pkg/cgtracker/test/cgtracker_test.go
@@ -215,6 +215,11 @@ func doProgTest(t *testing.T, cgfsPath string) {
 // TestCgTrackerPolicyFilter checks that cgroup tracking works with policyfilter
 func TestCgTrackerPolicyFilter(t *testing.T) {
 	build.SkipIfK8sDisabled(t)
+	oldEnableK8s := option.Config.EnableK8s
+	option.Config.EnableK8s = true
+	t.Cleanup(func() {
+		option.Config.EnableK8s = oldEnableK8s
+	})
 
 	cgfsPath := "/sys/fs/cgroup"
 	testutils.CaptureLog(t, logger.GetLogger())

--- a/pkg/sensors/k8s.go
+++ b/pkg/sensors/k8s.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 
 	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
@@ -22,6 +23,18 @@ import (
 //	policyfilter.PolicyID(tpID), nil if filtering is needed and policyfilter has been successfully set up
 //	_, err if an error occurred
 func (h *handler) updatePolicyFilter(tp tracingpolicy.TracingPolicy, tpID uint64) (policyfilter.PolicyID, error) {
+	if !option.K8SControlPlaneEnabled() {
+		if ps := tp.TpSpec().PodSelector; ps != nil {
+			return policyfilter.NoFilterID, errors.New("podSelector not allowed in non-k8s environment")
+		}
+
+		if ps := tp.TpSpec().ContainerSelector; ps != nil {
+			return policyfilter.NoFilterID, errors.New("containerSelector not allowed in non-k8s environment")
+		}
+
+		return policyfilter.NoFilterID, nil
+	}
+
 	namespace := tp.TpNamespace()
 	podSelector := tp.TpSpec().PodSelector
 	containerSelector := tp.TpSpec().ContainerSelector

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/sensors/program"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
@@ -136,6 +137,12 @@ func TestAddPolicyLoadError(t *testing.T) {
 func TestPolicyFilterDisabled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+
+	oldEnableK8s := option.Config.EnableK8s
+	option.Config.EnableK8s = true
+	t.Cleanup(func() {
+		option.Config.EnableK8s = oldEnableK8s
+	})
 
 	mgr, err := StartSensorManagerWithPF("", policyfilter.DisabledState())
 	require.NoError(t, err)

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -107,6 +107,12 @@ func createCgroup(t *testing.T, dir string, pids ...uint64) policyfilter.CgroupI
 // TestNamespacedPolicies tests namespace filtering on tracepoints and kprobes
 func TestNamespacedPolicies(t *testing.T) {
 	build.SkipIfK8sDisabled(t)
+	oldEnableK8s := option.Config.EnableK8s
+	option.Config.EnableK8s = true
+	t.Cleanup(func() {
+		option.Config.EnableK8s = oldEnableK8s
+	})
+
 	testutils.CaptureLog(t, logger.GetLogger())
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()


### PR DESCRIPTION
Backport of https://github.com/cilium/tetragon/pull/5218
