### PR TITLE
sensors: keep LSM enforcement active after agent exit

### DIFF
--- a/pkg/sensors/program/loader_linux.go
+++ b/pkg/sensors/program/loader_linux.go
@@ -555,7 +555,7 @@ func LSMOpen(load *Program) OpenFunc {
 	}
 }
 
-func LSMAttach() AttachFunc {
+func LSMAttach(load *Program, bpfDir string) AttachFunc {
 	return func(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
 
@@ -567,6 +567,10 @@ func LSMAttach() AttachFunc {
 		lnk, err := linkFn()
 		if err != nil {
 			return nil, fmt.Errorf("attaching '%s' failed: %w", spec.Name, err)
+		}
+		if err := LinkPin(lnk, bpfDir, load, spec.Name); err != nil {
+			lnk.Close()
+			return nil, err
 		}
 		return &unloader.RelinkUnloader{
 			UnloadProg: unloader.ProgUnloader{Prog: prog}.Unload,
@@ -779,7 +783,7 @@ func LoadTracingProgram(bpfDir string, load *Program, maps []*Map, verbose int) 
 
 func LoadLSMProgram(bpfDir string, load *Program, maps []*Map, verbose int) error {
 	opts := &LoadOpts{
-		Attach: LSMAttach(),
+		Attach: LSMAttach(load, bpfDir),
 		Open:   LSMOpen(load),
 		Maps:   maps,
 	}
@@ -788,7 +792,7 @@ func LoadLSMProgram(bpfDir string, load *Program, maps []*Map, verbose int) erro
 
 func LoadLSMProgramSimple(bpfDir string, load *Program, maps []*Map, verbose int) error {
 	opts := &LoadOpts{
-		Attach: LSMAttach(),
+		Attach: LSMAttach(load, bpfDir),
 		Maps:   maps,
 	}
 	return loadProgram(bpfDir, load, opts, verbose)


### PR DESCRIPTION
When starting tetragon with `./tetragon --btf /sys/kernel/btf/vmlinux --bpf-lib ./bpf/objs/ --keep-sensors-on-exit` and load the following policy with `./tetra tp add pol-kprobes.yaml`

```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "kprobes-file-open"
spec:
  kprobes:
  - call: "security_file_open"
    syscall: false
    args:
      - index: 0
        type: "file"
    selectors:
    - matchArgs:
      - index: 0
        operator: "Prefix"
        values:
        - "/mnt/"
      matchActions:
      - action: Override
        argError: -1
      - action: Post
```

The expected behaviour is to block all open calls to files under `/mnt/`. For example: 
```
$ cat /mnt/aa.txt
cat: /mnt/aa.txt: Operation not permitted (os error 1)
```

As we also use `--keep-sensors-on-exit` if we kill tetragon agent, this bpf programs should remain there and still block that operation. And this is the case.

On the other hand, if we use a lsm based policy such as: 
```yaml
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "lsm-file-open"
spec:
  lsmhooks:
  - hook: "file_open"
    args:
      - index: 0
        type: "file"
    selectors:
    - matchArgs:
      - index: 0
        operator: "Prefix"
        values:
        - "/mnt/"
      matchActions:
      - action: Override
        argError: -1
      - action: Post
```
The behaviour should be the same, but enforcement does not work after agent stops.

This patch fixes that by pinning LSM links so enforcement remains active after Tetragon exits with `--keep-sensors-on-exit`. Previously, only the programs and maps remained pinned, while closing the unpinned link detached the LSM programs.