### PR TITLE
metricsconfig: return bind errors and graceful shutdown for metrics

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -493,7 +493,15 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 	}
 
 	if option.Config.MetricsServer != "" {
-		go metricsconfig.EnableMetrics(option.Config.MetricsServer)
+		stopMetrics, err := metricsconfig.EnableMetrics(option.Config.MetricsServer)
+		if err != nil {
+			log.Error("Failed to start metrics server", "addr", option.Config.MetricsServer, logfields.Error, err)
+		} else {
+			// Deferring stopMetrics covers both the signal path (cancel()
+			// above makes tetragonExecuteCtx return normally) and any error
+			// path below, and waits for the server to actually shut down.
+			defer stopMetrics()
+		}
 
 		reg := metricsconfig.GetRegistry()
 		metricsconfig.InitHealthMetrics(reg)

--- a/pkg/metricsconfig/root.go
+++ b/pkg/metricsconfig/root.go
@@ -4,6 +4,9 @@
 package metricsconfig
 
 import (
+	"context"
+	"errors"
+	"net"
 	"net/http"
 	"sync"
 
@@ -11,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/cilium/tetragon/pkg/logger"
+	"github.com/cilium/tetragon/pkg/logger/logfields"
 )
 
 var (
@@ -25,10 +29,61 @@ func GetRegistry() *prometheus.Registry {
 	return registry
 }
 
-func EnableMetrics(address string) {
+// newMetricsServer builds the metrics server and binds its listener. Binding is
+// separate from serving so that callers observe bind errors synchronously, and
+// so tests can learn the address that was actually bound (e.g. when asking for
+// port 0).
+func newMetricsServer(address string) (*http.Server, net.Listener, error) {
 	reg := GetRegistry()
 
-	logger.GetLogger().Info("Starting metrics server", "addr", address)
-	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
-	http.ListenAndServe(address, nil)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
+
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &http.Server{Handler: mux}, listener, nil
+}
+
+// serve starts serving on the already-bound listener in a background
+// goroutine and returns a stop function. stop gracefully shuts the server down
+// and blocks until the serving goroutine has returned, so callers can rely on
+// the server being fully stopped once stop returns. stop is safe to call
+// multiple times; typically it is deferred right after a successful
+// EnableMetrics.
+func serve(server *http.Server, listener net.Listener) (stop func()) {
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.GetLogger().Error("Metrics server exited unexpectedly", logfields.Error, err)
+		}
+	})
+
+	var stopOnce sync.Once
+	return func() {
+		stopOnce.Do(func() {
+			if err := server.Shutdown(context.Background()); err != nil {
+				logger.GetLogger().Error("Failed to shutdown metrics server", logfields.Error, err)
+			}
+			wg.Wait()
+			logger.GetLogger().Info("Metrics server stopped", "addr", listener.Addr())
+		})
+	}
+}
+
+// EnableMetrics starts a Prometheus metrics HTTP server on the given address.
+// It binds synchronously and returns any bind error to the caller. On success
+// it returns a stop function that gracefully shuts the server down and waits
+// for it to finish; callers should defer stop() so both the signal and the
+// error paths stop the server.
+func EnableMetrics(address string) (stop func(), err error) {
+	server, listener, err := newMetricsServer(address)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.GetLogger().Info("Starting metrics server", "addr", listener.Addr())
+	return serve(server, listener), nil
 }

--- a/pkg/metricsconfig/root_test.go
+++ b/pkg/metricsconfig/root_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metricsconfig
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient returns a client that never reuses connections, so that a
+// request made after the server has shut down actually attempts to dial rather
+// than picking up a pooled connection.
+func newTestClient() *http.Client {
+	return &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+}
+
+// TestEnableMetricsBindError checks that a failure to bind is reported to the
+// caller instead of being silently swallowed, which was the bug behind the
+// metrics server appearing to start while never serving anything.
+func TestEnableMetricsBindError(t *testing.T) {
+	t.Run("address already in use", func(t *testing.T) {
+		occupied, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		t.Cleanup(func() { occupied.Close() })
+
+		stop, err := EnableMetrics(occupied.Addr().String())
+		require.Error(t, err)
+		require.Nil(t, stop)
+	})
+
+	t.Run("malformed address", func(t *testing.T) {
+		stop, err := EnableMetrics(":::::2112")
+		require.Error(t, err)
+		require.Nil(t, stop)
+	})
+}
+
+// TestMetricsServer covers the happy path and the shutdown path of the metrics
+// server. Both subtests share a single server, so they must run sequentially.
+func TestMetricsServer(t *testing.T) {
+	// Registered on the same package-level registry the server is wired to, so
+	// seeing it in the response body proves the handler serves that registry
+	// and not, say, an empty one.
+	counter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "tetragon_metricsconfig_test_total",
+		Help: "Test-only counter asserting the metrics endpoint serves the registry.",
+	})
+	GetRegistry().MustRegister(counter)
+	t.Cleanup(func() { GetRegistry().Unregister(counter) })
+	counter.Inc()
+
+	server, listener, err := newMetricsServer("127.0.0.1:0")
+	require.NoError(t, err)
+
+	stop := serve(server, listener)
+	t.Cleanup(stop)
+
+	url := "http://" + listener.Addr().String() + "/metrics"
+	client := newTestClient()
+
+	t.Run("serves the registry", func(t *testing.T) {
+		// No readiness polling needed: the listener is already bound before
+		// serve is called, so the kernel queues this connection until Serve()
+		// accepts it.
+		resp, err := client.Get(url)
+		require.NoError(t, err)
+		t.Cleanup(func() { resp.Body.Close() })
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "tetragon_metricsconfig_test_total 1")
+	})
+
+	t.Run("shuts down when stop is called", func(t *testing.T) {
+		// stop blocks until the serving goroutine has returned, so once it
+		// completes the server is guaranteed to no longer answer: no polling
+		// needed.
+		stop()
+
+		_, err := client.Get(url)
+		require.Error(t, err, "metrics server still serving after stop returned")
+	})
+}

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -245,7 +245,14 @@ func getDefaultObserver(tb testing.TB, ctx context.Context, initialSensor *senso
 	// at some point in the future. I just don't see a better way that doesn't involve
 	// a lot of code changes in a lot of a files.
 	metricsEnableOnce.Do(func() {
-		go metricsconfig.EnableMetrics(metricsAddr)
+		// The stop function is intentionally discarded: this server is a
+		// singleton for the whole test binary, so it must outlive whichever
+		// test happened to run first, and the OS reclaims it at exit.
+		if _, err := metricsconfig.EnableMetrics(metricsAddr); err != nil {
+			logger.GetLogger().Warn("Failed to start test metrics server, continuing without it",
+				"addr", metricsAddr, logfields.Error, err)
+			return
+		}
 		metricsconfig.InitHealthMetrics(metricsconfig.GetRegistry())
 		metricsconfig.InitEventsMetrics(metricsconfig.GetRegistry())
 	})


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that use Generative AI.
-->
Fixes #5368

### Description

`metricsconfig.EnableMetrics()` discards `http.ListenAndServe()` errors. As noted in #5368, if metrics port was already occupied, Tetragon logged `"Starting metrics server"` and continued without working metrics. Its worth noting that other error types fail in similar ways, such as not having permissions to bind to a priv port, using an invalid tcp port, or invalid IP address, ect.

This PR proposes a few changes:
- `EnableMetrics` binds synchronously via `net.Listen` and returns bind errors. This allows `main.go` to handle the error in whatever way it sees fit.
- It uses a dedicated `*http.Server` with a private `http.ServeMux` so we can shut down gracefully and avoid accidental route pollution from the global mux.
- It returns a stop function that gracefully shuts the server down (`http.Server.Shutdown`) and blocks until the serving goroutine returns (`sync.WaitGroup.Wait`). Callers defer stop(), which covers both the signal and error paths in main without touching cleanupWg, sidestepping the potential deadlock described at cmd/tetragon/main.go:536.

The daemon caller logs the bind error and continues running. This was suggested in #5368, we could easily swap to terminate on startup easily from `main.go` if desired, however the easiest/non breaking change would be to log and continue running so the behavior is observable.

### Manual verification:

Port already in use:
```
python3 -m http.server 2112 --bind 0.0.0.0&
sudo ./tetragon --metrics-server=':2112' --bpf-dir=$(pwd)/bpf/objs --bpf-lib=$(pwd)/bpf/objs
snip...
level=error msg="Failed to start metrics server" addr=:2112 error="listen tcp :2112: bind: address already in use"
```

nonsensical tcp port config:
```
~/tetragon$ sudo ./tetragon --metrics-server=':::::2112' --bpf-dir=$(pwd)/bpf/objs --bpf-lib=$(pwd)/bpf/objs
...snip
level=error msg="Failed to start metrics server" addr=:::::2112 error="listen tcp: address :::::2112: too many colons in address"
```

Non-local IP:
```
sudo ./tetragon --metrics-server=203.0.113.99:2112 --bpf-dir=$(pwd)/bpf/objs --bpf-lib=$(pwd)/bpf/objs
...snip
level=error msg="Failed to start metrics server" addr=203.0.113.99:2112 error="listen tcp 203.0.113.99:2112: bind: cannot assign requested address"
```

Graceful shutdown on SIGTERM:
```
sudo ./tetragon --metrics-server=':2112' --bpf-dir=$(pwd)/bpf/objs --bpf-lib=$(pwd)/bpf/objs
...snip...
level=info msg="Starting metrics server" addr=:::2112
...snip...
level=info msg="Received signal terminated, shutting down..."
level=info msg="Listening for events completed." error="context canceled"
level=info msg="Unloading sensor base"
level=info msg="Sensor unloaded" sensor=base maps-error=[]
level=info msg="Metrics server stopped" addr=:::2112
level=info msg="BPF events statistics: 16 received, 0% events loss"
level=info msg="Observer events statistics" received=16 lost=0 errors=0 filterPass=0 filterDrop=0
```

### Changelog
Surface metrics server bind errors and add graceful shutdown via a caller-deferred stop function.