### PR TITLE
add celexpr bit shift operators

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/selectors.md
+++ b/docs/content/en/docs/concepts/tracing-policy/selectors.md
@@ -911,7 +911,7 @@ Currently, `MatchCEL` supports:
 * Logical AND (`&&`), OR (`||`), and NOT (`!`) operators
 * Comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`)
 * Integer casting to 32-bits (`int32()`, `uint32()`)
-* Bitwise operations (`and()`, `or()`, `xor()`, `not()`)
+* Bitwise operations (`and()`, `or()`, `xor()`, `not()`, `lsh()`, `rsh()`)
 
 ## Actions filter
 

--- a/pkg/celbpf/cel_eval_test.go
+++ b/pkg/celbpf/cel_eval_test.go
@@ -160,6 +160,23 @@ var celBitwiseXOR = celBinArithOp(
 	func(a, b uint32) uint32 { return a ^ b },
 )
 
+// Go shifts panic on a negative shift count, ensure they're positive.
+// Also, the shift count operand for ebpf shift instructions is limited to 5/6
+// bits which is why there's a value of 31/63
+var celBitwiseLSH = celBinArithOp(
+	func(a, b celTypes.Int) celTypes.Int { return a << (uint64(b) & 63) },
+	func(a, b celTypes.Uint) celTypes.Uint { return a << (uint64(b) & 63) },
+	func(a, b int32) int32 { return a << (uint(b) & 31) },
+	func(a, b uint32) uint32 { return a << (uint(b) & 31) },
+)
+
+var celBitwiseRSH = celBinArithOp(
+	func(a, b celTypes.Int) celTypes.Int { return a >> (uint64(b) & 63) },
+	func(a, b celTypes.Uint) celTypes.Uint { return a >> (uint64(b) & 63) },
+	func(a, b int32) int32 { return a >> (uint(b) & 31) },
+	func(a, b uint32) uint32 { return a >> (uint(b) & 31) },
+)
+
 func celBitwiseNOT(value ref.Val) ref.Val {
 	switch v := value.(type) {
 	case celTypes.Int:
@@ -258,6 +275,14 @@ func getOverloadOpts(t *testing.T, o *fnOverload) []cel.OverloadOpt {
 
 	if strings.HasPrefix(o.name, notFn) {
 		return append(ret, cel.UnaryBinding(celBitwiseNOT))
+	}
+
+	if strings.HasPrefix(o.name, lshFn) {
+		return append(ret, cel.BinaryBinding(celBitwiseLSH))
+	}
+
+	if strings.HasPrefix(o.name, rshFn) {
+		return append(ret, cel.BinaryBinding(celBitwiseRSH))
 	}
 
 	for _, ineq := range []string{"lt", "lq", "gt", "gq"} {

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -178,6 +178,36 @@ func (c *compiler) compileCall(expr cgAst.Expr) error {
 			return c.cg.emitBitwiseNot(scratchRegs[0], argTypes[0])
 		}
 
+	case lshFn:
+		emitCall = func() error {
+			if err := c.cg.emitArithOp(
+				asm.LSh,
+				scratchRegs[0], argTypes[0],
+				scratchRegs[1], argTypes[1],
+			); err != nil {
+				return fmt.Errorf("bitwise LSH %w", err)
+			}
+			return nil
+		}
+
+	case rshFn:
+		emitCall = func() error {
+			op := asm.RSh
+
+			// Use Arithmetic shift to sign extend for signed types
+			if argTypes[0].TypeName() == s32Ty.TypeName() || argTypes[0].TypeName() == s64Ty.TypeName() {
+				op = asm.ArSh
+			}
+			if err := c.cg.emitArithOp(
+				op,
+				scratchRegs[0], argTypes[0],
+				scratchRegs[1], argTypes[1],
+			); err != nil {
+				return fmt.Errorf("bitwise RSH %w", err)
+			}
+			return nil
+		}
+
 	default:
 		emitCall = func() error {
 			return fmt.Errorf("compileCall: call %q (%+v) not supported", call.FunctionName(), call)

--- a/pkg/celbpf/env.go
+++ b/pkg/celbpf/env.go
@@ -28,6 +28,8 @@ var (
 	orFn  = "or"
 	xorFn = "xor"
 	notFn = "not"
+	lshFn = "lsh"
+	rshFn = "rsh"
 )
 
 type fnOverload struct {
@@ -91,6 +93,8 @@ func getFnsOpts() []fnOpts {
 		{name: orFn, overloads: intBinaryOperatorFnOverloads(orFn)},
 		{name: xorFn, overloads: intBinaryOperatorFnOverloads(xorFn)},
 		{name: notFn, overloads: intUnaryOperatorFnOverloads(notFn)},
+		{name: lshFn, overloads: intBinaryOperatorFnOverloads(lshFn)},
+		{name: rshFn, overloads: intBinaryOperatorFnOverloads(rshFn)},
 
 		// Integer casting
 		{name: int32Fn, overloads: []fnOverload{


### PR DESCRIPTION
Add support for bitwise shifting (part of #4661) to CelExpr.

### Description
This adds support for bit shifting (`lsh()` and `rsh()`) to CelExpr, which can be used as part of the `MatchCEL` selector. Note that it also includes logic to use `ArSh` to arithmetically shift right if the values are signed in order to sign extend.

It also expands the oracle in `cel_eval_test` to include bit shifting and was tested with `FuzzCelExpr`. Testing was first done by intentially incorrectly implementing the operators to ensure it was caught, and then corrected.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
celbpf: add bit shifting operators for CEL expressions (lsh, rsh)
```
