### PR TITLE
disable process cache tests

### DIFF
--- a/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -434,9 +434,21 @@ func (checker *ProcessExecChecker) WithProcess(check *ProcessChecker) *ProcessEx
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessExecChecker
+func (checker *ProcessExecChecker) UnsetProcess() *ProcessExecChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessExecChecker
 func (checker *ProcessExecChecker) WithParent(check *ProcessChecker) *ProcessExecChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessExecChecker
+func (checker *ProcessExecChecker) UnsetParent() *ProcessExecChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -667,9 +679,21 @@ func (checker *ProcessExitChecker) WithProcess(check *ProcessChecker) *ProcessEx
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessExitChecker
+func (checker *ProcessExitChecker) UnsetProcess() *ProcessExitChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessExitChecker
 func (checker *ProcessExitChecker) WithParent(check *ProcessChecker) *ProcessExitChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessExitChecker
+func (checker *ProcessExitChecker) UnsetParent() *ProcessExitChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -873,9 +897,21 @@ func (checker *ProcessKprobeChecker) WithProcess(check *ProcessChecker) *Process
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessKprobeChecker
+func (checker *ProcessKprobeChecker) UnsetProcess() *ProcessKprobeChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessKprobeChecker
 func (checker *ProcessKprobeChecker) WithParent(check *ProcessChecker) *ProcessKprobeChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessKprobeChecker
+func (checker *ProcessKprobeChecker) UnsetParent() *ProcessKprobeChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -1469,9 +1505,21 @@ func (checker *ProcessTracepointChecker) WithProcess(check *ProcessChecker) *Pro
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessTracepointChecker
+func (checker *ProcessTracepointChecker) UnsetProcess() *ProcessTracepointChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessTracepointChecker
 func (checker *ProcessTracepointChecker) WithParent(check *ProcessChecker) *ProcessTracepointChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessTracepointChecker
+func (checker *ProcessTracepointChecker) UnsetParent() *ProcessTracepointChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -1716,9 +1764,21 @@ func (checker *ProcessUprobeChecker) WithProcess(check *ProcessChecker) *Process
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessUprobeChecker
+func (checker *ProcessUprobeChecker) UnsetProcess() *ProcessUprobeChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessUprobeChecker
 func (checker *ProcessUprobeChecker) WithParent(check *ProcessChecker) *ProcessUprobeChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessUprobeChecker
+func (checker *ProcessUprobeChecker) UnsetParent() *ProcessUprobeChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -1996,9 +2056,21 @@ func (checker *ProcessUsdtChecker) WithProcess(check *ProcessChecker) *ProcessUs
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessUsdtChecker
+func (checker *ProcessUsdtChecker) UnsetProcess() *ProcessUsdtChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessUsdtChecker
 func (checker *ProcessUsdtChecker) WithParent(check *ProcessChecker) *ProcessUsdtChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessUsdtChecker
+func (checker *ProcessUsdtChecker) UnsetParent() *ProcessUsdtChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -2239,9 +2311,21 @@ func (checker *ProcessLsmChecker) WithProcess(check *ProcessChecker) *ProcessLsm
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessLsmChecker
+func (checker *ProcessLsmChecker) UnsetProcess() *ProcessLsmChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessLsmChecker
 func (checker *ProcessLsmChecker) WithParent(check *ProcessChecker) *ProcessLsmChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessLsmChecker
+func (checker *ProcessLsmChecker) UnsetParent() *ProcessLsmChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -2562,6 +2646,12 @@ func (checker *ProcessLoaderChecker) WithProcess(check *ProcessChecker) *Process
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessLoaderChecker
+func (checker *ProcessLoaderChecker) UnsetProcess() *ProcessLoaderChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithPath adds a Path check to the ProcessLoaderChecker
 func (checker *ProcessLoaderChecker) WithPath(check *stringmatcher.StringMatcher) *ProcessLoaderChecker {
 	checker.Path = check
@@ -2577,6 +2667,12 @@ func (checker *ProcessLoaderChecker) WithBuildid(check *bytesmatcher.BytesMatche
 // WithParent adds a Parent check to the ProcessLoaderChecker
 func (checker *ProcessLoaderChecker) WithParent(check *ProcessChecker) *ProcessLoaderChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessLoaderChecker
+func (checker *ProcessLoaderChecker) UnsetParent() *ProcessLoaderChecker {
+	checker.Parent = nil
 	return checker
 }
 

--- a/pkg/sensors/tracing/tracepoint_test.go
+++ b/pkg/sensors/tracing/tracepoint_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cilium/tetragon/pkg/testutils"
 	tuo "github.com/cilium/tetragon/pkg/testutils/observer"
 	"github.com/cilium/tetragon/pkg/testutils/perfring"
+	"github.com/cilium/tetragon/pkg/testutils/policytest"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 
 	_ "github.com/cilium/tetragon/pkg/sensors/exec"
@@ -1026,60 +1027,5 @@ spec:
 }
 
 func TestTracepointResolve(t *testing.T) {
-	if !kernels.MinKernelVersion("5.4") {
-		t.Skip("Test requires kernel 5.4+")
-	}
-
-	var doneWG, readyWG sync.WaitGroup
-	defer doneWG.Wait()
-
-	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
-	defer cancel()
-
-	hook := `
-apiVersion: cilium.io/v1alpha1
-kind: TracingPolicy
-metadata:
-  name: "rawtp"
-spec:
-  tracepoints:
-    - subsystem: "sched"
-      event: "sched_process_exec"
-      raw: true
-      args:
-        - index: 2
-          type: "file"
-          resolve: "file"
-`
-
-	createCrdFile(t, hook)
-
-	testNop := testutils.RepoRootPath("contrib/tester-progs/nop")
-
-	obs, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib)
-	if err != nil {
-		t.Fatalf("GetDefaultObserverWithFile error: %s", err)
-	}
-	observertesthelper.LoopEvents(ctx, t, &doneWG, &readyWG, obs)
-	readyWG.Wait()
-
-	if err := exec.Command(testNop).Run(); err != nil {
-		fmt.Printf("Failed to execute test binary: %s\n", err)
-	}
-
-	tpChecker := ec.NewProcessTracepointChecker("").
-		WithSubsys(stringmatcher.Full("sched")).
-		WithEvent(stringmatcher.Full("sched_process_exec")).
-		WithArgs(ec.NewKprobeArgumentListMatcher().
-			WithOperator(lc.Ordered).
-			WithValues(
-				ec.NewKprobeArgumentChecker().WithFileArg(ec.NewKprobeFileChecker().
-					WithPath(stringmatcher.Full(testNop)),
-				),
-			))
-
-	checker := ec.NewUnorderedEventChecker(tpChecker)
-
-	err = jsonchecker.JsonTestCheck(t, checker)
-	require.NoError(t, err)
+	policytest.AllPolicyTests.DoObserverTest(t, "tracepoint-resolve", nil)
 }

--- a/pkg/testutils/policytest/checkers.go
+++ b/pkg/testutils/policytest/checkers.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package policytest
+
+import (
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/tetragoninfo"
+)
+
+func processCacheDisabled(info *tetragoninfo.Info) bool {
+	if info != nil {
+		disabledPC, _ := info.Conf["disable-process-cache"].(bool)
+		return disabledPC
+	}
+	return false
+}
+
+// unsetProcessChecks strips any Process check set via WithProcess() from the
+// individual checkers of a scenario's EventChecker, e.g. for cases where the
+// process cache is disabled and the Process field can't be checked.
+func unsetProcessChecks(checker ec.MultiEventChecker) {
+	getter, ok := checker.(interface{ GetChecks() []ec.EventChecker })
+	if !ok {
+		return
+	}
+	for _, c := range getter.GetChecks() {
+		switch v := c.(type) {
+		// no case for *ec.ProcessExecChecker, because this check is
+		// always valid, regardless of whether the process cache is
+		// enabled or disabled
+		case *ec.ProcessExitChecker:
+			v.UnsetProcess()
+		case *ec.ProcessKprobeChecker:
+			v.UnsetProcess()
+		case *ec.ProcessTracepointChecker:
+			v.UnsetProcess()
+		case *ec.ProcessUprobeChecker:
+			v.UnsetProcess()
+		case *ec.ProcessUsdtChecker:
+			v.UnsetProcess()
+		case *ec.ProcessLsmChecker:
+			v.UnsetProcess()
+		case *ec.ProcessLoaderChecker:
+			v.UnsetProcess()
+		}
+	}
+}
+
+// unsetParentChecks strips any Parent check set via WithParent() from the
+// individual checkers of a scenario's EventChecker, e.g. for cases where the
+// process cache is disabled and the Parent field can't be checked.
+func unsetParentChecks(checker ec.MultiEventChecker) {
+	getter, ok := checker.(interface{ GetChecks() []ec.EventChecker })
+	if !ok {
+		return
+	}
+	for _, c := range getter.GetChecks() {
+		switch v := c.(type) {
+		case *ec.ProcessExecChecker:
+			v.UnsetParent()
+		case *ec.ProcessExitChecker:
+			v.UnsetParent()
+		case *ec.ProcessKprobeChecker:
+			v.UnsetParent()
+		case *ec.ProcessTracepointChecker:
+			v.UnsetParent()
+		case *ec.ProcessUprobeChecker:
+			v.UnsetParent()
+		case *ec.ProcessUsdtChecker:
+			v.UnsetParent()
+		case *ec.ProcessLsmChecker:
+			v.UnsetParent()
+		case *ec.ProcessLoaderChecker:
+			v.UnsetParent()
+		}
+	}
+}

--- a/pkg/testutils/policytest/runner.go
+++ b/pkg/testutils/policytest/runner.go
@@ -231,6 +231,12 @@ func (r *LocalRunner) RunScenario(
 	ctx, cancel := context.WithTimeout(r.cli.Ctx, time.Second*10)
 	defer cancel()
 
+	// the process cache is disabled, so Process/Parent fields won't be populated: skip those checks
+	if processCacheDisabled(r.info) {
+		unsetProcessChecks(scenario.EventChecker)
+		unsetParentChecks(scenario.EventChecker)
+	}
+
 	// start the checker
 	resChan := make(chan *tetragon.GetEventsResponse, 128)
 	retChan := make(chan checkerRet)

--- a/tests/policytests/tracepoint.go
+++ b/tests/policytests/tracepoint.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package tests
+
+import (
+	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
+	"github.com/cilium/tetragon/pkg/bpf"
+	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
+	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/testutils/policytest"
+)
+
+var _ = policytest.NewBuilder("tracepoint-exec").WithLabels("tracepoint").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tracepoint-exec"
+spec:
+  tracepoints:
+  - subsystem: "syscalls"
+    event: "sys_enter_execve"
+    args:
+    - index: 5
+      type: "string"
+`).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	nop := c.TestBinary("nop")
+	checker := ec.NewProcessTracepointChecker("tracepoint-exec").
+		WithSubsys(sm.Full("syscalls")).
+		WithEvent(sm.Full("sys_enter_execve")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithStringArg(sm.Full(nop)),
+			))
+
+	return &policytest.Scenario{
+		Name:         "execute nop and check tracepoint event",
+		Trigger:      policytest.NewCmdTrigger(nop),
+		EventChecker: ec.NewUnorderedEventChecker(checker),
+	}
+}).RegisterAtInit()
+
+var _ = policytest.NewBuilder("tracepoint-resolve").WithLabels("tracepoint").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tracepoint-resolve"
+spec:
+  tracepoints:
+  - subsystem: "sched"
+    event: "sched_process_exec"
+    raw: true
+    args:
+    - index: 2
+      type: "file"
+      resolve: "file"
+`).WithSkip(func(si *policytest.SkipInfo) string {
+	if !si.AgentInfo.Probes[bpf.LargeProgsProbe] {
+		return "resolve requires kernel support for large programs (v5.3 or newer)"
+	}
+	return ""
+}).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	nop := c.TestBinary("nop")
+	checker := ec.NewProcessTracepointChecker("tracepoint-resolve").
+		WithSubsys(sm.Full("sched")).
+		WithEvent(sm.Full("sched_process_exec")).
+		WithArgs(ec.NewKprobeArgumentListMatcher().
+			WithOperator(lc.Ordered).
+			WithValues(
+				ec.NewKprobeArgumentChecker().WithFileArg(ec.NewKprobeFileChecker().WithPath(sm.Full(nop))),
+			))
+	return &policytest.Scenario{
+		Name:         "execute nop and check raw tracepoint event",
+		Trigger:      policytest.NewCmdTrigger(nop),
+		EventChecker: ec.NewUnorderedEventChecker(checker),
+	}
+}).RegisterAtInit()

--- a/tools/protoc-gen-go-tetragon/eventchecker/field.go
+++ b/tools/protoc-gen-go-tetragon/eventchecker/field.go
@@ -58,6 +58,22 @@ func (field *Field) generateWith(g *protogen.GeneratedFile, msg *CheckedMessage)
 	return nil
 }
 
+// generateUnset emits an UnsetProcess/UnsetParent helper for the Process and
+// Parent fields, letting callers clear a check previously set via FromXxx.
+func (field *Field) generateUnset(g *protogen.GeneratedFile, msg *CheckedMessage) error {
+	if field.GoName != "Process" && field.GoName != "Parent" {
+		return nil
+	}
+
+	g.P(`// Unset` + field.GoName + ` unsets the ` + field.GoName + ` check to the ` + msg.checkerName(g))
+	g.P(`func (checker *` + msg.checkerName(g) + `) Unset` + field.GoName + `() *` + msg.checkerName(g) + `{
+        checker.` + field.GoName + ` = nil
+        return checker
+    }`)
+
+	return nil
+}
+
 func (field *Field) generateFrom(g *protogen.GeneratedFile, msg *CheckedMessage) error {
 	from, err := field.getFrom(g, msg)
 	if err != nil {

--- a/tools/protoc-gen-go-tetragon/eventchecker/message.go
+++ b/tools/protoc-gen-go-tetragon/eventchecker/message.go
@@ -126,6 +126,7 @@ func (msg *CheckedMessage) generateChecker(g *protogen.GeneratedFile, isEvent bo
 	for _, rawField := range msg.Fields {
 		field := &Field{Field: rawField, IsInnerField: false}
 		field.generateWith(g, msg)
+		field.generateUnset(g, msg)
 	}
 
 	// Generate From funcs

--- a/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
+++ b/vendor/github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker/eventchecker.pb.go
@@ -434,9 +434,21 @@ func (checker *ProcessExecChecker) WithProcess(check *ProcessChecker) *ProcessEx
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessExecChecker
+func (checker *ProcessExecChecker) UnsetProcess() *ProcessExecChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessExecChecker
 func (checker *ProcessExecChecker) WithParent(check *ProcessChecker) *ProcessExecChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessExecChecker
+func (checker *ProcessExecChecker) UnsetParent() *ProcessExecChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -667,9 +679,21 @@ func (checker *ProcessExitChecker) WithProcess(check *ProcessChecker) *ProcessEx
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessExitChecker
+func (checker *ProcessExitChecker) UnsetProcess() *ProcessExitChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessExitChecker
 func (checker *ProcessExitChecker) WithParent(check *ProcessChecker) *ProcessExitChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessExitChecker
+func (checker *ProcessExitChecker) UnsetParent() *ProcessExitChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -873,9 +897,21 @@ func (checker *ProcessKprobeChecker) WithProcess(check *ProcessChecker) *Process
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessKprobeChecker
+func (checker *ProcessKprobeChecker) UnsetProcess() *ProcessKprobeChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessKprobeChecker
 func (checker *ProcessKprobeChecker) WithParent(check *ProcessChecker) *ProcessKprobeChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessKprobeChecker
+func (checker *ProcessKprobeChecker) UnsetParent() *ProcessKprobeChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -1469,9 +1505,21 @@ func (checker *ProcessTracepointChecker) WithProcess(check *ProcessChecker) *Pro
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessTracepointChecker
+func (checker *ProcessTracepointChecker) UnsetProcess() *ProcessTracepointChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessTracepointChecker
 func (checker *ProcessTracepointChecker) WithParent(check *ProcessChecker) *ProcessTracepointChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessTracepointChecker
+func (checker *ProcessTracepointChecker) UnsetParent() *ProcessTracepointChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -1716,9 +1764,21 @@ func (checker *ProcessUprobeChecker) WithProcess(check *ProcessChecker) *Process
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessUprobeChecker
+func (checker *ProcessUprobeChecker) UnsetProcess() *ProcessUprobeChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessUprobeChecker
 func (checker *ProcessUprobeChecker) WithParent(check *ProcessChecker) *ProcessUprobeChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessUprobeChecker
+func (checker *ProcessUprobeChecker) UnsetParent() *ProcessUprobeChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -1996,9 +2056,21 @@ func (checker *ProcessUsdtChecker) WithProcess(check *ProcessChecker) *ProcessUs
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessUsdtChecker
+func (checker *ProcessUsdtChecker) UnsetProcess() *ProcessUsdtChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessUsdtChecker
 func (checker *ProcessUsdtChecker) WithParent(check *ProcessChecker) *ProcessUsdtChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessUsdtChecker
+func (checker *ProcessUsdtChecker) UnsetParent() *ProcessUsdtChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -2239,9 +2311,21 @@ func (checker *ProcessLsmChecker) WithProcess(check *ProcessChecker) *ProcessLsm
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessLsmChecker
+func (checker *ProcessLsmChecker) UnsetProcess() *ProcessLsmChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithParent adds a Parent check to the ProcessLsmChecker
 func (checker *ProcessLsmChecker) WithParent(check *ProcessChecker) *ProcessLsmChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessLsmChecker
+func (checker *ProcessLsmChecker) UnsetParent() *ProcessLsmChecker {
+	checker.Parent = nil
 	return checker
 }
 
@@ -2562,6 +2646,12 @@ func (checker *ProcessLoaderChecker) WithProcess(check *ProcessChecker) *Process
 	return checker
 }
 
+// UnsetProcess unsets the Process check to the ProcessLoaderChecker
+func (checker *ProcessLoaderChecker) UnsetProcess() *ProcessLoaderChecker {
+	checker.Process = nil
+	return checker
+}
+
 // WithPath adds a Path check to the ProcessLoaderChecker
 func (checker *ProcessLoaderChecker) WithPath(check *stringmatcher.StringMatcher) *ProcessLoaderChecker {
 	checker.Path = check
@@ -2577,6 +2667,12 @@ func (checker *ProcessLoaderChecker) WithBuildid(check *bytesmatcher.BytesMatche
 // WithParent adds a Parent check to the ProcessLoaderChecker
 func (checker *ProcessLoaderChecker) WithParent(check *ProcessChecker) *ProcessLoaderChecker {
 	checker.Parent = check
+	return checker
+}
+
+// UnsetParent unsets the Parent check to the ProcessLoaderChecker
+func (checker *ProcessLoaderChecker) UnsetParent() *ProcessLoaderChecker {
+	checker.Parent = nil
 	return checker
 }
 


### PR DESCRIPTION
[This related PR](https://github.com/cilium/tetragon/pull/5248) introduces a new flag which allows disabling the process cache. This mode of tetragon is limited in its ability to enrich events with process information. As such, I don't expect policytests to pass when the checker utilizes `WithProcess` or `WithParent` while running in this mode.

This PR reverts the effect of `WithProcess()` and `WithParent()` on a checker when a policytest is run against an agent with its process cache disabled.

I added/converted tracepoints tests in order to get policytest coverage for the tracepoint hook type. This way, I am able to test that events for each hook type can still be delivered with the process cache disabled.