### PR TITLE
fix(strutils): handle empty size values

### DIFF
--- a/pkg/strutils/strutls.go
+++ b/pkg/strutils/strutls.go
@@ -28,6 +28,10 @@ func UTF8FromBPFBytes(b []byte) string {
 }
 
 func ParseSize(str string) (int, error) {
+	if str == "" {
+		return 0, nil
+	}
+
 	suffix := str[len(str)-1:]
 
 	if !strings.Contains("KMG", suffix) {

--- a/pkg/strutils/strutls_test.go
+++ b/pkg/strutils/strutls_test.go
@@ -17,6 +17,7 @@ type parseSize struct {
 
 func TestParseSize(t *testing.T) {
 	var tests = []parseSize{
+		parseSize{"", false, 0},
 		parseSize{"1K", false, 1024},
 		parseSize{"256M", false, 256 * 1024 * 1024},
 		parseSize{"10G", false, 10 * 1024 * 1024 * 1024},


### PR DESCRIPTION
### Description

An empty `rb-size` drop-in is a supported way to clear an override. 
Right now it panics in `ParseSize`

Treat empty sizes as zero, which already means use the default

Repro:

```sh
config_dir=$(mktemp -d)
touch "$config_dir/rb-size"
go run ./cmd/tetragon --config-dir "$config_dir"
```

Before this change startup hits a slice bounds panic. 
After it gets past config parsing

Test: `go test ./pkg/strutils`

### Changelog

```release-note
Fix Tetragon startup panic when a ring buffer setting is cleared with an empty value.
```
