### PR TITLE
build: tidy tools after root module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,10 +497,10 @@ vendor: ## Tidy and vendor Go modules.
 	$(MAKE) -C api vendor
 	$(MAKE) -C pkg/k8s vendor
 	$(MAKE) -C contrib/tetragon-rthooks vendor
-	$(MAKE) -C tools tidy
 	$(GO) mod tidy
 	$(GO) mod vendor
 	$(GO) mod verify
+	$(MAKE) -C tools tidy
 
 .PHONY: clang-format
 ifeq (1,$(LOCAL_CLANG_FORMAT))


### PR DESCRIPTION
The tools module replaces the root module locally, so its dependency graph must be tidied after the root module has been updated. This makes a single `make vendor` invocation sufficient and prevents subsequent tool builds from requiring another `go mod tidy`.

See [here](https://github.com/cilium/tetragon/actions/runs/34582180581/job/103208076349)  for the renovate log that corresponds to a failed update because of this problem.

```
2026-09-11T09:12:07.9636719Z        "artifactErrors": [
2026-09-11T09:12:07.9637319Z          {
2026-09-11T09:12:07.9638001Z            "stderr": "Command failed: /bin/sh -c make protogen\ngo: updates to go.mod needed; to update it:\n\tgo mod tidy\nmake: *** [Makefile:478: protoc-gen-go-tetragon] Error 1\n"
2026-09-11T09:12:07.9638915Z          }
2026-09-11T09:12:07.9639320Z        ]
```