### PR TITLE
tetragon: fixing debug maps output

### DIFF
--- a/bpf/process/uprobe_offload.h
+++ b/bpf/process/uprobe_offload.h
@@ -44,6 +44,7 @@ struct {
 	__uint(max_entries, 1); // will be resized by agent when needed
 	__type(key, __u64);
 	__type(value, __u32);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } sleepable_offload SEC(".maps");
 
 FUNC_INLINE void do_uprobe_override(void *ctx, __u32 idx)

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -279,6 +279,10 @@ options:
       default_value: "false"
       usage: |
         Require and verify client certificates (mTLS). Requires --server-tls-client-ca-files.
+    - name: sleepable-offload-size
+      default_value: "32768"
+      usage: |
+        Set the maximum number of entries in the sleepable offload map
     - name: sleepable-preload-size
       default_value: "32768"
       usage: |

--- a/pkg/bugtool/maps.go
+++ b/pkg/bugtool/maps.go
@@ -327,38 +327,54 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 		})
 	}
 
-	// aggregates maps total memory use
-	aggregatedMapsSet := map[string]struct {
-		bpf.ExtendedMapInfo
-		count uint64
+	// aggregates maps total memory use. key on these five fields
+	type aggregatedKey struct {
+		Name       string
+		Type       ebpf.MapType
+		KeySize    uint32
+		ValueSize  uint32
+		MaxEntries uint32
+	}
+
+	aggregatedMapsSet := map[aggregatedKey]struct {
+		Count        uint64
+		TotalMemlock uint64
 	}{}
 	var total uint64
 	for _, m := range union {
 		total += m.Memlock
-		if e, exist := aggregatedMapsSet[m.Name]; exist {
-			e.Memlock += m.Memlock
-			e.count++
-			aggregatedMapsSet[m.Name] = e
-		} else {
-			aggregatedMapsSet[m.Name] = struct {
-				bpf.ExtendedMapInfo
-				count uint64
-			}{m, 1}
+		key := aggregatedKey{
+			Name:       m.Name,
+			Type:       m.Type,
+			KeySize:    m.KeySize,
+			ValueSize:  m.ValueSize,
+			MaxEntries: m.MaxEntries,
 		}
+		if e, exists := aggregatedMapsSet[key]; exists {
+			e.Count++
+			e.TotalMemlock += m.Memlock
+			aggregatedMapsSet[key] = e
+		} else {
+			aggregatedMapsSet[key] = struct {
+				Count        uint64
+				TotalMemlock uint64
+			}{1, m.Memlock}
+		}
+
 	}
 
 	out.AggregatedMaps = make([]AggregatedMap, 0, len(aggregatedMapsSet))
-	for m := range maps.Values(aggregatedMapsSet) {
+	for k, m := range aggregatedMapsSet {
 		out.AggregatedMaps = append(out.AggregatedMaps, AggregatedMap{
-			Name:              m.Name,
-			Type:              m.Type.String(),
-			KeySize:           m.KeySize,
-			ValueSize:         m.ValueSize,
-			MaxEntries:        m.MaxEntries,
-			Count:             m.count,
-			MemlockBytes:      m.Memlock,
-			TotalMemlockBytes: m.Memlock * m.count,
-			PercentOfTotal:    float64(m.Memlock*m.count) / float64(total) * 100,
+			Name:              k.Name,
+			Type:              k.Type.String(),
+			KeySize:           k.KeySize,
+			ValueSize:         k.ValueSize,
+			MaxEntries:        k.MaxEntries,
+			Count:             m.Count,
+			MemlockBytes:      m.TotalMemlock / m.Count,
+			TotalMemlockBytes: m.TotalMemlock,
+			PercentOfTotal:    float64(m.TotalMemlock) / float64(total) * 100,
 		})
 	}
 

--- a/pkg/bugtool/maps.go
+++ b/pkg/bugtool/maps.go
@@ -9,6 +9,7 @@ import (
 	"iter"
 	"maps"
 	"os"
+	"path/filepath"
 	"sort"
 	"syscall"
 
@@ -103,6 +104,10 @@ func FindPinnedMaps(path string) ([]bpf.ExtendedMapInfo, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve extended info from map %v: %w", m, err)
 		}
+
+		// The map name returned from ExtendedInfoFromMap is truncated to 15
+		// characters. It's more helpful to the user to have the full name
+		xInfo.Name = filepath.Base(pin.Path)
 		infos = append(infos, xInfo)
 	}
 
@@ -292,7 +297,10 @@ func RunMapsChecks(path string) (*MapsChecksOutput, error) {
 	}
 
 	diff := diff(pinnedMapsSet, pinnedProgsMapsSet)
-	union := union(pinnedMapsSet, pinnedProgsMapsSet)
+
+	// put pinnedMapsSet second so full map names overwrite truncated names in
+	// pinnedProgsMapsSet when constructing the union
+	union := union(pinnedProgsMapsSet, pinnedMapsSet)
 
 	out.MapsStats.PinnedProgsMaps = len(pinnedProgsMapsSet)
 	out.MapsStats.PinnedMaps = len(pinnedMaps)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -75,6 +75,9 @@ const (
 	// DefaultSleepablePreloadSize is the default maximum number of entries in the sleepable preload map.
 	DefaultSleepablePreloadSize = 32768
 
+	// DefaultSleepableOffloadSize is the default maximum number of entries in the sleepable offload map.
+	DefaultSleepableOffloadSize = 32768
+
 	// DefaultMaxGRPCRecvMsgSize is the default maximum gRPC receive message
 	// size for the tetra CLI (10MB).
 	DefaultMaxGRPCRecvMsgSize = 10 * 1024 * 1024

--- a/pkg/defaults/defaults_windows.go
+++ b/pkg/defaults/defaults_windows.go
@@ -62,6 +62,9 @@ const (
 	// DefaultSleepablePreloadSize is the default maximum number of entries in the sleepable preload map.
 	DefaultSleepablePreloadSize = 32768
 
+	// DefaultSleepableOffloadSize is the default maximum number of entries in the sleepable offload map.
+	DefaultSleepableOffloadSize = 32768
+
 	// DefaultMaxGRPCRecvMsgSize is the default maximum gRPC receive message
 	// size for the tetra CLI (10MB).
 	DefaultMaxGRPCRecvMsgSize = 10 * 1024 * 1024

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -143,6 +143,7 @@ type config struct {
 	RetprobesCacheSize int
 
 	SleepablePreloadSize int
+	SleepableOffloadSize int
 
 	EnableGRPCDeprecatedTP bool
 
@@ -190,6 +191,9 @@ var (
 
 		// Set default value for sleepable preload maps.
 		SleepablePreloadSize: defaults.DefaultSleepablePreloadSize,
+
+		// Set default value for sleepable offload maps.
+		SleepableOffloadSize: defaults.DefaultSleepableOffloadSize,
 
 		// Set default value for deleted pod lru cache
 		DeletedPodCacheSize: constants.WatcherDeletedPodCacheSize,

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -94,6 +94,7 @@ const (
 	KeyDisableUprobeMulti = "disable-uprobe-multi"
 
 	KeySleepablePreloadSize = "sleepable-preload-size"
+	KeySleepableOffloadSize = "sleepable-offload-size"
 
 	KeyUsePerfRingBuffer = "use-perf-ring-buffer"
 	KeyRBSize            = "rb-size"
@@ -339,6 +340,7 @@ func ReadAndSetFlags() error {
 	Config.RetprobesCacheSize = viper.GetInt(KeyRetprobesCacheSize)
 
 	Config.SleepablePreloadSize = viper.GetInt(KeySleepablePreloadSize)
+	Config.SleepableOffloadSize = viper.GetInt(KeySleepableOffloadSize)
 
 	Config.EnableGRPCDeprecatedTP = viper.GetBool(KeyEnableDeprecatedTPGRPC)
 
@@ -603,6 +605,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.Int(KeyRetprobesCacheSize, defaults.DefaultRetprobesCacheSize, "Set {k,u}retprobes events cache maximum size")
 
 	flags.Int(KeySleepablePreloadSize, defaults.DefaultSleepablePreloadSize, "Set the maximum number of entries in the sleepable preload map")
+	flags.Int(KeySleepableOffloadSize, defaults.DefaultSleepableOffloadSize, "Set the maximum number of entries in the sleepable offload map")
 
 	flags.Bool(KeyEnableDeprecatedTPGRPC, false, "Enable deprecated gRPC TracingPolicy APIs")
 

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -468,6 +468,7 @@ type uprobeHas struct {
 	sleepablePreload     bool
 	substring            bool
 	sleepablePreloadSize int
+	sleepableOffloadSize int
 }
 
 func validateMultiUprobeConsistency(uprobes []v1alpha1.UProbeSpec) error {
@@ -900,6 +901,9 @@ func createGenericUprobeSensor(
 
 	// user sleepable_preload override
 	has.sleepablePreloadSize = polInfo.specOpts.SleepablePreloadSize
+
+	// user sleepable_offload override
+	has.sleepableOffloadSize = polInfo.specOpts.SleepableOffloadSize
 
 	if useMulti {
 		// if we are using multi-uprobe, CEL expressions are shared across all uprobes
@@ -1423,6 +1427,19 @@ func getSleepablePreloadMap(userSize int, load *program.Program) *program.Map {
 	return m
 }
 
+func getSleepableOffloadMap(userSize int, load *program.Program) *program.Map {
+	var m *program.Map
+
+	if userSize != 0 {
+		m = program.MapBuilderProgram("sleepable_offload", load)
+		m.SetMaxEntries(userSize)
+	} else {
+		m = program.MapShared("sleepable_offload", load)
+		m.SetMaxEntries(option.Config.SleepableOffloadSize)
+	}
+	return m
+}
+
 func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []idtable.EntryID, has uprobeHas) ([]*program.Program, []*program.Map, error) {
 	var multiRetIDs []idtable.EntryID
 	var progs []*program.Program
@@ -1485,8 +1502,7 @@ func createMultiUprobeSensor(polInfo *policyInfo, sensorPath string, multiIDs []
 	if has.sleepableOffload {
 		regsMap := program.MapBuilderProgram("regs_map", load)
 		regsMap.SetMaxEntries(max(regsMapEntries, 1))
-		sleepableOffloadMap := program.MapBuilderProgram("sleepable_offload", load)
-		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
+		sleepableOffloadMap := getSleepableOffloadMap(has.sleepableOffloadSize, load)
 		maps = append(maps, regsMap, sleepableOffloadMap)
 	}
 
@@ -1600,8 +1616,7 @@ func createUprobeSensorFromEntry(polInfo *policyInfo, uprobeEntry *genericUprobe
 		// in the same policy needs the override action)
 		regsMapEntries := max(len(uprobeEntry.loadArgs.selectors.entry.Regs()), 1)
 		regsMap.SetMaxEntries(regsMapEntries)
-		sleepableOffloadMap := program.MapBuilderProgram("sleepable_offload", load)
-		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
+		sleepableOffloadMap := getSleepableOffloadMap(has.sleepableOffloadSize, load)
 		maps = append(maps, regsMap, sleepableOffloadMap)
 	}
 

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -252,8 +252,8 @@ func createMultiUsdtSensor(
 	maps = append(maps, createSelectorMaps(load, nil)...)
 
 	if has.sleepableOffload {
-		sleepableOffloadMap := program.MapBuilderProgram("write_offload", load)
-		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
+		sleepableOffloadMap := program.MapShared("write_offload", load)
+		sleepableOffloadMap.SetMaxEntries(option.Config.SleepableOffloadSize)
 		maps = append(maps, sleepableOffloadMap)
 	}
 
@@ -323,8 +323,8 @@ func createUsdtSensorFromEntry(polInfo *policyInfo, usdtEntry *genericUsdt,
 	maps = append(maps, createSelectorMaps(load, usdtEntry.selectors)...)
 
 	if has.sleepableOffload {
-		sleepableOffloadMap := program.MapBuilderProgram("write_offload", load)
-		sleepableOffloadMap.SetMaxEntries(sleepableOffloadMaxEntries)
+		sleepableOffloadMap := program.MapShared("write_offload", load)
+		sleepableOffloadMap.SetMaxEntries(option.Config.SleepableOffloadSize)
 		maps = append(maps, sleepableOffloadMap)
 	}
 

--- a/pkg/sensors/tracing/options.go
+++ b/pkg/sensors/tracing/options.go
@@ -46,6 +46,7 @@ type specOptions struct {
 	DisableKprobeMulti   bool
 	DisableUprobeMulti   bool
 	SleepablePreloadSize int
+	SleepableOffloadSize int
 	OverrideMethod       OverrideMethod
 	policyMode           policyconf.Mode
 }
@@ -105,6 +106,19 @@ var opts = map[string]opt{
 				return fmt.Errorf("sleepable-preload-size must be positive, got %d", size)
 			}
 			options.SleepablePreloadSize = size
+			return nil
+		},
+	},
+	option.KeySleepableOffloadSize: {
+		set: func(str string, options *specOptions) (err error) {
+			size, err := strconv.Atoi(str)
+			if err != nil {
+				return err
+			}
+			if size <= 0 {
+				return fmt.Errorf("sleepable-offload-size must be positive, got %d", size)
+			}
+			options.SleepableOffloadSize = size
 			return nil
 		},
 	},

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -1290,22 +1290,45 @@ spec:
 }
 
 func TestUprobeSleepablePreloadMapConfig(t *testing.T) {
-	testUprobeSleepablePreloadMapConfig(t, false)
+	testUprobeSleepableMapsConfig(t, "sleepable_preload", false)
+}
+
+func TestUprobeSleepableOffloadMapConfig(t *testing.T) {
+	testUprobeSleepableMapsConfig(t, "sleepable_offload", false)
 }
 
 func TestUprobeSleepablePreloadMapConfigWithMax(t *testing.T) {
-	testUprobeSleepablePreloadMapConfig(t, true)
+	testUprobeSleepableMapsConfig(t, "sleepable_preload", true)
 }
 
-func testUprobeSleepablePreloadMapConfig(t *testing.T, withMax bool) {
+func TestUprobeSleepableOffloadMapConfigWithMax(t *testing.T) {
+	testUprobeSleepableMapsConfig(t, "sleepable_offload", true)
+}
+
+func testUprobeSleepableMapsConfig(t *testing.T, mapName string, withMax bool) {
 	if !bpf.HasKfunc("bpf_copy_from_user_str") {
 		t.Skip("skipping, no string preload support")
 	}
 	if runtime.GOARCH == "arm64" {
 		t.Skip("skipping, x86_64 only test")
 	}
+	if mapName == "sleepable_offload" && !bpf.HasUprobeRegsChange() {
+		t.Skip("skipping, no regs change support in kernel")
+	}
 
 	testBinary := testutils.RepoRootPath("contrib/tester-progs/regs-override")
+
+	selectors := ""
+
+	if mapName == "sleepable_offload" {
+		selectors = `
+    selectors:
+    - matchActions:
+      - action: Override
+        argRegs:
+        - "rip=7%rip"
+`
+	}
 
 	// uprobe policy with a preload data argument; opts is the options block (may be empty)
 	policy := func(opts string) string {
@@ -1313,7 +1336,7 @@ func testUprobeSleepablePreloadMapConfig(t *testing.T, withMax bool) {
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
-  name: "preload"
+  name: "sleepable"
 spec:` + opts + `
   uprobes:
   - path: "` + testBinary + `"
@@ -1323,8 +1346,7 @@ spec:` + opts + `
     - index: 0
       type: "string"
       source: "pt_regs"
-      resolve: "rdi"
-`
+      resolve: "rdi"` + selectors
 	}
 
 	loadSensors := func(t *testing.T, config string) []*sensors.Sensor {
@@ -1343,10 +1365,10 @@ spec:` + opts + `
 		sensors.UnloadSensors(sensi)
 	}
 
-	findPreloadMap := func(sens []*sensors.Sensor) *program.Map {
+	findSleepableMap := func(sens []*sensors.Sensor) *program.Map {
 		for _, s := range sens {
 			for _, m := range s.Maps {
-				if m.Name == "sleepable_preload" {
+				if m.Name == mapName {
 					return m
 				}
 			}
@@ -1362,40 +1384,59 @@ spec:` + opts + `
 	}
 
 	if withMax {
-		originalSize := option.Config.SleepablePreloadSize
-		option.Config.SleepablePreloadSize = 2048
-		t.Cleanup(func() { option.Config.SleepablePreloadSize = originalSize })
+		if mapName == "sleepable_preload" {
+			originalSize := option.Config.SleepablePreloadSize
+			option.Config.SleepablePreloadSize = 2048
+			t.Cleanup(func() { option.Config.SleepablePreloadSize = originalSize })
+		} else {
+			originalSize := option.Config.SleepableOffloadSize
+			option.Config.SleepableOffloadSize = 2048
+			t.Cleanup(func() { option.Config.SleepableOffloadSize = originalSize })
+		}
 	}
 
-	// sleepable_preload as MapShared at global scope (/sys/fs/bpf/tetragon/sleepable_preload)
+	// sleepable_preload/offload as MapShared at global scope (/sys/fs/bpf/tetragon/sleepable_[preload|offload])
 	t.Run("shared", func(t *testing.T) {
 		sens := loadSensors(t, policy(""))
 		defer unloadSensors(sens)
 
-		m := findPreloadMap(sens)
-		require.NotNil(t, m, "sleepable_preload map not found in sensor")
+		m := findSleepableMap(sens)
+		logger.GetLogger().Info("Sensor list")
+		require.NotNil(t, m, mapName+" map not found in sensor")
 
-		assert.Equal(t, "sleepable_preload", m.PinPath)
+		assert.Equal(t, mapName, m.PinPath)
 		if withMax {
 			assert.Equal(t, uint32(2048), getMaxEntries(m))
 		} else {
-			assert.Equal(t, uint32(defaults.DefaultSleepablePreloadSize), getMaxEntries(m))
+			if mapName == "sleepable_preload" {
+				assert.Equal(t, uint32(defaults.DefaultSleepablePreloadSize), getMaxEntries(m))
+			} else {
+				assert.Equal(t, uint32(defaults.DefaultSleepableOffloadSize), getMaxEntries(m))
+			}
 		}
 	})
 
-	// sleepable_preload as MapBuilderProgram at program scope (.../policy/sensor/prog/sleepable_preload)
+	// sleepable_preload/offload as MapBuilderProgram at program scope (.../policy/sensor/prog/sleepable_[preload|offload])
 	t.Run("program", func(t *testing.T) {
-		sens := loadSensors(t, policy(`
+		var sens []*sensors.Sensor
+		if mapName == "sleepable_preload" {
+			sens = loadSensors(t, policy(`
   options:
   - name: "sleepable-preload-size"
     value: "1024"`))
+		} else {
+			sens = loadSensors(t, policy(`
+  options:
+  - name: "sleepable-offload-size"
+    value: "1024"`))
+		}
 		defer unloadSensors(sens)
 
-		m := findPreloadMap(sens)
-		require.NotNil(t, m, "sleepable_preload map not found in sensor")
+		m := findSleepableMap(sens)
+		require.NotNil(t, m, mapName+"map not found in sensor")
 
-		assert.NotEqual(t, "sleepable_preload", m.PinPath)
-		assert.Equal(t, "sleepable_preload", filepath.Base(m.PinPath))
+		assert.NotEqual(t, mapName, m.PinPath)
+		assert.Equal(t, mapName, filepath.Base(m.PinPath))
 		assert.Equal(t, uint32(1024), getMaxEntries(m))
 	})
 }


### PR DESCRIPTION
### Description
Fixes some output issues we were seeing with `tetra debug maps`. It uses full map name where available, fixing how multiple maps are aggregated together (previous used only truncated name, now it keys on 5 parts of the map). It also disables preallocating of the `sleepable_offload` map and adds a flag to configure its max size


### Changelog
```release-note
bugtool: Fixing bug in debug map output aggregation
tetragon: Make sleepable_offload not preload and max size configurable
```
