### PR TITLE
Simplify making grpc clients to tetragon

### DIFF
--- a/cmd/tetra/common/client.go
+++ b/cmd/tetra/common/client.go
@@ -36,7 +36,7 @@ import (
 // Also note that the final backoff duration is completely random and chosen
 // between 0 and the final duration that was computed via to the params:
 // https://github.com/grpc/grpc-go/blob/v1.65.0/stream.go#L702
-func RetryPolicy(retries int) string {
+func RetryPolicy(retries int, service string) string {
 	if retries <= 0 {
 		// An empty service config disables application-level retries.
 		return "{}"
@@ -48,8 +48,7 @@ func RetryPolicy(retries int) string {
 	return fmt.Sprintf(`{
 	"methodConfig": [{
 	  "name": [
-		{"service": "tetragon.FineGuidanceSensors"},
-		{"service": "tetragon.EventLogService"}
+		{"service": "%s"}
 	  ],
 	  "retryPolicy": {
 		  "MaxAttempts": %d,
@@ -58,40 +57,38 @@ func RetryPolicy(retries int) string {
 		  "BackoffMultiplier": 2,
 		  "RetryableStatusCodes": [ "UNAVAILABLE" ]
 	  }
-	}]}`, maxAttempt)
+	}]}`, service, maxAttempt)
 }
 
-type ClientWithContext struct {
-	Client tetragon.FineGuidanceSensorsClient
+// This can be reused for various tetra clients by embedding it in a struct that
+// has a client as a field using the connection.
+type ConnWithContext struct {
 	// Ctx is a combination of the signal context and the timeout context
 	Ctx context.Context
 	// SignalCtx is only the signal context, you might want to use that context
 	// when the command should never timeout (like a stream command)
 	SignalCtx context.Context
-	conn      *grpc.ClientConn
+	Conn      *grpc.ClientConn
 	// The signal context is the parent of the timeout context, so cancelling
 	// signal will cancel its child, timeout
 	signalCancel  context.CancelFunc
 	timeoutCancel context.CancelFunc
 }
 
+type ClientWithContext struct {
+	ConnWithContext
+	Client tetragon.FineGuidanceSensorsClient
+}
+
 // Close cleanup resources, it closes the connection and cancel the context
-func (c ClientWithContext) Close() {
-	c.conn.Close()
+func (c ConnWithContext) Close() {
+	c.Conn.Close()
 	c.signalCancel()
 	c.timeoutCancel() // this should be a nop
 }
 
-// NewClientWithDefaultContextAndAddress returns a client to a tetragon
-// server after resolving the server address using helpers, accompanied with an
-// initialized context that can be used for the RPC call, caller must call
-// Close() on the client.
-func NewClientWithDefaultContextAndAddress() (*ClientWithContext, error) {
-	return NewClient(context.Background(), ResolveServerAddress(), Timeout)
-}
-
-func NewClient(ctx context.Context, address string, timeout time.Duration) (*ClientWithContext, error) {
-	c := &ClientWithContext{}
+func NewConnWithContext(ctx context.Context, address string, timeout time.Duration, service string) (*ConnWithContext, error) {
+	c := &ConnWithContext{}
 
 	c.SignalCtx, c.signalCancel = signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	c.Ctx, c.timeoutCancel = context.WithTimeout(c.SignalCtx, timeout)
@@ -104,16 +101,37 @@ func NewClient(ctx context.Context, address string, timeout time.Duration) (*Cli
 	if tlsCreds != nil {
 		creds = tlsCreds
 	}
-	c.conn, err = grpc.NewClient(address,
+	c.Conn, err = grpc.NewClient(address,
 		grpc.WithTransportCredentials(creds),
-		grpc.WithDefaultServiceConfig(RetryPolicy(Retries)),
+		grpc.WithDefaultServiceConfig(RetryPolicy(Retries, service)),
 		grpc.WithMaxCallAttempts(Retries+1), // maxAttempt includes the first call
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC client with address %s: %w", address, err)
 	}
-	c.Client = tetragon.NewFineGuidanceSensorsClient(c.conn)
+
+	return c, nil
+}
+
+// NewClientWithDefaultContextAndAddress returns a client to a tetragon
+// server after resolving the server address using helpers, accompanied with an
+// initialized context that can be used for the RPC call, caller must call
+// Close() on the client.
+func NewClientWithDefaultContextAndAddress() (*ClientWithContext, error) {
+	return NewClient(context.Background(), ResolveServerAddress(), Timeout)
+}
+
+func NewClient(ctx context.Context, address string, timeout time.Duration) (*ClientWithContext, error) {
+	ret, err := NewConnWithContext(ctx, address, timeout, "tetragon.FineGuidanceSensors")
+	if err != nil {
+		return nil, err
+	}
+
+	c := &ClientWithContext{
+		ConnWithContext: *ret,
+		Client:          tetragon.NewFineGuidanceSensorsClient(ret.Conn),
+	}
 
 	return c, nil
 }

--- a/cmd/tetra/common/client_test.go
+++ b/cmd/tetra/common/client_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRetryPolicyDisablesRetriesAtZero(t *testing.T) {
-	require.JSONEq(t, `{}`, RetryPolicy(0))
+	require.JSONEq(t, `{}`, RetryPolicy(0, ""))
 }
 
 func TestNewClientWithZeroRetries(t *testing.T) {

--- a/cmd/tetra/eventlog/client.go
+++ b/cmd/tetra/eventlog/client.go
@@ -5,50 +5,26 @@ package eventlog
 
 import (
 	"context"
-	"fmt"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/cilium/tetragon/api/v1/tetragon"
 	"github.com/cilium/tetragon/cmd/tetra/common"
 )
 
 type ClientWithContext struct {
-	conn          *grpc.ClientConn
-	Client        tetragon.EventLogServiceClient
-	ctx           context.Context
-	timeoutCancel context.CancelFunc
-}
-
-func (c ClientWithContext) Close() {
-	c.conn.Close()
-	c.timeoutCancel()
+	common.ConnWithContext
+	Client tetragon.EventLogServiceClient
 }
 
 func NewClient() (*ClientWithContext, error) {
-	c := &ClientWithContext{}
-	c.ctx, c.timeoutCancel = context.WithTimeout(context.Background(), common.Timeout)
-
-	tlsCreds, err := common.TLSCredentials(common.TLS)
-	if err != nil {
-		return nil, fmt.Errorf("building TLS credentials: %w", err)
-	}
-	creds := credentials.TransportCredentials(insecure.NewCredentials())
-	if tlsCreds != nil {
-		creds = tlsCreds
-	}
-	c.conn, err = grpc.NewClient(
-		common.ResolveServerAddress(),
-		grpc.WithTransportCredentials(creds),
-		grpc.WithDefaultServiceConfig(common.RetryPolicy(common.Retries)),
-		grpc.WithMaxCallAttempts(common.Retries+1), // maxAttempt includes the first call
-	)
+	ret, err := common.NewConnWithContext(context.Background(), common.ResolveServerAddress(), common.Timeout, "tetragon.EventLogService")
 	if err != nil {
 		return nil, err
 	}
-	c.Client = tetragon.NewEventLogServiceClient(c.conn)
+
+	c := &ClientWithContext{
+		ConnWithContext: *ret,
+		Client:          tetragon.NewEventLogServiceClient(ret.Conn),
+	}
 
 	return c, nil
 }

--- a/cmd/tetra/eventlog/client_test.go
+++ b/cmd/tetra/eventlog/client_test.go
@@ -60,7 +60,7 @@ func TestClientRetriesUnavailableRPC(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(client.Close)
 
-	_, err = client.Client.GetEventLogParams(client.ctx, &tetragon.GetEventLogParamsRequest{})
+	_, err = client.Client.GetEventLogParams(client.Ctx, &tetragon.GetEventLogParamsRequest{})
 	require.NoError(t, err)
 	require.Equal(t, int32(2), retrySrv.calls.Load())
 }

--- a/cmd/tetra/eventlog/eventlog.go
+++ b/cmd/tetra/eventlog/eventlog.go
@@ -43,7 +43,7 @@ func setCmd() *cobra.Command {
 			if cmd.Flags().Lookup("rotation-interval").Changed {
 				interval = new(rotationIntervalVar.String())
 			}
-			_, err = c.Client.SetEventLogParams(c.ctx, &tetragon.SetEventLogParamsRequest{
+			_, err = c.Client.SetEventLogParams(c.Ctx, &tetragon.SetEventLogParamsRequest{
 				MaxSize:          maxSize,
 				RotationInterval: interval,
 				MaxBackups:       maxBackups,
@@ -72,7 +72,7 @@ func getCmd() *cobra.Command {
 			}
 			defer c.Close()
 
-			params, err := c.Client.GetEventLogParams(c.ctx, &tetragon.GetEventLogParamsRequest{})
+			params, err := c.Client.GetEventLogParams(c.Ctx, &tetragon.GetEventLogParamsRequest{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->


### Description
Make it easier/remove redundant code from the multiple grpc service clients of tetragon. Currently, each client must create/manage their own grpc connection, contexts, timeouts, and cancellation functions.

Modify tetra common to add a NewConnWithContext(ctx, addr, timeout, service) function and supporting struct that handles creating the grpc connection and setting up the various contexts. It returns a ConnWithContext that can be embedded in a ClientWithContext struct via:

```
type ClientWithContext struct {
	ConnWithContext
	Client tetragon.FineGuidanceSensorsClient
}
```

replacing tetragon.FindGuidanceSensorsClient with whatever grpc interface the caller needs.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```
Make it easier to create grpc clients to tetragon via a new function NewConnWithContext().
```
