### PR TITLE
build: Bump clang image to clang-22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
 
 # First builder (cross-)compile the BPF programs
-FROM --platform=$BUILDPLATFORM quay.io/cilium/clang:b97f5b3d5c38da62fb009f21a53cd42aefd54a2f@sha256:e1c8ed0acd2e24ed05377f2861d8174af28e09bef3bbc79649c8eba165207df0 AS bpf-builder
+FROM --platform=$BUILDPLATFORM quay.io/cilium/clang:969f95f8ef7923af36bf657ba6d4c65691f56882@sha256:ff83e52d3ea150b3d93e4ae40ae86620003ac3f6d91fe6e939dcc95469f83ff2 AS bpf-builder
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN apt-get update && apt-get install -y linux-libc-dev gzip ccache
 COPY . ./
@@ -41,7 +41,7 @@ RUN apk add --no-cache git \
 # This builder (cross-)compile a stripped static version of bpftool.
 # This step was kept because the downloaded version includes LLVM libs with the
 # disassembler that makes the static binary grow from ~2Mo to ~30Mo.
-FROM --platform=$BUILDPLATFORM quay.io/cilium/clang:b97f5b3d5c38da62fb009f21a53cd42aefd54a2f@sha256:e1c8ed0acd2e24ed05377f2861d8174af28e09bef3bbc79649c8eba165207df0 AS bpftool-builder
+FROM --platform=$BUILDPLATFORM quay.io/cilium/clang:969f95f8ef7923af36bf657ba6d4c65691f56882@sha256:ff83e52d3ea150b3d93e4ae40ae86620003ac3f6d91fe6e939dcc95469f83ff2 AS bpftool-builder
 WORKDIR /bpftool
 ARG TARGETARCH BUILDARCH
 RUN if [ $BUILDARCH != $TARGETARCH ]; \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM quay.io/cilium/clang:b97f5b3d5c38da62fb009f21a53cd42aefd54a2f@sha256:e1c8ed0acd2e24ed05377f2861d8174af28e09bef3bbc79649c8eba165207df0 AS bpf-builder
+FROM quay.io/cilium/clang:969f95f8ef7923af36bf657ba6d4c65691f56882@sha256:ff83e52d3ea150b3d93e4ae40ae86620003ac3f6d91fe6e939dcc95469f83ff2 AS bpf-builder
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN apt-get update
 RUN apt-get install -y linux-libc-dev

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM quay.io/cilium/clang:b97f5b3d5c38da62fb009f21a53cd42aefd54a2f@sha256:e1c8ed0acd2e24ed05377f2861d8174af28e09bef3bbc79649c8eba165207df0 AS bpf-builder
+FROM quay.io/cilium/clang:969f95f8ef7923af36bf657ba6d4c65691f56882@sha256:ff83e52d3ea150b3d93e4ae40ae86620003ac3f6d91fe6e939dcc95469f83ff2 AS bpf-builder
 WORKDIR /go/src/github.com/cilium/tetragon
 RUN apt-get update
 RUN apt-get install -y linux-libc-dev

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LOCAL_CLANG ?= 0
 LOCAL_CLANG_FORMAT ?= 0
 FORMAT_FIND_FLAGS ?= -name '*.c' -o -name '*.h'
 NOOPT ?= 0
-CLANG_IMAGE = quay.io/cilium/clang:b97f5b3d5c38da62fb009f21a53cd42aefd54a2f@sha256:e1c8ed0acd2e24ed05377f2861d8174af28e09bef3bbc79649c8eba165207df0
+CLANG_IMAGE = quay.io/cilium/clang:969f95f8ef7923af36bf657ba6d4c65691f56882@sha256:ff83e52d3ea150b3d93e4ae40ae86620003ac3f6d91fe6e939dcc95469f83ff2
 TESTER_PROGS_DIR = "contrib/tester-progs"
 # Extra flags to pass to test binary
 EXTRA_TESTFLAGS ?=

--- a/bpf/process/bpf_execve_event.h
+++ b/bpf/process/bpf_execve_event.h
@@ -116,9 +116,11 @@ FUNC_INLINE __u32 read_envs(void *ctx, struct msg_execve_event *event)
 	free_size = (char *)&event->process + BUFFER - envs;
 	envs_size = env_end - env_start;
 
-	if (envs_size < BUFFER && envs_size < free_size) {
-		if (envs_size)
-			envs_size -= 1;
+	if (envs_size < 2) {
+		/* envs contains at most a '\0', nothing to read */
+		size = 0;
+	} else if (envs_size < BUFFER && envs_size < free_size) {
+		envs_size -= 1; // strip trailing '\0'
 		size = envs_size & 0x3ff; /* BUFFER - 1 */
 
 		err = probe_read(envs, size, (char *)env_start);

--- a/bpf/process/string_maps.h
+++ b/bpf/process/string_maps.h
@@ -131,7 +131,7 @@ struct {
 #ifdef __LARGE_BPF_PROG
 #define STRING_POSTFIX_MAX_MATCH_LENGTH STRING_POSTFIX_MAX_LENGTH
 #else
-#define STRING_POSTFIX_MAX_MATCH_LENGTH 95
+#define STRING_POSTFIX_MAX_MATCH_LENGTH 88
 #endif
 
 struct string_postfix_lpm_trie {

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1050,11 +1050,20 @@ filter_file_type(struct selector_arg_filter *filter, struct string_buf *args)
 		return 0;
 
 	__u32 mode_off = args->len;
-	// Avoid unbounded access, needed on 4.19 only
-	asm volatile("%[mode_off] &= 0xfff;\n" : [mode_off] "+r"(mode_off));
+	char *mode_ptr = (char *)args;
+
+	/* Mask and add in one asm block so nothing can be scheduled between
+	 * them: clang > 20 otherwise spills the masked value and reloads it,
+	 * and pre-5.7 verifiers lose the range across the spill. The constant
+	 * part of the offset stays out of the mask so it cannot wrap it.
+	 */
+	asm volatile("%[mode_off] &= 0xfff;\n"
+		     "%[mode_ptr] += %[mode_off];\n"
+		     : [mode_off] "+r"(mode_off),
+		       [mode_ptr] "+r"(mode_ptr));
+
 	// Offset from args: args->len (path) + 4 (len field) + 4 (flags)
-	mode_off += sizeof(args->len) + sizeof(__u32);
-	memcpy(&mode, (char *)args + mode_off, sizeof(mode));
+	memcpy(&mode, mode_ptr + sizeof(args->len) + sizeof(__u32), sizeof(mode));
 
 	/* filter->value contains the target file type constants (e.g. S_IFREG,
 	 * S_IFIFO) written by the userspace agent from the fileTypeTable.

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -561,19 +561,21 @@ FUNC_INLINE bool has_max_data(unsigned long argm)
 
 FUNC_INLINE unsigned long get_arg_meta(int meta, struct msg_generic_kprobe *e)
 {
-	switch (meta & ARGM_INDEX_MASK) {
-	case 1:
-		return e->a0;
-	case 2:
-		return e->a1;
-	case 3:
-		return e->a2;
-	case 4:
-		return e->a3;
-	case 5:
-		return e->a4;
-	}
-	return 0;
+	int idx = meta & ARGM_INDEX_MASK;
+
+	if (idx < 1 || idx > MAX_POSSIBLE_ARGS)
+		return 0;
+
+	/* Mask after the decrement so the bound holds unconditionally:
+	 * clang > 20 copies the index before its own range check, and
+	 * pre-5.7 verifiers do not propagate the narrowed range to the
+	 * copy.
+	 */
+	idx -= 1;
+	asm volatile("%[idx] &= %[mask];\n"
+		     : [idx] "+r"(idx)
+		     : [mask] "i"(MAX_POSSIBLE_ARGS_MASK));
+	return (&e->a0)[idx];
 }
 
 FUNC_INLINE u16 string_padded_len(u16 len)


### PR DESCRIPTION
Relates: #5453

```release-note
build: bump clang image to clang-22
```

---

Complexity report diff can be found here https://github.com/cilium/tetragon/actions/runs/34188243560?pr=5583