### PR TITLE
bpf: clear stale LSM output state before policy filtering

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -50,6 +50,10 @@ generic_start_process_filter(void *ctx, struct bpf_map_def *calls)
 	if (!msg)
 		return 0;
 
+	/* Clear state consumed by LSM output before any early return. */
+	msg->lsm.post = false;
+	msg->common.flags = 0;
+
 	/* setup index, check policy filter, and setup function id */
 	msg->idx = get_index(ctx);
 	config = map_lookup_elem(&config_map, &msg->idx);
@@ -81,9 +85,6 @@ generic_start_process_filter(void *ctx, struct bpf_map_def *calls)
 #ifdef __CAP_CHANGES_FILTER
 	msg->sel.match_cap = 0;
 #endif
-
-	msg->lsm.post = false;
-	msg->common.flags = 0;
 
 	/* Tail call into filters. */
 	tail_call(ctx, calls, TAIL_CALL_FILTER);

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
@@ -399,6 +400,113 @@ func TestUprobeNamespacedPolicy(t *testing.T) {
 	require.Equal(t, 0, countUprobes(func() {
 		t.Logf("%s", lseekPipeCmd2.Lseek(-42, 0, 0))
 	}))
+}
+
+func TestLsmNamespacedPolicyClearsPostState(t *testing.T) {
+	if !bpf.HasLSMPrograms() || !config.EnableLargeProgs() {
+		t.Skip("BPF LSM programs are not supported on this kernel")
+	}
+	build.SkipIfK8sDisabled(t)
+
+	oldEnableK8s := option.Config.EnableK8s
+	option.Config.EnableK8s = true
+	t.Cleanup(func() {
+		option.Config.EnableK8s = oldEnableK8s
+	})
+
+	testutils.CaptureLog(t, logger.GetLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	err := observer.InitDataCache(1024)
+	require.NoError(t, err)
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	err = confmap.UpdateTgRuntimeConf(bpf.MapPrefixPath(), os.Getpid())
+	require.NoError(t, err)
+
+	policyfilter.TestingEnableAndReset(t)
+
+	tus.LoadInitialSensor(t)
+	tus.LoadSensor(t, testsensor.GetTestSensor())
+	sm := tuo.GetTestSensorManager(t)
+
+	matchingProcess := newUsdtPipe(t, ctx)
+	nonMatchingProcess := newUsdtPipe(t, ctx)
+
+	var availableCPUs unix.CPUSet
+	require.NoError(t, unix.SchedGetaffinity(0, &availableCPUs))
+	cpu := -1
+	for i := 0; i < 1024; i++ {
+		if availableCPUs.IsSet(i) {
+			cpu = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, cpu, "no available CPU found")
+
+	var affinity unix.CPUSet
+	affinity.Set(cpu)
+	require.NoError(t, unix.SchedSetaffinity(matchingProcess.pid(), &affinity))
+	require.NoError(t, unix.SchedSetaffinity(nonMatchingProcess.pid(), &affinity))
+
+	now := time.Now().Format("20060102150405")
+	matchingCgID := createCgroup(t, fmt.Sprintf("%s.matching.%s.slice", t.Name(), now), uint64(matchingProcess.pid()))
+	nonMatchingCgID := createCgroup(t, fmt.Sprintf("%s.nonmatching.%s.slice", t.Name(), now), uint64(nonMatchingProcess.pid()))
+
+	pfState, err := policyfilter.GetState()
+	require.NoError(t, err)
+	t.Cleanup(func() { pfState.Close() })
+
+	targetFile := filepath.Join(t.TempDir(), "target")
+	require.NoError(t, os.WriteFile(targetFile, []byte("test"), 0o600))
+
+	policy := &tracingpolicy.GenericTracingPolicyNamespaced{
+		Metadata: v1.ObjectMeta{
+			Name:      "lsm-policy-filter-test",
+			Namespace: "ns1",
+		},
+		Spec: v1alpha1.TracingPolicySpec{
+			LsmHooks: []v1alpha1.LsmHookSpec{{
+				Hook: "file_open",
+				Args: []v1alpha1.KProbeArg{{Index: 0, Type: "file"}},
+				Selectors: []v1alpha1.KProbeSelector{{
+					MatchArgs: []v1alpha1.ArgSelector{{
+						Index:    0,
+						Operator: "Equal",
+						Values:   []string{targetFile},
+					}},
+					MatchActions: []v1alpha1.ActionSelector{{Action: "Post"}},
+				}},
+			}},
+		},
+	}
+	err = sm.Manager.AddTracingPolicy(ctx, policy)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sm.Manager.DeleteTracingPolicy(ctx, policy.TpName(), policy.TpNamespace(), policy.TpDomain())
+	})
+	err = pfState.AddPodContainer(policyfilter.PodID(uuid.New()), "ns1", nil,
+		"matching-container", matchingCgID, podhelpers.ContainerInfo{Name: "matching-container", Repo: "test"})
+	require.NoError(t, err)
+	err = pfState.AddPodContainer(policyfilter.PodID(uuid.New()), "ns2", nil,
+		"non-matching-container", nonMatchingCgID, podhelpers.ContainerInfo{Name: "non-matching-container", Repo: "test"})
+	require.NoError(t, err)
+
+	events := perfring.RunTestEvents(t, ctx, func() {
+		matchingProcess.run(t, fmt.Sprintf("cat %q >/dev/null", targetFile))
+		for range 5 {
+			nonMatchingProcess.run(t, "cat /dev/null >/dev/null")
+		}
+	})
+
+	count := 0
+	for _, event := range events {
+		if lsm, ok := event.(*tracing.MsgGenericLsmUnix); ok &&
+			lsm.Hook == "file_open" && lsm.PolicyName == policy.TpName() {
+			count++
+		}
+	}
+	require.Equal(t, 1, count)
 }
 
 // usdtPipe is a long running shell used to run the usdt tester program from


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Fixes #5237

### Description
The generic LSM output program can read a stale per CPU message before the core program runs.

In `generic_start_process_filter()`, `lsm.post` and `common.flags` were only cleared after the configuration and policy-filter checks. If an invocation was rejected by one of those checks the function returned early and left the previous state intact. The output program could then emit the last matching event again for an unrelated hook invocation.

This change clears the LSM output state immediately after retrieving the per-CPU message, before any early return.
A same-CPU namespaced regression test was also added to verify that only the expected `file_open` event is delivered.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
bpf: Prevent namespaced LSM policies from emitting stale duplicate events
```
