### PR TITLE
WinCI: GH actions Node 24 update

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: "Download artifact"
       id: download
-      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.setup.outputs.ARTIFACT_PATH }}

--- a/.github/actions/download-file/action.yml
+++ b/.github/actions/download-file/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: "Restore cache"
       id: cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.setup.outputs.DOWNLOAD_PATH }}
         key: ${{ steps.setup.outputs.CACHE_KEY }}
@@ -116,7 +116,7 @@ runs:
 
     - name: "Save cache"
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ steps.setup.outputs.DOWNLOAD_PATH }}
         key: ${{ steps.setup.outputs.CACHE_KEY }}

--- a/.github/actions/install-msi/action.yml
+++ b/.github/actions/install-msi/action.yml
@@ -110,7 +110,7 @@ runs:
         }
 
     - name: "Upload install log"
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: msi-silent-install-log


### PR DESCRIPTION
WinCI: This updates GitHub actions from versions that used Node 20 to ones that use Node 24