### PR TITLE
[v1.5] tracing: Scope uprobe events via policyfilter

### DIFF
--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/tetragon/pkg/logger/logfields"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
+	"github.com/cilium/tetragon/pkg/policyfilter"
 	"github.com/cilium/tetragon/pkg/selectors"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/sensors/base"
@@ -250,6 +251,7 @@ func isValidUprobeSelectors(selectors []v1alpha1.KProbeSelector) error {
 type addUprobeIn struct {
 	sensorPath string
 	policyName string
+	policyID   policyfilter.PolicyID
 	useMulti   bool
 }
 
@@ -266,6 +268,7 @@ func createGenericUprobeSensor(
 	in := addUprobeIn{
 		sensorPath: name,
 		policyName: polInfo.name,
+		policyID:   polInfo.policyID,
 
 		// use multi kprobe only if:
 		// - it's not disabled by spec option
@@ -411,6 +414,7 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 		}
 
 		config := initEventConfig()
+		config.PolicyID = uint32(in.policyID)
 		config.ArgType = argTypes
 		config.ArgMeta = argMeta
 		config.ArgIndex = argIdx

--- a/pkg/sensors/tracing/policyfilter_test.go
+++ b/pkg/sensors/tracing/policyfilter_test.go
@@ -16,12 +16,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/bpf"
 	tgcgroups "github.com/cilium/tetragon/pkg/cgroups"
 	grpcexec "github.com/cilium/tetragon/pkg/grpc/exec"
 	"github.com/cilium/tetragon/pkg/grpc/tracing"
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/logger"
 	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/option"
@@ -35,8 +39,6 @@ import (
 	"github.com/cilium/tetragon/pkg/testutils/perfring"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
-	"github.com/google/uuid"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/containerd/cgroups"
 	cgroupsv2 "github.com/containerd/cgroups/v2"
@@ -300,4 +302,95 @@ func TestNamespacedPolicies(t *testing.T) {
 
 	lseekPipeCmd1.Close()
 	lseekPipeCmd2.Close()
+}
+
+// TestUprobeNamespacedPolicy tests namespace filtering on uprobes
+func TestUprobeNamespacedPolicy(t *testing.T) {
+	if !kernels.MinKernelVersion("5.10") {
+		t.Skip("uprobe policyfilter scoping requires kernel >= 5.10")
+	}
+
+	oldEnableK8s := option.Config.EnableK8s
+	option.Config.EnableK8s = true
+	t.Cleanup(func() {
+		option.Config.EnableK8s = oldEnableK8s
+	})
+
+	testutils.CaptureLog(t, logger.GetLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	err := observer.InitDataCache(1024)
+	require.NoError(t, err)
+	option.Config.HubbleLib = tus.Conf().TetragonLib
+	err = confmap.UpdateTgRuntimeConf(bpf.MapPrefixPath(), os.Getpid())
+	require.NoError(t, err)
+
+	policyfilter.TestingEnableAndReset(t)
+
+	tus.LoadInitialSensor(t)
+	tus.LoadSensor(t, testsensor.GetTestSensor())
+	sm := tuo.GetTestSensorManager(t)
+
+	// Same trick as TestNamespacedPolicies: put two lseek-pipe commands in two
+	// different cgroups, so that tetragon sets up the cgroup ids in the
+	// execve_map at exec time. Here we do not care about the lseek itself, only
+	// about the exec, which runs main.main: the symbol we attach the uprobe to.
+	lseekPipeCmd1 := testutils.NewLseekPipe(t, ctx)
+	lseekPipeCmd2 := testutils.NewLseekPipe(t, ctx)
+	defer lseekPipeCmd1.Close()
+	defer lseekPipeCmd2.Close()
+	cgDir1 := fmt.Sprintf("%s.cgroup1.%s.slice", t.Name(), time.Now().Format("20060102150405"))
+	cgDir2 := fmt.Sprintf("%s.cgroup2.%s.slice", t.Name(), time.Now().Format("20060102150405"))
+	cgID1 := createCgroup(t, cgDir1, uint64(lseekPipeCmd1.Pid()))
+	cgID2 := createCgroup(t, cgDir2, uint64(lseekPipeCmd2.Pid()))
+
+	// Pretend that our two cgroups are containers, and add them to the
+	// policyfilter state: the first one in the "ns1" namespace the policy is
+	// installed in, the second one in "ns2".
+	pfState, err := policyfilter.GetState()
+	require.NoError(t, err)
+	t.Cleanup(func() { pfState.Close() })
+	err = pfState.AddPodContainer(policyfilter.PodID(uuid.New()), "ns1", "wl1", "kind1", nil,
+		"pod1-container1", cgID1, podhelpers.ContainerInfo{Name: "container-name1", Repo: "container-repo1"})
+	require.NoError(t, err)
+	err = pfState.AddPodContainer(policyfilter.PodID(uuid.New()), "ns2", "wl2", "kind2", nil,
+		"pod1-container2", cgID2, podhelpers.ContainerInfo{Name: "container-name2", Repo: "container-repo2"})
+	require.NoError(t, err)
+
+	symbol := "main.main"
+	upPolicyConf := tracingpolicy.GenericTracingPolicyNamespaced{
+		Metadata: v1.ObjectMeta{
+			Name:      "uprobe-test",
+			Namespace: "ns1",
+		},
+		Spec: v1alpha1.TracingPolicySpec{
+			UProbes: []v1alpha1.UProbeSpec{{
+				Path:    testutils.RepoRootPath("contrib/tester-progs/lseek-pipe"),
+				Symbols: []string{symbol},
+			}},
+		},
+	}
+	err = sm.Manager.AddTracingPolicy(ctx, &upPolicyConf)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sm.Manager.DeleteTracingPolicy(ctx, upPolicyConf.TpName(), upPolicyConf.TpNamespace())
+	})
+
+	countUprobes := func(trigger func()) int {
+		count := 0
+		for _, ev := range perfring.RunTestEvents(t, ctx, trigger) {
+			if up, ok := ev.(*tracing.MsgGenericUprobeUnix); ok && up.Symbol == symbol {
+				count++
+			}
+		}
+		return count
+	}
+
+	require.Equal(t, 1, countUprobes(func() {
+		t.Logf("%s", lseekPipeCmd1.Lseek(-42, 0, 0))
+	}))
+	require.Equal(t, 0, countUprobes(func() {
+		t.Logf("%s", lseekPipeCmd2.Lseek(-42, 0, 0))
+	}))
 }


### PR DESCRIPTION
 * [ ] #5348 (@sayboras) :warning: resolved conflicts

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 5348
```

```release-note
tracing: Scope uprobe events via policyfilter - #5407
```