### PR TITLE
make execve sensor use raw tracepoint

### DIFF
--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -425,7 +425,7 @@ struct {
  * through the execve call. The list of current hooks is:
  *   1. kprobe/security_bprm_committing_creds
  *      For details check tg_kp_bprm_committing_creds bpf program.
- *   2. tracepoint/sys_execve
+ *   2. raw_tracepoint/sys_execve
  *      For details see event_execve bpf program.
  *
  * Important: the information stored here is complementary

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -17,15 +17,9 @@
 
 char _license[] __attribute__((section("license"), used)) = "Dual BSD/GPL";
 
-#ifdef __RHEL7_BPF_PROG
-#define exec_ctx_struct ftrace_raw_sched_process_exec
-#else
-#define exec_ctx_struct trace_event_raw_sched_process_exec
-#endif
-
 #ifndef OVERRIDE_TAILCALL
 int execve_rate(void *ctx);
-int execve_send(struct exec_ctx_struct *ctx);
+int execve_send(struct bpf_raw_tracepoint_args *ctx);
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
@@ -249,14 +243,15 @@ read_execve_shared_info(void *ctx, struct msg_process *p, __u64 pid)
 	execve_joined_info_map_clear(pid);
 }
 
-__attribute__((section("tracepoint/sys_execve"), used)) int
-event_execve(struct exec_ctx_struct *ctx)
+__attribute__((section("raw_tracepoint/sys_execve"), used)) int
+event_execve(struct bpf_raw_tracepoint_args *ctx)
 {
 	struct task_struct *task = (struct task_struct *)get_current_task();
-	char *filename = (char *)ctx + (_(ctx->__data_loc_filename) & 0xFFFF);
+	struct linux_binprm *bprm = (struct linux_binprm *)ctx->args[2];
 	struct msg_execve_event *event;
 	struct execve_map_value *parent;
 	struct msg_process *p;
+	char *filename;
 	__u32 zero = 0;
 	__u64 pid;
 
@@ -295,6 +290,7 @@ event_execve(struct exec_ctx_struct *ctx)
 	p->auid = get_auid();
 	read_execve_shared_info(ctx, p, pid);
 
+	probe_read(&filename, sizeof(filename), _(&bprm->filename));
 	p->size += read_path(ctx, event, filename);
 	p->size += read_args(ctx, event);
 	p->size += read_cwd(ctx, p);
@@ -322,7 +318,7 @@ event_execve(struct exec_ctx_struct *ctx)
 	return 0;
 }
 
-__attribute__((section("tracepoint"), used)) int
+__attribute__((section("raw_tracepoint"), used)) int
 execve_rate(void *ctx __arg_ctx)
 {
 #ifndef __RHEL7_BPF_PROG
@@ -351,9 +347,10 @@ execve_rate(void *ctx __arg_ctx)
  * is to update the pid execve_map entry to reflect the new execve event that
  * has already been collected, then send it to the perf buffer.
  */
-__attribute__((section("tracepoint"), used)) int
-execve_send(struct exec_ctx_struct *ctx __arg_ctx)
+__attribute__((section("raw_tracepoint"), used)) int
+execve_send(struct bpf_raw_tracepoint_args *ctx __arg_ctx)
 {
+	struct linux_binprm *bprm __maybe_unused = (struct linux_binprm *)ctx->args[2];
 	struct msg_execve_event *event;
 	struct execve_map_value *curr;
 	struct msg_process *p;
@@ -439,8 +436,10 @@ execve_send(struct exec_ctx_struct *ctx __arg_ctx)
 		curr->bin.args[len] = 0x00;
 		curr->bin.args[len + 1] = 0x00;
 #else
-		char *filename = (char *)ctx + (_(ctx->__data_loc_filename) & 0xFFFF);
+		struct linux_binprm *bprm = (struct linux_binprm *)ctx->args[2];
+		char *filename;
 
+		probe_read(&filename, sizeof(filename), _(&bprm->filename));
 		curr->bin.path_length = probe_read_str(curr->bin.path, BINARY_PATH_MAX_LEN, (void *)filename);
 		if (curr->bin.path_length > 1) {
 			// don't include the NULL byte in the length

--- a/bpf/process/bpf_execve_event.c
+++ b/bpf/process/bpf_execve_event.c
@@ -314,9 +314,6 @@ event_execve(struct exec_ctx_struct *ctx)
 	 */
 	p->uid = event->creds.euid;
 	get_namespaces(&event->ns, task);
-#ifndef __RHEL7_BPF_PROG
-	p->flags |= __event_get_cgroup_info(task, &event->kube);
-#endif
 
 	// Zero the cleanup key to prevent user space confusion.
 	event->cleanup_key = (struct msg_execve_key){ 0 };
@@ -328,12 +325,19 @@ event_execve(struct exec_ctx_struct *ctx)
 __attribute__((section("tracepoint"), used)) int
 execve_rate(void *ctx __arg_ctx)
 {
+#ifndef __RHEL7_BPF_PROG
+	struct task_struct *task = (struct task_struct *)get_current_task();
+#endif
 	struct msg_execve_event *msg;
 	__u32 zero = 0;
 
 	msg = map_lookup_elem(&execve_msg_heap_map, &zero);
 	if (!msg)
 		return 0;
+
+#ifndef __RHEL7_BPF_PROG
+	msg->process.flags |= __event_get_cgroup_info(task, &msg->kube);
+#endif
 
 	if (cgroup_rate(ctx, &msg->kube, msg->common.ktime))
 		tail_call(ctx, &execve_calls, 1);

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -32,7 +32,7 @@ var (
 	Execve = program.Builder(
 		config.ExecObj(),
 		"sched/sched_process_exec",
-		"tracepoint/sys_execve",
+		"raw_tracepoint/sys_execve",
 		"event_execve",
 		"execve",
 	).SetPolicy(sensors.BaseSensorName)

--- a/pkg/sensors/exec/exec_linux.go
+++ b/pkg/sensors/exec/exec_linux.go
@@ -273,7 +273,7 @@ func handleThrottleEvent(r *bytes.Reader) ([]observer.Event, error) {
 type execProbe struct{}
 
 func (e *execProbe) LoadProbe(args sensors.LoadProbeArgs) error {
-	return program.LoadTracepointProgram(args.BPFDir, args.Load, args.Maps, args.Verbose)
+	return program.LoadRawTracepointProgram(args.BPFDir, args.Load, args.Maps, args.Verbose)
 }
 
 func init() {

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -138,12 +138,12 @@ func mergeSensorMaps(_ *testing.T, maps1, maps2 []SensorMap, progs1, progs2 []Se
 
 func CheckSensorLoad(sensors []*sensors.Sensor, sensorMaps []SensorMap, sensorProgs []SensorProg, t *testing.T) {
 	var baseProgs = []SensorProg{
-		0: SensorProg{Name: "event_execve", Type: ebpf.TracePoint},
+		0: SensorProg{Name: "event_execve", Type: ebpf.RawTracepoint},
 		1: SensorProg{Name: "event_exit", Type: ebpf.Kprobe, Match: ProgMatchPartial},
 		2: SensorProg{Name: "event_wake_up_new_task", Type: ebpf.Kprobe},
-		3: SensorProg{Name: "execve_send", Type: ebpf.TracePoint},
+		3: SensorProg{Name: "execve_send", Type: ebpf.RawTracepoint},
 		4: SensorProg{Name: "tg_kp_bprm_committing_creds", Type: ebpf.Kprobe},
-		5: SensorProg{Name: "execve_rate", Type: ebpf.TracePoint},
+		5: SensorProg{Name: "execve_rate", Type: ebpf.RawTracepoint},
 		6: SensorProg{Name: "execve_map_update", Type: ebpf.SocketFilter},
 	}
 

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -185,7 +185,7 @@ func CheckSensorLoad(sensors []*sensors.Sensor, sensorMaps []SensorMap, sensorPr
 		baseMaps = append(baseMaps, SensorMap{Name: "tg_rb_events", Progs: []uint{0, 1, 2, 3, 5}})
 		baseMaps = append(baseMaps, SensorMap{Name: "tg_conf_map", Progs: []uint{0, 1, 2, 3, 5}})
 	} else {
-		baseMaps = append(baseMaps, SensorMap{Name: "tg_conf_map", Progs: []uint{0, 2}})
+		baseMaps = append(baseMaps, SensorMap{Name: "tg_conf_map", Progs: []uint{2, 5}})
 	}
 
 	CheckSensorLoadBase(t, sensors, sensorMaps, sensorProgs, baseMaps, baseProgs)


### PR DESCRIPTION
raw tracepoints are faster than standard perf based tracepoints,
switching execve sensor to use it