### PR TITLE
process: check k8s before podinfo lookup

### DIFF
--- a/pkg/process/podinfo.go
+++ b/pkg/process/podinfo.go
@@ -77,7 +77,7 @@ func getPodInfo(
 	args string,
 	nspid uint32,
 ) *tetragon.Pod {
-	if containerID == "" {
+	if w == nil || containerID == "" {
 		return nil
 	}
 	pod, container, ok := w.FindContainer(containerID)


### PR DESCRIPTION
Commit 62cb806cd8d6 ("process: decouple k8s watcher and process cache") fixed a nil dereference panic by ensuring that k8s is set, regardless if the process cache is enabled or not.

This check is meant to support a possible future, where we decide to support a mode where the k8s watcher is not set.

One reason why we might want to support this is if decide to disable best effort podinfo resolution when the process cache is disabled.

Regardless if we go that direction, it doesn't hurt to be defensive here.