### PR TITLE
helm: Set hostUsers where applicable

### DIFF
--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -27,12 +27,13 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":1},"generateCA":true,"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.4.6"},"nodeSelector":{},"podLabels":{},"resources":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | cilium-certgen settings used by tetragon.grpc.tls.auto.method=cronJob. Mirrors the same block in cilium/cilium so operators familiar with the hubble TLS workflow find consistent knobs. |
+| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":1},"generateCA":true,"hostUsers":true,"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.4.6"},"nodeSelector":{},"podLabels":{},"resources":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | cilium-certgen settings used by tetragon.grpc.tls.auto.method=cronJob. Mirrors the same block in cilium/cilium so operators familiar with the hubble TLS workflow find consistent knobs. |
 | certgen.affinity | object | `{}` | Affinity for certgen pods. |
 | certgen.annotations | object | `{"cronJob":{},"job":{}}` | Annotations applied to certgen Job/CronJob objects. |
 | certgen.cronJob.failedJobsHistoryLimit | int | `1` | Number of failed CronJob runs to retain. |
 | certgen.cronJob.successfulJobsHistoryLimit | int | `1` | Number of successful CronJob runs to retain. |
 | certgen.generateCA | bool | `true` | Whether the certgen invocation should generate a CA when one isn't found in the configured CA Secret. |
+| certgen.hostUsers | bool | `true` | Run the certgen pods in the host user namespace. certgen needs no host access, set to false to run it in a user namespace. Requires Kubernetes 1.33 or later. |
 | certgen.nodeSelector | object | `{}` | Node selector for certgen pods. |
 | certgen.podLabels | object | `{}` | Pod labels added to certgen pods. |
 | certgen.resources | object | `{}` | Resource requests/limits for the certgen container. |
@@ -189,6 +190,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragonOperator.failoverLease.leaseRetryPeriod | string | `"2s"` | The timeout between retries if renewal fails |
 | tetragonOperator.failoverLease.namespace | string | `""` | Kubernetes Namespace in which the Lease resource is created. Defaults to the namespace where Tetragon is deployed in, if it's empty. |
 | tetragonOperator.forceUpdateCRDs | bool | `false` |  |
+| tetragonOperator.hostUsers | bool | `true` | Run the Tetragon Operator Deployment Pods in the host user namespace. The operator needs no host access, set to false to run it in a user namespace. Requires Kubernetes 1.33 or later. |
 | tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.7.0"}` | tetragon-operator image. |
 | tetragonOperator.nameOverride | string | `""` | The name of the Tetragon Operator deployment. |
 | tetragonOperator.nodeSelector | object | `{}` | Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules. |

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -29,6 +29,9 @@ K8S_VERSION = master
 # top of the chart defaults. Add a file to cover more of the chart.
 HELM_VALUES_DIR = kubeconform
 HELM_VALUES_FILES = $(notdir $(wildcard $(HELM_VALUES_DIR)/*.yaml))
+# Render for the version we validate against, so that version-gated fields
+# match the schema. "master" is not a semver, let Helm use its own default.
+HELM_KUBE_VERSION = $(if $(filter master,$(K8S_VERSION)),,--kube-version $(K8S_VERSION))
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 TETRAGON_CHART = tetragon
 CRDS_RELATIVE_DIR = pkg/k8s/apis/cilium.io/client/crds/v1alpha1
@@ -120,6 +123,7 @@ kubeconform:
 		echo ""; \
 		echo "==> $$values (Kubernetes $(K8S_VERSION))"; \
 		if $(HELM) template $(TETRAGON_CHART) . \
+			$(HELM_KUBE_VERSION) \
 			-f values.yaml \
 			-f /$(HELM_VALUES_DIR)/$$values \
 			| docker run --rm -i -u $(shell id -u):$(shell id -g) \

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -9,12 +9,13 @@ Helm chart for Tetragon
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":1},"generateCA":true,"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.4.6"},"nodeSelector":{},"podLabels":{},"resources":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | cilium-certgen settings used by tetragon.grpc.tls.auto.method=cronJob. Mirrors the same block in cilium/cilium so operators familiar with the hubble TLS workflow find consistent knobs. |
+| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":1},"generateCA":true,"hostUsers":true,"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.4.6"},"nodeSelector":{},"podLabels":{},"resources":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | cilium-certgen settings used by tetragon.grpc.tls.auto.method=cronJob. Mirrors the same block in cilium/cilium so operators familiar with the hubble TLS workflow find consistent knobs. |
 | certgen.affinity | object | `{}` | Affinity for certgen pods. |
 | certgen.annotations | object | `{"cronJob":{},"job":{}}` | Annotations applied to certgen Job/CronJob objects. |
 | certgen.cronJob.failedJobsHistoryLimit | int | `1` | Number of failed CronJob runs to retain. |
 | certgen.cronJob.successfulJobsHistoryLimit | int | `1` | Number of successful CronJob runs to retain. |
 | certgen.generateCA | bool | `true` | Whether the certgen invocation should generate a CA when one isn't found in the configured CA Secret. |
+| certgen.hostUsers | bool | `true` | Run the certgen pods in the host user namespace. certgen needs no host access, set to false to run it in a user namespace. Requires Kubernetes 1.33 or later. |
 | certgen.nodeSelector | object | `{}` | Node selector for certgen pods. |
 | certgen.podLabels | object | `{}` | Pod labels added to certgen pods. |
 | certgen.resources | object | `{}` | Resource requests/limits for the certgen container. |
@@ -171,6 +172,7 @@ Helm chart for Tetragon
 | tetragonOperator.failoverLease.leaseRetryPeriod | string | `"2s"` | The timeout between retries if renewal fails |
 | tetragonOperator.failoverLease.namespace | string | `""` | Kubernetes Namespace in which the Lease resource is created. Defaults to the namespace where Tetragon is deployed in, if it's empty. |
 | tetragonOperator.forceUpdateCRDs | bool | `false` |  |
+| tetragonOperator.hostUsers | bool | `true` | Run the Tetragon Operator Deployment Pods in the host user namespace. The operator needs no host access, set to false to run it in a user namespace. Requires Kubernetes 1.33 or later. |
 | tetragonOperator.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/tetragon-operator","tag":"v1.7.0"}` | tetragon-operator image. |
 | tetragonOperator.nameOverride | string | `""` | The name of the Tetragon Operator deployment. |
 | tetragonOperator.nodeSelector | object | `{}` | Steer the Tetragon Operator Deployment Pod placement via nodeSelector, tolerations and affinity rules. |

--- a/install/kubernetes/tetragon/templates/daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/daemonset.yaml
@@ -72,6 +72,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
+      {{- if (semverCompare ">= 1.33-0" .Capabilities.KubeVersion.Version) }}
+      hostUsers: true
+      {{- end }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       terminationGracePeriodSeconds: 1
       volumes:

--- a/install/kubernetes/tetragon/templates/operator_deployment.yaml
+++ b/install/kubernetes/tetragon/templates/operator_deployment.yaml
@@ -102,6 +102,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "tetragon-operator.serviceAccount" . }}
+      {{- if (semverCompare ">= 1.33-0" .Capabilities.KubeVersion.Version) }}
+      hostUsers: {{ .Values.tetragonOperator.hostUsers }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
         - name: tetragon-operator-config

--- a/install/kubernetes/tetragon/templates/rthooks-daemonset.yaml
+++ b/install/kubernetes/tetragon/templates/rthooks-daemonset.yaml
@@ -61,6 +61,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if (semverCompare ">= 1.33-0" .Capabilities.KubeVersion.Version) }}
+      hostUsers: true
+      {{- end }}
       volumes:
       - name: oci-hook-install-path
         hostPath:

--- a/install/kubernetes/tetragon/templates/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/_job-spec.tpl
@@ -18,6 +18,9 @@ template:
   spec:
     restartPolicy: OnFailure
     serviceAccountName: {{ include "tetragon.name" . }}-certgen
+    {{- if (semverCompare ">= 1.33-0" .Capabilities.KubeVersion.Version) }}
+    hostUsers: {{ .Values.certgen.hostUsers }}
+    {{- end }}
     securityContext:
       runAsNonRoot: true
       runAsUser: 65534

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -338,6 +338,10 @@ tetragonOperator:
     create: true
     annotations: {}
     name: ""
+  # -- Run the Tetragon Operator Deployment Pods in the host user namespace.
+  # The operator needs no host access, set to false to run it in a user
+  # namespace. Requires Kubernetes 1.33 or later.
+  hostUsers: true
   # -- securityContext for the Tetragon Operator Deployment Pods.
   podSecurityContext: {}
   # -- securityContext for the Tetragon Operator Deployment Pod container.
@@ -567,6 +571,10 @@ certgen:
   # -- Whether the certgen invocation should generate a CA when one isn't
   # found in the configured CA Secret.
   generateCA: true
+  # -- Run the certgen pods in the host user namespace. certgen needs no host
+  # access, set to false to run it in a user namespace. Requires Kubernetes
+  # 1.33 or later.
+  hostUsers: true
   # -- Pod labels added to certgen pods.
   podLabels: {}
   # -- Annotations applied to certgen Job/CronJob objects.


### PR DESCRIPTION
### Description
Set hostUsers: true on the agent and rthooks DaemonSets, which need host access. Let the operator and certgen opt into a user namespace.

Fixes: #5250

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
helm: Set hostUsers where applicable
```
