### PR TITLE
fix(cmd/tetra): reject invalid explain output formats

### DIFF
--- a/cmd/tetra/explain/explain.go
+++ b/cmd/tetra/explain/explain.go
@@ -63,6 +63,9 @@ Examples:
 			}
 			return cobra.ExactArgs(1)(cmd, args)
 		},
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return validateOutputFormat(outputFormat)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if listMode {
 				listResources(cmd.OutOrStdout())
@@ -80,6 +83,15 @@ Examples:
 	cmd.Flags().StringVar(&apiVersion, "api-version", "", "Specify the API version to use")
 
 	return cmd
+}
+
+func validateOutputFormat(format string) error {
+	switch format {
+	case "", "json", "yaml":
+		return nil
+	default:
+		return fmt.Errorf("invalid value for %q flag: %s", "output", format)
+	}
 }
 
 func listResources(w io.Writer) {

--- a/cmd/tetra/explain/explain_test.go
+++ b/cmd/tetra/explain/explain_test.go
@@ -6,7 +6,9 @@
 package explain
 
 import (
+	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -132,4 +134,76 @@ func TestNormalizePath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateOutputFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		wantErr string
+	}{
+		{name: "default", format: ""},
+		{name: "json", format: "json"},
+		{name: "yaml", format: "yaml"},
+		{name: "invalid", format: "bogus", wantErr: `invalid value for "output" flag: bogus`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOutputFormat(tt.format)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("validateOutputFormat(%q) unexpected error: %v", tt.format, err)
+			}
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("validateOutputFormat(%q) expected error", tt.format)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("validateOutputFormat(%q) error = %q, want %q", tt.format, err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandOutputValidation(t *testing.T) {
+	t.Run("rejects invalid output", func(t *testing.T) {
+		resetExplainGlobals()
+
+		cmd := New()
+		cmd.SetArgs([]string{"tracingpolicy", "-o", "bogus"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected invalid output format to fail")
+		}
+		if got, want := err.Error(), `invalid value for "output" flag: bogus`; got != want {
+			t.Fatalf("unexpected error %q, want %q", got, want)
+		}
+	})
+
+	t.Run("keeps default output", func(t *testing.T) {
+		resetExplainGlobals()
+
+		cmd := New()
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"tracingpolicy"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() unexpected error: %v", err)
+		}
+		if got := out.String(); !strings.Contains(got, "KIND:     TracingPolicy") {
+			t.Fatalf("expected default explain output, got %q", got)
+		}
+	})
+}
+
+func resetExplainGlobals() {
+	outputFormat = ""
+	recursive = false
+	showExample = false
+	listMode = false
+	apiVersion = ""
 }


### PR DESCRIPTION
### Description
`tetra explain` says `-o` only accepts `json|yaml`, but typos still slipped through and the command quietly fell back to the default text output

This fix makes bad `-o` values fail fast, and adds a small regression test.

Repro:
`go run ./cmd/tetra explain tracingpolicy -o bogus`

Before:
exit `0`, regular text output

After:
exit `1`, `Error: invalid value for "output" flag: bogus`

### Changelog
```release-note
Fix `tetra explain` so invalid `--output` values fail instead of silently falling back to text output.
```
