### PR TITLE
api/ops: don't log the OpCode from its own Stringer

### DIFF
--- a/pkg/api/ops/ops.go
+++ b/pkg/api/ops/ops.go
@@ -87,7 +87,10 @@ var OpCodeStrings = map[OpCode]string{
 func (op OpCode) String() string {
 	s, ok := OpCodeStrings[op]
 	if !ok {
-		logger.GetLogger().With("opcode", op).Info("Unknown OpCode. This is a bug, please report it to Tetragon developers.")
+		// Log the numeric value, not op: op is a Stringer, so formatting
+		// the record would call this method again and recurse until the
+		// stack overflows.
+		logger.GetLogger().With("opcode", int(op)).Info("Unknown OpCode. This is a bug, please report it to Tetragon developers.")
 		return fmt.Sprintf("Unknown(%d)", op)
 	}
 	return s

--- a/pkg/api/ops/ops_test.go
+++ b/pkg/api/ops/ops_test.go
@@ -41,3 +41,17 @@ func TestCgroupState(t *testing.T) {
 		}
 	}
 }
+
+func TestOpCode(t *testing.T) {
+	testcases := map[OpCode]string{
+		MSG_OP_EXECVE: "Execve",
+		MSG_OP_EXIT:   "Exit",
+		OpCode(200):   "Unknown(200)",
+	}
+
+	for op, str := range testcases {
+		if op.String() != str {
+			t.Errorf("OpCode mismatch - want:%s  got:%s", str, op.String())
+		}
+	}
+}


### PR DESCRIPTION
OpCode.String() logs the OpCode when it has no OpCodeStrings entry. OpCode is a Stringer, so formatting that record calls String() again, which logs again, until the process dies:

```
  fatal error: stack overflow
  github.com/cilium/tetragon/pkg/api/ops.OpCode.String(0xc8)
  github.com/cilium/tetragon/pkg/api/ops.OpCode.String(0xc8)
```

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
api/ops: don't log the OpCode from its own Stringer
```
