### PR TITLE
Pr/mstemm/make deleted pod cache size configurable

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -100,6 +100,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.cri | object | `{"enabled":false,"socketHostPath":""}` | Configure tetragon pod so that it can contact the CRI running on the host |
 | tetragon.cri.socketHostPath | string | `""` | path of the CRI socket on the host. This will typically be "/run/containerd/containerd.sock" for containerd or "/var/run/crio/crio.sock"  for crio. |
 | tetragon.debug | bool | `false` | If you want to run Tetragon in debug mode change this value to true |
+| tetragon.deletedPodCacheSize | int | `1024` | Tetragon keeps recently deleted pod/container mappings in an LRU cache to resolve pod metadata for late-arriving events. |
 | tetragon.enableK8sAPI | bool | `true` | Access Kubernetes API to associate Tetragon events with Kubernetes pods. |
 | tetragon.enableKeepSensorsOnExit | bool | `false` | Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone. |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -402,6 +402,10 @@ The total number of tracing policy actions observed per selector.
 | `selector_index` | `    0` |
 | `selector_label` | `example-selector` |
 
+### `tetragon_watcher_delete_pod_cache_evictions`
+
+The total evictions from the deleted pod cache.
+
 ### `tetragon_watcher_delete_pod_cache_hits`
 
 The total hits for pod information in the deleted pod cache.

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -29,6 +29,9 @@ options:
       shorthand: d
       default_value: "false"
       usage: Enable debug messages. Equivalent to '--log-level=debug'
+    - name: deleted-pod-cache-size
+      default_value: "1024"
+      usage: Size of the deleted pod cache
     - name: disable-kprobe-multi
       default_value: "false"
       usage: Allow to disable kprobe multi interface

--- a/examples/configuration/tetragon.yaml
+++ b/examples/configuration/tetragon.yaml
@@ -41,6 +41,7 @@ metrics-label-filter:
 netns-dir: /var/run/docker/netns/
 pprof-address:
 process-cache-size: 65536
+deleted-pod-cache-size: 1024
 procfs: /proc/
 rb-size: 0
 rb-size-total: 0

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -82,6 +82,7 @@ Helm chart for Tetragon
 | tetragon.cri | object | `{"enabled":false,"socketHostPath":""}` | Configure tetragon pod so that it can contact the CRI running on the host |
 | tetragon.cri.socketHostPath | string | `""` | path of the CRI socket on the host. This will typically be "/run/containerd/containerd.sock" for containerd or "/var/run/crio/crio.sock"  for crio. |
 | tetragon.debug | bool | `false` | If you want to run Tetragon in debug mode change this value to true |
+| tetragon.deletedPodCacheSize | int | `1024` | Tetragon keeps recently deleted pod/container mappings in an LRU cache to resolve pod metadata for late-arriving events. |
 | tetragon.enableK8sAPI | bool | `true` | Access Kubernetes API to associate Tetragon events with Kubernetes pods. |
 | tetragon.enableKeepSensorsOnExit | bool | `false` | Persistent enforcement to allow the enforcement policy to continue running even when its Tetragon process is gone. |
 | tetragon.enableMsgHandlingLatency | bool | `false` | Enable latency monitoring in message handling |

--- a/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
+++ b/install/kubernetes/tetragon/templates/tetragon_configmap.yaml
@@ -23,6 +23,7 @@ data:
   enable-process-ns: {{ .Values.tetragon.enableProcessNs | quote }}
   enable-ancestors: {{ .Values.tetragon.processAncestors.enabled | quote }}
   process-cache-size: {{ .Values.tetragon.processCacheSize | quote }}
+  deleted-pod-cache-size: {{ .Values.tetragon.deletedPodCacheSize | quote }}
 {{- if .Values.tetragon.exportFilename }}
   export-filename: {{ .Values.exportDirectory}}/{{ .Values.tetragon.exportFilename }}
   export-file-perm: {{ .Values.tetragon.exportFilePerm | quote }}

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -63,6 +63,9 @@ tetragon:
   # -- Tetragon puts processes in an LRU cache. The cache is used to find ancestors
   # for subsequently exec'ed processes.
   processCacheSize: 65536
+  # -- Tetragon keeps recently deleted pod/container mappings in an LRU cache to
+  # resolve pod metadata for late-arriving events.
+  deletedPodCacheSize: 1024
   # -- If you want to run Tetragon in debug mode change this value to true
   debug: false
   # -- JSON export filename. Set it to an empty string to disable JSON export altogether.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package constants
+
+const (
+	WatcherDeletedPodCacheSize = 1024
+)

--- a/pkg/metrics/watchermetrics/watchermetrics.go
+++ b/pkg/metrics/watchermetrics/watchermetrics.go
@@ -61,12 +61,19 @@ var (
 		"The total hits for pod information in the deleted pod cache.",
 		nil, nil, nil,
 	), nil)
+
+	WatcherDeletedPodCacheEvictions = metrics.MustNewCounter(metrics.NewOpts(
+		consts.MetricsNamespace, "", "watcher_delete_pod_cache_evictions",
+		"The total evictions from the deleted pod cache.",
+		nil, nil, nil,
+	), nil)
 )
 
 func RegisterMetrics(group metrics.Group) {
 	group.MustRegister(WatcherErrors)
 	group.MustRegister(WatcherEvents)
 	group.MustRegister(WatcherDeletedPodCacheHits)
+	group.MustRegister(WatcherDeletedPodCacheEvictions)
 }
 
 func InitMetrics() {
@@ -74,6 +81,7 @@ func InitMetrics() {
 	GetWatcherEvents(K8sWatcher).Add(0)
 	GetWatcherErrors(K8sWatcher, FailedToGetPodError).Add(0)
 	GetWatcherDeletedPodCacheHits().Add(0)
+	GetWatcherDeletedPodCacheEvictions().Add(0)
 }
 
 // Get a new handle on an WatcherEvents metric for a watcher type
@@ -88,4 +96,8 @@ func GetWatcherErrors(watcherType Watcher, watcherError ErrorType) prometheus.Co
 
 func GetWatcherDeletedPodCacheHits() prometheus.Counter {
 	return WatcherDeletedPodCacheHits.WithLabelValues()
+}
+
+func GetWatcherDeletedPodCacheEvictions() prometheus.Counter {
+	return WatcherDeletedPodCacheEvictions.WithLabelValues()
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 
+	"github.com/cilium/tetragon/pkg/constants"
 	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/logger/logfields"
@@ -67,6 +68,7 @@ type config struct {
 
 	ProcessCacheSize       int
 	DataCacheSize          int
+	DeletedPodCacheSize    int
 	ProcessCacheGCInterval time.Duration
 
 	MetricsServer      string
@@ -186,6 +188,9 @@ var (
 
 		// Set default value for sleepable preload maps.
 		SleepablePreloadSize: defaults.DefaultSleepablePreloadSize,
+
+		// Set default value for deleted pod lru cache
+		DeletedPodCacheSize: constants.WatcherDeletedPodCacheSize,
 	}
 )
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/cilium/tetragon/pkg/constants"
 	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/logger/logfields"
@@ -32,6 +33,7 @@ const (
 	KeyVerbosity              = "verbose"
 	KeyProcessCacheSize       = "process-cache-size"
 	KeyDataCacheSize          = "data-cache-size"
+	KeyDeletedPodCacheSize    = "deleted-pod-cache-size"
 	KeyProcessCacheGCInterval = "process-cache-gc-interval"
 	KeyForceSmallProgs        = "force-small-progs"
 	KeyForceLargeProgs        = "force-large-progs"
@@ -236,6 +238,7 @@ func ReadAndSetFlags() error {
 
 	Config.ProcessCacheSize = viper.GetInt(KeyProcessCacheSize)
 	Config.DataCacheSize = viper.GetInt(KeyDataCacheSize)
+	Config.DeletedPodCacheSize = viper.GetInt(KeyDeletedPodCacheSize)
 	Config.ProcessCacheGCInterval = viper.GetDuration(KeyProcessCacheGCInterval)
 
 	if Config.ProcessCacheGCInterval <= 0 {
@@ -457,6 +460,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Int(KeyVerbosity, 0, "set verbosity level for eBPF verifier dumps. Pass 0 for silent, 1 for truncated logs, 2 for a full dump")
 	flags.Int(KeyProcessCacheSize, 65536, "Size of the process cache")
 	flags.Int(KeyDataCacheSize, 1024, "Size of the data events cache")
+	flags.Int(KeyDeletedPodCacheSize, constants.WatcherDeletedPodCacheSize, "Size of the deleted pod cache")
 	flags.Duration(KeyProcessCacheGCInterval, defaults.DefaultProcessCacheGCInterval, "Time between checking the process cache for old entries")
 	flags.Bool(KeyForceSmallProgs, false, "Force loading small programs, even in kernels with >= 5.3 versions")
 	flags.Bool(KeyForceLargeProgs, false, "Force loading large programs, even in kernels with < 5.3 versions")

--- a/pkg/watcher/deleted_pod_cache.go
+++ b/pkg/watcher/deleted_pod_cache.go
@@ -38,6 +38,7 @@ func NewDeletedPodCache() (*DeletedPodCache, error) {
 			"pod.namespace", podNamespace,
 			"pod.name", podName,
 		)
+		watchermetrics.GetWatcherDeletedPodCacheEvictions().Inc()
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/watcher/deleted_pod_cache.go
+++ b/pkg/watcher/deleted_pod_cache.go
@@ -25,7 +25,20 @@ type DeletedPodCache struct {
 }
 
 func NewDeletedPodCache() (*DeletedPodCache, error) {
-	c, err := lru.New[string, deletedPodCacheEntry](option.Config.DeletedPodCacheSize)
+	c, err := lru.NewWithEvict[string, deletedPodCacheEntry](option.Config.DeletedPodCacheSize, func(key string, value deletedPodCacheEntry) {
+		podNamespace := ""
+		podName := ""
+		if value.pod != nil {
+			podNamespace = value.pod.Namespace
+			podName = value.pod.Name
+		}
+
+		logger.GetLogger().Debug("Evicted entry from deleted pod cache",
+			"key", key,
+			"pod.namespace", podNamespace,
+			"pod.name", podName,
+		)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/watcher/deleted_pod_cache.go
+++ b/pkg/watcher/deleted_pod_cache.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
+	"github.com/cilium/tetragon/pkg/option"
 )
 
 type deletedPodCacheEntry struct {
@@ -24,7 +25,7 @@ type DeletedPodCache struct {
 }
 
 func NewDeletedPodCache() (*DeletedPodCache, error) {
-	c, err := lru.New[string, deletedPodCacheEntry](128)
+	c, err := lru.New[string, deletedPodCacheEntry](option.Config.DeletedPodCacheSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/watcher/deleted_pod_cache_test.go
+++ b/pkg/watcher/deleted_pod_cache_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !nok8s
+
+package watcher
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/tetragon/pkg/metrics/watchermetrics"
+	"github.com/cilium/tetragon/pkg/option"
+)
+
+type DeletedPodCacheTestSuite struct {
+	suite.Suite
+	originalDeletedPodCacheSize int
+	cache                       *DeletedPodCache
+}
+
+func (suite *DeletedPodCacheTestSuite) SetupSuite() {
+	suite.originalDeletedPodCacheSize = option.Config.DeletedPodCacheSize
+	option.Config.DeletedPodCacheSize = 1
+
+	cache, err := NewDeletedPodCache()
+	suite.Require().NoError(err)
+	suite.cache = cache
+}
+
+func (suite *DeletedPodCacheTestSuite) TestMetrics() {
+	firstContainerID := "container-id-1"
+	secondContainerID := "container-id-2"
+
+	firstPod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{ContainerID: firstContainerID},
+			},
+		},
+	}
+
+	secondPod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{ContainerID: secondContainerID},
+			},
+		},
+	}
+
+	hitsBefore := testutil.ToFloat64(watchermetrics.GetWatcherDeletedPodCacheHits())
+	evictionsBefore := testutil.ToFloat64(watchermetrics.GetWatcherDeletedPodCacheEvictions())
+
+	suite.cache.Add(firstContainerID, deletedPodCacheEntry{
+		pod:        firstPod,
+		contStatus: &firstPod.Status.ContainerStatuses[0],
+	})
+
+	pod, _, found := suite.cache.FindContainer(firstContainerID)
+	suite.Require().True(found)
+	suite.Require().NotNil(pod)
+
+	hitsAfterFirstFind := testutil.ToFloat64(watchermetrics.GetWatcherDeletedPodCacheHits())
+	suite.InDelta(hitsBefore+1, hitsAfterFirstFind, 1e-9)
+
+	// This will evict the first entry added and increment the evicted count.
+	suite.cache.Add(secondContainerID, deletedPodCacheEntry{
+		pod:        secondPod,
+		contStatus: &secondPod.Status.ContainerStatuses[0],
+	})
+
+	_, _, found = suite.cache.FindContainer(firstContainerID)
+	suite.False(found)
+
+	evictionsAfter := testutil.ToFloat64(watchermetrics.GetWatcherDeletedPodCacheEvictions())
+	suite.InDelta(evictionsBefore+1, evictionsAfter, 1e-9)
+}
+
+func (suite *DeletedPodCacheTestSuite) TearDownSuite() {
+	option.Config.DeletedPodCacheSize = suite.originalDeletedPodCacheSize
+}
+
+func TestDeletedPodCacheSuite(t *testing.T) {
+	suite.Run(t, new(DeletedPodCacheTestSuite))
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Fixes #5251.

### Description
In busy environments, there is a lot of stress put on the deleted pod lru cache, leading to evictions pretty quickly. Make the size configurable, increase the default size, and add logging/metrics to track when items are evicted.

```release-note
Make the size of the deleted pod lru cache configurable and increase the default to 1024 items. Add additional debug logging and metrics to track when items are evicted from the deleted pod lru cache.
```

Note: This pull request was authored with the assistance of Github Copilot. Reviewers should keep this in mind during code review.