### PR TITLE
new: enum like flags

### DIFF
--- a/cmd/tetra/explain/explain.go
+++ b/cmd/tetra/explain/explain.go
@@ -21,11 +21,13 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/cilium/tetragon/pkg/option"
+
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client"
 )
 
 var (
-	outputFormat string
+	outputFormat *option.Enum
 	recursive    bool
 	showExample  bool
 	listMode     bool
@@ -73,7 +75,8 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format. One of: json|yaml")
+	outputFormat, _ = option.NewEnum([]string{"text", "json", "yaml"}, "text")
+	cmd.Flags().VarP(outputFormat, "output", "o", "Output format "+outputFormat.Allowed())
 	cmd.Flags().BoolVarP(&recursive, "recursive", "R", false, "Print the fields of fields recursively")
 	cmd.Flags().BoolVar(&showExample, "example", false, "Show example usage")
 	cmd.Flags().BoolVar(&listMode, "list", false, "List all supported resources")
@@ -251,7 +254,7 @@ func runExplain(w io.Writer, path string) error {
 	}
 
 	// Handle different output formats
-	switch outputFormat {
+	switch outputFormat.Value {
 	case "json":
 		return outputJSON(w, current)
 	case "yaml":

--- a/cmd/tetra/getevents/getevents.go
+++ b/cmd/tetra/getevents/getevents.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -18,16 +17,18 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	"github.com/cilium/tetragon/pkg/option"
+
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/cmd/tetra/common"
 	"github.com/cilium/tetragon/pkg/encoder"
 )
 
 type Opts struct {
-	Output         string
-	Color          string
+	Output         *option.Enum
+	Color          *option.Enum
 	IncludeFields  []string
-	EventTypes     []string
+	EventTypes     *option.SliceEnum
 	ExcludeFields  []string
 	Namespaces     []string
 	Namespace      []string // deprecated: use Namespaces
@@ -86,10 +87,10 @@ var GetFilter = func() *tetragon.Filter {
 	}
 
 	// Is used to filter on the event types i.e. PROCESS_EXEC, PROCESS_EXIT etc.
-	if len(Options.EventTypes) > 0 {
+	if len(Options.EventTypes.Values) > 0 {
 		var eventType tetragon.EventType
 
-		for _, v := range Options.EventTypes {
+		for _, v := range Options.EventTypes.Values {
 			eventType = tetragon.EventType(tetragon.EventType_value[v])
 			filter.EventSet = append(filter.EventSet, eventType)
 		}
@@ -140,7 +141,7 @@ func getEvents(ctx context.Context, client tetragon.FineGuidanceSensorsClient) e
 	if err != nil {
 		return fmt.Errorf("failed to call GetEvents: %w", err)
 	}
-	eventEncoder := GetEncoder(os.Stdout, encoder.ColorMode(Options.Color), Options.Timestamps, Options.Output == "compact", Options.TTYEncode, Options.StackTraces, Options.ImaHash)
+	eventEncoder := GetEncoder(os.Stdout, encoder.ColorMode(Options.Color.Value), Options.Timestamps, Options.Output.Value == "compact", Options.TTYEncode, Options.StackTraces, Options.ImaHash)
 	for {
 		res, err := stream.Recv()
 		if err != nil {
@@ -174,24 +175,6 @@ redirection of events to the stdin. Examples:
   # Include only process and parent.pod fields
   tetra getevents -f process,parent.pod`,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
-			if Options.Output != "json" && Options.Output != "compact" {
-				return fmt.Errorf("invalid value for %q flag: %s", common.KeyOutput, Options.Output)
-			}
-			if Options.Color != "auto" && Options.Color != "always" && Options.Color != "never" {
-				return fmt.Errorf("invalid value for %q flag: %s", "color", Options.Color)
-			}
-
-			for _, v := range Options.EventTypes {
-				if _, found := tetragon.EventType_value[v]; !found {
-					supported := make([]string, 0, len(tetragon.EventType_value))
-					for name := range tetragon.EventType_value {
-						supported = append(supported, name)
-					}
-					sort.Strings(supported)
-					return fmt.Errorf("invalid value for %q flag: %s. Supported are %s", "event-types", v, strings.Join(supported, ", "))
-				}
-			}
-
 			// merge deprecated to new flags, appending since order does not matter
 			Options.Namespaces = append(Options.Namespace, Options.Namespaces...)
 			Options.Pods = append(Options.Pod, Options.Pods...)
@@ -234,11 +217,21 @@ redirection of events to the stdin. Examples:
 		},
 	}
 
+	// Prepare enum-like flags
+	Options.Output, _ = option.NewEnum([]string{"json", "compact"}, "json")
+	Options.Color, _ = option.NewEnum([]string{"auto", "always", "never"}, "auto")
+	supported := make([]string, 0, len(tetragon.EventType_value))
+	for name := range tetragon.EventType_value {
+		supported = append(supported, name)
+	}
+	sort.Strings(supported)
+	Options.EventTypes, _ = option.NewSliceEnum(supported, nil)
+
 	flags := cmd.Flags()
-	flags.StringVarP(&Options.Output, common.KeyOutput, "o", "json", "Output format. json or compact")
-	flags.StringVar(&Options.Color, "color", "auto", "Colorize compact output. auto, always, or never")
+	flags.VarP(Options.Output, common.KeyOutput, "o", "Output format "+Options.Output.Allowed())
+	flags.Var(Options.Color, "color", "Colorize compact output "+Options.Color.Allowed())
 	flags.StringSliceVarP(&Options.IncludeFields, "include-fields", "f", nil, "Include only fields in events")
-	flags.StringSliceVarP(&Options.EventTypes, "event-types", "e", nil, "Include only events of given types")
+	flags.VarP(Options.EventTypes, "event-types", "e", "Include only events of given types")
 	flags.StringSliceVarP(&Options.ExcludeFields, "exclude-fields", "F", nil, "Exclude fields from events")
 
 	flags.StringSliceVarP(&Options.Namespace, "namespace", "n", nil, "Get events by Kubernetes namespace")

--- a/cmd/tetra/policytest/policytest.go
+++ b/cmd/tetra/policytest/policytest.go
@@ -17,16 +17,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cilium/tetragon/pkg/option"
+
 	"github.com/cilium/tetragon/cmd/tetra/common"
 	"github.com/cilium/tetragon/pkg/testutils/policytest"
 	_ "github.com/cilium/tetragon/tests/policytests" // so that tests can be registered
-)
-
-type outputFmt int
-
-const (
-	outputText outputFmt = iota
-	outputJSON
 )
 
 func New() *cobra.Command {
@@ -131,8 +126,8 @@ func runCmd() *cobra.Command {
 	allParams := false
 	allTests := false
 	var params map[string]string
-	var outputFormat = outputText
 	var outputFile = ""
+	outputFmt, _ := option.NewEnum([]string{"text", "json"}, "text")
 	cmd := cobra.Command{
 		Use:   "run",
 		Short: "Run Tetragon policy test(s)",
@@ -220,8 +215,8 @@ func runCmd() *cobra.Command {
 				out = f
 			}
 
-			switch outputFormat {
-			case outputJSON:
+			switch outputFmt.Value {
+			case "json":
 				for _, res := range results {
 					b, err := json.Marshal(res)
 					if err != nil {
@@ -229,7 +224,7 @@ func runCmd() *cobra.Command {
 					}
 					fmt.Fprintln(out, string(b))
 				}
-			case outputText:
+			case "text":
 				policytest.DumpResults(out, results)
 			}
 			return nil
@@ -241,36 +236,8 @@ func runCmd() *cobra.Command {
 	flags.BoolVar(&monitorMode, "monitor-mode", monitorMode, "set the policy(-ies) in monitor mode before running the test(s)")
 	flags.StringToStringVar(&params, "set-param", map[string]string{}, "Set a policy parameter")
 	flags.BoolVar(&allParams, "all-params", allParams, "Run policy tests using all available parameters")
-	flags.Var(&outputFormat, "output", "output format (text|json)")
+	flags.Var(outputFmt, "output", "output format "+outputFmt.Allowed())
 	flags.StringVar(&outputFile, "output-file", "", "file to save the tests output. If empty, stdout is used.")
 	flags.BoolVar(&allTests, "all-tests", allTests, "Run all available policy tests")
 	return &cmd
-}
-
-func (of *outputFmt) Set(v string) error {
-	switch v {
-	case "text":
-		*of = outputText
-	case "json":
-		*of = outputJSON
-	default:
-		return errors.New("output format must be either \"text\" or \"json\"")
-	}
-
-	return nil
-}
-
-func (of *outputFmt) String() string {
-	switch *of {
-	case outputText:
-		return "text"
-	case outputJSON:
-		return "json"
-	default:
-		return ""
-	}
-}
-
-func (of *outputFmt) Type() string {
-	return "output"
 }

--- a/cmd/tetra/tracingpolicy/tracingpolicy.go
+++ b/cmd/tetra/tracingpolicy/tracingpolicy.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cilium/tetragon/pkg/option"
+
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/cmd/tetra/common"
 	"github.com/cilium/tetragon/cmd/tetra/tracingpolicy/generate"
@@ -201,7 +203,7 @@ func tpDisableCmd() *cobra.Command {
 
 func tpListCmd() *cobra.Command {
 	var (
-		output string
+		output *option.Enum
 		domain string
 	)
 	ret := &cobra.Command{
@@ -209,12 +211,6 @@ func tpListCmd() *cobra.Command {
 		Short: "list loaded tracing policies",
 		Long:  "List loaded tracing policies, use the JSON output format for full output.",
 		Args:  cobra.ExactArgs(0),
-		PreRunE: func(_ *cobra.Command, _ []string) error {
-			if output != "json" && output != "text" {
-				return fmt.Errorf("invalid value for %q flag: %s", common.KeyOutput, output)
-			}
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			c, err := common.NewClientWithDefaultContextAndAddress()
 			if err != nil {
@@ -227,7 +223,7 @@ func tpListCmd() *cobra.Command {
 				return fmt.Errorf("failed to list tracing policies: %w", err)
 			}
 
-			switch output {
+			switch output.Value {
 			case "json":
 				b, err := res.MarshalJSON()
 				if err != nil {
@@ -241,8 +237,10 @@ func tpListCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	output, _ = option.NewEnum([]string{"text", "json"}, "text")
 	flags := ret.Flags()
-	flags.StringVarP(&output, common.KeyOutput, "o", "text", "Output format. text or json")
+	flags.VarP(output, common.KeyOutput, "o", "Output format "+output.Allowed())
 	flags.StringVarP(&domain, "domain", "", "", "Domain to be used. Use k8s to act on CRD policies. By default only acts against grpc domain.")
 	return ret
 }

--- a/pkg/option/enum.go
+++ b/pkg/option/enum.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package option
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+var _ pflag.Value = &Enum{}
+
+type Enum struct {
+	allowed []string
+	Value   string
+}
+
+func NewEnum(allowed []string, d string) (*Enum, error) {
+	e := Enum{
+		allowed: allowed,
+		Value:   d,
+	}
+	if !slices.Contains(allowed, d) {
+		return nil, fmt.Errorf("invalid default value %s, please provide one of %s", d, e.Allowed())
+	}
+	return &e, nil
+}
+
+func (e *Enum) String() string {
+	return e.Value
+}
+
+func (e *Enum) Allowed() string {
+	return fmt.Sprintf("(%s)", strings.Join(e.allowed, ", "))
+}
+
+func (e *Enum) Set(p string) error {
+	if !slices.Contains(e.allowed, p) {
+		return fmt.Errorf("invalid argument %s, please provide one of %s", p, e.Allowed())
+	}
+	e.Value = p
+	return nil
+}
+
+func (e *Enum) Type() string {
+	return "string"
+}
+
+var _ pflag.Value = &SliceEnum{}
+
+type SliceEnum struct {
+	allowed []string
+	Values  []string
+}
+
+func NewSliceEnum(allowed []string, d []string) (*SliceEnum, error) {
+	e := SliceEnum{
+		allowed: allowed,
+		Values:  d,
+	}
+	for _, dd := range d {
+		if !slices.Contains(allowed, dd) {
+			return nil, fmt.Errorf("invalid default value %s, please provide one of %s", dd, e.Allowed())
+		}
+	}
+	return &e, nil
+}
+
+func (e *SliceEnum) String() string {
+	return strings.Join(e.Values, ",")
+}
+
+func (e *SliceEnum) Allowed() string {
+	return fmt.Sprintf("(%s)", strings.Join(e.allowed, ", "))
+}
+
+func (e *SliceEnum) Set(p string) error {
+	if !slices.Contains(e.allowed, p) {
+		return fmt.Errorf("invalid argument %s, please provide one of %s", p, e.Allowed())
+	}
+	e.Values = append(e.Values, p)
+	return nil
+}
+
+func (e *SliceEnum) Type() string {
+	return "sliceString"
+}

--- a/pkg/option/enum_test.go
+++ b/pkg/option/enum_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package option
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnum(t *testing.T) {
+	_, err := NewEnum([]string{"foo", "bar"}, "baz")
+	require.Error(t, err)
+
+	e, err := NewEnum([]string{"foo", "bar", "baz"}, "foo")
+	require.NoError(t, err)
+
+	require.Equal(t, "foo", e.Value)
+	require.NoError(t, e.Set("bar"))
+	require.Equal(t, "bar", e.Value)
+	require.Error(t, e.Set("invalid"))
+	require.Equal(t, "bar", e.Value)
+}
+
+func TestSliceEnum(t *testing.T) {
+	_, err := NewSliceEnum([]string{"foo", "bar"}, []string{"baz", "bat"})
+	require.Error(t, err)
+
+	e, err := NewSliceEnum([]string{"foo", "bar", "baz"}, []string{"bar"})
+	require.NoError(t, err)
+	require.Len(t, e.Values, 1)
+	require.Equal(t, "bar", e.Values[0])
+
+	require.NoError(t, e.Set("baz"))
+	require.Len(t, e.Values, 2)
+	require.Equal(t, "bar", e.Values[0])
+	require.Equal(t, "baz", e.Values[1])
+
+	require.Error(t, e.Set("invalid"))
+	require.Len(t, e.Values, 2)
+}
+
+func TestEnumPflag(t *testing.T) {
+	currArgs := os.Args
+	t.Cleanup(func() { os.Args = currArgs })
+
+	os.Args = []string{"test", "--foo", "bar"}
+	e, err := NewEnum([]string{"bar", "baz", "bat"}, "baz")
+	require.NoError(t, err)
+	cmd := cobra.Command{
+		Use: "test",
+		Run: func(_ *cobra.Command, _ []string) {
+			require.Equal(t, "bar", e.Value)
+		},
+	}
+
+	// Prepare enum-like flags
+	flags := cmd.Flags()
+	flags.Var(e, "foo", "test")
+	require.NoError(t, cmd.Execute())
+}


### PR DESCRIPTION
### Description

This PR introduces support for enum-like flags setting by introducing new `option.Enum` and `option.SliceEnum` structures that implement the `pflag.Value` interface.
It helped us clean up a little bit a couple of tetra commands.
Also, this is the cobra-ish way of doing that :)

Example output:
```
$ ./tetra tracingpolicy list --output foo
Error: invalid argument "foo" for "-o, --output" flag: invalid argument jsonn, please provide one of (text, json)

$ ./tetra getevents --event-types foo
Error: invalid argument "foo" for "-e, --event-types" flag: invalid argument foo, please provide one of (PROCESS_EXEC, PROCESS_EXIT, PROCESS_KPROBE, PROCESS_LOADER, PROCESS_LSM, PROCESS_THROTTLE, PROCESS_TRACEPOINT, PROCESS_UPROBE, PROCESS_USDT, RATE_LIMIT_INFO, TEST, UNDEF)
```
