### PR TITLE
new: bpf DEBUG() macro to use rodata config

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -3,6 +3,8 @@
 #ifndef _MSG_COMMON__
 #define _MSG_COMMON__
 
+#include "config.h"
+
 /* msg_common internal flags */
 #define MSG_COMMON_FLAG_RETURN		  BIT(0)
 #define MSG_COMMON_FLAG_KERNEL_STACKTRACE BIT(1)
@@ -57,11 +59,15 @@ struct bpf_map_def {
 #define BIT(nr)	    (1 << (nr))
 #define BIT_ULL(nr) (1ULL << (nr))
 
-#ifdef TETRAGON_BPF_DEBUG
 #include <bpf_tracing.h>
-#define DEBUG(__fmt, ...) bpf_printk(__fmt, ##__VA_ARGS__)
+// If TETRAGON_BPF_DEBUG is set, always enable debug messages
+#ifdef TETRAGON_BPF_DEBUG
+#define DEBUG(__fmt, ...) bpf_printk("tetragon: " __fmt, ##__VA_ARGS__)
 #else
-#define DEBUG(__fmt, ...)
+// Use the proper CONFIG value to check whether debug messages are enabled
+#define DEBUG(__fmt, ...)              \
+	if (CONFIG(BPF_DEBUG_ENABLED)) \
+		bpf_printk("tetragon: " __fmt, ##__VA_ARGS__);
 #endif
 
 #if __has_attribute(btf_decl_tag)

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -60,14 +60,18 @@ struct bpf_map_def {
 #define BIT_ULL(nr) (1ULL << (nr))
 
 #include <bpf_tracing.h>
+#include "debug.h"
+
+#define DEBUG(__fmt, ...) DEBUG_AREA(BPF_AREA_GENERIC, __fmt, ##__VA_ARGS__)
+
 // If TETRAGON_BPF_DEBUG is set, always enable debug messages
 #ifdef TETRAGON_BPF_DEBUG
-#define DEBUG(__fmt, ...) bpf_printk("tetragon: " __fmt, ##__VA_ARGS__)
+#define DEBUG_AREA(area, __fmt, ...) bpf_printk("tetragon@" #area " | " __fmt, ##__VA_ARGS__)
 #else
 // Use the proper CONFIG value to check whether debug messages are enabled
-#define DEBUG(__fmt, ...)              \
-	if (CONFIG(BPF_DEBUG_ENABLED)) \
-		bpf_printk("tetragon: " __fmt, ##__VA_ARGS__);
+#define DEBUG_AREA(area, __fmt, ...)            \
+	if (CONFIG(BPF_DEBUG_ENABLED) & (area)) \
+		bpf_printk("tetragon@" #area " | " __fmt, ##__VA_ARGS__);
 #endif
 
 #if __has_attribute(btf_decl_tag)

--- a/bpf/lib/config.h
+++ b/bpf/lib/config.h
@@ -33,7 +33,8 @@ struct rodata_config {
 	__u8 USE_PERF_RING_BUF;
 	__u8 ENV_VARS_ENABLED;
 	__u8 PARENTS_MAP_ENABLED;
-	__u8 pad[4];
+	__u8 BPF_DEBUG_ENABLED;
+	__u8 pad[3];
 };
 
 volatile const struct rodata_config rodata_config
@@ -54,13 +55,14 @@ volatile const struct rodata_config rodata_config
  * without compile-time elimination both get verified, which failed to
  * load on a real v5.4 kernel in CI.
  *
- * PARENTS_MAP_ENABLED/ENV_VARS_ENABLED don't have that problem - their
- * call sites are plain guards with no alternate branch, so they work
+ * PARENTS_MAP_ENABLED/ENV_VARS_ENABLED/BPF_DEBUG_ENABLED don't have that problem -
+ * their call sites are plain guards with no alternate branch, so they work
  * fine as ordinary runtime values on any kernel.
  */
 #ifdef __LARGE_BPF_PROG
 volatile const __u8 PARENTS_MAP_ENABLED;
 volatile const __u8 ENV_VARS_ENABLED;
+volatile const __u8 BPF_DEBUG_ENABLED;
 #define ITER_NUM     0
 #define CONFIG(name) name
 #else

--- a/bpf/lib/debug.h
+++ b/bpf/lib/debug.h
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+
+#define BPF_AREA_GENERIC 1 << 0
+#define BPF_AREA_PROCESS 1 << 1

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -17,6 +17,7 @@
 #include "errmetrics.h"
 
 #define MATCH_BINARIES_PATH_MAX_LENGTH 256
+#define DEBUG_PROCESS(__fmt, ...)      DEBUG_AREA(BPF_AREA_PROCESS, __fmt, ##__VA_ARGS__)
 
 FUNC_INLINE __u64 __get_auid(struct task_struct *t)
 {
@@ -336,13 +337,13 @@ set_in_init_tree(struct execve_map_value *curr, struct execve_map_value *parent)
 {
 	if (parent && parent->flags & EVENT_IN_INIT_TREE) {
 		curr->flags |= EVENT_IN_INIT_TREE;
-		DEBUG("%s: parent in init tree", __func__);
+		DEBUG_PROCESS("%s: parent in init tree", __func__);
 		return;
 	}
 
 	if (curr->nspid == 1) {
 		curr->flags |= EVENT_IN_INIT_TREE;
-		DEBUG("%s: nspid=1", __func__);
+		DEBUG_PROCESS("%s: nspid=1", __func__);
 	}
 }
 

--- a/cmd/tetragon/main.go
+++ b/cmd/tetragon/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net"
@@ -673,6 +674,13 @@ func tetragonExecuteCtx(ctx context.Context, cancel context.CancelFunc, ready fu
 		go logStatus(ctx, obs)
 	}
 
+	// Start even if BPFDebugAreas is empty;
+	// BPF probe might've been compiled with TETRAGON_BPF_DEBUG
+	// thus all bpf_trace_printk() are forcefully enabled.
+	if option.Config.BPFDebugLog {
+		go logBPFDebug(ctx)
+	}
+
 	return obs.StartReady(ctx, ready)
 }
 
@@ -769,6 +777,45 @@ func logStatus(ctx context.Context, obs *observer.Observer) {
 				obs.PrintStats()
 				prevLost = lost
 				prevErrors = errors
+			}
+		}
+	}
+}
+
+func logBPFDebug(ctx context.Context) {
+	f, err := os.Open("/sys/kernel/debug/tracing/trace_pipe")
+	if err != nil {
+		log.Warn("failed to open /sys/kernel/debug/tracing/trace_pipe", "err", err)
+		return
+	}
+	defer f.Close()
+
+	buf := make([]byte, 4096)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		n, err := f.Read(buf)
+		if n > 0 {
+			lines := strings.SplitSeq(string(buf[:n]), "\n")
+			for line := range lines {
+				// Only print tetragon messages
+				i := strings.Index(line, "tetragon")
+				if i != -1 {
+					// Drop all stuff before tetragon prefix
+					logger.GetLogger().Info(line[i:])
+				} else if strings.Contains(line, "LOST") {
+					// Print LOST messages, eg:
+					// CPU:12 [LOST 711 EVENTS]
+					// CPU:3 [LOST 3698 EVENTS]
+					// CPU:1 [LOST 8509 EVENTS]
+					logger.GetLogger().Info(line)
+				}
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
 			}
 		}
 	}

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -3,6 +3,13 @@ synopsis: |
     Tetragon - eBPF-based Security Observability and Runtime Enforcement
 usage: tetragon [flags]
 options:
+    - name: bpf-debug-area
+      usage: |
+        Enable BPF tracing messages for specified areas (all, generic, process)
+    - name: bpf-debug-log
+      default_value: "false"
+      usage: |
+        Enable forwarding BPF trace messages to tetragon log as info messages
     - name: bpf-dir
       default_value: tetragon
       usage: Set tetragon bpf directory (default 'tetragon')

--- a/pkg/option/bpfdbgenum.go
+++ b/pkg/option/bpfdbgenum.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package option
+
+import (
+	"slices"
+
+	"maps"
+)
+
+type BPFDbgEnum struct {
+	*SliceEnum
+	areaMap map[string]uint8
+}
+
+func NewBPFDbgEnum(allowedMap map[string]uint8) *BPFDbgEnum {
+	allowedVals := slices.Collect(maps.Keys(allowedMap))
+	allowedVals = append(allowedVals, "all")
+	// Make the slice stable to generate stable flags documentation.
+	// Since we are collecting from a map, we need to guarantee it.
+	slices.Sort(allowedVals)
+	enum, _ := NewSliceEnum(allowedVals, nil)
+
+	return &BPFDbgEnum{
+		SliceEnum: enum,
+		areaMap:   allowedMap,
+	}
+}
+
+func (e *BPFDbgEnum) ToBPFConfig() uint8 {
+	if slices.Contains(e.Values, "all") {
+		return 0xff
+	}
+	var cfgVal uint8
+	for _, v := range e.Values {
+		cfgVal |= e.areaMap[v]
+	}
+	return cfgVal
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -164,6 +164,9 @@ type config struct {
 	// its ClientAuth policy to RequireAndVerifyClientCert; ServerTLSClientCAFiles
 	// must be non-empty.
 	ServerTLSRequireClientCert bool
+
+	BPFDebugAreas *BPFDbgEnum
+	BPFDebugLog   bool
 }
 
 var (
@@ -198,6 +201,13 @@ var (
 
 		// Set default value for deleted pod lru cache
 		DeletedPodCacheSize: constants.WatcherDeletedPodCacheSize,
+
+		// Set default value for bpf debug areas
+		// to be kept in sync with bpf/libs/debug.h
+		BPFDebugAreas: NewBPFDbgEnum(map[string]uint8{
+			"generic": 1 << 0,
+			"process": 1 << 1,
+		}),
 	}
 )
 

--- a/pkg/option/enum.go
+++ b/pkg/option/enum.go
@@ -81,7 +81,9 @@ func (e *SliceEnum) Set(p string) error {
 	if !slices.Contains(e.allowed, p) {
 		return fmt.Errorf("invalid argument %s, please provide one of %s", p, e.Allowed())
 	}
-	e.Values = append(e.Values, p)
+	if !slices.Contains(e.Values, p) {
+		e.Values = append(e.Values, p)
+	}
 	return nil
 }
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -160,6 +160,9 @@ const (
 	KeyServerTLSKeyFile           = "server-tls-key-file"
 	KeyServerTLSClientCAFiles     = "server-tls-client-ca-files"
 	KeyServerTLSRequireClientCert = "server-tls-require-client-cert"
+
+	KeyBpfDebugArea = "bpf-debug-area"
+	KeyBpfDebugLog  = "bpf-debug-log"
 )
 
 type UsernameMetadaCode int
@@ -357,6 +360,8 @@ func ReadAndSetFlags() error {
 	if err := validateServerTLSConfig(Config); err != nil {
 		return err
 	}
+
+	Config.BPFDebugLog = viper.GetBool(KeyBpfDebugLog)
 
 	warnIgnoredProcessCacheFlags(Config)
 
@@ -650,4 +655,7 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.String(KeyServerTLSKeyFile, "", "Path to the PEM-encoded private key matching --"+KeyServerTLSCertFile+". Required when --"+KeyServerTLSCertFile+" is set.")
 	flags.StringSlice(KeyServerTLSClientCAFiles, []string{}, "Paths to PEM-encoded CA bundles used to verify client certificates. Required when --"+KeyServerTLSRequireClientCert+" is true.")
 	flags.Bool(KeyServerTLSRequireClientCert, false, "Require and verify client certificates (mTLS). Requires --"+KeyServerTLSClientCAFiles+".")
+
+	flags.Var(Config.BPFDebugAreas, KeyBpfDebugArea, "Enable BPF tracing messages for specified areas "+Config.BPFDebugAreas.Allowed())
+	flags.Bool(KeyBpfDebugLog, false, "Enable forwarding BPF trace messages to tetragon log as info messages")
 }

--- a/pkg/sensors/base/base.go
+++ b/pkg/sensors/base/base.go
@@ -163,6 +163,10 @@ func setupSensor() {
 		Execve.RewriteConstants["PARENTS_MAP_ENABLED"] = uint8(1)
 	}
 
+	if !config.EnableV511Progs() && len(option.Config.BPFDebugAreas.Values) > 0 {
+		Execve.RewriteConstants["BPF_DEBUG_ENABLED"] = option.Config.BPFDebugAreas.ToBPFConfig()
+	}
+
 	if option.Config.ParentsMapEnabled {
 		entries = GetExecveEntries(option.Config.ParentsMapEntries, option.Config.ParentsMapSize)
 		ParentBinariesMap.SetMaxEntries(entries)

--- a/pkg/sensors/base/rodata_linux.go
+++ b/pkg/sensors/base/rodata_linux.go
@@ -20,7 +20,8 @@ type rodataConfig struct {
 	UsePerfRingBuf    uint8
 	EnvVarsEnabled    uint8
 	ParentsMapEnabled uint8
-	Pad               [4]uint8
+	BpfDebugEnabled   uint8
+	Pad               [3]uint8
 }
 
 func b2u8(b bool) uint8 {
@@ -45,11 +46,15 @@ func rodataCurrent() rodataConfig {
 	// parents match enabled by --parents-map-enabled option
 	parentsMapEnabled := b2u8(option.Config.ParentsMapEnabled)
 
+	// bpf debug match enabled by --bpf-debug
+	bpfDebugEnabled := option.Config.BPFDebugAreas.ToBPFConfig()
+
 	return rodataConfig{
 		IterNum:           iterNum,
 		UsePerfRingBuf:    usePerfRingBuf,
 		EnvVarsEnabled:    envVarsEnabled,
 		ParentsMapEnabled: parentsMapEnabled,
+		BpfDebugEnabled:   bpfDebugEnabled,
 	}
 }
 


### PR DESCRIPTION
### Description

This PR introduces the possibility to enable certain `bpf_trace_printk` messages at tetragon startup via 2 new CLI options:
* `--bpf-debug-area`
* `--bpf-debug-log`

The former allows the user to specify which area of the BPF probe to be traced. It leverages our `SliceEnum` to offer a static list of strings to choose from (the supported bpf areas); currently supported values: `all`, `generic` and `process`.
Debug `bpf_printk` messages in our bpf probes were moved from comp time defines to bpf constant/rodata; finally,
Bpf `DEBUG()` macro was expanded to allow for "areas" tags.

The latter allow to spawn a goroutine that continuously fetches lines from `/sys/kernel/debug/tracing/trace_pipe` and forwards them to tetragon log as INFO level messages.

The idea is that after this, we can start adding more debug messages that can not only be useful while developing, but might also be good to debug users' issues (eg: ask them to start tetragon with `--bpf-debug-area "process" --bpf-debug-log` and attach the log).

How it looks:
```
level=info msg="Listening for events..."
level=info msg="tetragon@BPF_AREA_PROCESS | set_in_init_tree: parent in init tree"
level=info msg="tetragon@BPF_AREA_PROCESS | set_in_init_tree: parent in init tree"
```

### Changelog

```release-note
new: bpf area-specific DEBUG() rodata config
```
