### PR TITLE
bpf: matchCmdArgs followups

### DIFF
--- a/bpf/process/bpf_execve_event.h
+++ b/bpf/process/bpf_execve_event.h
@@ -21,13 +21,11 @@ read_args(void *ctx, struct msg_execve_event *event)
 {
 	struct task_struct *task = (struct task_struct *)get_current_task();
 	struct msg_process *p = &event->process;
-	unsigned long start_stack, end_stack;
+	unsigned long start_stack;
 	unsigned long free_size, args_size;
-	__u32 zero = 0, size = 0;
-	struct execve_heap *heap;
-	struct mm_struct *mm;
+	struct args_source source;
+	__u32 size = 0;
 	char *args;
-	long off;
 	int err;
 
 #ifdef __LARGE_BPF_PROG
@@ -35,31 +33,10 @@ read_args(void *ctx, struct msg_execve_event *event)
 	event->args_source.len = 0;
 #endif
 
-	with_errmetrics(probe_read, &mm, sizeof(mm), _(&task->mm));
-	if (!mm)
+	if (!read_task_args_source(task, &source))
 		return 0;
-
-	with_errmetrics(probe_read, &start_stack, sizeof(start_stack),
-			_(&mm->arg_start));
-	with_errmetrics(probe_read, &end_stack, sizeof(start_stack), _(&mm->arg_end));
-
-	if (!start_stack || !end_stack)
-		return 0;
-
-	/* skip first argument - binary path */
-	heap = map_lookup_elem(&execve_heap, &zero);
-	if (!heap)
-		return 0;
-
-	/* poor man's strlen */
-	off = probe_read_str(&heap->maxpath, 4096, (char *)start_stack);
-	if (off < 0)
-		return 0;
-
-	start_stack += off;
-	if (start_stack > end_stack)
-		return 0;
-	args_size = end_stack - start_stack;
+	start_stack = source.start;
+	args_size = source.len;
 
 #ifdef __LARGE_BPF_PROG
 	/* Store pointer infos and late copy in execve_send_event() when storing

--- a/bpf/process/bpf_execve_event.h
+++ b/bpf/process/bpf_execve_event.h
@@ -80,28 +80,6 @@ read_args(void *ctx, struct msg_execve_event *event)
 
 #ifdef __LARGE_BPF_PROG
 
-FUNC_INLINE void
-copy_args(const struct args_source *source, struct args *args)
-{
-	__u64 source_start = source->start;
-	__u64 source_len = source->len;
-	__u32 len;
-
-	/* Reset the heap storage from leftovers. */
-	args->len = 0;
-
-	if (!source_start || !source_len)
-		return;
-
-	if (source_len > sizeof(args->buf))
-		len = sizeof(args->buf);
-	else
-		len = source_len;
-
-	if (with_errmetrics(probe_read, args->buf, len, (void *)source_start) >= 0)
-		args->len = len;
-}
-
 FUNC_INLINE __u32 read_envs(void *ctx, struct msg_execve_event *event)
 {
 	struct msg_process *p = &event->process;

--- a/bpf/process/bpf_fork.c
+++ b/bpf/process/bpf_fork.c
@@ -58,6 +58,7 @@ BPF_KPROBE(event_wake_up_new_task, struct task_struct *task)
 	curr->key.ktime = tg_get_ktime();
 	curr->nspid = get_task_pid_vnr_by_task(task);
 	memcpy(&curr->bin, &parent->bin, sizeof(curr->bin));
+	memcpy(&curr->args, &parent->args, sizeof(curr->args));
 	curr->pkey = parent->key;
 
 	/* Store the thread leader capabilities so we can check later

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -450,6 +450,7 @@ event_find_curr_probe(struct msg_generic_kprobe *msg)
 {
 	struct task_struct *task = (struct task_struct *)get_current_task();
 	struct execve_map_value *curr;
+	struct args_source source;
 
 	curr = &msg->curr;
 	curr->key.pid = BPF_CORE_READ(task, tgid);
@@ -478,6 +479,8 @@ event_find_curr_probe(struct msg_generic_kprobe *msg)
 	binary_reset(&curr->bin);
 	read_exe(task, &msg->exe);
 	copy_exe_to_bin(&msg->exe, &curr->bin);
+	read_task_args_source(task, &source);
+	copy_args(&source, &curr->args);
 	return curr;
 }
 #else

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -19,6 +19,48 @@
 #define MATCH_BINARIES_PATH_MAX_LENGTH 256
 #define DEBUG_PROCESS(__fmt, ...)      DEBUG_AREA(BPF_AREA_PROCESS, __fmt, ##__VA_ARGS__)
 
+/* Find the current task's command-line arguments, excluding argv[0]. */
+FUNC_INLINE int
+read_task_args_source(struct task_struct *task, struct args_source *source)
+{
+	unsigned long arg_start, arg_end;
+	struct execve_heap *heap;
+	struct mm_struct *mm;
+	__u32 zero = 0;
+	long off;
+
+	source->start = 0;
+	source->len = 0;
+
+	with_errmetrics(probe_read, &mm, sizeof(mm), _(&task->mm));
+	if (!mm)
+		return 0;
+
+	with_errmetrics(probe_read, &arg_start, sizeof(arg_start), _(&mm->arg_start));
+	with_errmetrics(probe_read, &arg_end, sizeof(arg_end), _(&mm->arg_end));
+
+	if (!arg_start || !arg_end)
+		return 0;
+
+	/* Use the existing execve heap as scratch space to find argv[0]'s end. */
+	heap = map_lookup_elem(&execve_heap, &zero);
+	if (!heap)
+		return 0;
+
+	/* poor man's strlen */
+	off = probe_read_str(&heap->maxpath, 4096, (char *)arg_start);
+	if (off <= 0)
+		return 0;
+
+	arg_start += off;
+	if (arg_start > arg_end)
+		return 0;
+
+	source->start = arg_start;
+	source->len = arg_end - arg_start;
+	return 1;
+}
+
 FUNC_INLINE __u64 __get_auid(struct task_struct *t)
 {
 	struct task_struct___local *task = (struct task_struct___local *)t;

--- a/bpf/process/bpf_process_event.h
+++ b/bpf/process/bpf_process_event.h
@@ -61,6 +61,30 @@ read_task_args_source(struct task_struct *task, struct args_source *source)
 	return 1;
 }
 
+#ifdef __LARGE_BPF_PROG
+FUNC_INLINE void
+copy_args(const struct args_source *source, struct args *args)
+{
+	__u64 source_start = source->start;
+	__u64 source_len = source->len;
+	__u32 len;
+
+	/* Reset the heap storage from leftovers. */
+	args->len = 0;
+
+	if (!source_start || !source_len)
+		return;
+
+	if (source_len > sizeof(args->buf))
+		len = sizeof(args->buf);
+	else
+		len = source_len;
+
+	if (with_errmetrics(probe_read, args->buf, len, (void *)source_start) >= 0)
+		args->len = len;
+}
+#endif
+
 FUNC_INLINE __u64 __get_auid(struct task_struct *t)
 {
 	struct task_struct___local *task = (struct task_struct___local *)t;

--- a/pkg/sensors/exec/procevents/proc_reader_linux.go
+++ b/pkg/sensors/exec/procevents/proc_reader_linux.go
@@ -424,6 +424,11 @@ func procToKeyValue(p procs, inInitTree map[uint32]struct{}) (*execvemap.ExecveK
 	v.Namespaces.UserInum = p.userNs
 	pathLength := copy(v.Binary.Path[:], p.exe)
 	v.Binary.PathLength = int32(pathLength)
+	// The execve map stores argv[1:] because argv[0] is represented by
+	// Binary.Path. procfs cmdline includes argv[0] as its first entry.
+	args, _ := procsFilename(p.cmdline)
+	argsLength := copy(v.Args.Buf[:], args)
+	v.Args.Len = uint32(argsLength)
 
 	// set v.Binary.End in a similar way to https://github.com/cilium/tetragon/blob/c8c74c5e73c28de0f76498190c576ce7f602c4b9/bpf/process/bpf_execve_event.c#L423-L425
 	if v.Binary.PathLength > selectors.StringPostfixMaxLength-1 {

--- a/pkg/sensors/exec/procevents/proc_reader_test.go
+++ b/pkg/sensors/exec/procevents/proc_reader_test.go
@@ -31,6 +31,17 @@ func TestListRunningProcs(t *testing.T) {
 	}
 }
 
+func TestProcToKeyValueArgsExcludeArgv0(t *testing.T) {
+	p := procs{
+		exe:     []byte("/usr/bin/curl"),
+		cmdline: []byte("curl\x00--output\x00/tmp/result\x00"),
+	}
+
+	_, v := procToKeyValue(p, make(map[uint32]struct{}))
+
+	assert.Equal(t, []byte("--output\x00/tmp/result\x00"), v.Args.Buf[:v.Args.Len])
+}
+
 func TestInInitTreeProcfs(t *testing.T) {
 	if err := exec.Command("docker", "version").Run(); err != nil {
 		t.Skipf("docker not available. skipping test: %s", err)


### PR DESCRIPTION
This is followups to the introduction of the matchCmdArgs from Jiri's comment (see https://github.com/cilium/tetragon/pull/5442#issuecomment-5477721804).

Basically the idea is to better supports process that were started before tetragon (with procfs reader and `event_find_curr_probe`) and clone event (with `event_wake_up_new_task`).