### PR TITLE
tracing: reject enforcer actions for uprobes and usdts

### DIFF
--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -2036,6 +2036,21 @@ func HasNotifyEnforcerAction(selectors []v1alpha1.KProbeSelector) bool {
 	return false
 }
 
+// HasEnforcerAction returns true if any selector has an action that needs the
+// enforcer sensor. Unlike HasNotifyEnforcerAction it also covers
+// CleanupEnforcerNotification and matchReturnActions.
+func HasEnforcerAction(selectors []v1alpha1.KProbeSelector) bool {
+	for _, s := range selectors {
+		for _, action := range slices.Concat(s.MatchActions, s.MatchReturnActions) {
+			switch actionTypeTable[strings.ToLower(action.Action)] {
+			case ActionTypeNotifyEnforcer, ActionTypeCleanupEnforcerNotification:
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func HasRateLimit(selectors []v1alpha1.KProbeSelector) bool {
 	for _, selector := range selectors {
 		for _, matchAction := range selector.MatchActions {

--- a/pkg/selectors/kernel_test.go
+++ b/pkg/selectors/kernel_test.go
@@ -1639,3 +1639,19 @@ func TestParseCapabilityMask(t *testing.T) {
 	_, err = parseCapabilitiesMask("CAP_PIZZA")
 	assert.Error(t, err)
 }
+
+func TestHasEnforcerAction(t *testing.T) {
+	sel := func(a v1alpha1.ActionSelector) []v1alpha1.KProbeSelector {
+		return []v1alpha1.KProbeSelector{{MatchActions: []v1alpha1.ActionSelector{a}}}
+	}
+	for _, action := range []string{"NotifyEnforcer", "notifyEnforcer", "CleanupEnforcerNotification"} {
+		require.True(t, HasEnforcerAction(sel(v1alpha1.ActionSelector{Action: action})), action)
+	}
+	// matchReturnActions runs in the return program, which is outside the gate too
+	require.True(t, HasEnforcerAction([]v1alpha1.KProbeSelector{{
+		MatchReturnActions: []v1alpha1.ActionSelector{{Action: "NotifyEnforcer"}},
+	}}))
+	for _, action := range []string{"Sigkill", "Signal", "Post", "Override", "Set"} {
+		require.False(t, HasEnforcerAction(sel(v1alpha1.ActionSelector{Action: action})), action)
+	}
+}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -555,6 +555,10 @@ type uprobeArgConfig struct {
 }
 
 func validateUprobeSpec(spec *v1alpha1.UProbeSpec, state *uprobeConfigState) error {
+	if selectors.HasEnforcerAction(spec.Selectors) {
+		return errors.New("enforcer actions are not supported for uprobes")
+	}
+
 	state.symbols = len(spec.Symbols)
 	state.offsets = len(spec.Offsets)
 	state.addrs = len(spec.Addrs)

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -381,6 +381,10 @@ func addUsdt(spec *v1alpha1.UsdtSpec, in *addUsdtIn, ids []idtable.EntryID, has 
 		return ids, fmt.Errorf("failed to configure usdt '%s/%s', GetUrl and DnsLookup actions not supported", spec.Provider, spec.Name)
 	}
 
+	if selectors.HasEnforcerAction(spec.Selectors) {
+		return ids, fmt.Errorf("failed to configure usdt '%s/%s', enforcer actions are not supported", spec.Provider, spec.Name)
+	}
+
 	// Parse Filters into kernel filter logic
 	state, err = selectors.InitKernelSelectorState(&selectors.KernelSelectorArgs{
 		Selectors: spec.Selectors,

--- a/pkg/sensors/tracing/uprobe_validation_test.go
+++ b/pkg/sensors/tracing/uprobe_validation_test.go
@@ -19,3 +19,23 @@ func TestUprobeEventConfigCarriesPolicyID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint32(7), state.eventConfig.PolicyID)
 }
+
+// The enforcer actions are only implemented for kprobes and tracepoints, so
+// they have to be rejected here rather than silently do nothing.
+func TestUprobeValidationEnforcerAction(t *testing.T) {
+	err := checkCrd(t, `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "uprobe-notify-enforcer"
+spec:
+  uprobes:
+  - path: "/proc/self/exe"
+    symbols: ["main"]
+    selectors:
+    - matchActions:
+      - action: NotifyEnforcer
+`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "enforcer actions are not supported")
+}

--- a/pkg/sensors/tracing/usdt_validation_test.go
+++ b/pkg/sensors/tracing/usdt_validation_test.go
@@ -145,3 +145,25 @@ func TestUsdtEventConfigCarriesPolicyID(t *testing.T) {
 		require.Equal(t, uint32(7), usdtEntry.config.PolicyID)
 	}
 }
+
+// The enforcer actions are only implemented for kprobes and tracepoints, so
+// they have to be rejected here rather than silently do nothing.
+func TestUsdtValidationEnforcerAction(t *testing.T) {
+	usdt := testutils.RepoRootPath("contrib/tester-progs/usdt-override")
+	err := checkCrd(t, `
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: "usdt-notify-enforcer"
+spec:
+  usdts:
+  - path: "`+usdt+`"
+    provider: "tetragon"
+    name: "test_1B"
+    selectors:
+    - matchActions:
+      - action: NotifyEnforcer
+`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "enforcer actions are not supported")
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->



### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
`NotifyEnforcer` on a uprobe or usdt is accepted and loads fine, but never kills anything:

```
apiVersion: cilium.io/v1alpha1
kind: TracingPolicy
metadata:
  name: "kill-on-readline"
spec:
  enforcers:
  - calls:
    - "sys_write"
  uprobes:
  - path: "/bin/bash"
    symbols:
    - "readline"
    selectors:
    - matchActions:
      - action: NotifyEnforcer
```
the `notify_enforcer` counter goes up on every hit and the event carries the action, so it looks like it works. Nothing is ever killed.

It's a no-op twice over. `do_action_notify_enforcer()` is only compiled for `GENERIC_KPROBE` and `GENERIC_TRACEPOINT`, everything else gets an empty macro. And uprobe/usdt never bind the enforcer maps, so widening the gate wouldn't help either. Hence a rejection, like LSM already does, rather than a feature.

Confirmed with `llvm-objdump`: kprobe and tracepoint objects carry 14 enforcer_data relocations, uprobe and usdt carry 8. Putting them in the gate brings both to 14, so the missing 6 are exactly the notify body.

The check runs before the binary is opened, so you get the real reason:

```
NotifyEnforcer action is not supported for uprobes
```
instead of an ELF error that says nothing about the action.




### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
Reject NotifyEnforcer and CleanupEnforcerNotification actions on uprobes and usdts. They were accepted but silently did nothing.
```
