### PR TITLE
ci: add action read permission to mock ariane workflow

### DIFF
--- a/.github/workflows/mock-ci.yaml
+++ b/.github/workflows/mock-ci.yaml
@@ -52,6 +52,7 @@ jobs:
     permissions:
       contents: read
       statuses: write
+      actions: read
     uses: ./.github/workflows/common-post-jobs.yml
     with:
       sha: ${{ inputs.SHA || github.sha }}


### PR DESCRIPTION


<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [x] All code is covered by unit and/or end-to-end tests where feasible.
- [x] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [x] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/release-notes/#upgrade-notes)).
- [x] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
- [x] Consult https://github.com/cilium/community/blob/main/AI-POLICY.md for PRs that
  use Generative AI.
-->

Fixes <!-- #issue-number -->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->

In `mock-ci.yaml` we call `common-post-jobs.yml`. In this file we call `cilium/actions/set-commit-status`.

For this last call the `merge-upload-and-status` job must call `common-post-jobs.yml` with the permission to call other workflows.

### Changelog
<!-- Enter the release note text in the codeblock below if needed or remove this section! -->

```release-note
ci: add action read permission to mock ariane workflow
```
