### PR TITLE
perf: optimise event reading

### DIFF
--- a/bpf/alignchecker/bpf_alignchecker.c
+++ b/bpf/alignchecker/bpf_alignchecker.c
@@ -16,6 +16,7 @@ struct msg_exit _msg_exit;
 struct msg_test _msg_test;
 struct msg_cgroup_event _msg_cgroup_event;
 struct msg_cred _msg_cred;
+struct msg_clone_event _msg_clone_event;
 
 // from maps
 struct event _event;

--- a/bpf/alignchecker/bpf_alignchecker.c
+++ b/bpf/alignchecker/bpf_alignchecker.c
@@ -19,6 +19,7 @@ struct msg_cgroup_event _msg_cgroup_event;
 struct msg_cred _msg_cred;
 struct msg_clone_event _msg_clone_event;
 struct msg_throttle _msg_throttle;
+struct msg_data _msg_data;
 
 // from maps
 struct event _event;

--- a/bpf/alignchecker/bpf_alignchecker.c
+++ b/bpf/alignchecker/bpf_alignchecker.c
@@ -7,6 +7,7 @@
 #include "lib/bpf_cred.h"
 #include "process/retprobe_map.h"
 #include "process/types/basic.h"
+#include "process/bpf_rate.h"
 #include "policy_stats.h"
 
 // event messages
@@ -17,6 +18,7 @@ struct msg_test _msg_test;
 struct msg_cgroup_event _msg_cgroup_event;
 struct msg_cred _msg_cred;
 struct msg_clone_event _msg_clone_event;
+struct msg_throttle _msg_throttle;
 
 // from maps
 struct event _event;

--- a/bpf/lib/process.h
+++ b/bpf/lib/process.h
@@ -208,7 +208,7 @@ struct msg_clone_event {
 	__u32 nspid;
 	__u32 flags;
 	__u64 ktime;
-} __attribute__((packed));
+}; // All fields aligned so no 'packed' attribute.
 
 struct exit_info {
 	__u32 code;

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/ebpf/btf"
 
+	"github.com/cilium/tetragon/pkg/api/dataapi"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	"github.com/cilium/tetragon/pkg/api/testapi"
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
@@ -47,6 +48,7 @@ var defaultChecks = map[string][]any{
 var defaultPrefixChecks = map[string][]any{
 	"msg_generic_kprobe": {tracingapi.MsgGenericKprobe{}, tracingapi.MsgGenericTracepoint{}},
 	"msg_execve_event":   {processapi.MsgExecveEvent{}},
+	"msg_data":           {dataapi.MsgData{}},
 }
 
 // CheckStructAlignmentsDefault calls CheckStructAlignments with the default alignment defaultChecks.

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -45,6 +45,7 @@ var defaultChecks = map[string][]any{
 }
 
 var defaultPrefixChecks = map[string][]any{
+	"msg_generic_kprobe": {tracingapi.MsgGenericKprobe{}, tracingapi.MsgGenericTracepoint{}},
 }
 
 // CheckStructAlignmentsDefault calls CheckStructAlignments with the default alignment defaultChecks.

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -46,6 +46,7 @@ var defaultChecks = map[string][]any{
 
 var defaultPrefixChecks = map[string][]any{
 	"msg_generic_kprobe": {tracingapi.MsgGenericKprobe{}, tracingapi.MsgGenericTracepoint{}},
+	"msg_execve_event":   {processapi.MsgExecveEvent{}},
 }
 
 // CheckStructAlignmentsDefault calls CheckStructAlignments with the default alignment defaultChecks.

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -44,9 +44,15 @@ var defaultChecks = map[string][]any{
 	"policy_stats": {policystats.PolicyStats{}},
 }
 
+var defaultPrefixChecks = map[string][]any{
+}
+
 // CheckStructAlignmentsDefault calls CheckStructAlignments with the default alignment defaultChecks.
 func CheckStructAlignmentsDefault(pathToObj string) error {
-	return CheckStructAlignments(pathToObj, defaultChecks, true)
+	if err := CheckStructAlignments(pathToObj, defaultChecks, true); err != nil {
+		return err
+	}
+	return CheckPrefixStructAlignments(pathToObj, defaultPrefixChecks)
 }
 
 // CheckStructAlignments defaultChecks whether size and offsets match of the given
@@ -72,6 +78,30 @@ func CheckStructAlignments(pathToObj string, toCheck map[string][]any, checkOffs
 
 	for cName, goStructs := range toCheck {
 		if err := check(cName, goStructs, structInfo, checkOffsets); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CheckPrefixStructAlignments is like CheckStructAlignments, but for Go
+// structs that only mirror the leading portion of a larger C struct (the
+// remainder being variable-length or not exposed to userspace). It checks
+// that the Go struct is no larger than the C struct, and that every
+// `align`-tagged field lands at the correct offset.
+func CheckPrefixStructAlignments(pathToObj string, toCheck map[string][]any) error {
+	spec, err := btf.LoadSpec(pathToObj)
+	if err != nil {
+		return fmt.Errorf("cannot parse BTF debug info %s: %w", pathToObj, err)
+	}
+
+	structInfo, err := getStructInfosFromBTF(spec, toCheck)
+	if err != nil {
+		return fmt.Errorf("cannot extract struct info from BTF %s: %w", pathToObj, err)
+	}
+
+	for cName, goStructs := range toCheck {
+		if err := checkPrefix(cName, goStructs, structInfo); err != nil {
 			return err
 		}
 	}
@@ -240,6 +270,30 @@ func check(name string, toCheck []any, structs map[string]*structInfo, checkOffs
 
 		if !checkOffsets {
 			continue
+		}
+
+		if err := checkFieldOffsets(g, name, c); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkPrefix(name string, toCheck []any, structs map[string]*structInfo) error {
+	for _, i := range toCheck {
+		c, found := structs[name]
+		if !found {
+			return fmt.Errorf("could not find C struct %s", name)
+		}
+
+		g, err := checkGoType(i, name)
+		if err != nil {
+			return err
+		}
+
+		if uint32(g.Size()) > c.size {
+			return fmt.Errorf("%s(%d) is larger than %s(%d), cannot be a valid prefix", g, g.Size(), name, c.size)
 		}
 
 		if err := checkFieldOffsets(g, name, c); err != nil {

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -27,6 +27,7 @@ var defaultChecks = map[string][]any{
 	"execve_map_value": {execvemap.ExecveValue{}},
 	"msg_cgroup_event": {processapi.MsgCgroupEvent{}},
 	"msg_cred":         {processapi.MsgGenericCred{}},
+	"msg_clone_event":  {processapi.MsgCloneEvent{}},
 
 	// configuration
 	"event_config":  {tracingapi.EventConfig{}},

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -28,6 +28,7 @@ var defaultChecks = map[string][]any{
 	"msg_cgroup_event": {processapi.MsgCgroupEvent{}},
 	"msg_cred":         {processapi.MsgGenericCred{}},
 	"msg_clone_event":  {processapi.MsgCloneEvent{}},
+	"msg_throttle":     {processapi.MsgThrottleEvent{}},
 
 	// configuration
 	"event_config":  {tracingapi.EventConfig{}},

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -186,6 +186,41 @@ func memberOffsets(members []btf.Member) map[string]uint32 {
 	return offsets
 }
 
+func checkGoType(i any, name string) (reflect.Type, error) {
+	g := reflect.TypeOf(i)
+	if g == nil {
+		return nil, fmt.Errorf("nil interface passed for type %s", name)
+	}
+
+	if g.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("type %s is not a struct", name)
+	}
+
+	if bs, rs := binary.Size(i), int(g.Size()); bs != rs {
+		return nil, fmt.Errorf("type %s's binary.Size (%d) does not equal its unsafe.Sizeof (%d) size (struct with implicit trailing padding?)", g.Name(), bs, rs)
+	}
+
+	return g, nil
+}
+
+func checkFieldOffsets(g reflect.Type, name string, c *structInfo) error {
+	for field := range g.Fields() {
+		fieldName := field.Tag.Get("align")
+		if fieldName == "" {
+			continue
+		}
+		goOffset := uint32(field.Offset)
+		if cOffset, ok := c.fieldOffsets[fieldName]; !ok {
+			return fmt.Errorf("%s.%s does not match any field (should match %s.%s) [debug=%v]",
+				g, field.Name, name, fieldName, c.fieldOffsets)
+		} else if goOffset != cOffset {
+			return fmt.Errorf("%s.%s offset(%d) does not match %s.%s(%d) [debug=%v]",
+				g, field.Name, goOffset, name, fieldName, cOffset, c.fieldOffsets)
+		}
+	}
+	return nil
+}
+
 func check(name string, toCheck []any, structs map[string]*structInfo, checkOffsets bool) error {
 	for _, i := range toCheck {
 		c, found := structs[name]
@@ -193,18 +228,9 @@ func check(name string, toCheck []any, structs map[string]*structInfo, checkOffs
 			return fmt.Errorf("could not find C struct %s", name)
 		}
 
-		g := reflect.TypeOf(i)
-		if g == nil {
-			return fmt.Errorf("nil interface passed for type %s", name)
-		}
-
-		// Input type must be a struct.
-		if g.Kind() != reflect.Struct {
-			return fmt.Errorf("type %s is not a struct", name)
-		}
-
-		if bs, rs := binary.Size(i), int(g.Size()); bs != rs {
-			return fmt.Errorf("type %s's binary.Size (%d) does not equal its unsafe.Sizeof (%d) size (struct with implicit trailing padding?)", g.Name(), bs, rs)
+		g, err := checkGoType(i, name)
+		if err != nil {
+			return err
 		}
 
 		if c.size != uint32(g.Size()) {
@@ -216,20 +242,8 @@ func check(name string, toCheck []any, structs map[string]*structInfo, checkOffs
 			continue
 		}
 
-		for field := range g.Fields() {
-			fieldName := field.Tag.Get("align")
-			// Ignore fields without `align` struct tag
-			if fieldName == "" {
-				continue
-			}
-			goOffset := uint32(field.Offset)
-			if cOffset, ok := c.fieldOffsets[fieldName]; !ok {
-				return fmt.Errorf("%s.%s does not match any field (should match %s.%s) [debug=%v]",
-					g, field.Name, name, fieldName, c.fieldOffsets)
-			} else if goOffset != cOffset {
-				return fmt.Errorf("%s.%s offset(%d) does not match %s.%s(%d) [debug=%v]",
-					g, field.Name, goOffset, name, fieldName, cOffset, c.fieldOffsets)
-			}
+		if err := checkFieldOffsets(g, name, c); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/api/dataapi/data.go
+++ b/pkg/api/dataapi/data.go
@@ -19,6 +19,6 @@ type DataEventDesc struct {
 }
 
 type MsgData struct {
-	Common processapi.MsgCommon
-	Id     DataEventId
+	Common processapi.MsgCommon `align:"common"`
+	Id     DataEventId          `align:"id"`
 }

--- a/pkg/api/decode.go
+++ b/pkg/api/decode.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package api
+
+import (
+	"bytes"
+	"io"
+	"unsafe"
+)
+
+func ReadBPFStruct[T any](r *bytes.Reader, dst *T) error {
+	buf := unsafe.Slice((*byte)(unsafe.Pointer(dst)), unsafe.Sizeof(*dst))
+
+	if len(buf) > r.Len() {
+		return io.ErrUnexpectedEOF
+	}
+
+	n, err := r.Read(buf)
+
+	if err != nil {
+		return err
+	}
+
+	if n != len(buf) {
+		return io.ErrUnexpectedEOF
+	}
+
+	return nil
+}

--- a/pkg/api/decode.go
+++ b/pkg/api/decode.go
@@ -5,19 +5,60 @@ package api
 
 import (
 	"bytes"
+	"encoding/binary"
+	"fmt"
 	"io"
 	"unsafe"
 )
 
+type Integer interface {
+	~int8 | ~int16 | ~int32 | ~int64 | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// ReadIntegerLE is a zero heap allocation convenience function, an
+// alternative to the more expensive binary.Read(). binary.Read() takes its
+// reader as an io.Reader interface, so it must heap-allocate the temporary
+// buffer it reads into on every call, since escape analysis can't see past
+// the interface's dynamic dispatch to prove the buffer doesn't escape.
+func ReadIntegerLE[T Integer](r *bytes.Reader) (T, error) {
+	var v T
+	size := int(unsafe.Sizeof(v))
+
+	if size > r.Len() {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	var buf [8]byte
+	n, err := r.Read(buf[:size])
+	if err != nil {
+		return 0, err
+	}
+
+	if n != size {
+		return 0, io.ErrUnexpectedEOF
+	}
+
+	switch size {
+	case 1:
+		return T(buf[0]), nil
+	case 2:
+		return T(binary.LittleEndian.Uint16(buf[:2])), nil
+	case 4:
+		return T(binary.LittleEndian.Uint32(buf[:4])), nil
+	case 8:
+		return T(binary.LittleEndian.Uint64(buf[:8])), nil
+	}
+
+	return 0, fmt.Errorf("unsupported integer size %d", size)
+}
+
 func ReadBPFStruct[T any](r *bytes.Reader, dst *T) error {
 	buf := unsafe.Slice((*byte)(unsafe.Pointer(dst)), unsafe.Sizeof(*dst))
-
 	if len(buf) > r.Len() {
 		return io.ErrUnexpectedEOF
 	}
 
 	n, err := r.Read(buf)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/api/decode_test.go
+++ b/pkg/api/decode_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Tetragon
+
+package api
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadIntegerLEUint(t *testing.T) {
+	r := bytes.NewReader([]byte{
+		0x01,
+		0x02, 0x00,
+		0x03, 0x00, 0x00, 0x00,
+		0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	})
+
+	u8, err := ReadIntegerLE[uint8](r)
+	require.NoError(t, err)
+	require.Equal(t, uint8(1), u8)
+
+	u16, err := ReadIntegerLE[uint16](r)
+	require.NoError(t, err)
+	require.Equal(t, uint16(2), u16)
+
+	u32, err := ReadIntegerLE[uint32](r)
+	require.NoError(t, err)
+	require.Equal(t, uint32(3), u32)
+
+	u64, err := ReadIntegerLE[uint64](r)
+	require.NoError(t, err)
+	require.Equal(t, uint64(4), u64)
+
+	require.Zero(t, r.Len())
+}
+
+func TestReadIntegerLEInt(t *testing.T) {
+	r := bytes.NewReader([]byte{
+		0xff,
+		0xfe, 0xff,
+		0xfd, 0xff, 0xff, 0xff,
+		0xfc, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	})
+
+	i8, err := ReadIntegerLE[int8](r)
+	require.NoError(t, err)
+	require.Equal(t, int8(-1), i8)
+
+	i16, err := ReadIntegerLE[int16](r)
+	require.NoError(t, err)
+	require.Equal(t, int16(-2), i16)
+
+	i32, err := ReadIntegerLE[int32](r)
+	require.NoError(t, err)
+	require.Equal(t, int32(-3), i32)
+
+	i64, err := ReadIntegerLE[int64](r)
+	require.NoError(t, err)
+	require.Equal(t, int64(-4), i64)
+}
+
+func TestReadIntegerLEShortRead(t *testing.T) {
+	r := bytes.NewReader([]byte{0x01, 0x02, 0x03})
+
+	_, err := ReadIntegerLE[uint32](r)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestReadIntegerLEEmpty(t *testing.T) {
+	r := bytes.NewReader(nil)
+
+	_, err := ReadIntegerLE[uint64](r)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestReadIntegerLESequential(t *testing.T) {
+	r := bytes.NewReader([]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88})
+
+	a, err := ReadIntegerLE[uint32](r)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0x44332211), a)
+
+	b, err := ReadIntegerLE[uint32](r)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0x88776655), b)
+
+	require.Zero(t, r.Len())
+}
+
+type testBPFStruct struct {
+	A uint32
+	B uint16
+	C uint16
+	D uint64
+}
+
+func TestReadBPFStruct(t *testing.T) {
+	r := bytes.NewReader([]byte{
+		0x01, 0x00, 0x00, 0x00,
+		0x02, 0x00,
+		0x03, 0x00,
+		0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	})
+
+	var dst testBPFStruct
+	err := ReadBPFStruct(r, &dst)
+	require.NoError(t, err)
+	require.Equal(t, testBPFStruct{A: 1, B: 2, C: 3, D: 4}, dst)
+	require.Zero(t, r.Len())
+}
+
+func TestReadBPFStructShortRead(t *testing.T) {
+	r := bytes.NewReader([]byte{0x01, 0x00, 0x00, 0x00, 0x02, 0x00})
+
+	var dst testBPFStruct
+	err := ReadBPFStruct(r, &dst)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestReadBPFStructPreservesTrailingData(t *testing.T) {
+	r := bytes.NewReader([]byte{
+		0x01, 0x00, 0x00, 0x00,
+		0x02, 0x00,
+		0x03, 0x00,
+		0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0xaa, 0xbb,
+	})
+
+	var dst testBPFStruct
+	err := ReadBPFStruct(r, &dst)
+	require.NoError(t, err)
+	require.Equal(t, testBPFStruct{A: 1, B: 2, C: 3, D: 4}, dst)
+	require.Equal(t, 2, r.Len())
+
+	rest, err := ReadIntegerLE[uint16](r)
+	require.NoError(t, err)
+	require.Equal(t, uint16(0xbbaa), rest)
+}

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -145,13 +145,13 @@ type MsgExecveEventUnix struct {
 }
 
 type MsgCloneEvent struct {
-	Common MsgCommon
-	Parent MsgExecveKey
-	PID    uint32
-	TID    uint32
-	NSPID  uint32
-	Flags  uint32
-	Ktime  uint64
+	Common MsgCommon    `align:"common"`
+	Parent MsgExecveKey `align:"parent"`
+	PID    uint32       `align:"tgid"`
+	TID    uint32       `align:"tid"`
+	NSPID  uint32       `align:"nspid"`
+	Flags  uint32       `align:"flags"`
+	Ktime  uint64       `align:"ktime"`
 }
 
 type MsgCapabilities struct {

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -257,8 +257,8 @@ type MsgCgroupEvent struct {
 }
 
 type MsgThrottleEvent struct {
-	Common MsgCommon
-	Kube   MsgK8s
+	Common MsgCommon `align:"common"`
+	Kube   MsgK8s    `align:"kube"`
 }
 
 type KernelStats struct {

--- a/pkg/api/processapi/processapi.go
+++ b/pkg/api/processapi/processapi.go
@@ -129,13 +129,13 @@ type MsgGenericCred struct {
 }
 
 type MsgExecveEvent struct {
-	Common         MsgCommon
-	Kube           MsgK8s
-	Parent         MsgExecveKey
-	ParentFlags    uint64
-	Creds          MsgGenericCred
-	Namespaces     MsgNamespaces
-	CleanupProcess MsgExecveKey
+	Common         MsgCommon      `align:"common"`
+	Kube           MsgK8s         `align:"kube"`
+	Parent         MsgExecveKey   `align:"parent"`
+	ParentFlags    uint64         `align:"parent_flags"`
+	Creds          MsgGenericCred `align:"creds"`
+	Namespaces     MsgNamespaces  `align:"ns"`
+	CleanupProcess MsgExecveKey   `align:"cleanup_key"`
 }
 
 type MsgExecveEventUnix struct {

--- a/pkg/api/tracingapi/client_kprobe.go
+++ b/pkg/api/tracingapi/client_kprobe.go
@@ -47,17 +47,17 @@ type MsgLoader struct {
 }
 
 type MsgGenericKprobe struct {
-	Common        processapi.MsgCommon
-	ProcessKey    processapi.MsgExecveKey
-	Namespaces    processapi.MsgNamespaces
-	Capabilities  processapi.MsgCapabilities
-	FuncId        uint64
-	RetProbeId    uint64
-	ActionId      uint64
-	ActionArgId   uint32
-	Tid           uint32 // The recorded TID that triggered the event
-	KernelStackID int64
-	UserStackID   int64
+	Common        processapi.MsgCommon       `align:"common"`
+	ProcessKey    processapi.MsgExecveKey    `align:"current"`
+	Namespaces    processapi.MsgNamespaces   `align:"ns"`
+	Capabilities  processapi.MsgCapabilities `align:"caps"`
+	FuncId        uint64                     `align:"func_id"`
+	RetProbeId    uint64                     `align:"retprobe_id"`
+	ActionId      uint64                     `align:"action"`
+	ActionArgId   uint32                     `align:"action_arg_id"`
+	Tid           uint32                     `align:"tid"` // The recorded TID that triggered the event
+	KernelStackID int64                      `align:"kernel_stack_id"`
+	UserStackID   int64                      `align:"user_stack_id"`
 }
 
 func (m MsgGenericKprobe) HasKernelStack() bool {

--- a/pkg/api/tracingapi/client_tracepoint.go
+++ b/pkg/api/tracingapi/client_tracepoint.go
@@ -8,15 +8,15 @@ import "github.com/cilium/tetragon/pkg/api/processapi"
 type MsgGenericTracepointArg any
 
 type MsgGenericTracepoint struct {
-	Common        processapi.MsgCommon
-	ProcessKey    processapi.MsgExecveKey
-	Namespaces    processapi.MsgNamespaces
-	Capabilities  processapi.MsgCapabilities
-	FuncId        int64
-	RetProbeId    uint64
-	ActionId      uint64
-	ActionArgId   uint32
-	Tid           uint32 // The recorded TID that triggered the event
-	KernelStackID int64
-	UserStackID   int64
+	Common        processapi.MsgCommon       `align:"common"`
+	ProcessKey    processapi.MsgExecveKey    `align:"current"`
+	Namespaces    processapi.MsgNamespaces   `align:"ns"`
+	Capabilities  processapi.MsgCapabilities `align:"caps"`
+	FuncId        int64                      `align:"func_id"`
+	RetProbeId    uint64                     `align:"retprobe_id"`
+	ActionId      uint64                     `align:"action"`
+	ActionArgId   uint32                     `align:"action_arg_id"`
+	Tid           uint32                     `align:"tid"` // The recorded TID that triggered the event
+	KernelStackID int64                      `align:"kernel_stack_id"`
+	UserStackID   int64                      `align:"user_stack_id"`
 }

--- a/pkg/observer/data.go
+++ b/pkg/observer/data.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/dataapi"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/logger"
@@ -86,7 +87,7 @@ func HandleData(r *bytes.Reader) ([]Event, error) {
 	DataEventMetricInc(DataEventReceived)
 
 	m := dataapi.MsgData{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		return nil, errors.New("failed to read data msg")
 	}

--- a/pkg/sensors/exec/exec_linux.go
+++ b/pkg/sensors/exec/exec_linux.go
@@ -88,7 +88,7 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, error) {
 	}
 	exec := processapi.MsgExec{}
 
-	if err := binary.Read(reader, binary.LittleEndian, &exec); err != nil {
+	if err := api.ReadBPFStruct(reader, &exec); err != nil {
 		logger.GetLogger().Debug("Failed to read exec event", logfields.Error, err)
 		return proc, err
 	}
@@ -122,7 +122,7 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, error) {
 		if uint16(unsafe.Sizeof(desc)) != size {
 			return nil, errors.New("msg exec mismatched size")
 		}
-		if err := binary.Read(reader, binary.LittleEndian, &desc); err != nil {
+		if err := api.ReadBPFStruct(reader, &desc); err != nil {
 			return nil, err
 		}
 		return observer.DataGet(desc)
@@ -206,7 +206,7 @@ func execParse(reader *bytes.Reader) (processapi.MsgProcess, error) {
 
 func handleExecve(r *bytes.Reader) ([]observer.Event, error) {
 	m := processapi.MsgExecveEvent{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func msgToExitUnix(m *processapi.MsgExitEvent) *exec.MsgExitEventUnix {
 
 func handleExit(r *bytes.Reader) ([]observer.Event, error) {
 	m := processapi.MsgExitEvent{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func handleExit(r *bytes.Reader) ([]observer.Event, error) {
 
 func handleClone(r *bytes.Reader) ([]observer.Event, error) {
 	m := processapi.MsgCloneEvent{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func handleClone(r *bytes.Reader) ([]observer.Event, error) {
 
 func handleCgroupEvent(r *bytes.Reader) ([]observer.Event, error) {
 	m := processapi.MsgCgroupEvent{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func handleCgroupEvent(r *bytes.Reader) ([]observer.Event, error) {
 
 func handleThrottleEvent(r *bytes.Reader) ([]observer.Event, error) {
 	m := processapi.MsgThrottleEvent{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sensors/exec/exec_windows.go
+++ b/pkg/sensors/exec/exec_windows.go
@@ -5,7 +5,6 @@ package exec
 
 import (
 	"bytes"
-	"encoding/binary"
 	"unsafe"
 
 	"github.com/cilium/tetragon/pkg/api"
@@ -58,7 +57,7 @@ func handleExecve(r *bytes.Reader) ([]observer.Event, error) {
 	var empty bool
 
 	m := processapi.MsgCreateProcessEvent{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +95,7 @@ func msgToExitUnix(m *processapi.MsgExitProcessEvent) *exec.MsgExitEventUnix {
 
 func handleExit(r *bytes.Reader) ([]observer.Event, error) {
 	m := processapi.MsgExitProcessEvent{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sensors/test/test.go
+++ b/pkg/sensors/test/test.go
@@ -8,11 +8,11 @@ package test
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 
 	"sync/atomic"
 
+	tetragonapi "github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	api "github.com/cilium/tetragon/pkg/api/testapi"
 	"github.com/cilium/tetragon/pkg/config"
@@ -52,7 +52,7 @@ func msgToTestUnix(m *api.MsgTestEvent) *test.MsgTestEventUnix {
 
 func handleTest(r *bytes.Reader) ([]observer.Event, error) {
 	m := api.MsgTestEvent{}
-	if err := binary.Read(r, binary.LittleEndian, &m); err != nil {
+	if err := tetragonapi.ReadBPFStruct(r, &m); err != nil {
 		return nil, err
 	}
 	msgUnix := msgToTestUnix(&m)

--- a/pkg/sensors/tracing/args_linux.go
+++ b/pkg/sensors/tracing/args_linux.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"strconv"
 
@@ -126,10 +125,10 @@ func getTracepointMetaValue(arg *v1alpha1.KProbeArg) int {
 }
 
 func getArgStatus(r *bytes.Reader) (*api.MsgGenericKprobeArgError, error) {
-	var status uint32
 	var arg api.MsgGenericKprobeArgError
 
-	if err := binary.Read(r, binary.LittleEndian, &status); err != nil {
+	status, err := tetragonapi.ReadIntegerLE[uint32](r)
+	if err != nil {
 		return nil, err
 	}
 
@@ -162,14 +161,13 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 
 	switch a.ty {
 	case gt.GenericIntType, gt.GenericS32Type:
-		var output int32
 		var arg api.MsgGenericKprobeArgInt
 
 		if a.userType != gt.GenericInvalidType {
 			arg.UserSpaceType = int32(a.userType)
 		}
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		output, err := tetragonapi.ReadIntegerLE[int32](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "int type error",
 				slog.String("arg.usertype", gt.GenericUserTypeToString(a.userType)),
@@ -182,8 +180,6 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		return arg
 	case gt.GenericFileType, gt.GenericFdType, gt.GenericKiocb:
 		var arg api.MsgGenericKprobeArgFile
-		var flags uint32
-		var mode uint16
 
 		arg.Index = uint64(a.index)
 		arg.Value, err = parseString(r)
@@ -201,13 +197,13 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		}
 
 		// read the first byte that keeps the flags
-		err := binary.Read(r, binary.LittleEndian, &flags)
+		flags, err := tetragonapi.ReadIntegerLE[uint32](r)
 		if err != nil {
 			flags = 0
 		}
 
 		if a.ty == gt.GenericFileType || a.ty == gt.GenericFdType || a.ty == gt.GenericKiocb {
-			err := binary.Read(r, binary.LittleEndian, &mode)
+			mode, err := tetragonapi.ReadIntegerLE[uint16](r)
 			if err != nil {
 				mode = 0
 			}
@@ -219,8 +215,6 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		return arg
 	case gt.GenericPathType, gt.GenericDentryType:
 		var arg api.MsgGenericKprobeArgPath
-		var flags uint32
-		var mode uint16
 
 		arg.Index = uint64(a.index)
 		arg.Value, err = parseString(r)
@@ -233,12 +227,12 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		}
 
 		// read the first byte that keeps the flags
-		err := binary.Read(r, binary.LittleEndian, &flags)
+		flags, err := tetragonapi.ReadIntegerLE[uint32](r)
 		if err != nil {
 			flags = 0
 		}
 
-		err = binary.Read(r, binary.LittleEndian, &mode)
+		mode, err := tetragonapi.ReadIntegerLE[uint16](r)
 		if err != nil {
 			mode = 0
 		}
@@ -368,10 +362,9 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Path = decodeSockaddrUnPath(sockaddr.Path[:], sockaddr.PathLen, sockaddr.IsAbstract)
 		return arg
 	case gt.GenericS64Type:
-		var output int64
 		var arg api.MsgGenericKprobeArgLong
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		output, err := tetragonapi.ReadIntegerLE[int64](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "s64 type err", slog.Any(logfields.Error, err))
 		}
@@ -381,10 +374,9 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericSizeType, gt.GenericU64Type:
-		var output uint64
 		var arg api.MsgGenericKprobeArgSize
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		output, err := tetragonapi.ReadIntegerLE[uint64](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "size/u64 type err", slog.Any(logfields.Error, err))
 		}
@@ -456,10 +448,9 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericU32Type:
-		var output uint32
 		var arg api.MsgGenericKprobeArgUInt
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		output, err := tetragonapi.ReadIntegerLE[uint32](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "u32 type error", slog.Any(logfields.Error, err))
 		}
@@ -529,10 +520,10 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericU16Type:
-		var output uint32
 		var arg api.MsgGenericKprobeArgUInt
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		// reads a uint16 + 16-bit padding (hence uint32)
+		output, err := tetragonapi.ReadIntegerLE[uint32](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "u16 type error", slog.Any(logfields.Error, err))
 		}
@@ -542,10 +533,10 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericU8Type:
-		var output uint32
 		var arg api.MsgGenericKprobeArgUInt
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		// reads a uint8 + 24-bit padding (hence uint32)
+		output, err := tetragonapi.ReadIntegerLE[uint32](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "u8 type error", slog.Any(logfields.Error, err))
 		}
@@ -555,10 +546,10 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericS16Type:
-		var output uint32
 		var arg api.MsgGenericKprobeArgInt
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		// reads an int16 + 16-bit padding (hence uint32)
+		output, err := tetragonapi.ReadIntegerLE[uint32](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "s16 type error", slog.Any(logfields.Error, err))
 		}
@@ -568,10 +559,10 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericS8Type:
-		var output uint32
 		var arg api.MsgGenericKprobeArgInt
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		// reads an int8 + 24-bit padding (hence uint32)
+		output, err := tetragonapi.ReadIntegerLE[uint32](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "s8 type error", slog.Any(logfields.Error, err))
 		}
@@ -581,10 +572,9 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericKernelCap:
-		var output uint64
 		var arg api.MsgGenericKprobeArgKernelCapType
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		output, err := tetragonapi.ReadIntegerLE[uint64](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "kernel_cap_t type error", slog.Any(logfields.Error, err))
 		} else {
@@ -595,10 +585,9 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericCapInheritable:
-		var output uint64
 		var arg api.MsgGenericKprobeArgCapInheritable
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		output, err := tetragonapi.ReadIntegerLE[uint64](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "kernel_cap_t cap_inheritable type error", slog.Any(logfields.Error, err))
 		} else {
@@ -609,10 +598,9 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericCapPermitted:
-		var output uint64
 		var arg api.MsgGenericKprobeArgCapPermitted
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		output, err := tetragonapi.ReadIntegerLE[uint64](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "kernel_cap_t cap_permitted type error", slog.Any(logfields.Error, err))
 		} else {
@@ -623,10 +611,9 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		arg.Label = a.label
 		return arg
 	case gt.GenericCapEffective:
-		var output uint64
 		var arg api.MsgGenericKprobeArgCapEffective
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		output, err := tetragonapi.ReadIntegerLE[uint64](r)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "kernel_cap_t cap_effective type error", slog.Any(logfields.Error, err))
 		} else {
@@ -638,8 +625,6 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		return arg
 	case gt.GenericLinuxBinprmType:
 		var arg api.MsgGenericKprobeArgLinuxBinprm
-		var flags uint32
-		var mode uint16
 
 		arg.Index = uint64(a.index)
 		arg.Value, err = parseString(r)
@@ -651,12 +636,12 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 			}
 		}
 
-		err := binary.Read(r, binary.LittleEndian, &flags)
+		flags, err := tetragonapi.ReadIntegerLE[uint32](r)
 		if err != nil {
 			flags = 0
 		}
 
-		err = binary.Read(r, binary.LittleEndian, &mode)
+		mode, err := tetragonapi.ReadIntegerLE[uint16](r)
 		if err != nil {
 			mode = 0
 		}
@@ -676,9 +661,8 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 // | 4 bytes | N bytes |
 // |  size   | string  |
 // *---------*---------*
-func parseString(r io.Reader) (string, error) {
-	var size int32
-	err := binary.Read(r, binary.LittleEndian, &size)
+func parseString(r *bytes.Reader) (string, error) {
+	size, err := tetragonapi.ReadIntegerLE[int32](r)
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", errParseStringSize, err)
 	}
@@ -706,12 +690,12 @@ func parseString(r io.Reader) (string, error) {
 }
 
 func ReadArgBytes(r *bytes.Reader, index int, hasMaxData bool) (*api.MsgGenericKprobeArgBytes, error) {
-	var bytes, bytesRd, hasDataEvents int32
 	var arg api.MsgGenericKprobeArgBytes
 
 	if hasMaxData {
 		/* First int32 indicates if data events are used (1) or not (0). */
-		if err := binary.Read(r, binary.LittleEndian, &hasDataEvents); err != nil {
+		hasDataEvents, err := tetragonapi.ReadIntegerLE[int32](r)
+		if err != nil {
 			return nil, fmt.Errorf("failed to read original size for buffer argument: %w", err)
 		}
 		if hasDataEvents != 0 {
@@ -731,7 +715,8 @@ func ReadArgBytes(r *bytes.Reader, index int, hasMaxData bool) (*api.MsgGenericK
 		}
 	}
 
-	if err := binary.Read(r, binary.LittleEndian, &bytes); err != nil {
+	bytes, err := tetragonapi.ReadIntegerLE[int32](r)
+	if err != nil {
 		return nil, fmt.Errorf("failed to read original size for buffer argument: %w", err)
 	}
 
@@ -747,7 +732,8 @@ func ReadArgBytes(r *bytes.Reader, index int, hasMaxData bool) (*api.MsgGenericK
 		return &arg, nil
 	}
 	arg.OrigSize = uint64(bytes)
-	if err := binary.Read(r, binary.LittleEndian, &bytesRd); err != nil {
+	bytesRd, err := tetragonapi.ReadIntegerLE[int32](r)
+	if err != nil {
 		return nil, fmt.Errorf("failed to read size for buffer argument: %w", err)
 	}
 

--- a/pkg/sensors/tracing/args_linux.go
+++ b/pkg/sensors/tracing/args_linux.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"strconv"
 
+	tetragonapi "github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/dataapi"
 	processapi "github.com/cilium/tetragon/pkg/api/processapi"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
@@ -261,7 +262,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var cred processapi.MsgGenericCred
 		var arg api.MsgGenericKprobeArgCred
 
-		err := binary.Read(r, binary.LittleEndian, &cred)
+		err := tetragonapi.ReadBPFStruct(r, &cred)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "error paring arg type cred", slog.Any(logfields.Error, err))
 		}
@@ -296,7 +297,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var skb api.MsgGenericKprobeSkb
 		var arg api.MsgGenericKprobeArgSkb
 
-		err := binary.Read(r, binary.LittleEndian, &skb)
+		err := tetragonapi.ReadBPFStruct(r, &skb)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "skb type err", slog.Any(logfields.Error, err))
 		}
@@ -320,7 +321,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var sock api.MsgGenericKprobeSock
 		var arg api.MsgGenericKprobeArgSock
 
-		err := binary.Read(r, binary.LittleEndian, &sock)
+		err := tetragonapi.ReadBPFStruct(r, &sock)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "sock type err", slog.Any(logfields.Error, err))
 		}
@@ -343,7 +344,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var address api.MsgGenericKprobeSockaddr
 		var arg api.MsgGenericKprobeArgSockaddr
 
-		err := binary.Read(r, binary.LittleEndian, &address)
+		err := tetragonapi.ReadBPFStruct(r, &address)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "sockaddr type err", slog.Any(logfields.Error, err))
 		}
@@ -357,7 +358,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var sockaddr api.MsgGenericKprobeSockaddrUn
 		var arg api.MsgGenericKprobeArgSockaddrUn
 
-		err := binary.Read(r, binary.LittleEndian, &sockaddr)
+		err := tetragonapi.ReadBPFStruct(r, &sockaddr)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "sockaddrun type err", slog.Any(logfields.Error, err))
 		}
@@ -398,7 +399,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var output api.MsgGenericKprobeBpfAttr
 		var arg api.MsgGenericKprobeArgBpfAttr
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		err := tetragonapi.ReadBPFStruct(r, &output)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "bpf_attr type err", slog.Any(logfields.Error, err))
 		}
@@ -412,7 +413,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var output api.MsgGenericKprobeBpfProg
 		var arg api.MsgGenericKprobeArgBpfProg
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		err := tetragonapi.ReadBPFStruct(r, &output)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "bpf_prog type err", slog.Any(logfields.Error, err))
 		}
@@ -426,7 +427,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var output api.MsgGenericKprobePerfEvent
 		var arg api.MsgGenericKprobeArgPerfEvent
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		err := tetragonapi.ReadBPFStruct(r, &output)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "perf_event type error", slog.Any(logfields.Error, err))
 		}
@@ -441,7 +442,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var output api.MsgGenericKprobeBpfMap
 		var arg api.MsgGenericKprobeArgBpfMap
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		err := tetragonapi.ReadBPFStruct(r, &output)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "bpf_map type error", slog.Any(logfields.Error, err))
 		}
@@ -471,7 +472,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var output api.MsgGenericUserNamespace
 		var arg api.MsgGenericKprobeArgUserNamespace
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		err := tetragonapi.ReadBPFStruct(r, &output)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "user_namespace type error", slog.Any(logfields.Error, err))
 		}
@@ -485,7 +486,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var output api.MsgGenericKprobeCapability
 		var arg api.MsgGenericKprobeArgCapability
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		err := tetragonapi.ReadBPFStruct(r, &output)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "capability type error", slog.Any(logfields.Error, err))
 		}
@@ -496,7 +497,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var output api.MsgGenericLoadModule
 		var arg api.MsgGenericKprobeArgLoadModule
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		err := tetragonapi.ReadBPFStruct(r, &output)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "load_module type error", slog.Any(logfields.Error, err))
 		} else if output.Name[0] != 0x00 {
@@ -514,7 +515,7 @@ func getArg(l getArgLogger, r *bytes.Reader, a argPrinter) api.MsgGenericKprobeA
 		var output api.MsgGenericLoadModule
 		var arg api.MsgGenericKprobeArgKernelModule
 
-		err := binary.Read(r, binary.LittleEndian, &output)
+		err := tetragonapi.ReadBPFStruct(r, &output)
 		if err != nil {
 			l.LogAttrs(slog.LevelWarn, "kernel module type error", slog.Any(logfields.Error, err))
 		} else if output.Name[0] != 0x00 {
@@ -716,7 +717,7 @@ func ReadArgBytes(r *bytes.Reader, index int, hasMaxData bool) (*api.MsgGenericK
 		if hasDataEvents != 0 {
 			var desc dataapi.DataEventDesc
 
-			if err := binary.Read(r, binary.LittleEndian, &desc); err != nil {
+			if err := tetragonapi.ReadBPFStruct(r, &desc); err != nil {
 				return nil, err
 			}
 			data, err := observer.DataGet(desc)

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -24,6 +24,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 
 	tetragon "github.com/cilium/tetragon/api/v1/tetragon"
+	tetragonapi "github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
@@ -1319,7 +1320,7 @@ func dnsLookup(fqdn string) {
 
 func handleGenericKprobe(r *bytes.Reader) ([]observer.Event, error) {
 	m := api.MsgGenericKprobe{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := tetragonapi.ReadBPFStruct(r, &m)
 	if err != nil {
 		logger.GetLogger().Warn("Failed to read process call msg", logfields.Error, err)
 		return nil, errors.New("failed to read process call msg")

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -1376,7 +1376,7 @@ func handleMsgGenericKprobe(m *api.MsgGenericKprobe, gk *genericKprobe, r *bytes
 	var printers []argPrinter
 	if returnEvent {
 		// if this a return event, also read the ktime of the enter event
-		err := binary.Read(r, binary.LittleEndian, &ktimeEnter)
+		ktimeEnter, err = tetragonapi.ReadIntegerLE[uint64](r)
 		if err != nil {
 			return nil, errors.New("failed to read ktimeEnter")
 		}

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -167,8 +167,7 @@ func handleGenericLsm(r *bytes.Reader) ([]observer.Event, error) {
 
 	// Get file hashes calculated using IMA
 	if m.Common.Flags&processapi.MSG_COMMON_FLAG_IMA_HASH != 0 {
-		var state int8
-		err := binary.Read(r, binary.LittleEndian, &state)
+		state, err := tetragonapi.ReadIntegerLE[int8](r)
 		if err != nil {
 			gl.LogAttrs(slog.LevelWarn, "failed to read IMA hash state", slog.Any(logfields.Error, err))
 			return nil, errors.New("failed to read IMA hash state")
@@ -177,8 +176,7 @@ func handleGenericLsm(r *bytes.Reader) ([]observer.Event, error) {
 			gl.LogAttrs(slog.LevelWarn, "LSM bpf program chain is violated", slog.Any(logfields.Error, err))
 			return nil, errors.New("LSM bpf program chain is violated")
 		}
-		var algo int8
-		err = binary.Read(r, binary.LittleEndian, &algo)
+		algo, err := tetragonapi.ReadIntegerLE[int8](r)
 		if err != nil {
 			gl.LogAttrs(slog.LevelWarn, "failed to read IMA hash algorithm", slog.Any(logfields.Error, err))
 			return nil, errors.New("failed to read IMA hash algorithm")

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 
+	tetragonapi "github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
@@ -133,7 +134,7 @@ func (k *observerLsmSensor) LoadProbe(args sensors.LoadProbeArgs) error {
 
 func handleGenericLsm(r *bytes.Reader) ([]observer.Event, error) {
 	m := api.MsgGenericKprobe{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := tetragonapi.ReadBPFStruct(r, &m)
 	if err != nil {
 		logger.GetLogger().Warn("Failed to read process call msg", logfields.Error, err)
 		return nil, errors.New("failed to read process call msg")
@@ -183,7 +184,7 @@ func handleGenericLsm(r *bytes.Reader) ([]observer.Event, error) {
 			return nil, errors.New("failed to read IMA hash algorithm")
 		}
 		unix.ImaHash.Algo = int32(algo)
-		err = binary.Read(r, binary.LittleEndian, &unix.ImaHash.Hash)
+		err = tetragonapi.ReadBPFStruct(r, &unix.ImaHash.Hash)
 		if err != nil {
 			gl.LogAttrs(slog.LevelWarn, "failed to read IMA hash value", slog.Any(logfields.Error, err))
 			return nil, errors.New("failed to read IMA hash value")

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/ebpf"
 
+	"github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/bpf"
@@ -836,7 +837,7 @@ func LoadGenericTracepointSensor(bpfDir string, load *program.Program, maps []*p
 
 func handleGenericTracepoint(r *bytes.Reader) ([]observer.Event, error) {
 	m := tracingapi.MsgGenericTracepoint{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read tracepoint: %w", err)
 	}
@@ -1047,7 +1048,7 @@ func handleMsgGenericTracepoint(
 			var skb tracingapi.MsgGenericKprobeSkb
 			var arg tracingapi.MsgGenericKprobeArgSkb
 
-			err := binary.Read(r, binary.LittleEndian, &skb)
+			err := api.ReadBPFStruct(r, &skb)
 			if err != nil {
 				logger.GetLogger().Warn("skb type err", logfields.Error, err)
 			}
@@ -1069,7 +1070,7 @@ func handleMsgGenericTracepoint(
 			var sock tracingapi.MsgGenericKprobeSock
 			var arg tracingapi.MsgGenericKprobeArgSock
 
-			err := binary.Read(r, binary.LittleEndian, &sock)
+			err := api.ReadBPFStruct(r, &sock)
 			if err != nil {
 				logger.GetLogger().Warn("sock type err", logfields.Error, err)
 			}
@@ -1091,7 +1092,7 @@ func handleMsgGenericTracepoint(
 			var address tracingapi.MsgGenericKprobeSockaddr
 			var arg tracingapi.MsgGenericKprobeArgSockaddr
 
-			err := binary.Read(r, binary.LittleEndian, &address)
+			err := api.ReadBPFStruct(r, &address)
 			if err != nil {
 				logger.GetLogger().Warn("sockaddr type err", logfields.Error, err)
 			}
@@ -1105,7 +1106,7 @@ func handleMsgGenericTracepoint(
 			var sockaddr tracingapi.MsgGenericKprobeSockaddrUn
 			var arg tracingapi.MsgGenericKprobeArgSockaddrUn
 
-			err := binary.Read(r, binary.LittleEndian, &sockaddr)
+			err := api.ReadBPFStruct(r, &sockaddr)
 			if err != nil {
 				logger.GetLogger().Warn("sockaddrun type err", logfields.Error, err)
 			}

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -908,40 +908,35 @@ func handleMsgGenericTracepoint(
 
 		switch out.genericTypeId {
 		case gt.GenericU64Type:
-			var val uint64
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[uint64](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
 			unix.Args = append(unix.Args, val)
 
 		case gt.GenericS64Type:
-			var val int64
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[int64](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
 			unix.Args = append(unix.Args, val)
 
 		case gt.GenericU32Type:
-			var val uint32
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[uint32](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
 			unix.Args = append(unix.Args, val)
 
 		case gt.GenericIntType, gt.GenericS32Type:
-			var val int32
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[int32](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
 			unix.Args = append(unix.Args, val)
 
 		case gt.GenericU16Type:
-			var val uint16
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[uint16](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
@@ -954,8 +949,7 @@ func handleMsgGenericTracepoint(
 			unix.Args = append(unix.Args, val)
 
 		case gt.GenericS16Type:
-			var val int16
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[int16](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
@@ -968,8 +962,7 @@ func handleMsgGenericTracepoint(
 			unix.Args = append(unix.Args, val)
 
 		case gt.GenericU8Type:
-			var val uint8
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[uint8](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
@@ -982,8 +975,7 @@ func handleMsgGenericTracepoint(
 			unix.Args = append(unix.Args, val)
 
 		case gt.GenericS8Type:
-			var val int8
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[int8](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
@@ -996,9 +988,7 @@ func handleMsgGenericTracepoint(
 			unix.Args = append(unix.Args, val)
 
 		case gt.GenericSizeType:
-			var val uint64
-
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[uint64](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
@@ -1025,9 +1015,8 @@ func handleMsgGenericTracepoint(
 
 				switch intTy.Base {
 				case tracepoint.IntTyLong:
-					var val uint64
 					for i := range arrTy.Size {
-						err := binary.Read(r, binary.LittleEndian, &val)
+						val, err := api.ReadIntegerLE[uint64](r)
 						if err != nil {
 							logger.GetLogger().Warn(fmt.Sprintf("failed to read element %d from array", i), logfields.Error, err)
 							return nil, err
@@ -1116,8 +1105,7 @@ func handleMsgGenericTracepoint(
 			unix.Args = append(unix.Args, arg)
 
 		case gt.GenericSyscall64:
-			var val uint64
-			err := binary.Read(r, binary.LittleEndian, &val)
+			val, err := api.ReadIntegerLE[uint64](r)
 			if err != nil {
 				logger.GetLogger().Warn(fmt.Sprintf("Size type error sizeof %d", m.Common.Size), logfields.Error, err)
 			}
@@ -1126,8 +1114,6 @@ func handleMsgGenericTracepoint(
 
 		case gt.GenericLinuxBinprmType:
 			var arg tracingapi.MsgGenericKprobeArgLinuxBinprm
-			var flags uint32
-			var mode uint16
 			var err error
 
 			arg.Value, err = parseString(r)
@@ -1139,12 +1125,12 @@ func handleMsgGenericTracepoint(
 				}
 			}
 
-			err = binary.Read(r, binary.LittleEndian, &flags)
+			flags, err := api.ReadIntegerLE[uint32](r)
 			if err != nil {
 				flags = 0
 			}
 
-			err = binary.Read(r, binary.LittleEndian, &mode)
+			mode, err := api.ReadIntegerLE[uint16](r)
 			if err != nil {
 				mode = 0
 			}
@@ -1154,8 +1140,6 @@ func handleMsgGenericTracepoint(
 
 		case gt.GenericFileType, gt.GenericFdType, gt.GenericKiocb:
 			var arg tracingapi.MsgGenericKprobeArgFile
-			var flags uint32
-			var mode uint16
 			var err error
 
 			arg.Value, err = parseString(r)
@@ -1173,13 +1157,13 @@ func handleMsgGenericTracepoint(
 			}
 
 			// read the first byte that keeps the flags
-			err = binary.Read(r, binary.LittleEndian, &flags)
+			flags, err := api.ReadIntegerLE[uint32](r)
 			if err != nil {
 				flags = 0
 			}
 
 			if out.genericTypeId == gt.GenericFileType || out.genericTypeId == gt.GenericFdType || out.genericTypeId == gt.GenericKiocb {
-				err = binary.Read(r, binary.LittleEndian, &mode)
+				mode, err := api.ReadIntegerLE[uint16](r)
 				if err != nil {
 					mode = 0
 				}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 
 	tetragon "github.com/cilium/tetragon/api/v1/tetragon"
+	tetragonapi "github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/processapi"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
@@ -175,7 +176,7 @@ func genericUprobeTableGet(id idtable.EntryID) (*genericUprobe, error) {
 
 func handleGenericUprobe(r *bytes.Reader) ([]observer.Event, error) {
 	m := api.MsgGenericKprobe{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := tetragonapi.ReadBPFStruct(r, &m)
 	if err != nil {
 		logger.GetLogger().Warn("Failed to read process call msg", logfields.Error, err)
 		return nil, errors.New("failed to read process call msg")

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -204,7 +204,7 @@ func handleGenericUprobe(r *bytes.Reader) ([]observer.Event, error) {
 	var ktimeEnter uint64
 	if returnEvent {
 		// if this a return event, also read the ktime of the enter event
-		err = binary.Read(r, binary.LittleEndian, &ktimeEnter)
+		ktimeEnter, err = tetragonapi.ReadIntegerLE[uint64](r)
 		if err != nil {
 			return nil, errors.New("failed to read ktimeEnter")
 		}

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 
+	tetragonapi "github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	api "github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/bpf"
@@ -642,7 +643,7 @@ func loadMultiUsdtSensor(ids []idtable.EntryID, args sensors.LoadProbeArgs) erro
 
 func handleGenericUsdt(r *bytes.Reader) ([]observer.Event, error) {
 	m := api.MsgGenericKprobe{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := tetragonapi.ReadBPFStruct(r, &m)
 	if err != nil {
 		logger.GetLogger().Warn("Failed to read process call msg", logfields.Error, err)
 		return nil, errors.New("failed to read process call msg")

--- a/pkg/sensors/tracing/loader_linux.go
+++ b/pkg/sensors/tracing/loader_linux.go
@@ -27,7 +27,6 @@ package tracing
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"log"
@@ -37,6 +36,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sys/unix"
 
+	"github.com/cilium/tetragon/pkg/api"
 	"github.com/cilium/tetragon/pkg/api/ops"
 	"github.com/cilium/tetragon/pkg/api/tracingapi"
 	"github.com/cilium/tetragon/pkg/bpf"
@@ -208,7 +208,7 @@ func inCache(pid uint32, path string) bool {
 
 func handleLoader(r *bytes.Reader) ([]observer.Event, error) {
 	m := tracingapi.MsgLoader{}
-	err := binary.Read(r, binary.LittleEndian, &m)
+	err := api.ReadBPFStruct(r, &m)
 	if err != nil {
 		logger.GetLogger().Warn("Failed to read process call msg", logfields.Error, err)
 		return nil, errors.New("failed to read process call msg")


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description

Event structs coming from the ebpf perf and ring buffers are usually deserialised into their target structs by the means of:
```
binary.Read(r, binary.LittleEndian, &m)
```

The usage of `binary.Read` is not ideal in the event hotpath - being an all-purpose function, it needs to perform quite a expensive/slow operations under the hood. For example, when reading into a struct, it does something along the lines of:
```
v := reflect.ValueOf(data)
size := dataSize(v)
d := &decoder{order: order, buf: make([]byte, size)}
if _, err := io.ReadFull(r, d.buf); err != nil { ... }
d.value(v.Elem())
```
In other words:
 - data any + reflect.ValueOf(data) causes data to escape to the heap
 - the decoder creates a brand-new temp buffer every call
 - d.value() must walk the struct causing several interface dispatches -
       none of which can be inlined

This PR introduces an alternative function meant to be used in the ebpf event hotpath, `ReadBPFStruct()`. We can leverage the fact that ebpf event structs are PODs/trivially copyable (i.e. fixed-size, pointer-free) structs and deserialise them in-place on the target struct (akin to a `memcpy()`).

For integral types, it introduces an analogous generic function, `ReadIntegerLE()`, carries the same rationale as `ReadBPFStruct()`.

#### Performance gains

CPU and allocation profiles were collected twice for both the baseline (A)
and this change (B), using the same workload.

Cumulative CPU under `HandlePerfData` decreased consistently:

    A1 -> B1: 4.33s -> 3.15s  (-27.3%)
    A2 -> B2: 4.62s -> 3.35s  (-27.5%)

Cumulative CPU attributed to `encoding/binary.Read` decreased by ~59%:

    A1 -> B1: 2.34s -> 0.96s  (-59.0%)
    A2 -> B2: 2.42s -> 1.00s  (-58.7%)

Overall sampled CPU decreased by ~2.7%.

_After the change, `encoding/binary.Read` disappears from this path entirely, whilst the replacement `bytes.Reader.Read` does not appear as a measurable CPU consumer in `top`/`peek`._

Allocation profiling (`alloc_space`) shows a reduction in total allocated
memory:

    6990.3 MB -> 6577.2 MB  (-5.9%)

The reduction can also be seen directly at `encoding/binary.Read`:

    flat alloc_space:

    A1 -> B1: ~275 MiB less
    A2 -> B2: ~298 MiB less

`alloc_objects` additionally attributes approximately 2.1 million fewer
allocations per run directly to `encoding/binary.Read`.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Performance improvements when deserializing ebpf event messages.
```
