### PR TITLE
bpf: write retprobe error before the map calls in copy_char_buf/iovec

### DIFF
--- a/bpf/process/generic_calls.h
+++ b/bpf/process/generic_calls.h
@@ -135,10 +135,15 @@ copy_char_buf(void *ctx, long off, unsigned long arg, int argm,
 	int *s = (int *)args_off(e, off);
 
 	if (has_return_copy(argm)) {
+		/* Write the error before the calls below. Otherwise clang
+		 * computes 's' only after them, which means keeping the offset
+		 * on the stack across the calls.
+		 */
+		int ret = return_error(s, char_buf_saved_for_retprobe);
 		__u64 retid = retprobe_map_get_key(ctx);
 
 		retprobe_map_set(e->func_id, retid, e->common.ktime, arg);
-		return return_error(s, char_buf_saved_for_retprobe);
+		return ret;
 	}
 	return __copy_char_buf(ctx, off, arg, get_arg_meta(argm, e), has_max_data(argm), e);
 }

--- a/bpf/process/types/basic.h
+++ b/bpf/process/types/basic.h
@@ -1367,10 +1367,11 @@ copy_char_iovec(void *ctx, long off, unsigned long arg, int argm,
 	meta = get_arg_meta(argm, e);
 
 	if (has_return_copy(argm)) {
+		int ret = return_error(s, char_buf_saved_for_retprobe);
 		u64 retid = retprobe_map_get_key(ctx);
 
 		retprobe_map_set_iovec(e->func_id, retid, e->common.ktime, arg, meta);
-		return return_error(s, char_buf_saved_for_retprobe);
+		return ret;
 	}
 	return __copy_char_iovec(off, arg, meta, 0, e);
 }


### PR DESCRIPTION
### Description

In the has_return_copy() branch the only use of the args_off() pointer was the final store, so clang computed the pointer after retprobe_map_get_key() and retprobe_map_set(), keeping the offset on the stack across them. Kernels before 5.5 lose the bounds of a stack-saved offset, so the verifier rejected the access with:

```
  math between map_value pointer and register with unbounded min value is not allowed
```

This commits stores before the calls to keep the pointer arithmetic where the offset is still bounded. The behavior should not change.

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

