### PR TITLE
Some eBPF fixes to be able to build with newer clang versions

### DIFF
--- a/Dockerfile.clang
+++ b/Dockerfile.clang
@@ -1,8 +1,26 @@
 FROM docker.io/library/ubuntu:24.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
-RUN apt-get update && apt-get install -y --no-install-recommends  \
-    clang-20 libclang-common-20-dev libclang-cpp20    	          \
-    libllvm20 llvm-20-linker-tools libclang1-20                   \
-    llvm-20 llvm-20-runtime llvm-20-linker-tools make             \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN ln -vsnf /usr/lib/llvm-20/bin/clang /usr/bin/clang
-RUN ln -vsnf /usr/lib/llvm-20/bin/llc /usr/bin/llc
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gnupg \
+        wget \
+    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+        | gpg --dearmor -o /usr/share/keyrings/llvm.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] https://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
+        > /etc/apt/sources.list.d/llvm.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang-22 \
+        libclang-common-22-dev \
+        libclang-cpp22 \
+        libllvm22 \
+        llvm-22-linker-tools \
+        libclang1-22 \
+        llvm-22 \
+        llvm-22-runtime \
+        make \
+    && ln -vsnf /usr/lib/llvm-22/bin/clang /usr/bin/clang \
+    && ln -vsnf /usr/lib/llvm-22/bin/llc /usr/bin/llc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -721,8 +721,12 @@ read_exe(struct task_struct *task, struct heap_exe *exe)
 	asm volatile("%[len] &= 0xff;\n"
 		     : [len] "+r"(exe->len));
 	with_errmetrics(probe_read, exe->buf, exe->len, buffer);
-	if (revlen < STRING_POSTFIX_MAX_LENGTH)
+	if (revlen < STRING_POSTFIX_MAX_LENGTH) {
+		if (offset > MAX_BUF_LEN)
+			offset = MAX_BUF_LEN;
+
 		with_errmetrics(probe_read, exe->end, revlen, (char *)(buffer + offset));
+	}
 	return exe->len;
 }
 #endif

--- a/bpf/libbpf/bpf_core_read.h
+++ b/bpf/libbpf/bpf_core_read.h
@@ -217,7 +217,13 @@ enum bpf_type_info_kind {
 #define ___arrow10(a, b, c, d, e, f, g, h, i, j) a->b->c->d->e->f->g->h->i->j
 #define ___arrow(...) ___apply(___arrow, ___narg(__VA_ARGS__))(__VA_ARGS__)
 
+#if defined(__clang__) && (__clang_major__ >= 19)
+#define ___type(...) __typeof_unqual__(___arrow(__VA_ARGS__))
+#elif defined(__GNUC__) && (__GNUC__ >= 14)
+#define ___type(...) __typeof_unqual__(___arrow(__VA_ARGS__))
+#else
 #define ___type(...) typeof(___arrow(__VA_ARGS__))
+#endif
 
 #define ___read(read_fn, dst, src_type, src, accessor)			    \
 	read_fn((void *)(dst), sizeof(*(dst)), &((src_type)(src))->accessor)

--- a/bpf/process/bpf_execve_event.h
+++ b/bpf/process/bpf_execve_event.h
@@ -68,9 +68,12 @@ read_args(void *ctx, struct msg_execve_event *event)
 	free_size = (char *)&event->process + BUFFER - args;
 	args_size = end_stack - start_stack;
 
-	if (args_size < BUFFER && args_size < free_size) {
-		if (args_size)
-			args_size -= 1;
+	if (args_size < 2) {
+		/* args contains at most a '\0', nothing to read */
+		size = 0;
+	} else if (args_size < BUFFER && args_size < free_size) {
+		/* args fit in the inline buffer, read them in */
+		args_size -= 1; // strip trailing '\0'
 		size = args_size & 0x3ff /* BUFFER - 1 */;
 		err = with_errmetrics(probe_read, args, size, (char *)start_stack);
 		if (err < 0) {
@@ -78,6 +81,7 @@ read_args(void *ctx, struct msg_execve_event *event)
 			size = 0;
 		}
 	} else {
+		/* args too big for inline buffer, use data event */
 		size = data_event_bytes(ctx, (struct data_event_desc *)args,
 					(unsigned long)start_stack,
 					args_size,


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Fixes #5452 <!-- #issue-number -->

### Description
1. fix ebpf files failing to compile against clang-22
2. fix ebpf programs  failing to load
3. update the clang Dockerfile image

Please see individual commit messages
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Add support for building against clang-22
```
