### PR TITLE
Backports/v1.7: uprobe/usdt: Reject GetUrl and DnsLookup Actions

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1749,6 +1749,18 @@ func HasOverride(selectors []v1alpha1.KProbeSelector) bool {
 	return false
 }
 
+func HasGetUrlOrDnsLookup(selectors []v1alpha1.KProbeSelector) bool {
+	for _, s := range selectors {
+		for _, action := range s.MatchActions {
+			act := actionTypeTable[strings.ToLower(action.Action)]
+			if act == ActionTypeGetUrl || act == ActionTypeDnsLookup {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func HasOperator(selectors []v1alpha1.KProbeSelector, op uint32) bool {
 	for _, s := range selectors {
 		for _, a := range slices.Concat(s.MatchArgs, s.MatchData, s.MatchReturnArgs) {

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -565,6 +565,10 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 		has.substring = true
 	}
 
+	if selectors.HasGetUrlOrDnsLookup(spec.Selectors) {
+		return nil, errors.New("failed to configure uprobe, GetUrl and DnsLookup actions not supported")
+	}
+
 	// Parse Filters into kernel filter logic
 	uprobeSelectorState, err := selectors.InitKernelSelectorState(&selectors.KernelSelectorArgs{
 		Selectors: spec.Selectors,

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -326,6 +326,10 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		found       bool
 	)
 
+	if selectors.HasGetUrlOrDnsLookup(spec.Selectors) {
+		return ids, fmt.Errorf("failed to configure usdt '%s/%s', GetUrl and DnsLookup actions not supported", spec.Provider, spec.Name)
+	}
+
 	for _, target := range targets {
 		if spec.Provider != target.Spec.Provider || spec.Name != target.Spec.Name {
 			continue

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/tetragon/pkg/bpf"
 	"github.com/cilium/tetragon/pkg/kernels"
 	bc "github.com/cilium/tetragon/pkg/matchers/bytesmatcher"
+	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/selectors"
 
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
@@ -226,6 +227,87 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+// The purpose of the GetUrl and DnsLookup tests is to check that Tetragon does
+// not crash, and instead returns an error, if a GetUrl or DnsLookup action is
+// specified in a uprobe policy.
+func TestUprobeCheckGetUrlAction(t *testing.T) {
+	uprobeGetUrlHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: check-geturl-action
+spec:
+  uprobes:
+  - path: "/bin/ls"
+    symbols: ["__libc_start_main"]
+    selectors:
+    - matchActions:
+      - action: GetUrl
+        argUrl: "http://127.0.0.1/x"
+`
+
+	noConfig := `
+apiversion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "noconfig"
+spec: {}
+`
+
+	createCrdFile(t, noConfig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	_, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	require.NoError(t, err)
+
+	tp, err := tracingpolicy.FromYAML(uprobeGetUrlHook)
+	require.NoError(t, err)
+	err = observer.GetSensorManager().AddTracingPolicy(ctx, tp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "GetUrl and DnsLookup actions not supported")
+}
+
+func TestUprobeCheckDnsLookupAction(t *testing.T) {
+	uprobeDnsLookupHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: check-dnslookup-action
+spec:
+  uprobes:
+  - path: "/bin/ls"
+    symbols: ["__libc_start_main"]
+    selectors:
+    - matchActions:
+      - action: DnsLookup
+        argFqdn: "ebpf.io"
+`
+
+	noConfig := `
+apiversion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "noconfig"
+spec: {}
+`
+
+	createCrdFile(t, noConfig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	_, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	require.NoError(t, err)
+
+	tp, err := tracingpolicy.FromYAML(uprobeDnsLookupHook)
+	require.NoError(t, err)
+	err = observer.GetSensorManager().AddTracingPolicy(ctx, tp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "GetUrl and DnsLookup actions not supported")
 }
 
 func TestUretprobeRetCopy(t *testing.T) {

--- a/pkg/sensors/tracing/usdt_test.go
+++ b/pkg/sensors/tracing/usdt_test.go
@@ -23,11 +23,13 @@ import (
 	"github.com/cilium/tetragon/pkg/jsonchecker"
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/testutils"
 	"github.com/cilium/tetragon/pkg/testutils/policytest"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
+	"github.com/cilium/tetragon/pkg/tracingpolicy"
 )
 
 func TestUsdtLoadSensor(t *testing.T) {
@@ -151,6 +153,89 @@ spec:
 		sensi = append(sensi, s)
 	}
 	sensors.UnloadSensors(sensi)
+}
+
+// The purpose of the GetUrl and DnsLookup tests is to check that Tetragon does
+// not crash, and instead returns an error, if a GetUrl or DnsLookup action is
+// specified in a usdt policy.
+func TestUsdtCheckGetUrlAction(t *testing.T) {
+	usdtGetUrlHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: check-geturl-action
+spec:
+  usdts:
+  - path: "/bin/ls"
+    provider: "test"
+    name: "geturl"
+    selectors:
+    - matchActions:
+      - action: GetUrl
+        argUrl: "http://127.0.0.1/x"
+`
+
+	noConfig := `
+apiversion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "noconfig"
+spec: {}
+`
+
+	createCrdFile(t, noConfig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	_, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	require.NoError(t, err)
+
+	tp, err := tracingpolicy.FromYAML(usdtGetUrlHook)
+	require.NoError(t, err)
+	err = observer.GetSensorManager().AddTracingPolicy(ctx, tp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "GetUrl and DnsLookup actions not supported")
+}
+
+func TestUsdtCheckDnsLookupAction(t *testing.T) {
+	usdtDnsLookupHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: check-dnslookup-action
+spec:
+  usdts:
+  - path: "/bin/ls"
+    provider: "test"
+    name: "dnslookup"
+    selectors:
+    - matchActions:
+      - action: DnsLookup
+        argFqdn: "ebpf.io"
+`
+
+	noConfig := `
+apiversion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "noconfig"
+spec: {}
+`
+
+	createCrdFile(t, noConfig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	_, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	require.NoError(t, err)
+
+	tp, err := tracingpolicy.FromYAML(usdtDnsLookupHook)
+	require.NoError(t, err)
+	err = observer.GetSensorManager().AddTracingPolicy(ctx, tp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "GetUrl and DnsLookup actions not supported")
 }
 
 func TestUsdtGeneric(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/cilium/security-tetragon/issues/10

### Description
The GetUrl and DnsLookup actions are not supported for uprobes or usdt. Using them can cause crashes as required state isn't initialised. This pull request checks for GetUrl and DnsLookup actions in uprobe and usdt and returns an error if any are found.

[Upstream PR: #5380]

Reported-by: Artem Cherezov <cherez0ff@proton.me>

### Changelog
Fix crash when unsupported GetUrl or DnsLookup actions are included in uprobe or usdt tracing policies.

```release-note
Fix crash when unsupported GetUrl or DnsLookup actions are included in uprobe or usdt tracing policies.
```
