### PR TITLE
metrics: standardize common labels

### DIFF
--- a/contrib/upgrade-notes/latest.md
+++ b/contrib/upgrade-notes/latest.md
@@ -37,4 +37,26 @@ Depending on your setup, changes listed here might require a manual intervention
 
 ### Metrics
 
-* TBD
+Labels holding a message opcode are now consistently named `opcode` (the numeric
+`ops.OpCode`), and every metric using one also exposes a human-readable `opstr`
+label. Update any dashboards, alerts or recording rules that select on the old
+label names. For example:
+
+```
+- tetragon_msg_op_total{msg_op="5"} 1
++ tetragon_msg_op_total{opcode="5",opstr="Execve"} 1
+```
+
+* `tetragon_msg_op_total`: the `msg_op` label is renamed to `opcode`, and a new
+  `opstr` label with the human-readable opcode name is added.
+* `tetragon_bpf_missed_events_total`: the `msg_op` label is renamed to `opcode`,
+  and a new `opstr` label with the human-readable opcode name is added.
+* `tetragon_handling_latency`: the numeric opcode is now reported in a new
+  `opcode` label, and the human-readable name in a new `opstr` label. The old
+  `op` label is removed, so queries matching on it need updating.
+* `tetragon_handler_errors_total`: a new `opstr` label with the human-readable
+  opcode name is added, alongside the existing `opcode` label.
+* `tetragon_data_event_size`: the `op` label is renamed to `status`. It reports
+  whether handling a data event succeeded (`ok`/`bad`) and is not an opcode.
+* `tetragon_events_total`: the `type` label is renamed to `event_type`, matching
+  the label already used for the event type by other metrics.

--- a/docs/content/en/docs/reference/metrics.md
+++ b/docs/content/en/docs/reference/metrics.md
@@ -28,7 +28,8 @@ Number of Tetragon perf events that are failed to be sent from the kernel.
 | label | values |
 | ----- | ------ |
 | `error` | `E2BIG, EAGAIN, EBUSY, EINVAL, ENOENT, ENOSPC, unknown` |
-| `msg_op` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
+| `opcode` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
+| `opstr` | `Cgroup, Clone, Data, Execve, Exit, GenericKprobe, GenericLSM, GenericTracepoint, GenericUSDT, GenericUprobe, Loader, Throttle` |
 
 ### `tetragon_build_info`
 
@@ -84,7 +85,7 @@ The size of received data events.
 
 | label | values |
 | ----- | ------ |
-| `op   ` | `bad, ok` |
+| `status` | `bad, ok` |
 
 ### `tetragon_data_events_total`
 
@@ -206,6 +207,7 @@ The total number of event handler errors. For internal use only.
 | ----- | ------ |
 | `error` | `event_handler_failed, perf_empty_data, unknown_opcode` |
 | `opcode` | `0, 13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
+| `opstr` | `Cgroup, Clone, Data, Execve, Exit, GenericKprobe, GenericLSM, GenericTracepoint, GenericUSDT, GenericUprobe, Loader, Throttle, Undef` |
 
 ### `tetragon_handling_latency`
 
@@ -213,7 +215,8 @@ The latency of handling messages in us.
 
 | label | values |
 | ----- | ------ |
-| `op   ` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
+| `opcode` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
+| `opstr` | `Cgroup, Clone, Data, Execve, Exit, GenericKprobe, GenericLSM, GenericTracepoint, GenericUSDT, GenericUprobe, Loader, Throttle` |
 
 ### `tetragon_map_capacity`
 
@@ -271,7 +274,8 @@ The total number of times we encounter a given message opcode. For internal use 
 
 | label | values |
 | ----- | ------ |
-| `msg_op` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
+| `opcode` | `13, 14, 15, 16, 23, 24, 25, 26, 27, 28, 5, 7` |
+| `opstr` | `Cgroup, Clone, Data, Execve, Exit, GenericKprobe, GenericLSM, GenericTracepoint, GenericUSDT, GenericUprobe, Loader, Throttle` |
 
 ### `tetragon_notify_overflowed_events_total`
 
@@ -598,10 +602,10 @@ The total number of Tetragon events
 | label | values |
 | ----- | ------ |
 | `binary` | `example-binary` |
+| `event_type` | `PROCESS_EXEC, PROCESS_EXIT, PROCESS_KPROBE, PROCESS_LOADER, PROCESS_LSM, PROCESS_THROTTLE, PROCESS_TRACEPOINT, PROCESS_UPROBE, PROCESS_USDT, RATE_LIMIT_INFO` |
 | `namespace` | `example-namespace` |
 | `node_name` | `example-node-name` |
 | `pod  ` | `example-pod` |
-| `type ` | `PROCESS_EXEC, PROCESS_EXIT, PROCESS_KPROBE, PROCESS_LOADER, PROCESS_LSM, PROCESS_THROTTLE, PROCESS_TRACEPOINT, PROCESS_UPROBE, PROCESS_USDT, RATE_LIMIT_INFO` |
 | `workload` | `example-workload` |
 
 ### `tetragon_policy_events_total`

--- a/pkg/metrics/errormetrics/errormetrics.go
+++ b/pkg/metrics/errormetrics/errormetrics.go
@@ -65,20 +65,6 @@ var (
 		Name:   "error",
 		Values: slices.Collect(maps.Values(errorTypeLabelValues)),
 	}
-	// Constrained label for opcode (numeric strings)
-	opcodeLabel = metrics.ConstrainedLabel{
-		Name: "opcode",
-		Values: func() []string {
-			res := make([]string, 0, len(ops.OpCodeStrings))
-			for opcode := range ops.OpCodeStrings {
-				if opcode != ops.MSG_OP_TEST {
-					// include UNDEF (0) to represent unknown opcodes in docs/metrics
-					res = append(res, strconv.Itoa(int(int32(opcode))))
-				}
-			}
-			return res
-		}(),
-	}
 	// Constrained label for handler error type
 	handlerErrTypeLabel = metrics.ConstrainedLabel{
 		Name:   "error",
@@ -98,7 +84,11 @@ var (
 		metrics.NewOpts(
 			consts.MetricsNamespace, "", "handler_errors_total",
 			"The total number of event handler errors. For internal use only.",
-			nil, []metrics.ConstrainedLabel{opcodeLabel, handlerErrTypeLabel}, nil,
+			nil, []metrics.ConstrainedLabel{
+				metrics.OpCodeLabelWithUndef,
+				metrics.OpCodeNameLabelWithUndef,
+				handlerErrTypeLabel,
+			}, nil,
 		),
 		nil,
 	)
@@ -142,7 +132,7 @@ func ErrorTotalInc(er ErrorType) {
 
 // Get a new handle on the HandlerErrors metric
 func GetHandlerErrors(opcode ops.OpCode, er EventHandlerError) prometheus.Counter {
-	return HandlerErrors.WithLabelValues(strconv.Itoa(int(int32(opcode))), er.String())
+	return HandlerErrors.WithLabelValues(strconv.Itoa(int(opcode)), opcode.String(), er.String())
 }
 
 // Increment the HandlerErrors metric

--- a/pkg/metrics/eventmetrics/bpfcollector.go
+++ b/pkg/metrics/eventmetrics/bpfcollector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/metrics"
 	"github.com/cilium/tetragon/pkg/option"
@@ -50,16 +51,17 @@ func collect(ch chan<- prometheus.Metric) {
 	for opcode, errors := range sum.SentFailed {
 		for er, count := range errors {
 			if count > 0 {
-				ch <- MissedEvents.MustMetric(float64(count), strconv.Itoa(opcode), perfEventErrors[er])
+				ch <- MissedEvents.MustMetric(float64(count), strconv.Itoa(opcode), ops.OpCode(opcode).String(), perfEventErrors[er])
 			}
 		}
 	}
 }
 
 func collectForDocs(ch chan<- prometheus.Metric) {
-	for _, opcode := range metrics.OpCodeLabel.Values {
+	for i, opcode := range metrics.OpCodeLabel.Values {
+		opName := metrics.OpCodeNameLabel.Values[i]
 		for _, er := range perfEventErrorLabel.Values {
-			ch <- MissedEvents.MustMetric(0, opcode, er)
+			ch <- MissedEvents.MustMetric(0, opcode, opName, er)
 		}
 	}
 }

--- a/pkg/metrics/eventmetrics/eventmetrics.go
+++ b/pkg/metrics/eventmetrics/eventmetrics.go
@@ -41,9 +41,10 @@ var (
 )
 
 var (
-	// Preserve label name "type" while using constrained values from EventTypeLabel.
+	// Same as metrics.EventTypeLabel, extended with "unknown" for events
+	// whose type could not be determined.
 	eventTypeLabel = metrics.ConstrainedLabel{
-		Name:   "type",
+		Name:   metrics.EventTypeLabel.Name,
 		Values: append(slices.Clone(metrics.EventTypeLabel.Values), "unknown"),
 	}
 
@@ -58,7 +59,11 @@ var (
 	MissedEvents = metrics.MustNewCustomCounter(metrics.NewOpts(
 		consts.MetricsNamespace, "bpf", "missed_events_total",
 		"Number of Tetragon perf events that are failed to be sent from the kernel.",
-		nil, []metrics.ConstrainedLabel{metrics.OpCodeLabel, perfEventErrorLabel}, nil,
+		nil, []metrics.ConstrainedLabel{
+			metrics.OpCodeLabel,
+			metrics.OpCodeNameLabel,
+			perfEventErrorLabel,
+		}, nil,
 	))
 	FlagCount = metrics.MustNewCounter(
 		metrics.NewOpts(

--- a/pkg/metrics/eventmetrics/eventmetrics_test.go
+++ b/pkg/metrics/eventmetrics/eventmetrics_test.go
@@ -76,20 +76,20 @@ func TestHandleProcessedEvent(t *testing.T) {
 
 	expected := strings.NewReader(`# HELP tetragon_events_total The total number of Tetragon events
 # TYPE tetragon_events_total counter
-tetragon_events_total{binary="",namespace="",node_name="",pod="",type="PROCESS_KPROBE",workload=""} 1
-tetragon_events_total{binary="",namespace="",node_name="",pod="",type="PROCESS_EXEC",workload=""} 1
-tetragon_events_total{binary="",namespace="",node_name="",pod="",type="PROCESS_EXIT",workload=""} 1
-tetragon_events_total{binary="",namespace="",node_name="",pod="",type="PROCESS_TRACEPOINT",workload=""} 1
-tetragon_events_total{binary="",namespace="",node_name="",pod="",type="unknown",workload=""} 1
-tetragon_events_total{binary="binary_a",namespace="",node_name="",pod="",type="PROCESS_KPROBE",workload=""} 1
-tetragon_events_total{binary="binary_a",namespace="namespace_a",node_name="",pod="pod_a",type="PROCESS_KPROBE",workload="workload_a"} 1
-tetragon_events_total{binary="binary_b",namespace="",node_name="",pod="",type="PROCESS_EXEC",workload=""} 1
-tetragon_events_total{binary="binary_b",namespace="namespace_b",node_name="",pod="pod_b",type="PROCESS_EXEC",workload="workload_b"} 1
-tetragon_events_total{binary="binary_c",namespace="",node_name="",pod="",type="PROCESS_TRACEPOINT",workload=""} 1
-tetragon_events_total{binary="binary_c",namespace="namespace_c",node_name="",pod="pod_c",type="PROCESS_TRACEPOINT",workload="workload_c"} 1
-tetragon_events_total{binary="binary_e",namespace="",node_name="",pod="",type="PROCESS_EXIT",workload=""} 1
-tetragon_events_total{binary="binary_e",namespace="namespace_e",node_name="",pod="pod_e",type="PROCESS_EXIT",workload="workload_e"} 1
-tetragon_events_total{binary="binary_f",namespace="",node_name="node_a",pod="",type="PROCESS_KPROBE",workload=""} 1
+tetragon_events_total{binary="",event_type="PROCESS_KPROBE",namespace="",node_name="",pod="",workload=""} 1
+tetragon_events_total{binary="",event_type="PROCESS_EXEC",namespace="",node_name="",pod="",workload=""} 1
+tetragon_events_total{binary="",event_type="PROCESS_EXIT",namespace="",node_name="",pod="",workload=""} 1
+tetragon_events_total{binary="",event_type="PROCESS_TRACEPOINT",namespace="",node_name="",pod="",workload=""} 1
+tetragon_events_total{binary="",event_type="unknown",namespace="",node_name="",pod="",workload=""} 1
+tetragon_events_total{binary="binary_a",event_type="PROCESS_KPROBE",namespace="",node_name="",pod="",workload=""} 1
+tetragon_events_total{binary="binary_a",event_type="PROCESS_KPROBE",namespace="namespace_a",node_name="",pod="pod_a",workload="workload_a"} 1
+tetragon_events_total{binary="binary_b",event_type="PROCESS_EXEC",namespace="",node_name="",pod="",workload=""} 1
+tetragon_events_total{binary="binary_b",event_type="PROCESS_EXEC",namespace="namespace_b",node_name="",pod="pod_b",workload="workload_b"} 1
+tetragon_events_total{binary="binary_c",event_type="PROCESS_TRACEPOINT",namespace="",node_name="",pod="",workload=""} 1
+tetragon_events_total{binary="binary_c",event_type="PROCESS_TRACEPOINT",namespace="namespace_c",node_name="",pod="pod_c",workload="workload_c"} 1
+tetragon_events_total{binary="binary_e",event_type="PROCESS_EXIT",namespace="",node_name="",pod="",workload=""} 1
+tetragon_events_total{binary="binary_e",event_type="PROCESS_EXIT",namespace="namespace_e",node_name="",pod="pod_e",workload="workload_e"} 1
+tetragon_events_total{binary="binary_f",event_type="PROCESS_KPROBE",namespace="",node_name="node_a",pod="",workload=""} 1
 `)
 	require.NoError(t, testutil.CollectAndCompare(EventsProcessed, expected))
 }

--- a/pkg/metrics/labels.go
+++ b/pkg/metrics/labels.go
@@ -4,6 +4,7 @@
 package metrics
 
 import (
+	"slices"
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -52,12 +53,29 @@ func promContainsLabel(labels prometheus.ConstrainedLabels, label string) bool {
 }
 
 var (
-	// TODO: Standardize labels used by different metrics: op, msg_op, opcode.
-	// Also, add a human-readable counterpart.
+	// OpCodeLabel holds the numeric value of an ops.OpCode. Pair it with
+	// OpCodeNameLabel to also expose the human-readable opcode name.
 	OpCodeLabel = ConstrainedLabel{
-		Name: "msg_op",
+		Name: "opcode",
 		// These are numbers, not human-readable names.
-		Values: getOpcodes(),
+		Values: getOpcodes(false),
+	}
+	// OpCodeNameLabel is the human-readable counterpart of OpCodeLabel.
+	OpCodeNameLabel = ConstrainedLabel{
+		Name:   "opstr",
+		Values: getOpcodeNames(false),
+	}
+	// OpCodeLabelWithUndef is OpCodeLabel extended with MSG_OP_UNDEF, for
+	// metrics that report on unknown opcodes.
+	OpCodeLabelWithUndef = ConstrainedLabel{
+		Name:   "opcode",
+		Values: getOpcodes(true),
+	}
+	// OpCodeNameLabelWithUndef is the human-readable counterpart of
+	// OpCodeLabelWithUndef.
+	OpCodeNameLabelWithUndef = ConstrainedLabel{
+		Name:   "opstr",
+		Values: getOpcodeNames(true),
 	}
 	EventTypeLabel = ConstrainedLabel{
 		Name:   "event_type",
@@ -65,14 +83,42 @@ var (
 	}
 )
 
-func getOpcodes() []string {
-	result := make([]string, len(ops.OpCodeStrings)-2)
-	i := 0
+// sortedOpCodes returns the opcodes exposed as metric labels, in ascending
+// order. MSG_OP_TEST is always excluded, as it's only used for testing.
+// MSG_OP_UNDEF is included only if withUndef is set: it's not a valid
+// operational opcode and is only used to report unknown opcodes.
+//
+// The order is deterministic so that getOpcodes and getOpcodeNames produce
+// index-aligned slices, and so that generated documentation is stable.
+func sortedOpCodes(withUndef bool) []ops.OpCode {
+	result := make([]ops.OpCode, 0, len(ops.OpCodeStrings))
 	for opcode := range ops.OpCodeStrings {
-		if opcode != ops.MSG_OP_UNDEF && opcode != ops.MSG_OP_TEST {
-			result[i] = strconv.Itoa(int(int32(opcode)))
-			i++
+		if opcode == ops.MSG_OP_TEST {
+			continue
 		}
+		if opcode == ops.MSG_OP_UNDEF && !withUndef {
+			continue
+		}
+		result = append(result, opcode)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func getOpcodes(withUndef bool) []string {
+	opcodes := sortedOpCodes(withUndef)
+	result := make([]string, len(opcodes))
+	for i, opcode := range opcodes {
+		result[i] = strconv.Itoa(int(opcode))
+	}
+	return result
+}
+
+func getOpcodeNames(withUndef bool) []string {
+	opcodes := sortedOpCodes(withUndef)
+	result := make([]string, len(opcodes))
+	for i, opcode := range opcodes {
+		result[i] = opcode.String()
 	}
 	return result
 }

--- a/pkg/metrics/labels_test.go
+++ b/pkg/metrics/labels_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package metrics
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/tetragon/pkg/api/ops"
+)
+
+// TestOpCodeLabelsAligned checks that the opcode label and its human-readable
+// counterpart are index-aligned. Consumers such as
+// eventmetrics.collectForDocs pair them by index, so a mismatch would report
+// an opcode under the wrong name.
+func TestOpCodeLabelsAligned(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		opcodes  ConstrainedLabel
+		opNames  ConstrainedLabel
+		hasUndef bool
+	}{
+		{"without undef", OpCodeLabel, OpCodeNameLabel, false},
+		{"with undef", OpCodeLabelWithUndef, OpCodeNameLabelWithUndef, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, "opcode", tc.opcodes.Name)
+			require.Equal(t, "opstr", tc.opNames.Name)
+			require.Len(t, tc.opNames.Values, len(tc.opcodes.Values))
+
+			for i, raw := range tc.opcodes.Values {
+				code, err := strconv.Atoi(raw)
+				require.NoError(t, err, "opcode value %q is not numeric", raw)
+				assert.Equal(t, ops.OpCode(code).String(), tc.opNames.Values[i],
+					"opcode %d and its name are not aligned at index %d", code, i)
+			}
+
+			assert.Contains(t, tc.opcodes.Values, strconv.Itoa(int(ops.MSG_OP_EXECVE)))
+			// MSG_OP_TEST is only used for testing and is never exposed.
+			assert.NotContains(t, tc.opcodes.Values, strconv.Itoa(int(ops.MSG_OP_TEST)))
+			assert.NotContains(t, tc.opNames.Values, ops.OpCode(ops.MSG_OP_TEST).String())
+
+			undef := strconv.Itoa(int(ops.MSG_OP_UNDEF))
+			if tc.hasUndef {
+				assert.Contains(t, tc.opcodes.Values, undef)
+			} else {
+				assert.NotContains(t, tc.opcodes.Values, undef)
+			}
+		})
+	}
+}
+
+// TestOpCodeLabelsDeterministic checks that label values are stable across
+// calls. They're built by ranging over a map, so they must be sorted to keep
+// generated documentation from churning.
+func TestOpCodeLabelsDeterministic(t *testing.T) {
+	for range 10 {
+		assert.Equal(t, OpCodeLabel.Values, getOpcodes(false))
+		assert.Equal(t, OpCodeNameLabel.Values, getOpcodeNames(false))
+		assert.Equal(t, OpCodeLabelWithUndef.Values, getOpcodes(true))
+		assert.Equal(t, OpCodeNameLabelWithUndef.Values, getOpcodeNames(true))
+	}
+}

--- a/pkg/metrics/opcodemetrics/opcodemetrics.go
+++ b/pkg/metrics/opcodemetrics/opcodemetrics.go
@@ -18,17 +18,7 @@ var (
 		metrics.NewOpts(
 			consts.MetricsNamespace, "", "msg_op_total",
 			"The total number of times we encounter a given message opcode. For internal use only.",
-			nil, []metrics.ConstrainedLabel{{Name: "msg_op", Values: func() []string {
-				res := make([]string, 0, len(ops.OpCodeStrings))
-				for opcode := range ops.OpCodeStrings {
-					// Exclude MSG_OP_UNDEF (0) as it's not a valid operational opcode - only used for error tracking.
-					// Also exclude MSG_OP_TEST as it's only used for testing purposes.
-					if opcode != ops.MSG_OP_UNDEF && opcode != ops.MSG_OP_TEST {
-						res = append(res, strconv.Itoa(int(int32(opcode))))
-					}
-				}
-				return res
-			}()}}, nil,
+			nil, []metrics.ConstrainedLabel{metrics.OpCodeLabel, metrics.OpCodeNameLabel}, nil,
 		),
 		nil,
 	)
@@ -38,15 +28,7 @@ var (
 			Opts: metrics.NewOpts(
 				consts.MetricsNamespace, "", "handling_latency",
 				"The latency of handling messages in us.",
-				nil, []metrics.ConstrainedLabel{{Name: "op", Values: func() []string {
-					res := make([]string, 0, len(ops.OpCodeStrings))
-					for opcode := range ops.OpCodeStrings {
-						if opcode != ops.MSG_OP_UNDEF && opcode != ops.MSG_OP_TEST {
-							res = append(res, strconv.Itoa(int(int32(opcode))))
-						}
-					}
-					return res
-				}()}}, nil,
+				nil, []metrics.ConstrainedLabel{metrics.OpCodeLabel, metrics.OpCodeNameLabel}, nil,
 			),
 			Buckets: []float64{50, 100, 500, 1000, 10000, 100000}, // 50us, 100us, 500us, 1ms, 10ms, 100ms
 		},
@@ -64,14 +46,25 @@ func InitMetrics() {
 	for opcode := range ops.OpCodeStrings {
 		if opcode != ops.MSG_OP_UNDEF && opcode != ops.MSG_OP_TEST {
 			GetOpTotal(opcode).Add(0)
-			LatencyStats.WithLabelValues(strconv.Itoa(int(int32(opcode))))
+			GetLatencyStats(opcode)
 		}
 	}
 }
 
+// opcodeLabelValues returns the label values for an opcode, in the order
+// expected by the {metrics.OpCodeLabel, metrics.OpCodeNameLabel} pair.
+func opcodeLabelValues(opcode ops.OpCode) []string {
+	return []string{strconv.Itoa(int(opcode)), opcode.String()}
+}
+
 // Get a new handle on a msgOpsCount metric for an OpCode
 func GetOpTotal(opcode ops.OpCode) prometheus.Counter {
-	return MsgOpsCount.WithLabelValues(strconv.Itoa(int(int32(opcode))))
+	return MsgOpsCount.WithLabelValues(opcodeLabelValues(opcode)...)
+}
+
+// Get a new handle on the handling latency metric for an OpCode
+func GetLatencyStats(opcode ops.OpCode) prometheus.Observer {
+	return LatencyStats.WithLabelValues(opcodeLabelValues(opcode)...)
 }
 
 // Increment an msgOpsCount for an OpCode

--- a/pkg/observer/data_stats.go
+++ b/pkg/observer/data_stats.go
@@ -30,13 +30,13 @@ func (e DataEventOp) String() string {
 }
 
 var (
-	// Constrained labels for event and op
+	// Constrained labels for event and status
 	eventLabel = metrics.ConstrainedLabel{
 		Name:   "event",
 		Values: slices.Collect(maps.Values(DataEventTypeStrings)),
 	}
-	opLabel = metrics.ConstrainedLabel{
-		Name:   "op",
+	statusLabel = metrics.ConstrainedLabel{
+		Name:   "status",
 		Values: []string{DataEventOpOk.String(), DataEventOpBad.String()},
 	}
 
@@ -55,7 +55,7 @@ var (
 			Opts: metrics.NewOpts(
 				consts.MetricsNamespace, "", "data_event_size",
 				"The size of received data events.",
-				nil, []metrics.ConstrainedLabel{opLabel}, nil,
+				nil, []metrics.ConstrainedLabel{statusLabel}, nil,
 			),
 			Buckets: prometheus.LinearBuckets(1000, 2000, 20),
 		},

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -144,7 +143,7 @@ func (k *Observer) receiveEvent(data []byte) {
 		k.observerListeners(event)
 	}
 	if metricsEnabled && option.Config.EnableMsgHandlingLatency {
-		opcodemetrics.LatencyStats.WithLabelValues(strconv.FormatUint(uint64(op), 10)).Observe(float64(time.Since(timer).Microseconds()))
+		opcodemetrics.GetLatencyStats(ops.OpCode(op)).Observe(float64(time.Since(timer).Microseconds()))
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
This PR standardizes metrics labels on `opcode` for the numeric ops.OpCode, add `opstr` for its human-readable name, and use `event_type` for EventType(see commits). Refs #2786.

**1. opcode for the numeric ops.OpCode (was msg_op in two metrics, op in another)**

**Before:**
```
tetragon_msg_op_total{msg_op="5"} 1
tetragon_bpf_missed_events_total{error="EBUSY",msg_op="5"} 3
tetragon_handling_latency_sum{op="5"} 87
```
**After:**
```
tetragon_msg_op_total{opcode="5",opstr="Execve"} 1
tetragon_bpf_missed_events_total{error="EBUSY",opcode="5",opstr="Execve"} 3
tetragon_handling_latency_sum{opcode="5",opstr="Execve"} 87
```

**2. opstr added with the human-readable name**

**Before:**
```
tetragon_msg_op_total{msg_op="13"} 1
tetragon_handler_errors_total{error="event_handler_failed",opcode="5"} 1
tetragon_data_event_size_sum{op="ok"} 1500
```
**After:**
```
tetragon_msg_op_total{opcode="13",opstr="GenericKprobe"} 1
tetragon_handler_errors_total{error="event_handler_failed",opcode="5",opstr="Execve"} 1
tetragon_data_event_size_sum{status="ok"} 1500
```
data_event_size: op -> status. Its value is ok/bad, so op was a misleading name for it.

**3. event_type for EventType**

**Before:**

`tetragon_events_total{binary="",namespace="",node_name="",pod="",type="PROCESS_EXEC",workload=""} 1`
**After:**
`tetragon_events_total{binary="",event_type="PROCESS_EXEC",namespace="",node_name="",pod="",workload=""} 1`



### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
standardize metrics labels: `opcode` for the numeric ops.OpCode, new `opstr` for its readable name, `event_type` for EventType.
```
