### PR TITLE
fix: close GetUrl HTTP response bodies

### DIFF
--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -1298,7 +1298,11 @@ func loadGenericKprobeSensor(bpfDir string, load *program.Program, maps []*progr
 
 func getUrl(url string) {
 	// We fire and forget URLs, and we don't care if they hit or not.
-	http.Get(url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
 }
 
 func dnsLookup(fqdn string) {

--- a/pkg/sensors/tracing/geturl_test.go
+++ b/pkg/sensors/tracing/geturl_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+//go:build !windows
+
+package tracing
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type getURLRoundTripper struct {
+	body   io.ReadCloser
+	called bool
+}
+
+func (r *getURLRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.called = true
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       r.body,
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestGetURLClosesResponseBody(t *testing.T) {
+	body := &closeTrackingBody{Reader: strings.NewReader("canary response")}
+	transport := &getURLRoundTripper{body: body}
+	oldTransport := http.DefaultClient.Transport
+	http.DefaultClient.Transport = transport
+	t.Cleanup(func() { http.DefaultClient.Transport = oldTransport })
+
+	getUrl("http://canary.example")
+	require.True(t, transport.called)
+	require.True(t, body.closed)
+}


### PR DESCRIPTION
### Description

`GetUrl` leaves successful HTTP response bodies open. 
Repeated matching events can keep connections around until Tetragon hits a socket or file descriptor limit

Close the body after every successful request. 
Requests still fire like before, just no leaked body

Repro:
1. Point the checked-in `open_geturl.yaml` policy at an HTTP server
2. Repeatedly open `/etc/passwd`
3. Watch Tetragon's open connections keep growing

The new unit test reproduces the missed close directly

### Changelog

```release-note
Fix GetUrl actions leaking HTTP response bodies.
```
