### PR TITLE
renovate: group golangci-lint upgrades together

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -271,7 +271,8 @@
       // GHA files and other usages. This needs to be after the GHA grouping.
       "groupName": "golangci-lint",
       "matchDepNames": [
-        "golangci/golangci-lint"
+        "golangci/golangci-lint",
+        "docker.io/golangci/golangci-lint"
       ]
     },
     {


### PR DESCRIPTION
Currently, the updates are in two separate PRs:

chore(deps): update dependency golangci/golangci-lint to v2.13.2 (main)
chore(deps): update docker.io/golangci/golangci-lint docker tag to v2.13.2 (main)

This should bundle them in the same group.
