### PR TITLE
ariane: add ariane-config

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -1,0 +1,7 @@
+allowed-teams:
+  - organization-members
+
+triggers:
+  /default\s*:
+    workflows:
+      - mock-ci.yaml

--- a/.github/workflows/common-post-jobs.yml
+++ b/.github/workflows/common-post-jobs.yml
@@ -1,0 +1,46 @@
+name: Common Post Jobs
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        description: "SHA under test on which to publish the final commit status."
+        required: true
+        type: string
+      success:
+        description: "Whether all jobs in the calling workflow completed successfully."
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+  actions: read
+  statuses: write
+
+jobs:
+  commit-status-final:
+    if: ${{ always() }}
+    name: Commit Status Final
+    runs-on: ubuntu-24.04
+    permissions:
+      statuses: write
+    steps:
+      - name: Set final commit status
+        uses: cilium/actions/set-commit-status@fe0702f5df0d8e44d48f1baa226c023b73ff6b5e # main
+        with:
+          sha: ${{ inputs.sha }}
+          status: ${{ inputs.success && 'success' || 'failure' }}
+
+  fail-workflow:
+    if: ${{ inputs.success == false }}
+    name: Fail job if result is failure
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Fail job if result is failure
+        # Besides reporting in the commit SHA if the test was or not successful,
+        # we should also report it in the workflow itself. This will allow to
+        # store the failure rate of the workflow on OpenSearch, instead of
+        # marking it as successful.
+        run: |
+          echo "::error::Workflow failed because one or more jobs failed"
+          exit 1

--- a/.github/workflows/mock-ci.yaml
+++ b/.github/workflows/mock-ci.yaml
@@ -1,0 +1,58 @@
+name: Mock CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        required: true
+        type: string
+        description: "Pull request number."
+      context-ref:
+        required: true
+        type: string
+        description: "Context in which the workflow runs. If the pull request is from a fork, this is the pull request target branch. Otherwise, this is the pull request branch so committers can test workflow changes directly."
+      SHA:
+        required: true
+        type: string
+        description: "SHA under test (head of the pull request branch)."
+      base-SHA:
+        required: true
+        type: string
+        description: "SHA of the base branch (target branch of the pull request)."
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.PR-number }}
+  cancel-in-progress: true
+
+jobs:
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Set initial commit status
+        uses: cilium/actions/set-commit-status@fe0702f5df0d8e44d48f1baa226c023b73ff6b5e # main
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  mock-ci:
+    name: Mock CI
+    needs: commit-status-start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Run mock CI
+        run: echo "Mock CI completed successfully"
+
+  merge-upload-and-status:
+    if: ${{ always() }}
+    name: Merge Upload and Status
+    needs: mock-ci
+    permissions:
+      contents: read
+      statuses: write
+    uses: ./.github/workflows/common-post-jobs.yml
+    with:
+      sha: ${{ inputs.SHA || github.sha }}
+      success: ${{ needs.mock-ci.result == 'success' }}


### PR DESCRIPTION


<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Add a ariane config and a mock CI workflow to test the integration. `common-post-jobs.yml` is adapted from the same file in cilium/cilium.

[This](https://github.com/3u13r/tetragon-workflows/pull/1#issuecomment-4987594310) is an example how the invocation might look like in the future.
Merging this PR doesn't change anything about the rest of the CI. It just adds one test workflow to test the Ariane integration. All existing workflows are triggered as before. Once the PR is merged, members of the cilium org can trigger the test workflow using a `/test` comment in a PR.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
ariane: add ariane-config and test CI workflow
```
