### PR TITLE
Disable automatic Windows GH runner upgrades.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -445,6 +445,12 @@
       "matchUpdateTypes": ["digest"],
       "matchPackageNames": ["!docker.io/library/alpine"],
     },
+    {
+      // Disable automatic Windows GH runner upgrades
+      "matchDepTypes": ["github-runner"],
+      "matchPackageNames": ["windows"],
+      "enabled": false,
+    },
     // automerge section
     {
       "matchPackageNames": [


### PR DESCRIPTION
see: https://github.com/cilium/tetragon/pull/5298
