### PR TITLE
fix(tetra): read large stdin event lines

### DIFF
--- a/cmd/tetra/getevents/io_reader_client.go
+++ b/cmd/tetra/getevents/io_reader_client.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/cmd/tetra/common"
 	"github.com/cilium/tetragon/pkg/event"
 	"github.com/cilium/tetragon/pkg/fieldfilters"
 	"github.com/cilium/tetragon/pkg/filters"
@@ -31,8 +32,11 @@ type ioReaderClient struct {
 }
 
 func newIOReaderClient(reader io.Reader, debug bool) *ioReaderClient {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(nil, max(bufio.MaxScanTokenSize, common.MaxRecvMsgSize))
+
 	return &ioReaderClient{
-		scanner:      bufio.NewScanner(reader),
+		scanner:      scanner,
 		unmarshaller: protojson.UnmarshalOptions{DiscardUnknown: true},
 		debug:        debug,
 	}

--- a/cmd/tetra/getevents/io_reader_client_test.go
+++ b/cmd/tetra/getevents/io_reader_client_test.go
@@ -4,6 +4,7 @@
 package getevents
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/pkg/testutils"
@@ -41,4 +43,26 @@ func Test_ioReaderClient_GetEventsSkipsInvalidJSON(t *testing.T) {
 
 	_, err = getEventsClient.Recv()
 	require.ErrorIs(t, err, io.EOF)
+}
+
+func Test_ioReaderClient_GetEventsLargeJSONLine(t *testing.T) {
+	want := bytes.Repeat([]byte{'a'}, 70*1024)
+	event, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(&tetragon.GetEventsResponse{
+		Event: &tetragon.GetEventsResponse_ProcessKprobe{
+			ProcessKprobe: &tetragon.ProcessKprobe{
+				Args: []*tetragon.KprobeArgument{{
+					Arg: &tetragon.KprobeArgument_BytesArg{BytesArg: want},
+				}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	client := newIOReaderClient(bytes.NewReader(append(event, '\n')), false)
+	getEventsClient, err := client.GetEvents(context.Background(), &tetragon.GetEventsRequest{})
+	require.NoError(t, err)
+
+	res, err := getEventsClient.Recv()
+	require.NoError(t, err)
+	require.Equal(t, want, res.GetProcessKprobe().GetArgs()[0].GetBytesArg())
 }


### PR DESCRIPTION
### Description

`tetra getevents` stops at 64 KiB in stdin mode.
This lets it read lines up to the configured receive limit and covers a real `char_buf.maxData` kprobe event

Repro:

```sh
( printf '%s' '{"process_kprobe":{"args":[{"bytes_arg":"'; head -c 70000 /dev/zero | base64 -w 0; printf '%s\n' '"}]}}' ) | tetra getevents
```

Before this stops with `bufio.Scanner: token too long`. After this the event is read

### Changelog

```release-note
Fix tetra getevents stdin mode for large event lines.
```