### PR TITLE
Allow renovate to update .github/actions; Prevent Windows runner upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,7 @@
   "includePaths": [
     ".github/renovate.json5",
     ".github/workflows/**",
+    ".github/actions/**",
     "go.mod",
     "go.sum",
     "api/go.mod",
@@ -89,7 +90,8 @@
       "groupName": "all github action dependencies",
       "groupSlug": "all-github-action",
       "matchFileNames": [
-        ".github/workflows/**"
+        ".github/workflows/**",
+        ".github/actions/**",
       ],
       "matchManagers": [
         "github-actions"
@@ -108,7 +110,8 @@
     },
     {
       "matchFileNames": [
-        ".github/workflows/**"
+        ".github/workflows/**",
+        ".github/actions/**"
       ],
       "matchManagers": [
         "github-actions"
@@ -406,6 +409,12 @@
       "matchUpdateTypes": ["digest"],
       "matchPackageNames": ["!docker.io/library/alpine"],
     },
+    {
+      // Disable automatic Windows GH runner upgrades
+      "matchDepTypes": ["github-runner"],
+      "matchPackageNames": ["windows"],
+      "enabled": false,
+    },
     // automerge section
     {
       "matchPackageNames": [
@@ -451,6 +460,7 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github/workflows/[^/]+\\.ya?ml$/",
+        "/^\\.github/actions/[^/]+\\.ya?ml$/",
         "docs/hugo.toml",
       ],
       "matchStrings": [


### PR DESCRIPTION
[upstream commit 3da75021a1428b7c3ee8711e45d0d5734b7349dd]