### PR TITLE
[v1.7] tracing: Scope uprobe and usdt events via policyfilter

### DIFF
--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/selectors"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/base"
@@ -414,6 +415,7 @@ func (k *observerUprobeSensor) LoadProbe(args sensors.LoadProbeArgs) error {
 type addUprobeIn struct {
 	sensorPath string
 	policyName string
+	policyID   policyfilter.PolicyID
 	useMulti   bool
 	celExprs   *selectors.CelExprFunctions
 }
@@ -449,9 +451,9 @@ func createGenericUprobeSensor(
 	in := addUprobeIn{
 		sensorPath: name,
 		policyName: polInfo.name,
-
-		useMulti: useMulti,
-		celExprs: celExprs,
+		policyID:   polInfo.policyID,
+		useMulti:   useMulti,
+		celExprs:   celExprs,
 	}
 
 	for _, uprobe := range spec.UProbes {
@@ -727,6 +729,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 	}
 
 	eventConfig := initEventConfig()
+	eventConfig.PolicyID = uint32(in.policyID)
 
 	// Parse ReturnArg, we have two types of return arg parsing. We
 	// support populating an uprobe buffer from uretprobe hooks. This

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/selectors"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/base"
@@ -103,6 +104,7 @@ func genericUsdtTableGet(id idtable.EntryID) (*genericUsdt, error) {
 type addUsdtIn struct {
 	sensorPath string
 	policyName string
+	policyID   policyfilter.PolicyID
 	useMulti   bool
 }
 
@@ -122,6 +124,7 @@ func createGenericUsdtSensor(
 	in := addUsdtIn{
 		sensorPath: name,
 		policyName: polInfo.name,
+		policyID:   polInfo.policyID,
 		useMulti:   !polInfo.specOpts.DisableUprobeMulti && bpf.HasUprobeMulti(),
 	}
 
@@ -329,6 +332,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		}
 
 		config := &api.EventConfig{}
+		config.PolicyID = uint32(in.policyID)
 		found = true
 
 		if len(spec.Args) > api.EventConfigMaxArgs {

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -6,8 +6,10 @@
 package tracing
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,6 +30,7 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/build"
 	tgcgroups "github.com/cilium/tetragon/pkg/cgroups"
+	"github.com/cilium/tetragon/pkg/config"
 	grpcexec "github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
@@ -308,4 +311,222 @@ func TestNamespacedPolicies(t *testing.T) {
 
 	lseekPipeCmd1.Close()
 	lseekPipeCmd2.Close()
+}
+
+// TestUprobeNamespacedPolicy tests namespace filtering on uprobes
+func TestUprobeNamespacedPolicy(t *testing.T) {
+	build.SkipIfK8sDisabled(t)
+	oldEnableK8s := option.Config.EnableK8s
+	option.Config.EnableK8s = true
+	t.Cleanup(func() {
+		option.Config.EnableK8s = oldEnableK8s
+	})
+
+	testutils.CaptureLog(t, logger.GetLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	err := observer.InitDataCache(1024)
+	require.NoError(t, err)
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	err = confmap.UpdateTgRuntimeConf(bpf.MapPrefixPath(), os.Getpid())
+	require.NoError(t, err)
+
+	policyfilter.TestingEnableAndReset(t)
+
+	tus.LoadInitialSensor(t)
+	tus.LoadSensor(t, testsensor.GetTestSensor())
+	sm := tuo.GetTestSensorManager(t)
+
+	// Same trick as TestNamespacedPolicies: put two lseek-pipe commands in two
+	// different cgroups, so that tetragon sets up the cgroup ids in the
+	// execve_map at exec time. Here we do not care about the lseek itself, only
+	// about the exec, which runs main.main: the symbol we attach the uprobe to.
+	lseekPipeCmd1 := testutils.NewLseekPipe(t, ctx)
+	lseekPipeCmd2 := testutils.NewLseekPipe(t, ctx)
+	defer lseekPipeCmd1.Close()
+	defer lseekPipeCmd2.Close()
+	cgDir1 := fmt.Sprintf("%s.cgroup1.%s.slice", t.Name(), time.Now().Format("20060102150405"))
+	cgDir2 := fmt.Sprintf("%s.cgroup2.%s.slice", t.Name(), time.Now().Format("20060102150405"))
+	cgID1 := createCgroup(t, cgDir1, uint64(lseekPipeCmd1.Pid()))
+	cgID2 := createCgroup(t, cgDir2, uint64(lseekPipeCmd2.Pid()))
+
+	// Pretend that our two cgroups are containers, and add them to the
+	// policyfilter state: the first one in the "ns1" namespace the policy is
+	// installed in, the second one in "ns2".
+	pfState, err := policyfilter.GetState()
+	require.NoError(t, err)
+	t.Cleanup(func() { pfState.Close() })
+	err = pfState.AddPodContainer(policyfilter.PodID(uuid.New()), "ns1", nil,
+		"pod1-container1", cgID1, podhelpers.ContainerInfo{Name: "container-name1", Repo: "container-repo1"})
+	require.NoError(t, err)
+	err = pfState.AddPodContainer(policyfilter.PodID(uuid.New()), "ns2", nil,
+		"pod1-container2", cgID2, podhelpers.ContainerInfo{Name: "container-name2", Repo: "container-repo2"})
+	require.NoError(t, err)
+
+	symbol := "main.main"
+	upPolicyConf := tracingpolicy.GenericTracingPolicyNamespaced{
+		Metadata: v1.ObjectMeta{
+			Name:      "uprobe-test",
+			Namespace: "ns1",
+		},
+		Spec: v1alpha1.TracingPolicySpec{
+			UProbes: []v1alpha1.UProbeSpec{{
+				Path:    testutils.RepoRootPath("contrib/tester-progs/lseek-pipe"),
+				Symbols: []string{symbol},
+			}},
+		},
+	}
+	err = sm.Manager.AddTracingPolicy(ctx, &upPolicyConf)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sm.Manager.DeleteTracingPolicy(ctx, upPolicyConf.TpName(), upPolicyConf.TpNamespace())
+	})
+
+	countUprobes := func(trigger func()) int {
+		count := 0
+		for _, ev := range perfring.RunTestEvents(t, ctx, trigger) {
+			if up, ok := ev.(*tracing.MsgGenericUprobeUnix); ok && up.Symbol == symbol {
+				count++
+			}
+		}
+		return count
+	}
+
+	require.Equal(t, 1, countUprobes(func() {
+		t.Logf("%s", lseekPipeCmd1.Lseek(-42, 0, 0))
+	}))
+	require.Equal(t, 0, countUprobes(func() {
+		t.Logf("%s", lseekPipeCmd2.Lseek(-42, 0, 0))
+	}))
+}
+
+// usdtPipe is a long running shell used to run the usdt tester program from
+// within a specific cgroup: the shell is added to the cgroup and the program
+// it spawns inherits it.
+type usdtPipe struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+}
+
+//revive:disable:context-as-argument
+func newUsdtPipe(t *testing.T, ctx context.Context) *usdtPipe {
+	cmd := exec.CommandContext(ctx, "/bin/sh")
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		stdin.Close()
+		cmd.Wait()
+	})
+	return &usdtPipe{cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdout)}
+}
+
+//revive:enable:context-as-argument
+
+func (up *usdtPipe) pid() int {
+	return up.cmd.Process.Pid
+}
+
+// run executes bin and returns once it exited, so that the usdt event it
+// triggers is guaranteed to be in the ring buffer.
+func (up *usdtPipe) run(t *testing.T, bin string) {
+	_, err := fmt.Fprintf(up.stdin, "%s; echo done\n", bin)
+	require.NoError(t, err)
+	line, err := up.stdout.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "done\n", line)
+}
+
+// TestUsdtNamespacedPolicy tests namespace filtering on usdts
+func TestUsdtNamespacedPolicy(t *testing.T) {
+	if !config.EnableLargeProgs() || !bpf.HasUprobeRefCtrOffset() {
+		t.Skip("Need 5.3 or newer kernel for usdt and uprobe ref_ctr_off support for this test.")
+	}
+	build.SkipIfK8sDisabled(t)
+	oldEnableK8s := option.Config.EnableK8s
+	option.Config.EnableK8s = true
+	t.Cleanup(func() {
+		option.Config.EnableK8s = oldEnableK8s
+	})
+
+	testutils.CaptureLog(t, logger.GetLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	err := observer.InitDataCache(1024)
+	require.NoError(t, err)
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	err = confmap.UpdateTgRuntimeConf(bpf.MapPrefixPath(), os.Getpid())
+	require.NoError(t, err)
+
+	policyfilter.TestingEnableAndReset(t)
+
+	tus.LoadInitialSensor(t)
+	tus.LoadSensor(t, testsensor.GetTestSensor())
+	sm := tuo.GetTestSensorManager(t)
+
+	// Same trick as TestNamespacedPolicies: put two shells in two different
+	// cgroups, so that tetragon sets up the cgroup ids in the execve_map at
+	// exec time. The usdt tester program each shell runs inherits its cgroup.
+	usdtPipe1 := newUsdtPipe(t, ctx)
+	usdtPipe2 := newUsdtPipe(t, ctx)
+	cgDir1 := fmt.Sprintf("%s.cgroup1.%s.slice", t.Name(), time.Now().Format("20060102150405"))
+	cgDir2 := fmt.Sprintf("%s.cgroup2.%s.slice", t.Name(), time.Now().Format("20060102150405"))
+	cgID1 := createCgroup(t, cgDir1, uint64(usdtPipe1.pid()))
+	cgID2 := createCgroup(t, cgDir2, uint64(usdtPipe2.pid()))
+
+	// Pretend that our two cgroups are containers, and add them to the
+	// policyfilter state: the first one in the "ns1" namespace the policy is
+	// installed in, the second one in "ns2".
+	pfState, err := policyfilter.GetState()
+	require.NoError(t, err)
+	t.Cleanup(func() { pfState.Close() })
+	err = pfState.AddPodContainer(policyfilter.PodID(uuid.New()), "ns1", nil,
+		"pod1-container1", cgID1, podhelpers.ContainerInfo{Name: "container-name1", Repo: "container-repo1"})
+	require.NoError(t, err)
+	err = pfState.AddPodContainer(policyfilter.PodID(uuid.New()), "ns2", nil,
+		"pod1-container2", cgID2, podhelpers.ContainerInfo{Name: "container-name2", Repo: "container-repo2"})
+	require.NoError(t, err)
+
+	usdtBin := testutils.RepoRootPath("contrib/tester-progs/usdt")
+	provider, name := "test", "usdt0"
+	usdtPolicyConf := tracingpolicy.GenericTracingPolicyNamespaced{
+		Metadata: v1.ObjectMeta{
+			Name:      "usdt-test",
+			Namespace: "ns1",
+		},
+		Spec: v1alpha1.TracingPolicySpec{
+			Usdts: []v1alpha1.UsdtSpec{{
+				Path:     usdtBin,
+				Provider: provider,
+				Name:     name,
+			}},
+		},
+	}
+	err = sm.Manager.AddTracingPolicy(ctx, &usdtPolicyConf)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sm.Manager.DeleteTracingPolicy(ctx, usdtPolicyConf.TpName(), usdtPolicyConf.TpNamespace())
+	})
+
+	countUsdts := func(trigger func()) int {
+		count := 0
+		for _, ev := range perfring.RunTestEvents(t, ctx, trigger) {
+			if u, ok := ev.(*tracing.MsgGenericUsdtUnix); ok && u.Provider == provider && u.Name == name {
+				count++
+			}
+		}
+		return count
+	}
+
+	require.Equal(t, 1, countUsdts(func() {
+		usdtPipe1.run(t, usdtBin)
+	}))
+	require.Equal(t, 0, countUsdts(func() {
+		usdtPipe2.run(t, usdtBin)
+	}))
 }

--- a/pkg/sensors/tracing/uprobe_validation_test.go
+++ b/pkg/sensors/tracing/uprobe_validation_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/testutils"
 )
 
@@ -41,4 +42,21 @@ spec:
 
 	err := checkCrd(t, crd)
 	require.Error(t, err)
+}
+
+func TestUprobeEventConfigCarriesPolicyID(t *testing.T) {
+	spec := &v1alpha1.UProbeSpec{
+		Path:    testutils.RepoRootPath("contrib/tester-progs/uprobe-test-1"),
+		Symbols: []string{"main"},
+	}
+
+	ids, err := addUprobe(spec, nil, &addUprobeIn{policyID: 7}, &uprobeHas{})
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	for _, id := range ids {
+		uprobeEntry, err := genericUprobeTableGet(id)
+		require.NoError(t, err)
+		require.Equal(t, uint32(7), uprobeEntry.loadArgs.config.PolicyID)
+	}
 }

--- a/pkg/sensors/tracing/usdt_validation_test.go
+++ b/pkg/sensors/tracing/usdt_validation_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	"github.com/cilium/tetragon/pkg/testutils"
 )
 
@@ -77,4 +78,28 @@ spec:
 
 	err := checkCrd(t, crd)
 	require.Error(t, err)
+}
+
+func TestUsdtEventConfigCarriesPolicyID(t *testing.T) {
+	spec := &v1alpha1.UsdtSpec{
+		Path:     testutils.RepoRootPath("contrib/tester-progs/usdt"),
+		Provider: "test",
+		Name:     "usdt0",
+	}
+
+	ids, err := addUsdt(spec, &addUsdtIn{policyID: 7}, nil, &usdtHas{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, id := range ids {
+			_, err := usdtTable.RemoveEntry(id)
+			require.NoError(t, err)
+		}
+	})
+	require.NotEmpty(t, ids)
+
+	for _, id := range ids {
+		usdtEntry, err := genericUsdtTableGet(id)
+		require.NoError(t, err)
+		require.Equal(t, uint32(7), usdtEntry.config.PolicyID)
+	}
 }


### PR DESCRIPTION
 * [ ] #5348 (@sayboras) :warning: resolved conflicts

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 5348
```

```release-note
tracing: Scope uprobe and usdt events via policyfilter
```
