### PR TITLE
uprobe: fix issue when deleting policy

### DIFF
--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -733,7 +733,12 @@ func cleanupUprobeEntries(ids []idtable.EntryID, openedFiles map[string]*os.File
 	}
 
 	for path, entryFile := range openedFiles {
-		if err := entryFile.Close(); err != nil {
+		// cleanupUprobeEntries() is called by the DestroyHook. During normal
+		// operation, the files are already closed by the PostLoadHook, so we
+		// expect this close to fail with os.ErrClosed. We still attempt closing
+		// here to cover the case where the sensor was created, but never
+		// loaded, before being destroyed.
+		if err := entryFile.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 			errs = errors.Join(errs, fmt.Errorf("problem closing path %q: %w", path, err))
 		}
 	}


### PR DESCRIPTION
Prior to this change, when a policy that utilizes the binaryDigests configuration is deleted, we would get an error message like:

level=warn msg="Destroy hook failed" sensor=generic_uprobe error="problem closing path \"/home/andy/src/sleep\": close /home/andy/src/sleep: file already closed"

This happens because the file was closed after the sensor was loaded. So when we try to close the file again when the sensor is destroyed, we hit this error.

We need to attempt to close the file during destroy for the case where the sensor is created, but never loaded, and then destroyed. This could happen when a policy's sensors are generated, and a subsequent sensor fails to be created after the uprobe sensor was created.

fixes: b8a63e96c91e ("uprobe: remove os.ErrClosed check")