### PR TITLE
fix(tetra): honor retry settings for all gRPC clients

### DIFF
--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -37,8 +37,8 @@ import (
 // between 0 and the final duration that was computed via to the params:
 // https://github.com/grpc/grpc-go/blob/v1.65.0/stream.go#L702
 func RetryPolicy(retries int) string {
-	if retries < 0 {
-		// gRPC should ignore the invalid retry policy but will issue a warning,
+	if retries <= 0 {
+		// An empty service config disables application-level retries.
 		return "{}"
 	}
 	// maxAttempt includes the first call

--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -47,7 +47,10 @@ func RetryPolicy(retries int) string {
 	// since we need to provide a value >0
 	return fmt.Sprintf(`{
 	"methodConfig": [{
-	  "name": [{"service": "tetragon.FineGuidanceSensors"}],
+	  "name": [
+		{"service": "tetragon.FineGuidanceSensors"},
+		{"service": "tetragon.EventLogService"}
+	  ],
 	  "retryPolicy": {
 		  "MaxAttempts": %d,
 		  "InitialBackoff": "1s",

--- a/cmd/tetra/common/client_test.go
+++ b/cmd/tetra/common/client_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryPolicyDisablesRetriesAtZero(t *testing.T) {
+	require.JSONEq(t, `{}`, RetryPolicy(0))
+}
+
+func TestNewClientWithZeroRetries(t *testing.T) {
+	oldRetries := Retries
+	oldTimeout := Timeout
+	t.Cleanup(func() {
+		Retries = oldRetries
+		Timeout = oldTimeout
+	})
+
+	Retries = 0
+	Timeout = time.Second
+	c, err := NewClient(context.Background(), "passthrough:///unused", Timeout)
+	require.NoError(t, err)
+	c.Close()
+}

--- a/cmd/tetra/eventlog/client.go
+++ b/cmd/tetra/eventlog/client.go
@@ -42,6 +42,7 @@ func NewClient() (*ClientWithContext, error) {
 	c.conn, err = grpc.NewClient(
 		common.ResolveServerAddress(),
 		grpc.WithTransportCredentials(creds),
+		grpc.WithDefaultServiceConfig(common.RetryPolicy(common.Retries)),
 		grpc.WithMaxCallAttempts(common.Retries+1), // maxAttempt includes the first call
 	)
 	if err != nil {

--- a/cmd/tetra/eventlog/client_test.go
+++ b/cmd/tetra/eventlog/client_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package eventlog
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/cilium/tetragon/api/v1/tetragon"
+	"github.com/cilium/tetragon/cmd/tetra/common"
+)
+
+type retryServer struct {
+	tetragon.UnimplementedEventLogServiceServer
+	calls atomic.Int32
+}
+
+func (s *retryServer) GetEventLogParams(context.Context, *tetragon.GetEventLogParamsRequest) (*tetragon.GetEventLogParamsResponse, error) {
+	if s.calls.Add(1) == 1 {
+		return nil, status.Error(codes.Unavailable, "try again")
+	}
+	return &tetragon.GetEventLogParamsResponse{}, nil
+}
+
+func TestClientRetriesUnavailableRPC(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	retrySrv := &retryServer{}
+	tetragon.RegisterEventLogServiceServer(server, retrySrv)
+	go server.Serve(listener)
+	t.Cleanup(func() {
+		server.Stop()
+		listener.Close()
+	})
+
+	oldAddress := common.ServerAddress
+	oldRetries := common.Retries
+	oldTimeout := common.Timeout
+	t.Cleanup(func() {
+		common.ServerAddress = oldAddress
+		common.Retries = oldRetries
+		common.Timeout = oldTimeout
+	})
+	common.ServerAddress = listener.Addr().String()
+	common.Retries = 1
+	common.Timeout = 5 * time.Second
+
+	client, err := NewClient()
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	_, err = client.Client.GetEventLogParams(client.ctx, &tetragon.GetEventLogParamsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), retrySrv.calls.Load())
+}


### PR DESCRIPTION
Fixes

### Description

The retry flag was half wired for EventLog. Also, retries set to zero made gRPC reject the client before any RPC.

The fix disables the policy cleanly at zero and applies the shared policy to EventLog. Added tests for both paths.

Repro:

    tetra status -retries=0 -timeout=100ms -server-address=127.0.0.1:54329

Before: client creation failed with invalid retry policy, MaxAttempts 1.

    tetra eventlog get -retries=1 -timeout=3s -server-address=127.0.0.1:54329

Before: UNAVAILABLE returned after one attempt. Now the client retries once.

### Changelog

```release-note
Fix tetra retry handling for zero retries and EventLog RPCs
```