### PR TITLE
helm: Fix grpc template issue for cronJob

### DIFF
--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: write
 
 env:
-  MIN_K8S_VERSION: "1.23.0"
+  MIN_K8S_VERSION: "1.30.0"
   # renovate: datasource=python-version
   PYTHON_VERSION: "3.12"
 

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -25,12 +25,18 @@ K8S_VERSION = master
 #
 # -- Variables
 #
-HELM_VALUES_OVERRIDE = helm_lint_values_override.yaml
+# Each values file in this directory is validated as a separate scenario, on
+# top of the chart defaults. Add a file to cover more of the chart.
+HELM_VALUES_DIR = kubeconform
+HELM_VALUES_FILES = $(notdir $(wildcard $(HELM_VALUES_DIR)/*.yaml))
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 TETRAGON_CHART = tetragon
 CRDS_RELATIVE_DIR = pkg/k8s/apis/cilium.io/client/crds/v1alpha1
 CRDS := $(ROOT_DIR)/$(CRDS_RELATIVE_DIR)
 JSON_SCHEMAS := $(ROOT_DIR)/install/kubernetes/schemas
+# Shared by every scenario, so the upstream schemas are fetched once, not once
+# per scenario.
+SCHEMAS_CACHE := $(ROOT_DIR)/install/kubernetes/schemas-cache
 
 #
 # -- Commands
@@ -42,7 +48,7 @@ PYTHON := docker run --rm \
 		$(PYTHON_IMAGE)
 HELM := docker run --rm -u $(shell id -u):$(shell id -g) \
 		-v $(CURDIR)/$(TETRAGON_CHART):/apps \
-		-v $(CURDIR)/$(HELM_VALUES_OVERRIDE):/$(HELM_VALUES_OVERRIDE) \
+		-v $(CURDIR)/$(HELM_VALUES_DIR):/$(HELM_VALUES_DIR) \
 		$(HELM_IMAGE)
 
 #
@@ -102,24 +108,44 @@ check-images-tags: ## Verify all image:tag references in values.yaml exist in th
 # To validate potentially included Tetragon CRs in the Helm chart (using
 # openapi2jsonschema.py), we need to have the JSON schema of the TracingPolicy
 # CRD. Skip validating the Tetragon CRDs themselves (circular dependency).
+# Skip the cert-manager Certificate too: its schema belongs to cert-manager and
+# is not available here.
 kubeconform: ## Validate Helm chart using kubeconform
 kubeconform:
-	mkdir -p $(JSON_SCHEMAS)/
+	mkdir -p $(JSON_SCHEMAS)/ $(SCHEMAS_CACHE)/
 	$(PYTHON) /bin/bash -c "pip install pyyaml && python /code/install/kubernetes/openapi2jsonschema.py /code/$(CRDS_RELATIVE_DIR)/*"
 	mv $(ROOT_DIR)/install/kubernetes/*-cilium.io.json $(JSON_SCHEMAS)/
-	@echo "## Testing Helm chart: \"$(TETRAGON_CHART)\""
-	$(HELM) template $(TETRAGON_CHART) . \
-	-f values.yaml \
-	-f /$(HELM_VALUES_OVERRIDE) \
-	| docker run --rm -i -v $(JSON_SCHEMAS):/schemas $(KUBECONFORM_IMAGE) \
-		-summary \
-		-verbose \
-		-schema-location default \
-		-schema-location '/schemas/{{ .ResourceKind }}-{{ .Group }}.json' \
-		-skip CustomResourceDefinition \
-		-strict \
-		-kubernetes-version $(K8S_VERSION)
-	rm -rf $(JSON_SCHEMAS)/
+	@failed=""; \
+	for values in $(HELM_VALUES_FILES); do \
+		echo ""; \
+		echo "==> $$values (Kubernetes $(K8S_VERSION))"; \
+		if $(HELM) template $(TETRAGON_CHART) . \
+			-f values.yaml \
+			-f /$(HELM_VALUES_DIR)/$$values \
+			| docker run --rm -i -u $(shell id -u):$(shell id -g) \
+				-v $(JSON_SCHEMAS):/schemas \
+				-v $(SCHEMAS_CACHE):/cache \
+				$(KUBECONFORM_IMAGE) \
+				-summary \
+				-verbose \
+				-cache /cache \
+				-schema-location default \
+				-schema-location '/schemas/{{ .ResourceKind }}-{{ .Group }}.json' \
+				-skip CustomResourceDefinition,Certificate \
+				-strict \
+				-kubernetes-version $(K8S_VERSION); then \
+			echo "==> PASS: $$values"; \
+		else \
+			echo "==> FAIL: $$values"; \
+			failed="$$failed $$values"; \
+		fi; \
+	done; \
+	rm -rf $(JSON_SCHEMAS)/ $(SCHEMAS_CACHE)/; \
+	if [ -n "$$failed" ]; then \
+		echo ""; \
+		echo "kubeconform failed for:$$failed"; \
+		exit 1; \
+	fi
 
 ##@ Documentation
 

--- a/install/kubernetes/helm_lint_values_override.yaml
+++ b/install/kubernetes/helm_lint_values_override.yaml
@@ -1,2 +1,0 @@
-crds:
-  installMethod: helm

--- a/install/kubernetes/kubeconform/crds-helm.yaml
+++ b/install/kubernetes/kubeconform/crds-helm.yaml
@@ -1,0 +1,3 @@
+# Renders the CRDs through Helm instead of the operator, which is the default.
+crds:
+  installMethod: helm

--- a/install/kubernetes/kubeconform/grpc-tls-cert-manager.yaml
+++ b/install/kubernetes/kubeconform/grpc-tls-cert-manager.yaml
@@ -1,0 +1,13 @@
+# Renders the cert-manager Certificate for the gRPC TLS listener
+# (auto.method=certmanager).
+tetragon:
+  grpc:
+    address: localhost:54321
+    tls:
+      enabled: true
+      auto:
+        method: certmanager
+        certManagerIssuerRef:
+          group: cert-manager.io
+          kind: ClusterIssuer
+          name: tetragon-ca-issuer

--- a/install/kubernetes/kubeconform/grpc-tls-cron-job.yaml
+++ b/install/kubernetes/kubeconform/grpc-tls-cron-job.yaml
@@ -1,0 +1,9 @@
+# Renders the gRPC TLS resources that the default values leave out: the certgen
+# Job and CronJob, their RBAC, and the agent with the TLS Secret mounted.
+tetragon:
+  grpc:
+    address: localhost:54321
+    tls:
+      enabled: true
+      auto:
+        method: cronJob

--- a/install/kubernetes/kubeconform/grpc-tls-helm.yaml
+++ b/install/kubernetes/kubeconform/grpc-tls-helm.yaml
@@ -1,0 +1,8 @@
+# Renders the gRPC TLS Secrets that Helm issues itself (auto.method=helm).
+tetragon:
+  grpc:
+    address: localhost:54321
+    tls:
+      enabled: true
+      auto:
+        method: helm

--- a/install/kubernetes/tetragon/templates/_helpers.tpl
+++ b/install/kubernetes/tetragon/templates/_helpers.tpl
@@ -63,6 +63,11 @@ app.kubernetes.io/component: operator
 {{ include "commonLabels" . }}
 app.kubernetes.io/component: rthooks
 {{- end }}
+{{- define "tetragon-certgen.labels" -}}
+{{ include "tetragon.selectorLabels" . }}
+{{ include "commonLabels" . }}
+app.kubernetes.io/component: certgen
+{{- end }}
 
 {{/*
 Selector labels

--- a/install/kubernetes/tetragon/templates/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/_job-spec.tpl
@@ -1,5 +1,5 @@
 {{/*
-Reusable PodSpec / JobSpec body for the certgen Job and CronJob. Renders the
+Reusable JobSpec body for the certgen Job and CronJob. Renders the
 cilium-certgen invocation that (re)creates the server + CA Secrets for the
 tetragon gRPC TLS listener.
 */}}
@@ -8,82 +8,81 @@ tetragon gRPC TLS listener.
 {{- $validityStr := printf "%dh" $validityHours -}}
 {{- $caValidityHours := mul .Values.tetragon.grpc.tls.ca.certValidityDuration 24 -}}
 {{- $caValidityStr := printf "%dh" $caValidityHours -}}
-spec:
-  template:
-    metadata:
-      labels:
-        {{- include "tetragon.labels" . | nindent 8 }}
-        app.kubernetes.io/component: certgen
-        {{- with .Values.certgen.podLabels }}
-        {{- toYaml . | nindent 8 }}
+template:
+  metadata:
+    labels:
+      {{- include "tetragon.labels" . | nindent 6 }}
+      app.kubernetes.io/component: certgen
+      {{- with .Values.certgen.podLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  spec:
+    restartPolicy: OnFailure
+    serviceAccountName: {{ include "tetragon.name" . }}-certgen
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      runAsGroup: 65534
+      seccompProfile:
+        type: RuntimeDefault
+    {{- with .Values.certgen.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.certgen.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.certgen.affinity }}
+    affinity:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.imagePullSecrets }}
+    imagePullSecrets:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    containers:
+      - name: certgen
+        image: "{{ if .Values.certgen.image.override }}{{ .Values.certgen.image.override }}{{ else }}{{ .Values.certgen.image.repository }}:{{ .Values.certgen.image.tag }}{{ end }}"
+        imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        command:
+          - "/usr/bin/cilium-certgen"
+        args:
+          - "--ca-generate={{ .Values.certgen.generateCA }}"
+          - "--ca-reuse-secret"
+          - "--ca-secret-namespace={{ .Release.Namespace }}"
+          - "--ca-secret-name={{ include "tetragon.caSecretName" . }}"
+          - "--ca-common-name=Tetragon CA"
+          - "--ca-validity-duration={{ $caValidityStr }}"
+        env:
+          - name: CILIUM_CERTGEN_CONFIG
+            value: |
+              certs:
+                - name: {{ include "tetragon.grpcTlsSecretName" . }}
+                  namespace: {{ .Release.Namespace }}
+                  commonName: {{ include "tetragon.grpcTls.commonName" . | quote }}
+                  hosts:
+                    - {{ include "tetragon.grpcTls.commonName" . | quote }}
+                    {{- range .Values.tetragon.grpc.tls.server.extraDnsNames }}
+                    - {{ . | quote }}
+                    {{- end }}
+                    {{- range .Values.tetragon.grpc.tls.server.extraIpAddresses }}
+                    - {{ . | quote }}
+                    {{- end }}
+                  usage:
+                    - signing
+                    - key encipherment
+                    - server auth
+                    - client auth
+                  validity: {{ $validityStr }}
+        {{- with .Values.certgen.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-    spec:
-      restartPolicy: OnFailure
-      serviceAccountName: {{ include "tetragon.name" . }}-certgen
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
-        seccompProfile:
-          type: RuntimeDefault
-      {{- with .Values.certgen.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.certgen.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.certgen.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      containers:
-        - name: certgen
-          image: "{{ if .Values.certgen.image.override }}{{ .Values.certgen.image.override }}{{ else }}{{ .Values.certgen.image.repository }}:{{ .Values.certgen.image.tag }}{{ end }}"
-          imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
-          command:
-            - "/usr/bin/cilium-certgen"
-          args:
-            - "--ca-generate={{ .Values.certgen.generateCA }}"
-            - "--ca-reuse-secret"
-            - "--ca-secret-namespace={{ .Release.Namespace }}"
-            - "--ca-secret-name={{ include "tetragon.caSecretName" . }}"
-            - "--ca-common-name=Tetragon CA"
-            - "--ca-validity-duration={{ $caValidityStr }}"
-          env:
-            - name: CILIUM_CERTGEN_CONFIG
-              value: |
-                certs:
-                  - name: {{ include "tetragon.grpcTlsSecretName" . }}
-                    namespace: {{ .Release.Namespace }}
-                    commonName: {{ include "tetragon.grpcTls.commonName" . | quote }}
-                    hosts:
-                      - {{ include "tetragon.grpcTls.commonName" . | quote }}
-                      {{- range .Values.tetragon.grpc.tls.server.extraDnsNames }}
-                      - {{ . | quote }}
-                      {{- end }}
-                      {{- range .Values.tetragon.grpc.tls.server.extraIpAddresses }}
-                      - {{ . | quote }}
-                      {{- end }}
-                    usage:
-                      - signing
-                      - key encipherment
-                      - server auth
-                      - client auth
-                    validity: {{ $validityStr }}
-          {{- with .Values.certgen.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
 {{- end -}}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/_job-spec.tpl
@@ -11,8 +11,7 @@ tetragon gRPC TLS listener.
 template:
   metadata:
     labels:
-      {{- include "tetragon.labels" . | nindent 6 }}
-      app.kubernetes.io/component: certgen
+      {{- include "tetragon-certgen.labels" . | nindent 6 }}
       {{- with .Values.certgen.podLabels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/cronjob.yaml
@@ -21,5 +21,6 @@ spec:
       labels:
         {{- include "tetragon.labels" . | nindent 8 }}
         app.kubernetes.io/component: certgen
-    {{- include "tetragon.certgen.jobSpec" . | nindent 4 }}
+    spec:
+      {{- include "tetragon.certgen.jobSpec" . | nindent 6 }}
 {{- end }}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/cronjob.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ include "tetragon.name" . }}-certgen
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "tetragon.labels" . | nindent 4 }}
-    app.kubernetes.io/component: certgen
+    {{- include "tetragon-certgen.labels" . | nindent 4 }}
   {{- with .Values.certgen.annotations.cronJob }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -19,8 +18,7 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        {{- include "tetragon.labels" . | nindent 8 }}
-        app.kubernetes.io/component: certgen
+        {{- include "tetragon-certgen.labels" . | nindent 8 }}
     spec:
       {{- include "tetragon.certgen.jobSpec" . | nindent 6 }}
 {{- end }}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/job.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/job.yaml
@@ -13,8 +13,7 @@ metadata:
   name: {{ include "tetragon.name" . }}-certgen-{{ $jobHash }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "tetragon.labels" . | nindent 4 }}
-    app.kubernetes.io/component: certgen
+    {{- include "tetragon-certgen.labels" . | nindent 4 }}
   {{- with .Values.certgen.annotations.job }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/tetragon/templates/tls-cronjob/role.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/role.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ include "tetragon.name" . }}-certgen
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "tetragon.labels" . | nindent 4 }}
-    app.kubernetes.io/component: certgen
+    {{- include "tetragon-certgen.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]

--- a/install/kubernetes/tetragon/templates/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/rolebinding.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ include "tetragon.name" . }}-certgen
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "tetragon.labels" . | nindent 4 }}
-    app.kubernetes.io/component: certgen
+    {{- include "tetragon-certgen.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/install/kubernetes/tetragon/templates/tls-cronjob/serviceaccount.yaml
+++ b/install/kubernetes/tetragon/templates/tls-cronjob/serviceaccount.yaml
@@ -5,6 +5,5 @@ metadata:
   name: {{ include "tetragon.name" . }}-certgen
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "tetragon.labels" . | nindent 4 }}
-    app.kubernetes.io/component: certgen
+    {{- include "tetragon-certgen.labels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
### Description

This PR is to fix the duplicate spec.spec and label if tls method is set as cronJob. Additionally, adding a test with kubeconform for different values files, which will help us to extend more testing in helm.

Relates: https://github.com/cilium/tetragon/pull/4950

### Testing

Without the first two commits, below is the error from kubeconform tests

```
$ make -C install/kubernetes kubeconform
...
==> grpc-tls-cron-job.yaml (Kubernetes master)
stdin - ServiceAccount tetragon-certgen failed validation: error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
  line 15: key "app.kubernetes.io/component" already set in map
stdin - ConfigMap tetragon-operator-config is valid
stdin - ServiceAccount tetragon is valid
stdin - ConfigMap tetragon-config is valid
stdin - ServiceAccount tetragon-operator-service-account is valid
stdin - ClusterRoleBinding tetragon is valid
stdin - ClusterRoleBinding tetragon-operator-rolebinding is valid
stdin - ClusterRole tetragon is valid
stdin - ClusterRole tetragon-operator is valid
stdin - Role tetragon-certgen failed validation: error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
  line 15: key "app.kubernetes.io/component" already set in map
stdin - RoleBinding tetragon-certgen failed validation: error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
  line 15: key "app.kubernetes.io/component" already set in map
stdin - Role tetragon is valid
stdin - RoleBinding tetragon is valid
stdin - Service tetragon-operator-metrics is valid
stdin - Job tetragon-certgen-093605b7d6 failed validation: error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
  line 15: key "app.kubernetes.io/component" already set in map
  line 29: key "app.kubernetes.io/component" already set in map
stdin - Service tetragon is valid
stdin - DaemonSet tetragon is valid
stdin - Deployment tetragon-operator is valid
stdin - CronJob tetragon-certgen failed validation: error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
  line 15: key "app.kubernetes.io/component" already set in map
  line 31: key "app.kubernetes.io/component" already set in map
  line 43: key "app.kubernetes.io/component" already set in map
Summary: 19 resources found parsing stdin - Valid: 14, Invalid: 0, Errors: 5, Skipped: 0
==> FAIL: grpc-tls-cron-job.yaml

```

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
helm: Fix grpc template issue for cronJob
```
