### PR TITLE
cleanup(pkg/tracingpolicy): split `go:embed` variable from nok8s.go.

### DIFF
--- a/pkg/tracingpolicy/nok8s.go
+++ b/pkg/tracingpolicy/nok8s.go
@@ -24,11 +24,7 @@ import (
 
 const tpURL = "file:///tracingpolicy"
 
-var (
-	//go:embed schemas/tracingpolicy-cilium.io.json
-	tracingpolicyJSONSchema []byte
-	tpSchema                *jsonschema.Schema
-)
+var tpSchema *jsonschema.Schema
 
 type memLoader struct{}
 

--- a/pkg/tracingpolicy/nok8s_embed.go
+++ b/pkg/tracingpolicy/nok8s_embed.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build nok8s
+
+package tracingpolicy
+
+import (
+	_ "embed"
+)
+
+//go:embed schemas/tracingpolicy-cilium.io.json
+var tracingpolicyJSONSchema []byte


### PR DESCRIPTION
### Description
This allows downstream clients to override the tracing policy json schema with another one by using `-overlay` flag.

### Changelog

```release-note
cleanup(pkg/tracingpolicy): split `go:embed` variable from nok8s.go.
```
