### PR TITLE
Bugs: Small fixes from clang analyze

### DIFF
--- a/bpf/lib/bpf_cgroup.h
+++ b/bpf/lib/bpf_cgroup.h
@@ -353,7 +353,7 @@ __tg_get_current_cgroup_id(struct cgroup *cgrp, __u64 cgrpfs_ver)
  */
 FUNC_INLINE __u64 tg_get_current_cgroup_id(void)
 {
-	__u32 error_flags;
+	__u32 error_flags = 0;
 	struct cgroup *cgrp;
 	__u64 cgrpfs_magic = 0;
 	struct task_struct *task;

--- a/bpf/process/user_preload.h
+++ b/bpf/process/user_preload.h
@@ -124,6 +124,9 @@ preload_arg(struct pt_regs *ctx, struct event_config *config, int index)
 	case 4:
 		a = PT_REGS_PARM5_CORE(ctx);
 		break;
+	default:
+		// This can't happen, but it keeps clang analyzer happier.
+		a = 0;
 	}
 #endif
 


### PR DESCRIPTION
### Description
While applying `clang --analyze` I discovered two issues. The first is not a bug, but it prevents clang from analyzing properly. The second is an uninitialised variable that is used and assumed to be 0. This PR fixes both.
