### PR TITLE
docs: add a release cadence note to the contribution guide

### DIFF
--- a/docs/content/en/docs/contribution-guide/release-cadence.md
+++ b/docs/content/en/docs/contribution-guide/release-cadence.md
@@ -1,0 +1,15 @@
+---
+title: "Release cadence"
+weight: 9
+description: "When Tetragon publishes minor and patch releases."
+---
+
+Tetragon minor releases (`X.Y.0`) follow a roughly six-month schedule,
+similar to [Cilium](https://docs.cilium.io/en/stable/contributing/release/organization/#release-cadence).
+
+Patch releases (`X.Y.Z`) do not follow a fixed calendar. They are published
+on demand when users need fixes. Bug fixes are backported onto maintained
+stable branches (including updates of critical packages).
+
+Published releases are listed on the
+[GitHub releases page](https://github.com/cilium/tetragon/releases).

--- a/docs/content/en/docs/contribution-guide/release-notes.md
+++ b/docs/content/en/docs/contribution-guide/release-notes.md
@@ -5,6 +5,7 @@ description: "Guide on how to write release notes for new contributions."
 ---
 
 Tetragon release notes are published on the [GitHub releases page](https://github.com/cilium/tetragon/releases).
+For when releases are published, see [Release cadence]({{< ref "/docs/contribution-guide/release-cadence" >}}).
 To ensure the release notes are accurate and helpful, contributors should write them alongside development. Then, at
 the time of release, the final notes are compiled and published.
 


### PR DESCRIPTION
Fixes #4893

### Description

Adds a short release cadence section to the contribution guide, using the wording already given on the issue: minor releases on a roughly six-month schedule like Cilium; patch releases on demand, with backports onto maintained stable branches.

- [x] Commits are signed-off
- [x] Docs-only; no generated files
- [x] Suggested label: release-note/docs

### Changelog

```release-note
Document Tetragon's release cadence in the contribution guide.
```
