### PR TITLE
tracing: Reject register Override in namespaced policies

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1814,6 +1814,23 @@ func HasOverride(selectors []v1alpha1.KProbeSelector) bool {
 	return false
 }
 
+// HasOverrideArgRegs reports whether any selector uses the register-modifying
+// variant of the Override action (argRegs), the register-write primitive that
+// can rewrite rip/rsp and read arbitrary user memory.
+func HasOverrideArgRegs(selectors []v1alpha1.KProbeSelector) bool {
+	for _, s := range selectors {
+		for _, action := range s.MatchActions {
+			if len(action.ArgRegs) == 0 {
+				continue
+			}
+			if actionTypeTable[strings.ToLower(action.Action)] == ActionTypeOverride {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func CountOverrideArgNewSymbolAddrOffset(selectors []v1alpha1.KProbeSelector) int {
 	for _, s := range selectors {
 		for _, action := range s.MatchActions {

--- a/pkg/sensors/tracing/policyhandler_linux.go
+++ b/pkg/sensors/tracing/policyhandler_linux.go
@@ -47,6 +47,45 @@ func newPolicyInfo(
 
 }
 
+// A namespaced policy is tenant-writable, so the register-modifying Override
+// action (argRegs) — which rewrites the probed process's registers and reads
+// arbitrary user memory — must stay a cluster-admin capability.
+var errNamespacedRegisterOverride = errors.New("register-modifying Override action (argRegs) is not allowed in a namespaced tracing policy")
+
+func hasRegisterOverride(spec *v1alpha1.TracingPolicySpec) bool {
+	for _, kprobe := range spec.KProbes {
+		if selectors.HasOverrideArgRegs(kprobe.Selectors) {
+			return true
+		}
+	}
+
+	for _, uprobe := range spec.UProbes {
+		if selectors.HasOverrideArgRegs(uprobe.Selectors) {
+			return true
+		}
+	}
+
+	for _, tp := range spec.Tracepoints {
+		if selectors.HasOverrideArgRegs(tp.Selectors) {
+			return true
+		}
+	}
+
+	for _, lsm := range spec.LsmHooks {
+		if selectors.HasOverrideArgRegs(lsm.Selectors) {
+			return true
+		}
+	}
+
+	for _, usdt := range spec.Usdts {
+		if selectors.HasOverrideArgRegs(usdt.Selectors) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func hasEnforcementActions(spec *v1alpha1.TracingPolicySpec) bool {
 	for _, kprobe := range spec.KProbes {
 		if selectors.HasEnforcementAction(kprobe.Selectors) || selectors.HasOverride(kprobe.Selectors) {
@@ -114,6 +153,10 @@ func newPolicyInfoFromSpec(
 	opts, err := getSpecOptions(spec.Options)
 	if err != nil {
 		return nil, err
+	}
+
+	if namespace != "" && hasRegisterOverride(spec) {
+		return nil, errNamespacedRegisterOverride
 	}
 
 	// If enforcement is not allowed, force monitor only

--- a/pkg/sensors/tracing/policyhandler_linux_test.go
+++ b/pkg/sensors/tracing/policyhandler_linux_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package tracing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
+	"github.com/cilium/tetragon/pkg/policyfilter"
+)
+
+func TestNewPolicyInfoRejectsNamespacedRegisterOverride(t *testing.T) {
+	spec := &v1alpha1.TracingPolicySpec{
+		UProbes: []v1alpha1.UProbeSpec{{
+			Path:    "/procRoot/1/root/usr/lib/x86_64-linux-gnu/libc.so.6",
+			Symbols: []string{"mount"},
+			Selectors: []v1alpha1.KProbeSelector{{
+				MatchActions: []v1alpha1.ActionSelector{{
+					Action:  "Override",
+					ArgRegs: []string{"rip=-901776%rip", "rsp=0%rsp"},
+				}},
+			}},
+		}},
+	}
+
+	// A namespaced (tenant-writable) policy must not carry the register-write
+	// Override primitive.
+	_, err := newPolicyInfoFromSpec("tenant", "reg-override", policyfilter.NoFilterID, spec, nil)
+	require.ErrorIs(t, err, errNamespacedRegisterOverride)
+
+	// The same spec is allowed for a cluster-wide policy (empty namespace).
+	_, err = newPolicyInfoFromSpec("", "reg-override", policyfilter.NoFilterID, spec, nil)
+	require.NoError(t, err)
+}
+
+func TestNewPolicyInfoAllowsNamespacedUprobeWithoutArgRegs(t *testing.T) {
+	spec := &v1alpha1.TracingPolicySpec{
+		UProbes: []v1alpha1.UProbeSpec{{
+			Path:    "/bin/bash",
+			Symbols: []string{"main"},
+		}},
+	}
+	_, err := newPolicyInfoFromSpec("tenant", "plain-uprobe", policyfilter.NoFilterID, spec, nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

_Just for testing purpose, still thinking if it's useful_

A TracingPolicyNamespaced is tenant-writable. The register-modifying Override variant (argRegs) rewrites a probed process's registers, including rip and rsp, and reads arbitrary user memory -- a node-root primitive that must remain a cluster-admin capability, so reject it at load time for namespaced policies.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
tracing: Reject register Override in namespaced policies
```
