### PR TITLE
new(ci): run policytest as part of the tarball-tests CI.

### DIFF
--- a/.github/actions/build-tarball/action.yml
+++ b/.github/actions/build-tarball/action.yml
@@ -20,6 +20,20 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y jq
+        sudo apt-get install -y libelf-dev netcat-traditional libcap-dev gcc pahole llvm
+        echo `which clang`
+        echo `which llc`
+        echo `clang --version`
+
+    - name: Install dependencies x86
+      shell: bash
+      run: sudo apt-get -y install libc6-dev-i386
+      if: runner.arch != 'ARM64'
+
+    - name: Install dependencies ARM
+      shell: bash
+      run: sudo apt-get -y install gcc-arm-linux-gnueabihf
+      if: runner.arch == 'ARM64'
 
     - name: Getting version tag
       id: tag
@@ -31,3 +45,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: make tarball
+
+    - name: Generate tester-progs tarball
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: make tester-progs-tarball

--- a/.github/workflows/tarball-tests.yaml
+++ b/.github/workflows/tarball-tests.yaml
@@ -44,7 +44,9 @@ jobs:
   standalone-tarball-tests:
     name: Packages e2e tests (${{ matrix.arch }})
     needs: [standalone-tarball-builds]
-    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-22.04-arm') || 'ubuntu-22.04' }}
+    # Ships kernel >= 7.x to test as many policytest cases as possible.
+    # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Readme.md
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-26.04-arm') || 'ubuntu-26.04' }}
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -133,6 +135,40 @@ jobs:
             sudo grep "tetra" /var/log/tetragon/tetragon.log
             sudo tetra tracingpolicy list | grep bpf -
             sudo tetra bugtool 2>&1 | grep "Successfully dumped gops pprof.*profile=heap" -
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libelf-dev netcat-traditional libcap-dev gcc pahole llvm
+
+      - name: Install dependencies x86
+        run: |
+          sudo apt-get -y install libc6-dev-i386
+        if: matrix.arch != 'arm64'
+
+      - name: Install dependencies ARM
+        run: |
+          sudo apt-get -y install gcc-arm-linux-gnueabihf
+        if: matrix.arch == 'arm64'
+
+      # Run policytest
+      # Since we don't support vmtests yet for arm64,
+      # and we are slowly moving existing tests to use policytest framework
+      # we are losing arm64 coverage unless we run policytest
+      # at least on github runners.
+      - name: Run policytest
+        run: |
+          make tester-progs
+          sudo tetra policytest run --all-tests --output-file /tmp/tetragon.policytest.txt
+          cat /tmp/tetragon.policytest.txt
+
+      - name: Upload policytest results
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tetragon-policytest-${{ matrix.arch }}
+          path: /tmp/tetragon.policytest.txt
+          retention-days: 5
 
       - name: Uninstall Tetragon Tarball
         run: |

--- a/.github/workflows/tarball-tests.yaml
+++ b/.github/workflows/tarball-tests.yaml
@@ -29,7 +29,7 @@ jobs:
         id: tarball
         uses: ./.github/actions/build-tarball
 
-      - name: Move tarball to upload directory
+      - name: Move Tetragon tarball to upload directory
         run: |
           mkdir upload/
           mv ./build/${{ matrix.arch }}/linux-tarball/tetragon-${{ steps.tarball.outputs.tag }}-${{ matrix.arch }}.tar.gz ./upload/
@@ -39,6 +39,13 @@ jobs:
         with:
           name: tetragon-${{ steps.tarball.outputs.tag }}-${{ matrix.arch }}
           path: upload/
+          retention-days: 1
+
+      - name: Save tetragon-${{ steps.tarball.outputs.tag }}-${{ matrix.arch }}-tester-progs.tar.gz Tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tetragon-${{ steps.tarball.outputs.tag }}-${{ matrix.arch }}-tester-progs
+          path: tester-progs.tar.gz
           retention-days: 1
 
   standalone-tarball-tests:
@@ -136,20 +143,16 @@ jobs:
             sudo tetra tracingpolicy list | grep bpf -
             sudo tetra bugtool 2>&1 | grep "Successfully dumped gops pprof.*profile=heap" -
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libelf-dev netcat-traditional libcap-dev gcc pahole llvm
+      - name: Retrieve tetragon-${{ needs.standalone-tarball-builds.outputs.tag }}-${{ matrix.arch }}-tester-progs.tar.gz
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tetragon-${{ needs.standalone-tarball-builds.outputs.tag }}-${{ matrix.arch }}-tester-progs
+          path: ./download
 
-      - name: Install dependencies x86
+      - name: Prepare tester-progs
         run: |
-          sudo apt-get -y install libc6-dev-i386
-        if: matrix.arch != 'arm64'
-
-      - name: Install dependencies ARM
-        run: |
-          sudo apt-get -y install gcc-arm-linux-gnueabihf
-        if: matrix.arch == 'arm64'
+          tar zxvf ./download/tester-progs.tar.gz
+          mv ./tester-progs/* contrib/tester-progs/
 
       # Run policytest
       # Since we don't support vmtests yet for arm64,
@@ -158,7 +161,6 @@ jobs:
       # at least on github runners.
       - name: Run policytest
         run: |
-          make tester-progs
           sudo tetra policytest run --all-tests --output-file /tmp/tetragon.policytest.txt
           cat /tmp/tetragon.policytest.txt
 

--- a/.github/workflows/vmpolicytests.yaml
+++ b/.github/workflows/vmpolicytests.yaml
@@ -28,21 +28,12 @@ jobs:
           # renovate: datasource=golang-version depName=go
           go-version: '1.27.1'
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libelf-dev netcat-traditional libcap-dev gcc libc6-dev-i386 pahole llvm
-          echo `which clang`
-          echo `which llc`
-          echo `clang --version`
-
-      - name: Build tester progs and vmtests
+      - name: Build vmtests
         env:
           GOPATH: /home/runner/work/tetragon/tetragon/go
         run: |
           cd go/src/github.com/cilium/tetragon/
           make -C tests/vmtests
-          make tester-progs-tarball
 
       - name: Tar build
         run: |
@@ -131,6 +122,12 @@ jobs:
           dest="go/src/github.com/cilium/tetragon/build/amd64/linux-tarball"
           mkdir -p "$dest"
           mv ./tarball-download/tetragon-${{ inputs.tag }}-amd64.tar.gz "$dest/"
+
+      - name: Download amd64 tester-progs tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tetragon-${{ inputs.tag }}-amd64-tester-progs
+          path: go/src/github.com/cilium/tetragon/
 
       - name: Test kernel ${{ matrix.kernel }}
         if: ${{ !startsWith(matrix.kernel, '4.19') }}


### PR DESCRIPTION
### Description
Since we don't support vmtests for arm64 yet, and we are slowly moving existing tests to use policytest framework, we are losing arm64 coverage unless we run policytest at least on github runners.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
new(ci): run policytest as part of the tarball-tests CI.
```
