### PR TITLE
contrib/verify: improve the verifier tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,8 @@ bpf-test:
 
 .PHONY: verify
 verify: tetragon-bpf ## Verify BPF programs.
-	DEBUG=${DEBUG} TETRAGONDIR=$(CURDIR)/bpf/objs $(GO) test -exec 'sudo -E' contrib/verify/verify_test.go -v
+	$(GO) test contrib/verify/verify_test.go -run TestExtractKernelVersion
+	DEBUG=${DEBUG} TETRAGONDIR=$(CURDIR)/bpf/objs $(GO) test -exec 'sudo -E' contrib/verify/verify_test.go -v -run TestVerifyTetragonPrograms
 
 .PHONY: alignchecker
 alignchecker: ## Run alignchecker.

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ bpf-test:
 
 .PHONY: verify
 verify: tetragon-bpf ## Verify BPF programs.
-	sudo DEBUG=${DEBUG} TETRAGONDIR=$(CURDIR)/bpf/objs $(GO) test contrib/verify/verify_test.go -v
+	DEBUG=${DEBUG} TETRAGONDIR=$(CURDIR)/bpf/objs $(GO) test -exec 'sudo -E' contrib/verify/verify_test.go -v
 
 .PHONY: alignchecker
 alignchecker: ## Run alignchecker.

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ bpf-test:
 .PHONY: verify
 verify: tetragon-bpf ## Verify BPF programs.
 	$(GO) test contrib/verify/verify_test.go -run TestExtractKernelVersion
-	DEBUG=${DEBUG} TETRAGONDIR=$(CURDIR)/bpf/objs $(GO) test -exec 'sudo -E' contrib/verify/verify_test.go -v -run TestVerifyTetragonPrograms
+	$(GO) test -exec 'sudo -E' contrib/verify/verify_test.go -v -run TestVerifyTetragonPrograms -tetragon-dir=$(CURDIR)/bpf/objs $(if $(DEBUG),-debug)
 
 .PHONY: alignchecker
 alignchecker: ## Run alignchecker.

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -27,6 +27,44 @@ const (
 	tetragondir = "/var/lib/tetragon"
 )
 
+func extractKernelVersion(t *testing.T, fileName string) string {
+	if idx := strings.LastIndex(fileName, "_v"); idx != -1 {
+		versionPart := strings.TrimSuffix(fileName[idx+2:], ".o")
+		if len(versionPart) >= 2 {
+			if versionPart[:1] == "1" {
+				t.Fatalf("version 10.x not supported (we will need to disambiguate notation): %s", versionPart)
+			}
+			return versionPart[:1] + "." + versionPart[1:]
+		}
+	}
+
+	return ""
+}
+
+func TestExtractKernelVersion(t *testing.T) {
+	tests := []struct {
+		fileName string
+		expected string
+	}{
+		{"bpf_generic_kprobe_v612.o", "6.12"},
+		{"bpf_generic_kprobe_v61.o", "6.1"},
+		{"bpf_generic_kprobe_v511.o", "5.11"},
+		{"bpf_generic_kprobe_v53.o", "5.3"},
+		{"bpf_generic_kprobe.o", ""},
+		{"bpf_alignchecker.o", ""},
+		{"bpf_loader_v511.o", "5.11"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fileName, func(t *testing.T) {
+			result := extractKernelVersion(t, tt.fileName)
+			if result != tt.expected {
+				t.Errorf("extractKernelVersion(%q) = %q, want %q", tt.fileName, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestVerifyTetragonPrograms(t *testing.T) {
 
 	tetragonDir := os.Getenv("TETRAGONDIR")
@@ -66,19 +104,16 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 			continue
 		}
 
-		// Skip v6.1 objects check for kernel < 6.1
-		if strings.HasSuffix(fileName, "61.o") && !kernels.MinKernelVersion("6.1") {
-			continue
-		}
-
-		// Skip v5.11 objects check for kernel < 5.11
-		if strings.HasSuffix(fileName, "511.o") && !kernels.MinKernelVersion("5.11") {
-			continue
-		}
-
 		// Skip rhel7 objects, it's special
 		if strings.HasSuffix(fileName, "310.o") {
 			continue
+		}
+
+		// Skip kernel version-specific objects if running on older kernel
+		if requiredVersion := extractKernelVersion(t, fileName); requiredVersion != "" {
+			if !kernels.MinKernelVersion(requiredVersion) {
+				continue
+			}
 		}
 
 		// Skip bpf_loader for kernel < 5.19

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -7,8 +7,6 @@ package verify
 
 import (
 	"errors"
-	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -38,7 +36,7 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 
 	files, err := os.ReadDir(tetragonDir)
 	if err != nil {
-		log.Fatalf("error: %v", err)
+		t.Fatalf("error: %v", err)
 	}
 
 	for _, file := range files {
@@ -122,9 +120,9 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 		require.NotNil(t, spec, "collection spec should not be nil")
 
 		if isDebugEnabled() {
-			fmt.Printf("[%s]\n", fileName)
+			t.Logf("[%s]", fileName)
 			for _, progSpec := range spec.Programs {
-				fmt.Printf("%s\n", progSpec.Instructions.String())
+				t.Log(progSpec.Instructions.String())
 			}
 		}
 
@@ -144,10 +142,10 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 		if err != nil {
 			var ve *ebpf.VerifierError
 			if errors.As(err, &ve) {
-				fmt.Printf("%+v\n", ve)
+				t.Logf("%+v", ve)
 
 				_, kver, _ := kernels.GetKernelVersion("", "/proc")
-				fmt.Printf("failed object %s, kernel %s\n", fileName, kver)
+				t.Logf("failed object %s, kernel %s", fileName, kver)
 			}
 		}
 

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -154,13 +154,6 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 		require.NoError(t, err, "failed to parse elf file into collection spec")
 		require.NotNil(t, spec, "collection spec should not be nil")
 
-		if *debug {
-			t.Logf("[%s]", fileName)
-			for _, progSpec := range spec.Programs {
-				t.Log(progSpec.Instructions.String())
-			}
-		}
-
 		if strings.HasPrefix(fileName, "bpf_generic_kprobe") {
 			if fileName != "bpf_generic_kprobe.o" { // 4.19 version does not need to be rewritten
 				for _, prog := range spec.Programs {
@@ -176,15 +169,13 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 		collection, err := ebpf.NewCollection(spec)
 		if err != nil {
 			var ve *ebpf.VerifierError
-			if errors.As(err, &ve) {
+			if errors.As(err, &ve) && *debug {
 				t.Logf("%+v", ve)
-
-				_, kver, _ := kernels.GetKernelVersion("", "/proc")
-				t.Logf("failed object %s, kernel %s", fileName, kver)
 			}
+			_, kver, _ := kernels.GetKernelVersion("", "/proc")
+			t.Errorf("%s ✗: failed to load object on kernel %s: %v", fileName, kver, err)
+			continue
 		}
-
-		require.NoError(t, err, "failed to load resources into the kernel")
 
 		collection.Close()
 		t.Logf("%s ✓", fileName)

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -95,46 +95,54 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 
 		// Multi kprobe support is still not widely around, skip the object
 		if strings.HasPrefix(fileName, "bpf_multi_") {
+			t.Logf("%s ⊘ (multi-kprobe)", fileName)
 			continue
 		}
 
 		// Can't load fentry/fexit objects without loader setup
 		if strings.HasPrefix(fileName, "bpf_generic_fentry") ||
 			strings.HasPrefix(fileName, "bpf_generic_fexit") {
+			t.Logf("%s ⊘ (fentry/fexit)", fileName)
 			continue
 		}
 
 		// Skip rhel7 objects, it's special
 		if strings.HasSuffix(fileName, "310.o") {
+			t.Logf("%s ⊘ (rhel7)", fileName)
 			continue
 		}
 
 		// Skip kernel version-specific objects if running on older kernel
 		if requiredVersion := extractKernelVersion(t, fileName); requiredVersion != "" {
 			if !kernels.MinKernelVersion(requiredVersion) {
+				t.Logf("%s ⊘ (requires kernel %s)", fileName, requiredVersion)
 				continue
 			}
 		}
 
 		// Skip bpf_loader for kernel < 5.19
 		if strings.HasPrefix(fileName, "bpf_loader") && !kernels.MinKernelVersion("5.19") {
+			t.Logf("%s ⊘ (requires kernel 5.19)", fileName)
 			continue
 		}
 
 		// Generic LSM BPF needs more complex userspace logic to load, so ignore it
 		if strings.HasPrefix(fileName, "bpf_generic_lsm") {
+			t.Logf("%s ⊘ (lsm)", fileName)
 			continue
 		}
 
 		// Check if bpf_override_return is available
 		if strings.HasPrefix(fileName, "bpf_generic_kprobe") || strings.HasPrefix(fileName, "bpf_enforcer") {
 			if err := features.HaveProgramHelper(ebpf.Kprobe, asm.FnOverrideReturn); err != nil {
+				t.Logf("%s ⊘ (no bpf_override_return)", fileName)
 				continue
 			}
 		}
 
 		// Check if uprobe regs change is available
 		if strings.HasPrefix(fileName, "bpf_generic_uprobe") && !bpf.HasUprobeRegsChange() {
+			t.Logf("%s ⊘ (no uprobe regs change)", fileName)
 			continue
 		}
 
@@ -142,6 +150,7 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 		if (strings.HasPrefix(fileName, "bpf_generic_uprobe") ||
 			strings.HasPrefix(fileName, "bpf_generic_usdt")) &&
 			!bpf.HasKfunc("bpf_copy_from_user_str") {
+			t.Logf("%s ⊘ (no bpf_copy_from_user_str)", fileName)
 			continue
 		}
 
@@ -182,6 +191,7 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 		require.NoError(t, err, "failed to load resources into the kernel")
 
 		collection.Close()
+		t.Logf("%s ✓", fileName)
 	}
 }
 

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -7,9 +7,9 @@ package verify
 
 import (
 	"errors"
+	"flag"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -19,12 +19,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/selectors"
 )
 
-const (
-	tetragondir = "/var/lib/tetragon"
+var (
+	tetragonDir = flag.String("tetragon-dir", defaults.DefaultTetragonLib, "Directory containing Tetragon BPF objects")
+	debug       = flag.Bool("debug", false, "Enable debug output")
 )
 
 func extractKernelVersion(t *testing.T, fileName string) string {
@@ -66,13 +68,7 @@ func TestExtractKernelVersion(t *testing.T) {
 }
 
 func TestVerifyTetragonPrograms(t *testing.T) {
-
-	tetragonDir := os.Getenv("TETRAGONDIR")
-	if tetragonDir == "" {
-		tetragonDir = tetragondir
-	}
-
-	files, err := os.ReadDir(tetragonDir)
+	files, err := os.ReadDir(*tetragonDir)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
@@ -154,11 +150,11 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 			continue
 		}
 
-		spec, err := ebpf.LoadCollectionSpec(tetragonDir + "/" + fileName)
+		spec, err := ebpf.LoadCollectionSpec(*tetragonDir + "/" + fileName)
 		require.NoError(t, err, "failed to parse elf file into collection spec")
 		require.NotNil(t, spec, "collection spec should not be nil")
 
-		if isDebugEnabled() {
+		if *debug {
 			t.Logf("[%s]", fileName)
 			for _, progSpec := range spec.Programs {
 				t.Log(progSpec.Instructions.String())
@@ -193,9 +189,4 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 		collection.Close()
 		t.Logf("%s ✓", fileName)
 	}
-}
-
-func isDebugEnabled() bool {
-	debug, err := strconv.ParseBool(os.Getenv("DEBUG"))
-	return err == nil && debug
 }

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -50,11 +50,6 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 			continue
 		}
 
-		// Globals is just for testing, so ignore it
-		if strings.HasPrefix(fileName, "bpf_alignchecker") {
-			continue
-		}
-
 		// Generic tracepoint needs more complex userspace logic to load, so ignore it
 		if strings.HasPrefix(fileName, "bpf_generic_tracepoint") {
 			continue


### PR DESCRIPTION
I have been bumping into this while building https://github.com/cilium/tetragon/pull/5442 and the output wasn't super useful, let's fix a few issues (we were not skipping correctly the programs built for a kernel version newer than the current) and make the output more useful.