### PR TITLE
[v1.6] pkg/encoder: escape untrusted strings from events

### DIFF
--- a/pkg/encoder/color.go
+++ b/pkg/encoder/color.go
@@ -105,11 +105,11 @@ func processCaps(c *tetragon.Capabilities) string {
 }
 
 func (c *Colorer) ProcessInfo(host string, process *tetragon.Process) (string, string) {
-	source := c.Green.Sprint(host)
+	source := c.Green.Sprint(maybeQuote(host))
 	if process.Pod != nil {
 		source = c.Green.Sprint(process.Pod.Namespace, "/", process.Pod.Name)
 	}
-	proc := c.Magenta.Sprint(process.Binary)
+	proc := c.Magenta.Sprint(maybeQuote(process.Binary))
 	caps := c.Magenta.Sprint(processCaps(process.Cap))
 	return fmt.Sprintf("%s %s", source, proc), caps
 }

--- a/pkg/encoder/encoder.go
+++ b/pkg/encoder/encoder.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
@@ -25,6 +26,20 @@ var (
 	ErrMissingProcessInfo = errors.New("process field is not set")
 	ErrUnknownEventType   = errors.New("unknown event type")
 )
+
+// maybeQuote quotes strings containing non-printable characters (like terminal
+// control sequence chars) or spaces that could confuse the human output. This
+// should be used for any non-trusted strings from events that we encode to the
+// terminal, typically anything user controlled like paths, arguments, symbols,
+// hostname, etc.
+func maybeQuote(s string) string {
+	for _, r := range s {
+		if !strconv.IsPrint(r) || r == ' ' {
+			return strconv.Quote(s)
+		}
+	}
+	return s
+}
 
 // EventEncoder is an interface for encoding tetragon.GetEventsResponse.
 type EventEncoder interface {
@@ -213,7 +228,7 @@ func HumanStackTrace(response *tetragon.GetEventsResponse, colorer *Colorer) str
 			fmt.Fprintf(out, "Kernel:\n")
 			for _, st := range ev.ProcessKprobe.KernelStackTrace {
 				colorer.Green.Fprintf(out, "   0x%x:", st.Address)
-				colorer.Blue.Fprintf(out, " %s", st.Symbol)
+				colorer.Blue.Fprintf(out, " %s", maybeQuote(st.Symbol))
 				fmt.Fprintf(out, "+")
 				colorer.Yellow.Fprintf(out, "0x%x\n", st.Offset)
 			}
@@ -223,9 +238,9 @@ func HumanStackTrace(response *tetragon.GetEventsResponse, colorer *Colorer) str
 			for _, st := range ev.ProcessKprobe.UserStackTrace {
 				colorer.Green.Fprintf(out, "   0x%x:", st.Address)
 				if st.Symbol != "" {
-					colorer.Blue.Fprintf(out, " %s", st.Symbol)
+					colorer.Blue.Fprintf(out, " %s", maybeQuote(st.Symbol))
 				}
-				colorer.Yellow.Fprintf(out, " (%s+0x%x)\n", st.Module, st.Offset)
+				colorer.Yellow.Fprintf(out, " (%s+0x%x)\n", maybeQuote(st.Module), st.Offset)
 			}
 		}
 	}
@@ -262,7 +277,7 @@ func HumanIMAHash(response *tetragon.GetEventsResponse, colorer *Colorer) string
 			default:
 			}
 			if path != "" {
-				colorer.Green.Fprintf(out, "   %s", path)
+				colorer.Green.Fprintf(out, "   %s", maybeQuote(path))
 				colorer.Blue.Fprintf(out, " %s\n", ev.ProcessLsm.ImaHash)
 			}
 		}
@@ -283,7 +298,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 		}
 		event := p.Colorer.Blue.Sprintf("🚀 %-7s", "process")
 		processInfo, caps := p.Colorer.ProcessInfo(response.NodeName, exec.Process)
-		args := p.Colorer.Cyan.Sprint(exec.Process.Arguments)
+		args := p.Colorer.Cyan.Sprint(maybeQuote(exec.Process.Arguments))
 		return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, args), caps), nil
 	case *tetragon.GetEventsResponse_ProcessExit:
 		exit := response.GetProcessExit()
@@ -292,7 +307,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 		}
 		event := p.Colorer.Blue.Sprintf("💥 %-7s", "exit")
 		processInfo, caps := p.Colorer.ProcessInfo(response.NodeName, exit.Process)
-		args := p.Colorer.Cyan.Sprint(exit.Process.Arguments)
+		args := p.Colorer.Cyan.Sprint(maybeQuote(exit.Process.Arguments))
 		var status string
 		if exit.Signal != "" {
 			status = p.Colorer.Red.Sprint(exit.Signal)
@@ -310,7 +325,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 		case tetragon.ThrottleType_THROTTLE_STOP:
 			typ = p.Colorer.Green.Sprint("STOP ")
 		}
-		return fmt.Sprintf("%s %s %s", event, typ, throttle.Cgroup), nil
+		return fmt.Sprintf("%s %s %s", event, typ, maybeQuote(throttle.Cgroup)), nil
 	case *tetragon.GetEventsResponse_ProcessLoader:
 		loader := response.GetProcessLoader()
 		if loader.Process == nil {
@@ -322,7 +337,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 		if len(loader.Buildid) > 0 {
 			buildid = hex.EncodeToString(loader.Buildid) + " "
 		}
-		path := p.Colorer.Yellow.Sprint(loader.Path)
+		path := p.Colorer.Yellow.Sprint(maybeQuote(loader.Path))
 		return CapTrailorPrinter(fmt.Sprintf("%s %s %s%s", event, processInfo,
 			buildid, path), caps), nil
 	case *tetragon.GetEventsResponse_ProcessKprobe:
@@ -337,7 +352,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 			event := p.Colorer.Blue.Sprintf("📝 %-7s", "write")
 			file := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil && kprobe.Args[0].GetFileArg() != nil {
-				file = p.Colorer.Cyan.Sprint(kprobe.Args[0].GetFileArg().Path)
+				file = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[0].GetFileArg().Path))
 			}
 			bytes := ""
 			if len(kprobe.Args) > 2 && kprobe.Args[2] != nil {
@@ -348,7 +363,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 			event := p.Colorer.Blue.Sprintf("📚 %-7s", "read")
 			file := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil && kprobe.Args[0].GetFileArg() != nil {
-				file = p.Colorer.Cyan.Sprint(kprobe.Args[0].GetFileArg().Path)
+				file = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[0].GetFileArg().Path))
 			}
 			bytes := ""
 			if len(kprobe.Args) > 2 && kprobe.Args[2] != nil {
@@ -359,39 +374,39 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 			event := p.Colorer.Blue.Sprintf("📬 %-7s", "open")
 			file := ""
 			if len(kprobe.Args) > 1 && kprobe.Args[1] != nil && kprobe.Args[1].GetFileArg() != nil {
-				file = p.Colorer.Cyan.Sprint(kprobe.Args[1].GetFileArg().Path)
+				file = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[1].GetFileArg().Path))
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, file), caps), nil
 		case "sys_openat":
 			event := p.Colorer.Blue.Sprintf("📬️ %-7s", "openat")
 			file := ""
 			if len(kprobe.Args) > 1 && kprobe.Args[1] != nil {
-				file = p.Colorer.Cyan.Sprint(kprobe.Args[1].GetStringArg())
+				file = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[1].GetStringArg()))
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, file), caps), nil
 		case "sys_open":
 			event := p.Colorer.Blue.Sprintf("📬️ %-7s", "open")
 			file := ""
 			if len(kprobe.Args) > 1 && kprobe.Args[1] != nil {
-				file = p.Colorer.Cyan.Sprint(kprobe.Args[1].GetStringArg())
+				file = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[1].GetStringArg()))
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, file), caps), nil
 		case "sys_close":
 			event := p.Colorer.Blue.Sprintf("📪 %-7s", "close")
 			file := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil && kprobe.Args[0].GetFileArg() != nil {
-				file = p.Colorer.Cyan.Sprint(kprobe.Args[0].GetFileArg().Path)
+				file = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[0].GetFileArg().Path))
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, file), caps), nil
 		case "sys_mount":
 			event := p.Colorer.Blue.Sprintf("💾 %-7s", "mount")
 			src := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil {
-				src = p.Colorer.Cyan.Sprint(kprobe.Args[0].GetStringArg())
+				src = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[0].GetStringArg()))
 			}
 			dst := ""
 			if len(kprobe.Args) > 1 && kprobe.Args[1] != nil {
-				dst = p.Colorer.Cyan.Sprint(kprobe.Args[1].GetStringArg())
+				dst = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[1].GetStringArg()))
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s %s", event, processInfo, src, dst), caps), nil
 		case "sys_setuid":
@@ -409,11 +424,11 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 			event := p.Colorer.Blue.Sprintf("💾 %-7s", "pivot_root")
 			src := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil {
-				src = p.Colorer.Cyan.Sprint(kprobe.Args[0].GetStringArg())
+				src = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[0].GetStringArg()))
 			}
 			dst := ""
 			if len(kprobe.Args) > 1 && kprobe.Args[1] != nil {
-				dst = p.Colorer.Cyan.Sprint(kprobe.Args[1].GetStringArg())
+				dst = p.Colorer.Cyan.Sprint(maybeQuote(kprobe.Args[1].GetStringArg()))
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s %s", event, processInfo, src, dst), caps), nil
 		case "proc_exec_connector":
@@ -491,7 +506,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 				case 0x04:
 					event = p.Colorer.Blue.Sprintf("📚 %-7s", "read")
 				}
-				attr = p.Colorer.Cyan.Sprintf("%s", file.Path)
+				attr = p.Colorer.Cyan.Sprint(maybeQuote(file.Path))
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, attr), caps), nil
 		case "security_mmap_file":
@@ -511,7 +526,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 					eventTag += "x"
 				}
 				event = p.Colorer.Blue.Sprintf("📝 %-7s", eventTag)
-				attr = p.Colorer.Cyan.Sprintf("%s", file.Path)
+				attr = p.Colorer.Cyan.Sprint(maybeQuote(file.Path))
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, attr), caps), nil
 		case "security_path_truncate":
@@ -519,7 +534,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 			attr := ""
 			if len(kprobe.Args) > 0 && kprobe.Args[0] != nil {
 				path := kprobe.Args[0].GetPathArg()
-				attr = p.Colorer.Cyan.Sprintf("%s", path.Path)
+				attr = p.Colorer.Cyan.Sprint(maybeQuote(path.Path))
 				event = p.Colorer.Blue.Sprintf("📝 %-7s", "truncate")
 			}
 			return CapTrailorPrinter(fmt.Sprintf("%s %s %s", event, processInfo, attr), caps), nil
@@ -549,7 +564,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 		}
 		processInfo, caps := p.Colorer.ProcessInfo(response.NodeName, uprobe.Process)
 		event := p.Colorer.Blue.Sprintf("🕵️ %-7s", "uprobe")
-		return CapTrailorPrinter(fmt.Sprintf("%s %s %s %s", event, processInfo, uprobe.Path, uprobe.Symbol), caps), nil
+		return CapTrailorPrinter(fmt.Sprintf("%s %s %s %s", event, processInfo, maybeQuote(uprobe.Path), maybeQuote(uprobe.Symbol)), caps), nil
 	case *tetragon.GetEventsResponse_ProcessLsm:
 		lsm := response.GetProcessLsm()
 		if lsm.Process == nil {
@@ -565,7 +580,7 @@ func (p *CompactEncoder) EventToString(response *tetragon.GetEventsResponse) (st
 		}
 		processInfo, caps := p.Colorer.ProcessInfo(response.NodeName, usdt.Process)
 		event := p.Colorer.Blue.Sprintf("🕵️ %-7s", "usdt")
-		return CapTrailorPrinter(fmt.Sprintf("%s %s %s %s %s", event, processInfo, usdt.Path, usdt.Provider, usdt.Name), caps), nil
+		return CapTrailorPrinter(fmt.Sprintf("%s %s %s %s %s", event, processInfo, maybeQuote(usdt.Path), maybeQuote(usdt.Provider), maybeQuote(usdt.Name)), caps), nil
 	}
 
 	return "", fmt.Errorf("%w: %s", ErrUnknownEventType, response.EventType())

--- a/pkg/encoder/encoder_test.go
+++ b/pkg/encoder/encoder_test.go
@@ -497,6 +497,309 @@ func TestCompactEncoder_EncodeWithTimestamp(t *testing.T) {
 	assert.Equal(t, "1970-01-01T00:00:00.000000000Z 🚀 process kube-system/tetragon /usr/bin/curl cilium.io\n", b.String())
 }
 
+func TestCompactEncoder_EscapeSpecialCharacters(t *testing.T) {
+	p := NewCompactEncoder(os.Stdout, Never, false, false, false)
+
+	t.Run("binary", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessExec{
+				ProcessExec: &tetragon.ProcessExec{
+					Process: &tetragon.Process{
+						Binary:    "/usr/bin/\x1b[31mmalicious\x1b[0m",
+						Arguments: "normal-args",
+						Pod: &tetragon.Pod{
+							Namespace: "kube-system",
+							Name:      "tetragon",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"/usr/bin/\\x1b[31mmalicious\\x1b[0m\"")
+		assert.NotContains(t, result, "\x1b")
+	})
+
+	t.Run("args", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessExec{
+				ProcessExec: &tetragon.ProcessExec{
+					Process: &tetragon.Process{
+						Binary:    "/bin/sh",
+						Arguments: "echo \x00null\rbyte",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "pod",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"echo \\x00null\\rbyte\"")
+		assert.NotContains(t, result, "\x00")
+		assert.NotContains(t, result, "\r")
+	})
+
+	t.Run("hostname", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessExec{
+				ProcessExec: &tetragon.ProcessExec{
+					Process: &tetragon.Process{
+						Binary:    "/usr/bin/test",
+						Arguments: "args",
+					},
+				},
+			},
+			NodeName: "host\nwith\nnewlines",
+		})
+		require.NoError(t, err)
+		// Verify hostname is escaped when no pod info is present
+		assert.Contains(t, result, "\"host\\nwith\\nnewlines\"")
+		assert.NotContains(t, result, "host\nwith\nnewlines")
+	})
+
+	t.Run("file", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessKprobe{
+				ProcessKprobe: &tetragon.ProcessKprobe{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/cat",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					FunctionName: "fd_install",
+					Args: []*tetragon.KprobeArgument{
+						nil,
+						{Arg: &tetragon.KprobeArgument_FileArg{FileArg: &tetragon.KprobeFile{Path: "/tmp/file\nwith\nnewlines"}}},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"/tmp/file\\nwith\\nnewlines\"")
+		assert.NotContains(t, result, "/tmp/file\nwith\nnewlines")
+	})
+
+	t.Run("cgroup", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessThrottle{
+				ProcessThrottle: &tetragon.ProcessThrottle{
+					Type:   tetragon.ThrottleType_THROTTLE_START,
+					Cgroup: "/sys/fs/cgroup\nmalicious",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"/sys/fs/cgroup\\nmalicious\"")
+		assert.NotContains(t, result, "/sys/fs/cgroup\nmalicious")
+	})
+
+	t.Run("loader", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessLoader{
+				ProcessLoader: &tetragon.ProcessLoader{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/loader",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					Path: "/lib/evil\x1b[31m.so",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"/lib/evil\\x1b[31m.so\"")
+		assert.NotContains(t, result, "\x1b")
+	})
+
+	t.Run("stringarg", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessKprobe{
+				ProcessKprobe: &tetragon.ProcessKprobe{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/cat",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					FunctionName: "sys_openat",
+					Args: []*tetragon.KprobeArgument{
+						nil,
+						{Arg: &tetragon.KprobeArgument_StringArg{StringArg: "/etc/bad\nfile"}},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"/etc/bad\\nfile\"")
+		assert.NotContains(t, result, "/etc/bad\nfile")
+	})
+
+	t.Run("filearg", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessKprobe{
+				ProcessKprobe: &tetragon.ProcessKprobe{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/write",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					FunctionName: "__x64_sys_write",
+					Args: []*tetragon.KprobeArgument{
+						{Arg: &tetragon.KprobeArgument_FileArg{
+							FileArg: &tetragon.KprobeFile{Path: "/var/log/bad\rfile"},
+						}},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"/var/log/bad\\rfile\"")
+		assert.NotContains(t, result, "\r")
+	})
+
+	t.Run("patharg", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessKprobe{
+				ProcessKprobe: &tetragon.ProcessKprobe{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/truncate",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					FunctionName: "security_path_truncate",
+					Args: []*tetragon.KprobeArgument{
+						{Arg: &tetragon.KprobeArgument_PathArg{
+							PathArg: &tetragon.KprobePath{Path: "/data/bad\nfile"},
+						}},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"/data/bad\\nfile\"")
+		assert.NotContains(t, result, "/data/bad\nfile")
+	})
+
+	t.Run("uprobe", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessUprobe{
+				ProcessUprobe: &tetragon.ProcessUprobe{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/test",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					Path:   "/lib/\x1b[31mevil\x1b[0m.so",
+					Symbol: "function_name",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"/lib/\\x1b[31mevil\\x1b[0m.so\"")
+		assert.NotContains(t, result, "\x1b")
+	})
+
+	t.Run("symbol", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessUprobe{
+				ProcessUprobe: &tetragon.ProcessUprobe{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/test",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					Path:   "/lib/test.so",
+					Symbol: "func\nname",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"func\\nname\"")
+		assert.NotContains(t, result, "func\nname")
+	})
+
+	t.Run("usdt", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessUsdt{
+				ProcessUsdt: &tetragon.ProcessUsdt{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/test",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					Path:     "/usr/lib/bad\x00path",
+					Provider: "provider",
+					Name:     "probe",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"/usr/lib/bad\\x00path\"")
+		assert.NotContains(t, result, "\x00")
+	})
+
+	t.Run("provider", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessUsdt{
+				ProcessUsdt: &tetragon.ProcessUsdt{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/test",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					Path:     "/usr/lib/test.so",
+					Provider: "prov\nider",
+					Name:     "probe",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"prov\\nider\"")
+		assert.NotContains(t, result, "prov\nider")
+	})
+
+	t.Run("name", func(t *testing.T) {
+		result, err := p.EventToString(&tetragon.GetEventsResponse{
+			Event: &tetragon.GetEventsResponse_ProcessUsdt{
+				ProcessUsdt: &tetragon.ProcessUsdt{
+					Process: &tetragon.Process{
+						Binary: "/usr/bin/test",
+						Pod: &tetragon.Pod{
+							Namespace: "default",
+							Name:      "test",
+						},
+					},
+					Path:     "/usr/lib/test.so",
+					Provider: "provider",
+					Name:     "probe\tname",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, result, "\"probe\\tname\"")
+		assert.NotContains(t, result, "\t")
+	})
+}
+
 func FuzzProtojsonCompatibility(f *testing.F) {
 	for _, n := range []int64{
 		1337,


### PR DESCRIPTION
Backport of https://github.com/cilium/tetragon/pull/5249

The encoder would blindly print and interpret special characters from some of the strings exposed in an event, for example:
- anything containing a path
- userspace provided symbols
- binary arguments
- binary path
- hostname

Linux is permissible on many system things such as path, hostname or generally arguments (this last one is more natural). And thus it's possible to inject special character by creating a with for example:

	touch $'\x1b[31mCOLOR\x1b[0m'

One could also rename binaries, set their hostname, inject symbols in a binary using any special characters and that could potentially manipulate the terminal on which "tetra getevents -o compact" runs.

However some other strings can be considered safe:
- enum disguised as strings
- kernel function names
- kubernetes names
- bpf map names
- ip address

Basically trying to escape anything user controlled that is not already sanitized.
    
Note that this patch makes the encoder escape on-demand only, meaning that the output is no longer consistent as it could or not include quotes depending on the field's value. This should be fine as the compact output is supposed to be used only by humans and we can still use the unambiguous JSON output for everything else.

```release-note
tetra: escape user provided strings special characters in compact encoder output
```