### PR TITLE
new: uprobe set action

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -1059,7 +1059,12 @@ do_action(void *ctx, __u32 i, struct selector_action *actions, bool *post, bool 
 		index = actions->act[++i];
 		value = actions->act[++i];
 		if (enforce_mode) {
+#if defined(GENERIC_UPROBE)
+			// value is discarded here
+			do_uprobe_override(ctx, index);
+#else
 			do_set_action(ctx, e, index, value);
+#endif
 			polacct = POLICY_SET;
 		} else {
 			polacct = POLICY_MONITOR_SET;

--- a/contrib/tester-progs/uprobe-simple.c
+++ b/contrib/tester-progs/uprobe-simple.c
@@ -2,15 +2,22 @@
 
 int
 __attribute__((noinline))
-pizza()
+pizza(int c)
 {
-	return 0;
+	return c;
+}
+
+int
+__attribute__((noinline))
+lasagna(int c)
+{
+	return c - 10;
 }
 
 int
 main(int argc, char *argv[])
 {
-	int ret = pizza();
+	int ret = pizza(0);
 	printf("pizza() returned %d\n", ret);
 	return ret;
 }

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -860,7 +860,7 @@ matches. They are defined under `matchActions` and currently, the following
 - [TrackSock action](#tracksock-action)
 - [UntrackSock action](#untracksock-action)
 - [Notify Enforcer action](#notify-enforcer-action)
-- [USDT Set action](#usdt-set-action)
+- [Set action](#set-action)
 
 {{< note >}}
 `Sigkill`, `Override`, `Post`,
@@ -1606,11 +1606,42 @@ spec:
       - action: "Sigkill"
 ```
 
-### USDT Set action
+### Set action
 
-The `Set` action is specific for USDT probes and allows tetragon to write
-value to configured USDT probe argument. This argument needs to meet few
-conditions:
+The `Set` action is specific for USDT and uprobe probes.
+It uses the following arguments:
+
+- The `argIndex` defines position of the argument.
+- The `argValue` defined the actual value to write.
+
+#### Uprobe
+
+For uprobes, the `Set` action allows setting the value of the argument at the given index.
+The argument needs to meet a few conditions:
+
+- It must be an integer parameter (`argValue` holds an `uint32`)
+- `argIndex` must be between 0 and 5 (the [tetragon maximum number of arguments](https://github.com/cilium/tetragon/blob/v1.7.1/pkg/api/tracingapi/client_kprobe.go#L684))
+- `argIndex` refers to the position of the argument in the traced function, starting from 0 for the first argument
+
+Example policy follows:
+```yaml
+spec:
+  uprobes:
+  - path: my-binary
+    symbols:
+    - "pizza"
+    selectors:
+    - matchActions:
+      - action: Set
+        argIndex: 0
+        argValue: 42
+```
+This policy will set the value of the first argument of the `pizza()` function to `42`.
+
+#### USDT
+
+For USDT probes, the `Set` action allows writing a value to a configured probe argument. 
+The argument needs to meet a few conditions:
 
 - It's stored in memory as `USDT deref` argument
 - It has size of 4 bytes
@@ -1678,11 +1709,6 @@ spec:
           argIndex: 0
           argValue: 1
 ```
-
-The `Set` action uses following arguments:
-
-- The `argIndex` defines position of the return argument.
-- The `argValue` defined the actual value to write.
 
 ## Selector Semantics
 

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -859,7 +859,7 @@ matches. They are defined under `matchActions` and currently, the following
 - [TrackSock action](#tracksock-action)
 - [UntrackSock action](#untracksock-action)
 - [Notify Enforcer action](#notify-enforcer-action)
-- [USDT Set action](#usdt-set-action)
+- [Set action](#set-action)
 
 {{< note >}}
 `Sigkill`, `Override`, `Post`,
@@ -1605,11 +1605,41 @@ spec:
       - action: "Sigkill"
 ```
 
-### USDT Set action
+### Set action
 
-The `Set` action is specific for USDT probes and allows tetragon to write
-value to configured USDT probe argument. This argument needs to meet few
-conditions:
+The `Set` action is specific for USDT and uprobe probes.
+It uses the following arguments:
+
+- The `argIndex` defines position of the argument.
+- The `argValue` defined the actual value to write.
+
+#### Uprobe
+
+For uprobes, the `Set` action allows setting the value of the argument at the given index.
+The argument needs to meet a few conditions:
+
+- It must be an integer parameter (`argValue` holds an `uint32`)
+- `argIndex` must be between 0 and the tetragon maximum number of arguments (5)
+
+Example policy follows:
+```yaml
+spec:
+  uprobes:
+  - path: my-binary
+    symbols:
+    - "pizza"
+    selectors:
+    - matchActions:
+      - action: Set
+        argIndex: 0
+        argValue: 42
+```
+This policy will set the value of the first argument of the `pizza()` function to `42`.
+
+#### USDT
+
+For USDT probes, the `Set` action allows writing a value to a configured probe argument. 
+The argument needs to meet a few conditions:
 
 - It's stored in memory as `USDT deref` argument
 - It has size of 4 bytes
@@ -1677,11 +1707,6 @@ spec:
           argIndex: 0
           argValue: 1
 ```
-
-The `Set` action uses following arguments:
-
-- The `argIndex` defines position of the return argument.
-- The `argValue` defined the actual value to write.
 
 ## Selector Semantics
 

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1863,8 +1863,8 @@ func HasOperator(selectors []v1alpha1.KProbeSelector, op uint32) bool {
 	return false
 }
 
-func HasSetArgIndex(spec *v1alpha1.UsdtSpec) (bool, uint32) {
-	for _, s := range spec.Selectors {
+func HasSetArgIndex(selectors []v1alpha1.KProbeSelector) (bool, uint32) {
+	for _, s := range selectors {
 		for _, action := range s.MatchActions {
 			act := actionTypeTable[strings.ToLower(action.Action)]
 			if act == ActionTypeSet {
@@ -1875,8 +1875,8 @@ func HasSetArgIndex(spec *v1alpha1.UsdtSpec) (bool, uint32) {
 	return false, 0
 }
 
-func HasSet(spec *v1alpha1.UsdtSpec) bool {
-	ok, _ := HasSetArgIndex(spec)
+func HasSet(selectors []v1alpha1.KProbeSelector) bool {
+	ok, _ := HasSetArgIndex(selectors)
 	return ok
 }
 

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1245,8 +1245,19 @@ func ParseMatchAction(k *KernelSelectorState, action *v1alpha1.ActionSelector, a
 	case ActionTypeCleanupEnforcerNotification:
 		// no arguments
 	case ActionTypeSet:
-		WriteSelectorUint32(&k.data, action.ArgIndex)
-		WriteSelectorUint32(&k.data, action.ArgValue)
+		if k.isUprobe {
+			err := parseSetRegs(k, selIdx, action.ArgIndex, action.ArgValue)
+			if err != nil {
+				return err
+			}
+			WriteSelectorUint32(&k.data, k.UprobeRegsMapID(selIdx))
+			// value is discarded since we use `regs_map` to pass the assignments.
+			WriteSelectorUint32(&k.data, action.ArgValue)
+		} else {
+			// usdt
+			WriteSelectorUint32(&k.data, action.ArgIndex)
+			WriteSelectorUint32(&k.data, action.ArgValue)
+		}
 	default:
 		return fmt.Errorf("ParseMatchAction: act %d (%s) is missing a handler", act, actionTypeStringTable[act])
 	}

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1851,8 +1851,8 @@ func HasOperator(selectors []v1alpha1.KProbeSelector, op uint32) bool {
 	return false
 }
 
-func HasSetArgIndex(spec *v1alpha1.UsdtSpec) (bool, uint32) {
-	for _, s := range spec.Selectors {
+func HasSetArgIndex(selectors []v1alpha1.KProbeSelector) (bool, uint32) {
+	for _, s := range selectors {
 		for _, action := range s.MatchActions {
 			act := actionTypeTable[strings.ToLower(action.Action)]
 			if act == ActionTypeSet {
@@ -1863,8 +1863,8 @@ func HasSetArgIndex(spec *v1alpha1.UsdtSpec) (bool, uint32) {
 	return false, 0
 }
 
-func HasSet(spec *v1alpha1.UsdtSpec) bool {
-	ok, _ := HasSetArgIndex(spec)
+func HasSet(selectors []v1alpha1.KProbeSelector) bool {
+	ok, _ := HasSetArgIndex(selectors)
 	return ok
 }
 

--- a/pkg/selectors/kernel_regs_amd64.go
+++ b/pkg/selectors/kernel_regs_amd64.go
@@ -53,3 +53,38 @@ func parseOverrideRegs(k *KernelSelectorState, selIdx int, values []string, errV
 	k.regs[selIdx] = regs
 	return nil
 }
+
+func parseSetRegs(k *KernelSelectorState, selIdx int, argIndex, argValue uint32) error {
+	var val string
+	switch argIndex {
+	case 0:
+		val = fmt.Sprintf("rdi=%d", argValue)
+	case 1:
+		val = fmt.Sprintf("rsi=%d", argValue)
+	case 2:
+		val = fmt.Sprintf("rdx=%d", argValue)
+	case 3:
+		val = fmt.Sprintf("rcx=%d", argValue)
+	case 4:
+		val = fmt.Sprintf("r8=%d", argValue)
+	case 5:
+		val = fmt.Sprintf("r9=%d", argValue)
+	}
+
+	ass, err := asm.ParseAssignment(val)
+	if err != nil {
+		return err
+	}
+
+	reg := processapi.RegAssignment{
+		Type:    ass.Type,
+		Src:     ass.Src,
+		Dst:     ass.Dst,
+		SrcSize: ass.SrcSize,
+		DstSize: ass.DstSize,
+		Off:     ass.Off,
+	}
+
+	k.regs[selIdx] = append(k.regs[selIdx], reg)
+	return nil
+}

--- a/pkg/selectors/kernel_regs_arm64.go
+++ b/pkg/selectors/kernel_regs_arm64.go
@@ -52,3 +52,24 @@ func parseOverrideRegs(k *KernelSelectorState, selIdx int, values []string, errV
 	k.regs[selIdx] = regs
 	return nil
 }
+
+func parseSetRegs(k *KernelSelectorState, selIdx int, argIndex, argValue uint32) error {
+	val := fmt.Sprintf("x%d=%d", argIndex, argValue)
+
+	ass, err := asm.ParseAssignment(val)
+	if err != nil {
+		return err
+	}
+
+	reg := processapi.RegAssignment{
+		Type:    ass.Type,
+		Src:     ass.Src,
+		Dst:     ass.Dst,
+		SrcSize: ass.SrcSize,
+		DstSize: ass.DstSize,
+		Off:     ass.Off,
+	}
+
+	k.regs[selIdx] = append(k.regs[selIdx], reg)
+	return nil
+}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -590,6 +590,19 @@ func validateUprobeSpec(spec *v1alpha1.UProbeSpec, state *uprobeConfigState) err
 		return fmt.Errorf("uprobe Override action needs exactly one of either argNewSymbol, argNewOffset or argNewAddr defined; %d found", numArgNewArgs)
 	}
 	state.overrideSymbol = numArgNewArgs == 1
+
+	if selectors.HasSet(spec.Selectors) {
+		for _, s := range spec.Selectors {
+			for _, action := range s.MatchActions {
+				if action.Action != "Set" {
+					continue
+				}
+				if action.ArgIndex >= api.EventConfigMaxArgs {
+					return fmt.Errorf("uprobe Set action argIndex %d out of range", action.ArgIndex)
+				}
+			}
+		}
+	}
 	return nil
 }
 
@@ -597,6 +610,13 @@ func validateUprobeFeatures(spec *v1alpha1.UProbeSpec, has *uprobeHas) error {
 	if selectors.HasOverride(spec.Selectors) {
 		if !bpf.HasUprobeRegsChange() {
 			return errors.New("can't use override regs action, no kernel support")
+		}
+		has.sleepableOffload = true
+	}
+
+	if selectors.HasSet(spec.Selectors) {
+		if !bpf.HasUprobeRegsChange() {
+			return errors.New("can't use set action, no kernel support")
 		}
 		has.sleepableOffload = true
 	}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -594,6 +594,17 @@ func validateUprobeSpec(spec *v1alpha1.UProbeSpec, state *uprobeConfigState) err
 	if selectors.HasGetUrlOrDnsLookup(spec.Selectors) {
 		return errors.New("failed to configure uprobe, GetUrl and DnsLookup actions not supported")
 	}
+
+	for _, s := range spec.Selectors {
+		for _, action := range s.MatchActions {
+			if action.Action != "Set" {
+				continue
+			}
+			if action.ArgIndex >= api.EventConfigMaxArgs {
+				return fmt.Errorf("uprobe Set action argIndex %d out of range", action.ArgIndex)
+			}
+		}
+	}
 	return nil
 }
 
@@ -601,6 +612,13 @@ func validateUprobeFeatures(spec *v1alpha1.UProbeSpec, has *uprobeHas) error {
 	if selectors.HasOverride(spec.Selectors) {
 		if !bpf.HasUprobeRegsChange() {
 			return errors.New("can't use override regs action, no kernel support")
+		}
+		has.sleepableOffload = true
+	}
+
+	if selectors.HasSet(spec.Selectors) {
+		if !bpf.HasUprobeRegsChange() {
+			return errors.New("can't use set action, no kernel support")
 		}
 		has.sleepableOffload = true
 	}

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -181,7 +181,7 @@ func createGenericUsdtSensor(
 		if err != nil {
 			return nil, err
 		}
-		hasSetAction = hasSetAction || selectors.HasSet(&usdt)
+		hasSetAction = hasSetAction || selectors.HasSet(usdt.Selectors)
 	}
 
 	has.sleepableOffload = hasSetAction && config.EnableV61Progs()
@@ -407,7 +407,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		}
 
 		// Validate argument for set action
-		if ok, idx := selectors.HasSetArgIndex(spec); ok {
+		if ok, idx := selectors.HasSetArgIndex(spec.Selectors); ok {
 			// argument index is within usdt args in spec
 			if idx > uint32(len(spec.Args)) {
 				return ids, fmt.Errorf("failed to configure usdt '%s/%s', set action argument spec index %d out of bounds",

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -181,7 +181,7 @@ func createGenericUsdtSensor(
 		if err != nil {
 			return nil, err
 		}
-		hasSetAction = hasSetAction || selectors.HasSet(&usdt)
+		hasSetAction = hasSetAction || selectors.HasSet(usdt.Selectors)
 	}
 
 	has.sleepableOffload = hasSetAction && config.EnableV61Progs()
@@ -411,7 +411,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		}
 
 		// Validate argument for set action
-		if ok, idx := selectors.HasSetArgIndex(spec); ok {
+		if ok, idx := selectors.HasSetArgIndex(spec.Selectors); ok {
 			// argument index is within usdt args in spec
 			if idx > uint32(len(spec.Args)) {
 				return ids, fmt.Errorf("failed to configure usdt '%s/%s', set action argument spec index %d out of bounds",

--- a/tests/policytests/uprobes.go
+++ b/tests/policytests/uprobes.go
@@ -491,3 +491,98 @@ spec:
 		EventChecker: ec.NewUnorderedEventChecker(upChecker),
 	}
 }).RegisterAtInit()
+
+var _ = policytest.NewBuilder("uprobe-set").WithLabels("uprobes").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe-set"
+spec:
+  uprobes:
+  - path: {{ testBinary "uprobe-simple" }}
+    symbols:
+    - "pizza"
+    selectors:
+    - matchActions:
+      - action: Set
+        argIndex: 0
+        argValue: 42
+`).WithSkip(func(si *policytest.SkipInfo) string {
+	// skip if uprobe_regs_change is not supported
+	if !si.AgentInfo.Probes[bpf.UprobeRegsChangeProbe] {
+		return "uprobes cannot change registers"
+	}
+	return ""
+}).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	myBin := c.TestBinary("uprobe-simple")
+	upChecker := ec.NewProcessUprobeChecker("uprobe-set").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(myBin))).
+		WithSymbol(sm.Full("pizza"))
+
+	exitCode := 42
+	if c.TestConf != nil && c.TestConf.MonitorMode {
+		exitCode = 0
+	}
+	postCnt := uint64(1)
+	setCnt := uint64(1)
+	return &policytest.Scenario{
+		Name:         "execute uprobe-simple, check set action and events",
+		Trigger:      policytest.NewCmdTrigger(myBin).ExpectExitCode(exitCode),
+		EventChecker: ec.NewUnorderedEventChecker(upChecker),
+		ActCountChecker: policytest.ActionCounts{
+			Post: &postCnt,
+			Set:  &setCnt,
+		},
+	}
+}).RegisterAtInit()
+
+var _ = policytest.NewBuilder("uprobe-override-set").WithLabels("uprobes").WithPolicyTemplate(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe-override-set"
+spec:
+  uprobes:
+  - path: {{ testBinary "uprobe-simple" }}
+    symbols:
+    - "pizza"
+    selectors:
+    - matchActions:
+      - action: Override
+        argNewSymbol: "lasagna"
+      - action: Set
+        argIndex: 0
+        argValue: 42
+`).WithSkip(func(si *policytest.SkipInfo) string {
+	// skip if uprobe_regs_change is not supported
+	if !si.AgentInfo.Probes[bpf.UprobeRegsChangeProbe] {
+		return "uprobes cannot change registers"
+	}
+	return ""
+}).AddScenario(func(c *policytest.Conf) *policytest.Scenario {
+	myBin := c.TestBinary("uprobe-simple")
+	upChecker := ec.NewProcessUprobeChecker("uprobe-override-set").
+		WithProcess(ec.NewProcessChecker().
+			WithBinary(sm.Full(myBin))).
+		WithSymbol(sm.Full("pizza"))
+
+	// see uprobe-simple.c: lasagna() returns (param - 10)
+	exitCode := 32
+	if c.TestConf != nil && c.TestConf.MonitorMode {
+		exitCode = 0
+	}
+	postCnt := uint64(1)
+	setCnt := uint64(1)
+	overrideCnt := uint64(1)
+	return &policytest.Scenario{
+		Name:         "execute uprobe-simple, check set action and events",
+		Trigger:      policytest.NewCmdTrigger(myBin).ExpectExitCode(exitCode),
+		EventChecker: ec.NewUnorderedEventChecker(upChecker),
+		ActCountChecker: policytest.ActionCounts{
+			Post:     &postCnt,
+			Set:      &setCnt,
+			Override: &overrideCnt,
+		},
+	}
+}).RegisterAtInit()


### PR DESCRIPTION
### Description

In a similar vein to #4990 , add support to set function call **integer arguments** in uprobes, via `Set` action (that was previously `USDTs` only).
Again, just like #4990 , the feat is mostly a proxy on top of `Override.argRegs` with an improved UX.

If, in the future, we'd like to expand it to also support string arguments, we should:
* leverage `bpf_probe_write_user`
* add a secondary map to hold `dst_reg, char new_val[256]`
  for each configured `Set` action
* find a way to use a "scratch" address to hold our `new_val` string

The latter is the hardest one, since there is no clear way on how to find the `scratch` are; a full example would be:
```C
char new_str[] = "world!\n";

__u64 scratch_addr = ?????;

long ret = bpf_probe_write_user((void *)scratch_addr, new_str, sizeof(new_str));
if (ret != 0)
    return 0;

ctx->rdi = scratch_addr;
```

and, as you can see, the `scratch_addr` must be there and writable from the uprobe context.

### Changelog

```release-note
new: uprobe set action
```
