### PR TITLE
ci: skip vmtests artifact delete on fork PRs

### DIFF
--- a/.github/workflows/vmpolicytests.yaml
+++ b/.github/workflows/vmpolicytests.yaml
@@ -169,7 +169,8 @@ jobs:
   post-test:
     runs-on: ubuntu-latest
     needs: [test]
-    if: success()
+    # Fork PRs get a read-only GITHUB_TOKEN that cannot delete artifacts.
+    if: success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       # delete the built binaries from the artifacts in case of overall success
       - uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0

--- a/.github/workflows/vmtests.yml
+++ b/.github/workflows/vmtests.yml
@@ -177,7 +177,8 @@ jobs:
   post-test:
     runs-on: ubuntu-latest
     needs: [test]
-    if: success()
+    # Fork PRs get a read-only GITHUB_TOKEN that cannot delete artifacts.
+    if: success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       # delete the built binaries from the artifacts in case of overall success
       - uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Fixes #2010

### Description

`geekyeggo/delete-artifact` in the vmtests / vmpolicytests `post-test` jobs fails on pull requests from forks with `Resource not accessible by integration`, because the restricted `GITHUB_TOKEN` cannot delete artifacts.

Skip the cleanup job for fork PRs. Same-repo PRs and pushes to `main` still delete the build artifact on overall success.

### Changelog

```release-note
ci: skip vmtests artifact deletion on fork PRs
```