### PR TITLE
bpf: reduce recent kernels (6.1+) complexity in `filter_arg` programs

### DIFF
--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -891,10 +891,11 @@ struct filter_char_substring_data {
 	char *arg_str;
 	uint arg_len;
 	bool igncase;
+	bool match;
 };
 
-FUNC_LOCAL long
-do_filter_char_substring(int i, struct filter_char_substring_data *data, bool igncase)
+FUNC_INLINE long
+do_filter_char_substring(__u32 i, struct filter_char_substring_data *data, bool igncase)
 {
 	__u32 id = ((__u32 *)&data->filter->value)[i];
 	char *sub_str;
@@ -904,13 +905,43 @@ do_filter_char_substring(int i, struct filter_char_substring_data *data, bool ig
 	if (!sub_str)
 		return 0;
 
-	if (igncase)
+	if (igncase) {
+		if (!bpf_ksym_exists(bpf_strncasestr))
+			return 0;
 		idx = bpf_strncasestr(data->arg_str, sub_str, data->arg_len);
-	else
+	} else {
+		if (!bpf_ksym_exists(bpf_strnstr))
+			return 0;
 		idx = bpf_strnstr(data->arg_str, sub_str, data->arg_len);
+	}
 
 	return idx >= 0 ? 1 : 0;
 }
+
+#ifdef __V61_BPF_PROG
+FUNC_LOCAL long
+do_filter_char_substring_loop(__u32 i, struct filter_char_substring_data *data)
+{
+	/*
+	 * The verifier does not preserve the bpf_loop callback index bound when
+	 * it is used for pointer arithmetic. Force a verifier-visible upper bound
+	 * before indexing filter->value. bpf_loop itself only supplies 0..99.
+	 */
+	asm volatile("%[i] &= 0x7f;\n" : [i] "+r"(i));
+	if (i >= MAX_SUBSTRING_VALUES)
+		return 1;
+
+	/* Match the original loop's post-iteration vallen check. */
+	if (i && i * sizeof(__u32) + 8 >= data->filter->vallen)
+		return 1;
+
+	if (do_filter_char_substring(i, data, data->igncase)) {
+		data->match = true;
+		return 1;
+	}
+	return 0;
+}
+#endif
 
 FUNC_LOCAL long
 filter_char_substring(struct selector_arg_filter *filter, char *arg_str, uint arg_len, bool igncase)
@@ -919,7 +950,13 @@ filter_char_substring(struct selector_arg_filter *filter, char *arg_str, uint ar
 		.filter = filter,
 		.arg_str = arg_str,
 		.arg_len = arg_len,
+		.igncase = igncase,
 	};
+
+#ifdef __V61_BPF_PROG
+	loop(MAX_SUBSTRING_VALUES, do_filter_char_substring_loop, &data, 0);
+	return data.match;
+#else
 	int i, j = 0;
 
 	if (CONFIG(ITER_NUM)) {
@@ -941,6 +978,7 @@ filter_char_substring(struct selector_arg_filter *filter, char *arg_str, uint ar
 		}
 	}
 	return 0;
+#endif
 }
 #endif /* __LARGE_BPF_PROG */
 

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -2364,6 +2364,9 @@ selector_arg_offset(void *ctx, struct bpf_map_def *tailcalls,
 		return seloff;
 
 #ifdef __LARGE_BPF_PROG
+#ifdef __V61_BPF_PROG
+#pragma unroll
+#endif
 	for (i = 0; i < 5; i++)
 #endif
 	{

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -797,7 +797,7 @@ struct copy_reverse_data {
 	uint mask;
 };
 
-FUNC_LOCAL int do_copy_reverse(uint i, struct copy_reverse_data *data)
+FUNC_INLINE int do_copy_reverse(uint i, struct copy_reverse_data *data)
 {
 	uint len = data->len, offset = data->offset, mask = data->mask;
 
@@ -834,7 +834,6 @@ FUNC_INLINE void __copy_reverse(__u8 *dest, uint len, __u8 *src, uint offset, ui
 				return;
 		}
 	} else {
-#ifndef __V61_BPF_PROG
 #ifndef __LARGE_BPF_PROG
 #pragma unroll
 #endif
@@ -842,9 +841,6 @@ FUNC_INLINE void __copy_reverse(__u8 *dest, uint len, __u8 *src, uint offset, ui
 			if (do_copy_reverse(i, &data))
 				return;
 		}
-#else
-		loop(STRING_POSTFIX_MAX_MATCH_LENGTH - 1, do_copy_reverse, &data, 0);
-#endif /* __V61_BPF_PROG */
 	}
 }
 


### PR DESCRIPTION
veristat results for `generic_rawtp_filter_arg` from `bpf_generic_rawtp_v61.o` across the series:

```
Kernel          Result   Insns       States        Peak
---             ---         ---          ---         ---
6.1             before    40246         3116        2565
bpf-next (7.2+) before   966293        33030       84267
---             ---         ---          ---         ---
6.1             after    108690(+170%)  7058(+127%) 4954(+93%)
bpf-next (7.2+) after    128510(-87%)   8647(-74%)  4582(-95%)
```

Across the series, processed instructions on 7.2+ decrease by 87%, total states by 74%, and peak states by 95%. This comes at the cost of increasing processed instructions on 6.1 by 170%, total states by 127%, and peak states by 93%. The final verifier complexity is nevertheless relatively consistent between 6.1 and 7.2+.

This is needed because touching the `filter_arg` programs was no longer possible since we almost reached the 1M limit insns count and I was blocked for https://github.com/cilium/tetragon/pull/5442.

Veristat compare results can be found here as well https://github.com/cilium/tetragon/actions/runs/32717601635?pr=5491.