### PR TITLE
new: make regs_map selector idx aware

### DIFF
--- a/bpf/process/uprobe_offload.h
+++ b/bpf/process/uprobe_offload.h
@@ -33,7 +33,7 @@ struct uprobe_regs {
 };
 
 struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 1);
 	__type(key, __u32);
 	__type(value, struct uprobe_regs);

--- a/contrib/tester-progs/uprobe-test.c
+++ b/contrib/tester-progs/uprobe-test.c
@@ -23,8 +23,12 @@ int uprobe_test_lib_string_arg2(int one, int two, char *str, int four, int five)
 int uprobe_test_lib_string_arg3(int one, int two, int three, char *str, int five);
 int uprobe_test_lib_string_arg4(int one, int two, int three, int four, char *str);
 
-int main(void)
+int main(int argc, char *argv[])
 {
+	if (argc > 1) {
+		return uprobe_test_lib_string_arg1(atoi(argv[1]), "two", 3, 4, 5);
+	}
+
 	char *str_arg = "hello world!";
 
 	uprobe_test_lib();
@@ -46,4 +50,5 @@ int main(void)
 	uprobe_test_lib_string_arg2(1, 2, "three", 4, 5);
 	uprobe_test_lib_string_arg3(1, 2, 3, "four", 5);
 	uprobe_test_lib_string_arg4(1, 2, 3, 4, "five");
+	return 0;
 }

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1164,7 +1164,7 @@ func parseRateLimit(str string, scopeStr string) (uint32, uint32, error) {
 	return uint32(rateLimit), scope, nil
 }
 
-func ParseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, actionArgTable *idtable.Table) error {
+func ParseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, actionArgTable *idtable.Table, selIdx int) error {
 	act, ok := actionTypeTable[strings.ToLower(action.Action)]
 	if !ok {
 		return fmt.Errorf("parseMatchAction: ActionType %s unknown", action.Action)
@@ -1187,11 +1187,11 @@ func ParseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, a
 	switch act {
 	case ActionTypeOverride:
 		if k.isUprobe {
-			id, err := parseOverrideRegs(k, action.ArgRegs, uint64(action.ArgError), k.overrideActionIPDelta)
+			err := parseOverrideRegs(k, selIdx, action.ArgRegs, uint64(action.ArgError), k.overrideActionIPDelta)
 			if err != nil {
 				return err
 			}
-			WriteSelectorUint32(&k.data, id)
+			WriteSelectorUint32(&k.data, k.UprobeRegsMapID(selIdx))
 		} else {
 			WriteSelectorInt32(&k.data, action.ArgError)
 		}
@@ -1303,13 +1303,13 @@ func ParseMatchWorkloads(k *KernelSelectorState, workload *v1alpha1.WorkloadsSel
 	return nil
 }
 
-func ParseMatchActions(k *KernelSelectorState, actions []v1alpha1.ActionSelector, actionArgTable *idtable.Table) error {
+func ParseMatchActions(k *KernelSelectorState, actions []v1alpha1.ActionSelector, actionArgTable *idtable.Table, selIdx int) error {
 	if len(actions) > 3 {
 		return fmt.Errorf("only %d actions are support for selector (current number of values is %d)", 3, len(actions))
 	}
 	loff := AdvanceSelectorLength(&k.data)
 	for _, a := range actions {
-		if err := ParseMatchAction(k, &a, actionArgTable); err != nil {
+		if err := ParseMatchAction(k, &a, actionArgTable, selIdx); err != nil {
 			return err
 		}
 	}
@@ -1745,7 +1745,7 @@ func InitKernelSelectorState(args *KernelSelectorArgs) (*KernelSelectorState, er
 		if err := ParseMatchWorkloads(k, selector.MatchWorkloads, selIdx); err != nil {
 			return fmt.Errorf("parseMatchWorkloads  error: %w", err)
 		}
-		if err := ParseMatchActions(k, selector.MatchActions, args.ActionArgTable); err != nil {
+		if err := ParseMatchActions(k, selector.MatchActions, args.ActionArgTable, selIdx); err != nil {
 			return fmt.Errorf("parseMatchActions error: %w", err)
 		}
 		return nil
@@ -1757,11 +1757,11 @@ func InitKernelSelectorState(args *KernelSelectorArgs) (*KernelSelectorState, er
 func InitKernelReturnSelectorState(selectors []v1alpha1.KProbeSelector, returnArg *v1alpha1.KProbeArg,
 	actionArgTable *idtable.Table, listReader ValueReader, maps *KernelSelectorMaps) (*KernelSelectorState, error) {
 
-	parse := func(k *KernelSelectorState, selector *v1alpha1.KProbeSelector, _ int) error {
+	parse := func(k *KernelSelectorState, selector *v1alpha1.KProbeSelector, selIdx int) error {
 		if err := ParseMatchArgs(k, selector.MatchReturnArgs, []v1alpha1.ArgSelector{}, []v1alpha1.KProbeArg{*returnArg}, []v1alpha1.KProbeArg{}); err != nil {
 			return fmt.Errorf("parseMatchArgs  error: %w", err)
 		}
-		if err := ParseMatchActions(k, selector.MatchReturnActions, actionArgTable); err != nil {
+		if err := ParseMatchActions(k, selector.MatchReturnActions, actionArgTable, selIdx); err != nil {
 			return fmt.Errorf("parseMatchActions error: %w", err)
 		}
 		return nil

--- a/pkg/selectors/kernel_regs_amd64.go
+++ b/pkg/selectors/kernel_regs_amd64.go
@@ -13,9 +13,9 @@ import (
 	"github.com/cilium/tetragon/pkg/asm"
 )
 
-func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64, newOffset int64) (uint32, error) {
-	if len(k.regs) > 0 {
-		return uint32(0xffffffff), errors.New("only single instance of regs action is allowed")
+func parseOverrideRegs(k *KernelSelectorState, selIdx int, values []string, errValue uint64, newOffset int64) error {
+	if _, exists := k.regs[selIdx]; exists {
+		return errors.New("only single instance of regs action is allowed")
 	}
 
 	regs := []processapi.RegAssignment{}
@@ -37,7 +37,7 @@ func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64,
 	for _, val := range values {
 		ass, err := asm.ParseAssignment(val)
 		if err != nil {
-			return uint32(0xffffffff), err
+			return err
 		}
 
 		regs = append(regs, processapi.RegAssignment{
@@ -50,6 +50,6 @@ func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64,
 		})
 	}
 
-	k.regs = regs
-	return uint32(k.uprobeID), nil
+	k.regs[selIdx] = regs
+	return nil
 }

--- a/pkg/selectors/kernel_regs_arm64.go
+++ b/pkg/selectors/kernel_regs_arm64.go
@@ -13,9 +13,9 @@ import (
 	"github.com/cilium/tetragon/pkg/asm"
 )
 
-func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64, newOffset int64) (uint32, error) {
-	if len(k.regs) > 0 {
-		return uint32(0xffffffff), errors.New("only single instance of regs action is allowed")
+func parseOverrideRegs(k *KernelSelectorState, selIdx int, values []string, errValue uint64, newOffset int64) error {
+	if _, exists := k.regs[selIdx]; exists {
+		return errors.New("only single instance of regs action is allowed")
 	}
 
 	regs := []processapi.RegAssignment{}
@@ -36,7 +36,7 @@ func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64,
 	for _, val := range values {
 		ass, err := asm.ParseAssignment(val)
 		if err != nil {
-			return uint32(0xffffffff), err
+			return err
 		}
 
 		regs = append(regs, processapi.RegAssignment{
@@ -49,6 +49,6 @@ func parseOverrideRegs(k *KernelSelectorState, values []string, errValue uint64,
 		})
 	}
 
-	k.regs = regs
-	return uint32(k.uprobeID), nil
+	k.regs[selIdx] = regs
+	return nil
 }

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -864,7 +864,7 @@ func TestParseMatchAction(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // UserStackTrace = 0
 		0x00, 0x00, 0x00, 0x00, // ImaHash = 0
 	}
-	if err := ParseMatchAction(k, act1, &actionArgTable); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
+	if err := ParseMatchAction(k, act1, &actionArgTable, 0); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
 		t.Errorf("parseMatchAction: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e[0:d.off], act1)
 	}
 	// This is a bit contrived because we only have single action so far
@@ -885,7 +885,7 @@ func TestParseMatchAction(t *testing.T) {
 	act := []v1alpha1.ActionSelector{*act1, *act2}
 	ks := &KernelSelectorState{data: KernelSelectorData{off: 0}}
 	d = &ks.data
-	if err := ParseMatchActions(ks, act, &actionArgTable); err != nil || bytes.Equal(expected, d.e[0:d.off]) == false {
+	if err := ParseMatchActions(ks, act, &actionArgTable, 0); err != nil || bytes.Equal(expected, d.e[0:d.off]) == false {
 		t.Errorf("parseMatchActions: error %v expected %v bytes %v parsing %v\n", err, expected, d.e[0:d.off], act)
 	}
 }
@@ -902,7 +902,7 @@ func TestParseMatchActionMax(t *testing.T) {
 
 	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
 
-	err := ParseMatchActions(k, actions, &actionArgTable)
+	err := ParseMatchActions(k, actions, &actionArgTable, 0)
 	if err == nil {
 		t.Errorf("ParseMatchActions expected to fail")
 	}

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -136,7 +136,7 @@ type KernelSelectorState struct {
 	uprobeID              int
 	overrideActionIPDelta int64
 
-	regs []processapi.RegAssignment
+	regs map[int][]processapi.RegAssignment
 
 	subStrs []string
 
@@ -171,6 +171,7 @@ func NewKernelSelectorState(
 		overrideActionIPDelta: overrideActionIPDelta,
 		celExprFunctions:      celExprs,
 		matchWorkloadIDs:      make(map[int]policyfilter.PolicyID),
+		regs:                  make(map[int][]processapi.RegAssignment),
 	}
 }
 
@@ -244,7 +245,7 @@ func (k *KernelSelectorState) StringPostfixMaps() []map[KernelLPMTrieStringPostf
 	return k.maps.stringPostfixMaps
 }
 
-func (k *KernelSelectorState) Regs() []processapi.RegAssignment {
+func (k *KernelSelectorState) Regs() map[int][]processapi.RegAssignment {
 	return k.regs
 }
 
@@ -549,4 +550,8 @@ func (k *KernelSelectorState) newStringPostfixMap() (uint32, map[KernelLPMTrieSt
 
 func (k *KernelSelectorState) CelExprFunctions() *CelExprFunctions {
 	return k.celExprFunctions
+}
+
+func (k *KernelSelectorState) UprobeRegsMapID(selIdx int) uint32 {
+	return uint32(k.uprobeID<<16 + selIdx)
 }

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -115,7 +115,7 @@ type genericUprobe struct {
 	pendingEvents *lru.Cache[pendingEventKey, pendingEvent[*tracing.MsgGenericUprobeUnix]]
 }
 
-func populateUprobeRegs(m *ebpf.Map, id int, regs []processapi.RegAssignment) error {
+func populateUprobeRegs(m *ebpf.Map, id uint32, regs []processapi.RegAssignment) error {
 	uprobeRegs := processapi.UprobeRegs{}
 
 	n := copy(uprobeRegs.Ass[:], regs)
@@ -123,7 +123,17 @@ func populateUprobeRegs(m *ebpf.Map, id int, regs []processapi.RegAssignment) er
 		logger.GetLogger().Warn("register assignments count mismatch", "#regs", len(regs))
 	}
 	uprobeRegs.Cnt = uint32(n)
-	return m.Update(uint32(id), uprobeRegs, ebpf.UpdateAny)
+	return m.Update(id, uprobeRegs, ebpf.UpdateAny)
+}
+
+func populateSelectorRegsMap(m *ebpf.Map, selector *selectors.KernelSelectorState) error {
+	for selIdx, regs := range selector.Regs() {
+		err := populateUprobeRegs(m, selector.UprobeRegsMapID(selIdx), regs)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (g *genericUprobe) SetID(id idtable.EntryID) {
@@ -272,7 +282,7 @@ func loadSingleUprobeSensor(uprobeEntry *genericUprobe, args sensors.LoadProbeAr
 				&program.MapLoad{
 					Name: "regs_map",
 					Load: func(m *ebpf.Map, _ string) error {
-						return populateUprobeRegs(m, 0, selector.Regs())
+						return populateSelectorRegsMap(m, selector)
 					},
 				},
 			)
@@ -389,7 +399,7 @@ func loadMultiUprobeSensor(ids []idtable.EntryID, args sensors.LoadProbeArgs) er
 					&program.MapLoad{
 						Name: "regs_map",
 						Load: func(m *ebpf.Map, _ string) error {
-							return populateUprobeRegs(m, index, selector.Regs())
+							return populateSelectorRegsMap(m, selector)
 						},
 					},
 				)
@@ -1377,18 +1387,25 @@ func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []
 	var progs []*program.Program
 	var maps []*program.Map
 	var substringMapEntries int
+	var regsMapEntries int
 
 	for _, id := range multiIDs {
 		gu, err := genericUprobeTableGet(id)
 		if err != nil {
 			return nil, nil, err
 		}
+		selector := gu.loadArgs.selectors.entry
 		if gu.loadArgs.retprobe {
 			multiRetIDs = append(multiRetIDs, id)
+			selector = gu.loadArgs.selectors.retrn
 		}
 
 		if has.substring && substringMapEntries == 0 {
 			substringMapEntries = len(gu.loadArgs.selectors.entry.SubStrings())
+		}
+
+		if selector != nil && selector.Regs() != nil {
+			regsMapEntries += len(selector.Regs())
 		}
 	}
 
@@ -1426,7 +1443,7 @@ func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []
 
 	if has.sleepableOffload {
 		regsMap := program.MapBuilderProgram("regs_map", load)
-		regsMap.SetMaxEntries(len(multiIDs))
+		regsMap.SetMaxEntries(max(regsMapEntries, 1))
 		sleepableOffloadMap := program.MapBuilderProgram("sleepable_offload", load)
 		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
 		maps = append(maps, regsMap, sleepableOffloadMap)
@@ -1537,6 +1554,11 @@ func createUprobeSensorFromEntry(polInfo *policyInfo, uprobeEntry *genericUprobe
 
 	if has.sleepableOffload {
 		regsMap := program.MapBuilderProgram("regs_map", load)
+		// keep the map valid even when this particular entry has no
+		// register assignments of its own (e.g. only a sibling uprobe
+		// in the same policy needs the override action)
+		regsMapEntries := max(len(uprobeEntry.loadArgs.selectors.entry.Regs()), 1)
+		regsMap.SetMaxEntries(regsMapEntries)
 		sleepableOffloadMap := program.MapBuilderProgram("sleepable_offload", load)
 		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
 		maps = append(maps, regsMap, sleepableOffloadMap)

--- a/pkg/testutils/policytest/trigger.go
+++ b/pkg/testutils/policytest/trigger.go
@@ -32,60 +32,74 @@ func (c *CmdTrigger) Trigger(ctx context.Context) error {
 
 func (c *CmdTrigger) ExpectExitCode(val int) *ExecTester {
 	return &ExecTester{
-		CmdTrigger: CmdTrigger{
-			Bin:  c.Bin,
-			Args: c.Args,
-		},
-		ExpectedExitCode: &val,
+		MultiCmdTrigger:  MultiCmdTrigger{triggers: []CmdTrigger{*c}},
+		ExpectedExitCode: []int{val},
 	}
 }
 
 func (c *CmdTrigger) ExpectSignal(sig syscall.Signal) *ExecTester {
 	return &ExecTester{
-		CmdTrigger: CmdTrigger{
-			Bin:  c.Bin,
-			Args: c.Args,
-		},
-		ExpectedSignal: &sig,
+		MultiCmdTrigger: MultiCmdTrigger{triggers: []CmdTrigger{*c}},
+		ExpectedSignal:  []syscall.Signal{sig},
 	}
 }
 
 // MultiCmdTrigger simply wraps multiple exec.CommandContext().Run() into a Trigger
 type MultiCmdTrigger struct {
-	BinToArgs map[string][]string
+	triggers []CmdTrigger
 }
 
-func NewMultiCmdTrigger(bin2args map[string][]string) *MultiCmdTrigger {
+func NewMultiCmdTrigger(triggers []CmdTrigger) *MultiCmdTrigger {
 	return &MultiCmdTrigger{
-		BinToArgs: bin2args,
+		triggers: triggers,
 	}
 }
 
 func (c *MultiCmdTrigger) Trigger(ctx context.Context) error {
-	for bin, args := range c.BinToArgs {
-		if err := exec.CommandContext(ctx, bin, args...).Run(); err != nil {
+	for _, trigger := range c.triggers {
+		if err := exec.CommandContext(ctx, trigger.Bin, trigger.Args...).Run(); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+func (c *MultiCmdTrigger) ExpectExitCodes(vals []int) *ExecTester {
+	return &ExecTester{
+		MultiCmdTrigger:  *c,
+		ExpectedExitCode: vals,
+	}
+}
+
+func (c *MultiCmdTrigger) ExpectSignals(sigs []syscall.Signal) *ExecTester {
+	return &ExecTester{
+		MultiCmdTrigger: *c,
+		ExpectedSignal:  sigs,
+	}
+}
+
 type ExecTester struct {
-	CmdTrigger
+	MultiCmdTrigger
 	// Execution should either terminate normally (with an exit code) or by a signal
 	// only one of those should be not nill
-	ExpectedExitCode *int
-	ExpectedSignal   *syscall.Signal
+	ExpectedExitCode []int
+	ExpectedSignal   []syscall.Signal
 }
 
 func (et *ExecTester) Trigger(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, et.Bin, et.Args...)
-	err := cmd.Start()
-	if err != nil {
-		return fmt.Errorf("failed to execute cmd: %w", err)
+	for idx, trigger := range et.triggers {
+		cmd := exec.CommandContext(ctx, trigger.Bin, trigger.Args...)
+		err := cmd.Start()
+		if err != nil {
+			return fmt.Errorf("failed to execute cmd: %w", err)
+		}
+		cmd.Wait()
+		err = et.check(cmd, idx)
+		if err != nil {
+			return err
+		}
 	}
-	cmd.Wait()
-	return et.check(cmd)
+	return nil
 }
 
 // ExecTestError will be returned if the command did not exit as expected.
@@ -103,7 +117,7 @@ func (e *ExecTestError) Error() string {
 }
 
 // check should be called after command has been executed
-func (et *ExecTester) check(cmd *exec.Cmd) error {
+func (et *ExecTester) check(cmd *exec.Cmd, idx int) error {
 	st := cmd.ProcessState.Sys()
 	status, ok := st.(syscall.WaitStatus)
 	if !ok {
@@ -111,26 +125,26 @@ func (et *ExecTester) check(cmd *exec.Cmd) error {
 	}
 
 	if status.Exited() {
-		return et.checkExit(cmd, status.ExitStatus())
+		return et.checkExit(cmd, status.ExitStatus(), idx)
 	}
 
 	if status.Signaled() {
-		return et.checkSignal(cmd, status.Signal())
+		return et.checkSignal(cmd, status.Signal(), idx)
 	}
 
 	// if neither status.Exited() or status.Signaled() is true, the process was stopped
 	return errors.New("process stopped")
 }
 
-func (et *ExecTester) checkSignal(cmd *exec.Cmd, exitSignal syscall.Signal) error {
-	if et.ExpectedExitCode != nil {
-		expected := *(et.ExpectedExitCode)
+func (et *ExecTester) checkSignal(cmd *exec.Cmd, exitSignal syscall.Signal, idx int) error {
+	if len(et.ExpectedExitCode) > idx {
+		expected := et.ExpectedExitCode[idx]
 		return NewExecTestErr("command %v terminated by a signal (%d), but was expected to exit normally with %d", cmd, exitSignal, expected)
 	}
-	if et.ExpectedSignal == nil {
+	if len(et.ExpectedSignal) <= idx {
 		return errors.New("BUG: neither ExpectExitCode or ExpectSignal defined")
 	}
-	expected := *(et.ExpectedSignal)
+	expected := et.ExpectedSignal[idx]
 	if expected != exitSignal {
 		return NewExecTestErr("command %v terminated by signal %d, but was expected to terminate with signal %d", cmd, exitSignal, expected)
 	}
@@ -139,16 +153,16 @@ func (et *ExecTester) checkSignal(cmd *exec.Cmd, exitSignal syscall.Signal) erro
 }
 
 // checkExit checks exit expectations when the process exited normally (i.e., without a signal)
-func (et *ExecTester) checkExit(cmd *exec.Cmd, exitStatus int) error {
-	if et.ExpectedSignal != nil {
-		expected := *(et.ExpectedSignal)
+func (et *ExecTester) checkExit(cmd *exec.Cmd, exitStatus int, idx int) error {
+	if len(et.ExpectedSignal) > idx {
+		expected := et.ExpectedSignal[idx]
 		return NewExecTestErr("command %v terminated normally (%d), but was expected to exit via a signal (%d)", cmd, exitStatus, expected)
 	}
-	if et.ExpectedExitCode == nil {
+	if len(et.ExpectedExitCode) <= idx {
 		return errors.New("BUG: neither ExpectExitCode or ExpectSignal defined")
 	}
 
-	expected := *(et.ExpectedExitCode)
+	expected := et.ExpectedExitCode[idx]
 	if expected != exitStatus {
 		return NewExecTestErr("command %v terminated normally with %d, but was expected to terminate with %d", cmd, exitStatus, expected)
 	}

--- a/tests/policytests/uprobes.go
+++ b/tests/policytests/uprobes.go
@@ -290,8 +290,15 @@ spec:
 			WithBinary(sm.Full(binTwo))).WithSymbol(sm.Full("main"))
 
 	return &policytest.Scenario{
-		Name:         "check both events occur",
-		Trigger:      policytest.NewMultiCmdTrigger(map[string][]string{binOne: {"v8", "7"}, binTwo: {}}),
+		Name: "check both events occur",
+		Trigger: policytest.NewMultiCmdTrigger([]policytest.CmdTrigger{
+			{
+				Bin:  binOne,
+				Args: []string{"v8", "7"},
+			}, {
+				Bin: binTwo,
+			},
+		}),
 		EventChecker: ec.NewUnorderedEventChecker(up1Checker, up2Checker),
 	}
 }).RegisterAtInit()

--- a/tests/policytests/uprobes.go
+++ b/tests/policytests/uprobes.go
@@ -345,3 +345,94 @@ spec:
 		EventChecker: ec.NewUnorderedEventChecker(upChecker),
 	}
 }).RegisterAtInit()
+
+var _ = policytest.NewBuilder("uprobe-override-multiple-selectors").WithLabels("uprobes").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe-multiple-selectors"
+spec:
+  uprobes:
+  - path: {{ testBinary "libuprobe.so" }}
+    symbols:
+    - "uprobe_test_lib_string_arg_empty"
+    args:
+    - index: 0
+      type: "string"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+          - ""
+      matchActions:
+      - action: Override
+        argNewSymbol: "uprobe_test_lib_string_arg__"
+  - path: {{ testBinary "libuprobe.so" }}
+    symbols:
+    - "uprobe_test_lib_string_arg1"
+    args:
+    - index: 0
+      type: "int"
+    selectors:
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+          - "22"
+      matchActions:
+      - action: Override
+        argError: 22
+    - matchArgs:
+      - index: 0
+        operator: "Equal"
+        values:
+          - "33"
+      matchActions:
+      - action: Override
+        argError: 33
+`).WithSkip(func(si *policytest.SkipInfo) string {
+	if !si.AgentInfo.Probes[bpf.UprobeRegsChangeProbe] {
+		return "need writing to regs kernel support (6.18+)"
+	}
+	return ""
+}).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	bin := c.TestBinary("uprobe-test-1")
+	upChecker := ec.NewProcessUprobeChecker("UPROBE_SELECTOR_MATCH").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(bin))).
+		WithSymbol(sm.Full("uprobe_test_lib_string_arg_empty"))
+	upChecker1 := ec.NewProcessUprobeChecker("UPROBE_SELECTOR_MATCH").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(bin))).
+		WithSymbol(sm.Full("uprobe_test_lib_string_arg1")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(ec.NewKprobeArgumentChecker().WithIntArg(22)))
+	upChecker2 := ec.NewProcessUprobeChecker("UPROBE_SELECTOR_MATCH").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(bin))).
+		WithSymbol(sm.Full("uprobe_test_lib_string_arg1")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(ec.NewKprobeArgumentChecker().WithIntArg(33)))
+
+	return &policytest.Scenario{
+		Name: "check all selectors work fine",
+		// See uprobe-lib.c/uprobe-test.c return code for uprobe_test_lib_string_arg__().
+		// It will return 100 when the symbol is overridden.
+		// It will be considered an error by `cmd.Run()`.
+		Trigger: policytest.NewMultiCmdTrigger([]policytest.CmdTrigger{
+			{
+				Bin: bin,
+			}, {
+				Bin:  bin,
+				Args: []string{"22"},
+			}, {
+				Bin:  bin,
+				Args: []string{"33"},
+			},
+		}).ExpectExitCodes([]int{100, 22, 33}),
+		EventChecker: ec.NewUnorderedEventChecker(upChecker, upChecker1, upChecker2),
+	}
+}).RegisterAtInit()


### PR DESCRIPTION
### Description

Prior to this change, if multiple selectors had an `Override` match action for uprobe sensor, we would fail with:
> error: only single instance of regs action is allowed.

This is because we were not being selector id aware, therefore every selector for the same hook shared the same `regs` instance (and thus `regs_maps` entry).
This PR makes `KernelSelectorState.regs` , `MatchActions` and `populateUprobeRegs` selector idx aware.
Also, `TestUprobeOverrideMultipleSelectors` was created to show the bug and avoid future regressions.

### Changelog

```release-note
fix: make regs_map selector idx aware
```
