### PR TITLE
add cve-2026-65960 tracing policy

### DIFF
--- a/examples/tracingpolicy/cves/cve-2026-65960.yaml
+++ b/examples/tracingpolicy/cves/cve-2026-65960.yaml
@@ -1,0 +1,66 @@
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: cve-2026-65960
+  annotations:
+    created-at: '2026-07-02T10:12:45Z'
+    description: Unauthenticated Tetragon gRPC admin API accessible from hostNetwork pods
+spec:
+  kprobes:
+    - call: security_socket_connect
+      syscall: false
+      args:
+        - index: 1
+          type: sockaddr
+      data:
+        - index: 0
+          source: current_task
+          type: uint32
+          resolve: cred.euid.val
+          label: euid
+      selectors:
+        - matchArgs:
+            - index: 1
+              operator: SAddr
+              values:
+                - 127.0.0.1
+            - index: 1
+              operator: SPort
+              values:
+                - '54321'
+          matchNamespaces:
+            - namespace: Cgroup
+              operator: NotIn
+              values:
+                - host_ns
+          matchActions:
+            - action: Post
+            - action: NotifyEnforcer
+              argError: -1
+        - matchArgs:
+            - index: 1
+              operator: SAddr
+              values:
+                - 127.0.0.1
+            - index: 1
+              operator: SPort
+              values:
+                - '54321'
+          matchData:
+            - index: 0
+              operator: NotEqual
+              values:
+                - '0'
+          matchNamespaces:
+            - namespace: Cgroup
+              operator: In
+              values:
+                - host_ns
+          matchActions:
+            - action: Post
+            - action: NotifyEnforcer
+              argError: -1
+      message: cve-embargo vulnerability protection
+  enforcers:
+    - calls:
+        - security_socket_connect


### PR DESCRIPTION


<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
-->



### Description
Adds the recommended tracing policy from the  [security advisory](https://github.com/cilium/tetragon/security/advisories/GHSA-6qqg-3qf7-p3v5) to the list of tracing policies for CVEs
