### PR TITLE
pkg/bugtool: avoid pprof logs without gops

### DIFF
--- a/pkg/bugtool/bugtool.go
+++ b/pkg/bugtool/bugtool.go
@@ -623,6 +623,10 @@ func (s *bugtoolInfo) getPProf(file string, gopsSignal byte) error {
 }
 
 func (s *bugtoolInfo) addPProfInfo() {
+	if s.info.GopsAddr == "" {
+		return
+	}
+
 	profiles := map[string]byte{
 		"cpu":  gopssignal.CPUProfile,
 		"heap": gopssignal.HeapProfile,

--- a/pkg/bugtool/bugtool.go
+++ b/pkg/bugtool/bugtool.go
@@ -319,8 +319,12 @@ func doBugtool(info *InitInfo, outFname string, commandActions []CommandAction, 
 	si.ExecCmd("dmesg.out", "dmesg")
 	si.addTcInfo()
 	si.addBpftoolInfo()
-	si.addGopsInfo()
-	si.addPProfInfo()
+	if si.info.GopsAddr == "" {
+		si.multiLog.Info("Skipping gops dump info as daemon is running without gops, use --gops-address to enable gops")
+	} else {
+		si.addGopsInfo()
+		si.addPProfInfo()
+	}
 	si.dumpPolicyFilterMap()
 	si.addProcessCache()
 	si.addExecveMap()
@@ -595,11 +599,6 @@ func (s *bugtoolInfo) addBpftoolInfo() {
 }
 
 func (s *bugtoolInfo) getPProf(file string, gopsSignal byte) error {
-	if s.info.GopsAddr == "" {
-		s.multiLog.Info("Skipping gops dump info as daemon is running without gops, use --gops-address to enable gops")
-		return nil
-	}
-
 	s.multiLog.WithField("gops-address", s.info.GopsAddr).Info("Contacting gops server for pprof dump")
 
 	conn, err := net.Dial("tcp", s.info.GopsAddr)

--- a/pkg/bugtool/bugtool.go
+++ b/pkg/bugtool/bugtool.go
@@ -643,11 +643,6 @@ func (s *bugtoolInfo) addPProfInfo() {
 }
 
 func (s *bugtoolInfo) addGopsInfo() {
-	if s.info.GopsAddr == "" {
-		s.multiLog.Info("Skipping gops dump info as daemon is running without gops, use --gops-address to enable gops")
-		return
-	}
-
 	if s.info.GopsPath == "" {
 		s.multiLog.WithField("gops-address", s.info.GopsAddr).Warn("Failed to locate gops. Please install it or specify its path, see 'bugtool --help'")
 		return

--- a/pkg/bugtool/bugtool.go
+++ b/pkg/bugtool/bugtool.go
@@ -319,8 +319,12 @@ func doBugtool(info *InitInfo, outFname string, commandActions []CommandAction, 
 	si.ExecCmd("dmesg.out", "dmesg")
 	si.addTcInfo()
 	si.addBpftoolInfo()
-	si.addGopsInfo()
-	si.addPProfInfo()
+	if si.info.GopsAddr == "" {
+		si.multiLog.Info("Skipping gops dump info as daemon is running without gops, use --gops-address to enable gops")
+	} else {
+		si.addGopsInfo()
+		si.addPProfInfo()
+	}
 	si.dumpPolicyFilterMap()
 	si.addProcessCache()
 	si.addExecveMap()
@@ -595,11 +599,6 @@ func (s *bugtoolInfo) addBpftoolInfo() {
 }
 
 func (s *bugtoolInfo) getPProf(file string, gopsSignal byte) error {
-	if s.info.GopsAddr == "" {
-		s.multiLog.Info("Skipping gops dump info as daemon is running without gops, use --gops-address to enable gops")
-		return nil
-	}
-
 	s.multiLog.WithField("gops-address", s.info.GopsAddr).Info("Contacting gops server for pprof dump")
 
 	conn, err := net.Dial("tcp", s.info.GopsAddr)
@@ -623,10 +622,6 @@ func (s *bugtoolInfo) getPProf(file string, gopsSignal byte) error {
 }
 
 func (s *bugtoolInfo) addPProfInfo() {
-	if s.info.GopsAddr == "" {
-		return
-	}
-
 	profiles := map[string]byte{
 		"cpu":  gopssignal.CPUProfile,
 		"heap": gopssignal.HeapProfile,
@@ -648,11 +643,6 @@ func (s *bugtoolInfo) addPProfInfo() {
 }
 
 func (s *bugtoolInfo) addGopsInfo() {
-	if s.info.GopsAddr == "" {
-		s.multiLog.Info("Skipping gops dump info as daemon is running without gops, use --gops-address to enable gops")
-		return
-	}
-
 	if s.info.GopsPath == "" {
 		s.multiLog.WithField("gops-address", s.info.GopsAddr).Warn("Failed to locate gops. Please install it or specify its path, see 'bugtool --help'")
 		return

--- a/pkg/bugtool/bugtool_test.go
+++ b/pkg/bugtool/bugtool_test.go
@@ -4,8 +4,10 @@
 package bugtool
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,6 +15,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/tetragon/pkg/logger"
 )
 
 func TestSaveAndLoad(t *testing.T) {
@@ -69,6 +73,24 @@ func TestLoadExtraFilesMissing(t *testing.T) {
 	got, err := doLoadExtraFiles(filepath.Join(t.TempDir(), "does-not-exist.json"))
 	require.NoError(t, err)
 	require.Nil(t, got)
+}
+
+func TestGopsDisabledLogsOnce(t *testing.T) {
+	var buff bytes.Buffer
+	info := bugtoolInfo{
+		info: &InitInfo{},
+		multiLog: MultiLog{
+			Logs: []logger.FieldLogger{
+				slog.New(slog.NewTextHandler(&buff, nil)),
+			},
+		},
+	}
+
+	info.addGopsInfo()
+	info.addPProfInfo()
+
+	require.Equal(t, 1, strings.Count(buff.String(), "Skipping gops dump info"))
+	require.NotContains(t, buff.String(), "Successfully dumped gops pprof")
 }
 
 func Test_findCgroupMountPath(t *testing.T) {

--- a/pkg/bugtool/bugtool_test.go
+++ b/pkg/bugtool/bugtool_test.go
@@ -4,10 +4,11 @@
 package bugtool
 
 import (
-	"bytes"
+	"archive/tar"
+	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,8 +16,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/cilium/tetragon/pkg/logger"
 )
 
 func TestSaveAndLoad(t *testing.T) {
@@ -76,21 +75,35 @@ func TestLoadExtraFilesMissing(t *testing.T) {
 }
 
 func TestGopsDisabledLogsOnce(t *testing.T) {
-	var buff bytes.Buffer
-	info := bugtoolInfo{
-		info: &InitInfo{},
-		multiLog: MultiLog{
-			Logs: []logger.FieldLogger{
-				slog.New(slog.NewTextHandler(&buff, nil)),
-			},
-		},
+	out := filepath.Join(t.TempDir(), "bugtool.tar.gz")
+	require.NoError(t, doBugtool(&InitInfo{
+		LibDir:     t.TempDir(),
+		ServerAddr: "unix:///dev/null",
+	}, out, nil, nil))
+
+	f, err := os.Open(out)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+
+	gz, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, gz.Close()) })
+
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			t.Fatal("tetragon-bugtool.log not found")
+		}
+		require.NoError(t, err)
+		if strings.HasSuffix(header.Name, "tetragon-bugtool.log") {
+			logs, err := io.ReadAll(tr)
+			require.NoError(t, err)
+			require.Equal(t, 1, strings.Count(string(logs), "Skipping gops dump info"))
+			require.NotContains(t, string(logs), "Successfully dumped gops pprof")
+			return
+		}
 	}
-
-	info.addGopsInfo()
-	info.addPProfInfo()
-
-	require.Equal(t, 1, strings.Count(buff.String(), "Skipping gops dump info"))
-	require.NotContains(t, buff.String(), "Successfully dumped gops pprof")
 }
 
 func Test_findCgroupMountPath(t *testing.T) {

--- a/pkg/bugtool/bugtool_test.go
+++ b/pkg/bugtool/bugtool_test.go
@@ -4,10 +4,7 @@
 package bugtool
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"encoding/json"
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -72,38 +69,6 @@ func TestLoadExtraFilesMissing(t *testing.T) {
 	got, err := doLoadExtraFiles(filepath.Join(t.TempDir(), "does-not-exist.json"))
 	require.NoError(t, err)
 	require.Nil(t, got)
-}
-
-func TestGopsDisabledLogsOnce(t *testing.T) {
-	out := filepath.Join(t.TempDir(), "bugtool.tar.gz")
-	require.NoError(t, doBugtool(&InitInfo{
-		LibDir:     t.TempDir(),
-		ServerAddr: "unix:///dev/null",
-	}, out, nil, nil))
-
-	f, err := os.Open(out)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, f.Close()) })
-
-	gz, err := gzip.NewReader(f)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, gz.Close()) })
-
-	tr := tar.NewReader(gz)
-	for {
-		header, err := tr.Next()
-		if errors.Is(err, io.EOF) {
-			t.Fatal("tetragon-bugtool.log not found")
-		}
-		require.NoError(t, err)
-		if strings.HasSuffix(header.Name, "tetragon-bugtool.log") {
-			logs, err := io.ReadAll(tr)
-			require.NoError(t, err)
-			require.Equal(t, 1, strings.Count(string(logs), "Skipping gops dump info"))
-			require.NotContains(t, string(logs), "Successfully dumped gops pprof")
-			return
-		}
-	}
 }
 
 func Test_findCgroupMountPath(t *testing.T) {


### PR DESCRIPTION
Fixes #5308

### Description

Skip pprof collection when Tetragon has no gops address. This leaves the
single skip message from the existing gops collection path and prevents false
success messages for CPU and heap profiles.

Add a focused regression test for both reported log problems.

Checks:

- `go test ./pkg/bugtool -run '^TestGopsDisabledLogsOnce$' -count=1`
- Non-BPF bugtool unit tests
- `golangci-lint run ./pkg/bugtool/...`
- `gofmt -d pkg/bugtool/bugtool.go pkg/bugtool/bugtool_test.go`
- `git diff --check`

The full `go test ./pkg/bugtool` command could not complete in the fresh
Linux container because the unrelated `TestFindMaps/BaseSensorMemlock` test
requires the generated `bpf/objs/bpf_exit_v511.o` object, which was not
present.

AI assistance: Codex was used for code-path analysis, the guard and regression
test, running checks, and PR preparation. The final diff and test results were
shown to the contributor for review before submission.

### Changelog

```release-note
Fix misleading pprof logs when bugtool runs without gops.
```
