### PR TITLE
[v1.7] sync: lsm dup hook bug and uprobe override matchaction fix

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1580,6 +1580,7 @@ type KernelSelectorArgs struct {
 	ListReader     ValueReader
 	Maps           *KernelSelectorMaps
 	IsUprobe       bool
+	UprobeID       int
 	CelExprs       *CelExprFunctions
 }
 
@@ -1644,13 +1645,14 @@ func createKernelSelectorState(
 	listReader ValueReader,
 	maps *KernelSelectorMaps,
 	isUprobe bool,
+	uprobeID int,
 	celExprs *CelExprFunctions,
 	parseSelector func(k *KernelSelectorState, selectors *v1alpha1.KProbeSelector, selIdx int) error,
 ) (*KernelSelectorState, error) {
 	if len(selectors) > MaxSelectors {
 		return nil, fmt.Errorf("no more than %d selectors supported (%d provided)", MaxSelectors, len(selectors))
 	}
-	state := NewKernelSelectorState(listReader, maps, isUprobe, celExprs)
+	state := NewKernelSelectorState(listReader, maps, isUprobe, uprobeID, celExprs)
 
 	WriteSelectorUint32(&state.data, uint32(len(selectors)))
 	soff := make([]uint32, len(selectors))
@@ -1701,7 +1703,7 @@ func InitKernelSelectorState(args *KernelSelectorArgs) (*KernelSelectorState, er
 		return nil
 	}
 
-	return createKernelSelectorState(args.Selectors, args.ListReader, args.Maps, args.IsUprobe, args.CelExprs, parse)
+	return createKernelSelectorState(args.Selectors, args.ListReader, args.Maps, args.IsUprobe, args.UprobeID, args.CelExprs, parse)
 }
 
 func InitKernelReturnSelectorState(selectors []v1alpha1.KProbeSelector, returnArg *v1alpha1.KProbeArg,
@@ -1717,7 +1719,7 @@ func InitKernelReturnSelectorState(selectors []v1alpha1.KProbeSelector, returnAr
 		return nil
 	}
 
-	return createKernelSelectorState(selectors, listReader, maps, false, nil, parse)
+	return createKernelSelectorState(selectors, listReader, maps, false, 0, nil, parse)
 }
 
 func CleanupKernelSelectorState(state *KernelSelectorState) error {

--- a/pkg/selectors/kernel_regs_amd64.go
+++ b/pkg/selectors/kernel_regs_amd64.go
@@ -47,5 +47,5 @@ func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64)
 	}
 
 	k.regs = regs
-	return uint32(0), nil
+	return uint32(k.uprobeID), nil
 }

--- a/pkg/selectors/kernel_regs_arm64.go
+++ b/pkg/selectors/kernel_regs_arm64.go
@@ -46,5 +46,5 @@ func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64)
 	}
 
 	k.regs = regs
-	return uint32(0), nil
+	return uint32(k.uprobeID), nil
 }

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -318,7 +318,7 @@ func TestParseMatchArgs(t *testing.T) {
 	expected = append(expected, data1Expected[:]...)
 	expected = append(expected, data2Expected[:]...)
 
-	ks := NewKernelSelectorState(nil, nil, false, nil)
+	ks := NewKernelSelectorState(nil, nil, false, 0, nil)
 	d := &ks.data
 	if err := ParseMatchArgs(ks, argsSel, dataSel, args, data); err != nil || bytes.Equal(expected, d.e[0:d.off]) == false {
 		t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\n", err, expected, d.e[0:d.off])
@@ -345,7 +345,7 @@ func TestParseMatchData(t *testing.T) {
 	}
 
 	arg1 := &v1alpha1.ArgSelector{Index: 0, Operator: "Equal", Values: []string{"ex"}}
-	k := NewKernelSelectorState(nil, nil, false, nil)
+	k := NewKernelSelectorState(nil, nil, false, 0, nil)
 	d := &k.data
 
 	expected1 := []byte{
@@ -516,7 +516,7 @@ func TestParseMatchArg(t *testing.T) {
 	}
 
 	arg1 := &v1alpha1.ArgSelector{Index: 1, Operator: "Equal", Values: []string{"foobar"}}
-	k := NewKernelSelectorState(nil, nil, false, nil)
+	k := NewKernelSelectorState(nil, nil, false, 0, nil)
 	d := &k.data
 
 	expected1 := []byte{
@@ -676,7 +676,7 @@ func TestParseMatchArg(t *testing.T) {
 		expected3 := append(length, expected1[:]...)
 		expected3 = append(expected3, expected2[:]...)
 		arg12 := []v1alpha1.ArgSelector{*arg1, *arg2}
-		ks := NewKernelSelectorState(nil, nil, false, nil)
+		ks := NewKernelSelectorState(nil, nil, false, 0, nil)
 		d = &ks.data
 		if err := ParseMatchArgs(ks, arg12, []v1alpha1.ArgSelector{}, sig, []v1alpha1.KProbeArg{}); err != nil || bytes.Equal(expected3, d.e[0:d.off]) == false {
 			t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected3, d.e[0:d.off], arg3)
@@ -703,7 +703,7 @@ func TestParseMatchArg(t *testing.T) {
 			{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}: {},
 		}
 
-		ks = NewKernelSelectorState(nil, nil, false, nil)
+		ks = NewKernelSelectorState(nil, nil, false, 0, nil)
 		d = &ks.data
 		if err := ParseMatchArg(ks, arg13, sig); err != nil ||
 			bytes.Equal(expected12, d.e[0:d.off]) == false ||

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -132,6 +132,7 @@ type KernelSelectorState struct {
 	maps *KernelSelectorMaps
 
 	isUprobe bool
+	uprobeID int
 
 	regs []processapi.RegAssignment
 
@@ -144,6 +145,7 @@ func NewKernelSelectorState(
 	listReader ValueReader,
 	maps *KernelSelectorMaps,
 	isUprobe bool,
+	uprobeID int,
 	celExprs *CelExprFunctions,
 ) *KernelSelectorState {
 	if maps == nil {
@@ -158,6 +160,7 @@ func NewKernelSelectorState(
 		listReader:         listReader,
 		maps:               maps,
 		isUprobe:           isUprobe,
+		uprobeID:           uprobeID,
 		celExprFunctions:   celExprs,
 	}
 }

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -74,6 +74,8 @@ type genericLsm struct {
 	tags []string
 	// is IMA hash collector program needed to load
 	imaProgLoad bool
+	// instance identifier to mitigate duplicate hooks at same location
+	instance int
 }
 
 func (g *genericLsm) SetID(id idtable.EntryID) {
@@ -289,7 +291,7 @@ type addLsmIn struct {
 	selMaps    *selectors.KernelSelectorMaps
 }
 
-func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err error) {
+func addLsm(f *v1alpha1.LsmHookSpec, instance int, in *addLsmIn) (id idtable.EntryID, err error) {
 	var argSigPrinters []argPrinter
 	var argsBTFSet [api.MaxArgsSupported]bool
 	var allBTFArgs [api.EventConfigMaxArgs][api.MaxBTFArgDepth]api.ConfigBTFArg
@@ -377,6 +379,7 @@ func addLsm(f *v1alpha1.LsmHookSpec, in *addLsmIn) (id idtable.EntryID, err erro
 		message:     msgField,
 		tags:        tagsField,
 		imaProgLoad: false,
+		instance:    instance,
 	}
 
 	for _, sel := range f.Selectors {
@@ -431,12 +434,19 @@ func createGenericLsmSensor(
 		selMaps:    selMaps,
 	}
 
+	dups := make(map[string]int)
 	for _, hook := range lsmHooks {
 		if err := appendMacrosSelectors(hook.Selectors, spec.SelectorsMacros); err != nil {
 			return nil, fmt.Errorf("append macros selectors: %w", err)
 		}
 
-		id, err := addLsm(&hook, &in)
+		instance, ok := dups[hook.Hook]
+		if ok {
+			instance++
+		}
+		dups[hook.Hook] = instance
+
+		id, err := addLsm(&hook, instance, &in)
 		if err != nil {
 			return nil, err
 		}
@@ -531,6 +541,10 @@ func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 	progs []*program.Program, maps []*program.Map) ([]*program.Program, []*program.Map) {
 
 	loadProgCoreName, loadProgOutputName := config.GenericLsmObjs()
+	pinName := lsmEntry.hook
+	if lsmEntry.instance != 0 {
+		pinName = fmt.Sprintf("%s:%d", lsmEntry.hook, lsmEntry.instance)
+	}
 
 	/* We need to load LSM programs in the following order:
 	   1. bpf_generic_lsm_output
@@ -541,7 +555,7 @@ func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 		path.Join(option.Config.HubbleLib, loadProgOutputName),
 		lsmEntry.hook,
 		"lsm/generic_lsm_output",
-		lsmEntry.hook,
+		pinName,
 		"generic_lsm").
 		SetLoaderData(lsmEntry.tableId).
 		SetPolicy(lsmEntry.policyName)
@@ -551,7 +565,7 @@ func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 		path.Join(option.Config.HubbleLib, loadProgCoreName),
 		lsmEntry.hook,
 		"lsm/generic_lsm_core",
-		lsmEntry.hook,
+		pinName,
 		"generic_lsm").
 		SetLoaderData(lsmEntry.tableId).
 		SetPolicy(lsmEntry.policyName)
@@ -565,7 +579,7 @@ func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 				path.Join(option.Config.HubbleLib, loadProgImaName),
 				lsmEntry.hook,
 				"lsm.s/generic_lsm_ima_"+loadProgImaType,
-				lsmEntry.hook,
+				pinName,
 				"generic_lsm").
 				SetLoaderData(lsmEntry.tableId).
 				SetPolicy(lsmEntry.policyName)

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -83,7 +83,7 @@ type genericUprobe struct {
 	pendingEvents *lru.Cache[pendingEventKey, pendingEvent[*tracing.MsgGenericUprobeUnix]]
 }
 
-func populateUprobeRegs(m *ebpf.Map, regs []processapi.RegAssignment) error {
+func populateUprobeRegs(m *ebpf.Map, id int, regs []processapi.RegAssignment) error {
 	uprobeRegs := processapi.UprobeRegs{}
 
 	n := copy(uprobeRegs.Ass[:], regs)
@@ -91,7 +91,7 @@ func populateUprobeRegs(m *ebpf.Map, regs []processapi.RegAssignment) error {
 		logger.GetLogger().Warn("register assignments count mismatch", "#regs", len(regs))
 	}
 	uprobeRegs.Cnt = uint32(n)
-	return m.Update(uint32(0), uprobeRegs, ebpf.UpdateAny)
+	return m.Update(uint32(id), uprobeRegs, ebpf.UpdateAny)
 }
 
 func (g *genericUprobe) SetID(id idtable.EntryID) {
@@ -239,7 +239,7 @@ func loadSingleUprobeSensor(uprobeEntry *genericUprobe, args sensors.LoadProbeAr
 				&program.MapLoad{
 					Name: "regs_map",
 					Load: func(m *ebpf.Map, _ string) error {
-						return populateUprobeRegs(m, selector.Regs())
+						return populateUprobeRegs(m, 0, selector.Regs())
 					},
 				},
 			)
@@ -356,7 +356,7 @@ func loadMultiUprobeSensor(ids []idtable.EntryID, args sensors.LoadProbeArgs) er
 					&program.MapLoad{
 						Name: "regs_map",
 						Load: func(m *ebpf.Map, _ string) error {
-							return populateUprobeRegs(m, selector.Regs())
+							return populateUprobeRegs(m, index, selector.Regs())
 						},
 					},
 				)
@@ -569,6 +569,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 		Args:      spec.Args,
 		Data:      spec.Data,
 		IsUprobe:  true,
+		UprobeID:  len(ids),
 		CelExprs:  in.celExprs,
 	})
 	if err != nil {
@@ -931,6 +932,7 @@ func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []
 
 	if has.sleepableOffload {
 		regsMap := program.MapBuilderProgram("regs_map", load)
+		regsMap.SetMaxEntries(len(multiIDs))
 		sleepableOffloadMap := program.MapBuilderProgram("sleepable_offload", load)
 		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
 		maps = append(maps, regsMap, sleepableOffloadMap)

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -38,7 +38,10 @@ func TestUprobeOverrideAction(t *testing.T) {
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
 
 	// Put uprobe at the beginning of test_1 function and make sure
-	// uprobe overrides test_1 return value (with 123).
+	// uprobe overrides test_1 return value (with 123),
+	// even if a second hook on `test_3` exists with return value 234.
+	// Also make sure that second hook is correct too.
+	// See https://github.com/cilium/tetragon/issues/5285.
 
 	pathHook := `
 apiVersion: cilium.io/v1alpha1
@@ -54,15 +57,26 @@ spec:
     - matchActions:
       - action: Override
         argError: 123
+  - path: "` + testBinary + `"
+    symbols:
+    - "test_3"
+    selectors:
+    - matchActions:
+      - action: Override
+        argError: 234
 `
 
 	createCrdFile(t, pathHook)
 
-	upChecker := ec.NewProcessUprobeChecker("UPROBE_OVERRIDE").
+	up1Checker := ec.NewProcessUprobeChecker("UPROBE_OVERRIDE_1").
 		WithProcess(ec.NewProcessChecker().
 			WithBinary(sm.Full(testBinary))).
 		WithSymbol(sm.Full("test_1"))
-	checker := ec.NewUnorderedEventChecker(upChecker)
+	up3Checker := ec.NewProcessUprobeChecker("UPROBE_OVERRIDE_3").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(testBinary))).
+		WithSymbol(sm.Full("test_3"))
+	checker := ec.NewUnorderedEventChecker(up1Checker, up3Checker)
 
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
@@ -80,6 +94,10 @@ spec:
 	cmd := exec.Command(testBinary, "1")
 	require.Error(t, cmd.Run())
 	require.Equal(t, 123, cmd.ProcessState.ExitCode())
+
+	cmd = exec.Command(testBinary, "3")
+	require.Error(t, cmd.Run())
+	require.Equal(t, 234, cmd.ProcessState.ExitCode())
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)


### PR DESCRIPTION
### Description

Cherry picks:
* https://github.com/cilium/tetragon/pull/5286
* 86952168ca9158cf03077acd50ea6890782f3020 from https://github.com/cilium/tetragon/pull/5114

Note:
* 86952168ca9158cf03077acd50ea6890782f3020 and 048527e283cfd73b3e8d3b489516f497392c7a5b had some small conflicts that should be correctly solved. PTAL

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
sync: lsm dup hook bug and uprobe override matchaction fix
```
