### PR TITLE
fix: preserve matching USDT events when filtering by policy name

### DIFF
--- a/cmd/tetra/getevents/io_reader_client_test.go
+++ b/cmd/tetra/getevents/io_reader_client_test.go
@@ -45,6 +45,25 @@ func Test_ioReaderClient_GetEventsSkipsInvalidJSON(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 }
 
+func Test_ioReaderClient_GetEventsUsdtPolicyName(t *testing.T) {
+	input := `{"process_usdt":{"process":{"binary":"/usr/bin/app","pid":1234},"path":"/usr/bin/app","provider":"test","name":"usdt0","policy_name":"other"}}
+{"process_usdt":{"process":{"binary":"/usr/bin/app","pid":1234},"path":"/usr/bin/app","provider":"test","name":"usdt0","policy_name":"usdts"}}
+`
+	client := newIOReaderClient(strings.NewReader(input), false)
+	stream, err := client.GetEvents(context.Background(), &tetragon.GetEventsRequest{
+		AllowList: []*tetragon.Filter{{PolicyNames: []string{"usdts"}}},
+	})
+	require.NoError(t, err)
+
+	res, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, res.GetProcessUsdt())
+	require.Equal(t, "usdts", res.GetProcessUsdt().GetPolicyName())
+
+	_, err = stream.Recv()
+	require.ErrorIs(t, err, io.EOF)
+}
+
 func Test_ioReaderClient_GetEventsLargeJSONLine(t *testing.T) {
 	want := bytes.Repeat([]byte{'a'}, 70*1024)
 	event, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(&tetragon.GetEventsResponse{

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -206,6 +206,8 @@ func GetPolicyName(event *event.Event) string {
 		return ev.ProcessUprobe.GetPolicyName()
 	case *tetragon.GetEventsResponse_ProcessLsm:
 		return ev.ProcessLsm.GetPolicyName()
+	case *tetragon.GetEventsResponse_ProcessUsdt:
+		return ev.ProcessUsdt.GetPolicyName()
 	default:
 		return ""
 	}

--- a/pkg/filters/policies_test.go
+++ b/pkg/filters/policies_test.go
@@ -77,10 +77,19 @@ func TestPolicyNamesFilterNilValue(t *testing.T) {
 	}
 }
 
-// eventsWithPolicyName generates kprobe, tracepoint, uprobe, and lsm events
+// eventsWithPolicyName generates kprobe, tracepoint, uprobe, lsm, and usdt events
 // with the specified policy name.
 func eventsWithPolicyName(policyName string) []event.Event {
 	return []event.Event{
+		{
+			Event: &tetragon.GetEventsResponse{
+				Event: &tetragon.GetEventsResponse_ProcessUsdt{
+					ProcessUsdt: &tetragon.ProcessUsdt{
+						PolicyName: policyName,
+					},
+				},
+			},
+		},
 		{
 			Event: &tetragon.GetEventsResponse{
 				Event: &tetragon.GetEventsResponse_ProcessKprobe{


### PR DESCRIPTION
### Description

USDT events vanish when filtered by their matching policy name. 
`GetPolicyName` misses USDT, so this adds the missing case and regression tests. 
Same gap as #3044, for USDT

Repro with a built `tetra`:

```sh
printf '%s\n' '{"process_usdt":{"process":{"binary":"/usr/bin/app","pid":1234},"path":"/usr/bin/app","provider":"test","name":"usdt0","policy_name":"usdts"}}' | tetra getevents --policy-names usdts
```

Before: no output. 
After: the event is printed. Nonmatching policies still produce no output

Tests: `go test ./pkg/filters ./cmd/tetra/getevents -count=1` passes. The new regression tests fail before the fix.

### Changelog

```release-note
Fix policy-name filtering silently dropping matching USDT events.
```
