### PR TITLE
docs: fix argIndex range

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -1635,7 +1635,7 @@ For uprobes, the `Set` action allows setting the value of the argument at the gi
 The argument needs to meet a few conditions:
 
 - It must be an integer parameter (`argValue` holds an `uint32`)
-- `argIndex` must be between 0 and 4 (the [tetragon maximum number of arguments](https://github.com/cilium/tetragon/blob/v1.7.1/pkg/api/tracingapi/client_kprobe.go#L684))
+- `argIndex` must be between 0 and 4 (tetragon's accessible arguments)
 - `argIndex` refers to the position of the argument in the traced function, starting from 0 for the first argument
 
 Example policy follows:

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -1635,7 +1635,7 @@ For uprobes, the `Set` action allows setting the value of the argument at the gi
 The argument needs to meet a few conditions:
 
 - It must be an integer parameter (`argValue` holds an `uint32`)
-- `argIndex` must be between 0 and 5 (the [tetragon maximum number of arguments](https://github.com/cilium/tetragon/blob/v1.7.1/pkg/api/tracingapi/client_kprobe.go#L684))
+- `argIndex` must be between 0 and 4 (the [tetragon maximum number of arguments](https://github.com/cilium/tetragon/blob/v1.7.1/pkg/api/tracingapi/client_kprobe.go#L684))
 - `argIndex` refers to the position of the argument in the traced function, starting from 0 for the first argument
 
 Example policy follows:

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -685,6 +685,7 @@ const (
 	EventConfigMaxUsdtArgs = 8
 	EventConfigMaxRegArgs  = 8
 	MaxBTFArgDepth         = 10 // Artificial value for compilation, may be extended
+	MaxAccessibleArgs      = 5  // Maximum reachable arg index in function signature. Should match MAX_ACCESSIBLE_ARGS in bpf code.
 )
 
 type EventConfig struct {

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -811,7 +811,7 @@ func addKprobe(funcName string, instance InstanceID, f *v1alpha1.KProbeSpec, in 
 			argRetprobe = &f.Args[j]
 			argRetprobeIdx = j
 		}
-		if a.Index > 4 {
+		if a.Index >= api.MaxAccessibleArgs {
 			return fmt.Errorf("error add arg: ArgType %s Index %d out of bounds",
 				a.Type, int(a.Index))
 		}

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -220,7 +220,7 @@ func isValidLsmSelectors(selectors []v1alpha1.KProbeSelector) error {
 }
 
 func validateLsmArg(j int, a *v1alpha1.KProbeArg) error {
-	if a.Index > 4 {
+	if a.Index >= api.MaxAccessibleArgs {
 		return fmt.Errorf("args[%d]: arg type %s index %d out of bounds",
 			j, a.Type, a.Index)
 	}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -601,7 +601,7 @@ func validateUprobeSpec(spec *v1alpha1.UProbeSpec, state *uprobeConfigState) err
 			if action.Action != "Set" {
 				continue
 			}
-			if action.ArgIndex >= api.EventConfigMaxArgs {
+			if action.ArgIndex >= api.MaxAccessibleArgs {
 				return fmt.Errorf("uprobe Set action argIndex %d out of range", action.ArgIndex)
 			}
 		}
@@ -1175,7 +1175,7 @@ func getUprobeArgConfig(spec *v1alpha1.UProbeSpec, has *uprobeHas) (uprobeArgCon
 			cfg.argRetprobe = &spec.Args[i]
 			cfg.argRetprobeIdx = i
 		}
-		if a.Index > 4 {
+		if a.Index >= api.MaxAccessibleArgs {
 			return fmt.Errorf("error add arg: ArgType %s Index %d out of bounds",
 				a.Type, int(a.Index))
 		}


### PR DESCRIPTION
We can reach the first five arguments of function. The 5th arg's index is 4, because we start counting at 0.

Also, we shouldn't use EventConfigMaxArgs to explain the maximum reachable argument in a function signature. These concepts are treated separately in the bpf code. See [here](https://github.com/cilium/tetragon/blob/76f209584d7ece0abdec2dd99f9730122693c549/bpf/lib/generic.h#L28-L34).
