### PR TITLE
cel: add 16 and 8 bit (u)int support

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -913,6 +913,14 @@ Currently, `MatchCEL` supports:
 * Integer casting to 32-bits (`int32()`, `uint32()`)
 * Bitwise operations (`and()`, `or()`, `xor()`, `not()`, `lsh()`, `rsh()`)
 
+Shift operations (`lsh()`, `rsh()`) mask the shift amount to the bit width of
+the operand. In other words, the shift amount is reduced modulo the bit width
+of the operand.
+
+For example, `lsh(uint8(16u), uint8(9u))` is equal to `lsh(uint8(16u),
+uint8(1u))` because the shift amount is masked by 7 (the bit width of a `uint8`
+minus 1) thus `9 & 7 = 1` or reduced modulo the bit width, thus `9 % 8 = 1`.
+
 ## Actions filter
 
 Actions filters are a list of actions that execute when an appropriate selector

--- a/pkg/celbpf/cel_eval_test.go
+++ b/pkg/celbpf/cel_eval_test.go
@@ -21,7 +21,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type celNumber[T int32 | uint32] struct {
+type number interface {
+	int8 | uint8 | int16 | uint16 | int32 | uint32
+}
+
+type celNumber[T number] struct {
 	value    T
 	typeInfo *celTypes.Type
 }
@@ -60,8 +64,28 @@ func (value celNumber[T]) Value() any {
 	return value.value
 }
 
+type celS8 = celNumber[int8]
+type celU8 = celNumber[uint8]
+type celS16 = celNumber[int16]
+type celU16 = celNumber[uint16]
 type celS32 = celNumber[int32]
 type celU32 = celNumber[uint32]
+
+func newCelS8(value int8) celS8 {
+	return celS8{value: value, typeInfo: s8Ty}
+}
+
+func newCelU8(value uint8) celU8 {
+	return celU8{value: value, typeInfo: u8Ty}
+}
+
+func newCelS16(value int16) celS16 {
+	return celS16{value: value, typeInfo: s16Ty}
+}
+
+func newCelU16(value uint16) celU16 {
+	return celU16{value: value, typeInfo: u16Ty}
+}
 
 func newCelS32(value int32) celS32 {
 	return celS32{value: value, typeInfo: s32Ty}
@@ -77,6 +101,14 @@ type celTestTypeAdapter struct {
 
 func (adapter celTestTypeAdapter) NativeToValue(value any) ref.Val {
 	switch value := value.(type) {
+	case celS8:
+		return value
+	case celU8:
+		return value
+	case celS16:
+		return value
+	case celU16:
+		return value
 	case celS32:
 		return value
 	case celU32:
@@ -101,6 +133,10 @@ func celBinArithOp(
 	uintOp func(celTypes.Uint, celTypes.Uint) celTypes.Uint,
 	s32Op func(int32, int32) int32,
 	u32Op func(uint32, uint32) uint32,
+	s16Op func(int16, int16) int16,
+	u16Op func(uint16, uint16) uint16,
+	s8Op func(int8, int8) int8,
+	u8Op func(uint8, uint8) uint8,
 ) func(left, right ref.Val) ref.Val {
 	return func(left, right ref.Val) ref.Val {
 		switch left := left.(type) {
@@ -120,6 +156,22 @@ func celBinArithOp(
 			if r, ok := right.(celU32); ok {
 				return newCelU32(u32Op(left.value, r.value))
 			}
+		case celS16:
+			if r, ok := right.(celS16); ok {
+				return newCelS16(s16Op(left.value, r.value))
+			}
+		case celU16:
+			if r, ok := right.(celU16); ok {
+				return newCelU16(u16Op(left.value, r.value))
+			}
+		case celS8:
+			if r, ok := right.(celS8); ok {
+				return newCelS8(int8(s8Op(int8(left.value), int8(r.value))))
+			}
+		case celU8:
+			if r, ok := right.(celU8); ok {
+				return newCelU8(uint8(u8Op(uint8(left.value), uint8(r.value))))
+			}
 		}
 		return celTypes.MaybeNoSuchOverloadErr(left)
 	}
@@ -130,6 +182,10 @@ var celAdd = celBinArithOp(
 	func(a, b celTypes.Uint) celTypes.Uint { return a + b },
 	func(a, b int32) int32 { return a + b },
 	func(a, b uint32) uint32 { return a + b },
+	func(a, b int16) int16 { return a + b },
+	func(a, b uint16) uint16 { return a + b },
+	func(a, b int8) int8 { return a + b },
+	func(a, b uint8) uint8 { return a + b },
 )
 
 var celSubtract = celBinArithOp(
@@ -137,6 +193,10 @@ var celSubtract = celBinArithOp(
 	func(a, b celTypes.Uint) celTypes.Uint { return a - b },
 	func(a, b int32) int32 { return a - b },
 	func(a, b uint32) uint32 { return a - b },
+	func(a, b int16) int16 { return a - b },
+	func(a, b uint16) uint16 { return a - b },
+	func(a, b int8) int8 { return a - b },
+	func(a, b uint8) uint8 { return a - b },
 )
 
 var celBitwiseAND = celBinArithOp(
@@ -144,6 +204,10 @@ var celBitwiseAND = celBinArithOp(
 	func(a, b celTypes.Uint) celTypes.Uint { return a & b },
 	func(a, b int32) int32 { return a & b },
 	func(a, b uint32) uint32 { return a & b },
+	func(a, b int16) int16 { return a & b },
+	func(a, b uint16) uint16 { return a & b },
+	func(a, b int8) int8 { return a & b },
+	func(a, b uint8) uint8 { return a & b },
 )
 
 var celBitwiseOR = celBinArithOp(
@@ -151,6 +215,10 @@ var celBitwiseOR = celBinArithOp(
 	func(a, b celTypes.Uint) celTypes.Uint { return a | b },
 	func(a, b int32) int32 { return a | b },
 	func(a, b uint32) uint32 { return a | b },
+	func(a, b int16) int16 { return a | b },
+	func(a, b uint16) uint16 { return a | b },
+	func(a, b int8) int8 { return a | b },
+	func(a, b uint8) uint8 { return a | b },
 )
 
 var celBitwiseXOR = celBinArithOp(
@@ -158,6 +226,10 @@ var celBitwiseXOR = celBinArithOp(
 	func(a, b celTypes.Uint) celTypes.Uint { return a ^ b },
 	func(a, b int32) int32 { return a ^ b },
 	func(a, b uint32) uint32 { return a ^ b },
+	func(a, b int16) int16 { return a ^ b },
+	func(a, b uint16) uint16 { return a ^ b },
+	func(a, b int8) int8 { return a ^ b },
+	func(a, b uint8) uint8 { return a ^ b },
 )
 
 // Go shifts panic on a negative shift count, ensure they're positive.
@@ -168,6 +240,10 @@ var celBitwiseLSH = celBinArithOp(
 	func(a, b celTypes.Uint) celTypes.Uint { return a << (uint64(b) & 63) },
 	func(a, b int32) int32 { return a << (uint(b) & 31) },
 	func(a, b uint32) uint32 { return a << (uint(b) & 31) },
+	func(a, b int16) int16 { return a << (uint16(b) & 15) },
+	func(a, b uint16) uint16 { return a << (uint16(b) & 15) },
+	func(a, b int8) int8 { return a << (uint8(b) & 7) },
+	func(a, b uint8) uint8 { return a << (uint8(b) & 7) },
 )
 
 var celBitwiseRSH = celBinArithOp(
@@ -175,6 +251,10 @@ var celBitwiseRSH = celBinArithOp(
 	func(a, b celTypes.Uint) celTypes.Uint { return a >> (uint64(b) & 63) },
 	func(a, b int32) int32 { return a >> (uint(b) & 31) },
 	func(a, b uint32) uint32 { return a >> (uint(b) & 31) },
+	func(a, b int16) int16 { return a >> (uint16(b) & 15) },
+	func(a, b uint16) uint16 { return a >> (uint16(b) & 15) },
+	func(a, b int8) int8 { return a >> (uint8(b) & 7) },
+	func(a, b uint8) uint8 { return a >> (uint8(b) & 7) },
 )
 
 func celBitwiseNOT(value ref.Val) ref.Val {
@@ -187,11 +267,19 @@ func celBitwiseNOT(value ref.Val) ref.Val {
 		return newCelS32(^v.value)
 	case celU32:
 		return newCelU32(^v.value)
+	case celS16:
+		return newCelS16(^v.value)
+	case celU16:
+		return newCelU16(^v.value)
+	case celS8:
+		return newCelS8(^v.value)
+	case celU8:
+		return newCelU8(^v.value)
 	}
 	return celTypes.MaybeNoSuchOverloadErr(value)
 }
 
-func compareIntegers[T int32 | uint32 | celTypes.Int | celTypes.Uint](op string, left, right T) ref.Val {
+func compareIntegers[T number | celTypes.Int | celTypes.Uint](op string, left, right T) ref.Val {
 	switch op {
 	case "lt":
 		return celTypes.Bool(left < right)
@@ -232,6 +320,30 @@ func celInequality(op string, left, right ref.Val) ref.Val {
 			return celTypes.MaybeNoSuchOverloadErr(right)
 		}
 		return compareIntegers(op, left.value, right.value)
+	case celS16:
+		right, ok := right.(celS16)
+		if !ok {
+			return celTypes.MaybeNoSuchOverloadErr(right)
+		}
+		return compareIntegers(op, left.value, right.value)
+	case celU16:
+		right, ok := right.(celU16)
+		if !ok {
+			return celTypes.MaybeNoSuchOverloadErr(right)
+		}
+		return compareIntegers(op, left.value, right.value)
+	case celS8:
+		right, ok := right.(celS8)
+		if !ok {
+			return celTypes.MaybeNoSuchOverloadErr(right)
+		}
+		return compareIntegers(op, left.value, right.value)
+	case celU8:
+		right, ok := right.(celU8)
+		if !ok {
+			return celTypes.MaybeNoSuchOverloadErr(right)
+		}
+		return compareIntegers(op, left.value, right.value)
 	default:
 		return celTypes.MaybeNoSuchOverloadErr(left)
 	}
@@ -240,6 +352,22 @@ func celInequality(op string, left, right ref.Val) ref.Val {
 func getOverloadOpts(t *testing.T, o *fnOverload) []cel.OverloadOpt {
 	var ret []cel.OverloadOpt
 	switch o.name {
+	case "s8fromint":
+		return append(ret, cel.UnaryBinding(func(value ref.Val) ref.Val {
+			return newCelS8(int8(value.(celTypes.Int)))
+		}))
+	case "u8fromuint":
+		return append(ret, cel.UnaryBinding(func(value ref.Val) ref.Val {
+			return newCelU8(uint8(value.(celTypes.Uint)))
+		}))
+	case "s16fromint":
+		return append(ret, cel.UnaryBinding(func(value ref.Val) ref.Val {
+			return newCelS16(int16(value.(celTypes.Int)))
+		}))
+	case "u16fromuint":
+		return append(ret, cel.UnaryBinding(func(value ref.Val) ref.Val {
+			return newCelU16(uint16(value.(celTypes.Uint)))
+		}))
 	case "u32fromuint":
 		return append(ret, cel.UnaryBinding(func(value ref.Val) ref.Val {
 			return newCelU32(uint32(value.(celTypes.Uint)))
@@ -306,7 +434,7 @@ func evalCEL(t *testing.T, expr string, hookArgs []any) uint32 {
 	t.Helper()
 
 	opts := []cel.EnvOption{
-		cel.Types(s32Ty, u32Ty),
+		cel.Types(s8Ty, u8Ty, s16Ty, u16Ty, s32Ty, u32Ty),
 		cel.CustomTypeAdapter(celTestTypeAdapter{Adapter: celTypes.DefaultTypeAdapter}),
 	}
 
@@ -323,12 +451,24 @@ func evalCEL(t *testing.T, expr string, hookArgs []any) uint32 {
 	for i, hookArg := range hookArgs {
 		argName := "arg" + strconv.Itoa(i)
 		switch value := hookArg.(type) {
+		case int8:
+			opts = append(opts, cel.Variable(argName, s8Ty))
+			values[argName] = newCelS8(value)
+		case int16:
+			opts = append(opts, cel.Variable(argName, s16Ty))
+			values[argName] = newCelS16(value)
 		case int32:
 			opts = append(opts, cel.Variable(argName, s32Ty))
 			values[argName] = newCelS32(value)
 		case int64:
 			opts = append(opts, cel.Variable(argName, s64Ty))
 			values[argName] = value
+		case uint8:
+			opts = append(opts, cel.Variable(argName, u8Ty))
+			values[argName] = newCelU8(value)
+		case uint16:
+			opts = append(opts, cel.Variable(argName, u16Ty))
+			values[argName] = newCelU16(value)
 		case uint32:
 			opts = append(opts, cel.Variable(argName, u32Ty))
 			values[argName] = newCelU32(value)

--- a/pkg/celbpf/cel_fuzz_test.go
+++ b/pkg/celbpf/cel_fuzz_test.go
@@ -40,8 +40,12 @@ func newRandExprSt(r *rand.Rand, nexprs int, nargs int) *randExprSt {
 	argTypes := []func() any{
 		func() any { return r.Uint64() },
 		func() any { return r.Uint32() },
+		func() any { return uint16(r.Uint64N(1 << 16)) },
+		func() any { return uint8(r.Uint64N(1 << 8)) },
 		func() any { return r.Int64() },
 		func() any { return r.Int32() },
+		func() any { return int16(r.Uint64N(1 << 16)) },
+		func() any { return int8(r.Uint64N(1 << 8)) },
 	}
 
 	randomArg := func() any {
@@ -73,12 +77,28 @@ func (st *randExprSt) celNullaryExpr(ty *cgTypes.Type) string {
 			if ty == u32Ty {
 				aidxs = append(aidxs, idx)
 			}
+		case uint16:
+			if ty == u16Ty {
+				aidxs = append(aidxs, idx)
+			}
+		case uint8:
+			if ty == u8Ty {
+				aidxs = append(aidxs, idx)
+			}
 		case int64:
 			if ty == s64Ty {
 				aidxs = append(aidxs, idx)
 			}
 		case int32:
 			if ty == s32Ty {
+				aidxs = append(aidxs, idx)
+			}
+		case int16:
+			if ty == s16Ty {
+				aidxs = append(aidxs, idx)
+			}
+		case int8:
+			if ty == s8Ty {
 				aidxs = append(aidxs, idx)
 			}
 		default:
@@ -109,6 +129,14 @@ func (st *randExprSt) celNullaryExpr(ty *cgTypes.Type) string {
 		return fmt.Sprintf("int32(%d)", st.r.Int32())
 	case u32Ty:
 		return fmt.Sprintf("uint32(%du)", st.r.Uint32())
+	case s16Ty:
+		return fmt.Sprintf("int16(%d)", int16(st.r.Uint64N(1<<16)))
+	case u16Ty:
+		return fmt.Sprintf("uint16(%du)", uint16(st.r.Uint64N(1<<16)))
+	case s8Ty:
+		return fmt.Sprintf("int8(%d)", int8(st.r.Uint64N(1<<8)))
+	case u8Ty:
+		return fmt.Sprintf("uint8(%du)", uint8(st.r.Uint64N(1<<8)))
 	}
 	panic(fmt.Sprintf("unknown/unhandled type: %v", ty))
 }

--- a/pkg/celbpf/celbpf_test.go
+++ b/pkg/celbpf/celbpf_test.go
@@ -70,21 +70,37 @@ func prepareArgs(t *testing.T, hookArgs []any) (DummyMsg, []v1alpha1.KProbeArg) 
 
 	for _, hArg := range hookArgs {
 		switch hArg.(type) {
+		case int8:
+			args = append(args, v1alpha1.KProbeArg{
+				Type: "int8",
+			})
+		case int16:
+			args = append(args, v1alpha1.KProbeArg{
+				Type: "int16",
+			})
 		case int32:
 			args = append(args, v1alpha1.KProbeArg{
 				Type: "int32",
 			})
-		case uint64:
+		case int64:
 			args = append(args, v1alpha1.KProbeArg{
-				Type: "uint64",
+				Type: "int64",
+			})
+		case uint8:
+			args = append(args, v1alpha1.KProbeArg{
+				Type: "uint8",
+			})
+		case uint16:
+			args = append(args, v1alpha1.KProbeArg{
+				Type: "uint16",
 			})
 		case uint32:
 			args = append(args, v1alpha1.KProbeArg{
 				Type: "uint32",
 			})
-		case int64:
+		case uint64:
 			args = append(args, v1alpha1.KProbeArg{
-				Type: "int64",
+				Type: "uint64",
 			})
 		default:
 			t.Fatalf("unknown type %T", hArg)
@@ -151,6 +167,16 @@ var argTestCases = []struct {
 		expr:     "arg0 == uint32(43u)",
 		ret:      0,
 		hookArgs: []any{uint32(42)},
+	},
+	{
+		expr:     "arg0 == int16(-1)",
+		ret:      1,
+		hookArgs: []any{int16(-1)},
+	},
+	{
+		expr:     "arg0 == uint8(255u)",
+		ret:      1,
+		hookArgs: []any{uint8(255)},
 	},
 	{
 		expr:     "arg2 == int32(42)",

--- a/pkg/celbpf/celbpfexpr_test.go
+++ b/pkg/celbpf/celbpfexpr_test.go
@@ -50,6 +50,14 @@ func addTestsTyped[T myInt](values []T, operators []string) []exprTest {
 
 	literal := func(x any) string {
 		switch x.(type) {
+		case int8:
+			return fmt.Sprintf("int8(%d)", x)
+		case uint8:
+			return fmt.Sprintf("uint8(%du)", x)
+		case int16:
+			return fmt.Sprintf("int16(%d)", x)
+		case uint16:
+			return fmt.Sprintf("uint16(%du)", x)
 		case int32:
 			return fmt.Sprintf("int32(%d)", x)
 		case uint32:
@@ -121,6 +129,23 @@ func TestExprs(t *testing.T) {
 		{"uint32(3u) == uint32(5u) - uint32(2u)", 1},
 		{"int32(10) == int32(5) + int32(5)", 1},
 		{"int32(-2) == int32(5) - int32(7)", 1},
+		{"int16(10) == int16(5) + int16(5)", 1},
+		{"int16(-2) == int16(5) - int16(7)", 1},
+		{"int8(10) == int8(5) + int8(5)", 1},
+		{"int8(-2) == int8(5) - int8(7)", 1},
+		{"uint16(10u) == uint16(5u) + uint16(5u)", 1},
+		{"uint16(3u) == uint16(5u) - uint16(2u)", 1},
+		{"uint16(65535u) + uint16(1u) == uint16(0u)", 1},
+		{"uint8(10u) == uint8(5u) + uint8(5u)", 1},
+		{"uint8(3u) == uint8(5u) - uint8(2u)", 1},
+		{"uint8(255u) + uint8(1u) == uint8(0u)", 1},
+		{"int16(-1) == int16(65535)", 1},
+		{"not(int16(0)) == int16(-1)", 1},
+		{"int16(0) == int16(65535) + int16(1)", 1},
+		{"int8(-1) == int8(255)", 1},
+		{"not(int8(0)) == int8(-1)", 1},
+		{"not(uint8(0u)) == uint8(255u)", 1},
+		{"int8(0) == int8(255) + int8(1)", 1},
 	}
 	testCases = append(testCases, testComparisons()...)
 

--- a/pkg/celbpf/codegen.go
+++ b/pkg/celbpf/codegen.go
@@ -59,11 +59,9 @@ func (g *codeGenerator) emitPushBool(val bool, tmp asm.Register) {
 	)
 }
 
-func (g *codeGenerator) emitPopBool(reg asm.Register) {
-	g.emitRaw(asm.LoadMem(reg, asm.R10, g.stackTop, asm.DWord))
-	g.stackTop += 8
-}
-
+// emitPushInt64 pushes the 64-bit register onto the stack.
+// This is used for all values, even ones with smaller widths,
+// to keep the stack aligned to 8 bytes for simplicity.
 func (g *codeGenerator) emitPushInt64(val int64, tmp asm.Register) {
 	g.stackTop -= 8
 	g.emitRaw(
@@ -72,12 +70,10 @@ func (g *codeGenerator) emitPushInt64(val int64, tmp asm.Register) {
 	)
 }
 
+// emitPopInt64 pops the 64-bit register from the stack.
+// This is used for all values, even ones with smaller widths,
+// to keep the stack aligned to 8 bytes for simplicity.
 func (g *codeGenerator) emitPopInt64(reg asm.Register) {
-	g.emitRaw(asm.LoadMem(reg, asm.R10, g.stackTop, asm.DWord))
-	g.stackTop += 8
-}
-
-func (g *codeGenerator) emitPopS32(reg asm.Register) {
 	g.emitRaw(asm.LoadMem(reg, asm.R10, g.stackTop, asm.DWord))
 	g.stackTop += 8
 }
@@ -94,11 +90,6 @@ func (g *codeGenerator) emitS32(reg asm.Register, regTy *cgTypes.Type) error {
 		asm.StoreMem(asm.R10, g.stackTop, reg, asm.DWord),
 	)
 	return nil
-}
-
-func (g *codeGenerator) emitPopU32(reg asm.Register) {
-	g.emitRaw(asm.LoadMem(reg, asm.R10, g.stackTop, asm.DWord))
-	g.stackTop += 8
 }
 
 func (g *codeGenerator) emitU32(reg asm.Register, regTy *cgTypes.Type) error {

--- a/pkg/celbpf/codegen.go
+++ b/pkg/celbpf/codegen.go
@@ -107,6 +107,68 @@ func (g *codeGenerator) emitU32(reg asm.Register, regTy *cgTypes.Type) error {
 	return nil
 }
 
+func (g *codeGenerator) emitS16(reg asm.Register, regTy *cgTypes.Type) error {
+	switch regTy {
+	case s64Ty:
+	default:
+		return fmt.Errorf("emitS16: unknown/unsupported type %s", regTy)
+	}
+
+	g.stackTop -= 8
+	g.emitRaw(
+		asm.LSh.Imm(reg, 48),
+		asm.ArSh.Imm(reg, 48),
+		asm.StoreMem(asm.R10, g.stackTop, reg, asm.DWord),
+	)
+	return nil
+}
+
+func (g *codeGenerator) emitU16(reg asm.Register, regTy *cgTypes.Type) error {
+	switch regTy {
+	case u64Ty:
+	default:
+		return fmt.Errorf("emitU16: unknown/unsupported type %s", regTy)
+	}
+
+	g.stackTop -= 8
+	g.emitRaw(
+		asm.And.Imm(reg, 0xffff),
+		asm.StoreMem(asm.R10, g.stackTop, reg, asm.DWord),
+	)
+	return nil
+}
+
+func (g *codeGenerator) emitS8(reg asm.Register, regTy *cgTypes.Type) error {
+	switch regTy {
+	case s64Ty:
+	default:
+		return fmt.Errorf("emitS8: unknown/unsupported type %s", regTy)
+	}
+
+	g.stackTop -= 8
+	g.emitRaw(
+		asm.LSh.Imm(reg, 56),
+		asm.ArSh.Imm(reg, 56),
+		asm.StoreMem(asm.R10, g.stackTop, reg, asm.DWord),
+	)
+	return nil
+}
+
+func (g *codeGenerator) emitU8(reg asm.Register, regTy *cgTypes.Type) error {
+	switch regTy {
+	case u64Ty:
+	default:
+		return fmt.Errorf("emitU8: unknown/unsupported type %s", regTy)
+	}
+
+	g.stackTop -= 8
+	g.emitRaw(
+		asm.And.Imm(reg, 0xff),
+		asm.StoreMem(asm.R10, g.stackTop, reg, asm.DWord),
+	)
+	return nil
+}
+
 func (g *codeGenerator) pushArg(argTy *cgTypes.Type, argOffset uint16, tmp1, tmp2 asm.Register) error {
 	off := int(argOffset * 8)
 	if off > math.MaxInt16 {
@@ -114,35 +176,61 @@ func (g *codeGenerator) pushArg(argTy *cgTypes.Type, argOffset uint16, tmp1, tmp
 	}
 	off16 := int16(off)
 
+	// Load the offset of the argument from argArgsOff into tmp1,
+	// and add it to argArgs to get the address of the argument.
+	g.emitRaw(
+		// tmp1 = *(u64 *)(argArgsOff + idx)
+		asm.LoadMem(tmp1, argArgsOff, off16, asm.DWord),
+		asm.And.Imm(tmp1, 0x7ff),
+		// tmp1 += args
+		asm.Add.Reg(tmp1, argArgs),
+	)
+
+	// Load the argument with the correct width into a register
 	switch argTy {
-	case u32Ty, s32Ty:
-		g.stackTop -= 8
+	case u8Ty:
 		g.emitRaw(
-			// tmp1 = *(u64 *)(argArgsOff + idx)
-			asm.LoadMem(tmp1, argArgsOff, off16, asm.DWord),
-			asm.And.Imm(tmp1, 0x7ff),
-			// tmp1 += args
-			asm.Add.Reg(tmp1, argArgs),
+			// tmp2 = *(u8 *)(tmp1)
+			asm.LoadMem(tmp2, tmp1, 0, asm.Byte),
+		)
+	case s8Ty:
+		g.emitRaw(
+			// tmp2 = *(s8 *)(tmp1)
+			asm.LoadMem(tmp2, tmp1, 0, asm.Byte),
+			asm.LSh.Imm(tmp2, 56),
+			asm.ArSh.Imm(tmp2, 56),
+		)
+	case u16Ty:
+		g.emitRaw(
+			// tmp2 = *(u16 *)(tmp1)
+			asm.LoadMem(tmp2, tmp1, 0, asm.Half),
+		)
+	case s16Ty:
+		g.emitRaw(
+			// tmp2 = *(s16 *)(tmp1)
+			asm.LoadMem(tmp2, tmp1, 0, asm.Half),
+			asm.LSh.Imm(tmp2, 48),
+			asm.ArSh.Imm(tmp2, 48),
+		)
+	case u32Ty, s32Ty:
+		g.emitRaw(
 			// tmp2 = *(u32 *)(tmp1)
 			asm.LoadMem(tmp2, tmp1, 0, asm.Word),
-			asm.StoreMem(asm.R10, g.stackTop, tmp2, asm.DWord),
 		)
 	case u64Ty, s64Ty:
-		g.stackTop -= 8
 		g.emitRaw(
-			// tmp1 = *(u64 *)(argArgsOff + idx)
-			asm.LoadMem(tmp1, argArgsOff, off16, asm.DWord),
-			asm.And.Imm(tmp1, 0x7ff),
-			// tmp1 += args
-			asm.Add.Reg(tmp1, argArgs),
 			// tmp2 = *(u64 *)(tmp1)
 			asm.LoadMem(tmp2, tmp1, 0, asm.DWord),
-			asm.StoreMem(asm.R10, g.stackTop, tmp2, asm.DWord),
 		)
 	default:
 		return fmt.Errorf("unsupported type: %s", argTy.TypeName())
 	}
 
+	// Push the loaded argument onto the stack as a 64-bit value.
+	g.stackTop -= 8
+	g.emitRaw(
+		asm.StoreMem(asm.R10, g.stackTop, tmp2, asm.DWord),
+	)
 	return nil
 }
 
@@ -152,6 +240,18 @@ func (g *codeGenerator) emitArithOp(
 	r1 asm.Register, ty1 *cgTypes.Type,
 	r2 asm.Register, ty2 *cgTypes.Type,
 ) error {
+	// Carry on the mask behavior for shift operations
+	// for 16 and 8 bit
+	// i.e. dst <<= (src & mask)
+	if op == asm.LSh || op == asm.RSh || op == asm.ArSh {
+		switch ty2.TypeName() {
+		case s16Ty.TypeName(), u16Ty.TypeName():
+			g.emitRaw(asm.And.Imm32(r2, 15))
+		case s8Ty.TypeName(), u8Ty.TypeName():
+			g.emitRaw(asm.And.Imm32(r2, 7))
+		}
+	}
+
 	var ins asm.Instruction
 	switch {
 	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName(),
@@ -159,22 +259,52 @@ func (g *codeGenerator) emitArithOp(
 		ins = op.Reg(r1, r2)
 
 	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
-		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+		ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName(),
+		ty1.TypeName() == s16Ty.TypeName() && ty2.TypeName() == s16Ty.TypeName(),
+		ty1.TypeName() == u16Ty.TypeName() && ty2.TypeName() == u16Ty.TypeName(),
+		ty1.TypeName() == s8Ty.TypeName() && ty2.TypeName() == s8Ty.TypeName(),
+		ty1.TypeName() == u8Ty.TypeName() && ty2.TypeName() == u8Ty.TypeName():
 		ins = op.Reg32(r1, r2)
 
 	default:
-		return fmt.Errorf("operation between types %s and %s is not supported", ty1.TypeName(), ty2.TypeName())
+		return fmt.Errorf("operation between types %s and %s is not supported %T %T", ty1.TypeName(), ty2.TypeName(), ty1, ty2)
 	}
 
 	if ins.OpCode == asm.InvalidOpCode {
 		return fmt.Errorf("invalid opcode for ALU op %v", op)
 	}
 
+	// Emit arithmetic instructions, the result is in r1.
+	g.emitRaw(ins)
+
+	// Convert the value to a lower width type if needed.
+	switch {
+	case ty1.TypeName() == u16Ty.TypeName() && ty2.TypeName() == u16Ty.TypeName():
+		g.emitRaw(
+			asm.And.Imm(r1, 0xffff),
+		)
+	case ty1.TypeName() == s16Ty.TypeName() && ty2.TypeName() == s16Ty.TypeName():
+		g.emitRaw(
+			asm.LSh.Imm(r1, 48),
+			asm.ArSh.Imm(r1, 48),
+		)
+	case ty1.TypeName() == u8Ty.TypeName() && ty2.TypeName() == u8Ty.TypeName():
+		g.emitRaw(
+			asm.And.Imm(r1, 0xff),
+		)
+	case ty1.TypeName() == s8Ty.TypeName() && ty2.TypeName() == s8Ty.TypeName():
+		g.emitRaw(
+			asm.LSh.Imm(r1, 56),
+			asm.ArSh.Imm(r1, 56),
+		)
+	}
+
+	// Finally store the result on the stack.
 	g.stackTop -= 8
 	g.emitRaw(
-		ins,
 		asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
 	)
+
 	return nil
 }
 
@@ -220,15 +350,33 @@ func (g *codeGenerator) emitBitwiseNot(
 		ins = asm.Xor.Imm(r1, -1)
 	case s32Ty.TypeName(), u32Ty.TypeName():
 		ins = asm.Xor.Imm32(r1, -1)
+	case s16Ty.TypeName(), u16Ty.TypeName():
+		ins = asm.Xor.Imm32(r1, 0xffff)
+	case s8Ty.TypeName(), u8Ty.TypeName():
+		ins = asm.Xor.Imm32(r1, 0xff)
 	default:
 		return fmt.Errorf("bitwise NOT on type %s is not supported", ty1.TypeName())
 	}
 
 	g.stackTop -= 8
-	g.emitRaw(
-		ins,
-		asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord),
-	)
+	g.emitRaw(ins)
+	switch ty1.TypeName() {
+	case u8Ty.TypeName():
+		g.emitRaw(asm.And.Imm(r1, 0xff))
+	case u16Ty.TypeName():
+		g.emitRaw(asm.And.Imm(r1, 0xffff))
+	case s8Ty.TypeName():
+		g.emitRaw(
+			asm.LSh.Imm(r1, 56),
+			asm.ArSh.Imm(r1, 56),
+		)
+	case s16Ty.TypeName():
+		g.emitRaw(
+			asm.LSh.Imm(r1, 48),
+			asm.ArSh.Imm(r1, 48),
+		)
+	}
+	g.emitRaw(asm.StoreMem(asm.R10, g.stackTop, r1, asm.DWord))
 	return nil
 }
 
@@ -242,14 +390,18 @@ func (g *codeGenerator) emitBranch(
 	var signed bool
 	var alu32 bool
 	switch {
-	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName():
+	case ty1.TypeName() == s32Ty.TypeName() && ty2.TypeName() == s32Ty.TypeName(),
+		ty1.TypeName() == s16Ty.TypeName() && ty2.TypeName() == s16Ty.TypeName(),
+		ty1.TypeName() == s8Ty.TypeName() && ty2.TypeName() == s8Ty.TypeName():
 		signed = true
 		alu32 = true
 
 	case ty1.TypeName() == s64Ty.TypeName() && ty2.TypeName() == s64Ty.TypeName():
 		signed = true
 
-	case ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName():
+	case ty1.TypeName() == u32Ty.TypeName() && ty2.TypeName() == u32Ty.TypeName(),
+		ty1.TypeName() == u16Ty.TypeName() && ty2.TypeName() == u16Ty.TypeName(),
+		ty1.TypeName() == u8Ty.TypeName() && ty2.TypeName() == u8Ty.TypeName():
 		alu32 = true
 
 	case ty1.TypeName() == u64Ty.TypeName() && ty2.TypeName() == u64Ty.TypeName():

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -226,14 +226,8 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 		i := len(callArgs) - j - 1
 		ty := argTypes[i]
 		switch ty.TypeName() {
-		case "int", "uint":
+		case "bool", "int", "uint", "s32", "u32":
 			c.cg.emitPopInt64(scratchRegs[i])
-		case "bool":
-			c.cg.emitPopBool(scratchRegs[i])
-		case "s32":
-			c.cg.emitPopS32(scratchRegs[i])
-		case "u32":
-			c.cg.emitPopU32(scratchRegs[i])
 		default:
 			return fmt.Errorf("unsupported argument type: %s", ty.TypeName())
 		}
@@ -317,7 +311,7 @@ func (c *compiler) compile() (asm.Instructions, []uint16, error) {
 	if err := c.compileExpr(expr); err != nil {
 		return nil, nil, fmt.Errorf("failed to compile CEL expression: %w", err)
 	}
-	c.cg.emitPopBool(asm.R0)
+	c.cg.emitPopInt64(asm.R0)
 	c.cg.emitRaw(asm.Return())
 
 	return c.cg.instructions(), c.arg_indexes, nil

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -78,8 +78,7 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 		}
 	case uint32Fn:
 		emitCall = func() error {
-			c.cg.emitU32(scratchRegs[0], argTypes[0])
-			return nil
+			return c.cg.emitU32(scratchRegs[0], argTypes[0])
 		}
 
 	case cgOperators.Add:

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -80,6 +80,22 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 		emitCall = func() error {
 			return c.cg.emitU32(scratchRegs[0], argTypes[0])
 		}
+	case int16Fn:
+		emitCall = func() error {
+			return c.cg.emitS16(scratchRegs[0], argTypes[0])
+		}
+	case uint16Fn:
+		emitCall = func() error {
+			return c.cg.emitU16(scratchRegs[0], argTypes[0])
+		}
+	case int8Fn:
+		emitCall = func() error {
+			return c.cg.emitS8(scratchRegs[0], argTypes[0])
+		}
+	case uint8Fn:
+		emitCall = func() error {
+			return c.cg.emitU8(scratchRegs[0], argTypes[0])
+		}
 
 	case cgOperators.Add:
 		emitCall = func() error {
@@ -194,7 +210,10 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 			op := asm.RSh
 
 			// Use Arithmetic shift to sign extend for signed types
-			if argTypes[0].TypeName() == s32Ty.TypeName() || argTypes[0].TypeName() == s64Ty.TypeName() {
+			if argTypes[0].TypeName() == s64Ty.TypeName() ||
+				argTypes[0].TypeName() == s32Ty.TypeName() ||
+				argTypes[0].TypeName() == s16Ty.TypeName() ||
+				argTypes[0].TypeName() == s8Ty.TypeName() {
 				op = asm.ArSh
 			}
 			if err := c.cg.emitArithOp(
@@ -226,7 +245,7 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 		i := len(callArgs) - j - 1
 		ty := argTypes[i]
 		switch ty.TypeName() {
-		case "bool", "int", "uint", "s32", "u32":
+		case "bool", "int", "uint", "s32", "u32", "u16", "s16", "u8", "s8":
 			c.cg.emitPopInt64(scratchRegs[i])
 		default:
 			return fmt.Errorf("unsupported argument type: %s", ty.TypeName())

--- a/pkg/celbpf/env.go
+++ b/pkg/celbpf/env.go
@@ -21,6 +21,10 @@ import (
 )
 
 var (
+	int8Fn   = "int8"
+	uint8Fn  = "uint8"
+	int16Fn  = "int16"
+	uint16Fn = "uint16"
 	int32Fn  = "int32"
 	uint32Fn = "uint32"
 
@@ -97,6 +101,18 @@ func getFnsOpts() []fnOpts {
 		{name: rshFn, overloads: intBinaryOperatorFnOverloads(rshFn)},
 
 		// Integer casting
+		{name: int8Fn, overloads: []fnOverload{
+			{name: "s8fromint", args: []*cgTypes.Type{cgTypes.IntType}, res: s8Ty},
+		}},
+		{name: uint8Fn, overloads: []fnOverload{
+			{name: "u8fromuint", args: []*cgTypes.Type{cgTypes.UintType}, res: u8Ty},
+		}},
+		{name: int16Fn, overloads: []fnOverload{
+			{name: "s16fromint", args: []*cgTypes.Type{cgTypes.IntType}, res: s16Ty},
+		}},
+		{name: uint16Fn, overloads: []fnOverload{
+			{name: "u16fromuint", args: []*cgTypes.Type{cgTypes.UintType}, res: u16Ty},
+		}},
 		{name: int32Fn, overloads: []fnOverload{
 			{name: "s32fromint", args: []*cgTypes.Type{cgTypes.IntType}, res: s32Ty},
 		}},

--- a/pkg/celbpf/types.go
+++ b/pkg/celbpf/types.go
@@ -20,6 +20,10 @@ var (
 	u64Ty         = cgTypes.UintType
 	s32Ty         = cgTypes.NewOpaqueType("s32")
 	u32Ty         = cgTypes.NewOpaqueType("u32")
+	s16Ty         = cgTypes.NewOpaqueType("s16")
+	u16Ty         = cgTypes.NewOpaqueType("u16")
+	s8Ty          = cgTypes.NewOpaqueType("s8")
+	u8Ty          = cgTypes.NewOpaqueType("u8")
 	boolTy        = cgTypes.BoolType
 	unsupportedTy = cgTypes.NewOpaqueType("unsupported")
 )
@@ -38,6 +42,14 @@ func (it *intType) opSuffix() string {
 		return "s32"
 	case u32Ty:
 		return "u32"
+	case s16Ty:
+		return "s16"
+	case u16Ty:
+		return "u16"
+	case s8Ty:
+		return "s8"
+	case u8Ty:
+		return "u8"
 	}
 
 	panic(fmt.Sprintf("opSuffix: unknown type: %v", it.ty))
@@ -50,8 +62,12 @@ func (it *intType) overloadOp(op string) string {
 var intTypes = []intType{
 	{s64Ty},
 	{s32Ty},
+	{s16Ty},
+	{s8Ty},
 	{u64Ty},
 	{u32Ty},
+	{u16Ty},
+	{u8Ty},
 }
 
 func intCmpOperatorFnOverloads(op string) []fnOverload {
@@ -96,10 +112,18 @@ func typeFromGenTy(genTy int) (*cgTypes.Type, error) {
 		return s64Ty, nil
 	case gt.GenericS32Type, gt.GenericIntType:
 		return s32Ty, nil
+	case gt.GenericS16Type:
+		return s16Ty, nil
+	case gt.GenericS8Type:
+		return s8Ty, nil
 	case gt.GenericU64Type:
 		return u64Ty, nil
 	case gt.GenericU32Type:
 		return u32Ty, nil
+	case gt.GenericU16Type:
+		return u16Ty, nil
+	case gt.GenericU8Type:
+		return u8Ty, nil
 	case gt.GenericInvalidType:
 		return nil, errors.New("cannot convert invalid generic type")
 	}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Part of https://github.com/cilium/tetragon/issues/4661#issue-3947169252

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Add support for 16 and 8 bit (u)int values and arithmetic operations. This is a bit more complicated, since for 64 and 32 bit we can just choose the correct ALU/ALU64 and eBPF takes care of the rest.

So we need to emulate certain operations by adding some conversion eBPF instructions.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
cel: add 16 and 8 bit (u)int support
```
