### PR TITLE
fix: uprobe multi hooks `override` action overwritten by latest one

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1620,6 +1620,7 @@ type KernelSelectorArgs struct {
 	ListReader     ValueReader
 	Maps           *KernelSelectorMaps
 	IsUprobe       bool
+	UprobeID       int
 	CelExprs       *CelExprFunctions
 }
 
@@ -1684,13 +1685,14 @@ func createKernelSelectorState(
 	listReader ValueReader,
 	maps *KernelSelectorMaps,
 	isUprobe bool,
+	uprobeID int,
 	celExprs *CelExprFunctions,
 	parseSelector func(k *KernelSelectorState, selectors *v1alpha1.KProbeSelector, selIdx int) error,
 ) (*KernelSelectorState, error) {
 	if len(selectors) > MaxSelectors {
 		return nil, fmt.Errorf("no more than %d selectors supported (%d provided)", MaxSelectors, len(selectors))
 	}
-	state := NewKernelSelectorState(listReader, maps, isUprobe, celExprs)
+	state := NewKernelSelectorState(listReader, maps, isUprobe, uprobeID, celExprs)
 
 	WriteSelectorUint32(&state.data, uint32(len(selectors)))
 	soff := make([]uint32, len(selectors))
@@ -1744,7 +1746,7 @@ func InitKernelSelectorState(args *KernelSelectorArgs) (*KernelSelectorState, er
 		return nil
 	}
 
-	return createKernelSelectorState(args.Selectors, args.ListReader, args.Maps, args.IsUprobe, args.CelExprs, parse)
+	return createKernelSelectorState(args.Selectors, args.ListReader, args.Maps, args.IsUprobe, args.UprobeID, args.CelExprs, parse)
 }
 
 func InitKernelReturnSelectorState(selectors []v1alpha1.KProbeSelector, returnArg *v1alpha1.KProbeArg,
@@ -1760,7 +1762,7 @@ func InitKernelReturnSelectorState(selectors []v1alpha1.KProbeSelector, returnAr
 		return nil
 	}
 
-	return createKernelSelectorState(selectors, listReader, maps, false, nil, parse)
+	return createKernelSelectorState(selectors, listReader, maps, false, 0, nil, parse)
 }
 
 func CleanupKernelSelectorState(state *KernelSelectorState) error {

--- a/pkg/selectors/kernel_regs_amd64.go
+++ b/pkg/selectors/kernel_regs_amd64.go
@@ -47,5 +47,5 @@ func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64)
 	}
 
 	k.regs = regs
-	return uint32(0), nil
+	return uint32(k.uprobeID), nil
 }

--- a/pkg/selectors/kernel_regs_arm64.go
+++ b/pkg/selectors/kernel_regs_arm64.go
@@ -46,5 +46,5 @@ func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64)
 	}
 
 	k.regs = regs
-	return uint32(0), nil
+	return uint32(k.uprobeID), nil
 }

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -318,7 +318,7 @@ func TestParseMatchArgs(t *testing.T) {
 	expected = append(expected, data1Expected[:]...)
 	expected = append(expected, data2Expected[:]...)
 
-	ks := NewKernelSelectorState(nil, nil, false, nil)
+	ks := NewKernelSelectorState(nil, nil, false, 0, nil)
 	d := &ks.data
 	if err := ParseMatchArgs(ks, argsSel, dataSel, args, data); err != nil || bytes.Equal(expected, d.e[0:d.off]) == false {
 		t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\n", err, expected, d.e[0:d.off])
@@ -345,7 +345,7 @@ func TestParseMatchData(t *testing.T) {
 	}
 
 	arg1 := &v1alpha1.ArgSelector{Index: 0, Operator: "Equal", Values: []string{"ex"}}
-	k := NewKernelSelectorState(nil, nil, false, nil)
+	k := NewKernelSelectorState(nil, nil, false, 0, nil)
 	d := &k.data
 
 	expected1 := []byte{
@@ -516,7 +516,7 @@ func TestParseMatchArg(t *testing.T) {
 	}
 
 	arg1 := &v1alpha1.ArgSelector{Index: 1, Operator: "Equal", Values: []string{"foobar"}}
-	k := NewKernelSelectorState(nil, nil, false, nil)
+	k := NewKernelSelectorState(nil, nil, false, 0, nil)
 	d := &k.data
 
 	expected1 := []byte{
@@ -676,7 +676,7 @@ func TestParseMatchArg(t *testing.T) {
 		expected3 := append(length, expected1[:]...)
 		expected3 = append(expected3, expected2[:]...)
 		arg12 := []v1alpha1.ArgSelector{*arg1, *arg2}
-		ks := NewKernelSelectorState(nil, nil, false, nil)
+		ks := NewKernelSelectorState(nil, nil, false, 0, nil)
 		d = &ks.data
 		if err := ParseMatchArgs(ks, arg12, []v1alpha1.ArgSelector{}, sig, []v1alpha1.KProbeArg{}); err != nil || bytes.Equal(expected3, d.e[0:d.off]) == false {
 			t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected3, d.e[0:d.off], arg3)
@@ -703,7 +703,7 @@ func TestParseMatchArg(t *testing.T) {
 			{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}: {},
 		}
 
-		ks = NewKernelSelectorState(nil, nil, false, nil)
+		ks = NewKernelSelectorState(nil, nil, false, 0, nil)
 		d = &ks.data
 		if err := ParseMatchArg(ks, arg13, sig); err != nil ||
 			bytes.Equal(expected12, d.e[0:d.off]) == false ||
@@ -1400,7 +1400,7 @@ func TestParseMatchArgSubString(t *testing.T) {
 			}
 
 			arg := &v1alpha1.ArgSelector{Index: 1, Operator: "SubString", Values: []string{"test"}}
-			k := NewKernelSelectorState(nil, nil, false, nil)
+			k := NewKernelSelectorState(nil, nil, false, 0, nil)
 			d := &k.data
 
 			expected := []byte{

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -133,6 +133,7 @@ type KernelSelectorState struct {
 	maps *KernelSelectorMaps
 
 	isUprobe bool
+	uprobeID int
 
 	regs []processapi.RegAssignment
 
@@ -149,6 +150,7 @@ func NewKernelSelectorState(
 	listReader ValueReader,
 	maps *KernelSelectorMaps,
 	isUprobe bool,
+	uprobeID int,
 	celExprs *CelExprFunctions,
 ) *KernelSelectorState {
 	if maps == nil {
@@ -163,6 +165,7 @@ func NewKernelSelectorState(
 		listReader:         listReader,
 		maps:               maps,
 		isUprobe:           isUprobe,
+		uprobeID:           uprobeID,
 		celExprFunctions:   celExprs,
 		matchWorkloadIDs:   make(map[int]policyfilter.PolicyID),
 	}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -88,7 +88,7 @@ type genericUprobe struct {
 	pendingEvents *lru.Cache[pendingEventKey, pendingEvent[*tracing.MsgGenericUprobeUnix]]
 }
 
-func populateUprobeRegs(m *ebpf.Map, regs []processapi.RegAssignment) error {
+func populateUprobeRegs(m *ebpf.Map, id int, regs []processapi.RegAssignment) error {
 	uprobeRegs := processapi.UprobeRegs{}
 
 	n := copy(uprobeRegs.Ass[:], regs)
@@ -96,7 +96,7 @@ func populateUprobeRegs(m *ebpf.Map, regs []processapi.RegAssignment) error {
 		logger.GetLogger().Warn("register assignments count mismatch", "#regs", len(regs))
 	}
 	uprobeRegs.Cnt = uint32(n)
-	return m.Update(uint32(0), uprobeRegs, ebpf.UpdateAny)
+	return m.Update(uint32(id), uprobeRegs, ebpf.UpdateAny)
 }
 
 func (g *genericUprobe) SetID(id idtable.EntryID) {
@@ -245,7 +245,7 @@ func loadSingleUprobeSensor(uprobeEntry *genericUprobe, args sensors.LoadProbeAr
 				&program.MapLoad{
 					Name: "regs_map",
 					Load: func(m *ebpf.Map, _ string) error {
-						return populateUprobeRegs(m, selector.Regs())
+						return populateUprobeRegs(m, 0, selector.Regs())
 					},
 				},
 			)
@@ -362,7 +362,7 @@ func loadMultiUprobeSensor(ids []idtable.EntryID, args sensors.LoadProbeArgs) er
 					&program.MapLoad{
 						Name: "regs_map",
 						Load: func(m *ebpf.Map, _ string) error {
-							return populateUprobeRegs(m, selector.Regs())
+							return populateUprobeRegs(m, index, selector.Regs())
 						},
 					},
 				)
@@ -573,12 +573,13 @@ func validateUprobeFeatures(spec *v1alpha1.UProbeSpec, has *uprobeHas) error {
 	return nil
 }
 
-func initUprobeSelectors(spec *v1alpha1.UProbeSpec, in *addUprobeIn, state *uprobeConfigState) error {
+func initUprobeSelectors(spec *v1alpha1.UProbeSpec, in *addUprobeIn, state *uprobeConfigState, nextIdx int) error {
 	entry, err := selectors.InitKernelSelectorState(&selectors.KernelSelectorArgs{
 		Selectors: spec.Selectors,
 		Args:      spec.Args,
 		Data:      spec.Data,
 		IsUprobe:  true,
+		UprobeID:  nextIdx,
 		CelExprs:  in.celExprs,
 	})
 	if err != nil {
@@ -1118,7 +1119,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, entryFile *os.File, ids []idtable.Entr
 		return ids, err
 	}
 
-	if err := initUprobeSelectors(spec, in, &state); err != nil {
+	if err := initUprobeSelectors(spec, in, &state, len(ids)); err != nil {
 		return ids, err
 	}
 
@@ -1204,6 +1205,7 @@ func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []
 
 	if has.sleepableOffload {
 		regsMap := program.MapBuilderProgram("regs_map", load)
+		regsMap.SetMaxEntries(len(multiIDs))
 		sleepableOffloadMap := program.MapBuilderProgram("sleepable_offload", load)
 		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
 		maps = append(maps, regsMap, sleepableOffloadMap)

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -38,7 +38,10 @@ func TestUprobeOverrideAction(t *testing.T) {
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
 
 	// Put uprobe at the beginning of test_1 function and make sure
-	// uprobe overrides test_1 return value (with 123).
+	// uprobe overrides test_1 return value (with 123),
+	// even if a second hook on `test_3` exists with return value 234.
+	// Also make sure that second hook is correct too.
+	// See https://github.com/cilium/tetragon/issues/5285.
 
 	pathHook := `
 apiVersion: cilium.io/v1alpha1
@@ -54,15 +57,26 @@ spec:
     - matchActions:
       - action: Override
         argError: 123
+  - path: "` + testBinary + `"
+    symbols:
+    - "test_3"
+    selectors:
+    - matchActions:
+      - action: Override
+        argError: 234
 `
 
 	createCrdFile(t, pathHook)
 
-	upChecker := ec.NewProcessUprobeChecker("UPROBE_OVERRIDE").
+	up1Checker := ec.NewProcessUprobeChecker("UPROBE_OVERRIDE_1").
 		WithProcess(ec.NewProcessChecker().
 			WithBinary(sm.Full(testBinary))).
 		WithSymbol(sm.Full("test_1"))
-	checker := ec.NewUnorderedEventChecker(upChecker)
+	up3Checker := ec.NewProcessUprobeChecker("UPROBE_OVERRIDE_3").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(testBinary))).
+		WithSymbol(sm.Full("test_3"))
+	checker := ec.NewUnorderedEventChecker(up1Checker, up3Checker)
 
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
@@ -80,6 +94,10 @@ spec:
 	cmd := exec.Command(testBinary, "1")
 	require.Error(t, cmd.Run())
 	require.Equal(t, 123, cmd.ProcessState.ExitCode())
+
+	cmd = exec.Command(testBinary, "3")
+	require.Error(t, cmd.Run())
+	require.Equal(t, 234, cmd.ProcessState.ExitCode())
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #5285

### Description

As described in the issue, whenever a spec with multiple uprobes, each of one with its own `override` match action, was applied, the last uprobe.matchAction.Override arguments would overwrite the override arguments for all other uprobes.
The problem is that `populateUprobeRegs` always overwrote the `0` index of the `regs_map`; that is correct in the single sensor, but for multi, each uprobe entry should fill its own index, otherwise the last entry would take over.
Needed also to pass the `uprobeID` (the index of the current uprobe entry we are creating) to `InitKernelSelectorState` to allow `selectors.parseOverrideRegs()` to correctly store the index to be looked for in ebpf.

### Changelog


```release-note
fix: uprobe multi hooks `override` action overwritten by latest one
```
