### PR TITLE
fix(selectors): cap matchPIDs.values at 4 and bounds-check selector buffer writes

### DIFF
--- a/bpf/tests/pid_match_test.go
+++ b/bpf/tests/pid_match_test.go
@@ -90,7 +90,7 @@ func (ctx *testContext) initKernelStateData(pids []uint32) error {
 		return errors.New("test_filter_map not found")
 	}
 
-	return filterMap.Update(uint32(0), k.Buffer(), 0)
+	return filterMap.Update(uint32(0), k.CopyToFixedBuffer(), 0)
 }
 
 func Test_PidMatch(t *testing.T) {

--- a/docs/content/en/docs/reference/tracing-policy.md
+++ b/docs/content/en/docs/reference/tracing-policy.md
@@ -1577,7 +1577,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -3501,7 +3501,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5094,7 +5094,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -6666,7 +6666,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -8217,7 +8217,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10085,7 +10085,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -11643,7 +11643,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -13780,7 +13780,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -15704,7 +15704,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -17297,7 +17297,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -18869,7 +18869,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -20420,7 +20420,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -22288,7 +22288,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -23846,7 +23846,7 @@ Note: The CelExpr operator is deprecated and will be removed in Tetragon OSS v1.
         <td><b>values</b></td>
         <td>[]integer</td>
         <td>
-          Process IDs to match.<br/>
+          Process IDs to match. Only the first 4 are matched by the kernel.<br/>
         </td>
         <td>true</td>
       </tr><tr>

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpolicies.yaml
@@ -1003,10 +1003,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -2392,10 +2394,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -3503,10 +3507,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -4570,10 +4576,12 @@ spec:
                             - NotIn
                             type: string
                           values:
-                            description: Process IDs to match.
+                            description: Process IDs to match. Only the first 4 are
+                              matched by the kernel.
                             items:
                               format: int32
                               type: integer
+                            maxItems: 4
                             type: array
                         required:
                         - operator
@@ -5630,10 +5638,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -6981,10 +6991,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -8074,10 +8086,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator

--- a/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/install/kubernetes/tetragon/crds-yaml/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1003,10 +1003,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -2392,10 +2394,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -3503,10 +3507,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -4570,10 +4576,12 @@ spec:
                             - NotIn
                             type: string
                           values:
-                            description: Process IDs to match.
+                            description: Process IDs to match. Only the first 4 are
+                              matched by the kernel.
                             items:
                               format: int32
                               type: integer
+                            maxItems: 4
                             type: array
                         required:
                         - operator
@@ -5630,10 +5638,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -6981,10 +6991,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -8074,10 +8086,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -1003,10 +1003,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -2392,10 +2394,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -3503,10 +3507,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -4570,10 +4576,12 @@ spec:
                             - NotIn
                             type: string
                           values:
-                            description: Process IDs to match.
+                            description: Process IDs to match. Only the first 4 are
+                              matched by the kernel.
                             items:
                               format: int32
                               type: integer
+                            maxItems: 4
                             type: array
                         required:
                         - operator
@@ -5630,10 +5638,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -6981,10 +6991,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -8074,10 +8086,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator

--- a/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1003,10 +1003,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -2392,10 +2394,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -3503,10 +3507,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -4570,10 +4576,12 @@ spec:
                             - NotIn
                             type: string
                           values:
-                            description: Process IDs to match.
+                            description: Process IDs to match. Only the first 4 are
+                              matched by the kernel.
                             items:
                               format: int32
                               type: integer
+                            maxItems: 4
                             type: array
                         required:
                         - operator
@@ -5630,10 +5638,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -6981,10 +6991,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -8074,10 +8086,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator

--- a/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -258,7 +258,8 @@ type PIDSelector struct {
 	// +kubebuilder:validation:Enum=In;NotIn
 	// PID selector operator.
 	Operator string `json:"operator"`
-	// Process IDs to match.
+	// +kubebuilder:validation:MaxItems=4
+	// Process IDs to match. Only the first 4 are matched by the kernel.
 	Values []uint32 `json:"values"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false

--- a/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.15"
+const CustomResourceDefinitionSchemaVersion = "1.8.16"

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -353,14 +353,18 @@ func pidSelectorFlags(pid *v1alpha1.PIDSelector) uint32 {
 	return flags
 }
 
-func pidSelectorValue(pid *v1alpha1.PIDSelector) ([]byte, uint32) {
+func pidSelectorValue(pid *v1alpha1.PIDSelector) ([]byte, uint32, error) {
+	if len(pid.Values) > 4 {
+		return nil, 0, fmt.Errorf("matchPIDs supports up to 4 values per filter (current number of values is %d)", len(pid.Values))
+	}
+
 	b := make([]byte, len(pid.Values)*4)
 
 	for i, v := range pid.Values {
 		off := i * 4
 		binary.LittleEndian.PutUint32(b[off:], v)
 	}
-	return b, uint32(len(b))
+	return b, uint32(len(b)), nil
 }
 
 func ParseMatchPid(k *KernelSelectorState, pid *v1alpha1.PIDSelector) error {
@@ -373,7 +377,10 @@ func ParseMatchPid(k *KernelSelectorState, pid *v1alpha1.PIDSelector) error {
 	flags := pidSelectorFlags(pid)
 	WriteSelectorUint32(&k.data, flags)
 
-	value, size := pidSelectorValue(pid)
+	value, size, err := pidSelectorValue(pid)
+	if err != nil {
+		return fmt.Errorf("matchpid error: %w", err)
+	}
 	WriteSelectorUint32(&k.data, size/4)
 	WriteSelectorByteArray(&k.data, value, size)
 	return nil

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1772,7 +1772,7 @@ type KernelSelectorArgs struct {
 // valueInt := [len][v]
 //
 // For some examples, see kernel_test.go
-func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg, data []v1alpha1.KProbeArg, actionArgTable *idtable.Table) ([4096]byte, error) {
+func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KProbeArg, data []v1alpha1.KProbeArg, actionArgTable *idtable.Table) ([KernelBufferSize]byte, error) {
 	state, err := InitKernelSelectorState(&KernelSelectorArgs{
 		Selectors:      selectors,
 		Args:           args,
@@ -1780,17 +1780,17 @@ func InitKernelSelectors(selectors []v1alpha1.KProbeSelector, args []v1alpha1.KP
 		ActionArgTable: actionArgTable,
 	})
 	if err != nil {
-		return [4096]byte{}, err
+		return [KernelBufferSize]byte{}, err
 	}
-	return state.data.e, nil
+	return state.CopyToFixedBuffer(), nil
 }
 
-func InitKernelReturnSelectors(selectors []v1alpha1.KProbeSelector, returnArg *v1alpha1.KProbeArg, actionArgTable *idtable.Table) ([4096]byte, error) {
+func InitKernelReturnSelectors(selectors []v1alpha1.KProbeSelector, returnArg *v1alpha1.KProbeArg, actionArgTable *idtable.Table) ([KernelBufferSize]byte, error) {
 	state, err := InitKernelReturnSelectorState(selectors, returnArg, actionArgTable, nil, nil)
 	if err != nil {
-		return [4096]byte{}, err
+		return [KernelBufferSize]byte{}, err
 	}
-	return state.data.e, nil
+	return state.CopyToFixedBuffer(), nil
 }
 
 func createKernelSelectorState(
@@ -1820,6 +1820,9 @@ func createKernelSelectorState(
 			return nil, err
 		}
 		WriteSelectorLength(&state.data, loff)
+	}
+	if len(state.data.e) > KernelBufferSize {
+		return nil, fmt.Errorf("selector encoding overflow: %d bytes exceeds %d byte buffer", len(state.data.e), KernelBufferSize)
 	}
 	return state, nil
 }

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -202,9 +202,15 @@ func TestPidSelectorFlags(t *testing.T) {
 func TestPidSelectorValue(t *testing.T) {
 	pid := &v1alpha1.PIDSelector{Operator: "In", Values: []uint32{1, 2, 3}, IsNamespacePID: true, FollowForks: true}
 	expected := []byte{0x1, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x3, 0x0, 0x0, 0x0}
-	if b, l := pidSelectorValue(pid); bytes.Equal(b, expected) == false || l != 12 {
-		t.Errorf("pidSelectorValue: expected %v actual %v\n", expected, b)
+	if b, l, err := pidSelectorValue(pid); err != nil || bytes.Equal(b, expected) == false || l != 12 {
+		t.Errorf("pidSelectorValue: expected %v actual %v (err: %v)", expected, b, err)
 	}
+}
+
+func TestPidSelectorValueTooManyValues(t *testing.T) {
+	pid := &v1alpha1.PIDSelector{Operator: "In", Values: []uint32{1, 2, 3, 4, 5}, IsNamespacePID: true, FollowForks: true}
+	_, _, err := pidSelectorValue(pid)
+	require.Error(t, err)
 }
 
 func TestNamespaceValue(t *testing.T) {

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestWriteSelectorUint32(t *testing.T) {
-	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	k := &KernelSelectorState{data: KernelSelectorData{}}
 	d := &k.data
 	v := uint32(0x1234abcd)
 
@@ -41,7 +41,8 @@ func TestWriteSelectorUint32(t *testing.T) {
 			d.e[0], d.e[1], d.e[2], d.e[3])
 	}
 
-	d.off = 1024
+	// grow by 1020 from offset 4 to reach offset 1024, then write uint32 at [1024:1028]
+	d.grow(1020)
 	WriteSelectorUint32(d, v)
 	if d.e[1027] != 0x12 || d.e[1026] != 0x34 || d.e[1025] != 0xab || d.e[1024] != 0xcd {
 		t.Errorf("SelectorStateWrite offset(1024) failed: %x %x %x %x\n",
@@ -50,7 +51,7 @@ func TestWriteSelectorUint32(t *testing.T) {
 }
 
 func TestWriteSelectorLength(t *testing.T) {
-	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	k := &KernelSelectorState{data: KernelSelectorData{}}
 	d := &k.data
 	v := uint32(0x1234abcd)
 
@@ -76,7 +77,7 @@ func TestWriteSelectorLength(t *testing.T) {
 }
 
 func TestWriteSelectorByteArray(t *testing.T) {
-	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	k := &KernelSelectorState{data: KernelSelectorData{}}
 	d := &k.data
 	v := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
 
@@ -252,7 +253,7 @@ func TestParseMatchCmdArgs(t *testing.T) {
 		// full header.
 		ks := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 		require.NoError(t, ParseMatchCmdArgs(ks, nil))
-		data := ks.data.e[:ks.data.off]
+		data := ks.data.e
 		require.Len(t, data, 24)
 		assert.Equal(t, uint32(len(data)), binary.LittleEndian.Uint32(data[:4]))
 		for off := 4; off < 24; off += 4 {
@@ -282,7 +283,7 @@ func TestParseMatchCmdArgs(t *testing.T) {
 		ks := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 		require.NoError(t, ParseMatchCmdArgs(ks, cmdArgs))
 
-		data := ks.data.e[:ks.data.off]
+		data := ks.data.e
 		require.GreaterOrEqual(t, len(data), 24)
 		sectionLength := binary.LittleEndian.Uint32(data[0:4])
 		assert.Equal(t, uint32(len(data)), sectionLength)
@@ -368,7 +369,7 @@ func TestInitKernelSelectorsMatchCmdArgsLayout(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	data := state.data.e[:state.data.off]
+	data := state.data.e
 	readUint32 := func(offset int) uint32 {
 		return binary.LittleEndian.Uint32(data[offset : offset+4])
 	}
@@ -489,8 +490,8 @@ func TestParseMatchArgs(t *testing.T) {
 
 	ks := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 	d := &ks.data
-	if err := ParseMatchArgs(ks, argsSel, dataSel, nil, args, data); err != nil || bytes.Equal(expected, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\n", err, expected, d.e[0:d.off])
+	if err := ParseMatchArgs(ks, argsSel, dataSel, nil, args, data); err != nil || bytes.Equal(expected, d.e) == false {
+		t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\n", err, expected, d.e)
 	}
 }
 
@@ -534,11 +535,11 @@ func TestParseMatchData(t *testing.T) {
 		0xff, 0xff, 0xff, 0xff, // map ID for strings 1025-2048
 		0xff, 0xff, 0xff, 0xff, // map ID for strings 2049-4096
 	}
-	if err := ParseMatchData(k, arg1, sig, 2); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected1, d.e[0:d.off], arg1)
+	if err := ParseMatchData(k, arg1, sig, 2); err != nil || bytes.Equal(expected1, d.e) == false {
+		t.Errorf("parseMatchArg: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected1, d.e, arg1)
 	}
 
-	nextArg := d.off
+	nextArg := len(d.e)
 	arg2 := &v1alpha1.ArgSelector{Index: 1, Operator: "Equal", Values: []string{"1", "2"}}
 	expected2 := []byte{
 		0x03, 0x00, 0x00, 0x00, // Index == 3 (1 + base 2)
@@ -548,11 +549,11 @@ func TestParseMatchData(t *testing.T) {
 		0x01, 0x00, 0x00, 0x00, // value 1
 		0x02, 0x00, 0x00, 0x00, // value 2
 	}
-	if err := ParseMatchData(k, arg2, sig, 2); err != nil || bytes.Equal(expected2, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextArg:d.off], arg2)
+	if err := ParseMatchData(k, arg2, sig, 2); err != nil || bytes.Equal(expected2, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextArg:], arg2)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg3 := &v1alpha1.ArgSelector{Index: 4, Operator: "SAddr", Values: []string{"127.0.0.1", "10.1.2.3/24", "192.168.254.254/20"}}
 	expected3 := []byte{
 		0x06, 0x00, 0x00, 0x00, // Index == 6 (4 + base 2)
@@ -562,11 +563,11 @@ func TestParseMatchData(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // Addr4LPM mapid = 0
 		0xff, 0xff, 0xff, 0xff, // Addr6LPM no map
 	}
-	if err := ParseMatchData(k, arg3, sig, 2); err != nil || bytes.Equal(expected3, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e[nextArg:d.off], arg3)
+	if err := ParseMatchData(k, arg3, sig, 2); err != nil || bytes.Equal(expected3, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e[nextArg:], arg3)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg4 := &v1alpha1.ArgSelector{Index: 5, Operator: "SPort", Values: []string{"8081", "25", "31337"}}
 	expected4 := []byte{
 		0x07, 0x00, 0x00, 0x00, // Index == 7 (5 + base 2)
@@ -575,11 +576,11 @@ func TestParseMatchData(t *testing.T) {
 		0x05, 0x00, 0x00, 0x00, // value type == skb
 		0x00, 0x00, 0x00, 0x00, // argfilter mapid = 0
 	}
-	if err := ParseMatchData(k, arg4, sig, 2); err != nil || bytes.Equal(expected4, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected4, d.e[nextArg:d.off], arg4)
+	if err := ParseMatchData(k, arg4, sig, 2); err != nil || bytes.Equal(expected4, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected4, d.e[nextArg:], arg4)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg5 := &v1alpha1.ArgSelector{Index: 6, Operator: "Protocol", Values: []string{"3", "IPPROTO_UDP", "IPPROTO_TCP"}}
 	expected5 := []byte{
 		0x08, 0x00, 0x00, 0x00, // Index == 8 (6 + base 2)
@@ -588,11 +589,11 @@ func TestParseMatchData(t *testing.T) {
 		0x05, 0x00, 0x00, 0x00, // value type == skb
 		1, 0x00, 0x00, 0x00, // argfilter mapid = 1
 	}
-	if err := ParseMatchData(k, arg5, sig, 2); err != nil || bytes.Equal(expected5, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected5, d.e[nextArg:d.off], arg5)
+	if err := ParseMatchData(k, arg5, sig, 2); err != nil || bytes.Equal(expected5, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected5, d.e[nextArg:], arg5)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg6 := &v1alpha1.ArgSelector{Index: 7, Operator: "SAddr", Values: []string{"127.0.0.1", "::1/128"}}
 	expected6 := []byte{
 		0x09, 0x00, 0x00, 0x00, // Index == 9 (7 + base 2)
@@ -602,11 +603,11 @@ func TestParseMatchData(t *testing.T) {
 		1, 0x00, 0x00, 0x00, // Addr4LPM mapid = 1
 		0x00, 0x00, 0x00, 0x00, // Addr6LPM mapid = 0
 	}
-	if err := ParseMatchData(k, arg6, sig, 2); err != nil || bytes.Equal(expected6, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected6, d.e[nextArg:d.off], arg6)
+	if err := ParseMatchData(k, arg6, sig, 2); err != nil || bytes.Equal(expected6, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected6, d.e[nextArg:], arg6)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg7 := &v1alpha1.ArgSelector{Index: 8, Operator: "SAddr", Values: []string{"127.0.0.1", "::1/128"}}
 	expected7 := []byte{
 		0x0a, 0x00, 0x00, 0x00, // Index == 10 (8 + base 2)
@@ -616,11 +617,11 @@ func TestParseMatchData(t *testing.T) {
 		2, 0x00, 0x00, 0x00, // Addr4LPM mapid = 2
 		1, 0x00, 0x00, 0x00, // Addr6LPM mapid = 1
 	}
-	if err := ParseMatchData(k, arg7, sig, 2); err != nil || bytes.Equal(expected7, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected7, d.e[nextArg:d.off], arg7)
+	if err := ParseMatchData(k, arg7, sig, 2); err != nil || bytes.Equal(expected7, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected7, d.e[nextArg:], arg7)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg8 := &v1alpha1.ArgSelector{Index: 9, Operator: "SAddr", Values: []string{"127.0.0.1", "::1/128"}}
 	expected8 := []byte{
 		0x0b, 0x00, 0x00, 0x00, // Index == 11 (9 + base 2)
@@ -630,12 +631,12 @@ func TestParseMatchData(t *testing.T) {
 		3, 0x00, 0x00, 0x00, // Addr4LPM mapid = 3
 		2, 0x00, 0x00, 0x00, // Addr6LPM mapid = 2
 	}
-	if err := ParseMatchData(k, arg8, sig, 2); err != nil || bytes.Equal(expected8, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected8, d.e[nextArg:d.off], arg8)
+	if err := ParseMatchData(k, arg8, sig, 2); err != nil || bytes.Equal(expected8, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected8, d.e[nextArg:], arg8)
 	}
 
 	if config.EnableLargeProgs() {
-		nextArg = d.off
+		nextArg = len(d.e)
 		arg9 := &v1alpha1.ArgSelector{Index: 10, Operator: "Equal", Values: []string{"1", "2"}}
 		expected9 := []byte{
 			0x0c, 0x00, 0x00, 0x00, // Index == 12 (10 + base 2)
@@ -645,11 +646,11 @@ func TestParseMatchData(t *testing.T) {
 			0x01, 0x00, 0x00, 0x00, // value 1
 			0x02, 0x00, 0x00, 0x00, // value 2
 		}
-		if err := ParseMatchData(k, arg9, sig, 2); err != nil || bytes.Equal(expected9, d.e[nextArg:d.off]) == false {
-			t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected9, d.e[nextArg:d.off], arg9)
+		if err := ParseMatchData(k, arg9, sig, 2); err != nil || bytes.Equal(expected9, d.e[nextArg:]) == false {
+			t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected9, d.e[nextArg:], arg9)
 		}
 
-		nextArg = d.off
+		nextArg = len(d.e)
 		arg10 := &v1alpha1.ArgSelector{Index: 11, Operator: "Equal", Values: []string{"1", "2"}}
 		expected10 := []byte{
 			0x0d, 0x00, 0x00, 0x00, // Index == 13 (11 + base 2)
@@ -659,8 +660,8 @@ func TestParseMatchData(t *testing.T) {
 			0x01, 0x00, 0x00, 0x00, // value 1
 			0x02, 0x00, 0x00, 0x00, // value 2
 		}
-		if err := ParseMatchData(k, arg10, sig, 2); err != nil || bytes.Equal(expected10, d.e[nextArg:d.off]) == false {
-			t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected10, d.e[nextArg:d.off], arg10)
+		if err := ParseMatchData(k, arg10, sig, 2); err != nil || bytes.Equal(expected10, d.e[nextArg:]) == false {
+			t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected10, d.e[nextArg:], arg10)
 		}
 	}
 }
@@ -705,11 +706,11 @@ func TestParseMatchArg(t *testing.T) {
 		0xff, 0xff, 0xff, 0xff, // map ID for strings 1025-2048
 		0xff, 0xff, 0xff, 0xff, // map ID for strings 2049-4096
 	}
-	if err := ParseMatchArg(k, arg1, sig); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected1, d.e[0:d.off], arg1)
+	if err := ParseMatchArg(k, arg1, sig); err != nil || bytes.Equal(expected1, d.e) == false {
+		t.Errorf("parseMatchArg: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected1, d.e, arg1)
 	}
 
-	nextArg := d.off
+	nextArg := len(d.e)
 	arg2 := &v1alpha1.ArgSelector{Index: 2, Operator: "Equal", Values: []string{"1", "2"}}
 	expected2 := []byte{
 		0x01, 0x00, 0x00, 0x00, // Index == 1
@@ -719,11 +720,11 @@ func TestParseMatchArg(t *testing.T) {
 		0x01, 0x00, 0x00, 0x00, // value 1
 		0x02, 0x00, 0x00, 0x00, // value 2
 	}
-	if err := ParseMatchArg(k, arg2, sig); err != nil || bytes.Equal(expected2, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextArg:d.off], arg2)
+	if err := ParseMatchArg(k, arg2, sig); err != nil || bytes.Equal(expected2, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextArg:], arg2)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg3 := &v1alpha1.ArgSelector{Index: 5, Operator: "SAddr", Values: []string{"127.0.0.1", "10.1.2.3/24", "192.168.254.254/20"}}
 	expected3 := []byte{
 		0x04, 0x00, 0x00, 0x00, // Index == 4
@@ -733,11 +734,11 @@ func TestParseMatchArg(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // Addr4LPM mapid = 0
 		0xff, 0xff, 0xff, 0xff, // Addr6LPM no map
 	}
-	if err := ParseMatchArg(k, arg3, sig); err != nil || bytes.Equal(expected3, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e[nextArg:d.off], arg3)
+	if err := ParseMatchArg(k, arg3, sig); err != nil || bytes.Equal(expected3, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e[nextArg:], arg3)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg4 := &v1alpha1.ArgSelector{Index: 6, Operator: "SPort", Values: []string{"8081", "25", "31337"}}
 	expected4 := []byte{
 		0x05, 0x00, 0x00, 0x00, // Index == 5
@@ -746,11 +747,11 @@ func TestParseMatchArg(t *testing.T) {
 		0x05, 0x00, 0x00, 0x00, // value type == skb
 		0x00, 0x00, 0x00, 0x00, // argfilter mapid = 0
 	}
-	if err := ParseMatchArg(k, arg4, sig); err != nil || bytes.Equal(expected4, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected4, d.e[nextArg:d.off], arg4)
+	if err := ParseMatchArg(k, arg4, sig); err != nil || bytes.Equal(expected4, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected4, d.e[nextArg:], arg4)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg5 := &v1alpha1.ArgSelector{Index: 7, Operator: "Protocol", Values: []string{"3", "IPPROTO_UDP", "IPPROTO_TCP"}}
 	expected5 := []byte{
 		0x06, 0x00, 0x00, 0x00, // Index == 6
@@ -759,11 +760,11 @@ func TestParseMatchArg(t *testing.T) {
 		0x05, 0x00, 0x00, 0x00, // value type == skb
 		1, 0x00, 0x00, 0x00, // argfilter mapid = 1
 	}
-	if err := ParseMatchArg(k, arg5, sig); err != nil || bytes.Equal(expected5, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected5, d.e[nextArg:d.off], arg5)
+	if err := ParseMatchArg(k, arg5, sig); err != nil || bytes.Equal(expected5, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected5, d.e[nextArg:], arg5)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg6 := &v1alpha1.ArgSelector{Index: 8, Operator: "SAddr", Values: []string{"127.0.0.1", "::1/128"}}
 	expected6 := []byte{
 		0x07, 0x00, 0x00, 0x00, // Index == 7
@@ -773,11 +774,11 @@ func TestParseMatchArg(t *testing.T) {
 		1, 0x00, 0x00, 0x00, // Addr4LPM mapid = 1
 		0x00, 0x00, 0x00, 0x00, // Addr6LPM mapid = 0
 	}
-	if err := ParseMatchArg(k, arg6, sig); err != nil || bytes.Equal(expected6, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected6, d.e[nextArg:d.off], arg6)
+	if err := ParseMatchArg(k, arg6, sig); err != nil || bytes.Equal(expected6, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected6, d.e[nextArg:], arg6)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg7 := &v1alpha1.ArgSelector{Index: 9, Operator: "SAddr", Values: []string{"127.0.0.1", "::1/128"}}
 	expected7 := []byte{
 		0x08, 0x00, 0x00, 0x00, // Index == 8
@@ -787,11 +788,11 @@ func TestParseMatchArg(t *testing.T) {
 		2, 0x00, 0x00, 0x00, // Addr4LPM mapid = 2
 		1, 0x00, 0x00, 0x00, // Addr6LPM mapid = 1
 	}
-	if err := ParseMatchArg(k, arg7, sig); err != nil || bytes.Equal(expected7, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected7, d.e[nextArg:d.off], arg7)
+	if err := ParseMatchArg(k, arg7, sig); err != nil || bytes.Equal(expected7, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected7, d.e[nextArg:], arg7)
 	}
 
-	nextArg = d.off
+	nextArg = len(d.e)
 	arg8 := &v1alpha1.ArgSelector{Index: 10, Operator: "SAddr", Values: []string{"127.0.0.1", "::1/128"}}
 	expected8 := []byte{
 		0x09, 0x00, 0x00, 0x00, // Index == 9
@@ -801,12 +802,12 @@ func TestParseMatchArg(t *testing.T) {
 		3, 0x00, 0x00, 0x00, // Addr4LPM mapid = 3
 		2, 0x00, 0x00, 0x00, // Addr6LPM mapid = 2
 	}
-	if err := ParseMatchArg(k, arg8, sig); err != nil || bytes.Equal(expected8, d.e[nextArg:d.off]) == false {
-		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected8, d.e[nextArg:d.off], arg8)
+	if err := ParseMatchArg(k, arg8, sig); err != nil || bytes.Equal(expected8, d.e[nextArg:]) == false {
+		t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected8, d.e[nextArg:], arg8)
 	}
 
 	if config.EnableLargeProgs() { // (u)int8/16 and multiple match args are supported only in kernels >= 5.4
-		nextArg = d.off
+		nextArg = len(d.e)
 		arg9 := &v1alpha1.ArgSelector{Index: 11, Operator: "Equal", Values: []string{"1", "2"}}
 		expected9 := []byte{
 			0x0a, 0x00, 0x00, 0x00, // Index == 10
@@ -816,11 +817,11 @@ func TestParseMatchArg(t *testing.T) {
 			0x01, 0x00, 0x00, 0x00, // value 1
 			0x02, 0x00, 0x00, 0x00, // value 2
 		}
-		if err := ParseMatchArg(k, arg9, sig); err != nil || bytes.Equal(expected9, d.e[nextArg:d.off]) == false {
-			t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected9, d.e[nextArg:d.off], arg9)
+		if err := ParseMatchArg(k, arg9, sig); err != nil || bytes.Equal(expected9, d.e[nextArg:]) == false {
+			t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected9, d.e[nextArg:], arg9)
 		}
 
-		nextArg = d.off
+		nextArg = len(d.e)
 		arg10 := &v1alpha1.ArgSelector{Index: 12, Operator: "Equal", Values: []string{"1", "2"}}
 		expected10 := []byte{
 			0x0b, 0x00, 0x00, 0x00, // Index == 11
@@ -830,8 +831,8 @@ func TestParseMatchArg(t *testing.T) {
 			0x01, 0x00, 0x00, 0x00, // value 1
 			0x02, 0x00, 0x00, 0x00, // value 2
 		}
-		if err := ParseMatchArg(k, arg10, sig); err != nil || bytes.Equal(expected10, d.e[nextArg:d.off]) == false {
-			t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected10, d.e[nextArg:d.off], arg10)
+		if err := ParseMatchArg(k, arg10, sig); err != nil || bytes.Equal(expected10, d.e[nextArg:]) == false {
+			t.Errorf("parseMatchArg: error %v expected %v bytes %v parsing %v\n", err, expected10, d.e[nextArg:], arg10)
 		}
 
 		length := []byte{
@@ -847,8 +848,8 @@ func TestParseMatchArg(t *testing.T) {
 		arg12 := []v1alpha1.ArgSelector{*arg1, *arg2}
 		ks := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 		d = &ks.data
-		if err := ParseMatchArgs(ks, arg12, []v1alpha1.ArgSelector{}, nil, sig, []v1alpha1.KProbeArg{}); err != nil || bytes.Equal(expected3, d.e[0:d.off]) == false {
-			t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected3, d.e[0:d.off], arg3)
+		if err := ParseMatchArgs(ks, arg12, []v1alpha1.ArgSelector{}, nil, sig, []v1alpha1.KProbeArg{}); err != nil || bytes.Equal(expected3, d.e) == false {
+			t.Errorf("parseMatchArgs: error %v expected:\n%v\nbytes:\n%v\nparsing %v\n", err, expected3, d.e, arg3)
 		}
 
 		// Regression test for https://github.com/cilium/tetragon/issues/4699
@@ -875,17 +876,17 @@ func TestParseMatchArg(t *testing.T) {
 		ks = NewKernelSelectorState(nil, nil, false, 0, 0, nil)
 		d = &ks.data
 		if err := ParseMatchArg(ks, arg13, sig); err != nil ||
-			bytes.Equal(expected12, d.e[0:d.off]) == false ||
+			bytes.Equal(expected12, d.e) == false ||
 			maps.Equal(ks.valueMaps[0].Data, expectMap) == false {
 			t.Errorf("parseMatchArg: error %v expected %v bytes %v expected map %v got %v parsing %v\n",
-				err, expected12, d.e[0:d.off], expectMap, ks.valueMaps[0].Data, arg13)
+				err, expected12, d.e, expectMap, ks.valueMaps[0].Data, arg13)
 		}
 	}
 }
 
 func TestParseMatchPid(t *testing.T) {
 	pid1 := &v1alpha1.PIDSelector{Operator: "In", Values: []uint32{1, 2, 3}, IsNamespacePID: true, FollowForks: true}
-	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	k := &KernelSelectorState{data: KernelSelectorData{}}
 	d := &k.data
 	expected1 := []byte{
 		0x05, 0x00, 0x00, 0x00, // op == In
@@ -895,11 +896,11 @@ func TestParseMatchPid(t *testing.T) {
 		0x02, 0x00, 0x00, 0x00, // Values[1] == 2
 		0x03, 0x00, 0x00, 0x00, // Values[2] == 3
 	}
-	if err := ParseMatchPid(k, pid1); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchPid: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e[0:d.off], pid1)
+	if err := ParseMatchPid(k, pid1); err != nil || bytes.Equal(expected1, d.e) == false {
+		t.Errorf("parseMatchPid: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e, pid1)
 	}
 
-	nextPid := d.off
+	nextPid := len(d.e)
 	pid2 := &v1alpha1.PIDSelector{Operator: "NotIn", Values: []uint32{1, 2, 3, 4}, IsNamespacePID: false, FollowForks: false}
 	expected2 := []byte{
 		0x06, 0x00, 0x00, 0x00, // op == NotIn
@@ -910,24 +911,24 @@ func TestParseMatchPid(t *testing.T) {
 		0x03, 0x00, 0x00, 0x00, // Values[2] == 3
 		0x04, 0x00, 0x00, 0x00, // Values[2] == 3
 	}
-	if err := ParseMatchPid(k, pid2); err != nil || bytes.Equal(expected2, d.e[nextPid:d.off]) == false {
-		t.Errorf("parseMatchPid: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextPid:d.off], pid2)
+	if err := ParseMatchPid(k, pid2); err != nil || bytes.Equal(expected2, d.e[nextPid:]) == false {
+		t.Errorf("parseMatchPid: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextPid:], pid2)
 	}
 
 	length := []byte{56, 0x00, 0x00, 0x00}
 	expected3 := append(length, expected1[:]...)
 	expected3 = append(expected3, expected2[:]...)
 	pid3 := []v1alpha1.PIDSelector{*pid1, *pid2}
-	ks := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	ks := &KernelSelectorState{data: KernelSelectorData{}}
 	d = &ks.data
-	if err := ParseMatchPids(ks, pid3); err != nil || bytes.Equal(expected3, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchPid: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e[0:d.off], pid3)
+	if err := ParseMatchPids(ks, pid3); err != nil || bytes.Equal(expected3, d.e) == false {
+		t.Errorf("parseMatchPid: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e, pid3)
 	}
 }
 
 func TestParseMatchNamespaces(t *testing.T) {
 	ns1 := &v1alpha1.NamespaceSelector{Namespace: "Pid", Operator: "In", Values: []string{"1", "2", "3"}}
-	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	k := &KernelSelectorState{data: KernelSelectorData{}}
 	d := &k.data
 	expected1 := []byte{
 		0x03, 0x00, 0x00, 0x00, // namespace == Pid
@@ -937,11 +938,11 @@ func TestParseMatchNamespaces(t *testing.T) {
 		0x02, 0x00, 0x00, 0x00, // Values[1] == 2
 		0x03, 0x00, 0x00, 0x00, // Values[2] == 3
 	}
-	if err := ParseMatchNamespace(k, ns1); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchNamespace: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e[0:d.off], ns1)
+	if err := ParseMatchNamespace(k, ns1); err != nil || bytes.Equal(expected1, d.e) == false {
+		t.Errorf("parseMatchNamespace: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e, ns1)
 	}
 
-	nextPid := d.off
+	nextPid := len(d.e)
 	ns2 := &v1alpha1.NamespaceSelector{Namespace: "Mnt", Operator: "NotIn", Values: []string{"1", "2", "3", "4"}}
 	expected2 := []byte{
 		0x02, 0x00, 0x00, 0x00, // namespace == Mnt
@@ -952,37 +953,37 @@ func TestParseMatchNamespaces(t *testing.T) {
 		0x03, 0x00, 0x00, 0x00, // Values[2] == 3
 		0x04, 0x00, 0x00, 0x00, // Values[2] == 3
 	}
-	if err := ParseMatchNamespace(k, ns2); err != nil || bytes.Equal(expected2, d.e[nextPid:d.off]) == false {
-		t.Errorf("parseMatchNamespace: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextPid:d.off], ns2)
+	if err := ParseMatchNamespace(k, ns2); err != nil || bytes.Equal(expected2, d.e[nextPid:]) == false {
+		t.Errorf("parseMatchNamespace: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextPid:], ns2)
 	}
 
 	length := []byte{56, 0x00, 0x00, 0x00}
 	expected3 := append(length, expected1[:]...)
 	expected3 = append(expected3, expected2[:]...)
 	ns3 := []v1alpha1.NamespaceSelector{*ns1, *ns2}
-	ks := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	ks := &KernelSelectorState{data: KernelSelectorData{}}
 	d = &ks.data
-	if err := ParseMatchNamespaces(ks, ns3); err != nil || bytes.Equal(expected3, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchNamespaces: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e[0:d.off], ns3)
+	if err := ParseMatchNamespaces(ks, ns3); err != nil || bytes.Equal(expected3, d.e) == false {
+		t.Errorf("parseMatchNamespaces: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e, ns3)
 	}
 }
 
 func TestParseMatchNamespaceChanges(t *testing.T) {
 	ns1 := &v1alpha1.NamespaceChangesSelector{Operator: "In", Values: []string{"Uts", "Mnt"}}
-	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	k := &KernelSelectorState{data: KernelSelectorData{}}
 	d := &k.data
 	expected1 := []byte{
 		0x05, 0x00, 0x00, 0x00, // op == In
 		0x05, 0x00, 0x00, 0x00, // values
 	}
-	if err := ParseMatchNamespaceChange(k, ns1); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchNamespaceChange: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e[0:d.off], ns1)
+	if err := ParseMatchNamespaceChange(k, ns1); err != nil || bytes.Equal(expected1, d.e) == false {
+		t.Errorf("parseMatchNamespaceChange: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e, ns1)
 	}
 }
 
 func TestParseMatchCapabilities(t *testing.T) {
 	cap1 := &v1alpha1.CapabilitiesSelector{Type: "Effective", Operator: "In", IsNamespaceCapability: false, Values: []string{"CAP_CHOWN", "CAP_NET_RAW"}}
-	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	k := &KernelSelectorState{data: KernelSelectorData{}}
 	d := &k.data
 	expected1 := []byte{
 		0x01, 0x00, 0x00, 0x00, // Type == Effective
@@ -990,11 +991,11 @@ func TestParseMatchCapabilities(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // IsNamespaceCapability = false
 		0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Values (uint64)
 	}
-	if err := ParseMatchCaps(k, cap1); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchCaps: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e[0:d.off], cap1)
+	if err := ParseMatchCaps(k, cap1); err != nil || bytes.Equal(expected1, d.e) == false {
+		t.Errorf("parseMatchCaps: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e, cap1)
 	}
 
-	nextPid := d.off
+	nextPid := len(d.e)
 	cap2 := &v1alpha1.CapabilitiesSelector{Type: "Inheritable", Operator: "NotIn", IsNamespaceCapability: false, Values: []string{"CAP_SETPCAP", "CAP_SYS_ADMIN"}}
 	expected2 := []byte{
 		0x02, 0x00, 0x00, 0x00, // Type == Inheritable
@@ -1002,18 +1003,18 @@ func TestParseMatchCapabilities(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // IsNamespaceCapability = false
 		0x00, 0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, // Values (uint64)
 	}
-	if err := ParseMatchCaps(k, cap2); err != nil || bytes.Equal(expected2, d.e[nextPid:d.off]) == false {
-		t.Errorf("parseMatchCaps: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextPid:d.off], cap2)
+	if err := ParseMatchCaps(k, cap2); err != nil || bytes.Equal(expected2, d.e[nextPid:]) == false {
+		t.Errorf("parseMatchCaps: error %v expected %v bytes %v parsing %v\n", err, expected2, d.e[nextPid:], cap2)
 	}
 
 	length := []byte{44, 0x00, 0x00, 0x00}
 	expected3 := append(length, expected1[:]...)
 	expected3 = append(expected3, expected2[:]...)
 	cap3 := []v1alpha1.CapabilitiesSelector{*cap1, *cap2}
-	ks := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	ks := &KernelSelectorState{data: KernelSelectorData{}}
 	d = &ks.data
-	if err := ParseMatchCapabilities(ks, cap3); err != nil || bytes.Equal(expected3, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchCapabilities: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e[0:d.off], cap3)
+	if err := ParseMatchCapabilities(ks, cap3); err != nil || bytes.Equal(expected3, d.e) == false {
+		t.Errorf("parseMatchCapabilities: error %v expected %v bytes %v parsing %v\n", err, expected3, d.e, cap3)
 	}
 }
 
@@ -1023,7 +1024,7 @@ func TestParseMatchAction(t *testing.T) {
 
 	act1 := &v1alpha1.ActionSelector{Action: "post"}
 	act2 := &v1alpha1.ActionSelector{Action: "post"}
-	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	k := &KernelSelectorState{data: KernelSelectorData{}}
 	d := &k.data
 	expected1 := []byte{
 		0x00, 0x00, 0x00, 0x00, // Action = "post"
@@ -1033,8 +1034,8 @@ func TestParseMatchAction(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // UserStackTrace = 0
 		0x00, 0x00, 0x00, 0x00, // ImaHash = 0
 	}
-	if err := ParseMatchAction(k, act1, &actionArgTable, 0); err != nil || bytes.Equal(expected1, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchAction: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e[0:d.off], act1)
+	if err := ParseMatchAction(k, act1, &actionArgTable, 0); err != nil || bytes.Equal(expected1, d.e) == false {
+		t.Errorf("parseMatchAction: error %v expected %v bytes %v parsing %v\n", err, expected1, d.e, act1)
 	}
 	// This is a bit contrived because we only have single action so far
 	// but once we get two we will update this. Point being we want to
@@ -1052,10 +1053,10 @@ func TestParseMatchAction(t *testing.T) {
 	expected = append(expected, expected2[:]...)
 
 	act := []v1alpha1.ActionSelector{*act1, *act2}
-	ks := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	ks := &KernelSelectorState{data: KernelSelectorData{}}
 	d = &ks.data
-	if err := ParseMatchActions(ks, act, &actionArgTable, 0); err != nil || bytes.Equal(expected, d.e[0:d.off]) == false {
-		t.Errorf("parseMatchActions: error %v expected %v bytes %v parsing %v\n", err, expected, d.e[0:d.off], act)
+	if err := ParseMatchActions(ks, act, &actionArgTable, 0); err != nil || bytes.Equal(expected, d.e) == false {
+		t.Errorf("parseMatchActions: error %v expected %v bytes %v parsing %v\n", err, expected, d.e, act)
 	}
 }
 
@@ -1069,7 +1070,7 @@ func TestParseMatchActionMax(t *testing.T) {
 		v1alpha1.ActionSelector{Action: "post"},
 	}
 
-	k := &KernelSelectorState{data: KernelSelectorData{off: 0}}
+	k := &KernelSelectorState{data: KernelSelectorData{}}
 
 	err := ParseMatchActions(k, actions, &actionArgTable, 0)
 	if err == nil {
@@ -1618,7 +1619,7 @@ func TestParseMatchArgSubString(t *testing.T) {
 
 			err := ParseMatchArg(k, arg, sig)
 			require.NoError(t, err)
-			require.Equal(t, expected, d.e[0:d.off])
+			require.Equal(t, expected, d.e)
 			require.Equal(t, []string{"test"}, k.SubStrings())
 		})
 	}

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -108,9 +108,12 @@ type MatchBinariesSelectorOptions struct {
 	MBSetID uint32
 }
 
+const KernelBufferSize = 4096
+
 type KernelSelectorData struct {
-	off uint32     // offset into encoding
-	e   [4096]byte // kernel encoding of selectors
+	// kernel encoding of selectors, grows as selectors are encoded. The
+	// current write offset is always len(e).
+	e []byte
 }
 
 type KernelSelectorState struct {
@@ -162,6 +165,9 @@ func NewKernelSelectorState(
 		celExprs = &CelExprFunctions{}
 	}
 	return &KernelSelectorState{
+		// Selectors are expected to fit into KernelBufferSize, so
+		// preallocate that much and avoid growing in the common case.
+		data:                  KernelSelectorData{e: make([]byte, 0, KernelBufferSize)},
 		matchBinaries:         make(map[int]MatchBinariesSelectorOptions),
 		matchBinariesPaths:    make(map[int][][processapi.BINARY_PATH_MAX_LEN]byte),
 		listReader:            listReader,
@@ -217,8 +223,10 @@ func (k *KernelSelectorState) MatchBinariesPathsMaxEntries() int {
 	return maxEntries
 }
 
-func (k *KernelSelectorState) Buffer() [4096]byte {
-	return k.data.e
+func (k *KernelSelectorState) CopyToFixedBuffer() [KernelBufferSize]byte {
+	var out [KernelBufferSize]byte
+	copy(out[:], k.data.e)
+	return out
 }
 
 func (k *KernelSelectorState) ValueMaps() []ValueMap {
@@ -319,28 +327,35 @@ func (k *KernelSelectorState) StringPostfixMapsMaxEntries() int {
 	return maxEntries
 }
 
+// grow appends size zeroed bytes to e and returns them, so callers can
+// write into the returned slice without worrying about the buffer end.
+func (k *KernelSelectorData) grow(size uint32) []byte {
+	oldLen := len(k.e)
+	k.e = append(k.e, make([]byte, size)...)
+	return k.e[oldLen:]
+}
+
 func WriteSelectorInt32(k *KernelSelectorData, v int32) {
-	binary.LittleEndian.PutUint32(k.e[k.off:], uint32(v))
-	k.off += 4
+	binary.LittleEndian.PutUint32(k.grow(4), uint32(v))
 }
 
 func WriteSelectorUint32(k *KernelSelectorData, v uint32) {
-	binary.LittleEndian.PutUint32(k.e[k.off:], v)
-	k.off += 4
+	binary.LittleEndian.PutUint32(k.grow(4), v)
 }
 
 func WriteSelectorInt64(k *KernelSelectorData, v int64) {
-	binary.LittleEndian.PutUint64(k.e[k.off:], uint64(v))
-	k.off += 8
+	binary.LittleEndian.PutUint64(k.grow(8), uint64(v))
 }
 
 func WriteSelectorUint64(k *KernelSelectorData, v uint64) {
-	binary.LittleEndian.PutUint64(k.e[k.off:], v)
-	k.off += 8
+	binary.LittleEndian.PutUint64(k.grow(8), v)
 }
 
+// WriteSelectorLength and WriteSelectorOffsetUint32 backpatch a uint32
+// previously reserved by AdvanceSelectorLength, so loff always refers to
+// bytes already appended to e.
 func WriteSelectorLength(k *KernelSelectorData, loff uint32) {
-	diff := k.off - loff
+	diff := uint32(len(k.e)) - loff
 	binary.LittleEndian.PutUint32(k.e[loff:], diff)
 }
 
@@ -349,19 +364,16 @@ func WriteSelectorOffsetUint32(k *KernelSelectorData, loff uint32, val uint32) {
 }
 
 func GetCurrentOffset(k *KernelSelectorData) uint32 {
-	return k.off
+	return uint32(len(k.e))
 }
 
 func WriteSelectorByteArray(k *KernelSelectorData, b []byte, size uint32) {
-	for l := range size {
-		k.e[k.off+l] = b[l]
-	}
-	k.off += size
+	copy(k.grow(size), b[:size])
 }
 
 func AdvanceSelectorLength(k *KernelSelectorData) uint32 {
-	off := k.off
-	k.off += 4
+	off := uint32(len(k.e))
+	k.grow(4)
 	return off
 }
 

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -549,7 +549,7 @@ func loadSingleUsdtSensor(usdtEntry *genericUsdt, args sensors.LoadProbeArgs) er
 	binary.Write(&configData, binary.LittleEndian, usdtEntry.config)
 
 	// filter_map data
-	selBuff := usdtEntry.selectors.Buffer()
+	selBuff := usdtEntry.selectors.CopyToFixedBuffer()
 
 	mapLoad := []*program.MapLoad{
 		{
@@ -596,7 +596,7 @@ func loadMultiUsdtSensor(ids []idtable.EntryID, args sensors.LoadProbeArgs) erro
 		binary.Write(&configData, binary.LittleEndian, usdtEntry.config)
 
 		// filter_map data
-		selBuff := usdtEntry.selectors.Buffer()
+		selBuff := usdtEntry.selectors.CopyToFixedBuffer()
 
 		mapLoad := []*program.MapLoad{
 			{

--- a/pkg/sensors/tracing/selectors.go
+++ b/pkg/sensors/tracing/selectors.go
@@ -20,7 +20,7 @@ import (
 )
 
 func selectorsMaploads(ks *selectors.KernelSelectorState, index uint32) []*program.MapLoad {
-	selBuff := ks.Buffer()
+	selBuff := ks.CopyToFixedBuffer()
 	maps := []*program.MapLoad{
 		{
 			Name: "filter_map",

--- a/pkg/tracingpolicy/schemas/tracingpolicy-cilium.io.json
+++ b/pkg/tracingpolicy/schemas/tracingpolicy-cilium.io.json
@@ -1028,11 +1028,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -2487,11 +2488,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -3680,11 +3682,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -4821,11 +4824,12 @@
                       "type": "string"
                     },
                     "values": {
-                      "description": "Process IDs to match.",
+                      "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                       "items": {
                         "format": "int32",
                         "type": "integer"
                       },
+                      "maxItems": 4,
                       "type": "array"
                     }
                   },
@@ -5946,11 +5950,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -7368,11 +7373,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -8534,11 +8540,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },

--- a/pkg/tracingpolicy/schemas/tracingpolicynamespaced-cilium.io.json
+++ b/pkg/tracingpolicy/schemas/tracingpolicynamespaced-cilium.io.json
@@ -1028,11 +1028,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -2487,11 +2488,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -3680,11 +3682,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -4821,11 +4824,12 @@
                       "type": "string"
                     },
                     "values": {
-                      "description": "Process IDs to match.",
+                      "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                       "items": {
                         "format": "int32",
                         "type": "integer"
                       },
+                      "maxItems": 4,
                       "type": "array"
                     }
                   },
@@ -5946,11 +5950,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -7368,11 +7373,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },
@@ -8534,11 +8540,12 @@
                             "type": "string"
                           },
                           "values": {
-                            "description": "Process IDs to match.",
+                            "description": "Process IDs to match. Only the first 4 are matched by the kernel.",
                             "items": {
                               "format": "int32",
                               "type": "integer"
                             },
+                            "maxItems": 4,
                             "type": "array"
                           }
                         },

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
@@ -1003,10 +1003,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -2392,10 +2394,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -3503,10 +3507,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -4570,10 +4576,12 @@ spec:
                             - NotIn
                             type: string
                           values:
-                            description: Process IDs to match.
+                            description: Process IDs to match. Only the first 4 are
+                              matched by the kernel.
                             items:
                               format: int32
                               type: integer
+                            maxItems: 4
                             type: array
                         required:
                         - operator
@@ -5630,10 +5638,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -6981,10 +6991,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -8074,10 +8086,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpoliciesnamespaced.yaml
@@ -1003,10 +1003,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -2392,10 +2394,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -3503,10 +3507,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -4570,10 +4576,12 @@ spec:
                             - NotIn
                             type: string
                           values:
-                            description: Process IDs to match.
+                            description: Process IDs to match. Only the first 4 are
+                              matched by the kernel.
                             items:
                               format: int32
                               type: integer
+                            maxItems: 4
                             type: array
                         required:
                         - operator
@@ -5630,10 +5638,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -6981,10 +6991,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator
@@ -8074,10 +8086,12 @@ spec:
                                   - NotIn
                                   type: string
                                 values:
-                                  description: Process IDs to match.
+                                  description: Process IDs to match. Only the first
+                                    4 are matched by the kernel.
                                   items:
                                     format: int32
                                     type: integer
+                                  maxItems: 4
                                   type: array
                               required:
                               - operator

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/types.go
@@ -258,7 +258,8 @@ type PIDSelector struct {
 	// +kubebuilder:validation:Enum=In;NotIn
 	// PID selector operator.
 	Operator string `json:"operator"`
-	// Process IDs to match.
+	// +kubebuilder:validation:MaxItems=4
+	// Process IDs to match. Only the first 4 are matched by the kernel.
 	Values []uint32 `json:"values"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false

--- a/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
+++ b/vendor/github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1/version.go
@@ -7,4 +7,4 @@ package v1alpha1
 // Used to determine if CRD needs to be updated in cluster
 //
 // Developers: Bump patch for each change in the CRD schema.
-const CustomResourceDefinitionSchemaVersion = "1.8.15"
+const CustomResourceDefinitionSchemaVersion = "1.8.16"


### PR DESCRIPTION
Fixes ##5384
Closes #5384 

Fixes agent crash from unbounded `matchPIDs.values` overflowing the fixed 4096-byte selector encoding buffer (panic: `index out of range [4096] with length 4096`).

**Root cause fix:** `pidSelectorValue` now caps `matchPIDs.values` at 4, matching the existing cap on `matchArgs`/`matchNamespaces` and the kernel's own `MAX_SELECTOR_VALUES=4` in `bpf/process/pfilter.h` the kernel matcher already ignores anything past the 4th value, so this closes both the overflow and a pre-existing dead-data gap.

**Defense-in-depth:** `KernelSelectorData` now tracks a sticky error; every `WriteSelector*`/`AdvanceSelectorLength` helper checks bounds before writing and no-ops on overflow instead of panicking. `createKernelSelectorState` surfaces that error once, as a normal returned error. Protects against any future selector type that forgets a cap.

**Schema hardening:** added `maxItems: 4` to `matchPIDs.values` in both CRD YAMLs (regenerated via `controller-gen`) and the embedded gRPC-path JSON schema, so malformed policies are rejected before reaching the parser.

**Verification (Ubuntu, kernel 7.0.0):**

Before fix the agent crashes:
```
panic: runtime error: index out of range [4096] with length 4096
```

After fix: dynamic add via gRPC:
```
$ sudo ./tetra tracingpolicy add crash.yaml
Error: failed to add tracing policy: rpc error: code = Unknown desc = policy handler 'tracing' failed loading policy 'crash': parseMatchPids error: matchpid error: matchPIDs supports up to 4 values per filter (current number of values is 2000)
```
Agent stays up, no panic.

After fix startup-file load (`--tracing-policy crash.yaml`):
```
level=warn msg="Server AddTracingPolicy request failed" error="policy handler 'tracing' failed loading policy 'crash': parseMatchPids error: matchpid error: matchPIDs supports up to 4 values per filter (current number of values is 2000)" metadata.name=crash
```
Clean warning log, agent continues running normally.

**Tests:** added `TestPidSelectorValueTooManyValues`; updated `TestPidSelectorValue` for the new error return. `go build`/`go vet` clean on `pkg/selectors`, `pkg/tracingpolicy`, `pkg/k8s`.