### PR TITLE
Add support for gRPC-based persistent policies

### DIFF
--- a/cmd/tetra/tracingpolicy/tracingpolicy.go
+++ b/cmd/tetra/tracingpolicy/tracingpolicy.go
@@ -295,19 +295,11 @@ func tpSetModeCmd() *cobra.Command {
 		Long:  "Set a tracing policy to monitor or enforce mode.",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			var mode tetragon.TracingPolicyMode
-			switch args[1] {
-			case "enforce":
-				mode = tetragon.TracingPolicyMode_TP_MODE_ENFORCE
-			case "monitor":
-				mode = tetragon.TracingPolicyMode_TP_MODE_MONITOR
-			// TracingPolicyMode_TP_MODE_MONITOR_ONLY unmanaged here
-			default:
-				return fmt.Errorf("invalid mode %q", args[1])
+			mode, err := tracingpolicy.TpStringToMode(args[1])
+			if err != nil {
+				return err
 			}
-
-			err := tpConfigure(args[0], namespace, domain, nil, &mode)
+			err = tpConfigure(args[0], namespace, domain, nil, &mode)
 			if err != nil {
 				return fmt.Errorf("failed set mode to %q tracing policy: %w", args[1], err)
 			}

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/policystore"
 	"github.com/cilium/tetragon/pkg/rthooks"
+	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/server/eventlog"
 
 	"github.com/cilium/tetragon/pkg/bpf"
@@ -226,6 +227,77 @@ func openGRPCPolicyStore() (*policystore.Store, error) {
 		"policies", len(store.List()))
 
 	return store, nil
+}
+
+type persistedTracingPolicy struct {
+	policy  tracingpolicy.TracingPolicy
+	enabled bool
+}
+
+func restoreGRPCPolicies(ctx context.Context, store *policystore.Store, manager *sensors.Manager) error {
+	if store == nil {
+		return nil
+	}
+
+	// Validate all records before loading any of them. This avoids partially
+	// restoring a store when a later record is malformed.
+	records := store.List()
+	log.Info("Starting persisted gRPC policy restoration",
+		"policies", len(records))
+	policies := make([]persistedTracingPolicy, 0, len(records))
+	for _, entry := range records {
+		policy, err := tracingpolicy.FromYAML(entry.Pol.YAML)
+		if err != nil {
+			return fmt.Errorf("restore persisted gRPC policy %s: parse YAML: %w", entry.ID.Name, err)
+		}
+		if policy.TpName() != entry.ID.Name || policy.TpNamespace() != entry.ID.Namespace {
+			return fmt.Errorf(
+				"restore persisted gRPC policy %s: record identity does not match YAML identity %s/%s",
+				entry.ID.Name, policy.TpNamespace(), policy.TpName())
+		}
+
+		policies = append(policies, persistedTracingPolicy{
+			policy: &server.GRPCTracingPolicy{
+				TracingPolicy: policy,
+				Domain:        entry.ID.Domain,
+			},
+			enabled: entry.Pol.Enabled,
+		})
+	}
+
+	for i, persisted := range policies {
+		policy := persisted.policy
+		state := sensors.DisabledState
+		if persisted.enabled {
+			state = sensors.EnabledState
+		}
+		log.Info("Loading persisted gRPC policy",
+			"name", policy.TpName(),
+			"namespace", policy.TpNamespace(),
+			"domain", policy.TpDomain(),
+			"enabled", persisted.enabled)
+		if err := manager.AddTracingPolicyWithState(ctx, policy, state); err != nil {
+			// as we want all-or-nothing semantics a single policy load error has to
+			// delete all previously loaded policies
+			var rollbackErr error
+			for j := i - 1; j >= 0; j-- {
+				restored := policies[j].policy
+				if err := manager.DeleteTracingPolicy(ctx, restored.TpName(), restored.TpNamespace(), restored.TpDomain()); err != nil {
+					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("roll back restored gRPC policy %s: %w", tracingpolicy.TpLongname(restored), err))
+				}
+			}
+			return errors.Join(fmt.Errorf("restore persisted gRPC policy %s: load: %w", tracingpolicy.TpLongname(policy), err), rollbackErr)
+		}
+		log.Info("Restored persisted gRPC policy",
+			"name", policy.TpName(),
+			"namespace", policy.TpNamespace(),
+			"domain", policy.TpDomain(),
+			"enabled", persisted.enabled)
+	}
+	log.Info("Completed persisted gRPC policy restoration",
+		"policies", len(policies))
+
+	return nil
 }
 
 func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready func()) error {
@@ -480,11 +552,14 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 	if err = loadInitialSensor(ctx); err != nil {
 		return err
 	}
-	observer.GetSensorManager().LogSensorsAndProbes(ctx)
 	defer func() {
 		observer.RemoveSensors(ctx)
 		os.Remove(observerDir)
 	}()
+	if err = restoreGRPCPolicies(ctx, grpcPolicyStore, observer.GetSensorManager()); err != nil {
+		return err
+	}
+	observer.GetSensorManager().LogSensorsAndProbes(ctx)
 
 	pm, err := tetragonGrpc.NewProcessManager(
 		ctx,

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/pkg/policystore"
 	"github.com/cilium/tetragon/pkg/rthooks"
 	"github.com/cilium/tetragon/pkg/server/eventlog"
 
@@ -210,6 +211,23 @@ func tetragonExecute() error {
 	return tetragonExecuteCtx(ctx, cancel, func() {})
 }
 
+func openGRPCPolicyStore() (*policystore.Store, error) {
+	if !option.Config.PersistGRPCPolicies {
+		return nil, nil
+	}
+
+	store, err := policystore.OpenAndLoad(option.Config.PersistGRPCPoliciesDir)
+	if err != nil {
+		return nil, fmt.Errorf("open persistent policy store %q: %w", option.Config.PersistGRPCPoliciesDir, err)
+	}
+
+	log.Info("Opened persistent policy store",
+		"directory", option.Config.PersistGRPCPoliciesDir,
+		"policies", len(store.List()))
+
+	return store, nil
+}
+
 func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready func()) error {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
@@ -223,6 +241,11 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 		logger.Fatal(log, fmt.Sprintf("Failed path specified by --tracing-policy-dir '%q' is not absolute", option.Config.TracingPolicyDir))
 	}
 	option.Config.TracingPolicyDir = filepath.Clean(option.Config.TracingPolicyDir)
+
+	grpcPolicyStore, err := openGRPCPolicyStore()
+	if err != nil {
+		return err
+	}
 
 	if option.Config.RBSize != 0 && option.Config.RBSizeTotal != 0 {
 		logger.Fatal(log, "Can't specify --rb-size and --rb-size-total together")
@@ -467,7 +490,8 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 		ctx,
 		&cleanupWg,
 		observer.GetSensorManager(),
-		hookRunner)
+		hookRunner,
+		grpcPolicyStore)
 	if err != nil {
 		return err
 	}

--- a/docs/content/en/docs/concepts/enforcement/persistent-grpc-policies.md
+++ b/docs/content/en/docs/concepts/enforcement/persistent-grpc-policies.md
@@ -1,0 +1,138 @@
+---
+title: "Persistent gRPC policies"
+weight: 2
+description: "Persist and restore tracing policies installed through gRPC"
+---
+
+Tetragon can persist tracing policies installed through the gRPC API and
+restore their desired state after the agent restarts. Combined with persistent
+enforcement, this allows the old BPF programs to remain active while Tetragon
+loads replacement programs from the stored policies.
+
+This feature applies only to policies installed through gRPC, including
+policies added with `tetra tracingpolicy add`. Kubernetes and statically loaded
+policies continue to be managed by their respective policy sources.
+
+## Configuration
+
+Start Tetragon with the following options:
+
+```shell
+sudo ./tetragon \
+  --btf /sys/kernel/btf/vmlinux \
+  --bpf-lib ./bpf/objs/ \
+  --keep-sensors-on-exit \
+  --release-pinned-bpf=false \
+  --persist-grpc-policies \
+  --persist-grpc-policies-dir /var/run/tetragon/grpc-policies
+```
+
+Use the same options each time Tetragon starts.
+
+{{< caution >}}
+`--release-pinned-bpf` defaults to `true`. Set it explicitly to `false` when
+continuous enforcement across an agent restart is required. Enabling only the
+policy store restores policies, but does not preserve the previous BPF tree
+during startup.
+{{< /caution >}}
+
+The options have the following roles:
+
+- `--keep-sensors-on-exit` leaves pinned sensors active when Tetragon exits.
+- `--release-pinned-bpf=false` prevents Tetragon from removing the previous BPF
+  tree at the beginning of startup. Tetragon moves the tree aside and removes
+  it only after replacement policies have loaded.
+- `--persist-grpc-policies` enables saving and restoring policies installed
+  through gRPC.
+- `--persist-grpc-policies-dir` selects the policy store directory. Its default
+  value is `/var/run/tetragon/grpc-policies`.
+
+## Restart sequence
+
+On a normal restart, Tetragon performs the following handoff:
+
+1. Rename `/sys/fs/bpf/tetragon` to `/sys/fs/bpf/tetragon_old`. The links pinned
+   below this directory keep the previous BPF programs attached.
+2. Create a new `/sys/fs/bpf/tetragon` tree and load the initial sensors.
+3. Read and validate all records in the gRPC policy store.
+4. Recreate each stored policy in the new BPF tree. Tetragon registers disabled
+   policies without loading their BPF programs.
+5. Remove `/sys/fs/bpf/tetragon_old`, which detaches the previous programs.
+
+The policies are rebuilt from the persistent store; Tetragon does not reload
+them from `tetragon_old`. The old BPF tree exists only to maintain coverage
+during the handoff.
+
+{{< note >}}
+There is an interval during startup in which both the old and replacement
+programs are attached. This avoids an enforcement gap.
+{{< /note >}}
+
+## Manage persisted policies
+
+Policies added through gRPC are persisted automatically after they load
+successfully:
+
+```shell
+sudo ./tetra tracingpolicy add policy.yaml
+```
+
+Deleting a policy removes it from both the running agent and the persistent
+store:
+
+```shell
+sudo ./tetra tracingpolicy delete policy-name
+```
+
+Enable and disable operations update the stored desired state:
+
+```shell
+sudo ./tetra tracingpolicy disable policy-name
+sudo ./tetra tracingpolicy enable policy-name
+```
+
+Mode changes also update the stored policy YAML:
+
+```shell
+sudo ./tetra tracingpolicy set-mode policy-name monitor
+sudo ./tetra tracingpolicy set-mode policy-name enforce
+```
+
+## Stored desired state
+
+The store uses one JSON record per policy. A policy is uniquely identified by
+its domain, namespace, and name.
+
+Each record contains:
+
+- `yaml`: the complete policy, including its configured policy mode;
+- `enabled`: whether the policy is enabled or not.
+
+The policy identity is encoded in the record filename as
+`<name>:<namespace>:<domain>.json`.
+
+For example:
+
+```json
+{
+  "yaml": "apiVersion: cilium.io/v1alpha1\nkind: TracingPolicy\nmetadata:\n  name: lsm-file-open\nspec:\n  options:\n  - name: policy-mode\n    value: monitor\n  lsmhooks:\n  - hook: file_open\n",
+  "enabled": true
+}
+```
+
+## Failure behavior
+
+The running policy and its stored desired state are updated together:
+
+- If adding a new record to the store fails, Tetragon removes the newly loaded
+  runtime policy and restores any previous store state.
+- Enable, disable, and mode changes write the desired state before changing the
+  running policy. If the runtime change fails, Tetragon restores the previous
+  record.
+- Deleting a policy removes its record before deleting the running policy. If
+  the runtime deletion fails, Tetragon restores the record.
+
+At startup, Tetragon validates every stored policy before loading any of them.
+If loading a policy fails, it rolls back policies restored earlier in the same
+startup attempt and reports the error. The old BPF tree is removed only after
+startup policy loading succeeds.

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -217,6 +217,14 @@ options:
       usage: Set entries for parents_map table (default 32768)
     - name: parents-map-size
       usage: Set size for parents_map table (allows K/M/G suffix)
+    - name: persist-grpc-policies
+      default_value: "false"
+      usage: |
+        Persist tracing policies installed over gRPC across agent restarts
+    - name: persist-grpc-policies-dir
+      default_value: /var/run/tetragon/grpc-policies
+      usage: |
+        Directory in which to persist tracing policies installed over gRPC
     - name: pprof-address
       usage: |
         Serves runtime profile data via HTTP (e.g. 'localhost:6060'). Disabled by default

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -229,7 +229,8 @@ func startBenchmarkExporter(ctx context.Context, obs *observer.Observer, summary
 		ctx,
 		&wg,
 		observer.GetSensorManager(),
-		hookRunner)
+		hookRunner,
+		nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -53,6 +53,9 @@ const (
 	// Default directory from where to load tracing policies.
 	DefaultTpDir = "/etc/tetragon/tetragon.tp.d"
 
+	// Default directory in which to persist tracing policies installed over gRPC.
+	DefaultGRPCPolicyDir = DefaultRunDir + "grpc-policies"
+
 	// Default secure export logs permissions
 	DefaultLogsPermission = "600"
 

--- a/pkg/defaults/defaults_windows.go
+++ b/pkg/defaults/defaults_windows.go
@@ -40,6 +40,9 @@ const (
 	// Default directory from where to load tracing policies.
 	DefaultTpDir = DefaultRunDir + "tetragon.tp.d"
 
+	// Default directory in which to persist tracing policies installed over gRPC.
+	DefaultGRPCPolicyDir = DefaultRunDir + "grpc-policies"
+
 	// Default secure export logs permissions
 	DefaultLogsPermission = "600"
 

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -99,7 +99,7 @@ func TestExporter_Send(t *testing.T) {
 	eventNotifier := newFakeNotifier()
 	ctx, cancel := context.WithCancel(context.Background())
 	dr := rthooks.DummyHookRunner{}
-	grpcServer := server.NewServer(ctx, &wg, eventNotifier, &server.FakeObserver{}, dr)
+	grpcServer := server.NewServer(ctx, &wg, eventNotifier, &server.FakeObserver{}, dr, nil)
 	numRecords := 2
 	results := newArrayWriter(numRecords)
 	encoder := encoder.NewProtojsonEncoder(results)
@@ -206,7 +206,7 @@ func Test_rateLimitExport(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				eventNotifier := newFakeNotifier()
 				dr := rthooks.DummyHookRunner{}
-				grpcServer := server.NewServer(ctx, &wg, eventNotifier, &server.FakeObserver{}, dr)
+				grpcServer := server.NewServer(ctx, &wg, eventNotifier, &server.FakeObserver{}, dr, nil)
 				results := newArrayWriter(tt.totalEvents)
 				encoder := encoder.NewProtojsonEncoder(results)
 				request := &tetragon.GetEventsRequest{}
@@ -249,7 +249,7 @@ func TestExporterSetLoggingParams(t *testing.T) {
 		eventNotifier := newFakeNotifier()
 
 		dr := rthooks.DummyHookRunner{}
-		grpcServer := server.NewServer(ctx, &wg, eventNotifier, &server.FakeObserver{}, dr)
+		grpcServer := server.NewServer(ctx, &wg, eventNotifier, &server.FakeObserver{}, dr, nil)
 
 		tempDir := t.TempDir()
 

--- a/pkg/grpc/process_manager.go
+++ b/pkg/grpc/process_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/policystore"
 	"github.com/cilium/tetragon/pkg/reader/node"
 	"github.com/cilium/tetragon/pkg/reader/notify"
 	"github.com/cilium/tetragon/pkg/rthooks"
@@ -33,12 +34,13 @@ func NewProcessManager(
 	wg *sync.WaitGroup,
 	manager *sensors.Manager,
 	hookRunner *rthooks.Runner,
+	policyStore *policystore.Store,
 ) (*ProcessManager, error) {
 	pm := &ProcessManager{
 		listeners: make(map[server.Listener]struct{}),
 	}
 
-	pm.Server = server.NewServer(ctx, wg, pm, manager, hookRunner)
+	pm.Server = server.NewServer(ctx, wg, pm, manager, hookRunner, policyStore)
 
 	// Exec cache is always needed to ensure events have an associated Process{}
 	eventcache.New(pm)

--- a/pkg/grpc/process_manager_test.go
+++ b/pkg/grpc/process_manager_test.go
@@ -159,7 +159,8 @@ func TestProcessManager_GetProcessExec(t *testing.T) {
 		context.Background(),
 		&wg,
 		nil,
-		&rthooks.Runner{})
+		&rthooks.Runner{},
+		nil)
 	require.NoError(t, err)
 	pi := &exec.MsgExecveEventUnix{
 		Unix: &processapi.MsgExecveEventUnix{

--- a/pkg/metrics/policymetrics/policymetrics_test.go
+++ b/pkg/metrics/policymetrics/policymetrics_test.go
@@ -16,6 +16,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/tetragon/pkg/observer"
+	"github.com/cilium/tetragon/pkg/sensors"
 	tuo "github.com/cilium/tetragon/pkg/testutils/observer"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
@@ -93,7 +94,7 @@ tetragon_tracingpolicy_loaded{state="skipped"} %d
 			Name: "salad",
 		},
 	}
-	err = manager.AddSkippedTracingPolicy(context.TODO(), &tp5)
+	err = manager.AddTracingPolicyWithState(context.TODO(), &tp5, sensors.SkippedState)
 	require.NoError(t, err)
 
 	err = testutil.CollectAndCompare(collector, expectedMetrics(0, 4, 0, 0, 1))

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -398,7 +398,7 @@ func loadExporter(tb testing.TB, ctx context.Context, obs *observer.Observer, op
 	// report nil or a pre-defined value. So no cache needed.
 	option.Config.EnableProcessNs = true
 	option.Config.EnableProcessCred = true
-	processManager, err := tetragonGrpc.NewProcessManager(ctx, &cancelWg, sensorManager, hookRunner)
+	processManager, err := tetragonGrpc.NewProcessManager(ctx, &cancelWg, sensorManager, hookRunner, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -117,7 +117,9 @@ type config struct {
 	HealthServerAddress  string
 	HealthServerInterval int
 
-	KeepSensorsOnExit bool
+	KeepSensorsOnExit      bool
+	PersistGRPCPolicies    bool
+	PersistGRPCPoliciesDir string
 
 	EnableCRI   bool
 	CRIEndpoint string

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -125,7 +125,9 @@ const (
 
 	KeyBpfDir = "bpf-dir"
 
-	KeyKeepSensorsOnExit = "keep-sensors-on-exit"
+	KeyKeepSensorsOnExit      = "keep-sensors-on-exit"
+	KeyPersistGRPCPolicies    = "persist-grpc-policies"
+	KeyPersistGRPCPoliciesDir = "persist-grpc-policies-dir"
 
 	KeyEnableCRI   = "enable-cri"
 	KeyCRIEndpoint = "cri-endpoint"
@@ -299,6 +301,8 @@ func ReadAndSetFlags() error {
 	Config.BpfDir = viper.GetString(KeyBpfDir)
 
 	Config.KeepSensorsOnExit = viper.GetBool(KeyKeepSensorsOnExit)
+	Config.PersistGRPCPolicies = viper.GetBool(KeyPersistGRPCPolicies)
+	Config.PersistGRPCPoliciesDir = viper.GetString(KeyPersistGRPCPoliciesDir)
 
 	Config.EnableCRI = viper.GetBool(KeyEnableCRI)
 	Config.CRIEndpoint = viper.GetString(KeyCRIEndpoint)
@@ -563,6 +567,8 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.String(KeyBpfDir, defaults.DefaultMapPrefix, "Set tetragon bpf directory (default 'tetragon')")
 
 	flags.Bool(KeyKeepSensorsOnExit, false, "Do not unload sensors on exit")
+	flags.Bool(KeyPersistGRPCPolicies, false, "Persist tracing policies installed over gRPC across agent restarts")
+	flags.String(KeyPersistGRPCPoliciesDir, defaults.DefaultGRPCPolicyDir, "Directory in which to persist tracing policies installed over gRPC")
 
 	flags.Bool(KeyEnableCRI, false, "enable CRI client for tetragon")
 	flags.String(KeyCRIEndpoint, "", "CRI endpoint")

--- a/pkg/policystore/format.go
+++ b/pkg/policystore/format.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package policystore
+
+import (
+	"fmt"
+)
+
+type PolicyID struct {
+	Name      string // policy name
+	Namespace string // can be empty
+	Domain    string // i.e. grpc, static, k8s
+}
+
+// returns the string representation of the policy ID
+func (id PolicyID) String() string {
+	return fmt.Sprintf("%s:%s:%s", id.Name, id.Namespace, id.Domain)
+}
+
+type PolicyWithState struct {
+	YAML    string `json:"yaml"`
+	Enabled bool   `json:"enabled"`
+}
+
+type PolicyEntry struct {
+	ID  PolicyID
+	Pol PolicyWithState
+}
+
+type PolicyStore interface {
+	Get(id PolicyID) (PolicyWithState, bool)
+	Put(id PolicyID, state PolicyWithState) error
+	Delete(id PolicyID) error
+	List() []PolicyEntry
+}

--- a/pkg/policystore/store.go
+++ b/pkg/policystore/store.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package policystore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/logger/logfields"
+)
+
+const (
+	recordFileSuffix     = ".json"
+	recordTempFileSuffix = ".json.tmp"
+	recordDirMode        = 0o700
+	recordFileMode       = 0o600
+)
+
+var errDstRemoved = errors.New("destination removed")
+
+type Store struct {
+	dir     string
+	mu      sync.Mutex
+	records map[PolicyID]PolicyWithState
+}
+
+// gets aaa:bbb:ccc.json and returns (aaa, bbb, ccc)
+func decodeFilename(name string) (string, string, string, error) {
+	base := strings.TrimSuffix(name, recordFileSuffix)
+	parts := strings.SplitN(base, ":", 3)
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("invalid filename %s: expected format aaa:bbb:ccc.json", name)
+	}
+
+	return parts[0], parts[1], parts[2], nil
+}
+
+func OpenAndLoad(dir string) (*Store, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, errors.New("policy store directory must not be empty")
+	}
+
+	dir = filepath.Clean(dir)
+	if err := os.MkdirAll(dir, recordDirMode); err != nil {
+		return nil, fmt.Errorf("create policy store directory %s: %w", dir, err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("stat policy store directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("policy store path %s is not a directory", dir)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read policy store directory %s: %w", dir, err)
+	}
+
+	s := &Store{
+		dir:     dir,
+		records: make(map[PolicyID]PolicyWithState),
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasSuffix(name, recordTempFileSuffix) || !strings.HasSuffix(name, recordFileSuffix) {
+			logger.GetLogger().Warn("unrecognized file in policy store",
+				"filename", name)
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			logger.GetLogger().Warn("stat policy record failed",
+				logfields.Error, err,
+				"path", filepath.Join(dir, name))
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			logger.GetLogger().Warn("policy record is not a regular file",
+				"path", filepath.Join(dir, name))
+			continue
+		}
+
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read policy record %s: %w", path, err)
+		}
+
+		var pol PolicyWithState
+		if err := json.Unmarshal(data, &pol); err != nil {
+			return nil, fmt.Errorf("decode policy record %s: %w", path, err)
+		}
+
+		polName, polNamespae, polDomain, polErr := decodeFilename(name)
+		if polErr != nil {
+			return nil, fmt.Errorf("policy record %s has unexpected filename", path)
+		}
+		id := PolicyID{
+			Name:      polName,
+			Namespace: polNamespae,
+			Domain:    polDomain,
+		}
+		if _, exists := s.records[id]; exists {
+			return nil, fmt.Errorf("duplicate policy record for %s", id)
+		}
+
+		s.records[id] = pol
+	}
+
+	return s, nil
+}
+
+func (s *Store) List() []PolicyEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries := make([]PolicyEntry, 0, len(s.records))
+	for id, pol := range s.records {
+		entries = append(entries, PolicyEntry{ID: id, Pol: pol})
+	}
+	return entries
+}
+
+func (s *Store) Get(id PolicyID) (PolicyWithState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.records[id]
+	return state, ok
+}
+
+func (s *Store) Put(id PolicyID, state PolicyWithState) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode policy record for %s: %w", id, err)
+	}
+	data = append(data, '\n')
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := writeAtomic(s.dir, id.String(), data); err != nil {
+		if errors.Is(err, errDstRemoved) {
+			delete(s.records, id)
+		}
+		return fmt.Errorf("write policy record for %s: %w", id, err)
+	}
+	s.records[id] = state
+	return nil
+}
+
+func (s *Store) Delete(id PolicyID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := filepath.Join(s.dir, id.String()+recordFileSuffix)
+	err := os.Remove(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("delete policy record for %s: %w", id, err)
+	}
+
+	delete(s.records, id)
+	if err == nil {
+		if err := syncDir(s.dir); err != nil {
+			return fmt.Errorf("sync policy store after deleting %s: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func chmodWriteSync(f *os.File, data []byte) error {
+	defer f.Close()
+	if err := f.Chmod(recordFileMode); err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeAtomic attempts to write data atomicaly to a file
+// if an error happens, the caller should try to put the previous
+// record if anything exists
+func writeAtomic(dir, name string, data []byte) (retErr error) {
+	tmp, err := os.CreateTemp(dir, name+".*"+recordTempFileSuffix)
+	if err != nil {
+		retErr = fmt.Errorf("failed to create tempfile in dir %q for name %q: %w", dir, name, err)
+		return
+	}
+
+	tmpName := tmp.Name()
+	fileToRemove := tmpName
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if err := os.Remove(fileToRemove); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("failed to remove %q: %w", fileToRemove, err))
+		} else {
+			if tmpName != fileToRemove {
+				retErr = errors.Join(retErr, errDstRemoved)
+			}
+		}
+		// make an attempt to sync the dir
+		syncDir(dir)
+	}()
+
+	if err := chmodWriteSync(tmp, data); err != nil {
+		retErr = fmt.Errorf("failed to write data to tempfile %q: %w", tmpName, err)
+		return
+	}
+
+	dst := filepath.Join(dir, name+recordFileSuffix)
+	if err := os.Rename(tmpName, dst); err != nil {
+		retErr = fmt.Errorf("failed rename tempfile %q to %q: %w", tmpName, dst, err)
+		return
+	}
+
+	// now the proper file exists, we need to sync the directory to make this fully atomic in
+	// the rare occasion that something bad happens, we remove the file
+	fileToRemove = dst
+	if err := syncDir(dir); err != nil {
+		retErr = fmt.Errorf("failed to sync directory: %w", err)
+		return
+	}
+
+	return
+}
+
+func syncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}

--- a/pkg/policystore/store_test.go
+++ b/pkg/policystore/store_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package policystore
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testPolicyID(name string) PolicyID {
+	return PolicyID{
+		Domain:    "grpc",
+		Namespace: "test-namespace",
+		Name:      name,
+	}
+}
+
+func testPolicyState(name string) PolicyWithState {
+	return PolicyWithState{
+		YAML:    "apiVersion: cilium.io/v1alpha1\nkind: TracingPolicy\nmetadata:\n  name: " + name + "\n",
+		Enabled: true,
+	}
+}
+
+func TestOpenCreatesEmptyStore(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "policies")
+
+	store, err := OpenAndLoad(dir)
+	require.NoError(t, err)
+	assert.Empty(t, store.List())
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestPutReplacesRecord(t *testing.T) {
+	store, err := OpenAndLoad(t.TempDir())
+	require.NoError(t, err)
+
+	id := testPolicyID("policy")
+	pol := testPolicyState("policy")
+	require.NoError(t, store.Put(id, pol))
+
+	pol.Enabled = false
+	pol.YAML += "spec: {}\n"
+	require.NoError(t, store.Put(id, pol))
+
+	assert.Equal(t, []PolicyEntry{{ID: id, Pol: pol}}, store.List())
+	reopened, err := OpenAndLoad(store.dir)
+	require.NoError(t, err)
+	assert.Equal(t, []PolicyEntry{{ID: id, Pol: pol}}, reopened.List())
+}
+
+func TestPolicyWithoutNamespace(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenAndLoad(dir)
+	require.NoError(t, err)
+
+	id := testPolicyID("cluster-wide-policy")
+	id.Namespace = ""
+	state := testPolicyState("cluster-wide-policy")
+	require.NoError(t, store.Put(id, state))
+
+	reopened, err := OpenAndLoad(dir)
+	require.NoError(t, err)
+	got, ok := reopened.Get(id)
+	require.True(t, ok)
+	assert.Equal(t, state, got)
+}
+
+func TestDelete(t *testing.T) {
+	store, err := OpenAndLoad(t.TempDir())
+	require.NoError(t, err)
+
+	id := testPolicyID("policy")
+	state := testPolicyState("policy")
+	require.NoError(t, store.Put(id, state))
+	require.NoError(t, store.Delete(id))
+	require.NoError(t, store.Delete(id))
+
+	_, ok := store.Get(id)
+	assert.False(t, ok)
+
+	reopened, err := OpenAndLoad(store.dir)
+	require.NoError(t, err)
+	assert.Empty(t, reopened.List())
+}
+
+func TestOpenRejectsInvalidRecords(t *testing.T) {
+	t.Run("invalid JSON", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "invalid.json"), []byte("{"), recordFileMode))
+
+		_, err := OpenAndLoad(dir)
+		require.ErrorContains(t, err, "decode policy record")
+	})
+
+	t.Run("unexpected filename", func(t *testing.T) {
+		dir := t.TempDir()
+		state := testPolicyState("policy")
+		data, err := json.Marshal(state)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "wrong.json"), data, recordFileMode))
+
+		_, err = OpenAndLoad(dir)
+		require.ErrorContains(t, err, "unexpected filename")
+	})
+}
+
+func TestOpenIgnoresTemporaryAndUnrelatedFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".record.json.tmp-123"), []byte("{"), recordFileMode))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README"), []byte("unrelated"), recordFileMode))
+
+	store, err := OpenAndLoad(dir)
+	require.NoError(t, err)
+	assert.Empty(t, store.List())
+}
+
+func TestOpenRejectsFilePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store")
+	require.NoError(t, os.WriteFile(path, nil, recordFileMode))
+
+	_, err := OpenAndLoad(path)
+	require.Error(t, err)
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	store, err := OpenAndLoad(t.TempDir())
+	require.NoError(t, err)
+
+	const count = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, count)
+	for i := range count {
+		wg.Go(func() {
+			id := testPolicyID(fmt.Sprintf("policy-%02d", i))
+			state := testPolicyState(fmt.Sprintf("policy-%02d", i))
+			if err := store.Put(id, state); err != nil {
+				errCh <- err
+				return
+			}
+			_, ok := store.Get(id)
+			if !ok {
+				errCh <- fmt.Errorf("record %q was not found", id.Name)
+			}
+		})
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	assert.Len(t, store.List(), count)
+}

--- a/pkg/sensors/handler.go
+++ b/pkg/sensors/handler.go
@@ -101,6 +101,10 @@ func (h *handler) addTracingPolicy(op *tracingPolicyAdd) error {
 	if err != nil {
 		return err
 	}
+	if op.state == SkippedState {
+		col.state = SkippedState
+		return nil
+	}
 
 	// update policy filter state before loading the sensors of the policy.
 	//
@@ -127,6 +131,10 @@ func (h *handler) addTracingPolicy(op *tracingPolicyAdd) error {
 	}
 	col.sensors = make([]SensorIface, 0, len(sensors))
 	col.sensors = append(col.sensors, sensors...)
+	if op.state == DisabledState {
+		col.state = DisabledState
+		return nil
+	}
 	col.state = LoadingState
 
 	notAllowedReasons := make([]string, 0, len(col.sensors))
@@ -150,20 +158,6 @@ func (h *handler) addTracingPolicy(op *tracingPolicyAdd) error {
 		return err
 	}
 	col.state = EnabledState
-	return nil
-}
-
-// addSkippedTracingPolicy tracks a policy that is not loaded on this node, so
-// that it is reported as skipped instead of being absent. No sensors and no
-// policyfilter state are created.
-func (h *handler) addSkippedTracingPolicy(op *tracingPolicyAdd) error {
-	h.collections.mu.Lock()
-	defer h.collections.mu.Unlock()
-	col, err := h.registerNewCollection(op)
-	if err != nil {
-		return err
-	}
-	col.state = SkippedState
 	return nil
 }
 

--- a/pkg/sensors/manager.go
+++ b/pkg/sensors/manager.go
@@ -132,23 +132,25 @@ func newTracingPolicyAdd(ctx context.Context, tp tracingpolicy.TracingPolicy) (*
 
 // AddTracingPolicy adds a new sensor based on a tracing policy
 func (h *Manager) AddTracingPolicy(ctx context.Context, tp tracingpolicy.TracingPolicy) error {
-	op, err := newTracingPolicyAdd(ctx, tp)
-	if err != nil {
-		return err
-	}
-
-	return h.handler.addTracingPolicy(op)
+	return h.AddTracingPolicyWithState(ctx, tp, EnabledState)
 }
 
-// AddSkippedTracingPolicy tracks tp as skipped, without loading any BPF, so
-// that it is reported instead of being absent on this node.
-func (h *Manager) AddSkippedTracingPolicy(ctx context.Context, tp tracingpolicy.TracingPolicy) error {
+// AddTracingPolicyWithState adds a new sensor based on a tracing policy and
+// controls its initial state. A disabled policy remains registered and can
+// subsequently be enabled with EnableTracingPolicy. A skipped policy is
+// tracked without creating sensors or policy filter state.
+func (h *Manager) AddTracingPolicyWithState(ctx context.Context, tp tracingpolicy.TracingPolicy, state TracingPolicyState) error {
+	if state != EnabledState && state != DisabledState && state != SkippedState {
+		return fmt.Errorf("invalid initial tracing policy state: %v", state)
+	}
+
 	op, err := newTracingPolicyAdd(ctx, tp)
 	if err != nil {
 		return err
 	}
 
-	return h.handler.addSkippedTracingPolicy(op)
+	op.state = state
+	return h.handler.addTracingPolicy(op)
 }
 
 // DeleteTracingPolicy deletes a new sensor based on a tracing policy
@@ -269,9 +271,10 @@ type Manager struct {
 
 // tracingPolicyAdd adds a sensor based on a the provided tracing policy
 type tracingPolicyAdd struct {
-	ctx context.Context
-	ck  collectionKey
-	tp  tracingpolicy.TracingPolicy
+	ctx   context.Context
+	ck    collectionKey
+	tp    tracingpolicy.TracingPolicy
+	state TracingPolicyState
 }
 
 type tracingPolicyDelete struct {

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -71,7 +71,7 @@ func TestAddSkippedTracingPolicy(t *testing.T) {
 
 	policy := v1alpha1.TracingPolicy{}
 	policy.Name = "skipped-policy"
-	err = mgr.AddSkippedTracingPolicy(ctx, &policy)
+	err = mgr.AddTracingPolicyWithState(ctx, &policy, SkippedState)
 	require.NoError(t, err)
 
 	// Reported as skipped.
@@ -93,7 +93,7 @@ func TestAddSkippedTracingPolicy(t *testing.T) {
 	require.ErrorContains(t, err, "is skipped")
 
 	// A skipped policy holds no state, so tracking it again is not an error.
-	err = mgr.AddSkippedTracingPolicy(ctx, &policy)
+	err = mgr.AddTracingPolicyWithState(ctx, &policy, SkippedState)
 	require.NoError(t, err)
 
 	// A skipped policy can be deleted like any tracked policy.
@@ -129,7 +129,7 @@ func TestSkippedTracingPolicyLoaded(t *testing.T) {
 
 			policy := v1alpha1.TracingPolicy{}
 			policy.Name = "test-policy"
-			require.NoError(t, mgr.AddSkippedTracingPolicy(ctx, &policy))
+			require.NoError(t, mgr.AddTracingPolicyWithState(ctx, &policy, SkippedState))
 
 			if tc.deleteBeforeAdd {
 				require.NoError(t, mgr.DeleteTracingPolicy(ctx, "test-policy", "", policy.TpDomain()))

--- a/pkg/sensors/manager_test.go
+++ b/pkg/sensors/manager_test.go
@@ -374,6 +374,41 @@ func TestPolicyStates(t *testing.T) {
 		assert.Len(t, l.Policies, 1)
 		assert.Equal(t, DisabledState.ToTetragonState(), l.Policies[0].State)
 	})
+
+	t.Run("InitiallyDisabled", func(t *testing.T) {
+		RegisterPolicyHandlerAtInit("dummy", &dummyHandler{s: &Sensor{Name: "dummy-sensor"}})
+		t.Cleanup(func() {
+			delete(registeredPolicyHandlers, "dummy")
+		})
+
+		policy := v1alpha1.TracingPolicy{}
+		mgr, err := StartSensorManager("")
+		require.NoError(t, err)
+		policy.Name = "test-policy"
+		err = mgr.AddTracingPolicyWithState(ctx, &policy, DisabledState)
+		require.NoError(t, err)
+
+		policies, err := mgr.ListTracingPolicies(ctx, policy.TpDomain())
+		require.NoError(t, err)
+		require.Len(t, policies.Policies, 1)
+		assert.Equal(t, DisabledState.ToTetragonState(), policies.Policies[0].State)
+
+		sensorStatuses, err := mgr.ListSensors(ctx)
+		require.NoError(t, err)
+		require.Len(t, *sensorStatuses, 1)
+		assert.False(t, (*sensorStatuses)[0].Enabled)
+
+		err = mgr.EnableTracingPolicy(ctx, policy.Name, policy.Namespace, policy.TpDomain())
+		require.NoError(t, err)
+		policies, err = mgr.ListTracingPolicies(ctx, policy.TpDomain())
+		require.NoError(t, err)
+		require.Len(t, policies.Policies, 1)
+		assert.Equal(t, EnabledState.ToTetragonState(), policies.Policies[0].State)
+		sensorStatuses, err = mgr.ListSensors(ctx)
+		require.NoError(t, err)
+		require.Len(t, *sensorStatuses, 1)
+		assert.True(t, (*sensorStatuses)[0].Enabled)
+	})
 }
 
 // TestPolicyLoadErrorOverride tests the fact that you can add a TracingPolicy

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -409,6 +409,7 @@ func (s *Server) EnableTracingPolicy(ctx context.Context, req *tetragon.EnableTr
 	}
 	return &tetragon.EnableTracingPolicyResponse{}, nil
 }
+
 func (s *Server) ConfigureTracingPolicy(ctx context.Context, req *tetragon.ConfigureTracingPolicyRequest) (*tetragon.ConfigureTracingPolicyResponse, error) {
 	logger.GetLogger().Debug("Received a ConfigureTrcingPolicy request", "name", req.GetName())
 
@@ -416,8 +417,47 @@ func (s *Server) ConfigureTracingPolicy(ctx context.Context, req *tetragon.Confi
 	if req.GetDomain() == "" {
 		req.Domain = GrpcDomain
 	}
+	id := policystore.PolicyID{Name: req.GetName(), Namespace: req.GetNamespace(), Domain: req.GetDomain()}
+
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+
+	var previous policystore.PolicyWithState
+	var exists bool
+	if s.policyStore != nil {
+		// policy store is enabled so first thing is to get the previous etry with the same id
+		previous, exists = s.policyStore.Get(id)
+		if exists {
+			next := previous
+			// an entry already exists so we update the in-memory representation to be disabled
+			// check if enabled state is changed
+			if req.Enable != nil {
+				next.Enabled = req.GetEnable()
+			}
+			// check if mode changed
+			if req.Mode != nil {
+				mode, err := tracingpolicy.TpModeToString(req.GetMode())
+				if err != nil {
+					return nil, err
+				}
+				policyYAML, err := tracingpolicy.PolicyYAMLSetMode([]byte(next.YAML), mode)
+				if err != nil {
+					return nil, fmt.Errorf("update stored policy mode: %w", err)
+				}
+				next.YAML = string(policyYAML)
+			}
+			if err := persistWithRollback(s.policyStore, id, next, previous); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	if err := s.observer.ConfigureTracingPolicy(ctx, req); err != nil {
+		if s.policyStore != nil && exists {
+			if restoreErr := s.policyStore.Put(id, previous); restoreErr != nil {
+				err = errors.Join(err, fmt.Errorf("restore persisted state for policy %s: %w", id.Name, restoreErr))
+			}
+		}
 		return nil, err
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/policystore"
 	"github.com/cilium/tetragon/pkg/process"
 	"github.com/cilium/tetragon/pkg/tetragoninfo"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
@@ -68,6 +69,16 @@ type Server struct {
 	notifier     Notifier
 	observer     observer
 	hookRunner   hookRunner
+	policyStore  *policystore.Store
+	// In most cases, the access pattern in the policyStore is:
+	// 1. Get the current (previous) entry.
+	// 2. Add the new entry.
+	// 3. Try the runtime call.
+	// 4. If (3) fails, restore the previous entry.
+	// This lock ensures that 1, 2, and 4 happen atomically during
+	// concurrent server operations, otherwise this can lead to an
+	// inconsistent state in the runtime and the store.
+	policyMu sync.Mutex
 	tetragon.UnimplementedFineGuidanceSensorsServer
 }
 
@@ -75,13 +86,14 @@ type getEventsListener struct {
 	events chan *tetragon.GetEventsResponse
 }
 
-func NewServer(ctx context.Context, cleanupWg *sync.WaitGroup, notifier Notifier, observer observer, hookRunner hookRunner) *Server {
+func NewServer(ctx context.Context, cleanupWg *sync.WaitGroup, notifier Notifier, observer observer, hookRunner hookRunner, policyStore *policystore.Store) *Server {
 	return &Server{
 		ctx:          ctx,
 		ctxCleanupWG: cleanupWg,
 		notifier:     notifier,
 		observer:     observer,
 		hookRunner:   hookRunner,
+		policyStore:  policyStore,
 	}
 }
 
@@ -266,6 +278,31 @@ func (s *Server) AddTracingPolicy(ctx context.Context, req *tetragon.AddTracingP
 			"metadata.name", tp.TpName())
 		return nil, err
 	}
+
+	if s.policyStore != nil {
+		id := policystore.PolicyID{Name: tp.TpName(), Namespace: tp.TpNamespace(), Domain: gtp.TpDomain()}
+
+		s.policyMu.Lock()
+		defer s.policyMu.Unlock()
+
+		state := policystore.PolicyWithState{
+			YAML:    req.GetYaml(),
+			Enabled: true,
+		}
+		if err := s.policyStore.Put(id, state); err != nil {
+			// as we didn't manage to make the add operation persistent
+			// remove that from the runtime as well and report an error
+			runtimeRollbackErr := s.observer.DeleteTracingPolicy(ctx, id.Name, id.Namespace, id.Domain)
+			if runtimeRollbackErr != nil {
+				runtimeRollbackErr = fmt.Errorf("roll back runtime policy %s: %w", id.Name, runtimeRollbackErr)
+			}
+
+			return nil, errors.Join(
+				fmt.Errorf("persist added policy %s: %w", id.Name, err),
+				runtimeRollbackErr,
+			)
+		}
+	}
 	return &tetragon.AddTracingPolicyResponse{}, nil
 }
 
@@ -276,9 +313,38 @@ func (s *Server) DeleteTracingPolicy(ctx context.Context, req *tetragon.DeleteTr
 	if req.GetDomain() != "" {
 		domain = req.GetDomain()
 	}
+	id := policystore.PolicyID{Name: req.GetName(), Namespace: req.GetNamespace(), Domain: domain}
+
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+
+	var previous policystore.PolicyWithState
+	var exists bool
+	if s.policyStore != nil {
+		previous, exists = s.policyStore.Get(id)
+		// policy may not loaded by grpc (i.e. static) so we need to handle
+		// the case where the policy does not exist in the store
+		if exists {
+			if err := s.policyStore.Delete(id); err != nil {
+				restoreErr := s.policyStore.Put(id, previous)
+				if restoreErr != nil {
+					restoreErr = fmt.Errorf("restore persisted state for policy %s: %w", id.Name, restoreErr)
+				}
+				return nil, errors.Join(
+					fmt.Errorf("delete persisted policy %s: %w", id.Name, err),
+					restoreErr,
+				)
+			}
+		}
+	}
 
 	if err := s.observer.DeleteTracingPolicy(ctx, req.GetName(), req.GetNamespace(), domain); err != nil {
 		logger.GetLogger().Warn("Server DeleteTracingPolicy request failed", "name", req.GetName(), logfields.Error, err)
+		if s.policyStore != nil && exists {
+			if restoreErr := s.policyStore.Put(id, previous); restoreErr != nil {
+				err = errors.Join(err, fmt.Errorf("restore persisted state for policy %s: %w", id.Name, restoreErr))
+			}
+		}
 		return nil, err
 	}
 	return &tetragon.DeleteTracingPolicyResponse{}, nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -306,6 +306,22 @@ func (s *Server) AddTracingPolicy(ctx context.Context, req *tetragon.AddTracingP
 	return &tetragon.AddTracingPolicyResponse{}, nil
 }
 
+// try to persist policy with id and next
+// if this fails tries to revert to previous
+func persistWithRollback(store *policystore.Store, id policystore.PolicyID, next, previous policystore.PolicyWithState) error {
+	if err := store.Put(id, next); err != nil { // and now we try to make that persistent
+		restoreErr := store.Put(id, previous) // the previous step failed so we try to put back the previous entry
+		if restoreErr != nil {                // and capture any errors from that
+			restoreErr = fmt.Errorf("restore persisted state for policy %s: %w", id.Name, restoreErr)
+		}
+		return errors.Join(
+			fmt.Errorf("persist desired state for policy %s: %w", id.Name, err),
+			restoreErr,
+		)
+	}
+	return nil
+}
+
 func (s *Server) DeleteTracingPolicy(ctx context.Context, req *tetragon.DeleteTracingPolicyRequest) (*tetragon.DeleteTracingPolicyResponse, error) {
 	logger.GetLogger().Debug("Received a DeleteTracingPolicy request", "name", req.GetName())
 
@@ -362,9 +378,33 @@ func (s *Server) EnableTracingPolicy(ctx context.Context, req *tetragon.EnableTr
 	if req.GetDomain() != "" {
 		domain = req.GetDomain()
 	}
+	id := policystore.PolicyID{Name: req.GetName(), Namespace: req.GetNamespace(), Domain: domain}
+
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+
+	var previous policystore.PolicyWithState
+	var exists bool
+	if s.policyStore != nil {
+		// policy store is enabled so first thing is to get the previous etry with the same id
+		previous, exists = s.policyStore.Get(id)
+		if exists {
+			// an entry already exists so we update the in-memory representation to be enabled
+			next := previous
+			next.Enabled = true
+			if err := persistWithRollback(s.policyStore, id, next, previous); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	if err := s.observer.EnableTracingPolicy(ctx, req.GetName(), req.GetNamespace(), domain); err != nil {
 		logger.GetLogger().Warn("Server EnableTracingPolicy request failed", "name", req.GetName(), logfields.Error, err)
+		if s.policyStore != nil && exists {
+			if restoreErr := s.policyStore.Put(id, previous); restoreErr != nil {
+				err = errors.Join(err, fmt.Errorf("restore persisted state for policy %s: %w", id.Name, restoreErr))
+			}
+		}
 		return nil, err
 	}
 	return &tetragon.EnableTracingPolicyResponse{}, nil
@@ -396,9 +436,33 @@ func (s *Server) DisableTracingPolicy(ctx context.Context, req *tetragon.Disable
 	if req.GetDomain() != "" {
 		domain = req.GetDomain()
 	}
+	id := policystore.PolicyID{Name: req.GetName(), Namespace: req.GetNamespace(), Domain: domain}
+
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+
+	var previous policystore.PolicyWithState
+	var exists bool
+	if s.policyStore != nil {
+		// policy store is enabled so first thing is to get the previous etry with the same id
+		previous, exists = s.policyStore.Get(id)
+		if exists {
+			// an entry already exists so we update the in-memory representation to be disabled
+			next := previous
+			next.Enabled = false
+			if err := persistWithRollback(s.policyStore, id, next, previous); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	if err := s.observer.DisableTracingPolicy(ctx, req.GetName(), req.GetNamespace(), domain); err != nil {
 		logger.GetLogger().Warn("Server DisableTracingPolicy request failed", "name", req.GetName(), logfields.Error, err)
+		if s.policyStore != nil && exists {
+			if restoreErr := s.policyStore.Put(id, previous); restoreErr != nil {
+				err = errors.Join(err, fmt.Errorf("restore persisted state for policy %s: %w", id.Name, restoreErr))
+			}
+		}
 		return nil, err
 	}
 	return &tetragon.DisableTracingPolicyResponse{}, nil

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -5,12 +5,14 @@ package server
 
 import (
 	"log/slog"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/policystore"
 )
 
 func TestServer(t *testing.T) {
@@ -63,4 +65,49 @@ func TestSetDebug(t *testing.T) {
 	_, err = srv.SetDebug(t.Context(), req)
 	require.NoError(t, err, "Expected SetDebug to succeed with valid log level")
 	require.NotEqual(t, logger.GetLogLevel(logger.GetLogger()), prevLogLevel, "Expected log level to change, but it didn't")
+}
+
+func TestConfigureTracingPolicyStoresModeInYAML(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("policy store filenames are not supported on Windows")
+	}
+
+	store, err := policystore.OpenAndLoad(t.TempDir())
+	require.NoError(t, err)
+	id := policystore.PolicyID{Name: "test-policy", Namespace: "", Domain: GrpcDomain}
+	state := policystore.PolicyWithState{
+		YAML: `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: test-policy
+spec:
+  options:
+  - name: policy-mode
+    value: enforce
+`,
+		Enabled: true,
+	}
+	require.NoError(t, store.Put(id, state))
+
+	enabled := false
+	mode := tetragon.TracingPolicyMode_TP_MODE_MONITOR
+	srv := &Server{observer: &FakeObserver{}, policyStore: store}
+	_, err = srv.ConfigureTracingPolicy(t.Context(), &tetragon.ConfigureTracingPolicyRequest{
+		Name:   "test-policy",
+		Enable: &enabled,
+		Mode:   &mode,
+	})
+	require.NoError(t, err)
+	state, exists := store.Get(id)
+	require.True(t, exists)
+	require.False(t, state.Enabled)
+	require.YAMLEq(t, `apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: test-policy
+spec:
+  options:
+  - name: policy-mode
+    value: monitor
+`, state.YAML)
 }

--- a/pkg/tracingpolicy/mode.go
+++ b/pkg/tracingpolicy/mode.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracingpolicy
+
+import (
+	"fmt"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+)
+
+func TpModeToString(m tetragon.TracingPolicyMode) (string, error) {
+	var mode string
+	switch m {
+	case tetragon.TracingPolicyMode_TP_MODE_ENFORCE:
+		mode = "enforce"
+	case tetragon.TracingPolicyMode_TP_MODE_MONITOR:
+		mode = "monitor"
+	default:
+		return "", fmt.Errorf("invalid mode: %v", m)
+	}
+	return mode, nil
+}
+
+func TpStringToMode(s string) (tetragon.TracingPolicyMode, error) {
+	var mode tetragon.TracingPolicyMode
+	switch s {
+	case "enforce":
+		mode = tetragon.TracingPolicyMode_TP_MODE_ENFORCE
+	case "monitor":
+		mode = tetragon.TracingPolicyMode_TP_MODE_MONITOR
+	default:
+		return tetragon.TracingPolicyMode_TP_MODE_UNKNOWN, fmt.Errorf("invalid mode: %s", s)
+	}
+	return mode, nil
+}

--- a/pkg/watcher/crdwatcher/tracingpolicy_namespaced_reconciler.go
+++ b/pkg/watcher/crdwatcher/tracingpolicy_namespaced_reconciler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/logger/logfields"
+	"github.com/cilium/tetragon/pkg/sensors"
 )
 
 // TracingPolicyNamespacedReconciler reconciles namespaced TracingPolicy
@@ -64,7 +65,7 @@ func (r *TracingPolicyNamespacedReconciler) Reconcile(ctx context.Context, req c
 		log.Info("skipping namespaced tracing policy: node does not match spec.nodeSelector")
 		// unlike a load failure below, this is not terminal: requeue so the
 		// policy does not stay untracked
-		if addErr := r.Sensors.AddSkippedTracingPolicy(ctx, tp); addErr != nil {
+		if addErr := r.Sensors.AddTracingPolicyWithState(ctx, tp, sensors.SkippedState); addErr != nil {
 			log.Warn("tracking skipped namespaced tracing policy failed", logfields.Error, addErr)
 			return ctrl.Result{}, addErr
 		}

--- a/pkg/watcher/crdwatcher/tracingpolicy_reconciler.go
+++ b/pkg/watcher/crdwatcher/tracingpolicy_reconciler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/logger/logfields"
+	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
 
@@ -28,7 +29,7 @@ import (
 // Defined where it is consumed so the Reconciler can be unit-tested with a fake.
 type sensorManager interface {
 	AddTracingPolicy(ctx context.Context, tp tracingpolicy.TracingPolicy) error
-	AddSkippedTracingPolicy(ctx context.Context, tp tracingpolicy.TracingPolicy) error
+	AddTracingPolicyWithState(ctx context.Context, tp tracingpolicy.TracingPolicy, state sensors.TracingPolicyState) error
 	DeleteTracingPolicy(ctx context.Context, name string, namespace string, domain string) error
 }
 
@@ -76,7 +77,7 @@ func (r *TracingPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		log.Info("skipping tracing policy: node does not match spec.nodeSelector")
 		// unlike a load failure below, this is not terminal: requeue so the
 		// policy does not stay untracked
-		if addErr := r.Sensors.AddSkippedTracingPolicy(ctx, tp); addErr != nil {
+		if addErr := r.Sensors.AddTracingPolicyWithState(ctx, tp, sensors.SkippedState); addErr != nil {
 			log.Warn("tracking skipped tracing policy failed", logfields.Error, addErr)
 			return ctrl.Result{}, addErr
 		}

--- a/pkg/watcher/crdwatcher/tracingpolicy_reconciler_integration_test.go
+++ b/pkg/watcher/crdwatcher/tracingpolicy_reconciler_integration_test.go
@@ -26,6 +26,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
 
@@ -45,9 +46,9 @@ func (r *recordingSensors) AddTracingPolicy(_ context.Context, tp tracingpolicy.
 	return nil
 }
 
-// AddSkippedTracingPolicy satisfies sensorManager. No policy here sets a
+// AddTracingPolicyWithState satisfies sensorManager. No policy here sets a
 // nodeSelector, so it is never called; nodeselector_test.go covers that path.
-func (r *recordingSensors) AddSkippedTracingPolicy(_ context.Context, _ tracingpolicy.TracingPolicy) error {
+func (r *recordingSensors) AddTracingPolicyWithState(_ context.Context, _ tracingpolicy.TracingPolicy, _ sensors.TracingPolicyState) error {
 	return nil
 }
 

--- a/pkg/watcher/crdwatcher/tracingpolicy_reconciler_test.go
+++ b/pkg/watcher/crdwatcher/tracingpolicy_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
 
@@ -60,7 +61,7 @@ func (f *fakeSensors) AddTracingPolicy(_ context.Context, tp tracingpolicy.Traci
 	return f.addErr
 }
 
-func (f *fakeSensors) AddSkippedTracingPolicy(_ context.Context, tp tracingpolicy.TracingPolicy) error {
+func (f *fakeSensors) AddTracingPolicyWithState(_ context.Context, tp tracingpolicy.TracingPolicy, _ sensors.TracingPolicyState) error {
 	f.skippedCalls = append(f.skippedCalls, addCall{tp.TpName(), tp.TpNamespace()})
 	return f.skippedErr
 }


### PR DESCRIPTION
This PR adds persistence for tracing policies installed through the gRPC API, including policies managed with `tetra tracingpolicy`.

Persisted policies are restored when Tetragon restarts, including their state (enabled or disabled) and configured policy mode. This allows policy enforcement to remain active across agent restarts when combined with the existing pinned BPF handoff.

Example configuration:

```bash
tetragon [...] --keep-sensors-on-exit --release-pinned-bpf=false --persist-grpc-policies --persist-grpc-policies-dir /var/run/tetragon/grpc-policies
```

Details on the command line arguments:

1. `--keep-sensors-on-exit` keeps the existing BPF programs active when Tetragon stops
2. `--release-pinned-bpf=false` prevents the previous BPF programs from being removed when Tetragon starts
3. `--persist-grpc-policies` enables persistence and restoration of gRPC-based policies
4. `--persist-grpc-policies-dir` configures the directory containing the persistent policies

This PR adds support for `--persist-grpc-policies` and `--persist-grpc-policies-dir`. The remaining arguments already existed in Tetragon.

During a Tetragon restart, the following steps take place:
1. When Tetragon stops, `/sys/fs/bpf/tetragon` is not deleted and for this reason enforcement is still active even if the agent is not running. This happens because of `--keep-sensors-on-exit`.
2. When Tetragon re-starts, the existing `/sys/fs/bpf/tetragon` directory is renamed to `/sys/fs/bpf/tetragon_old`. Enforcement remains active. This happens because of `--release-pinned-bpf=false`. 
3. Tetragon re-creates a new `/sys/fs/bpf/tetragon` and restores the policies from the persistent store. This happens because of `--persist-grpc-policies`.
4. After policy loading completes, `/sys/fs/bpf/tetragon_old` is removed.

There is a short interval during which both the old and new programs are active. This overlap is intentional and avoids an enforcement gap during the restart.

More details can be found on the commit messages.