### PR TITLE
flags: add `--verifier-log-level` for Go tests and replace previous name

### DIFF
--- a/cmd/tetragon/conf_test.go
+++ b/cmd/tetragon/conf_test.go
@@ -1158,7 +1158,7 @@ func TestReadConfigSettings(t *testing.T) {
 		flags.String(option.KeyHubbleLib, defaults.DefaultTetragonLib, "Location of Tetragon libs (btf and bpf files)")
 		flags.String(option.KeyBTF, "", "Location of btf")
 		flags.String(option.KeyExportFilename, "", "Filename for JSON export. Disabled by default")
-		flags.Int(option.KeyVerbosity, 0, "set verbosity level for eBPF verifier dumps. Pass 0 for silent, 1 for truncated logs, 2 for a full dump")
+		flags.Int(option.KeyVerbosity, 0, option.VerifierLogLevelHelp)
 		flags.Bool(option.KeyEnableK8sAPI, false, "Access Kubernetes API to associate tetragon events with Kubernetes pods")
 		flags.Uint(option.KeyEventQueueSize, 10000, "Set the size of the internal event queue.")
 		viper.BindPFlags(flags)

--- a/docs/data/tetragon_flags.yaml
+++ b/docs/data/tetragon_flags.yaml
@@ -304,5 +304,8 @@ options:
         Resolve UIDs to user names for processes running in host namespace
     - name: verbose
       default_value: "0"
+      usage: deprecated alias for --verifier-log-level
+    - name: verifier-log-level
+      default_value: "0"
       usage: |
-        set verbosity level for eBPF verifier dumps. Pass 0 for silent, 1 for truncated logs, 2 for a full dump
+        set eBPF verifier log level. Pass 0 for silent, 1 for truncated logs, 2 for a full dump

--- a/pkg/bench/bench.go
+++ b/pkg/bench/bench.go
@@ -69,7 +69,7 @@ func runTetragon(ctx context.Context, configFile string, args *Arguments, summar
 	bpf.CheckOrMountCgroup2()
 
 	if args.Debug {
-		option.Config.Verbosity = 5
+		option.Config.VerifierLogLevel = 5
 	}
 
 	if _, err := os.Stat("../../bpf/objs"); err == nil {

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -208,7 +208,7 @@ func getDefaultObserver(tb testing.TB, ctx context.Context, initialSensor *senso
 
 	obs := newDefaultObserver()
 	if testing.Verbose() {
-		option.Config.Verbosity = 1
+		option.Config.VerifierLogLevel = 1
 	}
 
 	if err := loadExporter(tb, ctx, obs, &o.exporter, &o.observer); err != nil {
@@ -324,7 +324,7 @@ func getDefaultSensors(tb testing.TB, initialSensor *sensors.Sensor, opts ...Tes
 	}
 
 	if testing.Verbose() {
-		option.Config.Verbosity = 1
+		option.Config.VerifierLogLevel = 1
 	}
 
 	var tp tracingpolicy.TracingPolicy

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -27,10 +27,11 @@ type config struct {
 	KernelVersion   string
 	HubbleLib       string
 	BTF             string
-	Verbosity       int
 	ForceSmallProgs bool
 	ForceLargeProgs bool
 	ClusterName     string
+
+	VerifierLogLevel int
 
 	EnablePodAnnotations bool
 

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -31,6 +31,7 @@ const (
 	KeyBTF                    = "btf"
 	KeyProcFS                 = "procfs"
 	KeyKernelVersion          = "kernel"
+	KeyVerifierLogLevel       = "verifier-log-level"
 	KeyVerbosity              = "verbose"
 	KeyProcessCacheSize       = "process-cache-size"
 	KeyDisableProcessCache    = "disable-process-cache"
@@ -182,7 +183,10 @@ func ReadAndSetFlags() error {
 	Config.BTF = viper.GetString(KeyBTF)
 	Config.ProcFS = viper.GetString(KeyProcFS)
 	Config.KernelVersion = viper.GetString(KeyKernelVersion)
-	Config.Verbosity = viper.GetInt(KeyVerbosity)
+	Config.VerifierLogLevel = viper.GetInt(KeyVerifierLogLevel)
+	if !viper.IsSet(KeyVerifierLogLevel) && viper.IsSet(KeyVerbosity) {
+		Config.VerifierLogLevel = viper.GetInt(KeyVerbosity)
+	}
 	Config.ForceSmallProgs = viper.GetBool(KeyForceSmallProgs)
 	Config.ForceLargeProgs = viper.GetBool(KeyForceLargeProgs)
 	Config.Debug = viper.GetBool(KeyDebug)
@@ -505,7 +509,9 @@ func AddFlags(flags *pflag.FlagSet) {
 
 	flags.String(KeyProcFS, "/proc/", "Location of procfs to consume existing PIDs")
 	flags.String(KeyKernelVersion, "", "Kernel version")
-	flags.Int(KeyVerbosity, 0, "set verbosity level for eBPF verifier dumps. Pass 0 for silent, 1 for truncated logs, 2 for a full dump")
+	flags.Int(KeyVerifierLogLevel, 0, "set eBPF verifier log level. Pass 0 for silent, 1 for truncated logs, 2 for a full dump")
+	flags.Int(KeyVerbosity, 0, "deprecated alias for --"+KeyVerifierLogLevel)
+	flags.MarkDeprecated(KeyVerbosity, "use --"+KeyVerifierLogLevel+" instead")
 	flags.Int(KeyProcessCacheSize, 65536, "Size of the process cache")
 	flags.Bool(KeyDisableProcessCache, false, "Disable process cache")
 	flags.Int(KeyDataCacheSize, 1024, "Size of the data events cache")

--- a/pkg/option/flags.go
+++ b/pkg/option/flags.go
@@ -163,6 +163,10 @@ const (
 	KeyServerTLSRequireClientCert = "server-tls-require-client-cert"
 )
 
+const (
+	VerifierLogLevelHelp = "set eBPF verifier log level. Pass 0 for silent, 1 for truncated logs, 2 for a full dump"
+)
+
 type UsernameMetadaCode int
 
 const (
@@ -509,7 +513,7 @@ func AddFlags(flags *pflag.FlagSet) {
 
 	flags.String(KeyProcFS, "/proc/", "Location of procfs to consume existing PIDs")
 	flags.String(KeyKernelVersion, "", "Kernel version")
-	flags.Int(KeyVerifierLogLevel, 0, "set eBPF verifier log level. Pass 0 for silent, 1 for truncated logs, 2 for a full dump")
+	flags.Int(KeyVerifierLogLevel, 0, VerifierLogLevelHelp)
 	flags.Int(KeyVerbosity, 0, "deprecated alias for --"+KeyVerifierLogLevel)
 	flags.MarkDeprecated(KeyVerbosity, "use --"+KeyVerifierLogLevel+" instead")
 	flags.Int(KeyProcessCacheSize, 65536, "Size of the process cache")

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -590,7 +590,7 @@ func TestLoadCgroupsPrograms(t *testing.T) {
 	testutils.CaptureLog(t, logger.GetLogger())
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
 	tus.LoadSensor(t, testsensor.GetCgroupSensor())
@@ -601,7 +601,7 @@ func TestTgRuntimeConf(t *testing.T) {
 	testutils.CaptureLog(t, logger.GetLogger())
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	tus.LoadInitialSensor(t)
 
@@ -632,7 +632,7 @@ func TestCgroupNoEvents(t *testing.T) {
 	defer cancel()
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
@@ -682,7 +682,7 @@ func TestCgroupEventMkdirRmdir(t *testing.T) {
 	defer cancel()
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
@@ -1021,7 +1021,7 @@ func TestCgroupv2K8sHierarchyInUnified(t *testing.T) {
 	defer cancel()
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
@@ -1045,7 +1045,7 @@ func TestCgroupv2K8sHierarchyInHybrid(t *testing.T) {
 	defer cancel()
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	tus.LoadInitialSensor(t)
 
@@ -1065,7 +1065,7 @@ func testCgroupv1K8sHierarchyInHybrid(t *testing.T, withExec bool, selectedContr
 	defer cancel()
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
@@ -1320,7 +1320,7 @@ func TestCgroupv2ExecK8sHierarchyInUnified(t *testing.T) {
 	defer cancel()
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())
@@ -1349,7 +1349,7 @@ func TestCgroupMissedTrackingErrMetrics(t *testing.T) {
 	defer cancel()
 
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	tus.LoadInitialSensor(t)
 	tus.LoadSensor(t, testsensor.GetTestSensor())

--- a/pkg/sensors/load_linux.go
+++ b/pkg/sensors/load_linux.go
@@ -136,29 +136,29 @@ func observerLoadInstance(bpfDir string, load *program.Program, maps []*program.
 	l.Debug(fmt.Sprintf("observerLoadInstance %s %d", load.Name, version), "prog", load.Name, "kern_version", version)
 	switch load.Type {
 	case "tracepoint":
-		err = loadInstance(bpfDir, load, maps, version, option.Config.Verbosity)
+		err = loadInstance(bpfDir, load, maps, version, option.Config.VerifierLogLevel)
 		if err != nil {
 			l.Info("Failed to load, trying to remove and retrying", "tracepoint", load.Name)
 			load.Unload(true)
-			err = loadInstance(bpfDir, load, maps, version, option.Config.Verbosity)
+			err = loadInstance(bpfDir, load, maps, version, option.Config.VerifierLogLevel)
 		}
 		if err != nil {
 			return fmt.Errorf("failed prog %s kern_version %d LoadTracingProgram: %w",
 				load.Name, version, err)
 		}
 	case "raw_tracepoint", "raw_tp":
-		err = loadInstance(bpfDir, load, maps, version, option.Config.Verbosity)
+		err = loadInstance(bpfDir, load, maps, version, option.Config.VerifierLogLevel)
 		if err != nil {
 			l.Info("Failed to load, trying to remove and retrying", "raw_tracepoint", load.Name)
 			load.Unload(true)
-			err = loadInstance(bpfDir, load, maps, version, option.Config.Verbosity)
+			err = loadInstance(bpfDir, load, maps, version, option.Config.VerifierLogLevel)
 		}
 		if err != nil {
 			return fmt.Errorf("failed prog %s kern_version %d LoadRawTracepointProgram: %w",
 				load.Name, version, err)
 		}
 	default:
-		err = loadInstance(bpfDir, load, maps, version, option.Config.Verbosity)
+		err = loadInstance(bpfDir, load, maps, version, option.Config.VerifierLogLevel)
 		if err != nil && load.ErrorFatal {
 			return fmt.Errorf("failed prog %s kern_version %d loadInstance: %w",
 				load.Name, version, err)

--- a/pkg/sensors/load_windows.go
+++ b/pkg/sensors/load_windows.go
@@ -21,7 +21,7 @@ func observerLoadInstance(bpfDir string, load *program.Program, maps []*program.
 	l := logger.GetLogger()
 	l.Debug(fmt.Sprintf("observerLoadInstance %s %d", load.Name, version), "prog", load.Name, "kern_version", version)
 
-	err = loadInstance(bpfDir, load, maps, version, option.Config.Verbosity)
+	err = loadInstance(bpfDir, load, maps, version, option.Config.VerifierLogLevel)
 	if err != nil && load.ErrorFatal {
 		return fmt.Errorf("failed prog %s kern_version %d loadInstance: %w",
 			load.Name, version, err)

--- a/pkg/sensors/test/sensors_test.go
+++ b/pkg/sensors/test/sensors_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestMapBuildersSingle(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	p1 := program.Builder(
 		"bpf_map_test_p1.o",
@@ -71,7 +71,7 @@ func TestMapBuildersSingle(t *testing.T) {
 
 func TestMapBuildersMulti(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	p1 := program.Builder(
 		"bpf_map_test_p1.o",
@@ -417,7 +417,7 @@ func TestMapUser(t *testing.T) {
 
 func TestPolicyMapPath(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	p1 := program.Builder(
 		"bpf_map_test_p1.o",
@@ -459,7 +459,7 @@ func getMaxEntries(t *testing.T, path string) uint32 {
 
 func TestMaxEntriesSingle(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	p1 := program.Builder(
 		"bpf_map_test_p1.o",
@@ -488,7 +488,7 @@ func TestMaxEntriesSingle(t *testing.T) {
 
 func TestMaxEntriesMulti(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	p1 := program.Builder(
 		"bpf_map_test_p1.o",
@@ -758,7 +758,7 @@ func TestCleanup(t *testing.T) {
 
 func TestMapShared(t *testing.T) {
 	option.Config.HubbleLib = tus.Conf().TetragonLib
-	option.Config.Verbosity = 5
+	option.Config.VerifierLogLevel = 5
 
 	p1 := program.Builder(
 		"bpf_map_test_p1.o",

--- a/pkg/testutils/sensors/testrun_linux.go
+++ b/pkg/testutils/sensors/testrun_linux.go
@@ -28,6 +28,11 @@ func TestSensorsRun(m *testing.M, sensorName string) int {
 	flag.StringVar(&config.TetragonLib,
 		"bpf-lib", ConfigDefaults.TetragonLib,
 		"tetragon lib directory (location of btf file and bpf objs). Will be overridden by an TETRAGON_LIB env variable.")
+	flag.IntVar(
+		&option.Config.VerifierLogLevel,
+		option.KeyVerifierLogLevel,
+		0,
+		option.VerifierLogLevelHelp)
 	flag.DurationVar(&config.CmdWaitTime,
 		"command-wait",
 		5*time.Minute,

--- a/pkg/testutils/sensors/testrun_windows.go
+++ b/pkg/testutils/sensors/testrun_windows.go
@@ -28,6 +28,11 @@ func TestSensorsRun(m *testing.M, sensorName string) int {
 	flag.StringVar(&config.TetragonLib,
 		"bpf-lib", ConfigDefaults.TetragonLib,
 		"tetragon lib directory (location of btf file and bpf objs). Will be overridden by an TETRAGON_LIB env variable.")
+	flag.IntVar(
+		&option.Config.VerifierLogLevel,
+		option.KeyVerifierLogLevel,
+		0,
+		option.VerifierLogLevelHelp)
 	flag.DurationVar(&config.CmdWaitTime,
 		"command-wait",
 		5*time.Minute,


### PR DESCRIPTION
When debugging an issue that arise in a Go test, it's useful to have a way of seeing verifier logs directly in the test failure, wire our existing flag into TestSensorRun().

The previous name was confusing: I always mixed it between --debug and --verbose and verbose was missing the idea that it was only for the verifier log and not for tetragon level logs.