### PR TITLE
option: validate export-rate-limit and warn on invalid or zero values

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -472,9 +472,11 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 		return err
 	}
 
-	// Fetch the exporter if needed
+	// Fetch the exporter if needed. An export rate limit of 0 disables JSON
+	// export altogether, so avoid creating an exporter that would drop every
+	// event.
 	var exporter *exporter.Exporter
-	if option.Config.ExportFilename != "" {
+	if option.Config.ExportFilename != "" && option.Config.ExportRateLimit != 0 {
 		exporter, err = getExporter(ctx, pm.Server)
 		if err != nil {
 			return fmt.Errorf("failed to fetch json exporter: %w", err)
@@ -681,7 +683,7 @@ func getExporter(ctx context.Context, server *server.Server) (*exporter.Exporter
 	encoderWriter := exporter.NewExportedBytesTotalWriter(writer)
 	encoder := encoder.NewProtojsonEncoder(encoderWriter)
 	var rateLimiter *ratelimit.RateLimiter
-	if option.Config.ExportRateLimit >= 0 {
+	if option.Config.ExportRateLimit > 0 {
 		rateLimiter = ratelimit.NewRateLimiter(ctx, 1*time.Minute, option.Config.ExportRateLimit, encoder)
 	}
 	var aggregationOptions *tetragon.AggregationOptions

--- a/docs/content/en/docs/reference/helm-chart.md
+++ b/docs/content/en/docs/reference/helm-chart.md
@@ -118,7 +118,7 @@ To use [the values available](#values), with `helm install` or `helm upgrade`, u
 | tetragon.exportFileMaxSizeMB | int | `10` | Size in megabytes at which to rotate JSON export files. |
 | tetragon.exportFilePerm | string | `"600"` | JSON export file permissions as a string. Typically it's either "600" (to restrict access to owner) or "640"/"644" (to allow read access by logs collector or another agent). |
 | tetragon.exportFilename | string | `"tetragon.log"` | JSON export filename. Set it to an empty string to disable JSON export altogether. |
-| tetragon.exportRateLimit | int | `-1` | Rate-limit event export (events per minute), Set to -1 to export all events. |
+| tetragon.exportRateLimit | int | `-1` | Rate-limit event export (events per minute). Must be a plain integer: -1 disables rate limiting and exports all events (default), 0 disables JSON export entirely, and a positive integer limits export to that many events per minute. Invalid (non-integer) values fall back to -1 and log a warning. |
 | tetragon.extraArgs | object | `{}` |  |
 | tetragon.extraEnv | list | `[]` |  |
 | tetragon.extraVolumeMounts | list | `[]` |  |

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -145,7 +145,7 @@ options:
     - name: export-rate-limit
       default_value: "-1"
       usage: |
-        Rate limit (per minute) for event export. Set to -1 to disable
+        Rate limit (per minute) for event export. Set to -1 to disable rate limiting, 0 to disable JSON export, or a positive integer to rate limit event export
     - name: expose-stack-addresses
       default_value: "false"
       usage: Expose real linear addresses in events stack traces

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.0
 	github.com/prometheus/procfs v0.21.1
+	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -128,7 +129,6 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
-	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/install/kubernetes/tetragon/README.md
+++ b/install/kubernetes/tetragon/README.md
@@ -100,7 +100,7 @@ Helm chart for Tetragon
 | tetragon.exportFileMaxSizeMB | int | `10` | Size in megabytes at which to rotate JSON export files. |
 | tetragon.exportFilePerm | string | `"600"` | JSON export file permissions as a string. Typically it's either "600" (to restrict access to owner) or "640"/"644" (to allow read access by logs collector or another agent). |
 | tetragon.exportFilename | string | `"tetragon.log"` | JSON export filename. Set it to an empty string to disable JSON export altogether. |
-| tetragon.exportRateLimit | int | `-1` | Rate-limit event export (events per minute), Set to -1 to export all events. |
+| tetragon.exportRateLimit | int | `-1` | Rate-limit event export (events per minute). Must be a plain integer: -1 disables rate limiting and exports all events (default), 0 disables JSON export entirely, and a positive integer limits export to that many events per minute. Invalid (non-integer) values fall back to -1 and log a warning. |
 | tetragon.extraArgs | object | `{}` |  |
 | tetragon.extraEnv | list | `[]` |  |
 | tetragon.extraVolumeMounts | list | `[]` |  |

--- a/install/kubernetes/tetragon/values.yaml
+++ b/install/kubernetes/tetragon/values.yaml
@@ -76,7 +76,10 @@ tetragon:
   exportFileMaxBackups: 5
   # -- Compress rotated JSON export files.
   exportFileCompress: false
-  # -- Rate-limit event export (events per minute), Set to -1 to export all events.
+  # -- Rate-limit event export (events per minute). Must be a plain integer: -1 disables rate
+  # limiting and exports all events (default), 0 disables JSON export entirely, and a positive
+  # integer limits export to that many events per minute. Invalid (non-integer) values fall back
+  # to -1 and log a warning.
   exportRateLimit: -1
   # -- Allowlist for JSON export. For example, to export only process_connect events from
   # the default namespace:

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/spf13/cast"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -252,7 +253,13 @@ func ReadAndSetFlags() error {
 	Config.ExportFileRotationInterval = viper.GetDuration(KeyExportFileRotationInterval)
 	Config.ExportFileMaxBackups = viper.GetInt(KeyExportFileMaxBackups)
 	Config.ExportFileCompress = viper.GetBool(KeyExportFileCompress)
-	Config.ExportRateLimit = viper.GetInt(KeyExportRateLimit)
+	value := viper.Get(KeyExportRateLimit)
+	Config.ExportRateLimit, err = cast.ToIntE(value)
+	if err != nil {
+		logger.GetLogger().Warn(fmt.Sprintf("failed to parse %s '%v', falling back to -1 (no rate limiting): set 0 to disable JSON export, or a positive integer to rate limit it", KeyExportRateLimit, value),
+			logfields.Error, err)
+		Config.ExportRateLimit = -1
+	}
 	Config.ExportFilePerm = viper.GetString(KeyExportFilePerm)
 
 	Config.EnableExportAggregation = viper.GetBool(KeyEnableExportAggregation)
@@ -464,7 +471,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Int(KeyExportFileMaxBackups, 5, "Number of rotated JSON export files to retain")
 	flags.Bool(KeyExportFileCompress, false, "Compress rotated JSON export files")
 	flags.String(KeyExportFilePerm, defaults.DefaultLogsPermission, "Access permissions on JSON export files")
-	flags.Int(KeyExportRateLimit, -1, "Rate limit (per minute) for event export. Set to -1 to disable")
+	flags.Int(KeyExportRateLimit, -1, "Rate limit (per minute) for event export. Set to -1 to disable rate limiting, 0 to disable JSON export, or a positive integer to rate limit event export")
 	flags.String(KeyLogLevel, "info", "Set log level")
 	flags.String(KeyLogFormat, "text", "Set log format")
 	flags.String(KeyLogFile, "", "Set log file where tetragon agent logs will be written (in addition to stdout or stderr)")

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -19,8 +19,8 @@ import (
 func Test_getLimit(t *testing.T) {
 	eps := 1e-9
 
-	assert.InDelta(t, float64(rate.Limit(0)), float64(getLimit(0, time.Minute)), eps)
-	assert.InDelta(t, float64(rate.Limit(0)), float64(getLimit(0, 0)), eps)
+	assert.Zero(t, getLimit(0, time.Minute))
+	assert.Zero(t, getLimit(0, 0))
 	assert.InEpsilon(t, float64(rate.Limit(1)), float64(getLimit(60, time.Minute)), eps)
 	assert.InEpsilon(t, float64(rate.Limit(10.0/60)), float64(getLimit(10, time.Minute)), eps)
 	// 1/ms => 1000/second


### PR DESCRIPTION
### Description
Fixes: #5281

`export-rate-limit` is registered as an integer flag, but when set via a config file with a non-integer value (e.g. `50000,1s`), `viper.GetInt` silently returns `0`. A rate limit of `0` creates a zero-burst-capacity limiter where `Allow()` always returns false. This silently drops 100% of events with no indication why.

This PR uses `cast.ToIntE(viper.Get(...))` so the same parse path handles both CLI and config-file values and actually reports parse failures. On a parse error, rate limiting is disabled (falls back to -1) and a startup warning is logged. A value of 0 disables JSON export entirely (no exporter is created), instead of building a rate limiter that would silently reject every event.

Flag description, generated docs, and Helm values are updated to document the plain-integer requirement.