### PR TITLE
Backports/v1.5: uprobe: Reject GetUrl and DnsLookup Actions

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -1478,6 +1478,18 @@ func HasOverride(selectors []v1alpha1.KProbeSelector) bool {
 	return false
 }
 
+func HasGetUrlOrDnsLookup(selectors []v1alpha1.KProbeSelector) bool {
+	for _, s := range selectors {
+		for _, action := range s.MatchActions {
+			act := actionTypeTable[strings.ToLower(action.Action)]
+			if act == ActionTypeGetUrl || act == ActionTypeDnsLookup {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func HasSigkillAction(kspec *v1alpha1.KProbeSpec) bool {
 	for i := range kspec.Selectors {
 		s := &kspec.Selectors[i]

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -353,6 +353,9 @@ func addUprobe(spec *v1alpha1.UProbeSpec, ids []idtable.EntryID, in *addUprobeIn
 	if err := isValidUprobeSelectors(spec.Selectors); err != nil {
 		return nil, err
 	}
+	if selectors.HasGetUrlOrDnsLookup(spec.Selectors) {
+		return nil, errors.New("failed to configure uprobe, GetUrl and DnsLookup actions not supported")
+	}
 
 	// Parse Filters into kernel filter logic
 	uprobeSelectorState, err := selectors.InitKernelSelectorState(spec.Selectors, args, nil, nil, nil)

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
+
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/config"
 	"github.com/cilium/tetragon/pkg/elf"
@@ -22,11 +23,13 @@ import (
 	"github.com/cilium/tetragon/pkg/logger"
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
+	"github.com/cilium/tetragon/pkg/observer"
 	"github.com/cilium/tetragon/pkg/observer/observertesthelper"
 	"github.com/cilium/tetragon/pkg/sensors"
 	"github.com/cilium/tetragon/pkg/testutils"
 	tus "github.com/cilium/tetragon/pkg/testutils/sensors"
 	"github.com/cilium/tetragon/pkg/tracingpolicy"
+
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -148,6 +151,87 @@ spec:
 
 	err = jsonchecker.JsonTestCheck(t, checker)
 	require.NoError(t, err)
+}
+
+// The purpose of the GetUrl and DnsLookup tests is to check that Tetragon does
+// not crash, and instead returns an error, if a GetUrl or DnsLookup action is
+// specified in a uprobe policy.
+func TestUprobeCheckGetUrlAction(t *testing.T) {
+	uprobeGetUrlHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: check-geturl-action
+spec:
+  uprobes:
+  - path: "/bin/ls"
+    symbols: ["__libc_start_main"]
+    selectors:
+    - matchActions:
+      - action: GetUrl
+        argUrl: "http://127.0.0.1/x"
+`
+
+	noConfig := `
+apiversion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "noconfig"
+spec: {}
+`
+
+	createCrdFile(t, noConfig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	_, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	require.NoError(t, err)
+
+	tp, err := tracingpolicy.FromYAML(uprobeGetUrlHook)
+	require.NoError(t, err)
+	err = observer.GetSensorManager().AddTracingPolicy(ctx, tp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "GetUrl and DnsLookup actions not supported")
+}
+
+func TestUprobeCheckDnsLookupAction(t *testing.T) {
+	uprobeDnsLookupHook := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: check-dnslookup-action
+spec:
+  uprobes:
+  - path: "/bin/ls"
+    symbols: ["__libc_start_main"]
+    selectors:
+    - matchActions:
+      - action: DnsLookup
+        argFqdn: "ebpf.io"
+`
+
+	noConfig := `
+apiversion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "noconfig"
+spec: {}
+`
+
+	createCrdFile(t, noConfig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
+	defer cancel()
+
+	_, err := observertesthelper.GetDefaultObserverWithFile(t, ctx, testConfigFile, tus.Conf().TetragonLib, observertesthelper.WithMyPid())
+	require.NoError(t, err)
+
+	tp, err := tracingpolicy.FromYAML(uprobeDnsLookupHook)
+	require.NoError(t, err)
+	err = observer.GetSensorManager().AddTracingPolicy(ctx, tp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "GetUrl and DnsLookup actions not supported")
 }
 
 func uprobePidMatch(t *testing.T, pid uint32) error {


### PR DESCRIPTION
Fixes: https://github.com/cilium/security-tetragon/issues/10

### Description
The GetUrl and DnsLookup actions are not supported for uprobes. Using them can cause crashes as required state isn't initialised. This pull request checks for GetUrl and DnsLookup actions in uprobes and returns an error if any are found.

[Upstream PR: #5380]

Reported-by: Artem Cherezov <cherez0ff@proton.me>

### Changelog
Fix crash when unsupported GetUrl or DnsLookup actions are included in uprobe tracing policies.

```release-note
Fix crash when unsupported GetUrl or DnsLookup actions are included in uprobe tracing policies.
```
