### PR TITLE
fix(tests): add a `WithSkip` clause to uprobe override newSymbol test.

### DIFF
--- a/tests/policytests/uprobes.go
+++ b/tests/policytests/uprobes.go
@@ -317,7 +317,12 @@ spec:
       matchActions:
       - action: Override
         argNewSymbol: "uprobe_test_lib_string_arg__"
-`).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+`).WithSkip(func(si *policytest.SkipInfo) string {
+	if !si.AgentInfo.Probes[bpf.UprobeRegsChangeProbe] {
+		return "need writing to regs kernel support (6.18+)"
+	}
+	return ""
+}).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
 	bin := c.TestBinary("uprobe-test-1")
 	upChecker := ec.NewProcessUprobeChecker("UPROBE_SELECTOR_MATCH").
 		WithProcess(ec.NewProcessChecker().


### PR DESCRIPTION
We rely upon `UprobeRegsChangeProbe`.
