### PR TITLE
fix(fieldfilters): apply all redaction regexes to each env var

### DIFF
--- a/pkg/fieldfilters/redaction.go
+++ b/pkg/fieldfilters/redaction.go
@@ -116,16 +116,11 @@ func (f RedactionFilter) Redact(binary, args string, envs []string) (string, []s
 		args, _ = redactString(re, args)
 	}
 
-	var (
-		envsRedacted []string
-		modified     bool
-	)
+	var envsRedacted []string
 
 	for _, v := range envs {
 		for _, re := range f.redact {
-			if v, modified = redactString(re, v); modified {
-				break
-			}
+			v, _ = redactString(re, v)
 		}
 		envsRedacted = append(envsRedacted, v)
 	}

--- a/pkg/fieldfilters/redaction_test.go
+++ b/pkg/fieldfilters/redaction_test.go
@@ -122,6 +122,19 @@ func TestRedact_Envs(t *testing.T) {
 	assert.Equal(t, "VAR1=XXX SSH_PASSWORD="+REDACTION_STR+" VAR2=YYY", str)
 }
 
+func TestRedact_EnvsMulti(t *testing.T) {
+	envs := []string{"CREDS=--password hunter2 TOPSECRET end"}
+
+	filterList := `{"redact": ["(?:--password|-p)[\\s=]+(\\S+)", "\\W(TOPSECRET)\\W"]}`
+	filters, err := ParseRedactionFilterList(filterList)
+	require.NoError(t, err)
+
+	_, redacted := filters.Redact("", "", envs)
+
+	str := strings.Join(redacted, " ")
+	assert.Equal(t, "CREDS=--password "+REDACTION_STR+" "+REDACTION_STR+" end", str)
+}
+
 func TestRedact_ArgsWithEnvs(t *testing.T) {
 	args := "--verbose=true --password ybx511!ackt544 --username foobar cheesecake TOPSECRET innocent"
 	envs := []string{


### PR DESCRIPTION
The env-var redaction loop stopped after the first regex that changed a given value, so if more than one configured regex matched the same environment variable, only the first was applied. The args path already applies every regex; this makes the env path consistent with it.

Added a test covering two redactions in a single env var, and confirmed the fieldfilters suite passes.

```release-note
Fix a bug where redaction filters were not applying to all environment variables.
```