### PR TITLE
 ci: set new checkout action flag to allow fork checkouts

### DIFF
--- a/.github/workflows/build-images-ci.yml
+++ b/.github/workflows/build-images-ci.yml
@@ -92,6 +92,7 @@ jobs:
           persist-credentials: false
           ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Login to quay.io for CI
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -168,6 +169,7 @@ jobs:
           submodules: true
           persist-credentials: false
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Push OCI Helm dev chart
         uses: cilium/reusable-workflows/.github/actions/push-helm-chart@6ae27958f2f37545bf48e44106b73df05b1f6d12 # v0.1.0


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->
I'm pretty sure we've broken the buiold-ci-images workflow because we've upgraded to v7 of the checkout action: https://github.com/actions/checkout/pull/2454

### Description
With v7 of the actions/checkout action one has to set the new
`allow-unsafe-pr-checkout: true` flag in order to checkout branches from
forks in a workflow with pull_request_target.

