### PR TITLE
Actions are deployed as directories, must renovate deeper

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -524,7 +524,7 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github/workflows/[^/]+\\.ya?ml$/",
-        "/^\\.github/actions/[^/]+\\.ya?ml$/",
+        "/^\\.github/actions/[^/]+/[^/]+\\.ya?ml$/",
         "docs/hugo.toml",
       ],
       "matchStrings": [


### PR DESCRIPTION
Actions are deployed as directories, regex must traverse at least one directory deeper.

Followup to #5575

cc: @mtardy 