### PR TITLE
tetragon: Sanitize loader sensor path retrieval

### DIFF
--- a/bpf/process/bpf_loader.c
+++ b/bpf/process/bpf_loader.c
@@ -122,6 +122,8 @@ loader_kprobe(struct pt_regs *ctx)
 
 	path = BPF_CORE_READ(mmap_event, file_name);
 	len = probe_read_str(&msg->path, sizeof(msg->path), path);
+	if (len <= 0)
+		return 0;
 	msg->path_size = (__u32)len;
 
 	msg->pid = tgid;

--- a/pkg/sensors/tracing/loader_linux.go
+++ b/pkg/sensors/tracing/loader_linux.go
@@ -214,6 +214,12 @@ func handleLoader(r *bytes.Reader) ([]observer.Event, error) {
 		return nil, errors.New("failed to read process call msg")
 	}
 
+	if m.PathSize == 0 || m.PathSize > uint32(len(m.Path)) {
+		logger.GetLogger().Warn("loader event has invalid path_size",
+			"path_size", m.PathSize,
+			"max", len(m.Path))
+		return nil, nil
+	}
 	path := m.Path[:m.PathSize-1]
 
 	// We can get multiple entries for given pid/path,


### PR DESCRIPTION
[ upstream commit c6e92166fbdcc309e183c8ac600314f761908329 ]

Make sure to properly check path legth before we use it in both bpf and go code.

Reported-by: Ravindu Priyankara <h.h.a.r.p.premachandra@gmail.com>
Suggested-by: Ravindu Priyankara <h.h.a.r.p.premachandra@gmail.com>