### PR TITLE
fix(elf): handle zero-argument USDT probes

### DIFF
--- a/pkg/elf/usdtargs_linux.go
+++ b/pkg/elf/usdtargs_linux.go
@@ -33,7 +33,7 @@ func compactDeref(ArgsStr string) string {
 
 // Arg parsing entrypoint
 func parseArgs(spec *UsdtSpec) error {
-	for idx, str := range strings.Split(compactDeref(spec.ArgsStr), " ") {
+	for idx, str := range strings.Fields(compactDeref(spec.ArgsStr)) {
 		arg := &spec.Args[idx]
 
 		for _, parse := range parsers {

--- a/pkg/elf/usdtargs_linux_test.go
+++ b/pkg/elf/usdtargs_linux_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package elf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseArgsEmpty(t *testing.T) {
+	spec := UsdtSpec{}
+
+	require.NoError(t, parseArgs(&spec))
+	require.Zero(t, spec.ArgsCnt)
+}


### PR DESCRIPTION
### Description

`tetra tracingpolicy generate usdts` treats a zero argument USDT probe as one argument with an empty type. 
Generated policy then fails validation

Repro on `main`:

```sh
tmp=$(mktemp -d)
gcc -Wall contrib/tester-progs/usdt.c -o "$tmp/usdt"
go run ./cmd/tetra tracingpolicy generate usdts -b "$tmp/usdt" | sed -n '/name: usdt0/,+8p'
```

`usdt0` entry gets `type: ""`. This uses `strings.Fields` so no bogus arg is emitted

Tested with `go test ./pkg/elf`

### Changelog

```release-note
Fix generated tracing policies for zero argument USDT probes
```
