### PR TITLE
contrib/verify: Initialize kernel BTF before probing kfuncs

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24.04, ubuntu-24.04-arm64 ]
+        os: [ ubuntu-24.04, ubuntu-24.04-arm64, ubuntu-26.04 ]
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -44,12 +44,12 @@ jobs:
     - name: Install dependencies x86
       run: |
         sudo apt-get -y install libc6-dev-i386
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ !endsWith(matrix.os, 'arm64') }}
 
     - name: Install dependencies ARM
       run: |
         sudo apt-get -y install gcc-arm-linux-gnueabihf
-      if: ${{ matrix.os == 'ubuntu-24.04-arm64' }}
+      if: ${{ endsWith(matrix.os, 'arm64') }}
 
     - name: Install bpftool
       uses: mtardy/setup-bpftool@9bc044304197616a6321d452e04cc059e006d8e2 # v1.0.4
@@ -62,6 +62,10 @@ jobs:
         make verify
 
     - name: Run go tests
+      # ubuntu-26.04 ships Rust coreutils behind symlinks, which breaks the
+      # matchBinaries tests expecting /usr/bin paths, see
+      # https://github.com/cilium/tetragon/issues/3583.
+      if: ${{ matrix.os != 'ubuntu-26.04' }}
       env:
         GOPATH: ${{ env.GITHUB_WORKSPACE }}/go
         SUDO: sudo -E

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/tetragon/pkg/bpf"
+	"github.com/cilium/tetragon/pkg/btf"
 	"github.com/cilium/tetragon/pkg/defaults"
 	"github.com/cilium/tetragon/pkg/kernels"
 	"github.com/cilium/tetragon/pkg/selectors"
@@ -30,6 +31,8 @@ var (
 )
 
 func TestVerifyTetragonPrograms(t *testing.T) {
+	require.NoError(t, btf.InitCachedBTF(*tetragonDir, ""), "failed to initialize kernel BTF")
+
 	files, err := os.ReadDir(*tetragonDir)
 	if err != nil {
 		t.Fatalf("error: %v", err)

--- a/contrib/verify/verify_test.go
+++ b/contrib/verify/verify_test.go
@@ -118,14 +118,14 @@ func TestVerifyTetragonPrograms(t *testing.T) {
 		require.NoError(t, err, "failed to parse elf file into collection spec")
 		require.NotNil(t, spec, "collection spec should not be nil")
 
-		if strings.HasPrefix(fileName, "bpf_generic_kprobe") {
-			if fileName != "bpf_generic_kprobe.o" { // 4.19 version does not need to be rewritten
-				for _, prog := range spec.Programs {
+		// The filter_arg programs call cel_expr_N functions generated at policy
+		// load time. The base (4.19) objects have no such calls.
+		if fileName != "bpf_generic_kprobe.o" && fileName != "bpf_generic_uprobe.o" {
+			for _, prog := range spec.Programs {
+				if prog.Name == "generic_kprobe_filter_arg" || prog.Name == "generic_uprobe_filter_arg" {
 					var exprs selectors.CelExprFunctions
-					if prog.Name == "generic_kprobe_filter_arg" {
-						err := exprs.RewriteProg(prog)
-						require.NoError(t, err, "failed to rewrite program for empty CEL expressions")
-					}
+					err := exprs.RewriteProg(prog)
+					require.NoError(t, err, "failed to rewrite program for empty CEL expressions")
 				}
 			}
 		}


### PR DESCRIPTION
HasKfunc() returns false unless the cached BTF path is the kernel's vmlinux, and the verify test never initialized it. The uprobe and usdt objects were therefore skipped on every kernel and never reached the verifier.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
contrib/verify: Initialize kernel BTF before probing kfuncs
```
