### PR TITLE
new: support multiple preloaded (string) resolved arguments

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -539,13 +539,16 @@ FUNC_INLINE long get_pt_regs_arg(struct pt_regs *ctx, struct event_config *confi
 #endif /* __TARGET_ARCH_x86 && (GENERIC_KPROBE || GENERIC_UPROBE) */
 
 #if defined(GENERIC_UPROBE) || defined(GENERIC_USDT)
-FUNC_INLINE unsigned long get_preload_arg(struct pt_regs *ctx, long ty, arg_status_t *status)
+FUNC_INLINE unsigned long get_preload_arg(struct pt_regs *ctx, long ty, int index, arg_status_t *status)
 {
 	unsigned long arg = 0;
-	__u64 id = get_current_pid_tgid();
+	struct preload_data *data;
+	struct preload_key key = {
+		.tgid = get_current_pid_tgid(),
+		.index = index,
+	};
 
-	struct preload_data *data = map_lookup_elem(&sleepable_preload, &id);
-
+	data = map_lookup_elem(&sleepable_preload, &key);
 	if (data)
 		*status = data->status;
 	else
@@ -564,7 +567,7 @@ FUNC_INLINE unsigned long get_preload_arg(struct pt_regs *ctx, long ty, arg_stat
 	return arg;
 }
 #else
-FUNC_INLINE long get_preload_arg(struct pt_regs *ctx, long ty, arg_status_t *status)
+FUNC_INLINE long get_preload_arg(struct pt_regs *ctx, long ty, int index, arg_status_t *status)
 {
 	return 0;
 }
@@ -612,7 +615,7 @@ FUNC_INLINE long generic_read_arg(void *ctx, int index, long off, struct bpf_map
 
 	a = (&e->a0)[index];
 	if (am & ARGM_PRELOAD)
-		a = get_preload_arg(ctx, ty, &e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
+		a = get_preload_arg(ctx, ty, index, &e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
 	else
 		extract_arg(config, index, &a, false, &e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
 #else
@@ -626,7 +629,7 @@ FUNC_INLINE long generic_read_arg(void *ctx, int index, long off, struct bpf_map
 	 *   - real argument value
 	 */
 	if (am & ARGM_PRELOAD) {
-		a = get_preload_arg(ctx, ty, &e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
+		a = get_preload_arg(ctx, ty, index, &e->arg_status[index & MAX_POSSIBLE_ARGS_MASK]);
 	} else {
 		asm volatile("%[index] &= %1 ;\n"
 			     : [index] "+r"(index)

--- a/bpf/process/user_preload.h
+++ b/bpf/process/user_preload.h
@@ -9,6 +9,12 @@
 #include "errmetrics.h"
 #include "usdt_arg.h"
 
+struct preload_key {
+	__u64 tgid;
+	__u8 index;
+	__u8 pad[7];
+};
+
 struct preload_data {
 	arg_status_t status;
 	unsigned char data[4096];
@@ -17,7 +23,7 @@ struct preload_data {
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1); // will be resized by agent when needed
-	__type(key, __u64);
+	__type(key, struct preload_key);
 	__type(value, struct preload_data);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } sleepable_preload SEC(".maps");
@@ -25,20 +31,23 @@ struct {
 #if defined(GENERIC_UPROBE) || defined(GENERIC_USDT)
 
 FUNC_INLINE int
-preload_string_type(struct pt_regs *ctx, struct event_config *config, unsigned long val,
+preload_string_type(struct pt_regs *ctx, struct event_config *config, int index, unsigned long val,
 		    arg_status_t status)
 {
-	__u64 id = get_current_pid_tgid();
 	struct preload_data *data;
 	__u32 zero = 0;
 	void *init;
+	struct preload_key key = {
+		.tgid = get_current_pid_tgid(),
+		.index = index,
+	};
 
 	init = map_lookup_elem(&heap_ro_zero, &zero);
 	if (!init)
 		return 0;
 
-	with_errmetrics(map_update_elem, &sleepable_preload, &id, init, BPF_ANY);
-	data = map_lookup_elem(&sleepable_preload, &id);
+	with_errmetrics(map_update_elem, &sleepable_preload, &key, init, BPF_ANY);
+	data = map_lookup_elem(&sleepable_preload, &key);
 	if (!data)
 		return 0;
 
@@ -81,7 +90,7 @@ preload_pt_regs_arg(struct pt_regs *ctx, struct event_config *config, int index)
 	switch (ty) {
 	case string_type:
 		if (bpf_ksym_exists(bpf_copy_from_user_str))
-			return preload_string_type(ctx, config, val, status);
+			return preload_string_type(ctx, config, index, val, status);
 	}
 
 	return 0;
@@ -127,7 +136,7 @@ preload_arg(struct pt_regs *ctx, struct event_config *config, int index)
 	switch (ty) {
 	case string_type:
 		if (bpf_ksym_exists(bpf_copy_from_user_str))
-			return preload_string_type(ctx, config, a, status);
+			return preload_string_type(ctx, config, index, a, status);
 	}
 
 	return 0;
@@ -186,12 +195,38 @@ user_preload(struct pt_regs *ctx)
 
 #endif /* GENERIC_UPROBE || GENERIC_USDT*/
 
+FUNC_LOCAL int
+cleanup_preload(int idx, struct preload_key *key)
+{
+	asm volatile("%[idx] &= %1 ;\n"
+		     : [idx] "+r"(idx)
+		     : "i"(MAX_POSSIBLE_ARGS_MASK));
+
+	key->index = idx;
+	map_delete_elem(&sleepable_preload, key);
+	return 0;
+}
+
 FUNC_INLINE int
 user_preload_cleanup(struct pt_regs *ctx)
 {
-	__u64 id = get_current_pid_tgid();
+	int i;
+	struct preload_key key = {
+		.tgid = get_current_pid_tgid(),
+	};
 
-	map_delete_elem(&sleepable_preload, &id);
+	if (CONFIG(ITER_NUM)) {
+		bpf_for(i, 0, MAX_POSSIBLE_ARGS)
+			cleanup_preload(i, &key);
+	} else {
+#ifndef __V61_BPF_PROG
+#pragma unroll
+		for (i = 0; i < MAX_POSSIBLE_ARGS; ++i)
+			cleanup_preload(i, &key);
+#else
+		loop(MAX_POSSIBLE_ARGS, cleanup_preload, &key, 0);
+#endif /* __V61_BPF_PROG */
+	}
 	return 0;
 }
 

--- a/bpf/process/user_preload.h
+++ b/bpf/process/user_preload.h
@@ -156,9 +156,9 @@ try_preload_arg(int idx, struct preload_arg_data *data)
 
 	if (data->config->arm[idx] & ARGM_PRELOAD) {
 		if (data->config->arm[idx] & ARGM_PT_REGS)
-			preload_pt_regs_arg(data->ctx, data->config, idx);
+			return preload_pt_regs_arg(data->ctx, data->config, idx);
 		else
-			preload_arg(data->ctx, data->config, idx);
+			return preload_arg(data->ctx, data->config, idx);
 	}
 	return 0;
 }
@@ -180,12 +180,17 @@ user_preload(struct pt_regs *ctx)
 	};
 	if (CONFIG(ITER_NUM)) {
 		bpf_for(i, 0, MAX_POSSIBLE_ARGS)
-			try_preload_arg(i, &preload_data);
+		{
+			if (try_preload_arg(i, &preload_data))
+				break;
+		}
 	} else {
 #ifndef __V61_BPF_PROG
 #pragma unroll
-		for (i = 0; i < MAX_POSSIBLE_ARGS; ++i)
-			try_preload_arg(i, &preload_data);
+		for (i = 0; i < MAX_POSSIBLE_ARGS; ++i) {
+			if (try_preload_arg(i, &preload_data))
+				break;
+		}
 #else
 		loop(MAX_POSSIBLE_ARGS, try_preload_arg, &preload_data, 0);
 #endif /* __V61_BPF_PROG */
@@ -217,12 +222,17 @@ user_preload_cleanup(struct pt_regs *ctx)
 
 	if (CONFIG(ITER_NUM)) {
 		bpf_for(i, 0, MAX_POSSIBLE_ARGS)
-			cleanup_preload(i, &key);
+		{
+			if (cleanup_preload(i, &key))
+				break;
+		}
 	} else {
 #ifndef __V61_BPF_PROG
 #pragma unroll
-		for (i = 0; i < MAX_POSSIBLE_ARGS; ++i)
-			cleanup_preload(i, &key);
+		for (i = 0; i < MAX_POSSIBLE_ARGS; ++i) {
+			if (cleanup_preload(i, &key))
+				break;
+		}
 #else
 		loop(MAX_POSSIBLE_ARGS, cleanup_preload, &key, 0);
 #endif /* __V61_BPF_PROG */

--- a/contrib/tester-progs/Makefile
+++ b/contrib/tester-progs/Makefile
@@ -185,7 +185,7 @@ pclntab-stripped: FORCE
 clean:
 	rm -f $(PROGS) $(LIBS) *.btf
 
-OTHER_FILES = resolve-nested-anon-struct.btf
+OTHER_FILES = resolve-nested-anon-struct.btf uprobe-resolve.btf
 
 # Used by top-level Makefile to create a tester-progs tarball
 .PHONY: all-files

--- a/contrib/tester-progs/uprobe-resolve.c
+++ b/contrib/tester-progs/uprobe-resolve.c
@@ -38,10 +38,10 @@ void usage(char *argv0)
 }
 
 // without noinline, the symbol is found, but no event fires
-__attribute__((noinline)) int func(int ret, struct mystruct *ms) {
-	// without doing something with ms, all the resolved args have
+__attribute__((noinline)) int func(int ret, struct mystruct *ms, struct mystruct *mss) {
+	// without doing something with ms/mss, all the resolved args have
 	// value 0, presumably due to optimization
-	printf("v64:%lu\n", ms->v64);
+	printf("v64:%lu | %lu\n", ms->v64, mss->v64);
 	return ret;
 }
 
@@ -49,6 +49,7 @@ int main(int argc, char *argv[])
 {
 	long val = 0;
 	struct mysubstruct ss = {0};
+	struct mysubstruct ssecond = {0};
 
 	if (argc < 3) {
 		usage(argv[0]);
@@ -66,6 +67,7 @@ int main(int argc, char *argv[])
 	}
 
 	struct mystruct s = {0};
+	struct mystruct second = {0};
 	if (!strcmp(field, "v8")) {
 		s.v8 = val;
 	} else if (!strcmp(field, "v16")) {
@@ -87,7 +89,9 @@ int main(int argc, char *argv[])
 		s.sub.v32 = val;
 	} else if (!strcmp(field, "subp.buff")) {
 		ss.buff = argv[2];
+		ssecond.buff = argv[3];
 		s.subp = pageout(&ss, sizeof(ss));
+		second.subp = pageout(&ssecond, sizeof(ssecond));
 	} else if ((field[0] == 'a' && field[1] == 'r' && field[2] == 'r')
             || (field[0] == 'd' && field[1] == 'y' && field[2] == 'n')) {
 		long idx = atol(&field[4]);
@@ -106,5 +110,5 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	return func(0, &s);
+	return func(0, &s, &second);
 }

--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -699,6 +699,12 @@ func HasSubStringKfunc() bool {
 	return HasProgramLargeSize() && HasKfunc("bpf_strnstr")
 }
 
+// HasCopyFromUserStr returns true if the kernel supports the bpf_copy_from_user_str kfunc
+// which is required for many uprobe register-related tests.
+func HasCopyFromUserStr() bool {
+	return HasKfunc("bpf_copy_from_user_str")
+}
+
 func detectMixBpfAndTailCalls() bool {
 	// create a tail call map
 	tcMap, err := ebpf.NewMap(&ebpf.MapSpec{
@@ -826,4 +832,5 @@ var FeatureProbes = []FeatureProbe{
 	{Fentry, HasFentryProgram},
 	{GetFuncRet, HasGetFuncRetHelper},
 	{SubStringKfuncProbe, HasSubStringKfunc},
+	{CopyFromUserStr, HasCopyFromUserStr},
 }

--- a/pkg/bpf/probes.go
+++ b/pkg/bpf/probes.go
@@ -25,4 +25,5 @@ const (
 	Fentry                      = "fentry"
 	GetFuncRet                  = "get_func_ret"
 	SubStringKfuncProbe         = "substring_kfunc"
+	CopyFromUserStr             = "copy_from_user_str"
 )

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -1093,9 +1093,6 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 					if !bpf.HasKfunc("bpf_copy_from_user_str") {
 						return fmt.Errorf("can't preload string for argument %d", i)
 					}
-					if cfg.preload {
-						return errors.New("error: can't preload more than one argument")
-					}
 					preloadArg = true
 				}
 			} else if hasCurrentTaskSource(a) {
@@ -1124,9 +1121,6 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 			if argType == gt.GenericStringType {
 				if !bpf.HasKfunc("bpf_copy_from_user_str") {
 					return fmt.Errorf("can't preload string for argument %d", i)
-				}
-				if cfg.preload {
-					return errors.New("error: can't preload more than one argument")
 				}
 				preloadArg = true
 			}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -1072,6 +1072,7 @@ func initUprobeArgs(spec *v1alpha1.UProbeSpec, has *uprobeHas, in *addUprobeIn, 
 
 func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgConfig, error) {
 	var cfg uprobeArgConfig
+	var preloadArgsCounter int
 
 	addArg := func(i int, a *v1alpha1.KProbeArg, data bool) error {
 		var preloadArg bool
@@ -1094,6 +1095,7 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 						return fmt.Errorf("can't preload string for argument %d", i)
 					}
 					preloadArg = true
+					preloadArgsCounter++
 				}
 			} else if hasCurrentTaskSource(a) {
 				if !bpf.HasProgramLargeSize() {
@@ -1123,6 +1125,7 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 					return fmt.Errorf("can't preload string for argument %d", i)
 				}
 				preloadArg = true
+				preloadArgsCounter++
 			}
 		}
 
@@ -1179,6 +1182,10 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 			return cfg, err
 		}
 		i = i + 1
+	}
+
+	if preloadArgsCounter > 1 {
+		logger.GetLogger().Warn(fmt.Sprintf("TracingPolicy specifies multiple preload args/data, %q might need to be increased.", option.KeySleepablePreloadSize))
 	}
 
 	return cfg, nil

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -388,6 +388,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 	}
 
 	var found bool
+	var preloadArgsCounter int
 
 	for _, target := range targets {
 		if spec.Provider != target.Spec.Provider || spec.Name != target.Spec.Name {
@@ -474,6 +475,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 					return ids, fmt.Errorf("can't preload string for argument %d", cfgIdx)
 				}
 
+				preloadArgsCounter++
 				preload = true
 				argMValue, err := getUserMetaValue(&arg, true)
 				if err != nil {
@@ -515,6 +517,11 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		return ids, fmt.Errorf("failed to configure usdt '%s/%s', not found in the binary: '%s'",
 			spec.Provider, spec.Name, spec.Path)
 	}
+
+	if preloadArgsCounter > 1 {
+		logger.GetLogger().Warn(fmt.Sprintf("TracingPolicy specifies multiple preload args, %q might need to be increased.", option.KeySleepablePreloadSize))
+	}
+
 	return ids, nil
 }
 

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -474,10 +474,6 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 					return ids, fmt.Errorf("can't preload string for argument %d", cfgIdx)
 				}
 
-				if preload {
-					return ids, errors.New("preloading multiple arguments per hook point is not supported")
-				}
-
 				preload = true
 				argMValue, err := getUserMetaValue(&arg, true)
 				if err != nil {

--- a/pkg/sensors/tracing/uprobe_validation_test.go
+++ b/pkg/sensors/tracing/uprobe_validation_test.go
@@ -11,38 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
-	"github.com/cilium/tetragon/pkg/testutils"
 )
-
-func TestUprobeValidationMultiplePreloadArguments(t *testing.T) {
-
-	// Using multiple preload arguments
-
-	uprobe := testutils.RepoRootPath("contrib/tester-progs/usdt-override")
-	crd := `
-apiVersion: cilium.io/v1alpha1
-kind: TracingPolicy
-metadata:
-  name: "uprobe"
-spec:
-  uprobes:
-  - path: "` + uprobe + `"
-    symbols:
-    - "test_3"
-    data:
-    - index: 0
-      type: "string"
-      source: "pt_regs"
-      resolve: "rdi"
-    - index: 1
-      type: "string"
-      source: "pt_regs"
-      resolve: "rsi"
-`
-
-	err := checkCrd(t, crd)
-	require.Error(t, err)
-}
 
 func TestUprobeEventConfigCarriesPolicyID(t *testing.T) {
 	var state uprobeConfigState

--- a/tests/policytests/uprobes.go
+++ b/tests/policytests/uprobes.go
@@ -436,3 +436,58 @@ spec:
 		EventChecker: ec.NewUnorderedEventChecker(upChecker, upChecker1, upChecker2),
 	}
 }).RegisterAtInit()
+
+var _ = policytest.NewBuilder("uprobe-multiple-string-preload").WithLabels("uprobes").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe"
+spec:
+  uprobes:
+  - path: {{ testBinary "uprobe-resolve" }}
+    btfPath: {{ testBinary "uprobe-resolve.btf" }}
+    symbols:
+    - "func"
+    args:
+    - index: 1
+      type: "string"
+      btfType: "mystruct"
+      resolve: "subp.buff"
+    - index: 2
+      type: "string"
+      btfType: "mystruct"
+      resolve: "subp.buff"
+`).WithSkip(func(si *policytest.SkipInfo) string {
+	if !si.AgentInfo.Probes[bpf.LargeProgsProbe] {
+		return "need 5.3 or newer kernel"
+	}
+
+	if !si.AgentInfo.Probes[bpf.UprobeRefCtrOffsetProbe] {
+		return "need uprobe ref_ctr_off support"
+	}
+
+	if !si.AgentInfo.Probes[bpf.CopyFromUserStr] {
+		return "SubString operator requires bpf_copy_from_user_str kfunc"
+	}
+
+	return ""
+}).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	bin := c.TestBinary("uprobe-resolve")
+	upChecker := ec.NewProcessUprobeChecker("uprobe-resolve").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(bin)).
+			WithArguments(
+				sm.Full("subp.buff hello world!"),
+			),
+		).WithArgs(ec.NewKprobeArgumentListMatcher().
+		WithOperator(lc.Ordered).
+		WithValues(ec.NewKprobeArgumentChecker().WithStringArg(sm.Full("hello")),
+			ec.NewKprobeArgumentChecker().WithStringArg(sm.Full("world!")),
+		))
+
+	return &policytest.Scenario{
+		Name:         "check we can preload multiple strings",
+		Trigger:      policytest.NewCmdTrigger(bin, "subp.buff", "hello", "world!"),
+		EventChecker: ec.NewUnorderedEventChecker(upChecker),
+	}
+}).RegisterAtInit()


### PR DESCRIPTION
### Description

Both uprobe and usdt support preloading a single `string` resolve argument:
* https://github.com/cilium/tetragon/blob/main/pkg/sensors/tracing/genericuprobe.go#L1037
* https://github.com/cilium/tetragon/blob/main/pkg/sensors/tracing/genericusdt.go#L474

With this patch, we aim to support `MAX_POSSIBLE_ARGS` arguments (5).

### Changelog

```release-note
new: support multiple preloaded (string) resolved arguments
```
