### PR TITLE
add checks for policy tests validation on nok8s

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -77,8 +77,8 @@ jobs:
     - name: Run nok8s go tests
       run: |
         cd go/src/github.com/cilium/tetragon/
-        go vet -tags nok8s ./pkg/sensors ./pkg/policyfilter ./pkg/tracingpolicy
-        go test -tags nok8s ./pkg/tracingpolicy
+        go vet -tags nok8s ./pkg/sensors ./pkg/policyfilter ./pkg/tracingpolicy ./pkg/testutils/policytest
+        go test -tags nok8s ./pkg/tracingpolicy ./pkg/testutils/policytest
 
     - name: Upload Tetragon logs
       if: failure()

--- a/pkg/testutils/policytest/render_test.go
+++ b/pkg/testutils/policytest/render_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package policytest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/tetragon/pkg/testutils/policytest"
+	"github.com/cilium/tetragon/pkg/tracingpolicy"
+	_ "github.com/cilium/tetragon/tests/policytests" // so that the policies are registered
+)
+
+// TestRenderPolicyTests renders the policy of every registered policytest, for
+// every combination of its parameters, and checks that it parses and validates.
+func TestRenderPolicyTests(t *testing.T) {
+	all := policytest.AllPolicyTests
+	require.NotZero(t, all.Len(), "no policy tests registered")
+
+	for i := range all.Len() {
+		pt := all.Get(i)
+		t.Run(pt.Name, func(t *testing.T) {
+			if pt.Policy == nil {
+				t.Skip("test has no policy")
+			}
+			for params := range pt.AllParamValues() {
+				check := func(t *testing.T) {
+					conf := &policytest.Conf{
+						BinsDir:  "/tetragon-policytests-bins",
+						TestConf: &policytest.TestConf{ParamValues: params},
+					}
+
+					pol, cleanup, err := pt.Policy(conf)
+					if cleanup != nil {
+						defer cleanup()
+					}
+					require.NoError(t, err, "failed to generate policy")
+
+					if len(pol) == 0 {
+						t.Skip("test generated no policy")
+					}
+
+					_, err = tracingpolicy.FromYAML(string(pol))
+					require.NoError(t, err, "failed to parse policy:\n%s", pol)
+				}
+
+				// Only nest a subtest when there is a parameter to name it after:
+				//
+				//	uprobe-generic (no params) -> uprobe-generic
+				//	kprobe-lseek   (Hook)      -> kprobe-lseek/Hook=kprobes
+				//	                              kprobe-lseek/Hook=fentries
+				if len(pt.Params) == 0 {
+					check(t)
+					continue
+				}
+				t.Run(params.String(), check)
+			}
+		})
+	}
+}

--- a/tests/policytests/uprobes.go
+++ b/tests/policytests/uprobes.go
@@ -231,18 +231,18 @@ metadata:
 spec:
   uprobes:
   - path: {{ testBinary "resolve-nested-anon-struct" }}
-    BTFPath: {{ testBinary "resolve-nested-anon-struct.btf" }}
+    btfPath: {{ testBinary "resolve-nested-anon-struct.btf" }}
     symbols:
     - "passit"
     args:
     - index: 0
       type: "int"
       resolve: "nested.ans.second"
-      BTFType: "mystruct"
+      btfType: "mystruct"
     - index: 0
       type: "int"
       resolve: "pnested.pans.second"
-      BTFType: "mystruct"
+      btfType: "mystruct"
 `).WithSkip(func(si *policytest.SkipInfo) string {
 	if !si.AgentInfo.Probes[bpf.LargeProgsProbe] {
 		return "need 5.3 or newer kernel"


### PR DESCRIPTION
Changing from `BTFPath` and `BTFType` to `btfPath` and `btfType` to match schema defined for JSON in the CRDs.

This was the only occurence of a wrong definition in a yml file for these params.

Also added tests for preventing these kind of bugs in the future
