### PR TITLE
pkg/process: avoid calling GetPodInfo in non k8s deployments

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -330,7 +330,10 @@ func initProcessInternalExec(
 	}
 	creds := &event.Msg.Creds
 	execID := GetExecID(&process)
-	protoPod := GetPodInfo(event.Kube.Docker, process.Filename, args, process.NSPID)
+	var protoPod *tetragon.Pod
+	if option.Config.EnableK8s && event.Kube.Docker != "" {
+		protoPod = GetPodInfo(event.Kube.Docker, process.Filename, args, process.NSPID)
+	}
 	apiCaps := caps.GetMsgCapabilities(event.Msg.Creds.Cap)
 	binary := path.GetBinaryAbsolutePath(process.Filename, cwd)
 	apiNs, err := namespace.GetMsgNamespaces(event.Msg.Namespaces)


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
`GetPodInfo()` gets called whether the `enable-k8s-api` option is true or not. In an environment with plain docker containers, this leads to numerous `tetragon_watcher_errors_total{error="failed_to_get_pod",watcher="k8s"}` errors in metrics.

Add a check for `option.Config.EnableK8s` before calling `GetPodInfo()`.

Fixes: #219

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
process: Add a missing guard for GetPodInfo call to avoid attempts to collect k8s pod metadata in non-k8s deployments.
```
