### PR TITLE
celbpf: introduce bitwise operators

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -225,6 +225,7 @@ Currently, CelExpr operators support:
 * Logical AND (`&&`), OR (`||`), and NOT (`!`) operators
 * Comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`)
 * Integer casting to 32-bits (`int32()`, `uint32()`)
+* Bitwise operations (`and()`, `or()`, `xor()`, `not()`)
 
 ## Data filter
 

--- a/pkg/celbpf/cel_eval_test.go
+++ b/pkg/celbpf/cel_eval_test.go
@@ -185,7 +185,7 @@ func celInequality(op string, left, right ref.Val) ref.Val {
 	}
 }
 
-func getOverloadOpts(o *fnOverload) []cel.OverloadOpt {
+func getOverloadOpts(t *testing.T, o *fnOverload) []cel.OverloadOpt {
 	var ret []cel.OverloadOpt
 	switch o.name {
 	case "u32fromuint":
@@ -196,6 +196,9 @@ func getOverloadOpts(o *fnOverload) []cel.OverloadOpt {
 		return append(ret, cel.UnaryBinding(func(value ref.Val) ref.Val {
 			return newCelS32(int32(value.(celTypes.Int)))
 		}))
+	case "equals", "not_equals", "logical_and", "logical_or":
+		return ret
+
 	}
 
 	if strings.HasPrefix(o.name, "sub_") {
@@ -219,6 +222,7 @@ func getOverloadOpts(o *fnOverload) []cel.OverloadOpt {
 		return append(ret, cel.UnaryBinding(celLogicalNot))
 	}
 
+	t.Fatalf("TODO: implement getOverloadOpts for %s", o.name)
 	return ret
 }
 
@@ -233,7 +237,7 @@ func evalCEL(t *testing.T, expr string, hookArgs []any) uint32 {
 	for _, fnOpt := range getFnsOpts() {
 		fnOpts := make([]cel.FunctionOpt, 0, len(fnOpt.overloads))
 		for _, o := range fnOpt.overloads {
-			overloadOpts := getOverloadOpts(&o)
+			overloadOpts := getOverloadOpts(t, &o)
 			fnOpts = append(fnOpts, cel.Overload(o.name, o.args, o.res, overloadOpts...))
 		}
 		opts = append(opts, cel.Function(fnOpt.name, fnOpts...))
@@ -267,7 +271,7 @@ func evalCEL(t *testing.T, expr string, hookArgs []any) uint32 {
 	prog, err := env.Program(ast)
 	require.NoError(t, err)
 	result, _, err := prog.Eval(values)
-	require.NoError(t, err)
+	require.NoError(t, err, "Failed to evaluate CEL program")
 
 	boolResult, ok := result.(celTypes.Bool)
 	require.True(t, ok, "CEL expression %q returned %T, not bool", expr, result)

--- a/pkg/celbpf/cel_eval_test.go
+++ b/pkg/celbpf/cel_eval_test.go
@@ -160,6 +160,20 @@ var celBitwiseXOR = celBinArithOp(
 	func(a, b uint32) uint32 { return a ^ b },
 )
 
+func celBitwiseNOT(value ref.Val) ref.Val {
+	switch v := value.(type) {
+	case celTypes.Int:
+		return ^v
+	case celTypes.Uint:
+		return ^v
+	case celS32:
+		return newCelS32(^v.value)
+	case celU32:
+		return newCelU32(^v.value)
+	}
+	return celTypes.MaybeNoSuchOverloadErr(value)
+}
+
 func compareIntegers[T int32 | uint32 | celTypes.Int | celTypes.Uint](op string, left, right T) ref.Val {
 	switch op {
 	case "lt":
@@ -240,6 +254,10 @@ func getOverloadOpts(t *testing.T, o *fnOverload) []cel.OverloadOpt {
 
 	if strings.HasPrefix(o.name, xorFn) {
 		return append(ret, cel.BinaryBinding(celBitwiseXOR))
+	}
+
+	if strings.HasPrefix(o.name, notFn) {
+		return append(ret, cel.UnaryBinding(celBitwiseNOT))
 	}
 
 	for _, ineq := range []string{"lt", "lq", "gt", "gq"} {

--- a/pkg/celbpf/cel_eval_test.go
+++ b/pkg/celbpf/cel_eval_test.go
@@ -146,6 +146,13 @@ var celBitwiseAND = celBinArithOp(
 	func(a, b uint32) uint32 { return a & b },
 )
 
+var celBitwiseOR = celBinArithOp(
+	func(a, b celTypes.Int) celTypes.Int { return a | b },
+	func(a, b celTypes.Uint) celTypes.Uint { return a | b },
+	func(a, b int32) int32 { return a | b },
+	func(a, b uint32) uint32 { return a | b },
+)
+
 func compareIntegers[T int32 | uint32 | celTypes.Int | celTypes.Uint](op string, left, right T) ref.Val {
 	switch op {
 	case "lt":
@@ -218,6 +225,10 @@ func getOverloadOpts(t *testing.T, o *fnOverload) []cel.OverloadOpt {
 
 	if strings.HasPrefix(o.name, andFn) {
 		return append(ret, cel.BinaryBinding(celBitwiseAND))
+	}
+
+	if strings.HasPrefix(o.name, orFn) {
+		return append(ret, cel.BinaryBinding(celBitwiseOR))
 	}
 
 	for _, ineq := range []string{"lt", "lq", "gt", "gq"} {

--- a/pkg/celbpf/cel_eval_test.go
+++ b/pkg/celbpf/cel_eval_test.go
@@ -94,67 +94,50 @@ func celLogicalNot(value ref.Val) ref.Val {
 	return celTypes.Bool(!bool(boolValue))
 }
 
-func celAdd(left, right ref.Val) ref.Val {
-	switch left := left.(type) {
-	case celTypes.Int:
-		right, ok := right.(celTypes.Int)
-		if !ok {
-			return celTypes.MaybeNoSuchOverloadErr(right)
+// celBinArithOp builds a binary arithmetic CEL function from per-type operators.
+// To add a new operation, just provide the four operator functions.
+func celBinArithOp(
+	intOp func(celTypes.Int, celTypes.Int) celTypes.Int,
+	uintOp func(celTypes.Uint, celTypes.Uint) celTypes.Uint,
+	s32Op func(int32, int32) int32,
+	u32Op func(uint32, uint32) uint32,
+) func(left, right ref.Val) ref.Val {
+	return func(left, right ref.Val) ref.Val {
+		switch left := left.(type) {
+		case celTypes.Int:
+			if r, ok := right.(celTypes.Int); ok {
+				return intOp(left, r)
+			}
+		case celTypes.Uint:
+			if r, ok := right.(celTypes.Uint); ok {
+				return uintOp(left, r)
+			}
+		case celS32:
+			if r, ok := right.(celS32); ok {
+				return newCelS32(s32Op(left.value, r.value))
+			}
+		case celU32:
+			if r, ok := right.(celU32); ok {
+				return newCelU32(u32Op(left.value, r.value))
+			}
 		}
-		return left + right
-	case celTypes.Uint:
-		right, ok := right.(celTypes.Uint)
-		if !ok {
-			return celTypes.MaybeNoSuchOverloadErr(right)
-		}
-		return left + right
-	case celS32:
-		right, ok := right.(celS32)
-		if !ok {
-			return celTypes.MaybeNoSuchOverloadErr(right)
-		}
-		return newCelS32(left.value + right.value)
-	case celU32:
-		right, ok := right.(celU32)
-		if !ok {
-			return celTypes.MaybeNoSuchOverloadErr(right)
-		}
-		return newCelU32(left.value + right.value)
-	default:
 		return celTypes.MaybeNoSuchOverloadErr(left)
 	}
 }
 
-func celSubtract(left, right ref.Val) ref.Val {
-	switch left := left.(type) {
-	case celTypes.Int:
-		right, ok := right.(celTypes.Int)
-		if !ok {
-			return celTypes.MaybeNoSuchOverloadErr(right)
-		}
-		return left - right
-	case celTypes.Uint:
-		right, ok := right.(celTypes.Uint)
-		if !ok {
-			return celTypes.MaybeNoSuchOverloadErr(right)
-		}
-		return left - right
-	case celS32:
-		right, ok := right.(celS32)
-		if !ok {
-			return celTypes.MaybeNoSuchOverloadErr(right)
-		}
-		return newCelS32(left.value - right.value)
-	case celU32:
-		right, ok := right.(celU32)
-		if !ok {
-			return celTypes.MaybeNoSuchOverloadErr(right)
-		}
-		return newCelU32(left.value - right.value)
-	default:
-		return celTypes.MaybeNoSuchOverloadErr(left)
-	}
-}
+var celAdd = celBinArithOp(
+	func(a, b celTypes.Int) celTypes.Int { return a + b },
+	func(a, b celTypes.Uint) celTypes.Uint { return a + b },
+	func(a, b int32) int32 { return a + b },
+	func(a, b uint32) uint32 { return a + b },
+)
+
+var celSubtract = celBinArithOp(
+	func(a, b celTypes.Int) celTypes.Int { return a - b },
+	func(a, b celTypes.Uint) celTypes.Uint { return a - b },
+	func(a, b int32) int32 { return a - b },
+	func(a, b uint32) uint32 { return a - b },
+)
 
 func compareIntegers[T int32 | uint32 | celTypes.Int | celTypes.Uint](op string, left, right T) ref.Val {
 	switch op {

--- a/pkg/celbpf/cel_eval_test.go
+++ b/pkg/celbpf/cel_eval_test.go
@@ -139,6 +139,13 @@ var celSubtract = celBinArithOp(
 	func(a, b uint32) uint32 { return a - b },
 )
 
+var celBitwiseAND = celBinArithOp(
+	func(a, b celTypes.Int) celTypes.Int { return a & b },
+	func(a, b celTypes.Uint) celTypes.Uint { return a & b },
+	func(a, b int32) int32 { return a & b },
+	func(a, b uint32) uint32 { return a & b },
+)
+
 func compareIntegers[T int32 | uint32 | celTypes.Int | celTypes.Uint](op string, left, right T) ref.Val {
 	switch op {
 	case "lt":
@@ -207,6 +214,10 @@ func getOverloadOpts(t *testing.T, o *fnOverload) []cel.OverloadOpt {
 
 	if strings.HasPrefix(o.name, "add_") {
 		return append(ret, cel.BinaryBinding(celAdd))
+	}
+
+	if strings.HasPrefix(o.name, andFn) {
+		return append(ret, cel.BinaryBinding(celBitwiseAND))
 	}
 
 	for _, ineq := range []string{"lt", "lq", "gt", "gq"} {

--- a/pkg/celbpf/cel_eval_test.go
+++ b/pkg/celbpf/cel_eval_test.go
@@ -153,6 +153,13 @@ var celBitwiseOR = celBinArithOp(
 	func(a, b uint32) uint32 { return a | b },
 )
 
+var celBitwiseXOR = celBinArithOp(
+	func(a, b celTypes.Int) celTypes.Int { return a ^ b },
+	func(a, b celTypes.Uint) celTypes.Uint { return a ^ b },
+	func(a, b int32) int32 { return a ^ b },
+	func(a, b uint32) uint32 { return a ^ b },
+)
+
 func compareIntegers[T int32 | uint32 | celTypes.Int | celTypes.Uint](op string, left, right T) ref.Val {
 	switch op {
 	case "lt":
@@ -229,6 +236,10 @@ func getOverloadOpts(t *testing.T, o *fnOverload) []cel.OverloadOpt {
 
 	if strings.HasPrefix(o.name, orFn) {
 		return append(ret, cel.BinaryBinding(celBitwiseOR))
+	}
+
+	if strings.HasPrefix(o.name, xorFn) {
+		return append(ret, cel.BinaryBinding(celBitwiseXOR))
 	}
 
 	for _, ineq := range []string{"lt", "lq", "gt", "gq"} {

--- a/pkg/celbpf/codegen.go
+++ b/pkg/celbpf/codegen.go
@@ -156,62 +156,34 @@ func (g *codeGenerator) pushArg(argTy *cgTypes.Type, argOffset uint16, tmp1, tmp
 }
 
 // emit subtraction
-func (g *codeGenerator) emitSub(
+func (g *codeGenerator) emitArithOp(
+	op asm.ALUOp,
 	r1 asm.Register, ty1 *cgTypes.Type,
 	r2 asm.Register, ty2 *cgTypes.Type,
 ) error {
+	var ins asm.Instruction
 	switch {
 	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName(),
 		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName():
-
-		g.stackTop -= 8
-		g.emitRaw(
-			asm.Sub.Reg(r1, r2),
-			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
-		)
+		ins = op.Reg(r1, r2)
 
 	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
 		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
-		g.stackTop -= 8
-		g.emitRaw(
-			asm.Sub.Reg32(r1, r2),
-			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
-		)
+		ins = op.Reg32(r1, r2)
 
 	default:
-		return fmt.Errorf("subtraction between types %s and %s is not supported", ty1.TypeName(), ty2.TypeName())
+		return fmt.Errorf("operation between types %s and %s is not supported", ty1.TypeName(), ty2.TypeName())
 	}
 
-	return nil
-}
-
-// emit addition
-func (g *codeGenerator) emitAdd(
-	r1 asm.Register, ty1 *cgTypes.Type,
-	r2 asm.Register, ty2 *cgTypes.Type,
-) error {
-	switch {
-	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName(),
-		ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName():
-
-		g.stackTop -= 8
-		g.emitRaw(
-			asm.Add.Reg(r1, r2),
-			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
-		)
-
-	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
-		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
-		g.stackTop -= 8
-		g.emitRaw(
-			asm.Add.Reg32(r1, r2),
-			asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
-		)
-
-	default:
-		return fmt.Errorf("addition between types %s and %s is not supported", ty1.TypeName(), ty2.TypeName())
+	if ins.OpCode == asm.InvalidOpCode {
+		return fmt.Errorf("invalid opcode for ALU op %v", op)
 	}
 
+	g.stackTop -= 8
+	g.emitRaw(
+		ins,
+		asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
+	)
 	return nil
 }
 

--- a/pkg/celbpf/codegen.go
+++ b/pkg/celbpf/codegen.go
@@ -220,6 +220,27 @@ func (g *codeGenerator) emitNot(r1 asm.Register, tmp asm.Register) error {
 	return nil
 }
 
+func (g *codeGenerator) emitBitwiseNot(
+	r1 asm.Register, ty1 *cgTypes.Type,
+) error {
+	var ins asm.Instruction
+	switch ty1.TypeName() {
+	case s64Ty.TypeName(), u64Ty.TypeName():
+		ins = asm.Xor.Imm(r1, -1)
+	case s32Ty.TypeName(), u32Ty.TypeName():
+		ins = asm.Xor.Imm32(r1, -1)
+	default:
+		return fmt.Errorf("bitwise NOT on type %s is not supported", ty1.TypeName())
+	}
+
+	g.stackTop -= 8
+	g.emitRaw(
+		ins,
+		asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
+	)
+	return nil
+}
+
 func (g *codeGenerator) emitBranch(
 	reg1 asm.Register, ty1 *cgTypes.Type,
 	reg2 asm.Register, ty2 *cgTypes.Type,

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -159,6 +159,18 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 			return nil
 		}
 
+	case xorFn:
+		emitCall = func() error {
+			if err := c.cg.emitArithOp(
+				asm.Xor,
+				scratchRegs[0], argTypes[0],
+				scratchRegs[1], argTypes[1],
+			); err != nil {
+				return fmt.Errorf("bitwise XOR %w", err)
+			}
+			return nil
+		}
+
 	default:
 		emitCall = func() error {
 			return fmt.Errorf("compileCall: call %q (%+v) not supported", call.FunctionName(), call)

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -147,6 +147,18 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 			return nil
 		}
 
+	case orFn:
+		emitCall = func() error {
+			if err := c.cg.emitArithOp(
+				asm.Or,
+				scratchRegs[0], argTypes[0],
+				scratchRegs[1], argTypes[1],
+			); err != nil {
+				return fmt.Errorf("bitwise OR %w", err)
+			}
+			return nil
+		}
+
 	default:
 		emitCall = func() error {
 			return fmt.Errorf("compileCall: call %q (%+v) not supported", call.FunctionName(), call)

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -135,6 +135,18 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 
 		}
 
+	case andFn:
+		emitCall = func() error {
+			if err := c.cg.emitArithOp(
+				asm.And,
+				scratchRegs[0], argTypes[0],
+				scratchRegs[1], argTypes[1],
+			); err != nil {
+				return fmt.Errorf("bitwise AND %w", err)
+			}
+			return nil
+		}
+
 	default:
 		emitCall = func() error {
 			return fmt.Errorf("compileCall: call %q (%+v) not supported", call.FunctionName(), call)

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -82,18 +82,26 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 
 	case cgOperators.Add:
 		emitCall = func() error {
-			return c.cg.emitAdd(
+			if err := c.cg.emitArithOp(
+				asm.Add,
 				scratchRegs[0], argTypes[0],
 				scratchRegs[1], argTypes[1],
-			)
+			); err != nil {
+				return fmt.Errorf("addition %w", err)
+			}
+			return nil
 		}
 
 	case cgOperators.Subtract:
 		emitCall = func() error {
-			return c.cg.emitSub(
+			if err := c.cg.emitArithOp(
+				asm.Sub,
 				scratchRegs[0], argTypes[0],
 				scratchRegs[1], argTypes[1],
-			)
+			); err != nil {
+				return fmt.Errorf("subtraction %w", err)
+			}
+			return nil
 		}
 
 	case cgOperators.LogicalAnd:

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -171,6 +171,11 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 			return nil
 		}
 
+	case notFn:
+		emitCall = func() error {
+			return c.cg.emitBitwiseNot(scratchRegs[0], argTypes[0])
+		}
+
 	default:
 		emitCall = func() error {
 			return fmt.Errorf("compileCall: call %q (%+v) not supported", call.FunctionName(), call)

--- a/pkg/celbpf/env.go
+++ b/pkg/celbpf/env.go
@@ -26,6 +26,7 @@ var (
 
 	andFn = "and"
 	orFn  = "or"
+	xorFn = "xor"
 )
 
 type fnOverload struct {
@@ -87,6 +88,7 @@ func getFnsOpts() []fnOpts {
 		// NB(kkourt): it seems that there is no way to add custom operators to CEL
 		{name: andFn, overloads: intBinaryOperatorFnOverloads(andFn)},
 		{name: orFn, overloads: intBinaryOperatorFnOverloads(orFn)},
+		{name: xorFn, overloads: intBinaryOperatorFnOverloads(xorFn)},
 
 		// Integer casting
 		{name: int32Fn, overloads: []fnOverload{

--- a/pkg/celbpf/env.go
+++ b/pkg/celbpf/env.go
@@ -27,6 +27,7 @@ var (
 	andFn = "and"
 	orFn  = "or"
 	xorFn = "xor"
+	notFn = "not"
 )
 
 type fnOverload struct {
@@ -89,6 +90,7 @@ func getFnsOpts() []fnOpts {
 		{name: andFn, overloads: intBinaryOperatorFnOverloads(andFn)},
 		{name: orFn, overloads: intBinaryOperatorFnOverloads(orFn)},
 		{name: xorFn, overloads: intBinaryOperatorFnOverloads(xorFn)},
+		{name: notFn, overloads: intUnaryOperatorFnOverloads(notFn)},
 
 		// Integer casting
 		{name: int32Fn, overloads: []fnOverload{

--- a/pkg/celbpf/env.go
+++ b/pkg/celbpf/env.go
@@ -25,6 +25,7 @@ var (
 	uint32Fn = "uint32"
 
 	andFn = "and"
+	orFn  = "or"
 )
 
 type fnOverload struct {
@@ -85,6 +86,7 @@ func getFnsOpts() []fnOpts {
 		// Bitwise functions
 		// NB(kkourt): it seems that there is no way to add custom operators to CEL
 		{name: andFn, overloads: intBinaryOperatorFnOverloads(andFn)},
+		{name: orFn, overloads: intBinaryOperatorFnOverloads(orFn)},
 
 		// Integer casting
 		{name: int32Fn, overloads: []fnOverload{

--- a/pkg/celbpf/env.go
+++ b/pkg/celbpf/env.go
@@ -23,6 +23,8 @@ import (
 var (
 	int32Fn  = "int32"
 	uint32Fn = "uint32"
+
+	andFn = "and"
 )
 
 type fnOverload struct {
@@ -79,6 +81,10 @@ func getFnsOpts() []fnOpts {
 		// Addition and Subtraction
 		{name: cgOperators.Add, overloads: intBinaryOperatorFnOverloads("add")},
 		{name: cgOperators.Subtract, overloads: intBinaryOperatorFnOverloads("sub")},
+
+		// Bitwise functions
+		// NB(kkourt): it seems that there is no way to add custom operators to CEL
+		{name: andFn, overloads: intBinaryOperatorFnOverloads(andFn)},
 
 		// Integer casting
 		{name: int32Fn, overloads: []fnOverload{

--- a/pkg/celbpf/types.go
+++ b/pkg/celbpf/types.go
@@ -78,6 +78,18 @@ func intBinaryOperatorFnOverloads(op string) []fnOverload {
 	return ret
 }
 
+func intUnaryOperatorFnOverloads(op string) []fnOverload {
+	ret := make([]fnOverload, 0, len(intTypes))
+	for _, ity := range intTypes {
+		ret = append(ret, fnOverload{
+			name: ity.overloadOp(op),
+			args: []*cgTypes.Type{ity.ty},
+			res:  ity.ty},
+		)
+	}
+	return ret
+}
+
 func typeFromGenTy(genTy int) (*cgTypes.Type, error) {
 	switch genTy {
 	case gt.GenericS64Type:


### PR DESCRIPTION
See commits.


```release-note
celbpf: introduce bitwise operators for CEL expressions (and, or, xor, not)
```