### PR TITLE
fix(k8s): case sensitive FromYAML()

### DIFF
--- a/pkg/crdutils/crdutils.go
+++ b/pkg/crdutils/crdutils.go
@@ -10,6 +10,7 @@ package crdutils
 
 import (
 	"context"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"os"
@@ -164,7 +165,7 @@ func (c *CRDContext[P]) FromYAML(data string) (P, error) {
 
 	// allocate a new instance of the underlying struct and unmarshal into it
 	cr = reflect.New(reflect.TypeOf(cr).Elem()).Interface().(P)
-	err = yaml.UnmarshalStrict(jsonData, cr)
+	err = json.Unmarshal(jsonData, cr, json.RejectUnknownMembers(true))
 	if err != nil {
 		return cr, fmt.Errorf("failed to unmarshal into typed object: %w", err)
 	}

--- a/pkg/crdutils/crdutils_test.go
+++ b/pkg/crdutils/crdutils_test.go
@@ -456,7 +456,7 @@ func TestTracingPolicyNotCoveredBySpec(t *testing.T) {
 	path := tempfile.CreateTempFile(t, tpNotCoveredBySpec)
 	_, err := TPContext.FromFile(path)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to unmarshal into typed object: error unmarshaling JSON: while decoding JSON: json: unknown field \"some_field\"")
+	assert.Contains(t, err.Error(), "unknown object member name \"some_field\" within \"/spec\"")
 }
 
 // TestXValidationHostSelector tests that XValidation rules work using the

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -131,7 +131,7 @@ spec:
 `
 
 	noConfig := `
-apiversion: cilium.io/v1alpha1
+apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
   name: "noconfig"
@@ -170,7 +170,7 @@ spec:
 `
 
 	noConfig := `
-apiversion: cilium.io/v1alpha1
+apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
   name: "noconfig"

--- a/pkg/sensors/tracing/usdt_test.go
+++ b/pkg/sensors/tracing/usdt_test.go
@@ -51,7 +51,7 @@ spec:
 `
 
 	noConfig := `
-apiversion: cilium.io/v1alpha1
+apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
   name: "noconfig"
@@ -91,7 +91,7 @@ spec:
 `
 
 	noConfig := `
-apiversion: cilium.io/v1alpha1
+apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
   name: "noconfig"

--- a/pkg/tracingpolicy/generictracingpolicy_test.go
+++ b/pkg/tracingpolicy/generictracingpolicy_test.go
@@ -92,6 +92,20 @@ func TestEmptyTracingPolicy(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestWrongCaseTracingPolicy(t *testing.T) {
+	_, err := FromYAML(`
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "tracepoint-test"
+spec:
+  Tracepoints: # wrong case
+  - subsystem: "syscalls"
+    event: "sys_enter_lseek"
+`)
+	require.Error(t, err)
+}
+
 const tpNodeSelector = `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy

--- a/testdata/specs/sigkill_unprivileged_user_namespace.yaml.tmpl
+++ b/testdata/specs/sigkill_unprivileged_user_namespace.yaml.tmpl
@@ -11,7 +11,7 @@ spec:
     - index: 0
       type: "nop"
     selectors:
-      - matchPids:
+      - matchPIDs:
         - operator: In
           values:
           - {{.MatchedPID}}

--- a/testdata/specs/sigkill_unprivileged_user_namespace_in_pid_namespace.yaml.tmpl
+++ b/testdata/specs/sigkill_unprivileged_user_namespace_in_pid_namespace.yaml.tmpl
@@ -11,7 +11,7 @@ spec:
     - index: 0
       type: "nop"
     selectors:
-      - matchPids:
+      - matchPIDs:
         - operator: In
           values:
           - {{.MatchedPID}}


### PR DESCRIPTION
### Description

https://github.com/cilium/tetragon/pull/5463 describes a bug that we should be getting in normal k8s builds too; that was not the case since the `FromYAML` function in k8s builds is case insensitive.

### Changelog

```release-note
fix: case sensitive FromYAML() in k8s builds
```