### PR TITLE
fix(selectors): cap range span in writeRangeInMap to prevent hang

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -457,10 +457,19 @@ func writeRangeInMap(v string, ty uint32, op uint32, m *ValueMap) error {
 			return fmt.Errorf("unknown type: %d", ty)
 		}
 	}
+	// maxRangeSpan bounds how many entries writeRangeInMap will enumerate into
+	// the map for a single "min:max" value. Without this, a range like
+	// "0:18446744073709551615" would try to insert billions of entries,
+	// pegging a CPU core and exhausting memory while parsing the policy.
+	const maxRangeSpan = 65536
+
 	switch ty {
 	case gt.GenericIntType, gt.GenericS64Type, gt.GenericS32Type, gt.GenericS16Type, gt.GenericS8Type, gt.GenericSyscall64, gt.GenericSizeType:
 		if sRangeVal[0] > sRangeVal[1] {
 			sRangeVal[0], sRangeVal[1] = sRangeVal[1], sRangeVal[0]
+		}
+		if uint64(sRangeVal[1])-uint64(sRangeVal[0]) > maxRangeSpan {
+			return fmt.Errorf("MatchArgs value %s invalid: range span exceeds %d", v, maxRangeSpan)
 		}
 		for val := sRangeVal[0]; ; val++ {
 			var valByte [8]byte
@@ -474,6 +483,9 @@ func writeRangeInMap(v string, ty uint32, op uint32, m *ValueMap) error {
 	case gt.GenericU64Type, gt.GenericU32Type, gt.GenericU16Type, gt.GenericU8Type:
 		if uRangeVal[0] > uRangeVal[1] {
 			uRangeVal[0], uRangeVal[1] = uRangeVal[1], uRangeVal[0]
+		}
+		if uRangeVal[1]-uRangeVal[0] > maxRangeSpan {
+			return fmt.Errorf("MatchArgs value %s invalid: range span exceeds %d", v, maxRangeSpan)
 		}
 		for val := uRangeVal[0]; ; val++ {
 			var valByte [8]byte

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -712,6 +712,17 @@ func TestParseMatchArg(t *testing.T) {
 				err, expected12, d.e[0:d.off], expectMap, ks.valueMaps[0].Data, arg13)
 		}
 	}
+
+	// A range whose span is larger than maxRangeSpan must be rejected instead
+	// of enumerated, otherwise parsing a policy can peg a CPU core and
+	// exhaust memory. See writeRangeInMap. Index 2 ("int") is used here since
+	// it is always present in sig, unlike the uint16/uint8 args which are
+	// gated behind config.EnableLargeProgs().
+	argHuge := &v1alpha1.ArgSelector{Index: 2, Operator: "InMap", Values: []string{"0:9223372036854775807"}}
+	ks := NewKernelSelectorState(nil, nil, false, 0, 0, nil)
+	if err := ParseMatchArg(ks, argHuge, sig); err == nil {
+		t.Errorf("parseMatchArg: expected error for oversized range but got none parsing %v\n", argHuge)
+	}
 }
 
 func TestParseMatchPid(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Fixes #5502 
Closes #5502 

## Summary
`writeRangeInMap` (pkg/selectors/kernel.go) parses a "min:max" string for matchArgs InMap/NotInMap and socket operators (Sport/Dport/Protocol/Family/State), and enumerates every integer in the range as a separate map entry instead of storing just the two bounds. There is no bound on the range span, so a policy with a wide range (e.g. "0:18446744073709551615") causes an effectively unbounded loop: single CPU core pegged, memory growing without limit, all inside the synchronous AddTracingPolicy gRPC handler it never returns.

This is separate from the InRange/NotInRange operator path (writeMatchValuesRange), which stores min/max directly for a real kernel-side range comparison and is already capped at 4 values that path is unaffected.

## Fix
Add a `maxRangeSpan` (65536) check before either enumeration loop (signed and unsigned), rejecting oversized ranges with a clear error at policy-parse time instead of hanging.

## Test plan
- [x] Added regression test in `pkg/selectors/kernel_test.go` using an oversized InMap range, asserting `ParseMatchArg` returns an error.
- [x] Verified the test correctly hangs/times out against the pre-fix code (`git stash` the fix) and passes instantly with the fix applied.
- [x] `go vet` / `go build` / `go test ./pkg/selectors/...` all pass.
