### PR TITLE
add ability to disable process cache

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -531,6 +531,10 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 
 	if option.Config.DisableProcessCache {
 		log.Info("Process cache is disabled")
+		// The k8s watcher is used to retrieve pod metadata independently of
+		// the process cache, so it must still be set for pod info to be
+		// attached to events.
+		process.SetK8sWatcher(podAccessor)
 	} else {
 		if err := process.InitCache(podAccessor, option.Config.ProcessCacheSize, pcGCInterval); err != nil {
 			return err

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -529,8 +529,12 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 		pcGCInterval = defaults.DefaultProcessCacheGCInterval
 	}
 
-	if err := process.InitCache(podAccessor, option.Config.ProcessCacheSize, pcGCInterval); err != nil {
-		return err
+	if option.Config.DisableProcessCache {
+		log.Info("Process cache is disabled")
+	} else {
+		if err := process.InitCache(podAccessor, option.Config.ProcessCacheSize, pcGCInterval); err != nil {
+			return err
+		}
 	}
 
 	// cleanupWg is needed to ensure that gRPC code cleanly finishes before we exit (e.g,

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -35,6 +35,9 @@ options:
     - name: disable-kprobe-multi
       default_value: "false"
       usage: Allow to disable kprobe multi interface
+    - name: disable-process-cache
+      default_value: "false"
+      usage: Disable process cache
     - name: enable-ancestors
       default_value: '[]'
       usage: |

--- a/pkg/api/flags.go
+++ b/pkg/api/flags.go
@@ -82,7 +82,7 @@ const (
 	// EventDataArgs indicates args are received with data event
 	EventDataArgs = 0x1000000
 
-	// EventDataArgs indicates that a clone event's process is in its
+	// EventInInitTree indicates that a clone event's process is in its
 	// container's init process tree.
 	EventInInitTree = 0x2000000
 )

--- a/pkg/grpc/exec/exec.go
+++ b/pkg/grpc/exec/exec.go
@@ -44,6 +44,8 @@ func GetProcessExec(event *MsgExecveEventUnix, useCache bool) *tetragon.ProcessE
 	var tetragonParent *tetragon.Process
 	var tetragonAncestors []*tetragon.Process
 	var ancestors []*process.ProcessInternal
+	var parent *process.ProcessInternal
+	var err error
 
 	proc := process.AddExecEvent(event.Unix)
 	tetragonProcess := proc.UnsafeGetProcess()
@@ -51,9 +53,11 @@ func GetProcessExec(event *MsgExecveEventUnix, useCache bool) *tetragon.ProcessE
 	parentId := tetragonProcess.ParentExecId
 	processId := tetragonProcess.ExecId
 
-	parent, err := process.Get(parentId)
-	if err == nil {
-		tetragonParent = parent.UnsafeGetProcess()
+	if !option.Config.DisableProcessCache {
+		parent, err = process.Get(parentId)
+		if err == nil {
+			tetragonParent = parent.UnsafeGetProcess()
+		}
 	}
 
 	// Set the ancestors only if --enable-ancestors flag includes 'base'.
@@ -367,6 +371,10 @@ func (msg *MsgCloneEventUnix) Retry(internal *process.ProcessInternal, _ notify.
 func (msg *MsgCloneEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 	var ancestors []*process.ProcessInternal
 
+	if option.Config.DisableProcessCache {
+		return nil
+	}
+
 	proc, _ := process.AddCloneEvent(&msg.MsgCloneEvent)
 	if option.Config.EnableProcessAncestors && proc.NeededAncestors() {
 		ancestors, _ = process.GetAncestorProcessesInternal(proc.UnsafeGetProcess().ParentExecId)
@@ -664,6 +672,10 @@ func (msg *MsgProcessCleanupEventUnix) Retry(_ *process.ProcessInternal, _ notif
 
 func (msg *MsgProcessCleanupEventUnix) HandleMessage() *tetragon.GetEventsResponse {
 	var ancestors []*process.ProcessInternal
+
+	if option.Config.DisableProcessCache {
+		return nil
+	}
 
 	msg.RefCntDone = [3]bool{false, false, false}
 	proc, parent := process.GetParentProcessInternal(msg.PID, msg.Ktime)

--- a/pkg/grpc/exec/kthread_init.go
+++ b/pkg/grpc/exec/kthread_init.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/option"
 	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/reader/notify"
 )
@@ -21,6 +22,9 @@ type MsgKThreadInitUnix struct {
 }
 
 func (msg *MsgKThreadInitUnix) HandleMessage() *tetragon.GetEventsResponse {
+	if option.Config.DisableProcessCache {
+		return nil
+	}
 	proc := process.AddExecEvent(msg.Unix)
 	parent, err := process.Get(proc.UnsafeGetProcess().ParentExecId)
 	if err != nil {

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -42,8 +42,10 @@ func NewProcessManager(
 
 	pm.Server = server.NewServer(ctx, wg, pm, manager, hookRunner, policyStore)
 
-	// Exec cache is always needed to ensure events have an associated Process{}
-	eventcache.New(pm)
+	if !option.Config.DisableProcessCache {
+		// Exec cache is always needed to ensure events have an associated Process{}
+		eventcache.New(pm)
+	}
 
 	logger.GetLogger().Info("Starting process manager",
 		"enableK8s", option.Config.EnableK8s,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -67,6 +67,7 @@ type config struct {
 	RBQueueSize       int
 
 	ProcessCacheSize       int
+	DisableProcessCache    bool
 	DataCacheSize          int
 	DeletedPodCacheSize    int
 	ProcessCacheGCInterval time.Duration

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -250,6 +250,10 @@ func ReadAndSetFlags() error {
 		return errors.New("failed to parse process-cache-gc-interval value. Must be >= 0")
 	}
 
+	if err := validateProcessCacheConfig(Config); err != nil {
+		return err
+	}
+
 	Config.MetricsServer = viper.GetString(KeyMetricsServer)
 	Config.EnableEventMetrics = viper.GetBool(KeyEnableEventMetrics)
 	Config.MetricsLabelFilter = DefaultLabelFilter().WithEnabledLabels(ParseMetricsLabelFilter(viper.GetString(KeyMetricsLabelFilter)))
@@ -398,6 +402,17 @@ func serverAddressUsesTCP(addr string) bool {
 	// only non-TCP form we accept; everything else is treated as a host
 	// or host:port for net.Listen("tcp", ...).
 	return !strings.HasPrefix(addr, "unix://")
+}
+
+// validateProcessCacheConfig rejects --enable-ancestors when the process
+// cache is disabled: ancestor reconstruction relies on the process cache,
+// so the combination is a misconfiguration rather than a silently reduced
+// feature.
+func validateProcessCacheConfig(c config) error {
+	if c.DisableProcessCache && c.EnableProcessAncestors {
+		return fmt.Errorf("--%s cannot be used together with --%s", KeyEnableAncestors, KeyDisableProcessCache)
+	}
+	return nil
 }
 
 type CgroupRate struct {

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -356,6 +356,8 @@ func ReadAndSetFlags() error {
 		return err
 	}
 
+	warnIgnoredProcessCacheFlags(Config)
+
 	return nil
 }
 
@@ -413,6 +415,22 @@ func validateProcessCacheConfig(c config) error {
 		return fmt.Errorf("--%s cannot be used together with --%s", KeyEnableAncestors, KeyDisableProcessCache)
 	}
 	return nil
+}
+
+// warnIgnoredProcessCacheFlags warns about flags that are silently ignored
+// when the process cache is disabled, because they only configure the
+// process cache itself or the event cache, which is never created in that
+// mode. Unlike validateProcessCacheConfig, these are not errors since the
+// resulting behavior is just a no-op, not a functional contradiction.
+func warnIgnoredProcessCacheFlags(c config) {
+	if !c.DisableProcessCache {
+		return
+	}
+	for _, key := range []string{KeyProcessCacheSize, KeyProcessCacheGCInterval, KeyEventCacheRetries, KeyEventCacheRetryDelay} {
+		if viper.IsSet(key) {
+			logger.GetLogger().Warn(fmt.Sprintf("--%s has no effect when --%s is set", key, KeyDisableProcessCache))
+		}
+	}
 }
 
 type CgroupRate struct {

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -33,6 +33,7 @@ const (
 	KeyKernelVersion          = "kernel"
 	KeyVerbosity              = "verbose"
 	KeyProcessCacheSize       = "process-cache-size"
+	KeyDisableProcessCache    = "disable-process-cache"
 	KeyDataCacheSize          = "data-cache-size"
 	KeyDeletedPodCacheSize    = "deleted-pod-cache-size"
 	KeyProcessCacheGCInterval = "process-cache-gc-interval"
@@ -240,6 +241,7 @@ func ReadAndSetFlags() error {
 	logger.PopulateLogOpts(Config.LogOpts, logLevel, logFormat, logFile)
 
 	Config.ProcessCacheSize = viper.GetInt(KeyProcessCacheSize)
+	Config.DisableProcessCache = viper.GetBool(KeyDisableProcessCache)
 	Config.DataCacheSize = viper.GetInt(KeyDataCacheSize)
 	Config.DeletedPodCacheSize = viper.GetInt(KeyDeletedPodCacheSize)
 	Config.ProcessCacheGCInterval = viper.GetDuration(KeyProcessCacheGCInterval)
@@ -470,6 +472,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.String(KeyKernelVersion, "", "Kernel version")
 	flags.Int(KeyVerbosity, 0, "set verbosity level for eBPF verifier dumps. Pass 0 for silent, 1 for truncated logs, 2 for a full dump")
 	flags.Int(KeyProcessCacheSize, 65536, "Size of the process cache")
+	flags.Bool(KeyDisableProcessCache, false, "Disable process cache")
 	flags.Int(KeyDataCacheSize, 1024, "Size of the data events cache")
 	flags.Int(KeyDeletedPodCacheSize, constants.WatcherDeletedPodCacheSize, "Size of the deleted pod cache")
 	flags.Duration(KeyProcessCacheGCInterval, defaults.DefaultProcessCacheGCInterval, "Time between checking the process cache for old entries")

--- a/pkg/option/validate_test.go
+++ b/pkg/option/validate_test.go
@@ -9,6 +9,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateProcessCacheConfig(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		c       config
+		wantErr bool
+	}{
+		{name: "defaults", c: config{}},
+		{name: "ancestors enabled, cache enabled", c: config{EnableProcessAncestors: true}},
+		{name: "cache disabled, ancestors disabled", c: config{DisableProcessCache: true}},
+		{name: "cache disabled, ancestors enabled", c: config{DisableProcessCache: true, EnableProcessAncestors: true}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateProcessCacheConfig(tc.c)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateServerTLSConfig(t *testing.T) {
 	t.Parallel()
 	const tcp = "0.0.0.0:54321"

--- a/pkg/process/podinfo.go
+++ b/pkg/process/podinfo.go
@@ -131,9 +131,3 @@ func getPodInfo(
 	}
 	return podInfo
 }
-
-// GetK8s returns PodAccessor. You must call InitCache before calling this function to ensure
-// that k8s has been initialized.
-func GetK8s() watcher.PodAccessor {
-	return k8s
-}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -84,12 +84,20 @@ func InitCache(w watcher.PodAccessor, size int, GCInterval time.Duration) error 
 		FreeCache()
 	}
 
-	k8s = w
+	SetK8sWatcher(w)
 	procCache, err = NewCache(size, GCInterval)
 	if err != nil {
-		k8s = nil
+		SetK8sWatcher(nil)
 	}
 	return err
+}
+
+// SetK8sWatcher sets the k8s watcher used to retrieve pod metadata for
+// processes. This is independent of the process cache, so callers should
+// invoke it even when the process cache is disabled (e.g. via
+// --disable-process-cache) to ensure pod info is still attached to events.
+func SetK8sWatcher(w watcher.PodAccessor) {
+	k8s = w
 }
 
 func FreeCache() {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -530,6 +530,10 @@ func GetPodInfo(containerID, bin, args string, nspid uint32) *tetragon.Pod {
 }
 
 func GetParentProcessInternal(pid uint32, ktime uint64) (*ProcessInternal, *ProcessInternal) {
+	if option.Config.DisableProcessCache {
+		return nil, nil
+	}
+
 	var parent, process *ProcessInternal
 	var err error
 
@@ -589,7 +593,10 @@ func AddExecEvent(event *tetragonAPI.MsgExecveEventUnix) *ProcessInternal {
 		proc = initProcessInternalExec(event, event.Msg.CleanupProcess)
 	}
 
-	procCache.add(proc)
+	if !option.Config.DisableProcessCache {
+		procCache.add(proc)
+	}
+
 	return proc
 }
 
@@ -621,7 +628,10 @@ func Get(execId string) (*ProcessInternal, error) {
 }
 
 func DumpProcessCache(opts *tetragon.DumpProcessCacheReqArgs) []*tetragon.ProcessInternal {
-	return procCache.dump(opts)
+	if !option.Config.DisableProcessCache {
+		return procCache.dump(opts)
+	}
+	return []*tetragon.ProcessInternal{}
 }
 
 // This function returns the process cache entries (and not the copies


### PR DESCRIPTION
The process cache can cause a lot of memory usage when many processes are executed on a system. The cache itself, and its deleteQueue expand under rapid process creation. Process churn can also cause significant memory fragmentation. This potential for an explosion of memory usage makes it difficult to estimate an upper bound of how much memory tetragon will use.


This change allows users to disable the process cache in order prevent its memory usage and fragmentation at the cost of not being able to reliably enrich events with process information.

## Testing

See [this PR](https://github.com/cilium/tetragon/pull/5354) for how I'm testing this change.


## Issue
https://github.com/cilium/tetragon/issues/5420
 