### PR TITLE
docs: fix typos across tracing-policy, installation and reference docs

### DIFF
--- a/api/export-doc.sh
+++ b/api/export-doc.sh
@@ -44,7 +44,7 @@ This page was generated with github.io/cilium/tetragon/api/export-doc.sh,
 please do not edit directly.
 {{< /comment >}}
 
-The Tetragon API is an independant Go module that can be found in the Tetragon
+The Tetragon API is an independent Go module that can be found in the Tetragon
 repository under [api](https://github.com/cilium/tetragon/tree/main/api). The
 version 1 of this API is defined in
 [github.com/cilium/tetragon/api/v1/tetragon](https://github.com/cilium/tetragon/tree/main/api/v1/tetragon).' | cat - $TMP_FILE > $1

--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -713,7 +713,7 @@ This functionality allows you to dynamically extract specific attributes from
 kernel structures passed as parameters to Kprobes and LSM hooks.
 For example, when using the `bprm_check_security` LSM hook, you can access and
 display attributes from the parameter `struct linux_binprm *bprm` at index 0.
-This parameter contains many informations you may want to access.
+This parameter contains many information you may want to access.
 With the resolve flag, you can easily access fields such as
 `mm.owner.real_parent.comm`, which provides the parent process comm.
 

--- a/docs/content/en/docs/concepts/tracing-policy/options.md
+++ b/docs/content/en/docs/concepts/tracing-policy/options.md
@@ -16,7 +16,7 @@ spec:
 ```
 
 Options array is passed and processed by each hook used in the spec file that
-supports options. At the moment it's availabe for kprobe and uprobe hooks.
+supports options. At the moment it's available for kprobe and uprobe hooks.
 
 - [`Kprobe Options`](#kprobe-options): options for kprobe hooks.
 - [`Uprobe Options`](#uprobe-options): options for uprobe hooks.

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -1167,7 +1167,7 @@ of each inspected argument is used in the matching. Only supported on kernels
 v5.3 onwards.)
 
 For example, you can specify a selector to only generate an event every 5
-minutes with adding the following action and its paramater:
+minutes with adding the following action and its parameter:
 
 ```yaml
 matchActions:

--- a/docs/content/en/docs/installation/metrics.md
+++ b/docs/content/en/docs/installation/metrics.md
@@ -136,7 +136,7 @@ helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
 
 Refer to the official [Kube-Prometheus-Stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) documentation for more details.
 
-Tetragon comes with default `ServiceMonitor` resources containing the scrape confguration for the Agent and Operator.
+Tetragon comes with default `ServiceMonitor` resources containing the scrape configuration for the Agent and Operator.
 You can enable it via Helm values:
 
 ```yaml

--- a/docs/content/en/docs/reference/grpc-api.md
+++ b/docs/content/en/docs/reference/grpc-api.md
@@ -11,7 +11,7 @@ This page was generated with github.io/cilium/tetragon/api/export-doc.sh,
 please do not edit directly.
 {{< /comment >}}
 
-The Tetragon API is an independant Go module that can be found in the Tetragon
+The Tetragon API is an independent Go module that can be found in the Tetragon
 repository under [api](https://github.com/cilium/tetragon/tree/main/api). The
 version 1 of this API is defined in
 [github.com/cilium/tetragon/api/v1/tetragon](https://github.com/cilium/tetragon/tree/main/api/v1/tetragon).


### PR DESCRIPTION
Five typo fixes in the documentation:

| File | Fix |
|---|---|
| `concepts/tracing-policy/hooks.md:716` | `informations` → `information` |
| `concepts/tracing-policy/options.md:19` | `availabe` → `available` |
| `concepts/tracing-policy/selectors.md:1170` | `paramater` → `parameter` |
| `installation/metrics.md:139` | `confguration` → `configuration` |
| `reference/grpc-api.md:14` | `independant` → `independent` |

Docs prose only.

```release-note
Docs: fix typos across the tracing-policy, installation and reference documentation.
```
