### PR TITLE
fix(cmd/tetra): accept redirected file stdin in getevents

### DIFF
--- a/cmd/tetra/getevents/getevents.go
+++ b/cmd/tetra/getevents/getevents.go
@@ -201,7 +201,7 @@ redirection of events to the stdin. Examples:
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fi, err := os.Stdin.Stat()
-			if err == nil && fi.Mode()&os.ModeNamedPipe != 0 {
+			if err == nil && fi.Mode()&os.ModeCharDevice == 0 {
 				// read events from stdin
 				return getEvents(context.Background(), newIOReaderClient(os.Stdin, common.Debug))
 			}

--- a/cmd/tetra/getevents/getevents_test.go
+++ b/cmd/tetra/getevents/getevents_test.go
@@ -210,3 +210,17 @@ func Test_GetEvents_ClosedStdinNoNilPanic(t *testing.T) {
 	// Must not panic; falls through to gRPC and gets a connection error instead.
 	require.NotPanics(t, func() { cmd.Execute() })
 }
+
+func Test_GetEvents_RegularFileStdin(t *testing.T) {
+	oldStdin := os.Stdin
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	events, err := os.Open(testutils.RepoRootPath("testdata/events.json"))
+	require.NoError(t, err)
+	t.Cleanup(func() { events.Close() })
+	os.Stdin = events
+
+	cmd := New()
+	output := testutils.RedirectStdoutExecuteCmd(t, cmd)
+	assert.Equal(t, 3, bytes.Count(output, []byte("\n")))
+}


### PR DESCRIPTION
stdin replay in `tetra getevents` only kicked in for named pipes, so `tetra getevents < events.json` would go try gRPC instead

This makes any non tty stdin use the replay path, so pipes still work and regular file redirection works too

Repro:
1. `printf '%s\n' '{"process_exec":{"process":{"binary":"/bin/echo"}}}' > /tmp/tetra-event.json`
2. `go run ./cmd/tetra getevents < /tmp/tetra-event.json`
3. before this patch it dials `localhost:54321` and fails. with this patch it prints the event.
