### PR TITLE
fix(metrics): prevent metrics updates when metrics are disabled

### DIFF
--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -173,6 +173,10 @@ func handleProcessedEvent(pInfo *tracingpolicy.PolicyInfo, processedEvent any) {
 }
 
 func ProcessEvent(originalEvent any, processedEvent any) {
+	if option.Config.MetricsServer == "" || !option.Config.EnableEventMetrics {
+		return
+	}
+
 	handleOriginalEvent(originalEvent)
 
 	var policyInfo tracingpolicy.PolicyInfo

--- a/pkg/metrics/metricwithpod_test.go
+++ b/pkg/metrics/metricwithpod_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/metrics/eventmetrics"
 	"github.com/cilium/tetragon/pkg/metricsconfig"
+	"github.com/cilium/tetragon/pkg/option"
 )
 
 var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
@@ -26,6 +27,14 @@ var sampleMsgGenericTracepointUnix = tracing.MsgGenericTracepointUnix{
 }
 
 func TestMetricsWithPod(t *testing.T) {
+	option.Config.MetricsServer = ":0"
+	option.Config.EnableEventMetrics = true
+
+	t.Cleanup(func() {
+		option.Config.MetricsServer = ""
+		option.Config.EnableEventMetrics = false
+	})
+
 	eventMetrics := []string{"tetragon_events_total", "tetragon_policy_events_total", "tetragon_syscalls_total"}
 	healthMetrics := []string{"tetragon_build_info", "tetragon_data_events_total"}
 

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -124,7 +124,13 @@ func (k *Observer) receiveEvent(data []byte) {
 	}
 
 	op, events, err := HandlePerfData(data)
-	opcodemetrics.OpTotalInc(ops.OpCode(op))
+
+	metricsEnabled := option.Config.MetricsServer != ""
+
+	if metricsEnabled {
+		opcodemetrics.OpTotalInc(ops.OpCode(op))
+	}
+
 	if err != nil {
 		errormetrics.HandlerErrorsInc(ops.OpCode(op), err.kind)
 		switch err.kind {
@@ -137,7 +143,7 @@ func (k *Observer) receiveEvent(data []byte) {
 	for _, event := range events {
 		k.observerListeners(event)
 	}
-	if option.Config.EnableMsgHandlingLatency {
+	if metricsEnabled && option.Config.EnableMsgHandlingLatency {
 		opcodemetrics.LatencyStats.WithLabelValues(strconv.FormatUint(uint64(op), 10)).Observe(float64(time.Since(timer).Microseconds()))
 	}
 }


### PR DESCRIPTION


<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

'eventmetrics' and 'opcodemetrics' were being updated even when metrics were effectively disabled. Their 'register/init' functions are correctly gated, but the update call sites were running unconditionally on a hotpath - wasting non-negligeble amounts of CPU and memory.

This is both a matter of correctness and performance.

Allocation and CPU profiles were taken, showing significant improvements on both memory and CPU usage. I stress-tested this by setting up tetragon with a uprobe based policy and hammering tetragon with execve events (by churning processes on my machine):

**allocs**
<img width="2036" height="1006" alt="image" src="https://github.com/user-attachments/assets/c2951ccc-db95-4502-aaa0-d9c693fdfbb2" />

**cpu**

<img width="3042" height="1324" alt="screenshot" src="https://github.com/user-attachments/assets/1f525433-11b4-4630-aac0-991c5dad2d6d" />
 

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Reduced memory and CPU usage when metrics export is disabled.
```
