### PR TITLE
policytest: make scenario preparation pluggable

### DIFF
--- a/cmd/tetra/commands_linux.go
+++ b/cmd/tetra/commands_linux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/tetragon/cmd/tetra/policytest"
 	"github.com/cilium/tetragon/cmd/tetra/probe"
 	"github.com/cilium/tetragon/cmd/tetra/tracingpolicy"
+	ptpkg "github.com/cilium/tetragon/pkg/testutils/policytest"
 )
 
 func addCommands(rootCmd *cobra.Command) {
@@ -29,5 +30,5 @@ func addCommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(loglevel.New())
 	common.AddSubCommandIfNotNil(rootCmd, cri.New())
 	rootCmd.AddCommand(cgtracker.New())
-	rootCmd.AddCommand(policytest.New())
+	rootCmd.AddCommand(policytest.New().WithPrepareScenario(ptpkg.PrepareScenario).Command())
 }

--- a/cmd/tetra/policytest/policytest.go
+++ b/cmd/tetra/policytest/policytest.go
@@ -22,10 +22,26 @@ import (
 
 	"github.com/cilium/tetragon/cmd/tetra/common"
 	"github.com/cilium/tetragon/pkg/testutils/policytest"
+	"github.com/cilium/tetragon/pkg/tetragoninfo"
 	_ "github.com/cilium/tetragon/tests/policytests" // so that tests can be registered
 )
 
-func New() *cobra.Command {
+type Command struct {
+	command          *cobra.Command
+	prepareScenarios []func(info *tetragoninfo.Info, scenario *policytest.Scenario)
+}
+
+func (c *Command) WithPrepareScenario(fn func(info *tetragoninfo.Info, scenario *policytest.Scenario)) *Command {
+	c.prepareScenarios = append(c.prepareScenarios, fn)
+	return c
+}
+
+func (c *Command) Command() *cobra.Command {
+	return c.command
+}
+
+func New() *Command {
+	ptCmd := &Command{}
 	tpCmd := &cobra.Command{
 		Use:     "policytest",
 		Aliases: []string{"pt"},
@@ -33,10 +49,15 @@ func New() *cobra.Command {
 	}
 	tpCmd.AddCommand(
 		listCmd(),
-		runCmd(),
+		runCmd(func(info *tetragoninfo.Info, scenario *policytest.Scenario) {
+			for _, fn := range ptCmd.prepareScenarios {
+				fn(info, scenario)
+			}
+		}),
 		dumpPolicyCmd(),
 	)
-	return tpCmd
+	ptCmd.command = tpCmd
+	return ptCmd
 }
 
 func listCmd() *cobra.Command {
@@ -119,7 +140,7 @@ func dumpPolicyCmd() *cobra.Command {
 	return &cmd
 }
 
-func runCmd() *cobra.Command {
+func runCmd(prepareScenario func(info *tetragoninfo.Info, scenario *policytest.Scenario)) *cobra.Command {
 	cwd, _ := os.Getwd()
 	testBinsPath := filepath.Join(cwd, "contrib/tester-progs")
 	dumpPolicyPath := ""
@@ -190,7 +211,7 @@ func runCmd() *cobra.Command {
 				BinsDir:        testBinsPath,
 				DumpPolicyPath: dumpPolicyPath,
 				Timeout:        &runnerTimeout,
-			})
+			}, prepareScenario)
 			if err != nil {
 				return fmt.Errorf("failed to start local runner: %w", err)
 			}

--- a/pkg/testutils/policytest/checkers.go
+++ b/pkg/testutils/policytest/checkers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cilium/tetragon/pkg/tetragoninfo"
 )
 
-func processCacheDisabled(info *tetragoninfo.Info) bool {
+func ProcessCacheDisabled(info *tetragoninfo.Info) bool {
 	if info != nil {
 		disabledPC, _ := info.Conf["disable-process-cache"].(bool)
 		return disabledPC
@@ -23,7 +23,7 @@ func processCacheDisabled(info *tetragoninfo.Info) bool {
 // is disabled and those fields won't be populated. It is meant to be passed
 // to NewLocalRunner.
 func PrepareScenario(info *tetragoninfo.Info, scenario *Scenario) {
-	if processCacheDisabled(info) {
+	if ProcessCacheDisabled(info) {
 		unsetProcessChecks(scenario.EventChecker)
 		unsetParentChecks(scenario.EventChecker)
 	}

--- a/pkg/testutils/policytest/checkers.go
+++ b/pkg/testutils/policytest/checkers.go
@@ -18,6 +18,17 @@ func processCacheDisabled(info *tetragoninfo.Info) bool {
 	return false
 }
 
+// PrepareScenario adjusts a scenario's EventChecker based on the agent's
+// configuration, e.g. skipping Process/Parent checks when the process cache
+// is disabled and those fields won't be populated. It is meant to be passed
+// to NewLocalRunner.
+func PrepareScenario(info *tetragoninfo.Info, scenario *Scenario) {
+	if processCacheDisabled(info) {
+		unsetProcessChecks(scenario.EventChecker)
+		unsetParentChecks(scenario.EventChecker)
+	}
+}
+
 // unsetProcessChecks strips any Process check set via WithProcess() from the
 // individual checkers of a scenario's EventChecker, e.g. for cases where the
 // process cache is disabled and the Process field can't be checked.

--- a/pkg/testutils/policytest/runner.go
+++ b/pkg/testutils/policytest/runner.go
@@ -33,6 +33,10 @@ type LocalRunner struct {
 	wg   sync.WaitGroup
 
 	fwdCtlChan chan fwdCtl
+
+	// prepareScenario is called on each scenario before it runs, e.g. to
+	// adjust its EventChecker based on the agent's configuration.
+	prepareScenario func(info *tetragoninfo.Info, scenario *Scenario)
 }
 
 // NewLocalRunner creates a new local runner
@@ -52,6 +56,7 @@ func NewLocalRunner(
 	ctx context.Context,
 	log *slog.Logger,
 	cnf *Conf,
+	prepareScenario func(info *tetragoninfo.Info, scenario *Scenario),
 ) (*LocalRunner, error) {
 	if cnf.GrpcAddr == "" {
 		info, err := bugtool.LoadInitInfo()
@@ -81,9 +86,10 @@ func NewLocalRunner(
 	}
 	info := tetragoninfo.Decode(res)
 	ret := &LocalRunner{
-		conf: cnf,
-		cli:  cli,
-		info: info,
+		conf:            cnf,
+		cli:             cli,
+		info:            info,
+		prepareScenario: prepareScenario,
 	}
 
 	// start two goroutines to handle Tetragon events:
@@ -231,10 +237,8 @@ func (r *LocalRunner) RunScenario(
 	ctx, cancel := context.WithTimeout(r.cli.Ctx, time.Second*10)
 	defer cancel()
 
-	// the process cache is disabled, so Process/Parent fields won't be populated: skip those checks
-	if processCacheDisabled(r.info) {
-		unsetProcessChecks(scenario.EventChecker)
-		unsetParentChecks(scenario.EventChecker)
+	if r.prepareScenario != nil {
+		r.prepareScenario(r.info, scenario)
 	}
 
 	// start the checker


### PR DESCRIPTION
This is useful for external packages that import this one and need to customize scenario preparation.

