### PR TITLE
perf(pkg/observer): reuse buffers when reading events

### DIFF
--- a/pkg/observer/observer_linux.go
+++ b/pkg/observer/observer_linux.go
@@ -26,6 +26,13 @@ const (
 	perCPUBufferBytes = 65535
 )
 
+var rawSampleBufPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 0)
+		return &buf
+	},
+}
+
 func (k *Observer) getRBSize(cpus int) int {
 	var size int
 
@@ -111,8 +118,12 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 	go func() {
 		defer wg.Done()
 		for stopCtx.Err() == nil {
-			record, err := perfReader.Read()
+			bufPtr := rawSampleBufPool.Get().(*[]byte)
+			record := perf.Record{RawSample: *bufPtr}
+			err := perfReader.ReadInto(&record)
+			*bufPtr = record.RawSample
 			if err != nil {
+				rawSampleBufPool.Put(bufPtr)
 				// NOTE(JM and Djalal): count and log errors while excluding the stopping context
 				if stopCtx.Err() == nil {
 					RingbufErrors.Inc()
@@ -122,12 +133,15 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 			} else {
 				if len(record.RawSample) > 0 {
 					select {
-					case eventsQueue <- &record.RawSample:
+					case eventsQueue <- bufPtr:
 					default:
 						// eventsQueue channel is full, drop the event
+						rawSampleBufPool.Put(bufPtr)
 						queueLost.Inc()
 					}
 					RingbufReceived.Inc()
+				} else {
+					rawSampleBufPool.Put(bufPtr)
 				}
 
 				if record.LostSamples > 0 {
@@ -141,8 +155,12 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 		// Service the BPF ring buffer as well.
 		wg.Go(func() {
 			for stopCtx.Err() == nil {
-				record, err := ringBufReader.Read()
+				bufPtr := rawSampleBufPool.Get().(*[]byte)
+				record := ringbuf.Record{RawSample: *bufPtr}
+				err := ringBufReader.ReadInto(&record)
+				*bufPtr = record.RawSample
 				if err != nil {
+					rawSampleBufPool.Put(bufPtr)
 					// NOTE(JM and Djalal): count and log errors while excluding the stopping context
 					if stopCtx.Err() == nil {
 						RingbufErrors.Inc()
@@ -152,12 +170,15 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 				} else {
 					if len(record.RawSample) > 0 {
 						select {
-						case eventsQueue <- &record.RawSample:
+						case eventsQueue <- bufPtr:
 						default:
 							// eventsQueue channel is full, drop the event
+							rawSampleBufPool.Put(bufPtr)
 							queueLost.Inc()
 						}
 						RingbufReceived.Inc()
+					} else {
+						rawSampleBufPool.Put(bufPtr)
 					}
 				}
 			}
@@ -170,6 +191,7 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 			select {
 			case eventRawSample := <-eventsQueue:
 				k.receiveEvent(*eventRawSample)
+				rawSampleBufPool.Put(eventRawSample)
 				queueReceived.Inc()
 			case <-stopCtx.Done():
 				k.log.Info("Listening for events completed.", logfields.Error, stopCtx.Err())


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

The existing `Read()` call allocates a buffer on each event read. This event is passed to a downstream sink (receiveEvent()) which never retains the event or parts thereof, but rather uses it to materialise higher-level objects. This means that, for each event received, we have:
```
  event alloc -> event is read -> event is freed
```
which causes significant allocation churn.

Instead, use a combination of `ReadInto()` and `sync.Pool`, so that the event buffers can be reused, i.e.:
```
  event buffer acquire -> event is read -> event buffer returns to the pool
```
Validated with a soak test hammering tetragon with millions of uniquely-marked `execve` events on a controlled cgroup, showing that allocations attributed to 'readRecord()' are almost entirely eliminated.

For example, in the longest run (~73 mins, 6.3M events):

|  | Before | After |
|---|---:|---:|
| total allocated space | 79.10 GB | 73.94 GB |
| total allocation objects | 1.15B | 1.11B |
| **`ringReader.readRecord` allocated space** | **4.86 GB** | **~54 MB** |

This corresponds to a ~98.9% reduction in allocation volume at `ringReader.readRecord`. The same profile showed approximately 19M fewer allocations directly attributed to this function.

The reduction was reproduced across independent runs at different event volumes.

No measurable cpu regression was observed (cpu profiles varied in both directions around the baseline)

The allocated-space figures above are cumulative allocations, rather than resident memory. The purpose of this change is to reduce short-lived allocation churn in the event reading path, not Tetragon's steady-state memory footprint. RSS measurements showed no evidence of increased memory retention from the use of `sync.Pool`.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
perf: reduce allocation overhead in the bpf event read path
```
