### PR TITLE
Fix args bounds checks

### DIFF
--- a/contrib/tester-progs/uprobe-simple.c
+++ b/contrib/tester-progs/uprobe-simple.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 int
 __attribute__((noinline))
@@ -15,9 +16,43 @@ lasagna(int c)
 }
 
 int
+__attribute__((noinline))
+manyargs(int zero, int one, int two, int three, int four, int five, int six, int seven, int retargidx)
+{
+	printf("manyargs was passed: %d,%d,%d,%d,%d,%d,%d,%d and retargidx: %d\n", zero, one, two, three, four, five, six, seven, retargidx);
+
+	switch (retargidx) {
+		case 0:
+			return zero;
+		case 1:
+			return one;
+		case 2:
+			return two;
+		case 3:
+			return three;
+		case 4:
+			return four;
+		case 5:
+			return five;
+		case 6:
+			return six;
+		case 7:
+			return seven;
+		default:
+			fprintf(stderr, "regargidx must be between 0 and 7");
+			return -1;
+	}
+}
+
+int
 main(int argc, char *argv[])
 {
 	int ret = pizza(0);
 	printf("pizza() returned %d\n", ret);
+
+	if (argc == 2) {
+		ret = manyargs(0, 1, 2, 3, 4, 5, 6, 7, (int)strtol(argv[1], NULL, 10));
+	}
+
 	return ret;
 }

--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -1635,7 +1635,7 @@ For uprobes, the `Set` action allows setting the value of the argument at the gi
 The argument needs to meet a few conditions:
 
 - It must be an integer parameter (`argValue` holds an `uint32`)
-- `argIndex` must be between 0 and 4 (tetragon's accessible arguments)
+- `argIndex` must be between 0 and 5 for amd64 and between 0 and 7 for arm64
 - `argIndex` refers to the position of the argument in the traced function, starting from 0 for the first argument
 
 Example policy follows:

--- a/pkg/selectors/kernel_regs_amd64.go
+++ b/pkg/selectors/kernel_regs_amd64.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cilium/tetragon/pkg/asm"
 )
 
+const ArgsInRegisters = 6 // Number of arguments passed by register per System V AMD64 ABI
+
 func parseOverrideRegs(k *KernelSelectorState, selIdx int, values []string, errValue uint64, newOffset int64) error {
 	if _, exists := k.regs[selIdx]; exists {
 		return errors.New("only single instance of regs action is allowed")

--- a/pkg/selectors/kernel_regs_arm64.go
+++ b/pkg/selectors/kernel_regs_arm64.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cilium/tetragon/pkg/asm"
 )
 
+const ArgsInRegisters = 8 // Number of arguments passed by register per AArch64 ABI
+
 func parseOverrideRegs(k *KernelSelectorState, selIdx int, values []string, errValue uint64, newOffset int64) error {
 	if _, exists := k.regs[selIdx]; exists {
 		return errors.New("only single instance of regs action is allowed")

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -255,9 +255,9 @@ func validateTracepointArg(subsys, event string, nfields uint32, argIndex uint32
 }
 
 func validateRawTracepointArg(subsys, event string, argIndex uint32, argIdx int) error {
-	if argIndex > 5 {
-		return fmt.Errorf("raw tracepoint %s/%s can read up to 5 arguments, but index %d was requested in args[%d]",
-			subsys, event, argIndex, argIdx)
+	if argIndex >= tracingapi.MaxAccessibleArgs {
+		return fmt.Errorf("raw tracepoint %s/%s can read argument indices 0 through %d, but index %d was requested in args[%d]",
+			subsys, event, tracingapi.MaxAccessibleArgs-1, argIndex, argIdx)
 	}
 	return nil
 }
@@ -421,7 +421,7 @@ func preValidateTracepoint(spec *v1alpha1.TracepointSpec) (*tpValidateInfo, erro
 			}
 		}
 	} else {
-		// For raw tracepoints, argument index must be <= 5
+		// For raw tracepoints, argument index must be less than MaxAccessibleArgs.
 		for i, arg := range spec.Args {
 			if err := validateRawTracepointArg(spec.Subsystem, spec.Event, arg.Index, i); err != nil {
 				return nil, err

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -601,7 +601,7 @@ func validateUprobeSpec(spec *v1alpha1.UProbeSpec, state *uprobeConfigState) err
 			if action.Action != "Set" {
 				continue
 			}
-			if action.ArgIndex >= api.MaxAccessibleArgs {
+			if action.ArgIndex >= selectors.ArgsInRegisters {
 				return fmt.Errorf("uprobe Set action argIndex %d out of range", action.ArgIndex)
 			}
 		}

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -413,14 +413,14 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		// Validate argument for set action
 		if ok, idx := selectors.HasSetArgIndex(spec.Selectors); ok {
 			// argument index is within usdt args in spec
-			if idx > uint32(len(spec.Args)) {
+			if idx >= uint32(len(spec.Args)) {
 				return ids, fmt.Errorf("failed to configure usdt '%s/%s', set action argument spec index %d out of bounds",
 					spec.Provider, spec.Name, idx)
 			}
 
 			// usdt spec argument points to existing usdt defined in elf note
 			arg := spec.Args[idx]
-			if arg.Index > uint32(len(target.Spec.Args)) {
+			if arg.Index >= target.Spec.ArgsCnt {
 				return ids, fmt.Errorf("failed to configure usdt '%s/%s', argument index %d out of bounds",
 					spec.Provider, spec.Name, arg.Index)
 			}
@@ -443,7 +443,7 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		var preload bool
 		for cfgIdx, arg := range spec.Args {
 			tgtIdx := arg.Index
-			if tgtIdx > target.Spec.ArgsCnt {
+			if tgtIdx >= target.Spec.ArgsCnt {
 				return ids, fmt.Errorf("failed to configure usdt '%s/%s', argument index %d out of bounds",
 					spec.Provider, spec.Name, tgtIdx)
 			}

--- a/pkg/sensors/tracing/tracepoint_validation_test.go
+++ b/pkg/sensors/tracing/tracepoint_validation_test.go
@@ -106,7 +106,7 @@ spec:
     event: "sys_enter"
     raw: true
     args:
-    - index: 6
+    - index: 5
       type: "int"
 `
 

--- a/pkg/sensors/tracing/usdt_validation_test.go
+++ b/pkg/sensors/tracing/usdt_validation_test.go
@@ -80,6 +80,53 @@ spec:
 	require.Error(t, err)
 }
 
+func TestUsdtValidationSetArgIndexOutOfBounds(t *testing.T) {
+	usdt := testutils.RepoRootPath("contrib/tester-progs/usdt-override")
+	crd := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "usdts"
+spec:
+  usdts:
+  - path: "` + usdt + `"
+    provider: "tetragon"
+    name: "test_1B"
+    args:
+    - index: 0
+      type: "int32"
+    selectors:
+    - matchActions:
+      - action: Set
+        argIndex: 1
+        argValue: 240
+`
+
+	err := checkCrd(t, crd)
+	require.ErrorContains(t, err, "set action argument spec index 1 out of bounds")
+}
+
+func TestUsdtValidationProbeArgIndexOutOfBounds(t *testing.T) {
+	usdt := testutils.RepoRootPath("contrib/tester-progs/usdt-override")
+	crd := `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "usdts"
+spec:
+  usdts:
+  - path: "` + usdt + `"
+    provider: "tetragon"
+    name: "test_1B"
+    args:
+    - index: 3
+      type: "int32"
+`
+
+	err := checkCrd(t, crd)
+	require.ErrorContains(t, err, "argument index 3 out of bounds")
+}
+
 func TestUsdtEventConfigCarriesPolicyID(t *testing.T) {
 	spec := &v1alpha1.UsdtSpec{
 		Path:     testutils.RepoRootPath("contrib/tester-progs/usdt"),

--- a/tests/policytests/uprobes.go
+++ b/tests/policytests/uprobes.go
@@ -6,12 +6,22 @@
 package tests
 
 import (
+	"runtime"
+	"strconv"
+
 	ec "github.com/cilium/tetragon/api/v1/tetragon/codegen/eventchecker"
 	"github.com/cilium/tetragon/pkg/bpf"
 	lc "github.com/cilium/tetragon/pkg/matchers/listmatcher"
 	sm "github.com/cilium/tetragon/pkg/matchers/stringmatcher"
 	"github.com/cilium/tetragon/pkg/testutils/policytest"
 )
+
+func uprobeSetArgIndex() int {
+	if runtime.GOARCH == "arm64" {
+		return 7
+	}
+	return 5
+}
 
 // uprobe-pclntab: attach to stripped Go binary via pclntab symbol resolution
 var _ = policytest.NewBuilder("uprobe-pclntab").WithLabels("uprobes").WithPolicyTemplate(`
@@ -501,11 +511,11 @@ spec:
   uprobes:
   - path: {{ testBinary "uprobe-simple" }}
     symbols:
-    - "pizza"
+    - "manyargs"
     selectors:
     - matchActions:
       - action: Set
-        argIndex: 0
+        argIndex: ` + strconv.Itoa(uprobeSetArgIndex()) + `
         argValue: 42
 `).WithSkip(func(si *policytest.SkipInfo) string {
 	// skip if uprobe_regs_change is not supported
@@ -518,17 +528,18 @@ spec:
 	upChecker := ec.NewProcessUprobeChecker("uprobe-set").
 		WithProcess(ec.NewProcessChecker().
 			WithBinary(sm.Full(myBin))).
-		WithSymbol(sm.Full("pizza"))
+		WithSymbol(sm.Full("manyargs"))
 
+	argIndex := uprobeSetArgIndex()
 	exitCode := 42
 	if c.TestConf != nil && c.TestConf.MonitorMode {
-		exitCode = 0
+		exitCode = argIndex
 	}
 	postCnt := uint64(1)
 	setCnt := uint64(1)
 	return &policytest.Scenario{
 		Name:         "execute uprobe-simple, check set action and events",
-		Trigger:      policytest.NewCmdTrigger(myBin).ExpectExitCode(exitCode),
+		Trigger:      policytest.NewCmdTrigger(myBin, strconv.Itoa(argIndex)).ExpectExitCode(exitCode),
 		EventChecker: ec.NewUnorderedEventChecker(upChecker),
 		ActCountChecker: policytest.ActionCounts{
 			Post: &postCnt,


### PR DESCRIPTION
Fix args bound checks for tracepoint, USDT and urprobe `Set` action. See individual commit messages for more details.

The second to last commit allows us to set uprobe args beyond the args that we can read. I'm not sure if the usefulness of this outweighs the potential for user confusion.

