### PR TITLE
fix(exporter): disable rotation at zero interval

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -40,10 +40,11 @@ type Exporter struct {
 	logFile     string
 	logsDir     string
 
-	// mu protects rotateTimer and rotationInterval for concurrent access.
-	mu               sync.Mutex
-	rotateTimer      *time.Timer
-	rotationInterval time.Duration
+	// mu protects the rotation timer state for concurrent access.
+	mu                 sync.Mutex
+	rotateTimer        *time.Timer
+	rotationInterval   time.Duration
+	rotationGeneration uint64
 }
 
 func NewExporter(
@@ -91,7 +92,7 @@ func (e *Exporter) Start() error {
 			e.mu.Unlock()
 			return fmt.Errorf("writer must be of type lumberjack.Logger but got %T", e.closer)
 		}
-		e.rotateTimer = time.AfterFunc(e.rotationInterval, e.rotate)
+		e.scheduleRotateLocked()
 	}
 	e.mu.Unlock()
 
@@ -115,18 +116,27 @@ func (e *Exporter) Start() error {
 	return nil
 }
 
-func (e *Exporter) rotate() {
+// scheduleRotateLocked schedules a rotation for the current configuration.
+// The caller must hold e.mu.
+func (e *Exporter) scheduleRotateLocked() {
+	generation := e.rotationGeneration
+	e.rotateTimer = time.AfterFunc(e.rotationInterval, func() {
+		e.rotate(generation)
+	})
+}
+
+func (e *Exporter) rotate(generation uint64) {
 	// Rotate is only called when writer is a lumberjack logger; no need to check.
 	writer := e.closer.(*lumberjack.Logger)
 	logger.GetLogger().Info("Rotating JSON logs export", "file", e.logFile, "directory", e.logsDir)
 	if rotationErr := writer.Rotate(); rotationErr != nil {
 		logger.GetLogger().Warn("Failed to rotate JSON export file", "file", option.Config.ExportFilename, logfields.Error, rotationErr)
 	}
-	// Do not reschedule once the context is cancelled, otherwise the timer
-	// keeps rescheduling itself forever even after the exporter is stopped.
+	// Do not reschedule once the context is cancelled or timed rotation is
+	// disabled.
 	e.mu.Lock()
-	if e.ctx.Err() == nil {
-		e.rotateTimer = time.AfterFunc(e.rotationInterval, e.rotate)
+	if e.ctx.Err() == nil && e.rotationInterval > 0 && e.rotationGeneration == generation {
+		e.scheduleRotateLocked()
 	}
 	e.mu.Unlock()
 }
@@ -135,8 +145,10 @@ func (e *Exporter) rotate() {
 func (e *Exporter) stopRotateTimer() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	e.rotationGeneration++
 	if e.rotateTimer != nil {
 		e.rotateTimer.Stop()
+		e.rotateTimer = nil
 	}
 }
 
@@ -196,17 +208,16 @@ func (e *Exporter) SetLogParams(params eventlog.Params) error {
 
 	if params.RotationInterval != nil {
 		e.mu.Lock()
+		e.rotationGeneration++
 		if e.rotateTimer != nil {
 			e.rotateTimer.Stop()
+			e.rotateTimer = nil
 		}
 		e.rotationInterval = *params.RotationInterval
-		// Do not install a new timer once the context is cancelled, otherwise
-		// it would outlive shutdown (see rotate() and stopRotateTimer()).
-		if e.ctx.Err() == nil {
-			e.rotateTimer = time.AfterFunc(
-				e.rotationInterval,
-				e.rotate,
-			)
+		// Do not install a new timer once the context is cancelled or timed
+		// rotation is disabled.
+		if e.ctx.Err() == nil && e.rotationInterval > 0 {
+			e.scheduleRotateLocked()
 		}
 		e.mu.Unlock()
 	}

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -314,3 +314,69 @@ func TestExporterSetLoggingParams(t *testing.T) {
 		<-eventNotifier.removed
 	})
 }
+
+func TestExporterSetRotationIntervalInvalidatesOldTimer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	writer := &lumberjack.Logger{
+		Filename: filepath.Join(t.TempDir(), "test.txt"),
+	}
+	t.Cleanup(func() {
+		require.NoError(t, writer.Close())
+	})
+
+	e := &Exporter{
+		ctx:              ctx,
+		closer:           writer,
+		logFile:          filepath.Base(writer.Filename),
+		logsDir:          filepath.Dir(writer.Filename),
+		rotationInterval: time.Hour,
+	}
+	e.mu.Lock()
+	staleGeneration := e.rotationGeneration
+	e.scheduleRotateLocked()
+	e.mu.Unlock()
+
+	require.NoError(t, e.SetLogParams(eventlog.Params{
+		RotationInterval: new(2 * time.Hour),
+	}))
+
+	e.mu.Lock()
+	rotationInterval := e.rotationInterval
+	rotateTimer := e.rotateTimer
+	e.mu.Unlock()
+	require.Equal(t, 2*time.Hour, rotationInterval)
+	require.NotNil(t, rotateTimer)
+
+	// Simulate the old timer callback completing after SetLogParams installed
+	// the new timer. It must not overwrite the new timer and create a second
+	// independent rotation loop.
+	e.rotate(staleGeneration)
+
+	e.mu.Lock()
+	gotRotateTimer := e.rotateTimer
+	staleGeneration = e.rotationGeneration
+	e.mu.Unlock()
+	require.Same(t, rotateTimer, gotRotateTimer)
+
+	require.NoError(t, e.SetLogParams(eventlog.Params{
+		RotationInterval: new(time.Duration),
+	}))
+
+	e.mu.Lock()
+	rotationInterval = e.rotationInterval
+	rotateTimer = e.rotateTimer
+	e.mu.Unlock()
+	require.Zero(t, rotationInterval)
+	require.Nil(t, rotateTimer)
+
+	// A callback from the previously active configuration must not re-enable
+	// rotation after a zero interval disables it.
+	e.rotate(staleGeneration)
+
+	e.mu.Lock()
+	rotateTimer = e.rotateTimer
+	e.mu.Unlock()
+	require.Nil(t, rotateTimer)
+}


### PR DESCRIPTION
### Description

With JSON export enabled, run:

```console
kubectl exec -n kube-system ds/tetragon -c tetragon -- tetra eventlog set --rotation-interval=0s
kubectl logs -n kube-system ds/tetragon -c tetragon --since=10s | grep "Rotating JSON logs export"
```

Before the fix this starts a zero-delay timer. 
Each callback rearms itself, so logs rotate in a tight loop and rotation messages get spammy fast

Zero now disables timed rotation, same as startup. 
The callback also checks the interval so an in-flight rotation cannot bring the timer back. 
Positive intervals work as before, tests cover both paths

### Changelog

```release-note
Fix timed log rotation when its interval is set to zero
```