### PR TITLE
lint: enable wsl_5 to enforce whitespace rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,7 @@ linters:
       default: none
       enable:
         - err
+        - leading-whitespace
     gomodguard:
       blocked:
         modules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - staticcheck
     - testifylint
     - unused
+    - wsl_v5
   settings:
     dupword:
       keywords:
@@ -59,6 +60,10 @@ linters:
       template: |-
         SPDX-License-Identifier: Apache-2.0
         Copyright Authors of {{ PROJECT }}
+    wsl_v5:
+      default: none
+      enable:
+        - err
     gomodguard:
       blocked:
         modules:

--- a/Makefile
+++ b/Makefile
@@ -255,14 +255,15 @@ tester-progs-tarball: tester-progs
 GOLANGCILINT_IMAGE=docker.io/golangci/golangci-lint:v2.13.1@sha256:d371321370bf2907bd13a8f6f8baff0e0ca7438d76fdf636b281eadf7e2305e3
 GOLANGCILINT_WANT_VERSION := $(subst @sha256,,$(patsubst v%,%,$(word 2,$(subst :, ,$(lastword $(subst /, ,$(GOLANGCILINT_IMAGE)))))))
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
-.PHONY: check
 ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION),$(GOLANGCILINT_VERSION)))
-check: ## Run Go linters.
-	golangci-lint run
+GOLANGCILINT_BIN = golangci-lint
 else
-check:
-	$(CONTAINER_ENGINE) run --rm -v `pwd`:/app:Z -w /app --env GOTOOLCHAIN=auto $(GOLANGCILINT_IMAGE) golangci-lint run
+GOLANGCILINT_BIN = $(CONTAINER_ENGINE) run --rm -v `pwd`:/app:Z -w /app --env GOTOOLCHAIN=auto $(GOLANGCILINT_IMAGE) golangci-lint
 endif
+
+.PHONY: check
+check: ## Run Go linters.
+	$(GOLANGCILINT_BIN) run
 
 .PHONY: copy-golangci-lint
 copy-golangci-lint:
@@ -521,6 +522,7 @@ go-format: ## Run code formatter on Go code.
 	-not -path '**/zz_generated.deepcopy.go' | \
 	  xargs realpath | \
 	  xargs $(GO) -C tools tool goimports -local github.com/cilium/tetragon,github.com/cilium/tetragon/api,github.com/cilium/tetragon/pkg/k8s,github.com/cilium/tetragon/tools -w
+	$(GOLANGCILINT_BIN) run --fix --enable-only wsl_v5
 
 .PHONY: format
 format: go-format clang-format ## Convenience alias for clang-format and go-format.

--- a/cmd/tetra/cgtracker/cgtracker_windows.go
+++ b/cmd/tetra/cgtracker/cgtracker_windows.go
@@ -24,11 +24,9 @@ func New() *cobra.Command {
 }
 
 func dumpCmd() *cobra.Command {
-
 	return nil
 }
 
 func addCommand() *cobra.Command {
-
 	return nil
 }

--- a/cmd/tetra/common/flags.go
+++ b/cmd/tetra/common/flags.go
@@ -62,7 +62,6 @@ func readActiveServerAddressFromFile(fname string) (string, error) {
 func ResolveServerAddress() string {
 	if ServerAddress == "" {
 		sa, err := readActiveServerAddressFromFile(defaults.InitInfoFile)
-
 		if err != nil {
 			logger.GetLogger().
 				Debug("failed to resolve server address reading init info file, using default value",

--- a/cmd/tetra/tracingpolicy/generate/generate.go
+++ b/cmd/tetra/tracingpolicy/generate/generate.go
@@ -22,7 +22,6 @@ import (
 )
 
 func New() *cobra.Command {
-
 	var matchBinary string
 	addSelectors := func(kprobe *v1alpha1.KProbeSpec) {
 		if matchBinary != "" {

--- a/cmd/tetragon-vmtests-run/image.go
+++ b/cmd/tetragon-vmtests-run/image.go
@@ -26,7 +26,6 @@ var (
 )
 
 func buildFilesystemActions(fs []QemuFS, tmpDir string) ([]images.Action, error) {
-
 	actions := make([]images.Action, 0, len(fs)+1)
 
 	var b bytes.Buffer
@@ -216,7 +215,6 @@ func (rc *NoNetworkCommand) ToSteps(s *images.StepConf) ([]step.Step, error) {
 }
 
 func buildTestImage(log slogger.Logger, rcnf *GoTestConf) error {
-
 	imagesDir, baseImage := filepath.Split(rcnf.baseImageFilename)
 
 	tmpDir, err := os.MkdirTemp("", "tetragon-vmtests-")

--- a/cmd/tetragon-vmtests-run/run_tests.go
+++ b/cmd/tetragon-vmtests-run/run_tests.go
@@ -32,7 +32,6 @@ type runTestsResults struct {
 func runGoTests(
 	rcnf *GoTestConf, qemuBin string, qemuArgs []string,
 ) (*runTestsResults, error) {
-
 	ctx := context.Background()
 	ctx, cancel := signal.NotifyContext(ctx, unix.SIGINT, unix.SIGTERM)
 	defer cancel()
@@ -114,7 +113,6 @@ type TestEvent struct {
 }
 
 func updateResultsDetailed(w io.Writer, res *vmtests.Result, out *runTestsResults) {
-
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/cmd/tetragon/conf_test.go
+++ b/cmd/tetragon/conf_test.go
@@ -1039,7 +1039,6 @@ func writeDropInConf(fullDir string, options map[string]any) error {
 }
 
 func setupConfig(testPath string, test testCase) error {
-
 	// Patch expected config-dir path with test path prefix
 	c := testCases[globalTestIndex]
 	val, ok := c.expectedOptions["config-dir"]

--- a/operator/podinfo/podinfo_controller_test.go
+++ b/operator/podinfo/podinfo_controller_test.go
@@ -155,7 +155,6 @@ func TestGeneratePod(t *testing.T) {
 // TestHasAllRequiredFields checks if a pod is ready or not.
 func TestHasAllRequiredFields(t *testing.T) {
 	t.Run("Check if all the necessary fields of pod are available", func(t *testing.T) {
-
 		// test ready pod.
 		t.Run("All fields available", func(*testing.T) {
 			pod := randomPodGenerator()

--- a/pkg/bpf/detect_linux.go
+++ b/pkg/bpf/detect_linux.go
@@ -669,7 +669,6 @@ func detectKfunc(name string) bool {
 }
 
 func HasKfunc(name string) bool {
-
 	// If we are using an external BTF file, the loader might poison the kfunc calls,
 	// even if the kernel supports them.
 	// The kfunc fixup logic in the loader ignores the BTF file that tetragon passes

--- a/pkg/bugtool/bugtool_test.go
+++ b/pkg/bugtool/bugtool_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestSaveAndLoad(t *testing.T) {
-
 	tmpFile, err := os.CreateTemp(t.TempDir(), "tetragon-bugtool-test-")
 	if err != nil {
 		t.Error("failed to create temporary file")

--- a/pkg/bugtool/multilog_test.go
+++ b/pkg/bugtool/multilog_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestMultiLog(t *testing.T) {
-
 	removeTimestamp := func(_ []string, a slog.Attr) slog.Attr {
 		if a.Key == slog.TimeKey {
 			return slog.Attr{} // Remove the "time" key

--- a/pkg/celbpf/cel_fuzz_test.go
+++ b/pkg/celbpf/cel_fuzz_test.go
@@ -115,7 +115,6 @@ func (st *randExprSt) celNullaryExpr(ty *cgTypes.Type) string {
 
 // Some of the types here are parametric, so make them concrete
 func concretizeArgs(r *rand.Rand, tys []*cgTypes.Type) []*cgTypes.Type {
-
 	allTys := []*cgTypes.Type{cgTypes.BoolType}
 	for _, ity := range intTypes {
 		allTys = append(allTys, ity.ty)

--- a/pkg/celbpf/codegen.go
+++ b/pkg/celbpf/codegen.go
@@ -102,7 +102,6 @@ func (g *codeGenerator) emitPopU32(reg asm.Register) {
 }
 
 func (g *codeGenerator) emitU32(reg asm.Register, regTy *cgTypes.Type) error {
-
 	switch regTy {
 	case u64Ty:
 	default:
@@ -247,7 +246,6 @@ func (g *codeGenerator) emitBranch(
 	op string,
 	tmp asm.Register,
 ) error {
-
 	var signed bool
 	var alu32 bool
 	switch {

--- a/pkg/celbpf/compiler.go
+++ b/pkg/celbpf/compiler.go
@@ -59,7 +59,6 @@ func (c *compiler) compileLiteral(lit cgRef.Val) error {
 }
 
 func (c *compiler) compileCall(expr cgAst.Expr) error {
-
 	call := expr.AsCall()
 
 	callArgs := call.Args()

--- a/pkg/celbpf/env.go
+++ b/pkg/celbpf/env.go
@@ -107,7 +107,6 @@ func getFnsOpts() []fnOpts {
 }
 
 func checkerAddFunctions(env *cgChecker.Env) error {
-
 	fnsOpts := getFnsOpts()
 	fns := make([]*cgDecls.FunctionDecl, 0, len(fnsOpts))
 	for _, fnOpts := range fnsOpts {

--- a/pkg/certloader/integration_test.go
+++ b/pkg/certloader/integration_test.go
@@ -187,7 +187,6 @@ func TestServerOnlyTLSRejectsPlaintextClient(t *testing.T) {
 // that do not yet exist, the watcher observes their CREATE, and handshakes
 // start succeeding without a server restart.
 func TestLazyReloaderRecoversWhenFilesAppear(t *testing.T) {
-
 	mountDir := t.TempDir()
 	certPath := filepath.Join(mountDir, "tls.crt")
 	keyPath := filepath.Join(mountDir, "tls.key")

--- a/pkg/cgrouprate/cgrouprate.go
+++ b/pkg/cgrouprate/cgrouprate.go
@@ -81,7 +81,6 @@ func newCgroupRate(
 	listener observer.Listener,
 	hash *program.Map,
 	opts *option.CgroupRate) *CgroupRate {
-
 	return &CgroupRate{
 		listener: listener,
 		log:      logger.GetLogger(),
@@ -95,7 +94,6 @@ func newCgroupRate(
 func NewCgroupRate(ctx context.Context,
 	listener observer.Listener,
 	opts *option.CgroupRate) error {
-
 	if opts.Events == 0 || opts.Interval == 0 {
 		logger.GetLogger().Info(fmt.Sprintf("Cgroup rate disabled (%d/%s)", opts.Events, time.Duration(opts.Interval).String()))
 		return nil
@@ -115,7 +113,6 @@ func NewCgroupRate(ctx context.Context,
 func NewTestCgroupRate(listener observer.Listener,
 	hash *program.Map,
 	opts *option.CgroupRate) {
-
 	glSt.handle = newCgroupRate(listener, hash, opts)
 }
 

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -798,7 +798,6 @@ func CgroupIDFromPID(pid uint32) (uint64, error) {
 // This function deals with this by checking for a child directory. If it finds one (and only one)
 // it uses the cgroup id from the child.
 func GetCgroupIDFromSubCgroup(p string) (uint64, error) {
-
 	getSingleDirChild := func() string {
 		var ret string
 		dentries, err := os.ReadDir(p)

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -126,7 +126,6 @@ perf_event	8	2	1
 }
 
 func TestParseCgroupSubSysIds(t *testing.T) {
-
 	testDir := t.TempDir()
 
 	d := struct {

--- a/pkg/cgroups/cgroups_windows.go
+++ b/pkg/cgroups/cgroups_windows.go
@@ -61,6 +61,5 @@ func CgroupIDFromPID(_ uint32) (uint64, error) {
 }
 
 func GetCgroupIDFromSubCgroup(_ string) (uint64, error) {
-
 	return 0, constants.ErrWindowsNotSupported
 }

--- a/pkg/cgtracker/cgtracker.go
+++ b/pkg/cgtracker/cgtracker.go
@@ -122,7 +122,6 @@ func (m *Map) AddCgroupTrackerPath(trackerPath string) error {
 }
 
 func RegisterCgroupTracker(sensor *sensors.Sensor) (*sensors.Sensor, error) {
-
 	if !option.Config.EnableCgTrackerID {
 		return sensor, nil
 	}

--- a/pkg/checkprocfs/checkprocfs.go
+++ b/pkg/checkprocfs/checkprocfs.go
@@ -16,7 +16,6 @@ import (
 
 // Check tries to determine whether the configured procfs is the host's procfs
 func Check() {
-
 	path := filepath.Join(option.Config.ProcFS, "1", "ns", "pid")
 	var stat syscall.Stat_t
 	if err := syscall.Stat(path, &stat); err != nil {

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -46,7 +46,6 @@ func NewClient(ctx context.Context, endpoint string) (criapi.RuntimeServiceClien
 }
 
 func newClientTry(ctx context.Context, endpoint string) (criapi.RuntimeServiceClient, error) {
-
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err

--- a/pkg/dump/processcache_test.go
+++ b/pkg/dump/processcache_test.go
@@ -46,8 +46,8 @@ func TestProcessCache(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		processes, err := GetProcessCacheForDump(ctx, mockClient, 4194304, false, false)
 
+		processes, err := GetProcessCacheForDump(ctx, mockClient, 4194304, false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -69,8 +69,8 @@ func TestProcessCache(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		_, err := GetProcessCacheForDump(ctx, mockClient, 4194304, false, false)
 
+		_, err := GetProcessCacheForDump(ctx, mockClient, 4194304, false, false)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -90,8 +90,8 @@ func TestProcessCache(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		_, err := GetProcessCacheForDump(ctx, mockClient, 4194304, false, false)
 
+		_, err := GetProcessCacheForDump(ctx, mockClient, 4194304, false, false)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}

--- a/pkg/errmetrics/map.go
+++ b/pkg/errmetrics/map.go
@@ -22,7 +22,6 @@ func OpenMap(fname string) (Map, error) {
 	m, err := ebpf.LoadPinnedMap(fname, &ebpf.LoadPinOptions{
 		ReadOnly: true,
 	})
-
 	if err != nil {
 		return Map{}, err
 	}

--- a/pkg/kernels/kernels_windows.go
+++ b/pkg/kernels/kernels_windows.go
@@ -17,7 +17,6 @@ func GetKernelVersion(kernelVersion, procfs string) (int, string, error) {
 		version = int(KernelStringToNumeric(kernelVersion))
 		verStr = kernelVersion
 	} else {
-
 		var mod = syscall.NewLazyDLL("ntdll.dll")
 		var proc = mod.NewProc("RtlGetVersion")
 
@@ -52,7 +51,6 @@ func GenericKprobeObjs() (string, string) {
 }
 
 func MinKernelVersion(kernel string) bool {
-
 	runningVersion, _, _ := GetKernelVersion("", "")
 
 	minVersion := int(KernelStringToNumeric(kernel))

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -121,7 +121,6 @@ func SelectorFromLabelSelector(ls *slimv1.LabelSelector) (Selector, error) {
 
 // Cmp checks if the labels are different. Returns true if they are.
 func (l Labels) Cmp(a Labels) bool {
-
 	if len(l) != len(a) {
 		return true
 	}

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -195,7 +195,6 @@ type testCmp struct {
 }
 
 func TestCmp(t *testing.T) {
-
 	cases := []testCmp{
 		{l1: map[string]string{}, l2: map[string]string{}, expected: false},
 		{l1: map[string]string{"label1": "a"}, l2: map[string]string{}, expected: true},

--- a/pkg/logger/klog_bridge.go
+++ b/pkg/logger/klog_bridge.go
@@ -133,7 +133,6 @@ func writerScanner(
 	reader *io.PipeReader,
 	defaultPrintFunc func(msg string, args ...any),
 	overrides []logLevelOverride) {
-
 	defer reader.Close()
 
 	scanner := bufio.NewScanner(reader)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -428,7 +428,6 @@ func (cm *ControllerManager) FindMirrorPod(hash string) (*corev1.Pod, error) {
 //   - *ControllerManager: The created controller manager instance, or nil on failure.
 //   - error: An error if the controller manager could not be created or api_server connectivity failed.
 func newControllerManagerWithRetry(ctx context.Context, cfg *rest.Config, controllerOptions ctrl.Options) (cm *ControllerManager, err error) {
-
 	retryCount := conf.K8sConfigRetry()
 	if retryCount < 0 {
 		// max int retries, until connection succeeds.

--- a/pkg/metrics/enforcermetrics/enforcermetrics.go
+++ b/pkg/metrics/enforcermetrics/enforcermetrics.go
@@ -43,7 +43,6 @@ type state struct {
 }
 
 func newState() *state {
-
 	st := &state{
 		policies: map[string]map[uint32]func(arg uint32) string{},
 	}

--- a/pkg/observer/observer_linux.go
+++ b/pkg/observer/observer_linux.go
@@ -77,8 +77,8 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 	defer perfMap.Close()
 
 	rbSize := k.getRBSize(int(perfMap.MaxEntries()))
-	perfReader, err := perf.NewReader(perfMap, rbSize)
 
+	perfReader, err := perf.NewReader(perfMap, rbSize)
 	if err != nil {
 		return fmt.Errorf("creating perf array reader failed: %w", err)
 	}
@@ -93,7 +93,6 @@ func (k *Observer) RunEvents(stopCtx context.Context, ready func()) error {
 		defer ringBufMap.Close()
 
 		ringBufReader, err = ringbuf.NewReader(ringBufMap)
-
 		if err != nil {
 			return fmt.Errorf("creating ring buffer reader failed: %w", err)
 		}

--- a/pkg/observer/observer_windows.go
+++ b/pkg/observer/observer_windows.go
@@ -25,8 +25,8 @@ func (observer *Observer) RunEvents(stopCtx context.Context, ready func()) error
 	ringBufMap := coll.Maps["process_ringbuf"]
 	defer ringBufMap.Close()
 	var ringBufReader *ringbuf.Reader
-	ringBufReader, err := ringbuf.NewReader(ringBufMap)
 
+	ringBufReader, err := ringbuf.NewReader(ringBufMap)
 	if err != nil {
 		return fmt.Errorf("creating ring buffer reader failed: %w", err)
 	}

--- a/pkg/observer/observertesthelper/observer_test_helper.go
+++ b/pkg/observer/observertesthelper/observer_test_helper.go
@@ -439,7 +439,6 @@ func loadExporter(tb testing.TB, ctx context.Context, obs *observer.Observer, op
 
 func loadObserver(tb testing.TB, ctx context.Context, base *sensors.Sensor,
 	tp tracingpolicy.TracingPolicy) error {
-
 	if err := base.Load(option.Config.BpfDir); err != nil {
 		tb.Fatalf("Load base error: %s\n", err)
 	}
@@ -522,7 +521,6 @@ func WaitForProcess(process string) error {
 	procDir, _ := os.ReadDir(procfs)
 	for range 120 {
 		for _, d := range procDir {
-
 			cmdline, err := os.ReadFile(filepath.Join(procfs, d.Name(), "/cmdline"))
 			if err != nil {
 				continue

--- a/pkg/pidfile/pid_alive_windows.go
+++ b/pkg/pidfile/pid_alive_windows.go
@@ -22,7 +22,6 @@ func IsPidAliveByHandle(hProc windows.Handle) bool {
 	return exitCode == 259
 }
 func IsPidAlive(pid int32) bool {
-
 	if (pid == 4) || (pid == 0) {
 		return true // pid 0(kernel) and 4(system) are always alive
 	}

--- a/pkg/policyfilter/map_test.go
+++ b/pkg/policyfilter/map_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func requirePfmEqualTo(t *testing.T, m PfMap, val map[uint64][]uint64) {
-
 	checkVals := map[PolicyID]map[CgroupID]struct{}{}
 	for k, ids := range val {
 		checkVals[PolicyID(k)] = map[CgroupID]struct{}{}

--- a/pkg/policyfilter/state.go
+++ b/pkg/policyfilter/state.go
@@ -453,7 +453,6 @@ func (m *state) AddPolicy(polID PolicyID, namespace string, podLabelSelector *sl
 
 // DelPolicy will destroy all information for the provided policy
 func (m *state) DelPolicy(polID PolicyID) error {
-
 	if polID == NoFilterPolicyID || polID == AllPodsPolicyID {
 		return nil
 	}
@@ -637,7 +636,6 @@ func (m *state) AddPodContainer(podID PodID, namespace string, podLabels labels.
 // delPodCgroupIDsFromPolicyMaps will delete cgorup entries for containers belonging to pod on all
 // policy maps.
 func (m *state) delPodCgroupIDsFromPolicyMaps(pod *podInfo, containers []containerInfo) {
-
 	if len(containers) == 0 {
 		return
 	}
@@ -798,7 +796,6 @@ func (m *state) applyPodPolicyDiff(pod *podInfo, polDiff *policiesDiffRes) {
 }
 
 func (pod *podInfo) containerDiff(newContainerIDs []string) ([]string, []string) {
-
 	// maintain a hash of new ids. The values indicate whether the id was seen in existing ids
 	// or not
 	newIDs := make(map[string]bool)

--- a/pkg/reader/network/inet.go
+++ b/pkg/reader/network/inet.go
@@ -9,7 +9,6 @@ import (
 )
 
 func InetFamily(family uint16) string {
-
 	if f, ok := inetFamily[family]; ok {
 		return f
 	}

--- a/pkg/reader/proc/proc_windows.go
+++ b/pkg/reader/proc/proc_windows.go
@@ -43,7 +43,6 @@ func getIDFromSID(strSID string) (string, error) {
 }
 
 func getStrLuidFromToken(token windows.Token) (string, error) {
-
 	var size uint32
 	err := windows.GetTokenInformation(token, windows.TokenStatistics, nil, 0, &size)
 	if !errors.Is(err, syscall.ERROR_INSUFFICIENT_BUFFER) {
@@ -114,7 +113,6 @@ func getTokenInfo(t syscall.Token, class uint32, initSize int) (unsafe.Pointer, 
 }
 
 func fillLoginUid(hProc windows.Handle, status *Status) error {
-
 	var token syscall.Token
 	err := syscall.OpenProcessToken(syscall.Handle(hProc), syscall.TOKEN_QUERY, &token)
 	if err != nil {

--- a/pkg/selectors/celexpr.go
+++ b/pkg/selectors/celexpr.go
@@ -33,7 +33,6 @@ func addMatchCelExpr(
 	arg *v1alpha1.ArgSelector,
 	sig, data []v1alpha1.KProbeArg,
 ) ([]uint16, error) {
-
 	if len(arg.Values) != 1 {
 		return nil, errors.New("addMatchCelExpr: only a single CelExpr value is supported")
 	}

--- a/pkg/selectors/kernel.go
+++ b/pkg/selectors/kernel.go
@@ -685,7 +685,6 @@ func writeMatchValues(k *KernelSelectorState, values []string, ty, op uint32) er
 
 	for _, v := range values {
 		switch ty {
-
 		case gt.GenericIntType, gt.GenericS32Type, gt.GenericSizeType, gt.GenericS16Type, gt.GenericS8Type:
 			if (ty == gt.GenericS16Type || ty == gt.GenericS8Type) && !config.EnableLargeProgs() {
 				return fmt.Errorf("MatchArgs type %s is only supported in kernels supporting large programs (normally versions >= 5.3)", gt.GenericTypeString(int(ty)))
@@ -1818,7 +1817,6 @@ func createKernelSelectorState(
 }
 
 func InitKernelSelectorState(args *KernelSelectorArgs) (*KernelSelectorState, error) {
-
 	parse := func(k *KernelSelectorState, selector *v1alpha1.KProbeSelector, selIdx int) error {
 		if err := ParseMatchPids(k, selector.MatchPIDs); err != nil {
 			return fmt.Errorf("parseMatchPids error: %w", err)
@@ -1861,7 +1859,6 @@ func InitKernelSelectorState(args *KernelSelectorArgs) (*KernelSelectorState, er
 
 func InitKernelReturnSelectorState(selectors []v1alpha1.KProbeSelector, returnArg *v1alpha1.KProbeArg,
 	actionArgTable *idtable.Table, listReader ValueReader, maps *KernelSelectorMaps) (*KernelSelectorState, error) {
-
 	parse := func(k *KernelSelectorState, selector *v1alpha1.KProbeSelector, selIdx int) error {
 		if err := ParseMatchCmdArgs(k, nil); err != nil {
 			return fmt.Errorf("parseMatchCmdArgs error: %w", err)

--- a/pkg/selectors/selectors.go
+++ b/pkg/selectors/selectors.go
@@ -519,7 +519,6 @@ func (k *KernelSelectorState) createStringMaps() SelectorStringMaps {
 //
 // For a simpler example of this construction, see the InMap functionality.
 func (k *KernelSelectorState) insertStringMaps(stringMaps SelectorStringMaps) [StringMapsNumSubMaps]uint32 {
-
 	details := [StringMapsNumSubMaps]uint32{}
 	mapid := uint32(0)
 

--- a/pkg/sensors/collection.go
+++ b/pkg/sensors/collection.go
@@ -353,7 +353,6 @@ func (c *collection) setMode(mode tetragon.TracingPolicyMode) error {
 // load will attempt to load a collection of sensors. If loading one of the sensors fails, it
 // will attempt to unload the already loaded sensors.
 func (c *collection) load(bpfDir string) error {
-
 	var err error
 	for _, sensor := range c.sensors {
 		if sensor.IsLoaded() {

--- a/pkg/sensors/exec/args_windows.go
+++ b/pkg/sensors/exec/args_windows.go
@@ -20,7 +20,6 @@ var (
 )
 
 func getArgsFromPID(PID uint32) (string, string, error) {
-
 	if (cmdMap == nil) || (imageMap == nil) {
 		coll, _ := bpf.GetCollection("ProcessMonitor")
 		if coll == nil {

--- a/pkg/sensors/exec/cgroups_test.go
+++ b/pkg/sensors/exec/cgroups_test.go
@@ -782,7 +782,6 @@ func TestCgroupEventMkdirRmdir(t *testing.T) {
 func testCgroupv2HierarchyInHybrid(ctx context.Context, t *testing.T,
 	cgroupRoot string, cgroupHierarchy []cgroupHierarchy, trackingCgrpLevel uint32,
 	triggers []func()) {
-
 	t.Logf("Test %s running in %s", t.Name(), cgroups.CgroupModeCode(cgroups.CGROUP_HYBRID).String())
 	unifiedCgroup := "unified" // in Hybrid setup the unified cgroup is the cgroupv2 instance
 	t.Logf("Test %s cgroup mount point: %s -> %s", t.Name(), filepath.Join(cgroups.GetCgroupFSPath(), unifiedCgroup), cgroupRoot)
@@ -807,7 +806,6 @@ func testCgroupv2HierarchyInHybrid(ctx context.Context, t *testing.T,
 func testCgroupv1HierarchyInHybrid(ctx context.Context, t *testing.T,
 	cgroupRoot string, usedController string, cgroupHierarchiesMap map[string][]cgroupHierarchy, trackingCgrpLevel uint32,
 	triggers []func()) {
-
 	t.Logf("Test %s running in %s", t.Name(), cgroups.CgroupModeCode(cgroups.CGROUP_HYBRID).String())
 
 	for hierarchy, cgroupHierarchy := range cgroupHierarchiesMap {
@@ -835,7 +833,6 @@ func testCgroupv1HierarchyInHybrid(ctx context.Context, t *testing.T,
 func testCgroupv2HierarchyInUnified(ctx context.Context, t *testing.T,
 	cgroupRoot string, cgroupHierarchy []cgroupHierarchy, trackingCgrpLevel uint32,
 	triggers []func()) {
-
 	t.Logf("Test %s running in %s", t.Name(), cgroups.CgroupModeCode(cgroups.CGROUP_UNIFIED).String())
 	t.Logf("Test %s cgroup mount point: %s -> %s", t.Name(), cgroups.GetCgroupFSPath(), cgroupRoot)
 

--- a/pkg/sensors/exec/fork_test.go
+++ b/pkg/sensors/exec/fork_test.go
@@ -81,7 +81,6 @@ func (fti *forkTesterInfo) ParseLine(l string) error {
 	var v uint64
 	if match := parentRe.FindStringSubmatch(l); len(match) > 0 {
 		v, err = strconv.ParseUint(match[1], 10, 32)
-
 		if err == nil {
 			fti.parentPid = uint32(v)
 		}

--- a/pkg/sensors/exec/procevents/proc_reader_linux.go
+++ b/pkg/sensors/exec/procevents/proc_reader_linux.go
@@ -81,7 +81,6 @@ func getCWD(pid uint32) (string, uint32) {
 }
 
 func updateExecveMapStats(procs int64) {
-
 	execveMapStats := base.GetExecveMapStats()
 
 	m, err := ebpf.LoadPinnedMap(filepath.Join(bpf.MapPrefixPath(), execveMapStats.Name), nil)

--- a/pkg/sensors/exec/procevents/proc_reader_windows.go
+++ b/pkg/sensors/exec/procevents/proc_reader_windows.go
@@ -253,7 +253,6 @@ func U16ToBytes(u []uint16) []byte {
 }
 
 func writeExecveMap(procs []procs) map[uint32]struct{} {
-
 	retMap := make(map[uint32]struct{})
 	// on Windows we use a different map atructure.
 	// There are two maps, one for commandline and another for image path
@@ -402,7 +401,6 @@ func init() {
 }
 
 func isProcess32Bit(h windows.Handle) bool {
-
 	var wow64Process uint
 	is2Bit := (unsafe.Sizeof(wow64Process) == 4)
 	switch processorArch {
@@ -444,7 +442,6 @@ func getProcessImagePathFromHandle(hProc windows.Handle) (string, error) {
 }
 
 func fetchProcessCmdLineFromHandle(hProc windows.Handle) (string, error) {
-
 	is32Bit := isProcess32Bit(hProc)
 
 	if is32Bit {
@@ -572,7 +569,6 @@ func NewProcess(procEntry windows.ProcessEntry32) (procs, error) {
 			hPProc, err = windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(ppid))
 		}
 		if (err == nil) && (pidfile.IsPidAliveByHandle(hPProc)) {
-
 			defer windows.CloseHandle(hPProc)
 			pcmdline, err = fetchProcessCmdLineFromHandle(hPProc)
 			if err != nil {

--- a/pkg/sensors/map_update.go
+++ b/pkg/sensors/map_update.go
@@ -52,7 +52,6 @@ func UpdateStatsMap(m *ebpf.Map, val int64) error {
 		},
 		License: "GPL",
 	})
-
 	if err != nil {
 		return err
 	}

--- a/pkg/sensors/program/loader.go
+++ b/pkg/sensors/program/loader.go
@@ -87,7 +87,6 @@ func loadProgram(
 	opts *LoadOpts,
 	verbose int,
 ) error {
-
 	// Attach function is mandatory
 	if opts.Attach == nil {
 		return errors.New("attach function is not provided")

--- a/pkg/sensors/program/loader_linux.go
+++ b/pkg/sensors/program/loader_linux.go
@@ -42,7 +42,6 @@ func LinkPin(lnk link.Link, bpfDir string, load *Program, extra ...string) error
 func RawAttachWithFlags(targetFD int, flags uint32) AttachFunc {
 	return func(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		err := link.RawAttachProgram(link.RawAttachProgramOptions{
 			Target:  targetFD,
 			Program: prog,
@@ -70,7 +69,6 @@ func RawAttachWithFlags(targetFD int, flags uint32) AttachFunc {
 func TracepointAttach(load *Program, bpfDir string) AttachFunc {
 	return func(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		parts := strings.Split(load.Attach, "/")
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("tracepoint attach argument must be in the form category/tracepoint, got: %s", load.Attach)
@@ -98,7 +96,6 @@ func TracepointAttach(load *Program, bpfDir string) AttachFunc {
 func RawTracepointAttach(load *Program) AttachFunc {
 	return func(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		var lnk link.Link
 		var err error
 
@@ -184,7 +181,6 @@ func kprobeAttach(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec,
 
 func kprobeAttachOverride(load *Program, bpfDir string,
 	coll *ebpf.Collection, collSpec *ebpf.CollectionSpec) error {
-
 	spec, ok := collSpec.Programs["generic_kprobe_override"]
 	if !ok {
 		return errors.New("spec for generic_kprobe_override program not found")
@@ -216,7 +212,6 @@ func kprobeAttachOverride(load *Program, bpfDir string,
 
 func fmodretAttachOverride(load *Program, bpfDir string,
 	coll *ebpf.Collection, collSpec *ebpf.CollectionSpec) error {
-
 	spec, ok := collSpec.Programs["generic_fmodret_override"]
 	if !ok {
 		return errors.New("spec for generic_fmodret_override program not found")
@@ -268,7 +263,6 @@ func fmodretAttachOverride(load *Program, bpfDir string,
 func KprobeAttach(load *Program, bpfDir string) AttachFunc {
 	return func(coll *ebpf.Collection, collSpec *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		if load.Override {
 			if load.OverrideFmodRet {
 				if err := fmodretAttachOverride(load, bpfDir, coll, collSpec); err != nil {
@@ -301,14 +295,12 @@ func UprobeOpen(load *Program) OpenFunc {
 func UprobeAttach(load *Program, bpfDir string) AttachFunc {
 	return func(coll *ebpf.Collection, collSpec *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		return uprobeAttach(load, bpfDir, coll, collSpec, prog, spec, uprobeAttachSingle)
 	}
 }
 
 func uprobeAttachSingle(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec,
 	bpfDir string, extra ...string) (unloader.Unloader, error) {
-
 	data, ok := load.AttachData.(*UprobeAttachData)
 	if !ok {
 		return nil, fmt.Errorf("attaching '%s' failed: wrong attach data", spec.Name)
@@ -352,7 +344,6 @@ func uprobeAttachSingle(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpe
 func MultiUprobeAttach(load *Program, bpfDir string) AttachFunc {
 	return func(coll *ebpf.Collection, collSpec *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		return uprobeAttach(load, bpfDir, coll, collSpec, prog, spec, uprobeAttachMulti)
 	}
 }
@@ -360,7 +351,6 @@ func MultiUprobeAttach(load *Program, bpfDir string) AttachFunc {
 func attachMultiUpobeLink(load *Program, prog *ebpf.Program, path string,
 	attach *MultiUprobeAttachSymbolsCookies, bpfDir string,
 	idx int, extra ...string) (link.Link, error) {
-
 	exec, err := link.OpenExecutable(path)
 	if err != nil {
 		return nil, err
@@ -391,7 +381,6 @@ func attachMultiUpobeLink(load *Program, prog *ebpf.Program, path string,
 
 func uprobeAttachMulti(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec,
 	bpfDir string, extra ...string) (unloader.Unloader, error) {
-
 	data, ok := load.AttachData.(*MultiUprobeAttachData)
 	if !ok {
 		return nil, fmt.Errorf("attaching '%s' failed: wrong attach data", spec.Name)
@@ -432,7 +421,6 @@ func uprobeAttachMulti(load *Program, prog *ebpf.Program, spec *ebpf.ProgramSpec
 func uprobeAttachExtra(load *Program, bpfDir string,
 	coll *ebpf.Collection, collSpec *ebpf.CollectionSpec,
 	progName, pin string, attach uprobeAttachFunc) (unloader.Unloader, error) {
-
 	spec, ok := collSpec.Programs[progName]
 	if !ok {
 		return nil, fmt.Errorf("spec for %s program not found", progName)
@@ -464,7 +452,6 @@ func uprobeAttachExtra(load *Program, bpfDir string,
 func uprobeAttach(load *Program, bpfDir string,
 	coll *ebpf.Collection, collSpec *ebpf.CollectionSpec,
 	prog *ebpf.Program, spec *ebpf.ProgramSpec, attach uprobeAttachFunc) (un unloader.Unloader, err error) {
-
 	var (
 		main             unloader.Unloader
 		sleepableOffload unloader.Unloader
@@ -568,7 +555,6 @@ func LSMOpen(load *Program) OpenFunc {
 func LSMAttach(load *Program, bpfDir string) AttachFunc {
 	return func(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		linkFn := func() (link.Link, error) {
 			return link.AttachLSM(link.LSMOptions{
 				Program: prog,
@@ -594,7 +580,6 @@ func LSMAttach(load *Program, bpfDir string) AttachFunc {
 func multiKprobeAttach(load *Program, prog *ebpf.Program,
 	spec *ebpf.ProgramSpec, opts link.KprobeMultiOptions,
 	bpfDir string, extra ...string) (unloader.Unloader, error) {
-
 	var lnk link.Link
 	var err error
 
@@ -625,7 +610,6 @@ func multiKprobeAttach(load *Program, prog *ebpf.Program,
 func MultiKprobeAttach(load *Program, bpfDir string) AttachFunc {
 	return func(coll *ebpf.Collection, collSpec *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		data, ok := load.AttachData.(*MultiKprobeAttachData)
 		if !ok {
 			return nil, fmt.Errorf("attaching '%s' failed: wrong attach data", spec.Name)
@@ -700,7 +684,6 @@ func LoadKprobeProgram(bpfDir string, load *Program, maps []*Map, verbose int) e
 func KprobeAttachMany(load *Program, syms []string, bpfDir string) AttachFunc {
 	return func(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		unloader := unloader.ChainUnloader{
 			unloader.ProgUnloader{
 				Prog: prog,
@@ -820,7 +803,6 @@ func LoadMultiUprobeProgram(bpfDir string, load *Program, maps []*Map, verbose i
 func SeccompAttach() AttachFunc {
 	return func(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 		prog *ebpf.Program, _ *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		return &unloader.ProgUnloader{
 			Prog: prog,
 		}, nil
@@ -839,7 +821,6 @@ func slimVerifierError(errStr string) string {
 	// The error is potentially up to 'verifierLogBufferSize' bytes long,
 	// and most of it is not interesting. For a user-friendly output, we'll
 	// only keep the first and last N lines.
-
 	nLines := 30
 	headLines := 0
 	headEnd := 0
@@ -872,7 +853,6 @@ func slimVerifierError(errStr string) string {
 
 func installTailCalls(bpfDir string, spec *ebpf.CollectionSpec, coll *ebpf.Collection, load *Program) error {
 	// FIXME(JM): This should be replaced by using the cilium/ebpf prog array initialization.
-
 	secToProgName := make(map[string]string)
 	for name, prog := range spec.Programs {
 		secToProgName[prog.SectionName] = name

--- a/pkg/sensors/program/loader_windows.go
+++ b/pkg/sensors/program/loader_windows.go
@@ -44,7 +44,6 @@ func makeGUID(data1 uint32, data2 uint16, data3 uint16, data4 [8]byte) windows.G
 
 func winAttachStub(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 	_ *ebpf.Program, _ *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 	return nil, constants.ErrWindowsNotSupported
 }
 
@@ -62,7 +61,6 @@ func getAttachTypeForAttachTarget(attachTarget string) (ebpf.AttachType, error) 
 
 func windowsAttach(_ *Program, prog *ebpf.Program, _ *ebpf.ProgramSpec,
 	attach string, _ string, _ ...string) (unloader.Unloader, error) {
-
 	attachType, err := getAttachTypeForAttachTarget(attach)
 	if err != nil {
 		return nil, err
@@ -89,7 +87,6 @@ func windowsAttach(_ *Program, prog *ebpf.Program, _ *ebpf.ProgramSpec,
 func WindowsAttach(load *Program, bpfDir string) AttachFunc {
 	return func(_ *ebpf.Collection, _ *ebpf.CollectionSpec,
 		prog *ebpf.Program, spec *ebpf.ProgramSpec) (unloader.Unloader, error) {
-
 		return windowsAttach(load, prog, spec, load.Attach, bpfDir)
 	}
 }
@@ -124,7 +121,6 @@ func doLoadProgram(
 	_ int,
 	_ bool,
 ) (*LoadedCollection, error) {
-
 	coll, err := bpf.GetCollectionByPath(load.Name)
 	if err != nil {
 		coll, err = ebpf.LoadCollection(load.Name)
@@ -138,7 +134,6 @@ func doLoadProgram(
 	collMaps := map[ebpf.MapID]*ebpf.Map{}
 	// we need a mapping by ID
 	for _, m := range coll.Maps {
-
 		info, err := m.Info()
 		if err != nil {
 			logger.GetLogger().Warn("failed to retrieve BPF map info", "map", m.String(), logfields.Error, err)

--- a/pkg/sensors/test/sensors_test.go
+++ b/pkg/sensors/test/sensors_test.go
@@ -153,7 +153,6 @@ func TestMapMultipleSensors(t *testing.T) {
 	// ./policy/sensor1
 	// ./policy/sensor1/p1
 	// ./policy/sensor1/p1/prog
-
 	p1 := program.Builder(
 		"bpf_map_test_p1.o",
 		"wake_up_new_task",

--- a/pkg/sensors/tracing/enforcer.go
+++ b/pkg/sensors/tracing/enforcer.go
@@ -89,7 +89,6 @@ func (kp *enforcerPolicy) PolicyHandler(
 	policy tracingpolicy.TracingPolicy,
 	_ policyfilter.PolicyID,
 ) (sensors.SensorIface, error) {
-
 	spec := policy.TpSpec()
 
 	if len(spec.Lists) > 0 {
@@ -192,7 +191,6 @@ func (kp *enforcerPolicy) createEnforcerSensor(
 	policyName string,
 	policyNamespace string,
 ) (*sensors.Sensor, error) {
-
 	if len(enforcers) > 1 {
 		return nil, errors.New("failed: we support only single enforcer sensor")
 	}

--- a/pkg/sensors/tracing/enforcer_builder.go
+++ b/pkg/sensors/tracing/enforcer_builder.go
@@ -101,7 +101,6 @@ func (ksb *EnforcerSpecBuilder) MustYAML() string {
 }
 
 func (ksb *EnforcerSpecBuilder) Build() (*v1alpha1.TracingPolicy, error) {
-
 	var listNames []string
 	var lists []v1alpha1.ListSpec
 	var enforcers []v1alpha1.EnforcerSpec

--- a/pkg/sensors/tracing/enforcer_test.go
+++ b/pkg/sensors/tracing/enforcer_test.go
@@ -61,7 +61,6 @@ func newCmdChecker(cmd string, checkFn func(t *testing.T, err error, rc int)) cm
 func testEnforcer(t *testing.T, configHook string,
 	checker *eventchecker.UnorderedEventChecker,
 	cmds ...cmdChecker) {
-
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -912,7 +911,6 @@ func TestEnforcerPersistentOverride(t *testing.T) {
 }
 
 func TestEnforcerPersistentKill(t *testing.T) {
-
 	test := testutils.RepoRootPath("contrib/tester-progs/enforcer-tester")
 
 	builder := func() *EnforcerSpecBuilder {

--- a/pkg/sensors/tracing/generic_test.go
+++ b/pkg/sensors/tracing/generic_test.go
@@ -148,7 +148,6 @@ spec:
 	for _, hook := range successHook {
 		for _, arg := range hook.Args {
 			lastBTFType, btfArg, err := resolveBTFArg(hook.Call, &arg, false)
-
 			if err != nil {
 				t.Fatal(hook.Call, err)
 			}

--- a/pkg/sensors/tracing/genericfentry.go
+++ b/pkg/sensors/tracing/genericfentry.go
@@ -33,7 +33,6 @@ func createGenericFentrySensor(
 	polInfo *policyInfo,
 	valInfo []*kpValidateInfo,
 ) (*sensors.Sensor, error) {
-
 	// TODO support enforcement ;-)
 	for _, fentry := range spec.Fentries {
 		if selectors.HasEnforcementAction(fentry.Selectors) {

--- a/pkg/sensors/tracing/generickprobe.go
+++ b/pkg/sensors/tracing/generickprobe.go
@@ -978,7 +978,6 @@ func addKprobe(funcName string, instance InstanceID, f *v1alpha1.KProbeSpec, in 
 
 func createKprobeSensorFromEntry(polInfo *policyInfo, kprobeEntry *genericKprobe,
 	progs []*program.Program, maps []*program.Map, has hasMaps) ([]*program.Program, []*program.Map) {
-
 	loadProgName, loadProgRetName := config.GenericKprobeObjs(false)
 	isSecurityFunc := strings.HasPrefix(kprobeEntry.funcName, "security_")
 
@@ -1195,7 +1194,6 @@ func getMapLoad(load *program.Program, kprobeEntry *genericKprobe, index uint32)
 
 func loadSingleKprobeSensor(id idtable.EntryID, bpfDir string, load *program.Program, maps []*program.Map,
 	verbose int, fentry bool) error {
-
 	gk, err := genericKprobeTableGet(id)
 	if err != nil {
 		return err

--- a/pkg/sensors/tracing/genericlsm.go
+++ b/pkg/sensors/tracing/genericlsm.go
@@ -539,7 +539,6 @@ func imaProgName(lsmEntry *genericLsm) (string, string) {
 
 func createLsmSensorFromEntry(polInfo *policyInfo, lsmEntry *genericLsm,
 	progs []*program.Program, maps []*program.Map) ([]*program.Program, []*program.Map) {
-
 	loadProgCoreName, loadProgOutputName := config.GenericLsmObjs()
 	pinName := lsmEntry.instance.PinProg(lsmEntry.hook)
 

--- a/pkg/sensors/tracing/generictracepoint.go
+++ b/pkg/sensors/tracing/generictracepoint.go
@@ -159,7 +159,6 @@ func (out *genericTracepointArg) String() string {
 // getGenericTypeId: returns the generic type Id of a tracepoint argument
 // if such an id cannot be termined, it returns an GenericInvalidType and an error
 func (out *genericTracepointArg) getGenericTypeId() (int, error) {
-
 	if out.userType != "" && out.userType != "auto" {
 		if out.userType == "const_buf" {
 			// const_buf type depends on the .format.field.Type to decode the result, so
@@ -516,7 +515,6 @@ func tpValidateAndAdjustEnforcerAction(
 	tpID int,
 	policyName string,
 	spec *v1alpha1.TracingPolicySpec) error {
-
 	registeredEnforcerMetrics := false
 	for _, sel := range tp.Selectors {
 		for _, act := range sel.MatchActions {
@@ -747,7 +745,6 @@ func (tp *genericTracepoint) InitKernelSelectors(lists []v1alpha1.ListSpec) erro
 }
 
 func (tp *genericTracepoint) EventConfig() (*tracingapi.EventConfig, error) {
-
 	if len(tp.args) > tracingapi.EventConfigMaxArgs {
 		return nil, fmt.Errorf("number of arguments (%d) larger than max (%d)", len(tp.args), tracingapi.EventConfigMaxArgs)
 	}
@@ -764,7 +761,6 @@ func (tp *genericTracepoint) EventConfig() (*tracingapi.EventConfig, error) {
 }
 
 func (tp *genericTracepoint) eventConfigRaw(config *tracingapi.EventConfig) (*tracingapi.EventConfig, error) {
-
 	// iterate over output arguments
 	for i, tpArg := range tp.args {
 		config.BTFArg[i] = tpArg.btf
@@ -778,7 +774,6 @@ func (tp *genericTracepoint) eventConfigRaw(config *tracingapi.EventConfig) (*tr
 }
 
 func (tp *genericTracepoint) eventConfig(config *tracingapi.EventConfig) (*tracingapi.EventConfig, error) {
-
 	// iterate over output arguments
 	for i, tpArg := range tp.args {
 		config.ArgTpCtxOff[i] = uint32(tpArg.CtxOffset)
@@ -793,7 +788,6 @@ func (tp *genericTracepoint) eventConfig(config *tracingapi.EventConfig) (*traci
 }
 
 func LoadGenericTracepointSensor(bpfDir string, load *program.Program, maps []*program.Map, verbose int) error {
-
 	tracepointLog = logger.GetLogger()
 
 	id, ok := load.LoaderData.(idtable.EntryID)
@@ -866,7 +860,6 @@ func handleMsgGenericTracepoint(
 	tp *genericTracepoint,
 	r *bytes.Reader,
 ) ([]observer.Event, error) {
-
 	switch m.ActionId {
 	case selectors.ActionTypeGetUrl, selectors.ActionTypeDnsLookup:
 		actionArgEntry, err := tp.actionArgs.GetEntry(idtable.EntryID{ID: int(m.ActionArgId)})
@@ -892,7 +885,6 @@ func handleMsgGenericTracepoint(
 	unix.Tags = tp.tags
 
 	for idx, out := range tp.args {
-
 		if out.nopTy {
 			continue
 		}

--- a/pkg/sensors/tracing/genericuprobe.go
+++ b/pkg/sensors/tracing/genericuprobe.go
@@ -1591,7 +1591,6 @@ func createSingleUprobeSensor(polInfo *policyInfo, ids []idtable.EntryID, has up
 
 func createUprobeSensorFromEntry(polInfo *policyInfo, uprobeEntry *genericUprobe,
 	progs []*program.Program, maps []*program.Map, has uprobeHas) ([]*program.Program, []*program.Map) {
-
 	var substringMapEntries int
 
 	if has.substring {

--- a/pkg/sensors/tracing/genericusdt.go
+++ b/pkg/sensors/tracing/genericusdt.go
@@ -289,7 +289,6 @@ func createSingleUsdtSensor(polInfo *policyInfo, ids []idtable.EntryID, has usdt
 
 func createUsdtSensorFromEntry(polInfo *policyInfo, usdtEntry *genericUsdt,
 	progs []*program.Program, maps []*program.Map, has usdtHas) ([]*program.Program, []*program.Map) {
-
 	loadProgName := config.GenericUsdtObjs(false)
 
 	attachData := &program.UprobeAttachData{

--- a/pkg/sensors/tracing/kprobe_net_test.go
+++ b/pkg/sensors/tracing/kprobe_net_test.go
@@ -1379,7 +1379,6 @@ spec:
 }
 
 func (suite *KprobeNet) TestKprobeSocketAndSockaddrUn() {
-
 	if !kernels.MinKernelVersion("5.11") {
 		suite.T().Skip("skipping test: sockaddr_un tests are gated at kernel >=5.11")
 	}
@@ -1460,7 +1459,6 @@ spec:
 }
 
 func (suite *KprobeNet) TestKprobeSockaddrUnPathEquals() {
-
 	if !kernels.MinKernelVersion("5.11") {
 		suite.T().Skip("skipping test: sockaddr_un tests are gated at kernel >=5.11")
 	}
@@ -1546,7 +1544,6 @@ spec:
 }
 
 func (suite *KprobeNet) TestKprobeSockaddrUnPathNotEqual() {
-
 	if !kernels.MinKernelVersion("5.11") {
 		suite.T().Skip("skipping test: sockaddr_un tests are gated at kernel >=5.11")
 	}
@@ -1619,7 +1616,6 @@ spec:
 }
 
 func (suite *KprobeNet) TestKprobeSockaddrUnPathNotPrefix() {
-
 	if !kernels.MinKernelVersion("5.11") {
 		suite.T().Skip("skipping test: sockaddr_un tests are gated at kernel >=5.11")
 	}

--- a/pkg/sensors/tracing/kprobe_test.go
+++ b/pkg/sensors/tracing/kprobe_test.go
@@ -711,7 +711,6 @@ func testKprobeObjectFiltered(t *testing.T,
 	mode int,
 	perm uint32,
 	fentry bool) {
-
 	if useMount == true {
 		if err := syscall.Mount("tmpfs", mntPath, "tmpfs", 0, ""); err != nil {
 			t.Logf("Mount failed: %s\n", err)
@@ -836,7 +835,6 @@ func testKprobeStringMatch(t *testing.T,
 	readHook string,
 	checker ec.MultiEventChecker,
 	dir string) {
-
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -1735,7 +1733,6 @@ func testKprobeObjectFilteredReturnValue(t *testing.T,
 	checker ec.MultiEventChecker,
 	path string,
 	expectFailure bool) {
-
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -4310,7 +4307,6 @@ func TestKprobeMatchBinaries(t *testing.T) {
 }
 
 func matchBinariesLargePathTest(t *testing.T, operator string, values []string, binary string, fentry bool) {
-
 	var doneWG, readyWG sync.WaitGroup
 	defer doneWG.Wait()
 
@@ -6837,7 +6833,6 @@ spec:
 	})
 
 	t.Run("dentry", func(t *testing.T) {
-
 		var doneWG, readyWG sync.WaitGroup
 		defer doneWG.Wait()
 
@@ -7693,7 +7688,6 @@ func TestKprobeResolveCurrent(t *testing.T) {
 }
 
 func testKprobeRangeOp(t *testing.T, in, fentry bool) {
-
 	if !config.EnableLargeProgs() {
 		t.Skipf("Skipping test since it needs kernel >= 5.3")
 	}
@@ -7786,7 +7780,6 @@ func TestKprobeRangeNotIn(t *testing.T) {
 }
 
 func testKprobeGT(t *testing.T, value uint64, fail, fentry bool) {
-
 	if !config.EnableLargeProgs() {
 		t.Skipf("Skipping test since it needs kernel >= 5.3")
 	}

--- a/pkg/sensors/tracing/kprobe_validation_test.go
+++ b/pkg/sensors/tracing/kprobe_validation_test.go
@@ -31,9 +31,7 @@ func checkCrd(t *testing.T, crd string) error {
 }
 
 func TestKprobeValidationListWrongSyscallName(t *testing.T) {
-
 	// messed up syscall name in the list
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -54,9 +52,7 @@ spec:
 }
 
 func TestKprobeValidationListWrongOverride(t *testing.T) {
-
 	// override on non override-able functions in list
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -82,9 +78,7 @@ spec:
 }
 
 func TestKprobeValidationListWrongName(t *testing.T) {
-
 	// wrong list name reference in kprobe's call
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -106,9 +100,7 @@ spec:
 }
 
 func TestKprobeValidationListGeneratedSyscallsNotEmpty(t *testing.T) {
-
 	// not empty values for generated syscalls list
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -130,9 +122,7 @@ spec:
 }
 
 func TestKprobeValidationListGeneratedFtraceNotEmpty(t *testing.T) {
-
 	// not empty values for generated ftrace list
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -154,9 +144,7 @@ spec:
 }
 
 func TestKprobeValidationListGeneratedFtraceNoPattern(t *testing.T) {
-
 	// no pattern specified for generated ftrace list
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -174,9 +162,7 @@ spec:
 	require.Error(t, err)
 }
 func TestKprobeValidationWrongSyscallName(t *testing.T) {
-
 	// messed up syscall name in kprobe's call
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -192,9 +178,7 @@ spec:
 }
 
 func TestKprobeValidationWrongOverride(t *testing.T) {
-
 	// override on non override-able functions in list
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -214,9 +198,7 @@ spec:
 }
 
 func TestKprobeValidationNonSyscallOverride(t *testing.T) {
-
 	// override on non syscall (non override-able) function
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -318,9 +300,7 @@ func TestKprobeValidationReturnArgActionInvalid(t *testing.T) {
 }
 
 func TestKprobeLTOp(t *testing.T) {
-
 	// missing returnArg while having return: true
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -349,9 +329,7 @@ spec:
 }
 
 func TestKprobeGTOp(t *testing.T) {
-
 	// missing returnArg while having return: true
-
 	crd := `
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy

--- a/pkg/sensors/tracing/matchbinaries_follow_children_test.go
+++ b/pkg/sensors/tracing/matchbinaries_follow_children_test.go
@@ -42,7 +42,6 @@ import (
 )
 
 func testMatchBinariesFollowChildren(t *testing.T, op string, result, resultMyPid int) {
-
 	testutils.CaptureLog(t, logger.GetLogger())
 	ctx, cancel := context.WithTimeout(context.Background(), tus.Conf().CmdWaitTime)
 	defer cancel()
@@ -139,7 +138,6 @@ func TestMatchBinariesFollowChildrenIDs(t *testing.T) {
 	// Limit this test to kprobe_multi systems, otherwise it'd take too long.
 	// The mbset functionality works the same for kprobe or kprobe_multi,
 	// so no harm done.
-
 	if !bpf.HasKprobeMulti() || !config.EnableLargeProgs() {
 		t.Skip("Test requires kprobe multi and large programs")
 	}

--- a/pkg/sensors/tracing/policyhandler_linux.go
+++ b/pkg/sensors/tracing/policyhandler_linux.go
@@ -174,7 +174,6 @@ func (h policyHandler) PolicyHandler(
 	policy tracingpolicy.TracingPolicy,
 	policyID policyfilter.PolicyID,
 ) (sensors.SensorIface, error) {
-
 	spec := policy.TpSpec()
 	sections := 0
 	if len(spec.KProbes) > 0 {

--- a/pkg/sensors/tracing/uprobe_reg_test.go
+++ b/pkg/sensors/tracing/uprobe_reg_test.go
@@ -627,7 +627,6 @@ func testUprobeOverrideRegsActionSize(t *testing.T, ass, num string) {
 
 	switch runtime.GOARCH {
 	case "amd64":
-
 		// Put uprobe in test_2 function at:
 		//
 		//       "push   %rbp\n"                        /* +0  55                            */

--- a/pkg/sensors/tracing/uprobe_test.go
+++ b/pkg/sensors/tracing/uprobe_test.go
@@ -1181,7 +1181,6 @@ spec:
 }
 
 func TestUprobeNULLStringAndReturnArg(t *testing.T) {
-
 	if !bpf.HasKfunc("bpf_copy_from_user_str") {
 		t.Skip("this test requires bpf_copy_from_user_str kfunc support")
 	}

--- a/pkg/sensors/tracing/usdt_validation_test.go
+++ b/pkg/sensors/tracing/usdt_validation_test.go
@@ -15,9 +15,7 @@ import (
 )
 
 func TestUsdtValidationSetWrongReturnSize1B(t *testing.T) {
-
 	// Using 1 bytes return argument with usdt set action
-
 	usdt := testutils.RepoRootPath("contrib/tester-progs/usdt-override")
 	crd := `
 apiVersion: cilium.io/v1alpha1
@@ -48,9 +46,7 @@ spec:
 }
 
 func TestUsdtValidationSetWrongReturnSize8B(t *testing.T) {
-
 	// Using 8 bytes return argument with usdt set action
-
 	usdt := testutils.RepoRootPath("contrib/tester-progs/usdt-override")
 	crd := `
 apiVersion: cilium.io/v1alpha1

--- a/pkg/server/addr.go
+++ b/pkg/server/addr.go
@@ -24,7 +24,6 @@ import (
 // Hence, because we want the same string to work the same way both on the client and the server, we
 // only support the two addresses above.
 func SplitListenAddr(arg string) (string, string, error) {
-
 	if after, ok := strings.CutPrefix(arg, "unix://"); ok {
 		path := after
 		if !filepath.IsAbs(path) {

--- a/pkg/syscallinfo/syscallinfo.go
+++ b/pkg/syscallinfo/syscallinfo.go
@@ -44,7 +44,6 @@ func init() {
 }
 
 func syscallNames(abi string) (map[int]string, error) {
-
 	switch abi {
 	case "x64":
 		return x64.Names, nil

--- a/pkg/testutils/perfring/perfring.go
+++ b/pkg/testutils/perfring/perfring.go
@@ -129,7 +129,6 @@ func ProcessEvents(t *testing.T, ctx context.Context, eventFn EventFn, wgStarted
 		complChecker := testsensor.NewCompletionChecker()
 
 		for ctxPerfRing.Err() == nil {
-
 			record, err := perfReader.Read()
 			if err != nil {
 				if ctxPerfRing.Err() == nil && !errors.Is(err, os.ErrClosed) {
@@ -154,11 +153,9 @@ func ProcessEvents(t *testing.T, ctx context.Context, eventFn EventFn, wgStarted
 		// Service the BPF ring buffer.
 		ctxBPFRing, cancelBPFRing = context.WithCancel(ctx)
 		wg.Go(func() {
-
 			complChecker := testsensor.NewCompletionChecker()
 
 			for ctxBPFRing.Err() == nil {
-
 				record, err := ringBufReader.Read()
 				if err != nil {
 					if ctxBPFRing.Err() == nil && !errors.Is(err, os.ErrClosed) {

--- a/pkg/testutils/policytest/actioncnts.go
+++ b/pkg/testutils/policytest/actioncnts.go
@@ -28,7 +28,6 @@ func actCountsCheck(
 	before, after *tetragon.TracingPolicyActionCounters,
 	expect *ActionCounts,
 ) error {
-
 	var err error
 	doCheck := func(cnt string, expected, before, after uint64) {
 		if expected != after-before {

--- a/pkg/testutils/policytest/runner.go
+++ b/pkg/testutils/policytest/runner.go
@@ -291,7 +291,6 @@ func runCheck(
 	inChan <-chan *tetragon.GetEventsResponse,
 	outChan chan<- checkerRet,
 ) {
-
 	log = log.With("goroutine", "checker")
 	log.Debug("goroutine started")
 	count := 0
@@ -414,7 +413,6 @@ type PolicyHandler struct {
 }
 
 func (ph *PolicyHandler) Cleanup(l *slog.Logger, conf *Conf, client *cli.ClientWithContext) error {
-
 	// call policy cleanup after we are done
 	if ph.cleanup != nil {
 		defer ph.cleanup()
@@ -453,7 +451,6 @@ func (ph *PolicyHandler) Cleanup(l *slog.Logger, conf *Conf, client *cli.ClientW
 func (ph *PolicyHandler) Configure(
 	l *slog.Logger, client *cli.ClientWithContext,
 	enable *bool, mode *tetragon.TracingPolicyMode) error {
-
 	_, err := client.Client.ConfigureTracingPolicy(client.Ctx, &tetragon.ConfigureTracingPolicyRequest{
 		Name:      ph.tpName,
 		Namespace: ph.tpNamespace,
@@ -470,7 +467,6 @@ func (ph *PolicyHandler) Configure(
 
 func (ph *PolicyHandler) GetCounts(
 	_ *slog.Logger, client *cli.ClientWithContext) (*tetragon.TracingPolicyActionCounters, error) {
-
 	res, err := client.Client.ListTracingPolicies(client.Ctx, &tetragon.ListTracingPoliciesRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get action counts: %w", err)

--- a/pkg/testutils/progs/tester.go
+++ b/pkg/testutils/progs/tester.go
@@ -134,7 +134,6 @@ func TestHelperMain() {
 
 //revive:disable:context-as-argument
 func StartTester(t *testing.T, ctx context.Context) *Tester {
-
 	prog := testutils.RepoRootPath("contrib/tester-progs/test-helper")
 	cmd := exec.CommandContext(ctx, prog)
 

--- a/pkg/testutils/sensors/load.go
+++ b/pkg/testutils/sensors/load.go
@@ -231,7 +231,6 @@ func CheckSensorLoad(sensors []*sensors.Sensor, sensorMaps []SensorMap, sensorPr
 func CheckSensorLoadBase(t *testing.T, sensors []*sensors.Sensor,
 	sensorMaps []SensorMap, sensorProgs []SensorProg,
 	baseMaps []SensorMap, baseProgs []SensorProg) {
-
 	sensorMaps, sensorProgs = mergeSensorMaps(t, sensorMaps, baseMaps, sensorProgs, baseProgs)
 
 	var cache []*prog

--- a/pkg/tracepoint/fieldtype.go
+++ b/pkg/tracepoint/fieldtype.go
@@ -67,7 +67,6 @@ func (e *ParseError) Error() string {
 }
 
 func parseTy(tyFields []string) (any, error) {
-
 	fidx := 0
 	nfields := len(tyFields)
 	isConst := false
@@ -167,7 +166,6 @@ func parseTy(tyFields []string) (any, error) {
 }
 
 func parseField(s string) (*Field, error) {
-
 	fields := strings.Fields(s)
 	nfields := len(fields)
 	if nfields < 2 {

--- a/pkg/tracepoint/tracepoint_test.go
+++ b/pkg/tracepoint/tracepoint_test.go
@@ -140,7 +140,6 @@ func TestTracepointLoadFormat(t *testing.T) {
 }
 
 func TestTracepointsAll(t *testing.T) {
-
 	tracepoints, err := GetAllTracepoints()
 	if err != nil {
 		t.Log(err)

--- a/pkg/vmtests/list.go
+++ b/pkg/vmtests/list.go
@@ -29,7 +29,6 @@ func (t *GoTest) ToPattern() string {
 }
 
 func fromString(testDir, s string) []GoTest {
-
 	sl := strings.SplitN(s, ":", 2)
 	prog := sl[0]
 	if len(sl) < 2 {
@@ -81,7 +80,6 @@ func ListTests(
 	packagesOnly bool,
 	ignorelist []GoTest,
 ) ([]GoTest, error) {
-
 	progs, err := listTestProgs(testDir, ignorelist)
 	if err != nil {
 		return nil, err

--- a/pkg/vmtests/vmtests.go
+++ b/pkg/vmtests/vmtests.go
@@ -99,7 +99,6 @@ func printProgress(f *os.File, done <-chan struct{}) {
 // An error is returned only if something unexpected happen and not if the
 // tests failed.
 func Run(cnf *Conf) error {
-
 	testDir := filepath.Join(cnf.TetragonDir, "go-tests")
 
 	if cnf.BTFFile != "" {
@@ -217,7 +216,6 @@ func gatherExportFiles(cnf *Conf) error {
 }
 
 func runTest(cnf *Conf, testName string, cmd string, args ...string) (*Result, error) {
-
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 

--- a/pkg/vtuple/vtuple.go
+++ b/pkg/vtuple/vtuple.go
@@ -102,7 +102,6 @@ func (e *UnknownV4ProtocolError) Error() string {
 }
 
 func CreateVTupleV4(proto byte, saddr [4]byte, sport uint16, daddr [4]byte, dport uint16) (Impl, error) {
-
 	switch proto {
 	case VT_TCP, VT_UDP:
 	default:


### PR DESCRIPTION
<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [ ] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [ ] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [ ] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

### Description
Enable [the **w**hite**s**pace **l**inter (wsl)](https://github.com/bombsimon/wsl) on the Tetragon codebase, in order to help enforce de-facto whitespace rules (and taking that weight off any reviewers).

This particular change enables two checks only:
  
  - err: no blank line between an error-producing assignment and its `if err != nil` check.
  - leading-whitespace: no blank line as the first line inside a block (e.g. right after `func foo() {`).


`leading-whitespace` is the flag that causes more changes - if that is not acceptable, we can remove it.


<!-- Please describe quickly the change but most importantly the reason or context of your change -->

```release-note
ci: introduce whitespace linter
```

