### PR TITLE
Restore bpf progs on failure during policy restore

### DIFF
--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -552,13 +552,29 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 	if err = loadInitialSensor(ctx); err != nil {
 		return err
 	}
+	if err = restoreGRPCPolicies(ctx, grpcPolicyStore, observer.GetSensorManager()); err != nil {
+		observer.RemoveSensors(ctx)
+		if oldBpfDir != "" {
+			// If we failed to restore policies, here we have already renamed the tetragon bpf directory
+			// to tetragon_old. On the next try, we will also remove tetragon_old and we will miss any
+			// persistent policies that we may had. To avoid that, in the case of failed policy restore,
+			// we rename back tetragon_old to tetragon.
+			if removeErr := os.RemoveAll(observerDir); removeErr != nil {
+				return errors.Join(err, fmt.Errorf("failed to remove bpf progs %s: %w", observerDir, removeErr))
+			}
+			if renameErr := os.Rename(oldBpfDir, observerDir); renameErr != nil {
+				return errors.Join(err, fmt.Errorf("failed to restore previous bpf progs from %s to %s: %w", oldBpfDir, observerDir, renameErr))
+			}
+			log.Info("Restored previous bpf progs", "from", oldBpfDir, "to", observerDir)
+		} else {
+			os.Remove(observerDir)
+		}
+		return err
+	}
 	defer func() {
 		observer.RemoveSensors(ctx)
 		os.Remove(observerDir)
 	}()
-	if err = restoreGRPCPolicies(ctx, grpcPolicyStore, observer.GetSensorManager()); err != nil {
-		return err
-	}
 	observer.GetSensorManager().LogSensorsAndProbes(ctx)
 
 	pm, err := tetragonGrpc.NewProcessManager(


### PR DESCRIPTION
In https://github.com/cilium/tetragon/pull/5279 we introduced persistent policies. In that case, we can keep all bpf programs after the agent exits and restore back old policies on agent restart.

The steps that we followed are (assuming that progs are inside /sys/fs/bpf/tetragon):
1. Rename /sys/fs/bpf/tetragon to /sys/fs/bpf/tetragon_old
2. Rstore policies that are pestisted before. This will create a new /sys/fs/bpf/tetragon.
3. Remove /sys/fs/bpf/tetragon_old

But if (2) fails, we end up with /sys/fs/bpf/tetragon_old that had the old policies. In the next agent restart, this will be removed because this is considered an old version of progs and we will end up losing persistent bpf progs.

To fix that, if (2) fails, we rename /sys/fs/bpf/tetragon_old back to /sys/fs/bpf/tetragon. On the next agent restart, we will try again to load the local polices.