### PR TITLE
WinCi refactor and  fix negative WaitGroup counter panic on Windows

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: "Download artifact"
       id: download
-      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.setup.outputs.ARTIFACT_PATH }}

--- a/.github/actions/download-file/action.yml
+++ b/.github/actions/download-file/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: "Restore cache"
       id: cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.setup.outputs.DOWNLOAD_PATH }}
         key: ${{ steps.setup.outputs.CACHE_KEY }}
@@ -116,7 +116,7 @@ runs:
 
     - name: "Save cache"
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.setup.outputs.DOWNLOAD_PATH }}
         key: ${{ steps.setup.outputs.CACHE_KEY }}

--- a/.github/actions/install-msi/action.yml
+++ b/.github/actions/install-msi/action.yml
@@ -110,7 +110,7 @@ runs:
         }
 
     - name: "Upload install log"
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: msi-silent-install-log

--- a/.github/workflows/windows-build-smoke-test.yml
+++ b/.github/workflows/windows-build-smoke-test.yml
@@ -246,59 +246,21 @@ jobs:
 
       - name: Run Smoke test Windows
         shell: pwsh
-        working-directory: C:\Program Files\Tetragon\cmd
-
-        #env:
-        #  PATH: ${{ runner.temp }};"C:\Program Files\ebpf-for-windows"
-
         run: |
-          # Tests
-          Write-Output "::group::PATH:"
-          $env:Path -split ';'
-          Write-Output "::endgroup::"
+          & '${{ github.workspace }}\tests\e2e\windows\smoke-test.ps1'
 
-          $jsonFilePath = "C:\Program Files\Tetragon\events.json"
+          # The smoke test exits with its number of failed checks, but an `exit`
+          # inside a called script only ends that script -- without this the step
+          # would pass no matter how many checks failed.
+          exit $LASTEXITCODE
 
-          # Start the process in the background and capture its PID
-          $TetragonArgs = @(
-            '--export-filename "' + $jsonFilePath + '"'
-          )
-
-          $tetragonBackgroundProcess = Start-Process `
-            -FilePath "C:\Program Files\Tetragon\cmd\Tetragon.exe" `
-            -WorkingDirectory "C:\Program Files\Tetragon\cmd" `
-            -ArgumentList $TetragonArgs `
-            -RedirectStandardOutput "C:\Program Files\Tetragon\tetragon.log" `
-            -NoNewWindow `
-            -PassThru
-          
-          # Wait for tetragon to be up and running  
-          Start-Sleep -Seconds 10
-
-          if(Get-Process -id $tetragonBackgroundProcess.Id) {
-            Write-Output "✓ Tetragon is Running"
-          }
-          else {
-            throw "✗ Tetragon Could not be started"
-          }
-
-          # Run notepad and look for it in event log
-          $notepad = Start-Process -FilePath "C:\Windows\System32\notepad.exe" -PassThru
-          $notepadPID = $notepad.Id
-          Write-Host "Process launched with PID: $notepadPID"
-          
-          # Give some time for the event to pop up in the event log
-          Start-Sleep -Seconds 5
-
-          $searchString = "\{\""process_exec\""\:\{\""process\""\:\{\""exec_id\""\:\"".{16,30}\""\,.{0,1}\""pid\""\:$notepadPID\,.{0,1}\""uid\""\:[0-9]{0,9}\,.{0,1}\""binary\""\:\""C:\\\\Windows\\\\system32\\\\notepad.exe\"""
-          Write-Host "Looking for regex: $searchString"
-
-          $jsonContent = Get-Content -Path $jsonFilePath 
-
-          # Search for the PID in the JSON file
-          if ($jsonContent -match $searchString) {
-              Write-Host "Found PID $notepadPID in JSON file: $searchString"
-          } else {
-              Write-Host "PID $notepadPID not found in event file: $jsonContent "
-              throw "PID not found in event JSON file."
-          }
+      - name: Upload Tetragon logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tetragon-smoke-test-logs
+          path: |
+            C:\Program Files\Tetragon\tetragon.log
+            C:\Program Files\Tetragon\tetragon.err.log
+            C:\Program Files\Tetragon\events.json
+          retention-days: 5

--- a/pkg/observer/observer_windows.go
+++ b/pkg/observer/observer_windows.go
@@ -43,18 +43,11 @@ func (observer *Observer) RunEvents(stopCtx context.Context, ready func()) error
 	// user everything is ready.
 	observer.log.Info("Listening for events...")
 
-	// Start reading records from the perf array. Reads until the reader is closed.
+	// Start reading records from the ring buffer. Reads until the reader is closed.
 	var wg sync.WaitGroup
-	wg.Add(1)
 	defer wg.Wait()
 
-	go func() {
-		defer wg.Done()
-	}()
-
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		for stopCtx.Err() == nil {
 			record, err := ringBufReader.Read()
 			if err != nil {
@@ -76,7 +69,7 @@ func (observer *Observer) RunEvents(stopCtx context.Context, ready func()) error
 				}
 			}
 		}
-	}()
+	})
 
 	// Start processing records from ringbuffer
 	wg.Go(func() {
@@ -101,5 +94,9 @@ func (observer *Observer) RunEvents(stopCtx context.Context, ready func()) error
 
 	// Wait for context to be cancelled and then stop.
 	<-stopCtx.Done()
-	return nil
+
+	// Closing the reader interrupts the blocking Read above. Without it the deferred
+	// wg.Wait never returns: ringBufMap.Close() was deferred first and so runs last.
+	// Linux closes its readers the same way.
+	return ringBufReader.Close()
 }

--- a/tests/e2e/windows/harness.ps1
+++ b/tests/e2e/windows/harness.ps1
@@ -1,0 +1,381 @@
+# Shared harness for the Windows smoke test.
+#
+# Dot-sourced by smoke-test.ps1. Everything here is independent of which Tetragon
+# features are under test; the feature-specific parts live in modules\*.ps1.
+#
+# This file is meant to be byte-identical in Tetragon OSS and Tetragon Enterprise
+# and copied between them verbatim, so nothing in it may name an Enterprise-only
+# flag, event type, path or module.
+#
+# ---------------------------------------------------------------------------
+# Module contract
+# ---------------------------------------------------------------------------
+#
+# A module is a .ps1 under modules\ that returns one hashtable. Discovery is by
+# directory listing, sorted by file name, so a repo ships a feature's checks by
+# shipping its file and nothing else -- there is no manifest to keep in sync.
+# Only 'Name' is required; unknown keys are a hard error, because a misspelled key
+# would otherwise silently delete a check.
+#
+#   Name    [string]  short identifier, used to qualify check names in the report.
+#
+#   State   [hashtable]  the module's own constants: ports, urls, probe paths.
+#           Merged over the seed the harness supplies (see New-SmokeState) into
+#           the module's state object, referred to as $s below. This is the one place
+#           a module's constants live, so a predicate and the probe that produces the
+#           events it matches cannot drift apart.
+#
+#   Flags   [ordered hashtable]  Tetragon command-line flags this module needs.
+#           $true means a bare switch, a string means flag + value. Unioned across
+#           modules; two modules asking for the same flag with different values is
+#           an error. A module that is not present contributes no flags, which is
+#           how a build that does not know a flag never sees it.
+#
+#   Ready   [array of @{ Stream = 'stdout'|'stderr'; Text = '...' }]  extra log
+#           markers to wait for before any probe runs.
+#
+#   Probe   [scriptblock] param($s)  start this module's activity and wait for it
+#           to reach the state its expectations assume. Probes started through
+#           Start-Probe are cleaned up automatically; anything else must call
+#           Register-Probe.
+#
+#   Expect  [scriptblock] param($s) -> [ordered]@{ <name> = { param($ev, $s) } }
+#           Events that must appear. Invoked after Probe, so a predicate can read
+#           the probe pids from $s.
+#
+#   Forbid  [scriptblock] param($s) -> [ordered]@{ <name> = @{ Test = { param($ev, $s) }; Why = '...' } }
+#           Events that must NOT appear. Evaluated on every parsed line of the same
+#           single pass as Expect. An absence check is only sound if the same module
+#           also expects an event that provably comes later in the stream.
+#
+#   Verify  [scriptblock] param($s) -> @( @{ Name = '...'; Failures = <int>; Detail = '...'; Why = '...' } )
+#           Checks that are not about the event stream at all, e.g. a probe's exit
+#           code. Failures is added to the run's failure count.
+#
+# Both $s and the state hashtables inside it are passed by reference, so a module
+# mutates its own state and the harness sees it.
+#
+# Why predicates take ($ev, $s) rather than closing over module locals: a module file's
+# scope is gone by the time the driver invokes anything the module returned, so a
+# variable set at the file's top level reads back as $null from inside Probe or a
+# predicate (measured, not assumed). Module state therefore has to arrive as an
+# argument. Two things do survive: functions, because this file is dot-sourced into the
+# driver, and $PSScriptRoot, which is bound to the scriptblock's own file rather than
+# looked up -- so it is still the module's directory, not the driver's. Locals of a
+# *live* invocation behave normally, so a scriptblock built inside Probe and passed to
+# Wait-Until sees them.
+
+# GitHub-specific output is gated on this so a dev-box run stays readable.
+function Test-OnRunner {
+    $env:GITHUB_ACTIONS -eq 'true'
+}
+
+function Start-LogGroup {
+    param([string]$Name)
+
+    if (Test-OnRunner) { Write-Host "::group::$Name" }
+}
+
+function Stop-LogGroup {
+    # Harmless with no group open, which is what makes it safe to call from a catch
+    # block -- an unclosed group would collapse the failure out of sight.
+    if (Test-OnRunner) { Write-Host '::endgroup::' }
+}
+
+function Write-Annotation {
+    param(
+        [ValidateSet('error', 'warning')]
+        [string]$Kind = 'error',
+        [string]$Title,
+        [string]$Message
+    )
+
+    if (-not (Test-OnRunner)) { return }
+    # A raw newline would end the command, and % is itself the escape character, so
+    # it has to go first.
+    $escaped = $Message -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A'
+    Write-Host "::$Kind title=$Title::$escaped"
+}
+
+function Wait-Until {
+    param(
+        [scriptblock]$Condition,
+        [int]$TimeoutSeconds,
+        [string]$What
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (& $Condition) { return }
+        Start-Sleep -Milliseconds 250
+    }
+    throw "timed out after ${TimeoutSeconds}s waiting for $What"
+}
+
+# Tetragon lowercases binary paths in events, so every comparison has to be
+# case-insensitive.
+function Test-Binary {
+    param([string]$Reported, [string]$Expected)
+    $Reported -and ($Reported -ieq $Expected)
+}
+
+# Records a process the harness must not leave behind. Start-Probe does it itself.
+function Register-Probe {
+    param([hashtable]$State, [System.Diagnostics.Process]$Process)
+
+    $State.Probes = @($State.Probes) + $Process
+    $Process
+}
+
+# Run a probe script under the binary the datapath is expected to see. That is
+# $State.PowershellExe -- Windows PowerShell, not pwsh -- because process selection
+# and the script-block channel are both implemented against that binary.
+function Start-Probe {
+    param(
+        [hashtable]$State,
+        [string]$Script,
+        [string[]]$ProbeArgs = @()
+    )
+
+    if (-not $Script) { $Script = $State.ProbeScript }
+    if (-not $Script) {
+        throw 'Start-Probe: no probe script; pass -Script or set ProbeScript in the module State'
+    }
+
+    # Start-Process joins ArgumentList with spaces without quoting, so any argument
+    # holding a path has to arrive already quoted.
+    $p = Start-Process -FilePath $State.PowershellExe -PassThru -ArgumentList (
+        @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$Script`"") + $ProbeArgs
+    )
+    Register-Probe -State $State -Process $p
+}
+
+# The uid Tetragon reports for the processes under test. On Windows it is the token's
+# AuthenticationId -- the logon session LUID, not a POSIX uid. Probes are the
+# harness's children and inherit its token, so one value covers all of them.
+function Get-LogonLuid {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class TetragonToken {
+    [StructLayout(LayoutKind.Sequential)] public struct LUID { public uint LowPart; public int HighPart; }
+    [StructLayout(LayoutKind.Sequential)] public struct TOKEN_STATISTICS { public LUID TokenId; public LUID AuthenticationId; }
+    [DllImport("kernel32.dll")] public static extern IntPtr GetCurrentProcess();
+    [DllImport("advapi32.dll", SetLastError = true)] public static extern bool OpenProcessToken(IntPtr process, uint access, out IntPtr token);
+    [DllImport("advapi32.dll", SetLastError = true)] public static extern bool GetTokenInformation(IntPtr token, int infoClass, IntPtr info, int length, out int returnLength);
+    [DllImport("kernel32.dll", SetLastError = true)] public static extern bool CloseHandle(IntPtr h);
+}
+'@
+
+    $tokenQuery = 0x0008
+    $tokenStatistics = 10
+
+    $token = [System.IntPtr]::Zero
+    if (-not [TetragonToken]::OpenProcessToken([TetragonToken]::GetCurrentProcess(), $tokenQuery, [ref]$token)) {
+        throw "OpenProcessToken failed: $([System.Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+    }
+    try {
+        # Size query first: the struct declared above is deliberately shorter than
+        # the real one, and a short buffer is rejected outright (error 122).
+        $size = 0
+        [TetragonToken]::GetTokenInformation($token, $tokenStatistics, [System.IntPtr]::Zero, 0, [ref]$size) | Out-Null
+        $buffer = [System.Runtime.InteropServices.Marshal]::AllocHGlobal($size)
+        try {
+            if (-not [TetragonToken]::GetTokenInformation($token, $tokenStatistics, $buffer, $size, [ref]$size)) {
+                throw "GetTokenInformation failed: $([System.Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+            }
+            $stats = [System.Runtime.InteropServices.Marshal]::PtrToStructure($buffer, [System.Type][TetragonToken+TOKEN_STATISTICS])
+            (([uint64]$stats.AuthenticationId.HighPart) -shl 32) -bor $stats.AuthenticationId.LowPart
+        }
+        finally { [System.Runtime.InteropServices.Marshal]::FreeHGlobal($buffer) }
+    }
+    finally { [TetragonToken]::CloseHandle($token) | Out-Null }
+}
+
+# SIGINT, via the console Tetragon owns. Go maps CTRL_C_EVENT to os.Interrupt, so
+# this is the only shutdown that makes Tetragon release its BPF pins. It is never
+# killed: release-pinned-bpf runs only on a graceful exit, so after a force-kill the
+# BPF programs stay pinned, stay attached and keep enforcing, and block every later
+# start until the eBPF services are cycled. If it does not honour the signal it is
+# left running instead, which needs no cycle.
+#
+# Attaching to that console requires detaching from the current one first, which is
+# why the signal is sent from a throwaway child process rather than here: a script
+# that frees its own console loses every line it prints afterwards when stdout is a
+# terminal, and leaves the calling shell unable to run a native command ("The handle
+# is invalid ... while getting the console mode"). A child detaches only itself, so
+# an interactive run ends as cleanly as a CI one.
+#
+# Tetragon still needs a console of its own (see the driver's Start-Process): the
+# event goes to every process in the console group, so a shared console would signal
+# the harness too.
+function Stop-Tetragon {
+    param(
+        [System.Diagnostics.Process]$Tetragon,
+        [string]$PwshExe,
+        [int]$TimeoutSeconds = 30
+    )
+
+    if (-not $Tetragon -or $Tetragon.HasExited) { return }
+
+    # Exit codes carry the outcome back: 1 = could not attach, 2 = the event was
+    # refused. Passed as -EncodedCommand, which removes all quoting of the script.
+    $signal = @"
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class TetragonConsole {
+    [DllImport("kernel32.dll")] public static extern bool FreeConsole();
+    [DllImport("kernel32.dll")] public static extern bool AttachConsole(uint pid);
+    [DllImport("kernel32.dll")] public static extern bool SetConsoleCtrlHandler(IntPtr handler, bool add);
+    [DllImport("kernel32.dll")] public static extern bool GenerateConsoleCtrlEvent(uint ctrlEvent, uint groupId);
+}
+'@
+[TetragonConsole]::FreeConsole() | Out-Null
+if (-not [TetragonConsole]::AttachConsole($($Tetragon.Id))) { exit 1 }
+# The console is shared as of the attach above, so ignore the event raised below.
+[TetragonConsole]::SetConsoleCtrlHandler([System.IntPtr]::Zero, `$true) | Out-Null
+if (-not [TetragonConsole]::GenerateConsoleCtrlEvent(0, 0)) { exit 2 }  # 0 = CTRL_C_EVENT
+exit 0
+"@
+
+    $signaller = Start-Process -FilePath $PwshExe -WindowStyle Hidden -PassThru -Wait `
+        -ArgumentList @(
+            '-NoProfile'
+            '-EncodedCommand'
+            [System.Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($signal))
+        )
+
+    if ($signaller.ExitCode -ne 0) {
+        Write-Host "tetragon: SIGINT could not be delivered (signaller exit $($signaller.ExitCode)); left running rather than killed"
+        return
+    }
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while (-not $Tetragon.HasExited -and (Get-Date) -lt $deadline) { Start-Sleep -Milliseconds 250 }
+
+    if ($Tetragon.HasExited) {
+        Write-Host "tetragon: exited on SIGINT with code $($Tetragon.ExitCode)"
+    }
+    else {
+        Write-Host "tetragon: still running ${TimeoutSeconds}s after SIGINT; left running (a kill would leave its BPF programs pinned)"
+    }
+}
+
+# What every module's state starts as, before its own State is merged over it.
+function New-SmokeState {
+    param(
+        [uint64]$Uid,
+        [int]$HarnessPid,
+        [string]$PowershellExe,
+        [string]$PwshExe,
+        [int]$ProbeTimeoutSeconds
+    )
+
+    @{
+        Uid                 = $Uid
+        HarnessPid          = $HarnessPid
+        PowershellExe       = $PowershellExe
+        PwshExe             = $PwshExe
+        ProbeTimeoutSeconds = $ProbeTimeoutSeconds
+        Probes              = @()
+    }
+}
+
+$script:smokeModuleKeys = @('Name', 'State', 'Flags', 'Ready', 'Probe', 'Expect', 'Forbid', 'Verify')
+
+function Import-SmokeModules {
+    param(
+        [string]$Path,
+        [hashtable]$Seed,
+        [string[]]$Only = @()
+    )
+
+    $files = @(Get-ChildItem -LiteralPath $Path -Filter '*.ps1' -File | Sort-Object Name)
+    if (-not $files) { throw "no modules found in $Path" }
+
+    $modules = @()
+    foreach ($file in $files) {
+        $mod = & $file.FullName
+        if ($mod -isnot [System.Collections.IDictionary]) {
+            throw "$($file.Name) did not return a module descriptor hashtable"
+        }
+        if (-not $mod.Name) { throw "$($file.Name) returned a descriptor with no Name" }
+        foreach ($key in $mod.Keys) {
+            if ($script:smokeModuleKeys -notcontains $key) {
+                throw "$($file.Name) has unknown descriptor key '$key'; expected one of $($script:smokeModuleKeys -join ', ')"
+            }
+        }
+        if ($Only.Count -gt 0 -and $Only -notcontains $mod.Name) { continue }
+
+        $state = New-SmokeState -Uid $Seed.Uid -HarnessPid $Seed.HarnessPid `
+            -PowershellExe $Seed.PowershellExe -PwshExe $Seed.PwshExe `
+            -ProbeTimeoutSeconds $Seed.ProbeTimeoutSeconds
+        if ($mod.State) {
+            foreach ($key in $mod.State.Keys) { $state[$key] = $mod.State[$key] }
+        }
+        $mod['S'] = $state
+        $modules += $mod
+    }
+
+    if ($Only.Count -gt 0) {
+        $missing = @($Only | Where-Object { $modules.Name -notcontains $_ })
+        if ($missing) { throw "no such module: $($missing -join ', ')" }
+    }
+    if (-not $modules) { throw "no modules selected" }
+    $modules
+}
+
+# One pass over the export, from wherever $Stream is positioned. Removes each
+# matched record from $Pending and marks any $Forbid record whose event appeared.
+# Returns when $Pending is empty or the deadline passes -- so an absence check is
+# only as strong as the presence checks that keep the loop reading.
+function Wait-ForEvents {
+    param(
+        [System.IO.Stream]$Stream,
+        [System.Collections.Generic.List[object]]$Pending,
+        [object[]]$Forbid,
+        [int]$TimeoutSeconds
+    )
+
+    $decoder = [System.Text.UTF8Encoding]::new($false).GetDecoder()
+    $bytes = [byte[]]::new(64 * 1024)
+    $chars = [char[]]::new($bytes.Length)
+    $partial = ''
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+
+    while ($Pending.Count -gt 0 -and (Get-Date) -lt $deadline) {
+        $read = $Stream.Read($bytes, 0, $bytes.Length)
+        if ($read -eq 0) {
+            Start-Sleep -Milliseconds 200
+            continue
+        }
+        # A decoder, not Encoding.GetString: a read can split a multi-byte character
+        # and the decoder carries that state across calls.
+        $partial += [string]::new($chars, 0, $decoder.GetChars($bytes, 0, $read, $chars, 0))
+
+        # Every record is newline-terminated, and a reader can observe a prefix of
+        # one, so only complete lines are parsed.
+        while (($nl = $partial.IndexOf("`n")) -ge 0) {
+            $line = $partial.Substring(0, $nl)
+            $partial = $partial.Substring($nl + 1)
+
+            $ev = $null
+            try { $ev = ConvertFrom-Json -InputObject $line } catch { }
+            if (-not $ev) { continue }
+
+            foreach ($check in @($Pending)) {
+                if (& $check.Test $ev $check.State) {
+                    $Pending.Remove($check) | Out-Null
+                    Write-Host "  matched $($check.Qualified)"
+                }
+            }
+            foreach ($check in $Forbid) {
+                if (-not $check.Violated -and (& $check.Test $ev $check.State)) {
+                    $check.Violated = $true
+                    Write-Host "  violated $($check.Qualified)"
+                }
+            }
+        }
+    }
+}

--- a/tests/e2e/windows/modules/10-process.ps1
+++ b/tests/e2e/windows/modules/10-process.ps1
@@ -1,0 +1,47 @@
+# process_exec and process_exit.
+#
+# The base sensor is all this needs, so it ships in every build of Tetragon for
+# Windows and needs no flags.
+#
+# cmd.exe is the probe, not notepad: notepad is a Store-app stub on recent Windows, so
+# its System32 path can exit by itself, which makes a Stop-Process on it race or throw.
+# cmd.exe is on every SKU, needs no interactive desktop, and exits on its own, which
+# this module's exit check requires.
+
+@{
+    Name = 'process'
+
+    State = @{
+        ProbeExe = (Join-Path $env:SystemRoot 'System32\cmd.exe')
+    }
+
+    Probe = { param($s)
+        $p = Register-Probe -State $s -Process (Start-Process `
+                -FilePath $s.ProbeExe -ArgumentList '/c', 'exit 0' -WindowStyle Hidden -PassThru)
+        $s.Probe = $p
+
+        Wait-Until -TimeoutSeconds $s.ProbeTimeoutSeconds -What 'the process probe to exit' -Condition {
+            $p.HasExited
+        }
+        Write-Host "probe: $(Split-Path -Leaf $s.ProbeExe) pid $($p.Id) ran and exited"
+    }
+
+    Expect = { param($s)
+        [ordered]@{
+            'exec' = { param($ev, $s)
+                $ev.process_exec -and
+                $ev.process_exec.process.pid -eq $s.Probe.Id -and
+                (Test-Binary $ev.process_exec.process.binary $s.ProbeExe) -and
+                $ev.process_exec.process.uid -eq $s.Uid -and
+                $ev.process_exec.parent.pid -eq $s.HarnessPid
+            }
+            'exit' = { param($ev, $s)
+                $ev.process_exit -and
+                $ev.process_exit.process.pid -eq $s.Probe.Id -and
+                (Test-Binary $ev.process_exit.process.binary $s.ProbeExe) -and
+                $ev.process_exit.process.uid -eq $s.Uid -and
+                $ev.process_exit.parent.pid -eq $s.HarnessPid
+            }
+        }
+    }
+}

--- a/tests/e2e/windows/smoke-test.ps1
+++ b/tests/e2e/windows/smoke-test.ps1
@@ -1,0 +1,303 @@
+# Windows smoke test for Tetragon.
+#
+# Starts Tetragon, lets each module under modules\ drive its own probes, and asserts
+# that the matching events reach the JSON export. Exit code is the number of failed
+# checks.
+#
+# What gets tested is exactly what modules\ contains: the modules are discovered by
+# listing that directory, and each one contributes the Tetragon flags it needs, the
+# readiness markers to wait for, its probes and its checks. A build that supports
+# fewer features ships fewer module files and nothing else changes -- this file, and
+# harness.ps1, are meant to be identical across Tetragon OSS and Tetragon Enterprise.
+#
+# "Tetragon" throughout means the Tetragon.exe process this script starts as an
+# ordinary application -- not a Tetragon service, which the caller is expected to
+# have stopped. At the end it is sent SIGINT so it unloads cleanly, never killed; see
+# Stop-Tetragon in harness.ps1 for why. Only Tetragon.exe is managed here; the eBPF
+# services are assumed to be installed and running.
+
+[CmdletBinding()]
+param(
+    [string]$TetragonExe = 'C:\Program Files\Tetragon\cmd\Tetragon.exe',
+    [string]$ExportFile = 'C:\Program Files\Tetragon\events.json',
+    [string]$TetragonLog = 'C:\Program Files\Tetragon\tetragon.log',
+    [string]$TetragonErrorLog = 'C:\Program Files\Tetragon\tetragon.err.log',
+
+    # defaults.DefaultPidFile. Deleted along with the logs, because a Tetragon that
+    # died without cleaning up leaves one behind and the next start then refuses with
+    # "another Tetragon instance seems to be up and running" -- a false positive as
+    # soon as the pid has been reused. Safe only because the run aborts first if a
+    # Tetragon process actually exists, which is the stronger check.
+    [string]$PidFile = 'C:\Program Files\Tetragon\tetragon.pid',
+
+    # Run only these modules, by Name. Empty means every module in modules\. For
+    # narrowing a failure down by hand; CI passes nothing.
+    [string[]]$Modules = @(),
+
+    [int]$ReadyTimeoutSeconds = 180,
+    [int]$ProbeTimeoutSeconds = 60,
+    [int]$EventTimeoutSeconds = 90
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'harness.ps1')
+
+# Logged last by observer.Start(), so it means sensors are loaded and the
+# ring-buffer reader is up -- unlike the export file, which exists as soon as the
+# exporter writes its first synthetic exec. Modules add their own markers on top.
+$readyMarker = 'Listening for events...'
+
+# Two binaries, two roles. $pwshExe is the harness's own, used for the processes the
+# test starts for itself. $powershellExe is the subject: probes run under it because
+# that is the binary the datapath enforces against and the one whose script blocks
+# Tetragon subscribes to.
+$pwshExe = (Get-Command 'pwsh.exe' -ErrorAction SilentlyContinue | Select-Object -First 1).Source
+if (-not $pwshExe) { throw 'pwsh.exe was not found on PATH' }
+$powershellExe = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+
+# Read before Tetragon starts, so a failure here costs no run.
+$expectedUid = Get-LogonLuid
+
+$loaded = @()
+$tetragon = $null
+$stream = $null
+try {
+    # --- modules -------------------------------------------------------------
+
+    $loaded = Import-SmokeModules -Path (Join-Path $PSScriptRoot 'modules') -Only $Modules -Seed @{
+        Uid                 = $expectedUid
+        HarnessPid          = $PID
+        PowershellExe       = $powershellExe
+        PwshExe             = $pwshExe
+        ProbeTimeoutSeconds = $ProbeTimeoutSeconds
+    }
+
+    # Flags are unioned rather than concatenated: two modules may legitimately need
+    # the same one, but two different values for it means the modules disagree about
+    # how Tetragon should be configured, and silently picking one would make the run
+    # meaningless.
+    $flags = [ordered]@{}
+    foreach ($mod in $loaded) {
+        if (-not $mod.Flags) { continue }
+        foreach ($flag in $mod.Flags.Keys) {
+            if ($flags.Contains($flag) -and "$($flags[$flag])" -ne "$($mod.Flags[$flag])") {
+                throw "modules disagree on $flag : '$($flags[$flag])' vs '$($mod.Flags[$flag])' (from $($mod.Name))"
+            }
+            $flags[$flag] = $mod.Flags[$flag]
+        }
+    }
+
+    $tetragonArgs = @('--debug')
+    foreach ($flag in $flags.Keys) {
+        $value = $flags[$flag]
+        if ($value -is [bool]) {
+            if ($value) { $tetragonArgs += $flag }
+        }
+        else {
+            $tetragonArgs += @($flag, "`"$value`"")
+        }
+    }
+    $tetragonArgs += @('--export-filename', "`"$ExportFile`"")
+
+    $readiness = @(@{ Stream = 'stdout'; Text = $readyMarker })
+    foreach ($mod in $loaded) {
+        foreach ($marker in @($mod.Ready)) {
+            if ($marker) { $readiness += $marker }
+        }
+    }
+
+    # --- tetragon ------------------------------------------------------------
+
+    $running = Get-Process -Name 'Tetragon' -ErrorAction SilentlyContinue
+    if ($running) {
+        throw "Tetragon is already running (pid $($running.Id -join ', ')); stop it before running this test"
+    }
+    foreach ($stale in $ExportFile, $TetragonLog, $TetragonErrorLog, $PidFile) {
+        if (Test-Path -LiteralPath $stale) { Remove-Item -LiteralPath $stale -Force }
+    }
+
+    Start-LogGroup 'tetragon startup'
+    Write-Host "tetragon: $TetragonExe"
+    Write-Host "modules: $(($loaded | ForEach-Object { $_.Name }) -join ', ')"
+    Write-Host "flags: $($tetragonArgs -join ' ')"
+    Write-Host "uid: $expectedUid"
+    # Its own console rather than -NoNewWindow, so the SIGINT in Stop-Tetragon cannot
+    # reach this script. Both streams therefore have to go to files.
+    $tetragon = Start-Process -FilePath $TetragonExe `
+        -WorkingDirectory (Split-Path -Parent $TetragonExe) `
+        -RedirectStandardOutput $TetragonLog `
+        -RedirectStandardError $TetragonErrorLog `
+        -WindowStyle Hidden -PassThru `
+        -ArgumentList $tetragonArgs
+
+    foreach ($marker in $readiness) {
+        $log = if ($marker.Stream -eq 'stderr') { $TetragonErrorLog } else { $TetragonLog }
+        Wait-Until -TimeoutSeconds $ReadyTimeoutSeconds -What "'$($marker.Text)' in $log" -Condition {
+            if ($tetragon.HasExited) { throw "Tetragon exited with code $($tetragon.ExitCode); see $TetragonLog" }
+            (Test-Path -LiteralPath $log) -and
+            (Select-String -LiteralPath $log -SimpleMatch $marker.Text -Quiet)
+        }
+        Write-Host "tetragon: saw '$($marker.Text)'"
+    }
+    Write-Host "tetragon: ready (pid $($tetragon.Id))"
+    Stop-LogGroup
+
+    # Take the export position before the probes run, so only their events are
+    # parsed. History before this point cannot contain them.
+    Wait-Until -TimeoutSeconds $ReadyTimeoutSeconds -What "$ExportFile to be created" -Condition {
+        Test-Path -LiteralPath $ExportFile
+    }
+    $stream = [System.IO.FileStream]::new(
+        $ExportFile,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::Read,
+        [System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete)
+    $stream.Seek(0, [System.IO.SeekOrigin]::End) | Out-Null
+
+    # --- probes --------------------------------------------------------------
+
+    Start-LogGroup 'probes'
+    foreach ($mod in $loaded) {
+        if ($mod.Probe) { & $mod.Probe $mod.S }
+    }
+    Stop-LogGroup
+
+    # --- expectations --------------------------------------------------------
+
+    # Built after the probes so the predicates can read pids from the module state.
+    # Names are qualified with the module so two modules can use the same short name
+    # and the report still says which one failed.
+    $expect = @()
+    $forbid = @()
+    $verify = @()
+    foreach ($mod in $loaded) {
+        if ($mod.Expect) {
+            $table = & $mod.Expect $mod.S
+            foreach ($name in $table.Keys) {
+                $expect += @{
+                    Qualified = "$($mod.Name)/$name"
+                    Test      = $table[$name]
+                    State     = $mod.S
+                }
+            }
+        }
+        if ($mod.Forbid) {
+            $table = & $mod.Forbid $mod.S
+            foreach ($name in $table.Keys) {
+                $forbid += @{
+                    Qualified = "$($mod.Name)/$name"
+                    Test      = $table[$name].Test
+                    Why       = $table[$name].Why
+                    State     = $mod.S
+                    Violated  = $false
+                }
+            }
+        }
+        if ($mod.Verify) {
+            foreach ($check in @(& $mod.Verify $mod.S)) {
+                $verify += @{
+                    Qualified = "$($mod.Name)/$($check.Name)"
+                    Failures  = [int]$check.Failures
+                    Detail    = $check.Detail
+                    Why       = $check.Why
+                }
+            }
+        }
+    }
+
+    $pending = [System.Collections.Generic.List[object]]::new()
+    foreach ($check in $expect) { $pending.Add($check) }
+
+    # --- match ---------------------------------------------------------------
+
+    Start-LogGroup 'events'
+    Write-Host "events: reading $ExportFile"
+    try {
+        Wait-ForEvents -Stream $stream -Pending $pending -Forbid $forbid -TimeoutSeconds $EventTimeoutSeconds
+    }
+    finally {
+        $stream.Dispose()
+    }
+    Stop-LogGroup
+
+    # --- report --------------------------------------------------------------
+
+    $failures = 0
+
+    Write-Host ''
+    # If Tetragon died mid-test, every check below fails for that one reason. It is
+    # reported as a warning rather than a failure because it is not itself a check.
+    if ($tetragon.HasExited) {
+        Write-Host "WARNING: Tetragon exited during the test with code $($tetragon.ExitCode); see $TetragonLog"
+        Write-Annotation -Kind warning -Title 'smoke-test tetragon' -Message (
+            "Tetragon exited during the test with code $($tetragon.ExitCode). " +
+            "Every event check fails for that one reason; see $TetragonLog."
+        )
+    }
+    Write-Host 'results'
+    foreach ($check in $expect) {
+        if ($pending.Contains($check)) {
+            Write-Host "  FAIL $($check.Qualified)"
+            Write-Annotation -Title "smoke-test $($check.Qualified)" -Message (
+                "No event matching $($check.Qualified) reached $ExportFile within " +
+                "${EventTimeoutSeconds}s of the probes finishing. Every field in the " +
+                'predicate has to match; the uploaded events.json says which did not.'
+            )
+            $failures++
+        }
+        else {
+            Write-Host "  ok   $($check.Qualified)"
+        }
+    }
+
+    foreach ($check in $forbid) {
+        if ($check.Violated) {
+            Write-Host "  FAIL $($check.Qualified) (an event that must not exist was exported)"
+            Write-Annotation -Title "smoke-test $($check.Qualified)" -Message $check.Why
+            $failures++
+        }
+        else {
+            Write-Host "  ok   $($check.Qualified)"
+        }
+    }
+
+    foreach ($check in $verify) {
+        if ($check.Failures -gt 0) {
+            Write-Host "  FAIL $($check.Qualified) ($($check.Detail))"
+            Write-Annotation -Title "smoke-test $($check.Qualified)" -Message $check.Why
+            $failures += $check.Failures
+        }
+        else {
+            Write-Host "  ok   $($check.Qualified)"
+        }
+    }
+
+    Write-Host ''
+    if ($failures -eq 0) {
+        Write-Host "all $($expect.Count + $forbid.Count + $verify.Count) checks passed"
+    }
+    else {
+        Write-Host "$failures check(s) failed"
+    }
+    exit $failures
+}
+catch {
+    # A failed pwsh step gets no annotation of its own, and a readiness timeout is
+    # the likeliest CI failure. Close the group first or the message lands inside a
+    # collapsed one.
+    Stop-LogGroup
+    Write-Annotation -Title 'smoke-test' -Message $_.Exception.Message
+    throw
+}
+finally {
+    # Dispose is idempotent, so this covers both the normal path and a throw before
+    # the match loop's own finally was reached.
+    if ($stream) { $stream.Dispose() }
+    foreach ($mod in $loaded) {
+        foreach ($p in @($mod.S.Probes)) {
+            if ($p -and -not $p.HasExited) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
+        }
+    }
+    Stop-Tetragon -Tetragon $tetragon -PwshExe $pwshExe
+}


### PR DESCRIPTION
1. Refactored WinCI for stability.

Architecture: smoke-test.ps1 drives a run, harness.ps1 holds everything independent of which features are built, and one module per feature under modules/ contributes the Tetragon flags it needs, the log markers to wait for, its probes and its checks. Modules are discovered by listing that directory. smoke-test.ps1, harness.ps1 and modules/10-process.ps1 are identical to their Tetragon  counterparts.

3. Fixed race in Tetragon shutdown flow on Windows

RunEvents called wg.Add(1) once, but two goroutines deferred wg.Done(): the ring-buffer reader and an empty goroutine above it. The counter hit zero immediately, making defer wg.Wait() a no-op, and the reader's Done() then panicked with "sync: negative WaitGroup counter" when its loop exited. The loop exited only when Read() returned, and nothing closed ringBufReader, so this depended on the deferred ringBufMap.Close() invalidating the map before the process exited. On panic Tetragon died mid-unload with status 2, leaving BPF programs pinned and a stale tetragon.pid; the next start then refused until the eBPF services were cycled.

Fix: use wg.Go for the reader, and close the reader after the stop context fires. The close interrupts the blocking Read, so the deferred wg.Wait returns. Linux closes its readers the same way. Verified on Windows with the OSS binary, where the race window is narrow: widened by a 3s sleep after RunEvents returns, the old code panicked 3/3 with status 2 and one pinned program each time, the new code exited 0 and left nothing 3/3. Without the sleep, six old runs and three new ones all looked clean.
